### PR TITLE
[orc-rt] Sink remaining Compiler.h macros into C API header

### DIFF
--- a/orc-rt/include/orc-rt-c/support/Compiler.h
+++ b/orc-rt/include/orc-rt-c/support/Compiler.h
@@ -7,12 +7,20 @@
 |*                                                                            *|
 |*===----------------------------------------------------------------------===*|
 |*                                                                            *|
-|* Compiler-abstraction macros used by the ORC runtime C API headers.         *|
+|* Compiler-abstraction macros for the ORC runtime C API, plus the            *|
+|* general-purpose ones that are usable from both C and C++. Macros specific  *|
+|* to the C++ API live in orc-rt/support/Compiler.h, which includes this      *|
+|* header.                                                                    *|
+|*                                                                            *|
+|* Some of the macros below were swiped from llvm/Support/Compiler.h.         *|
 |*                                                                            *|
 \*===----------------------------------------------------------------------===*/
 
 #ifndef ORC_RT_C_SUPPORT_COMPILER_H
 #define ORC_RT_C_SUPPORT_COMPILER_H
+
+/* For assert, used by ORC_RT_UNREACHABLE below. */
+#include <assert.h>
 
 /* ORC_RT_HAS_BUILTIN(X) expands to 1 if the compiler provides the builtin X,
    and to 0 otherwise.
@@ -83,6 +91,49 @@
   __attribute__((format(printf, FmtIdx, FirstArg)))
 #else
 #define ORC_RT_FORMAT_PRINTF(FmtIdx, FirstArg)
+#endif
+
+/* ORC_RT_LIKELY(EXPR) / ORC_RT_UNLIKELY(EXPR) hint to the optimizer which way a
+   condition is expected to go. */
+#if ORC_RT_HAS_BUILTIN(__builtin_expect)
+#define ORC_RT_LIKELY(EXPR) __builtin_expect(!!(EXPR), 1)
+#define ORC_RT_UNLIKELY(EXPR) __builtin_expect(!!(EXPR), 0)
+#else
+#define ORC_RT_LIKELY(EXPR) (EXPR)
+#define ORC_RT_UNLIKELY(EXPR) (EXPR)
+#endif
+
+/* ORC_RT_WEAK_IMPORT marks a symbol that may be absent at run time, so that
+   referencing it yields null rather than failing to load. */
+#if defined(__APPLE__)
+#define ORC_RT_WEAK_IMPORT __attribute__((weak_import))
+#elif defined(_WIN32)
+#define ORC_RT_WEAK_IMPORT
+#else
+#define ORC_RT_WEAK_IMPORT __attribute__((weak))
+#endif
+
+/* ORC_RT_BUILTIN_UNREACHABLE: an optimizer hint that the current location is
+   not reachable. */
+#if ORC_RT_HAS_BUILTIN(__builtin_unreachable) || defined(__GNUC__)
+#define ORC_RT_BUILTIN_UNREACHABLE __builtin_unreachable()
+#elif defined(_MSC_VER)
+#define ORC_RT_BUILTIN_UNREACHABLE __assume(0)
+#else
+#define ORC_RT_BUILTIN_UNREACHABLE
+#endif
+
+/* ORC_RT_UNREACHABLE(MSG): marks a point the program must never reach. In
+   +Asserts builds it aborts with MSG; otherwise it lowers to
+   ORC_RT_BUILTIN_UNREACHABLE. */
+#ifndef NDEBUG
+#define ORC_RT_UNREACHABLE(MSG)                                                \
+  do {                                                                         \
+    assert(0 && (MSG));                                                        \
+    ORC_RT_BUILTIN_UNREACHABLE;                                                \
+  } while (0)
+#else
+#define ORC_RT_UNREACHABLE(MSG) ORC_RT_BUILTIN_UNREACHABLE
 #endif
 
 #endif /* ORC_RT_C_SUPPORT_COMPILER_H */

