### PR TITLE
[lldb][AMDGPU] Support terminal DW_OP_LLVM_piece_end

### DIFF
--- a/lldb/source/Expression/DWARFExpression.cpp
+++ b/lldb/source/Expression/DWARFExpression.cpp
@@ -2228,6 +2228,24 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
       return llvm::createStringError("unimplemented opcode %s",
                                      DW_OP_value_to_name(opcode));
 
+    case DW_OP_LLVM_user:
+      if (op->getSubCode() == DW_OP_LLVM_piece_end) {
+        if (op->getEndOffset() != expr_data.size())
+          return llvm::createStringError(
+              "DW_OP_LLVM_piece_end is only supported at the end of an "
+              "expression");
+
+        // LLDB already constructs one composite in `pieces`, so a terminal
+        // DW_OP_LLVM_piece_end is a no-op. TODO: Support multiple composites
+        // and DW_OP_piece_end once LLVM implements DWARF 6 locations on the
+        // stack.
+        // Extension:
+        // https://llvm.org/docs/AMDGPUDwarfExtensionsForHeterogeneousDebugging.html
+        // Standard: https://dwarfstd.org/issues/230524.1-orig.html
+        break;
+      }
+      [[fallthrough]];
+
     default:
       if (eval_ctx.dwarf_cu) {
         const uint64_t operands_offset = op_offset + 1;

--- a/lldb/unittests/Expression/DWARFExpressionTest.cpp
+++ b/lldb/unittests/Expression/DWARFExpressionTest.cpp
@@ -1597,6 +1597,34 @@ TEST_F(DWARFExpressionMockProcessTest, DW_OP_regx) {
       ExpectScalar(0xBEEF, Value::ContextType::RegisterInfo));
 }
 
+TEST_F(DWARFExpressionMockProcessTest, DW_OP_LLVM_piece_end) {
+  TestContext ctx;
+  constexpr uint64_t reg_value = 0x8877665544332211;
+  ASSERT_TRUE(
+      CreateTestContext(&ctx, "i386-pc-linux", RegisterValue(reg_value)));
+
+  ExecutionContext exe_ctx(ctx.process_sp);
+  MockDwarfDelegate delegate = MockDwarfDelegate::Dwarf5();
+
+  // Match the expression emitted for a value split across two AMDGPU
+  // registers. A terminal DW_OP_LLVM_piece_end completes the composite.
+  EXPECT_THAT_EXPECTED(
+      Evaluate({DW_OP_regx, 0x20, DW_OP_piece, 4, DW_OP_regx, 0x21, DW_OP_piece,
+                4, DW_OP_LLVM_user, DW_OP_LLVM_piece_end},
+               {}, &delegate, &exe_ctx, ctx.reg_ctx_sp.get()),
+      ExpectHostAddress({0x11, 0x22, 0x33, 0x44, 0x11, 0x22, 0x33, 0x44}));
+}
+
+TEST(DWARFExpression, DW_OP_LLVM_piece_end_multiple) {
+  EXPECT_THAT_ERROR(
+      Evaluate({DW_OP_const1u, 0xaa, DW_OP_piece, 1, DW_OP_LLVM_user,
+                DW_OP_LLVM_piece_end, DW_OP_LLVM_user, DW_OP_LLVM_piece_end})
+          .takeError(),
+      llvm::FailedWithMessage(
+          "DW_OP_LLVM_piece_end is only supported at the end of an "
+          "expression"));
+}
+
 TEST_F(DWARFExpressionMockProcessTest, DW_OP_deref_size_zero) {
   // DW_OP_deref_size with size 0 must report an error instead of constructing
   // a DataExtractor with addr_size 0 (caught by lldb-dwarf-expression-fuzzer:


### PR DESCRIPTION
AMDGPU can emit a location expression whose pieces are followed by a terminal DW_OP_LLVM_piece_end. LLDB already assembles the DW_OP_piece operands into its single out-of-band composite, but currently rejects the final LLVM user operation.

Recognize one terminal DW_OP_LLVM_piece_end as a no-op. A non-terminal occurrence, including the first of multiple piece-end operations, remains an error. This intentionally does not implement multiple composite location descriptions.

Specification:
https://llvm.org/docs/AMDGPUDwarfExtensionsForHeterogeneousDebugging.html

The regression test matches the two-register expression observed in a GPU core file and covers the unsupported multiple-piece-end form.

Testing:
- Built tools/lldb/unittests/Expression/ExpressionTests in a Debug + assertions build from current main
- ExpressionTests: 164/164 passed