### PR TITLE
[AArch64][NFC] Make insertion of CMP for fused cond. branches reusable

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
@@ -864,6 +864,211 @@ unsigned AArch64InstrInfo::insertBranch(
   return 2;
 }
 
+AArch64CC::CondCode AArch64InstrInfo::insertCmpForCondBr(
+    MachineBasicBlock &MBB, MachineBasicBlock::iterator MI, const DebugLoc &DL,
+    ArrayRef<MachineOperand> Cond) const {
+  MachineRegisterInfo &MRI = MBB.getParent()->getRegInfo();
+
+  // Parse the condition code, see parseCondBranch() above.
+  AArch64CC::CondCode CC;
+  switch (Cond.size()) {
+  default:
+    llvm_unreachable("Unknown condition opcode in Cond");
+  case 1: // b.cc
+    CC = AArch64CC::CondCode(Cond[0].getImm());
+    break;
+  case 3: { // cbz/cbnz
+    // We must insert a compare against 0.
+    bool Is64Bit;
+    switch (Cond[1].getImm()) {
+    default:
+      llvm_unreachable("Unknown branch opcode in Cond");
+    case AArch64::CBZW:
+      Is64Bit = false;
+      CC = AArch64CC::EQ;
+      break;
+    case AArch64::CBZX:
+      Is64Bit = true;
+      CC = AArch64CC::EQ;
+      break;
+    case AArch64::CBNZW:
+      Is64Bit = false;
+      CC = AArch64CC::NE;
+      break;
+    case AArch64::CBNZX:
+      Is64Bit = true;
+      CC = AArch64CC::NE;
+      break;
+    }
+    Register SrcReg = Cond[2].getReg();
+    if (Is64Bit) {
+      // cmp reg, #0 is actually subs xzr, reg, #0.
+      MRI.constrainRegClass(SrcReg, &AArch64::GPR64spRegClass);
+      BuildMI(MBB, MI, DL, get(AArch64::SUBSXri), AArch64::XZR)
+          .addReg(SrcReg)
+          .addImm(0)
+          .addImm(0);
+    } else {
+      MRI.constrainRegClass(SrcReg, &AArch64::GPR32spRegClass);
+      BuildMI(MBB, MI, DL, get(AArch64::SUBSWri), AArch64::WZR)
+          .addReg(SrcReg)
+          .addImm(0)
+          .addImm(0);
+    }
+  } break;
+  case 4: { // tbz/tbnz
+    // We must insert a tst instruction.
+    switch (Cond[1].getImm()) {
+    default:
+      llvm_unreachable("Unknown branch opcode in Cond");
+    case AArch64::TBZW:
+    case AArch64::TBZX:
+      CC = AArch64CC::EQ;
+      break;
+    case AArch64::TBNZW:
+    case AArch64::TBNZX:
+      CC = AArch64CC::NE;
+      break;
+    }
+    // cmp reg, #foo is actually ands xzr, reg, #1<<foo.
+    if (Cond[1].getImm() == AArch64::TBZW || Cond[1].getImm() == AArch64::TBNZW)
+      BuildMI(MBB, MI, DL, get(AArch64::ANDSWri), AArch64::WZR)
+          .addReg(Cond[2].getReg())
+          .addImm(
+              AArch64_AM::encodeLogicalImmediate(1ull << Cond[3].getImm(), 32));
+    else
+      BuildMI(MBB, MI, DL, get(AArch64::ANDSXri), AArch64::XZR)
+          .addReg(Cond[2].getReg())
+          .addImm(
+              AArch64_AM::encodeLogicalImmediate(1ull << Cond[3].getImm(), 64));
+  } break;
+  case 5: { // cb
+    // We must insert a cmp, that is a subs
+    //            0       1   2    3    4
+    // Cond is { -1, Opcode, CC, Op0, Op1 }
+    unsigned SubsOpc, SubsDestReg;
+    bool IsImm = false;
+    CC = static_cast<AArch64CC::CondCode>(Cond[2].getImm());
+    switch (Cond[1].getImm()) {
+    default:
+      llvm_unreachable("Unknown branch opcode in Cond");
+    case AArch64::CBWPri:
+      SubsOpc = AArch64::SUBSWri;
+      SubsDestReg = AArch64::WZR;
+      IsImm = true;
+      break;
+    case AArch64::CBXPri:
+      SubsOpc = AArch64::SUBSXri;
+      SubsDestReg = AArch64::XZR;
+      IsImm = true;
+      break;
+    case AArch64::CBWPrr:
+      SubsOpc = AArch64::SUBSWrr;
+      SubsDestReg = AArch64::WZR;
+      IsImm = false;
+      break;
+    case AArch64::CBXPrr:
+      SubsOpc = AArch64::SUBSXrr;
+      SubsDestReg = AArch64::XZR;
+      IsImm = false;
+      break;
+    }
+
+    if (IsImm) {
+      MRI.constrainRegClass(Cond[3].getReg(), getRegClass(get(SubsOpc), 1));
+      BuildMI(MBB, MI, DL, get(SubsOpc), SubsDestReg)
+          .addReg(Cond[3].getReg())
+          .addImm(Cond[4].getImm())
+          .addImm(0);
+    } else {
+      MRI.constrainRegClass(Cond[3].getReg(), getRegClass(get(SubsOpc), 1));
+      MRI.constrainRegClass(Cond[4].getReg(), getRegClass(get(SubsOpc), 2));
+      BuildMI(MBB, MI, DL, get(SubsOpc), SubsDestReg)
+          .addReg(Cond[3].getReg())
+          .addReg(Cond[4].getReg());
+    }
+  } break;
+  case 7: { // cb[b,h]
+    // We must insert a cmp, that is a subs, but also zero- or sign-extensions
+    // that have been folded. For the first operand we codegen an explicit
+    // extension, for the second operand we fold the extension into cmp.
+    //            0       1   2    3    4    5      6
+    // Cond is { -1, Opcode, CC, Op0, Op1, Ext0, Ext1 }
+
+    // We need a new register for the now explicitly extended register
+    Register Reg = Cond[4].getReg();
+    if (Cond[5].getImm() != AArch64_AM::InvalidShiftExtend) {
+      unsigned ExtOpc;
+      unsigned ExtBits;
+      AArch64_AM::ShiftExtendType ExtendType =
+          AArch64_AM::getExtendType(Cond[5].getImm());
+      switch (ExtendType) {
+      default:
+        llvm_unreachable("Unknown shift-extend for CB instruction");
+      case AArch64_AM::SXTB:
+        assert(
+            Cond[1].getImm() == AArch64::CBBAssertExt &&
+            "Unexpected compare-and-branch instruction for SXTB shift-extend");
+        ExtOpc = AArch64::SBFMWri;
+        ExtBits = AArch64_AM::encodeLogicalImmediate(0xff, 32);
+        break;
+      case AArch64_AM::SXTH:
+        assert(
+            Cond[1].getImm() == AArch64::CBHAssertExt &&
+            "Unexpected compare-and-branch instruction for SXTH shift-extend");
+        ExtOpc = AArch64::SBFMWri;
+        ExtBits = AArch64_AM::encodeLogicalImmediate(0xffff, 32);
+        break;
+      case AArch64_AM::UXTB:
+        assert(
+            Cond[1].getImm() == AArch64::CBBAssertExt &&
+            "Unexpected compare-and-branch instruction for UXTB shift-extend");
+        ExtOpc = AArch64::ANDWri;
+        ExtBits = AArch64_AM::encodeLogicalImmediate(0xff, 32);
+        break;
+      case AArch64_AM::UXTH:
+        assert(
+            Cond[1].getImm() == AArch64::CBHAssertExt &&
+            "Unexpected compare-and-branch instruction for UXTH shift-extend");
+        ExtOpc = AArch64::ANDWri;
+        ExtBits = AArch64_AM::encodeLogicalImmediate(0xffff, 32);
+        break;
+      }
+
+      // Build the explicit extension of the first operand
+      Reg = MRI.createVirtualRegister(&AArch64::GPR32spRegClass);
+      MachineInstrBuilder MBBI =
+          BuildMI(MBB, MI, DL, get(ExtOpc), Reg).addReg(Cond[4].getReg());
+      if (ExtOpc != AArch64::ANDWri)
+        MBBI.addImm(0);
+      MBBI.addImm(ExtBits);
+    }
+
+    // Now, subs with an extended second operand
+    if (Cond[6].getImm() != AArch64_AM::InvalidShiftExtend) {
+      AArch64_AM::ShiftExtendType ExtendType =
+          AArch64_AM::getExtendType(Cond[6].getImm());
+      MRI.constrainRegClass(Reg, MRI.getRegClass(Cond[3].getReg()));
+      MRI.constrainRegClass(Cond[3].getReg(), &AArch64::GPR32spRegClass);
+      BuildMI(MBB, MI, DL, get(AArch64::SUBSWrx), AArch64::WZR)
+          .addReg(Cond[3].getReg())
+          .addReg(Reg)
+          .addImm(AArch64_AM::getArithExtendImm(ExtendType, 0));
+    } // If no extension is needed, just a regular subs
+    else {
+      MRI.constrainRegClass(Reg, MRI.getRegClass(Cond[3].getReg()));
+      MRI.constrainRegClass(Cond[3].getReg(), &AArch64::GPR32spRegClass);
+      BuildMI(MBB, MI, DL, get(AArch64::SUBSWrr), AArch64::WZR)
+          .addReg(Cond[3].getReg())
+          .addReg(Reg);
+    }
+
+    CC = static_cast<AArch64CC::CondCode>(Cond[2].getImm());
+  } break;
+  }
+  return CC;
+}
+
 bool llvm::optimizeTerminators(MachineBasicBlock *MBB,
                                const TargetInstrInfo &TII) {
   for (MachineInstr &MI : MBB->terminators()) {
@@ -1076,208 +1281,9 @@ void AArch64InstrInfo::insertSelect(MachineBasicBlock &MBB,
                                     const DebugLoc &DL, Register DstReg,
                                     ArrayRef<MachineOperand> Cond,
                                     Register TrueReg, Register FalseReg) const {
+
   MachineRegisterInfo &MRI = MBB.getParent()->getRegInfo();
-
-  // Parse the condition code, see parseCondBranch() above.
-  AArch64CC::CondCode CC;
-  switch (Cond.size()) {
-  default:
-    llvm_unreachable("Unknown condition opcode in Cond");
-  case 1: // b.cc
-    CC = AArch64CC::CondCode(Cond[0].getImm());
-    break;
-  case 3: { // cbz/cbnz
-    // We must insert a compare against 0.
-    bool Is64Bit;
-    switch (Cond[1].getImm()) {
-    default:
-      llvm_unreachable("Unknown branch opcode in Cond");
-    case AArch64::CBZW:
-      Is64Bit = false;
-      CC = AArch64CC::EQ;
-      break;
-    case AArch64::CBZX:
-      Is64Bit = true;
-      CC = AArch64CC::EQ;
-      break;
-    case AArch64::CBNZW:
-      Is64Bit = false;
-      CC = AArch64CC::NE;
-      break;
-    case AArch64::CBNZX:
-      Is64Bit = true;
-      CC = AArch64CC::NE;
-      break;
-    }
-    Register SrcReg = Cond[2].getReg();
-    if (Is64Bit) {
-      // cmp reg, #0 is actually subs xzr, reg, #0.
-      MRI.constrainRegClass(SrcReg, &AArch64::GPR64spRegClass);
-      BuildMI(MBB, I, DL, get(AArch64::SUBSXri), AArch64::XZR)
-          .addReg(SrcReg)
-          .addImm(0)
-          .addImm(0);
-    } else {
-      MRI.constrainRegClass(SrcReg, &AArch64::GPR32spRegClass);
-      BuildMI(MBB, I, DL, get(AArch64::SUBSWri), AArch64::WZR)
-          .addReg(SrcReg)
-          .addImm(0)
-          .addImm(0);
-    }
-    break;
-  }
-  case 4: { // tbz/tbnz
-    // We must insert a tst instruction.
-    switch (Cond[1].getImm()) {
-    default:
-      llvm_unreachable("Unknown branch opcode in Cond");
-    case AArch64::TBZW:
-    case AArch64::TBZX:
-      CC = AArch64CC::EQ;
-      break;
-    case AArch64::TBNZW:
-    case AArch64::TBNZX:
-      CC = AArch64CC::NE;
-      break;
-    }
-    // cmp reg, #foo is actually ands xzr, reg, #1<<foo.
-    if (Cond[1].getImm() == AArch64::TBZW || Cond[1].getImm() == AArch64::TBNZW)
-      BuildMI(MBB, I, DL, get(AArch64::ANDSWri), AArch64::WZR)
-          .addReg(Cond[2].getReg())
-          .addImm(
-              AArch64_AM::encodeLogicalImmediate(1ull << Cond[3].getImm(), 32));
-    else
-      BuildMI(MBB, I, DL, get(AArch64::ANDSXri), AArch64::XZR)
-          .addReg(Cond[2].getReg())
-          .addImm(
-              AArch64_AM::encodeLogicalImmediate(1ull << Cond[3].getImm(), 64));
-    break;
-  }
-  case 5: { // cb
-    // We must insert a cmp, that is a subs
-    //            0       1   2    3    4
-    // Cond is { -1, Opcode, CC, Op0, Op1 }
-
-    unsigned SubsOpc, SubsDestReg;
-    bool IsImm = false;
-    CC = static_cast<AArch64CC::CondCode>(Cond[2].getImm());
-    switch (Cond[1].getImm()) {
-    default:
-      llvm_unreachable("Unknown branch opcode in Cond");
-    case AArch64::CBWPri:
-      SubsOpc = AArch64::SUBSWri;
-      SubsDestReg = AArch64::WZR;
-      IsImm = true;
-      break;
-    case AArch64::CBXPri:
-      SubsOpc = AArch64::SUBSXri;
-      SubsDestReg = AArch64::XZR;
-      IsImm = true;
-      break;
-    case AArch64::CBWPrr:
-      SubsOpc = AArch64::SUBSWrr;
-      SubsDestReg = AArch64::WZR;
-      IsImm = false;
-      break;
-    case AArch64::CBXPrr:
-      SubsOpc = AArch64::SUBSXrr;
-      SubsDestReg = AArch64::XZR;
-      IsImm = false;
-      break;
-    }
-
-    if (IsImm) {
-      MRI.constrainRegClass(Cond[3].getReg(), getRegClass(get(SubsOpc), 1));
-      BuildMI(MBB, I, DL, get(SubsOpc), SubsDestReg)
-          .addReg(Cond[3].getReg())
-          .addImm(Cond[4].getImm())
-          .addImm(0);
-    } else {
-      MRI.constrainRegClass(Cond[3].getReg(), getRegClass(get(SubsOpc), 1));
-      MRI.constrainRegClass(Cond[4].getReg(), getRegClass(get(SubsOpc), 2));
-      BuildMI(MBB, I, DL, get(SubsOpc), SubsDestReg)
-          .addReg(Cond[3].getReg())
-          .addReg(Cond[4].getReg());
-    }
-  } break;
-  case 7: { // cb[b,h]
-    // We must insert a cmp, that is a subs, but also zero- or sign-extensions
-    // that have been folded. For the first operand we codegen an explicit
-    // extension, for the second operand we fold the extension into cmp.
-    //            0       1   2    3    4    5      6
-    // Cond is { -1, Opcode, CC, Op0, Op1, Ext0, Ext1 }
-
-    // We need a new register for the now explicitly extended register
-    Register Reg = Cond[4].getReg();
-    if (Cond[5].getImm() != AArch64_AM::InvalidShiftExtend) {
-      unsigned ExtOpc;
-      unsigned ExtBits;
-      AArch64_AM::ShiftExtendType ExtendType =
-          AArch64_AM::getExtendType(Cond[5].getImm());
-      switch (ExtendType) {
-      default:
-        llvm_unreachable("Unknown shift-extend for CB instruction");
-      case AArch64_AM::SXTB:
-        assert(
-            Cond[1].getImm() == AArch64::CBBAssertExt &&
-            "Unexpected compare-and-branch instruction for SXTB shift-extend");
-        ExtOpc = AArch64::SBFMWri;
-        ExtBits = AArch64_AM::encodeLogicalImmediate(0xff, 32);
-        break;
-      case AArch64_AM::SXTH:
-        assert(
-            Cond[1].getImm() == AArch64::CBHAssertExt &&
-            "Unexpected compare-and-branch instruction for SXTH shift-extend");
-        ExtOpc = AArch64::SBFMWri;
-        ExtBits = AArch64_AM::encodeLogicalImmediate(0xffff, 32);
-        break;
-      case AArch64_AM::UXTB:
-        assert(
-            Cond[1].getImm() == AArch64::CBBAssertExt &&
-            "Unexpected compare-and-branch instruction for UXTB shift-extend");
-        ExtOpc = AArch64::ANDWri;
-        ExtBits = AArch64_AM::encodeLogicalImmediate(0xff, 32);
-        break;
-      case AArch64_AM::UXTH:
-        assert(
-            Cond[1].getImm() == AArch64::CBHAssertExt &&
-            "Unexpected compare-and-branch instruction for UXTH shift-extend");
-        ExtOpc = AArch64::ANDWri;
-        ExtBits = AArch64_AM::encodeLogicalImmediate(0xffff, 32);
-        break;
-      }
-
-      // Build the explicit extension of the first operand
-      Reg = MRI.createVirtualRegister(&AArch64::GPR32spRegClass);
-      MachineInstrBuilder MBBI =
-          BuildMI(MBB, I, DL, get(ExtOpc), Reg).addReg(Cond[4].getReg());
-      if (ExtOpc != AArch64::ANDWri)
-        MBBI.addImm(0);
-      MBBI.addImm(ExtBits);
-    }
-
-    // Now, subs with an extended second operand
-    if (Cond[6].getImm() != AArch64_AM::InvalidShiftExtend) {
-      AArch64_AM::ShiftExtendType ExtendType =
-          AArch64_AM::getExtendType(Cond[6].getImm());
-      MRI.constrainRegClass(Reg, MRI.getRegClass(Cond[3].getReg()));
-      MRI.constrainRegClass(Cond[3].getReg(), &AArch64::GPR32spRegClass);
-      BuildMI(MBB, I, DL, get(AArch64::SUBSWrx), AArch64::WZR)
-          .addReg(Cond[3].getReg())
-          .addReg(Reg)
-          .addImm(AArch64_AM::getArithExtendImm(ExtendType, 0));
-    } // If no extension is needed, just a regular subs
-    else {
-      MRI.constrainRegClass(Reg, MRI.getRegClass(Cond[3].getReg()));
-      MRI.constrainRegClass(Cond[3].getReg(), &AArch64::GPR32spRegClass);
-      BuildMI(MBB, I, DL, get(AArch64::SUBSWrr), AArch64::WZR)
-          .addReg(Cond[3].getReg())
-          .addReg(Reg);
-    }
-
-    CC = static_cast<AArch64CC::CondCode>(Cond[2].getImm());
-  } break;
-  }
+  AArch64CC::CondCode CC = insertCmpForCondBr(MBB, I, DL, Cond);
 
   unsigned Opc = 0;
   const TargetRegisterClass *RC = nullptr;

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.h
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.h
@@ -418,6 +418,14 @@ public:
                         const DebugLoc &DL,
                         int *BytesAdded = nullptr) const override;
 
+  /// Inserts the compare instruction needed to un-fuse a fused conditional
+  /// branch instruction and returns the condition code of the original fused
+  /// branch.
+  AArch64CC::CondCode insertCmpForCondBr(MachineBasicBlock &MBB,
+                                         MachineBasicBlock::iterator MI,
+                                         const DebugLoc &DL,
+                                         ArrayRef<MachineOperand> Cond) const;
+
   std::unique_ptr<TargetInstrInfo::PipelinerLoopInfo>
   analyzeLoopForPipelining(MachineBasicBlock *LoopBB) const override;
 


### PR DESCRIPTION
Both if-conversion and CCMP-chain forming need to undo the fusion of conditional branches such as CBZ or CB.<cc>. With the introduction of FEAT_CMPBR, this logic got quite involved.

This patch makes the functionality reusable through AArch64InstrInfo.