--- a/orc-rt/include/orc-rt/support/Compiler.h
+++ b/orc-rt/include/orc-rt/support/Compiler.h
@@ -8,7 +8,12 @@
 //
 // This file is a part of the ORC runtime support library.
 //
-// Most functionality in this file was swiped from llvm/Support/Compiler.h.
+// Compiler-abstraction macros specific to the ORC runtime's C++ API. Macros
+// that are usable from both C and C++ live in orc-rt-c/support/Compiler.h,
+// which this header includes, so including this header gives access to both
+// sets.
+//
+// ORC_RT_CXX_EXPORT is currently the only C++-specific macro.
 //
 //===----------------------------------------------------------------------===//
 
@@ -17,55 +22,14 @@
 
 #include "orc-rt-c/support/Compiler.h"
 
-#include <cassert>
-
-// ORC_RT_EXPORT marks a symbol declared in orc-rt as part of the ORC runtime's
-// binary interface: exported from the runtime when it is built as a shared
-// library, and imported by consumers of that library.
+// ORC_RT_CXX_EXPORT marks a symbol declared in orc-rt as part of the ORC
+// runtime's binary interface: exported from the runtime when it is built as a
+// shared library, and imported by consumers of that library.
 //
 // Symbols belonging to the C API use ORC_RT_C_EXPORT instead. The two are
 // equivalent today, but the C++ API is expected to change far more often than
-// the C API, so ORC_RT_EXPORT may become separately switchable to allow the C++
-// API to be hidden.
-#define ORC_RT_EXPORT ORC_RT_C_EXPORT
-
-#if ORC_RT_HAS_BUILTIN(__builtin_expect)
-#define ORC_RT_LIKELY(EXPR) __builtin_expect((bool)(EXPR), true)
-#define ORC_RT_UNLIKELY(EXPR) __builtin_expect((bool)(EXPR), false)
-#else
-#define ORC_RT_LIKELY(EXPR) (EXPR)
-#define ORC_RT_UNLIKELY(EXPR) (EXPR)
-#endif
-
-#if defined(__APPLE__)
-#define ORC_RT_WEAK_IMPORT __attribute__((weak_import))
-#elif defined(_WIN32)
-#define ORC_RT_WEAK_IMPORT
-#else
-#define ORC_RT_WEAK_IMPORT __attribute__((weak))
-#endif
-
-// ORC_RT_BUILTIN_UNREACHABLE: an optimizer hint that the current location is
-// not reachable.
-#if ORC_RT_HAS_BUILTIN(__builtin_unreachable) || defined(__GNUC__)
-#define ORC_RT_BUILTIN_UNREACHABLE __builtin_unreachable()
-#elif defined(_MSC_VER)
-#define ORC_RT_BUILTIN_UNREACHABLE __assume(false)
-#else
-#define ORC_RT_BUILTIN_UNREACHABLE
-#endif
-
-// ORC_RT_UNREACHABLE(MSG): marks a point the program must never reach. In
-// +Asserts builds it aborts with MSG; otherwise it lowers to
-// ORC_RT_BUILTIN_UNREACHABLE.
-#ifndef NDEBUG
-#define ORC_RT_UNREACHABLE(MSG)                                                \
-  do {                                                                         \
-    assert(false && (MSG));                                                    \
-    ORC_RT_BUILTIN_UNREACHABLE;                                                \
-  } while (false)
-#else
-#define ORC_RT_UNREACHABLE(MSG) ORC_RT_BUILTIN_UNREACHABLE
-#endif
+// the C API, so ORC_RT_CXX_EXPORT may become separately switchable to allow the
+// C++ API to be hidden.
+#define ORC_RT_CXX_EXPORT ORC_RT_C_EXPORT
 
 #endif // ORC_RT_SUPPORT_COMPILER_H

--- a/orc-rt/test/unit/support/CAPICompileTest.c
+++ b/orc-rt/test/unit/support/CAPICompileTest.c
@@ -35,3 +35,23 @@ int orc_rt_test_hasBuiltinExpect(void) { return 0; }
 #if ORC_RT_HAS_BUILTIN(__builtin_orc_rt_not_a_real_builtin)
 #error "ORC_RT_HAS_BUILTIN reported support for a nonexistent builtin"
 #endif
+
+/* ORC_RT_LIKELY / ORC_RT_UNLIKELY must normalize their operand without relying
+   on bool, which is not a keyword in C before C23. */
+int orc_rt_test_likely(int X) { return ORC_RT_LIKELY(X) ? 1 : 0; }
+int orc_rt_test_unlikely(int X) { return ORC_RT_UNLIKELY(X) ? 1 : 0; }
+
+/* ORC_RT_WEAK_IMPORT must be applicable to a declaration in C. Never called;
+   this only checks that the attribute parses here. */
+ORC_RT_WEAK_IMPORT void orc_rt_test_weakImportDecl(void);
+
+/* ORC_RT_UNREACHABLE must compile in a value-returning C function, and must
+   satisfy the compiler that control does not fall off the end. */
+int orc_rt_test_unreachable(int X) {
+  switch (X) {
+  case 0:
+    return 0;
+  default:
+    ORC_RT_UNREACHABLE("only 0 is expected");
+  }
+}

--- a/orc-rt/test/unit/support/CompilerTest.cpp
+++ b/orc-rt/test/unit/support/CompilerTest.cpp
@@ -52,3 +52,33 @@ TEST(CompilerTest, HasBuiltinAgreesBetweenCAndCxx) {
   EXPECT_EQ(orc_rt_test_hasBuiltinExpect(),
             ORC_RT_HAS_BUILTIN(__builtin_expect) ? 1 : 0);
 }
+
+// Also defined in CAPICompileTest.c: these check that the macros moved into
+// orc-rt-c/support/Compiler.h behave correctly when used from C, not merely
+// that they parse there.
+extern "C" {
+int orc_rt_test_likely(int X);
+int orc_rt_test_unlikely(int X);
+int orc_rt_test_unreachable(int X);
+}
+
+TEST(CompilerTest, LikelyMacrosPreserveTruthinessInC) {
+  EXPECT_EQ(orc_rt_test_likely(0), 0);
+  EXPECT_EQ(orc_rt_test_likely(1), 1);
+  // A value whose low bits are zero must still be truthy: !! normalizes, a
+  // truncating conversion would not.
+  EXPECT_EQ(orc_rt_test_likely(256), 1);
+  EXPECT_EQ(orc_rt_test_unlikely(0), 0);
+  EXPECT_EQ(orc_rt_test_unlikely(1), 1);
+  EXPECT_EQ(orc_rt_test_unlikely(256), 1);
+}
+
+TEST(CompilerTest, UnreachableCompilesInReturningCFunction) {
+  EXPECT_EQ(orc_rt_test_unreachable(0), 0);
+}
+
+#ifndef NDEBUG
+TEST(CompilerDeathTest, UnreachableAbortsFromC) {
+  EXPECT_DEATH(orc_rt_test_unreachable(1), "only 0 is expected");
+}
+#endif


### PR DESCRIPTION
ORC_RT_LIKELY, ORC_RT_UNLIKELY, ORC_RT_WEAK_IMPORT, ORC_RT_BUILTIN_UNREACHABLE and ORC_RT_UNREACHABLE are useful from C but were only reachable through the C++ header, so move them to orc-rt-c/support/Compiler.h.

Rename ORC_RT_EXPORT to ORC_RT_CXX_EXPORT so that both export macros name their language explicitly. The C++ header is left holding only that macro. Keep the header separate anyway so that C APIs don't accidentally use ORC_RT_CXX_EXPORT.

Extend CAPICompileTest.c to use each moved macro from C, with assertions in CompilerTest.cpp so the behaviour is checked and not just the syntax.