### PR TITLE
[flang][OpenACC] Reland data-clause designator path handling

### DIFF
--- a/flang/include/flang/Evaluate/designator-path.h
+++ b/flang/include/flang/Evaluate/designator-path.h
@@ -1,0 +1,126 @@
+//===-- include/flang/Evaluate/designator-path.h ---------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef FORTRAN_EVALUATE_DESIGNATOR_PATH_H_
+#define FORTRAN_EVALUATE_DESIGNATOR_PATH_H_
+
+#include "flang/Evaluate/expression.h"
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace Fortran::evaluate {
+
+enum class DesignatorRelation {
+  Equal,
+  Contains,
+  ContainedBy,
+  Overlaps,
+  Disjoint,
+};
+
+struct DesignatorPath {
+  // A DesignatorPath represents a constrained prefix of a valid Fortran
+  // designator:
+  //   - an optional NamedEntity base, and
+  //   - zero or more suffix parts.
+  //
+  // The optional base distinguishes the named entity from subsequent part
+  // references. Each suffix part first applies optional subscripts to the
+  // current entity and then optionally selects a component symbol. An empty
+  // subscript list means there is no explicit subscript selector on this part;
+  // a full slice `(:)` is represented as a single Triplet subscript with no
+  // lower or upper bound and stride one. This can later grow a final optional
+  // variant for terminal designator pieces that are not part refs, such as
+  // complex parts, character substrings, or coarray references, while still
+  // preserving a valid designator shape.
+  struct Part {
+    std::vector<Subscript> subscripts;
+    const Symbol *symbol{nullptr};
+    bool operator==(const Part &that) const {
+      return subscripts == that.subscripts && symbol == that.symbol;
+    }
+  };
+
+  static std::optional<DesignatorPath> Get(
+      const std::optional<Expr<SomeType>> &);
+  DesignatorRelation Compare(const DesignatorPath &) const;
+  bool MayContain(const DesignatorPath &) const;
+  std::string AsFortran() const;
+  llvm::raw_ostream &AsFortran(llvm::raw_ostream &) const;
+  void SetBase(NamedEntity);
+  void AddComponent(const Symbol &);
+  void AddSubscripts(std::vector<Subscript>);
+  const std::optional<NamedEntity> &Base() const { return base; }
+  const std::vector<Part> &Parts() const { return parts; }
+  bool empty() const { return !base && parts.empty(); }
+  bool HasBaseOnly() const { return base && parts.empty(); }
+  bool operator==(const DesignatorPath &that) const {
+    return base == that.base && parts == that.parts;
+  }
+
+  struct ConstantSubscriptRange {
+    std::int64_t lower;
+    std::int64_t upper;
+  };
+
+  static std::optional<ConstantSubscriptRange> GetConstantSubscriptRange(
+      const Subscript &);
+  static bool IsFullTriplet(const Triplet &);
+  static DesignatorRelation CompareSubscripts(
+      const Subscript &, const Subscript &);
+  static DesignatorRelation CompareSubscriptLists(
+      const std::vector<Subscript> &, const std::vector<Subscript> &);
+  static DesignatorRelation CompareParts(const Part &, const Part &);
+  static DesignatorRelation CombineRelations(
+      bool contains, bool containedBy, bool overlaps);
+  static bool SubscriptMayContain(const Subscript &, const Subscript &);
+  static bool SubscriptListMayContain(
+      const std::vector<Subscript> &, const std::vector<Subscript> &);
+  static bool PartMayContain(const Part &, const Part &);
+
+private:
+  void AddDataRef(const DataRef &);
+  void AddComponent(const Component &);
+  void AddNamedEntity(const NamedEntity &);
+  void AddArrayRef(const ArrayRef &);
+  void AddCoarrayRef(const CoarrayRef &);
+
+  std::optional<NamedEntity> base;
+  std::vector<Part> parts;
+};
+
+template <typename A> class DesignatorPathMap {
+public:
+  struct Entry {
+    DesignatorPath path;
+    A value;
+  };
+  using iterator = typename std::vector<Entry>::iterator;
+  using const_iterator = typename std::vector<Entry>::const_iterator;
+
+  iterator begin() { return entries_.begin(); }
+  iterator end() { return entries_.end(); }
+  const_iterator begin() const { return entries_.begin(); }
+  const_iterator end() const { return entries_.end(); }
+  bool empty() const { return entries_.empty(); }
+  void clear() { entries_.clear(); }
+  iterator erase(iterator iter) { return entries_.erase(iter); }
+  void push_back(DesignatorPath path, A value) {
+    entries_.push_back({std::move(path), std::move(value)});
+  }
+
+private:
+  std::vector<Entry> entries_;
+};
+
+} // namespace Fortran::evaluate
+
+#endif // FORTRAN_EVALUATE_DESIGNATOR_PATH_H_

--- a/flang/include/flang/Semantics/tools.h
+++ b/flang/include/flang/Semantics/tools.h
@@ -13,6 +13,7 @@
 // canonically for use in semantic checking.
 
 #include "flang/Common/visit.h"
+#include "flang/Evaluate/designator-path.h"
 #include "flang/Evaluate/expression.h"
 #include "flang/Evaluate/shape.h"
 #include "flang/Evaluate/type.h"
@@ -206,6 +207,19 @@ bool IsAssumedLengthCharacter(const Symbol &);
 bool IsExternal(const Symbol &);
 bool IsModuleProcedure(const Symbol &);
 bool HasCoarray(const parser::Expr &);
+
+// Builds an evaluate::DesignatorPath (the structural prefix of a designator
+// used by OpenACC data-sharing analysis) from the parse tree. It uses the
+// already-resolved base symbol and component structure, and analyzes and folds
+// subscript expressions. Returns std::nullopt when the designator cannot be
+// represented (e.g. an unresolved name or a non-integer/erroneous subscript).
+std::optional<evaluate::DesignatorPath> GetDesignatorPath(
+    SemanticsContext &, const parser::Designator &);
+std::optional<evaluate::DesignatorPath> GetDesignatorPath(
+    SemanticsContext &, const parser::FunctionReference &);
+std::optional<evaluate::DesignatorPath> GetDesignatorPath(
+    SemanticsContext &, const parser::ArrayElement &);
+
 bool IsAssumedType(const Symbol &);
 bool IsEnumerationType(const Symbol &);
 bool IsEnumerationType(const DerivedTypeSpec &);

--- a/flang/lib/Evaluate/CMakeLists.txt
+++ b/flang/lib/Evaluate/CMakeLists.txt
@@ -35,6 +35,7 @@ add_flang_library(FortranEvaluate
   common.cpp
   complex.cpp
   constant.cpp
+  designator-path.cpp
   expression.cpp
   fold.cpp
   fold-character.cpp

--- a/flang/lib/Evaluate/designator-path.cpp
+++ b/flang/lib/Evaluate/designator-path.cpp
@@ -1,0 +1,441 @@
+//===-- lib/Evaluate/designator-path.cpp ---------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "flang/Evaluate/designator-path.h"
+#include "flang/Evaluate/fold.h"
+#include "flang/Evaluate/tools.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace Fortran::evaluate {
+
+static DesignatorRelation ComparePartSymbols(const Symbol *x, const Symbol *y) {
+  if (x == y) {
+    return DesignatorRelation::Equal;
+  }
+  if (!x) {
+    return DesignatorRelation::Contains;
+  }
+  if (!y) {
+    return DesignatorRelation::ContainedBy;
+  }
+  return DesignatorRelation::Disjoint;
+}
+
+static bool IsFullSubscriptList(const std::vector<Subscript> &subscripts) {
+  if (subscripts.empty()) {
+    return false;
+  }
+  for (const Subscript &subscript : subscripts) {
+    const auto *triplet{std::get_if<Triplet>(&subscript.u)};
+    if (!triplet || !DesignatorPath::IsFullTriplet(*triplet)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+static bool IsFullSlicePart(const DesignatorPath::Part &part) {
+  return !part.symbol && IsFullSubscriptList(part.subscripts);
+}
+
+static bool AreAllFullSliceParts(
+    const std::vector<DesignatorPath::Part> &parts, std::size_t first) {
+  for (std::size_t i{first}; i < parts.size(); ++i) {
+    if (!IsFullSlicePart(parts[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+std::optional<DesignatorPath::ConstantSubscriptRange>
+DesignatorPath::GetConstantSubscriptRange(const Subscript &subscript) {
+  // Surface syntax `x(i)` maps to a scalar Subscript that holds the integer
+  // expression `i`, not a Triplet.
+  if (const auto *expr{
+          std::get_if<IndirectSubscriptIntegerExpr>(&subscript.u)}) {
+    if (auto value{ToInt64(expr->value())}) {
+      return ConstantSubscriptRange{*value, *value};
+    }
+  } else if (const auto *triplet{std::get_if<Triplet>(&subscript.u)}) {
+    // Surface syntax `x(l:u)` maps to a Triplet with explicit lower and upper
+    // bounds and an implicit stride of one. Syntax like `x(:u)`, `x(l:)`, and
+    // `x(:)` maps to missing lower and/or upper bounds, so it is not a
+    // constant finite range here.
+    const auto *lowerExpr{triplet->GetLower()};
+    const auto *upperExpr{triplet->GetUpper()};
+    auto lower{lowerExpr ? ToInt64(*lowerExpr) : std::nullopt};
+    auto upper{upperExpr ? ToInt64(*upperExpr) : std::nullopt};
+    // Surface syntax `x(l:u:s)` maps to the same Triplet representation with a
+    // non-optional stride expression.
+    auto stride{ToInt64(triplet->GetStride())};
+    if (lower && upper && stride && *stride == 1) {
+      return ConstantSubscriptRange{*lower, *upper};
+    }
+  }
+  return std::nullopt;
+}
+
+bool DesignatorPath::IsFullTriplet(const Triplet &triplet) {
+  // Surface syntax `x(:)` maps to a Triplet with no lower or upper bound and
+  // an implicit stride of one.
+  auto stride{ToInt64(triplet.GetStride())};
+  return !triplet.GetLower() && !triplet.GetUpper() && stride && *stride == 1;
+}
+
+DesignatorRelation DesignatorPath::CompareSubscripts(
+    const Subscript &x, const Subscript &y) {
+  if (x == y) {
+    return DesignatorRelation::Equal;
+  }
+  const auto *xTriplet{std::get_if<Triplet>(&x.u)};
+  const auto *yTriplet{std::get_if<Triplet>(&y.u)};
+  if (xTriplet && IsFullTriplet(*xTriplet)) {
+    if (yTriplet && IsFullTriplet(*yTriplet)) {
+      return DesignatorRelation::Equal;
+    }
+    return DesignatorRelation::Contains;
+  }
+  if (yTriplet && IsFullTriplet(*yTriplet)) {
+    return DesignatorRelation::ContainedBy;
+  }
+  auto xRange{GetConstantSubscriptRange(x)};
+  auto yRange{GetConstantSubscriptRange(y)};
+  if (!xRange || !yRange) {
+    // Nonconstant selectors and constant triplets with non-unit strides cannot
+    // be compared precisely, so treat them as disjoint for now. Constant
+    // triplets could be made more precise by expanding them into index sets.
+    return DesignatorRelation::Disjoint;
+  }
+  if (xRange->upper < yRange->lower || yRange->upper < xRange->lower) {
+    return DesignatorRelation::Disjoint;
+  }
+  if (xRange->lower == yRange->lower && xRange->upper == yRange->upper) {
+    return DesignatorRelation::Equal;
+  }
+  if (xRange->lower <= yRange->lower && xRange->upper >= yRange->upper) {
+    return DesignatorRelation::Contains;
+  }
+  if (yRange->lower <= xRange->lower && yRange->upper >= xRange->upper) {
+    return DesignatorRelation::ContainedBy;
+  }
+  return DesignatorRelation::Overlaps;
+}
+
+bool DesignatorPath::SubscriptMayContain(
+    const Subscript &x, const Subscript &y) {
+  if (x == y) {
+    return true;
+  }
+  const auto *xTriplet{std::get_if<Triplet>(&x.u)};
+  const auto *yTriplet{std::get_if<Triplet>(&y.u)};
+  if (xTriplet && IsFullTriplet(*xTriplet)) {
+    return true;
+  }
+  if (yTriplet && IsFullTriplet(*yTriplet)) {
+    return false;
+  }
+  if (!xTriplet && yTriplet) {
+    return false;
+  }
+  auto xRange{GetConstantSubscriptRange(x)};
+  auto yRange{GetConstantSubscriptRange(y)};
+  if (xRange && yRange) {
+    return xRange->lower <= yRange->lower && xRange->upper >= yRange->upper;
+  }
+  if (xTriplet) {
+    return true;
+  }
+  return !ToInt64(std::get<IndirectSubscriptIntegerExpr>(x.u).value()) ||
+      !ToInt64(std::get<IndirectSubscriptIntegerExpr>(y.u).value());
+}
+
+bool DesignatorPath::SubscriptListMayContain(
+    const std::vector<Subscript> &x, const std::vector<Subscript> &y) {
+  if (x.empty()) {
+    return true;
+  }
+  if (IsFullSubscriptList(x)) {
+    return y.empty() || x.size() == y.size();
+  }
+  if (y.empty()) {
+    return false;
+  }
+  if (x.size() != y.size()) {
+    return false;
+  }
+  for (std::size_t i{0}; i < x.size(); ++i) {
+    if (!SubscriptMayContain(x[i], y[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool DesignatorPath::PartMayContain(const Part &x, const Part &y) {
+  return SubscriptListMayContain(x.subscripts, y.subscripts) &&
+      (!x.symbol || x.symbol == y.symbol);
+}
+
+DesignatorRelation DesignatorPath::CombineRelations(
+    bool contains, bool containedBy, bool overlaps) {
+  if (overlaps || (contains && containedBy)) {
+    return DesignatorRelation::Overlaps;
+  }
+  if (contains) {
+    return DesignatorRelation::Contains;
+  }
+  if (containedBy) {
+    return DesignatorRelation::ContainedBy;
+  }
+  return DesignatorRelation::Equal;
+}
+
+DesignatorRelation DesignatorPath::CompareSubscriptLists(
+    const std::vector<Subscript> &x, const std::vector<Subscript> &y) {
+  if (x.empty() && y.empty()) {
+    return DesignatorRelation::Equal;
+  }
+  if (x.empty()) {
+    return IsFullSubscriptList(y) ? DesignatorRelation::Equal
+                                  : DesignatorRelation::Contains;
+  }
+  if (y.empty()) {
+    return IsFullSubscriptList(x) ? DesignatorRelation::Equal
+                                  : DesignatorRelation::ContainedBy;
+  }
+  const bool xFull{IsFullSubscriptList(x)};
+  const bool yFull{IsFullSubscriptList(y)};
+  if (xFull || yFull) {
+    if (x.size() != y.size()) {
+      return DesignatorRelation::Disjoint;
+    }
+    if (xFull && yFull) {
+      return DesignatorRelation::Equal;
+    }
+    return xFull ? DesignatorRelation::Contains
+                 : DesignatorRelation::ContainedBy;
+  }
+  if (x.size() != y.size()) {
+    return DesignatorRelation::Disjoint;
+  }
+  bool contains{false};
+  bool containedBy{false};
+  bool overlaps{false};
+  for (std::size_t i{0}; i < x.size(); ++i) {
+    switch (CompareSubscripts(x[i], y[i])) {
+    case DesignatorRelation::Equal:
+      break;
+    case DesignatorRelation::Contains:
+      contains = true;
+      break;
+    case DesignatorRelation::ContainedBy:
+      containedBy = true;
+      break;
+    case DesignatorRelation::Overlaps:
+      overlaps = true;
+      break;
+    case DesignatorRelation::Disjoint:
+      return DesignatorRelation::Disjoint;
+    }
+  }
+  return CombineRelations(contains, containedBy, overlaps);
+}
+
+DesignatorRelation DesignatorPath::CompareParts(const Part &x, const Part &y) {
+  DesignatorRelation subscriptRelation{
+      CompareSubscriptLists(x.subscripts, y.subscripts)};
+  if (subscriptRelation == DesignatorRelation::Disjoint) {
+    return DesignatorRelation::Disjoint;
+  }
+  DesignatorRelation symbolRelation{ComparePartSymbols(x.symbol, y.symbol)};
+  if (symbolRelation == DesignatorRelation::Disjoint) {
+    return DesignatorRelation::Disjoint;
+  }
+  bool contains{subscriptRelation == DesignatorRelation::Contains ||
+      symbolRelation == DesignatorRelation::Contains};
+  bool containedBy{subscriptRelation == DesignatorRelation::ContainedBy ||
+      symbolRelation == DesignatorRelation::ContainedBy};
+  bool overlaps{subscriptRelation == DesignatorRelation::Overlaps ||
+      symbolRelation == DesignatorRelation::Overlaps};
+  return CombineRelations(contains, containedBy, overlaps);
+}
+
+DesignatorRelation DesignatorPath::Compare(const DesignatorPath &that) const {
+  if (*this == that) {
+    return DesignatorRelation::Equal;
+  }
+  if (empty() || that.empty()) {
+    return DesignatorRelation::Disjoint;
+  }
+  if (base || that.base) {
+    if (!base || !that.base || !(*base == *that.base)) {
+      return DesignatorRelation::Disjoint;
+    }
+  }
+  if (parts.empty() || that.parts.empty()) {
+    if ((!parts.empty() && AreAllFullSliceParts(parts, 0)) ||
+        (!that.parts.empty() && AreAllFullSliceParts(that.parts, 0))) {
+      return DesignatorRelation::Equal;
+    }
+    return parts.empty() ? DesignatorRelation::Contains
+                         : DesignatorRelation::ContainedBy;
+  }
+  bool contains{false};
+  bool containedBy{false};
+  bool overlaps{false};
+  const std::size_t commonSize{
+      parts.size() < that.parts.size() ? parts.size() : that.parts.size()};
+  for (std::size_t i{0}; i < commonSize; ++i) {
+    switch (CompareParts(parts[i], that.parts[i])) {
+    case DesignatorRelation::Equal:
+      break;
+    case DesignatorRelation::Contains:
+      contains = true;
+      break;
+    case DesignatorRelation::ContainedBy:
+      containedBy = true;
+      break;
+    case DesignatorRelation::Overlaps:
+      overlaps = true;
+      break;
+    case DesignatorRelation::Disjoint:
+      return DesignatorRelation::Disjoint;
+    }
+  }
+  if (parts.size() < that.parts.size()) {
+    if (!AreAllFullSliceParts(that.parts, parts.size())) {
+      contains = true;
+    }
+  } else if (that.parts.size() < parts.size()) {
+    if (!AreAllFullSliceParts(parts, that.parts.size())) {
+      containedBy = true;
+    }
+  }
+  return CombineRelations(contains, containedBy, overlaps);
+}
+
+bool DesignatorPath::MayContain(const DesignatorPath &that) const {
+  if (*this == that || empty()) {
+    return true;
+  }
+  if (base || that.base) {
+    if (!base || !that.base || !(*base == *that.base)) {
+      return false;
+    }
+  }
+  if (that.parts.empty()) {
+    return AreAllFullSliceParts(parts, 0);
+  }
+  if (parts.size() > that.parts.size() &&
+      !AreAllFullSliceParts(parts, that.parts.size())) {
+    return false;
+  }
+  if (parts.empty()) {
+    return true;
+  }
+  for (std::size_t i{0}; i < parts.size(); ++i) {
+    if (i >= that.parts.size()) {
+      return AreAllFullSliceParts(parts, i);
+    }
+    if (!PartMayContain(parts[i], that.parts[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+std::string DesignatorPath::AsFortran() const {
+  std::string result;
+  llvm::raw_string_ostream stream{result};
+  AsFortran(stream);
+  return result;
+}
+
+llvm::raw_ostream &DesignatorPath::AsFortran(llvm::raw_ostream &o) const {
+  if (!base) {
+    return o;
+  }
+  base->AsFortran(o);
+  for (const Part &part : parts) {
+    if (!part.subscripts.empty()) {
+      char separator{'('};
+      for (const Subscript &subscript : part.subscripts) {
+        subscript.AsFortran(o << separator);
+        separator = ',';
+      }
+      o << ')';
+    }
+    if (part.symbol) {
+      o << '%' << part.symbol->name();
+    }
+  }
+  return o;
+}
+
+void DesignatorPath::SetBase(NamedEntity entity) { base = std::move(entity); }
+
+void DesignatorPath::AddComponent(const Symbol &symbol) {
+  if (!parts.empty() && !parts.back().symbol) {
+    parts.back().symbol = &symbol;
+  } else {
+    parts.push_back({{}, &symbol});
+  }
+}
+
+void DesignatorPath::AddSubscripts(std::vector<Subscript> subscripts) {
+  parts.push_back({std::move(subscripts), nullptr});
+}
+
+void DesignatorPath::AddComponent(const Component &component) {
+  AddDataRef(component.base());
+  AddComponent(*component.symbol());
+}
+
+void DesignatorPath::AddNamedEntity(const NamedEntity &entity) {
+  if (const auto *symbol{entity.UnwrapSymbolRef()}) {
+    SetBase(NamedEntity{symbol->get()});
+  } else if (const auto *component{entity.UnwrapComponent()}) {
+    AddComponent(*component);
+  }
+}
+
+void DesignatorPath::AddArrayRef(const ArrayRef &arrayRef) {
+  AddNamedEntity(arrayRef.base());
+  AddSubscripts(arrayRef.subscript());
+}
+
+void DesignatorPath::AddCoarrayRef(const CoarrayRef &coarrayRef) {
+  AddDataRef(coarrayRef.base());
+}
+
+void DesignatorPath::AddDataRef(const DataRef &dataRef) {
+  common::visit(
+      common::visitors{
+          [&](SymbolRef symbol) { SetBase(NamedEntity{symbol.get()}); },
+          [&](const Component &component) { AddComponent(component); },
+          [&](const ArrayRef &arrayRef) { AddArrayRef(arrayRef); },
+          [&](const CoarrayRef &coarrayRef) { AddCoarrayRef(coarrayRef); },
+      },
+      dataRef.u);
+}
+
+std::optional<DesignatorPath> DesignatorPath::Get(
+    const std::optional<Expr<SomeType>> &expr) {
+  if (std::optional<DataRef> dataRef{ExtractDataRef(expr)}) {
+    DesignatorPath path;
+    path.AddDataRef(*dataRef);
+    if (!path.empty()) {
+      return path;
+    }
+  }
+  return std::nullopt;
+}
+
+} // namespace Fortran::evaluate

--- a/flang/lib/Semantics/expression.cpp
+++ b/flang/lib/Semantics/expression.cpp
@@ -1060,6 +1060,19 @@ MaybeExpr ExpressionAnalyzer::Analyze(const parser::Name &n) {
   if (context_.HasError(n.symbol)) { // includes case of no symbol
     return std::nullopt;
   } else {
+    // Name resolution gives array constructor and DATA implied-do indices
+    // their own scope.  Preserve that identity when an expression is analyzed
+    // by a fresh ExpressionAnalyzer without the active implied-do context.
+    // Other names referenced in an implied-do may have host-associated
+    // symbols owned by the same scope; only its local object is the index.
+    if (n.symbol->has<semantics::ObjectEntityDetails>() &&
+        semantics::IsImpliedDoIndex(*n.symbol)) {
+      if (std::optional<DynamicType> type{DynamicType::From(*n.symbol)};
+          type && type->category() == TypeCategory::Integer) {
+        return AsMaybeExpr(ConvertToKind<TypeCategory::Integer>(
+            type->kind(), AsExpr(ImpliedDoIndex{n.source})));
+      }
+    }
     const Symbol &ultimate{n.symbol->GetUltimate()};
     if (ultimate.has<semantics::TypeParamDetails>()) {
       // A bare reference to a derived type parameter within a parameterized

--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -2303,6 +2303,32 @@ Symbol *AccAttributeVisitor::DeclareOrMarkOtherAccessEntity(
   return &object;
 }
 
+static bool HaveSameAccDataSharingEntity(
+    const DesignatorPath &x, const DesignatorPath &y) {
+  if (x.Base().has_value() != y.Base().has_value() ||
+      (x.Base() && !(*x.Base() == *y.Base()))) {
+    return false;
+  }
+  auto xIter{x.Parts().begin()};
+  auto yIter{y.Parts().begin()};
+  while (true) {
+    while (xIter != x.Parts().end() && !xIter->symbol) {
+      ++xIter;
+    }
+    while (yIter != y.Parts().end() && !yIter->symbol) {
+      ++yIter;
+    }
+    if (xIter == x.Parts().end() || yIter == y.Parts().end()) {
+      return xIter == x.Parts().end() && yIter == y.Parts().end();
+    }
+    if (xIter->symbol != yIter->symbol) {
+      return false;
+    }
+    ++xIter;
+    ++yIter;
+  }
+}
+
 bool AccAttributeVisitor::CheckClauseConsistencyInCurrentConstruct(
     const parser::Name &name, Symbol::Flag accFlag, DesignatorPath designator,
     const parser::AccObject *occurrence, bool warnSameKindDuplicate) {
@@ -2316,7 +2342,8 @@ bool AccAttributeVisitor::CheckClauseConsistencyInCurrentConstruct(
   for (auto iter{objectsWithDSA.begin()}; iter != objectsWithDSA.end();) {
     AccDataSharingEntry &entry{iter->value};
     DesignatorRelation relation{iter->path.Compare(designator)};
-    if (relation == DesignatorRelation::Disjoint) {
+    if (relation == DesignatorRelation::Disjoint &&
+        !HaveSameAccDataSharingEntity(iter->path, designator)) {
       ++iter;
       continue;
     }
@@ -2364,8 +2391,16 @@ bool AccAttributeVisitor::CheckClauseConsistencyInCurrentConstruct(
       }
       return false;
     }
-    case DesignatorRelation::Disjoint:
-      llvm_unreachable("disjoint relation handled above");
+    case DesignatorRelation::Disjoint: {
+      auto &message{context_.Say(source,
+          "'%s' is a different part of an object that already appears in the same kind of data-sharing clause on the same OpenACC directive"_err_en_US,
+          displayName)};
+      if (entry.occurrence) {
+        message.Attach(parser::FindSourceLocation(*entry.occurrence),
+            "previous data-sharing object appears here"_en_US);
+      }
+      return false;
+    }
     }
   }
   objectsWithDSA.push_back(std::move(designator), {accFlag, occurrence});

--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -12,6 +12,7 @@
 #include "check-omp-structure.h"
 #include "resolve-names-utils.h"
 #include "flang/Common/idioms.h"
+#include "flang/Evaluate/designator-path.h"
 #include "flang/Evaluate/fold.h"
 #include "flang/Evaluate/tools.h"
 #include "flang/Evaluate/type.h"
@@ -32,8 +33,16 @@
 #include "llvm/Support/Debug.h"
 #include <list>
 #include <map>
+#include <optional>
+#include <string>
+#include <utility>
 
 namespace Fortran::semantics {
+
+using evaluate::DesignatorPath;
+using evaluate::DesignatorPathMap;
+using evaluate::DesignatorRelation;
+using evaluate::NamedEntity;
 
 template <typename T>
 static Scope *GetScope(SemanticsContext &context, const T &x) {
@@ -118,14 +127,6 @@ protected:
   bool IsObjectWithDSA(const Symbol &symbol) {
     return GetContext().FindSymbolWithDSA(symbol).has_value();
   }
-  bool IsObjectWithVisibleDSA(const Symbol &symbol) {
-    for (std::size_t i{dirContext_.size()}; i != 0; i--) {
-      if (dirContext_[i - 1].FindSymbolWithDSA(symbol).has_value()) {
-        return true;
-      }
-    }
-    return false;
-  }
 
   bool WithinConstruct() {
     return !dirContext_.empty() && GetContext().withinConstruct;
@@ -180,25 +181,68 @@ protected:
   std::vector<DirContext> dirContext_; // used as a stack
 };
 
-class AccAttributeVisitor : DirectiveAttributeVisitor<llvm::acc::Directive> {
+class AccAttributeVisitor {
+private:
+  struct AccDataSharingEntry {
+    Symbol::Flag flag;
+    const parser::AccObject *occurrence{nullptr};
+  };
+
+  struct AccDirContext {
+    AccDirContext(
+        const parser::CharBlock &source, llvm::acc::Directive d, Scope &s)
+        : directiveSource{source}, directive{d}, scope{s} {}
+    parser::CharBlock directiveSource;
+    llvm::acc::Directive directive;
+    Scope &scope;
+    Symbol::Flag defaultDSA{Symbol::Flag::AccShared};
+    DesignatorPathMap<AccDataSharingEntry> objectsWithDSA;
+    bool withinConstruct{false};
+    std::int64_t associatedLoopLevel{0};
+  };
+
+  AccDirContext &GetContext() {
+    CHECK(!dirContext_.empty());
+    return dirContext_.back();
+  }
+  const AccDirContext &GetContext() const {
+    CHECK(!dirContext_.empty());
+    return dirContext_.back();
+  }
+  Scope &currScope() { return GetContext().scope; }
+  bool WithinConstruct() const {
+    return !dirContext_.empty() && GetContext().withinConstruct;
+  }
+  void SetContextDefaultDSA(Symbol::Flag flag) {
+    GetContext().defaultDSA = flag;
+  }
+  void SetContextAssociatedLoopLevel(std::int64_t level) {
+    GetContext().associatedLoopLevel = level;
+  }
+  std::tuple<const parser::Name *, const parser::ScalarExpr *,
+      const parser::ScalarExpr *, const parser::ScalarExpr *>
+  GetLoopBounds(const parser::DoConstruct &);
+  static const parser::DoConstruct *GetDoConstructIf(
+      const parser::ExecutionPartConstruct &);
+
 public:
   explicit AccAttributeVisitor(SemanticsContext &context, Scope *topScope)
-      : DirectiveAttributeVisitor(context), topScope_(topScope) {}
+      : context_{context}, topScope_(topScope) {}
 
   template <typename A> void Walk(const A &x) { parser::Walk(x, *this); }
   template <typename A> bool Pre(const A &) { return true; }
   template <typename A> void Post(const A &) {}
 
   bool Pre(const parser::OpenACCBlockConstruct &);
-  void Post(const parser::OpenACCBlockConstruct &) { PopContext(); }
+  void Post(const parser::OpenACCBlockConstruct &) { PopAccContext(); }
   bool Pre(const parser::OpenACCCombinedConstruct &);
-  void Post(const parser::OpenACCCombinedConstruct &) { PopContext(); }
+  void Post(const parser::OpenACCCombinedConstruct &) { PopAccContext(); }
   void Post(const parser::AccBeginCombinedDirective &) {
     GetContext().withinConstruct = true;
   }
 
   bool Pre(const parser::OpenACCDeclarativeConstruct &);
-  void Post(const parser::OpenACCDeclarativeConstruct &) { PopContext(); }
+  void Post(const parser::OpenACCDeclarativeConstruct &) { PopAccContext(); }
 
   void Post(const parser::AccDeclarativeDirective &) {
     GetContext().withinConstruct = true;
@@ -213,7 +257,7 @@ public:
   }
 
   bool Pre(const parser::OpenACCLoopConstruct &);
-  void Post(const parser::OpenACCLoopConstruct &) { PopContext(); }
+  void Post(const parser::OpenACCLoopConstruct &) { PopAccContext(); }
   void Post(const parser::AccLoopDirective &) {
     GetContext().withinConstruct = true;
   }
@@ -222,27 +266,28 @@ public:
   template <typename A>
   bool Pre(const parser::LoopBounds<parser::ScalarName, A> &x) {
     if (!dirContext_.empty() && GetContext().withinConstruct) {
-      if (auto *symbol{ResolveAcc(
-              x.Name().thing, Symbol::Flag::AccPrivate, currScope())}) {
-        AddToContextObjectWithDSA(*symbol, Symbol::Flag::AccPrivate);
+      if (auto *symbol{DeclareOrMarkOtherAccessEntity(
+              x.Name().thing, Symbol::Flag::AccPrivate)}) {
+        CheckClauseConsistencyInCurrentConstruct(x.Name().thing,
+            Symbol::Flag::AccPrivate, MakeBaseDesignatorPath(*symbol));
       }
     }
     return true;
   }
 
   bool Pre(const parser::OpenACCStandaloneConstruct &);
-  void Post(const parser::OpenACCStandaloneConstruct &) { PopContext(); }
+  void Post(const parser::OpenACCStandaloneConstruct &) { PopAccContext(); }
   void Post(const parser::AccStandaloneDirective &) {
     GetContext().withinConstruct = true;
   }
 
   bool Pre(const parser::OpenACCWaitConstruct &);
-  void Post(const parser::OpenACCWaitConstruct &) { PopContext(); }
+  void Post(const parser::OpenACCWaitConstruct &) { PopAccContext(); }
   bool Pre(const parser::OpenACCAtomicConstruct &);
-  void Post(const parser::OpenACCAtomicConstruct &) { PopContext(); }
+  void Post(const parser::OpenACCAtomicConstruct &) { PopAccContext(); }
 
   bool Pre(const parser::OpenACCCacheConstruct &);
-  void Post(const parser::OpenACCCacheConstruct &) { PopContext(); }
+  void Post(const parser::OpenACCCacheConstruct &) { PopAccContext(); }
 
   void Post(const parser::AccDefaultClause &);
 
@@ -353,9 +398,29 @@ public:
     return false;
   }
 
+  bool Pre(const parser::Expr &);
+  void Post(const parser::Expr &);
+  bool Pre(const parser::Variable &);
+  void Post(const parser::Variable &);
+  bool Pre(const parser::ArrayElement &);
+  void Post(const parser::ArrayElement &);
   void Post(const parser::Name &);
 
 private:
+  void PushAccContext(const parser::CharBlock &, llvm::acc::Directive, Scope &);
+  void PushAccContext(const parser::CharBlock &, llvm::acc::Directive);
+  void PopAccContext();
+  static DesignatorPath MakeBaseDesignatorPath(const Symbol &);
+  bool IsObjectWithVisibleDSA(const DesignatorPath &) const;
+  void AdjustAccSymbolReference(const parser::Name &);
+  void enterExpressionLikeContext() { ++expressionLikeDepthCount_; }
+  void exitExpressionLikeContext() { --expressionLikeDepthCount_; }
+  bool inExpressionLikeContext() const {
+    return expressionLikeDepthCount_ != 0;
+  }
+  void CheckAccDefaultNoneReference(const parser::Name &, DesignatorPath);
+  template <typename A> void CheckAccDefaultNoneReferenceIn(const A &);
+
   std::int64_t GetAssociatedLoopLevelFromClauses(const parser::AccClauseList &);
   bool HasForceCollapseModifier(const parser::AccClauseList &);
 
@@ -379,15 +444,21 @@ private:
   void CheckAssociatedLoop(const parser::DoConstruct &, bool forceCollapsed);
   void ResolveAccObjectList(const parser::AccObjectList &, Symbol::Flag);
   void ResolveAccObject(const parser::AccObject &, Symbol::Flag);
-  Symbol *ResolveAcc(const parser::Name &, Symbol::Flag, Scope &);
-  Symbol *ResolveAcc(Symbol &, Symbol::Flag, Scope &);
+  // Called by ResolveAccObject() for a non-bare designator. Returns true only
+  // when a resolved unsupported designator was diagnosed; the caller must then
+  // stop processing that object.
+  bool DiagnoseUnsupportedAccClauseDesignator(const parser::Designator &);
   Symbol *ResolveName(const parser::Name &);
   Symbol *ResolveFctName(const parser::Name &);
   Symbol *ResolveAccCommonBlockName(const parser::Name *);
   Symbol *DeclareOrMarkOtherAccessEntity(const parser::Name &, Symbol::Flag);
   Symbol *DeclareOrMarkOtherAccessEntity(Symbol &, Symbol::Flag);
-  void CheckMultipleAppearances(const parser::Name &, const Symbol &,
-      Symbol::Flag, const parser::AccObject *occurrence = nullptr,
+  // Called for explicit clause objects and implicit loop privatization.
+  // Returns true iff the occurrence remains effective in the current OpenACC
+  // construct; common-block processing uses false to stop expanding the block.
+  bool CheckClauseConsistencyInCurrentConstruct(const parser::Name &,
+      Symbol::Flag, DesignatorPath,
+      const parser::AccObject *occurrence = nullptr,
       bool warnSameKindDuplicate = true);
   void AllowOnlyArrayAndSubArray(const parser::AccObjectList &objectList);
   void DoNotAllowAssumedSizedArray(const parser::AccObjectList &objectList);
@@ -403,6 +474,13 @@ private:
   void ClearUseDeviceObjects() { useDeviceObjects_.clear(); }
   UnorderedSymbolSet useDeviceObjects_;
 
+  SemanticsContext &context_;
+  std::vector<AccDirContext> dirContext_; // used as a stack
+  // Expr, Variable, and ArrayElement visitor nodes have path-aware post
+  // handlers. A Name outside those expression-like contexts is a whole-object
+  // reference that needs DEFAULT(NONE) checking directly (e.g. ALLOCATE,
+  // DEALLOCATE, NULLIFY, or the pointer in a pointer assignment).
+  int expressionLikeDepthCount_{0};
   Scope *topScope_;
 };
 
@@ -1156,6 +1234,31 @@ Symbol *DirectiveAttributeVisitor<T>::DeclareAccessEntity(
   }
 }
 
+std::tuple<const parser::Name *, const parser::ScalarExpr *,
+    const parser::ScalarExpr *, const parser::ScalarExpr *>
+AccAttributeVisitor::GetLoopBounds(const parser::DoConstruct &x) {
+  using Bounds = parser::LoopControl::Bounds;
+  if (x.GetLoopControl()) {
+    if (const Bounds *b{std::get_if<Bounds>(&x.GetLoopControl()->u)}) {
+      const auto &step = b->Step();
+      return {&b->Name().thing, &b->Lower(), &b->Upper(),
+          step.has_value() ? &step.value() : nullptr};
+    }
+  } else {
+    context_
+        .Say(std::get<parser::Statement<parser::NonLabelDoStmt>>(x.t).source,
+            "Loop control is not present in the DO LOOP"_err_en_US)
+        .Attach(GetContext().directiveSource,
+            "associated with the enclosing LOOP construct"_en_US);
+  }
+  return {nullptr, nullptr, nullptr, nullptr};
+}
+
+const parser::DoConstruct *AccAttributeVisitor::GetDoConstructIf(
+    const parser::ExecutionPartConstruct &x) {
+  return parser::Unwrap<parser::DoConstruct>(x);
+}
+
 bool AccAttributeVisitor::Pre(const parser::OpenACCBlockConstruct &x) {
   const auto &beginBlockDir{std::get<parser::AccBeginBlockDirective>(x.t)};
   const auto &blockDir{std::get<parser::AccBlockDirective>(beginBlockDir.t)};
@@ -1165,12 +1268,11 @@ bool AccAttributeVisitor::Pre(const parser::OpenACCBlockConstruct &x) {
   case llvm::acc::Directive::ACCD_kernels:
   case llvm::acc::Directive::ACCD_parallel:
   case llvm::acc::Directive::ACCD_serial:
-    PushContext(blockDir.source, blockDir.v);
+    PushAccContext(blockDir.source, blockDir.v);
     break;
   default:
     break;
   }
-  ClearDataSharingAttributeObjects();
   ClearUseDeviceObjects();
   return true;
 }
@@ -1180,9 +1282,8 @@ bool AccAttributeVisitor::Pre(const parser::OpenACCDeclarativeConstruct &x) {
           std::get_if<parser::OpenACCStandaloneDeclarativeConstruct>(&x.u)}) {
     const auto &declDir{
         std::get<parser::AccDeclarativeDirective>(declConstruct->t)};
-    PushContext(declDir.source, llvm::acc::Directive::ACCD_declare);
+    PushAccContext(declDir.source, llvm::acc::Directive::ACCD_declare);
   }
-  ClearDataSharingAttributeObjects();
   return true;
 }
 
@@ -1252,9 +1353,8 @@ bool AccAttributeVisitor::Pre(const parser::OpenACCLoopConstruct &x) {
   const auto &loopDir{std::get<parser::AccLoopDirective>(beginDir.t)};
   const auto &clauseList{std::get<parser::AccClauseList>(beginDir.t)};
   if (loopDir.v == llvm::acc::Directive::ACCD_loop) {
-    PushContext(loopDir.source, loopDir.v);
+    PushAccContext(loopDir.source, loopDir.v);
   }
-  ClearDataSharingAttributeObjects();
   SetContextAssociatedLoopLevel(GetAssociatedLoopLevelFromClauses(clauseList));
   const auto &outer{std::get<std::optional<parser::DoConstruct>>(x.t)};
   CheckAssociatedLoop(*outer, HasForceCollapseModifier(clauseList));
@@ -1270,12 +1370,11 @@ bool AccAttributeVisitor::Pre(const parser::OpenACCStandaloneConstruct &x) {
   case llvm::acc::Directive::ACCD_set:
   case llvm::acc::Directive::ACCD_shutdown:
   case llvm::acc::Directive::ACCD_update:
-    PushContext(standaloneDir.source, standaloneDir.v);
+    PushAccContext(standaloneDir.source, standaloneDir.v);
     break;
   default:
     break;
   }
-  ClearDataSharingAttributeObjects();
   return true;
 }
 
@@ -1397,10 +1496,10 @@ void AccAttributeVisitor::AddRoutineInfoToSymbol(
 bool AccAttributeVisitor::Pre(const parser::OpenACCRoutineConstruct &x) {
   const auto &verbatim{std::get<parser::Verbatim>(x.t)};
   if (topScope_) {
-    PushContext(
+    PushAccContext(
         verbatim.source, llvm::acc::Directive::ACCD_routine, *topScope_);
   } else {
-    PushContext(verbatim.source, llvm::acc::Directive::ACCD_routine);
+    PushAccContext(verbatim.source, llvm::acc::Directive::ACCD_routine);
   }
   const auto &names{std::get<std::list<parser::Name>>(x.t)};
   if (!names.empty()) {
@@ -1474,7 +1573,7 @@ bool AccAttributeVisitor::Pre(const parser::OpenACCCombinedConstruct &x) {
   case llvm::acc::Directive::ACCD_kernels_loop:
   case llvm::acc::Directive::ACCD_parallel_loop:
   case llvm::acc::Directive::ACCD_serial_loop:
-    PushContext(x.source, combinedDir.v);
+    PushAccContext(x.source, combinedDir.v);
     break;
   default:
     break;
@@ -1483,7 +1582,6 @@ bool AccAttributeVisitor::Pre(const parser::OpenACCCombinedConstruct &x) {
   SetContextAssociatedLoopLevel(GetAssociatedLoopLevelFromClauses(clauseList));
   const auto &outer{std::get<std::optional<parser::DoConstruct>>(x.t)};
   CheckAssociatedLoop(*outer, HasForceCollapseModifier(clauseList));
-  ClearDataSharingAttributeObjects();
   return true;
 }
 
@@ -1579,8 +1677,7 @@ void AccAttributeVisitor::AllowOnlyVariable(const parser::AccObject &object) {
 
 bool AccAttributeVisitor::Pre(const parser::OpenACCWaitConstruct &x) {
   const auto &verbatim{std::get<parser::Verbatim>(x.t)};
-  PushContext(verbatim.source, llvm::acc::Directive::ACCD_wait);
-  ClearDataSharingAttributeObjects();
+  PushAccContext(verbatim.source, llvm::acc::Directive::ACCD_wait);
   return true;
 }
 
@@ -1597,16 +1694,13 @@ bool AccAttributeVisitor::Pre(const parser::OpenACCAtomicConstruct &x) {
           },
       },
       x.u);
-  PushContext(verbatimSource, llvm::acc::Directive::ACCD_atomic);
-  ClearDataSharingAttributeObjects();
+  PushAccContext(verbatimSource, llvm::acc::Directive::ACCD_atomic);
   return true;
 }
 
 bool AccAttributeVisitor::Pre(const parser::OpenACCCacheConstruct &x) {
   const auto &verbatim{std::get<parser::Verbatim>(x.t)};
-  PushContext(verbatim.source, llvm::acc::Directive::ACCD_cache);
-  ClearDataSharingAttributeObjects();
-
+  PushAccContext(verbatim.source, llvm::acc::Directive::ACCD_cache);
   const auto &objectListWithModifier =
       std::get<parser::AccObjectListWithModifier>(x.t);
   const auto &objectList =
@@ -1738,7 +1832,7 @@ void AccAttributeVisitor::CheckAssociatedLoop(
           if (level <= 0)
             return;
           if (ivName && lower && upper) {
-            if (auto *symbol{ResolveAcc(*ivName, flag, currScope())}) {
+            if (auto *symbol{DeclareOrMarkOtherAccessEntity(*ivName, flag)}) {
               if (auto lowerExpr{semantics::AnalyzeExpr(context_, *lower)}) {
                 semantics::UnorderedSymbolSet lowerSyms =
                     evaluate::CollectSymbols(*lowerExpr);
@@ -1826,6 +1920,43 @@ void AccAttributeVisitor::Post(const parser::AccDefaultClause &x) {
   }
 }
 
+void AccAttributeVisitor::PushAccContext(
+    const parser::CharBlock &source, llvm::acc::Directive dir, Scope &scope) {
+  dirContext_.emplace_back(source, dir, scope);
+  if (dirContext_.size() > 1) {
+    GetContext().defaultDSA = dirContext_[dirContext_.size() - 2].defaultDSA;
+  }
+}
+
+void AccAttributeVisitor::PushAccContext(
+    const parser::CharBlock &source, llvm::acc::Directive dir) {
+  PushAccContext(source, dir, context_.FindScope(source));
+}
+
+void AccAttributeVisitor::PopAccContext() {
+  CHECK(!dirContext_.empty());
+  dirContext_.pop_back();
+}
+
+DesignatorPath AccAttributeVisitor::MakeBaseDesignatorPath(
+    const Symbol &symbol) {
+  DesignatorPath path;
+  path.SetBase(NamedEntity{symbol.GetUltimate()});
+  return path;
+}
+
+bool AccAttributeVisitor::IsObjectWithVisibleDSA(
+    const DesignatorPath &reference) const {
+  for (std::size_t i{dirContext_.size()}; i != 0; --i) {
+    for (const auto &entry : dirContext_[i - 1].objectsWithDSA) {
+      if (entry.path.MayContain(reference)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 // Returns true iff symbol qualifies for the pre-OpenACC-3.2 DEFAULT(NONE)
 // scalar extension: an intrinsic numeric or logical non-array, non-pointer,
 // non-allocatable variable.  Characters, derived types, allocatables, and
@@ -1845,11 +1976,34 @@ static bool IsAccScalar(const Symbol &symbol) {
   return det && !det->IsArray();
 }
 
-void AccAttributeVisitor::Post(const parser::Name &name) {
+void AccAttributeVisitor::AdjustAccSymbolReference(const parser::Name &name) {
+  if (!name.symbol || !WithinConstruct()) {
+    return;
+  }
+  const Symbol &symbol{name.symbol->GetUltimate()};
+  if (symbol.owner().IsDerivedType() || symbol.has<ProcEntityDetails>() ||
+      symbol.has<SubprogramDetails>() || symbol.has<AssocEntityDetails>() ||
+      symbol.has<MiscDetails>()) {
+    return;
+  }
+  if (Symbol *found{currScope().FindSymbol(name.source)};
+      found && &symbol != found) {
+    if (DoesScopeContain(&currScope(), symbol)) {
+      return;
+    }
+    // Adjust the symbol within the region.
+    // TODO: why didn't name resolution set the right name originally?
+    name.symbol = found;
+  }
+}
+
+void AccAttributeVisitor::CheckAccDefaultNoneReference(
+    const parser::Name &name, DesignatorPath designator) {
   if (name.symbol && WithinConstruct()) {
     const Symbol &symbol{name.symbol->GetUltimate()};
     if (!symbol.owner().IsDerivedType() && !symbol.has<ProcEntityDetails>() &&
-        !symbol.has<SubprogramDetails>() && !IsObjectWithVisibleDSA(symbol) &&
+        !symbol.has<SubprogramDetails>() &&
+        !IsObjectWithVisibleDSA(designator) &&
         !symbol.has<AssocEntityDetails>() && !symbol.has<MiscDetails>()) {
       if (Symbol * found{currScope().FindSymbol(name.source)}) {
         if (&symbol != found) {
@@ -1889,6 +2043,77 @@ void AccAttributeVisitor::Post(const parser::Name &name) {
       } else {
         // TODO: assertion here?  or clear name.symbol?
       }
+    }
+  }
+}
+
+bool AccAttributeVisitor::Pre(const parser::Expr &) {
+  enterExpressionLikeContext();
+  return true;
+}
+
+template <typename A>
+void AccAttributeVisitor::CheckAccDefaultNoneReferenceIn(const A &x) {
+  if (const auto *designator{
+          std::get_if<common::Indirection<parser::Designator>>(&x.u)}) {
+    std::optional<DesignatorPath> designatorPath{
+        GetDesignatorPath(context_, designator->value())};
+    if (designatorPath) {
+      CheckAccDefaultNoneReference(parser::GetFirstName(designator->value()),
+          std::move(*designatorPath));
+    }
+  } else if (const auto *functionReference{
+                 std::get_if<common::Indirection<parser::FunctionReference>>(
+                     &x.u)}) {
+    const parser::Name &name{parser::GetFirstName(functionReference->value())};
+    if (WithinConstruct() && GetContext().defaultDSA == Symbol::Flag::AccNone &&
+        name.symbol && name.symbol->has<ObjectEntityDetails>()) {
+      if (std::optional<DesignatorPath> designatorPath{
+              GetDesignatorPath(context_, functionReference->value())}) {
+        CheckAccDefaultNoneReference(name, std::move(*designatorPath));
+      }
+    }
+  }
+}
+
+void AccAttributeVisitor::Post(const parser::Expr &expr) {
+  exitExpressionLikeContext();
+  CheckAccDefaultNoneReferenceIn(expr);
+}
+
+bool AccAttributeVisitor::Pre(const parser::Variable &) {
+  enterExpressionLikeContext();
+  return true;
+}
+
+void AccAttributeVisitor::Post(const parser::Variable &variable) {
+  exitExpressionLikeContext();
+  CheckAccDefaultNoneReferenceIn(variable);
+}
+
+bool AccAttributeVisitor::Pre(const parser::ArrayElement &) {
+  enterExpressionLikeContext();
+  return true;
+}
+
+void AccAttributeVisitor::Post(const parser::ArrayElement &arrayElement) {
+  exitExpressionLikeContext();
+  if (std::optional<DesignatorPath> path{
+          GetDesignatorPath(context_, arrayElement)}) {
+    CheckAccDefaultNoneReference(
+        parser::GetFirstName(arrayElement.Base()), std::move(*path));
+  }
+}
+
+void AccAttributeVisitor::Post(const parser::Name &name) {
+  AdjustAccSymbolReference(name);
+  // A Name reached outside any Expr, Variable, or ArrayElement is a
+  // whole-object reference that no path-aware handler covers -- for instance
+  // the object of an ALLOCATE, DEALLOCATE, or NULLIFY, or the pointer of a
+  // pointer assignment. Its resolved name is an exact base-only path.
+  if (!inExpressionLikeContext()) {
+    if (name.symbol) {
+      CheckAccDefaultNoneReference(name, MakeBaseDesignatorPath(*name.symbol));
     }
   }
 }
@@ -1956,28 +2181,63 @@ static bool ContainsStructureComponent(const parser::Designator &designator) {
       designator.u);
 }
 
+bool AccAttributeVisitor::DiagnoseUnsupportedAccClauseDesignator(
+    const parser::Designator &designator) {
+  // Do not diagnose a syntactically unsupported object until it has been
+  // semantically resolved; otherwise an unresolved name or component should
+  // receive its ordinary Fortran diagnostic instead.
+  if (!AnalyzeExpr(context_, designator)) {
+    return false;
+  }
+  if (std::holds_alternative<parser::Substring>(designator.u)) {
+    context_.Say(designator.source,
+        "Substrings are not allowed on OpenACC directives or clauses"_err_en_US);
+    return true;
+  }
+  if (const auto *dataRef{std::get_if<parser::DataRef>(&designator.u)};
+      dataRef &&
+      std::holds_alternative<common::Indirection<parser::CoindexedNamedObject>>(
+          dataRef->u)) {
+    context_.Say(designator.source,
+        "Coindexed objects are not allowed on OpenACC directives or clauses"_err_en_US);
+    return true;
+  }
+  return false;
+}
+
 void AccAttributeVisitor::ResolveAccObject(
     const parser::AccObject &accObject, Symbol::Flag accFlag) {
   common::visit(
       common::visitors{
           [&](const parser::Designator &designator) {
-            const bool preciseDesignator{
+            // First form an exact structural path. If it cannot be represented,
+            // the check below diagnoses resolved unsupported designators;
+            // unresolved or otherwise invalid designators are not registered.
+            const bool isBareName{
                 parser::GetDesignatorNameIfDataRef(designator) != nullptr};
-            if (!preciseDesignator) {
-              // Subscripted designator: evaluate subscripts and detect
-              // the substring case that is disallowed in OpenACC clauses.
-              if (AnalyzeExpr(context_, designator)) {
-                if (std::holds_alternative<parser::Substring>(designator.u)) {
-                  context_.Say(designator.source,
-                      "Substrings are not allowed on OpenACC "
-                      "directives or clauses"_err_en_US);
-                  return;
-                }
+            DesignatorPath designatorPath;
+            bool canCheckMultipleAppearances{isBareName};
+            if (!isBareName) {
+              if (std::optional<DesignatorPath> path{
+                      GetDesignatorPath(context_, designator)}) {
+                designatorPath = std::move(*path);
+                canCheckMultipleAppearances = true;
+              }
+              if (DiagnoseUnsupportedAccClauseDesignator(designator)) {
+                return;
               }
             }
+            // Then resolve the base entity so ACC_DECLARE flags are applied.
             if (ContainsStructureComponent(designator)) {
-              // Do not register the base object for a component reference until
-              // OpenACC DSA tracking can distinguish subcomponents.
+              // Finally register or compare only the complete component path;
+              // a component clause does not cover every reference to its base.
+              if (canCheckMultipleAppearances) {
+                const parser::Name &baseName{parser::GetFirstName(designator)};
+                if (baseName.symbol && !designatorPath.empty()) {
+                  CheckClauseConsistencyInCurrentConstruct(
+                      baseName, accFlag, std::move(designatorPath), &accObject);
+                }
+              }
               return;
             }
             // GetFirstName extracts the base symbol from both bare data
@@ -1985,26 +2245,30 @@ void AccAttributeVisitor::ResolveAccObject(
             // that DEFAULT(NONE) checking does not spuriously flag variables
             // that are explicitly listed in a data clause as array sections.
             // TODO: Multiple array sections of the same array with different
-            // data sharing attributes is not currently supported.
-            // TODO: Subcomponent designators should also be tracked precisely.
+            // data mapping attributes is not currently supported.
             const parser::Name &baseName{parser::GetFirstName(designator)};
-            if (auto *symbol{ResolveAcc(baseName, accFlag, currScope())}) {
-              AddToContextObjectWithDSA(*symbol, accFlag);
-              if (preciseDesignator &&
-                  dataSharingAttributeFlags.test(accFlag)) {
-                CheckMultipleAppearances(
-                    baseName, *symbol, accFlag, &accObject, preciseDesignator);
+            if (auto *symbol{
+                    DeclareOrMarkOtherAccessEntity(baseName, accFlag)}) {
+              if (isBareName) {
+                designatorPath = MakeBaseDesignatorPath(*symbol);
+              }
+              if (canCheckMultipleAppearances && !designatorPath.empty()) {
+                CheckClauseConsistencyInCurrentConstruct(
+                    baseName, accFlag, std::move(designatorPath), &accObject);
               }
             }
           },
           [&](const parser::Name &name) { // common block
             if (auto *symbol{ResolveAccCommonBlockName(&name)}) {
-              CheckMultipleAppearances(
-                  name, *symbol, Symbol::Flag::AccCommonBlock);
+              if (!CheckClauseConsistencyInCurrentConstruct(name, accFlag,
+                      MakeBaseDesignatorPath(*symbol), &accObject)) {
+                return;
+              }
               for (auto &object : symbol->get<CommonBlockDetails>().objects()) {
                 if (auto *resolvedObject{
-                        ResolveAcc(*object, accFlag, currScope())}) {
-                  AddToContextObjectWithDSA(*resolvedObject, accFlag);
+                        DeclareOrMarkOtherAccessEntity(*object, accFlag)}) {
+                  CheckClauseConsistencyInCurrentConstruct(name, accFlag,
+                      MakeBaseDesignatorPath(*resolvedObject), &accObject);
                 }
               }
             } else {
@@ -2015,16 +2279,6 @@ void AccAttributeVisitor::ResolveAccObject(
           },
       },
       accObject.u);
-}
-
-Symbol *AccAttributeVisitor::ResolveAcc(
-    const parser::Name &name, Symbol::Flag accFlag, Scope &scope) {
-  return DeclareOrMarkOtherAccessEntity(name, accFlag);
-}
-
-Symbol *AccAttributeVisitor::ResolveAcc(
-    Symbol &symbol, Symbol::Flag accFlag, Scope &scope) {
-  return DeclareOrMarkOtherAccessEntity(symbol, accFlag);
 }
 
 Symbol *AccAttributeVisitor::DeclareOrMarkOtherAccessEntity(
@@ -2049,37 +2303,73 @@ Symbol *AccAttributeVisitor::DeclareOrMarkOtherAccessEntity(
   return &object;
 }
 
-void AccAttributeVisitor::CheckMultipleAppearances(const parser::Name &name,
-    const Symbol &symbol, Symbol::Flag accFlag,
+bool AccAttributeVisitor::CheckClauseConsistencyInCurrentConstruct(
+    const parser::Name &name, Symbol::Flag accFlag, DesignatorPath designator,
     const parser::AccObject *occurrence, bool warnSameKindDuplicate) {
-  const auto *target{&symbol};
-  if (HasDataSharingAttributeObject(*target)) {
-    // A same-kind duplicate (e.g. private(x, x) or private(x) private(x))
-    // is benign: warn and tag this AccObject occurrence so rewrite-parse-tree
-    // can drop it from the clause list. Cross-kind duplicates (e.g.
-    // private(x) firstprivate(x)) remain hard errors.
-    //
-    // Reduction is excluded from the benign case: two reduction clauses
-    // with the same Symbol::Flag may still differ in operator, which is a
-    // real conflict that dedup would silently hide.
-    auto firstFlag{GetContext().FindSymbolWithDSA(*target)};
-    if (warnSameKindDuplicate && occurrence && firstFlag &&
-        *firstFlag == accFlag && accFlag != Symbol::Flag::AccReduction) {
-      context_.Warn(common::UsageWarning::OpenAccUsage, name.source,
-          "'%s' appears more than once in the same kind of data-sharing clause on an OpenACC directive; duplicate ignored"_warn_en_US,
-          name.ToString());
-      context_.MarkAccObjectDuplicate(occurrence);
-    } else if (firstFlag && *firstFlag == accFlag &&
-        accFlag != Symbol::Flag::AccReduction) {
-      return;
-    } else {
-      context_.Say(name.source,
-          "'%s' appears in more than one data-sharing clause on the same OpenACC directive"_err_en_US,
-          name.ToString());
-    }
-  } else {
-    AddDataSharingAttributeObject(*target);
+  if (designator.empty()) {
+    return false;
   }
+  const parser::CharBlock source{
+      occurrence ? parser::FindSourceLocation(*occurrence) : name.source};
+  const std::string displayName{source.ToString()};
+  auto &objectsWithDSA{GetContext().objectsWithDSA};
+  for (auto iter{objectsWithDSA.begin()}; iter != objectsWithDSA.end();) {
+    AccDataSharingEntry &entry{iter->value};
+    DesignatorRelation relation{iter->path.Compare(designator)};
+    if (relation == DesignatorRelation::Disjoint) {
+      ++iter;
+      continue;
+    }
+
+    if (!(dataSharingAttributeFlags.test(entry.flag) &&
+            dataSharingAttributeFlags.test(accFlag))) {
+      ++iter;
+      continue;
+    }
+
+    // TODO: Record the reduction operator in AccDataSharingEntry so compatible
+    // reductions can use the ordinary same-kind duplicate handling. Also handle
+    // private/reduction interactions on loop constructs.
+    if (entry.flag != accFlag || accFlag == Symbol::Flag::AccReduction) {
+      auto &message{context_.Say(source,
+          "'%s' appears in more than one data-sharing clause on the same OpenACC directive"_err_en_US,
+          displayName)};
+      if (entry.occurrence) {
+        message.Attach(parser::FindSourceLocation(*entry.occurrence),
+            "previous data-sharing object appears here"_en_US);
+      }
+      return false;
+    }
+
+    switch (relation) {
+    case DesignatorRelation::Equal:
+      if (warnSameKindDuplicate && occurrence) {
+        context_.Warn(common::UsageWarning::OpenAccUsage, source,
+            "'%s' appears more than once in the same kind of data-sharing clause on an OpenACC directive; duplicate ignored"_warn_en_US,
+            displayName);
+        context_.MarkAccObjectDuplicate(occurrence);
+      }
+      return false;
+    case DesignatorRelation::Contains:
+    case DesignatorRelation::ContainedBy:
+    case DesignatorRelation::Overlaps: {
+      // TODO: Support non-identical same-kind objects once their containment
+      // and overlap semantics are defined.
+      auto &message{context_.Say(source,
+          "'%s' overlaps another object in the same kind of data-sharing clause on the same OpenACC directive"_err_en_US,
+          displayName)};
+      if (entry.occurrence) {
+        message.Attach(parser::FindSourceLocation(*entry.occurrence),
+            "previous data-sharing object appears here"_en_US);
+      }
+      return false;
+    }
+    case DesignatorRelation::Disjoint:
+      llvm_unreachable("disjoint relation handled above");
+    }
+  }
+  objectsWithDSA.push_back(std::move(designator), {accFlag, occurrence});
+  return true;
 }
 
 #ifndef NDEBUG

--- a/flang/lib/Semantics/tools.cpp
+++ b/flang/lib/Semantics/tools.cpp
@@ -9,6 +9,8 @@
 #include "flang/Parser/tools.h"
 #include "flang/Common/indirection.h"
 #include "flang/Evaluate/characteristics.h"
+#include "flang/Evaluate/fold.h"
+#include "flang/Evaluate/tools.h"
 #include "flang/Parser/dump-parse-tree.h"
 #include "flang/Parser/message.h"
 #include "flang/Parser/parse-tree.h"
@@ -20,10 +22,195 @@
 #include "flang/Support/Fortran.h"
 #include "llvm/Support/raw_ostream.h"
 #include <algorithm>
+#include <list>
+#include <optional>
 #include <set>
+#include <utility>
 #include <variant>
+#include <vector>
 
 namespace Fortran::semantics {
+
+// Parse-tree designator to evaluate::DesignatorPath conversion.
+//
+// These helpers build a DesignatorPath from the parse tree (see the note on
+// GetDesignatorPath in the header). They use already-resolved base and
+// component symbols, and analyze only subscript expressions. Anything that
+// cannot be represented is reported as absent so the caller can skip it.
+template <typename A>
+static std::optional<evaluate::Expr<evaluate::SubscriptInteger>>
+AnalyzeSubscriptExpr(SemanticsContext &context, const A &expr) {
+  if (auto maybe{evaluate::Fold(
+          context.foldingContext(), AnalyzeExpr(context, expr))}) {
+    if (auto *intExpr{
+            evaluate::UnwrapExpr<evaluate::Expr<evaluate::SomeInteger>>(
+                maybe)}) {
+      if (auto value{evaluate::ToInt64(*intExpr)}) {
+        return evaluate::Expr<evaluate::SubscriptInteger>{*value};
+      }
+      return evaluate::ConvertToType<evaluate::SubscriptInteger>(
+          std::move(*intExpr));
+    }
+  }
+  return std::nullopt;
+}
+
+static std::optional<evaluate::Subscript> AnalyzeSectionSubscript(
+    SemanticsContext &context, const parser::SectionSubscript &subscript) {
+  return common::visit(
+      common::visitors{
+          [&](const parser::SubscriptTriplet &triplet)
+              -> std::optional<evaluate::Subscript> {
+            const auto &lower{std::get<0>(triplet.t)};
+            const auto &upper{std::get<1>(triplet.t)};
+            const auto &stride{std::get<2>(triplet.t)};
+            auto lowerExpr{
+                lower ? AnalyzeSubscriptExpr(context, *lower) : std::nullopt};
+            auto upperExpr{
+                upper ? AnalyzeSubscriptExpr(context, *upper) : std::nullopt};
+            auto strideExpr{
+                stride ? AnalyzeSubscriptExpr(context, *stride) : std::nullopt};
+            if ((lower && !lowerExpr) || (upper && !upperExpr) ||
+                (stride && !strideExpr)) {
+              return std::nullopt;
+            }
+            auto result{evaluate::Triplet{std::move(lowerExpr),
+                std::move(upperExpr), std::move(strideExpr)}};
+            return evaluate::Subscript{std::move(result)};
+          },
+          [&](const parser::IntExpr &expr)
+              -> std::optional<evaluate::Subscript> {
+            if (auto subscript{AnalyzeSubscriptExpr(context, expr)}) {
+              return evaluate::Subscript{std::move(*subscript)};
+            }
+            return std::nullopt;
+          },
+      },
+      subscript.u);
+}
+
+static std::optional<std::vector<evaluate::Subscript>> AnalyzeSectionSubscripts(
+    SemanticsContext &context,
+    const std::list<parser::SectionSubscript> &list) {
+  std::vector<evaluate::Subscript> subscripts;
+  for (const parser::SectionSubscript &subscript : list) {
+    if (auto analyzed{AnalyzeSectionSubscript(context, subscript)}) {
+      subscripts.push_back(std::move(*analyzed));
+    } else {
+      return std::nullopt;
+    }
+  }
+  return subscripts;
+}
+
+static bool AddDesignatorPath(SemanticsContext &context,
+    const parser::DataRef &dataRef, evaluate::DesignatorPath &path) {
+  return common::visit(
+      common::visitors{
+          [&](const parser::Name &name) {
+            if (!name.symbol) {
+              return false;
+            }
+            path.SetBase(evaluate::NamedEntity{name.symbol->GetUltimate()});
+            return true;
+          },
+          [&](const common::Indirection<parser::StructureComponent>
+                  &component) {
+            if (!AddDesignatorPath(context, component.value().Base(), path)) {
+              return false;
+            }
+            if (const parser::Name &name{component.value().Component()};
+                name.symbol) {
+              path.AddComponent(name.symbol->GetUltimate());
+              return true;
+            }
+            return false;
+          },
+          [&](const common::Indirection<parser::ArrayElement> &arrayElement) {
+            if (!AddDesignatorPath(
+                    context, arrayElement.value().Base(), path)) {
+              return false;
+            }
+            if (auto subscripts{AnalyzeSectionSubscripts(
+                    context, arrayElement.value().Subscripts())}) {
+              path.AddSubscripts(std::move(*subscripts));
+              return true;
+            }
+            return false;
+          },
+          [](const common::Indirection<parser::CoindexedNamedObject> &) {
+            // DesignatorPath does not represent cosubscripts yet.  Do not
+            // collapse a coindexed reference to its local base object.
+            return false;
+          },
+      },
+      dataRef.u);
+}
+
+std::optional<evaluate::DesignatorPath> GetDesignatorPath(
+    SemanticsContext &context, const parser::Designator &designator) {
+  evaluate::DesignatorPath path;
+  bool ok{common::visit(common::visitors{
+                            [&](const parser::DataRef &dataRef) {
+                              return AddDesignatorPath(context, dataRef, path);
+                            },
+                            [](const parser::Substring &) { return false; },
+                        },
+      designator.u)};
+  if (ok && !path.empty()) {
+    return path;
+  }
+  return std::nullopt;
+}
+
+std::optional<evaluate::DesignatorPath> GetDesignatorPath(
+    SemanticsContext &context, const parser::FunctionReference &funcRef) {
+  const auto &call{funcRef.v};
+  const auto &procedureDesignator{
+      std::get<parser::ProcedureDesignator>(call.t)};
+  const auto *name{std::get_if<parser::Name>(&procedureDesignator.u)};
+  if (!name || !name->symbol || !name->symbol->has<ObjectEntityDetails>()) {
+    return std::nullopt;
+  }
+  std::vector<evaluate::Subscript> subscripts;
+  for (const parser::ActualArgSpec &arg :
+      std::get<std::list<parser::ActualArgSpec>>(call.t)) {
+    if (std::get<std::optional<parser::Keyword>>(arg.t)) {
+      return std::nullopt;
+    }
+    const auto *expr{std::get_if<common::Indirection<parser::Expr>>(
+        &std::get<parser::ActualArg>(arg.t).u)};
+    if (!expr) {
+      return std::nullopt;
+    }
+    if (auto subscript{AnalyzeSubscriptExpr(context, expr->value())}) {
+      subscripts.emplace_back(std::move(*subscript));
+    } else {
+      return std::nullopt;
+    }
+  }
+  if (subscripts.empty()) {
+    return std::nullopt;
+  }
+  evaluate::DesignatorPath path;
+  path.SetBase(evaluate::NamedEntity{name->symbol->GetUltimate()});
+  path.AddSubscripts(std::move(subscripts));
+  return path;
+}
+
+std::optional<evaluate::DesignatorPath> GetDesignatorPath(
+    SemanticsContext &context, const parser::ArrayElement &arrayElement) {
+  evaluate::DesignatorPath path;
+  if (!AddDesignatorPath(context, arrayElement.Base(), path)) {
+    return std::nullopt;
+  }
+  if (auto subscripts{
+          AnalyzeSectionSubscripts(context, arrayElement.Subscripts())}) {
+    path.AddSubscripts(std::move(*subscripts));
+    return path;
+  }
+  return std::nullopt;
+}
 
 // Find this or containing scope that matches predicate
 static const Scope *FindScopeContaining(

--- a/flang/test/Lower/OpenACC/acc-copy-reduction.f90
+++ b/flang/test/Lower/OpenACC/acc-copy-reduction.f90
@@ -1,0 +1,31 @@
+! RUN: bbc -fopenacc -emit-hlfir %s -o - | FileCheck %s
+
+subroutine copy_then_reduction()
+  integer :: x
+  !$acc parallel copy(x) reduction(+:x)
+  x = x + 1
+  !$acc end parallel
+end subroutine
+
+! CHECK-LABEL: func.func @_QPcopy_then_reduction()
+! CHECK: %[[COPY1:.*]] = acc.copyin varPtr({{.*}}) dataClause(acc_copy) name("x") -> !fir.ref<i32>
+! CHECK: %[[REDUCTION1:.*]] = acc.reduction varPtr({{.*}}) recipe({{.*}}) name("x") -> !fir.ref<i32>
+! CHECK: acc.parallel dataOperands(%[[COPY1]] : !fir.ref<i32>) reduction(%[[REDUCTION1]] : !fir.ref<i32>) {
+! TODO: The region body uses the first mapping for x, making lowering depend on
+! clause order. The reduction mapping should take priority in both cases.
+! CHECK: hlfir.declare %[[COPY1]]
+! CHECK: acc.copyout accPtr(%[[COPY1]] : !fir.ref<i32>)
+
+subroutine reduction_then_copy()
+  integer :: x
+  !$acc parallel reduction(+:x) copy(x)
+  x = x + 1
+  !$acc end parallel
+end subroutine
+
+! CHECK-LABEL: func.func @_QPreduction_then_copy()
+! CHECK: %[[REDUCTION2:.*]] = acc.reduction varPtr({{.*}}) recipe({{.*}}) name("x") -> !fir.ref<i32>
+! CHECK: %[[COPY2:.*]] = acc.copyin varPtr({{.*}}) dataClause(acc_copy) name("x") -> !fir.ref<i32>
+! CHECK: acc.parallel dataOperands(%[[COPY2]] : !fir.ref<i32>) reduction(%[[REDUCTION2]] : !fir.ref<i32>) {
+! CHECK: hlfir.declare %[[REDUCTION2]]
+! CHECK: acc.copyout accPtr(%[[COPY2]] : !fir.ref<i32>)

--- a/flang/test/Lower/OpenACC/implied-do-index.f90
+++ b/flang/test/Lower/OpenACC/implied-do-index.f90
@@ -1,0 +1,33 @@
+! RUN: bbc -fopenacc -emit-hlfir %s -o - | FileCheck %s
+
+! Exercise an array-constructor implied-do index after the OpenACC semantics
+! pass has analyzed an enclosing array subscript.  The enclosing declaration
+! with the same name must not turn the implied-do index into a SymbolRef.
+subroutine implied_do_index_host(a, x, n)
+  integer :: n
+  integer :: a(n, n), x(n), i
+
+  x = [(sum(a(:, i)), i = 1, n)]
+end subroutine
+
+! CHECK-LABEL: func.func @_QPimplied_do_index_host
+! CHECK: hlfir.elemental
+! CHECK: %[[HOST_INDEX:.*]] = fir.convert %{{.*}} : (index) -> i64
+! CHECK-NEXT: %[[HOST_KIND:.*]] = fir.convert %[[HOST_INDEX]] : (i64) -> i32
+! CHECK-NEXT: %[[HOST_SUBSCRIPT:.*]] = fir.convert %[[HOST_KIND]] : (i32) -> i64
+! CHECK: hlfir.designate {{.*}}%[[HOST_SUBSCRIPT]]
+
+! Preserve the explicit kind of an implied-do index when its resolved symbol,
+! rather than an active ExpressionAnalyzer entry, identifies the index.
+subroutine implied_do_index_kind8(a, x, n)
+  integer :: n
+  integer :: a(n, n), x(n), i
+
+  x = [(sum(a(:, i)), integer(8) :: i = 1, n)]
+end subroutine
+
+! CHECK-LABEL: func.func @_QPimplied_do_index_kind8
+! CHECK: hlfir.elemental
+! CHECK: %[[KIND8_INDEX:.*]] = fir.convert %{{.*}} : (index) -> i64
+! CHECK-NOT: fir.convert %[[KIND8_INDEX]]
+! CHECK: hlfir.designate {{.*}}%[[KIND8_INDEX]]

--- a/flang/test/Semantics/OpenACC/acc-common.f90
+++ b/flang/test/Semantics/OpenACC/acc-common.f90
@@ -39,3 +39,13 @@ program acc_decl_test
 !ERROR: Could not find COMMON block 'a_common_bad' used in OpenACC directive
 !$acc update device (/a_common_bad/)
 end program
+
+subroutine common_dsa_conflict()
+  integer :: a, b
+  common /dsa_common/ a, b
+
+  !ERROR: 'dsa_common' appears in more than one data-sharing clause on the same OpenACC directive
+  !$acc parallel private(/dsa_common/) firstprivate(/dsa_common/)
+  a = b
+  !$acc end parallel
+end subroutine

--- a/flang/test/Semantics/OpenACC/acc-component-ref-dsa.f90
+++ b/flang/test/Semantics/OpenACC/acc-component-ref-dsa.f90
@@ -1,10 +1,10 @@
 ! RUN: %python %S/../test_errors.py %s %flang -fopenacc -fno-openacc-default-none-scalars-strict
 
-! Derived-type component references in OpenACC clauses are accepted for now, but
-! the current DSA handling is deliberately imprecise:
-! - duplicate and conflicting component references are not diagnosed;
-! - component clauses do not satisfy DEFAULT(NONE) for the base object;
-! - whole-object/component conflicts are not diagnosed.
+! Derived-type component references in OpenACC clauses are accepted. Exact
+! duplicate and conflicting component references in data-sharing clauses are
+! diagnosed, but broader containment is deliberately limited for now:
+! - component clauses satisfy DEFAULT(NONE) only for contained references;
+! - bare whole-object/component conflicts are not diagnosed.
 
 module component_ref_types
   implicit none
@@ -35,13 +35,38 @@ subroutine test_component_clauses_are_accepted()
   !$acc end parallel
 end subroutine
 
-subroutine test_default_none_component_does_not_cover_object()
+subroutine test_default_none_component_covers_same_component()
   use component_ref_types, only: point_t
   type(point_t) :: p
-  ! TODO: should be an error, needs precise tracking of component references.
+  !$acc parallel default(none) copy(p%x)
+  p%x = 1.0
+  !$acc end parallel
+end subroutine
+
+subroutine test_default_none_component_does_not_cover_sibling()
+  use component_ref_types, only: point_t
+  type(point_t) :: p
   !$acc parallel default(none) copy(p%x)
   !ERROR: The DEFAULT(NONE) clause requires that 'p' must be listed in a data-mapping clause
-  p%x = 1.0
+  p%y = 1.0
+  !$acc end parallel
+end subroutine
+
+subroutine test_default_none_component_covers_contained_component()
+  use component_ref_types, only: nested_t
+  type(nested_t) :: n
+  !$acc parallel default(none) copy(n%pt)
+  n%pt%x = 1.0
+  !$acc end parallel
+end subroutine
+
+subroutine test_default_none_component_does_not_cover_parent()
+  use component_ref_types, only: nested_t, point_t
+  type(nested_t) :: n
+  type(point_t) :: p
+  !$acc parallel default(none) copy(n%pt%x, p)
+  !ERROR: The DEFAULT(NONE) clause requires that 'n' must be listed in a data-mapping clause
+  n%pt = p
   !$acc end parallel
 end subroutine
 
@@ -67,6 +92,7 @@ subroutine test_same_object_same_dsa_components()
   use component_ref_types, only: point_t
   type(point_t) :: p
   integer :: i
+  !WARNING: 'p%x' appears more than once in the same kind of data-sharing clause on an OpenACC directive; duplicate ignored [-Wopenacc-usage]
   !$acc parallel loop private(p%x, p%y, p%x)
   do i = 1, 10
     p%x = real(i)
@@ -79,6 +105,7 @@ subroutine test_same_object_incompatible_same_component()
   use component_ref_types, only: point_t
   type(point_t) :: p
   integer :: i
+  !ERROR: 'p%x' appears in more than one data-sharing clause on the same OpenACC directive
   !$acc parallel loop private(p%x) firstprivate(p%x)
   do i = 1, 10
     p%x = real(i)
@@ -98,10 +125,59 @@ subroutine test_same_object_incompatible_different_components()
   !$acc end parallel loop
 end subroutine
 
+subroutine test_contained_component_same_dsa()
+  use component_ref_types, only: nested_t
+  type(nested_t) :: n
+  integer :: i
+  !ERROR: 'n%pt%x' overlaps another object in the same kind of data-sharing clause on the same OpenACC directive
+  !$acc parallel loop private(n%pt, n%pt%x)
+  do i = 1, 10
+    n%pt%x = real(i)
+  end do
+  !$acc end parallel loop
+end subroutine
+
+subroutine test_contained_component_same_dsa_child_first()
+  use component_ref_types, only: nested_t
+  type(nested_t) :: n
+  integer :: i
+  !ERROR: 'n%pt' overlaps another object in the same kind of data-sharing clause on the same OpenACC directive
+  !$acc parallel loop private(n%pt%x, n%pt)
+  do i = 1, 10
+    n%pt%x = real(i)
+  end do
+  !$acc end parallel loop
+end subroutine
+
+subroutine test_contained_component_incompatible_parent_first()
+  use component_ref_types, only: nested_t
+  type(nested_t) :: n
+  integer :: i
+  !ERROR: 'n%pt%x' appears in more than one data-sharing clause on the same OpenACC directive
+  !$acc parallel loop private(n%pt) firstprivate(n%pt%x)
+  do i = 1, 10
+    n%pt%x = real(i)
+  end do
+  !$acc end parallel loop
+end subroutine
+
+subroutine test_contained_component_incompatible_child_first()
+  use component_ref_types, only: nested_t
+  type(nested_t) :: n
+  integer :: i
+  !ERROR: 'n%pt' appears in more than one data-sharing clause on the same OpenACC directive
+  !$acc parallel loop private(n%pt%x) firstprivate(n%pt)
+  do i = 1, 10
+    n%pt%x = real(i)
+  end do
+  !$acc end parallel loop
+end subroutine
+
 subroutine test_whole_object_incompatible_with_component()
   use component_ref_types, only: point_t
   type(point_t) :: p
   integer :: i
+  !ERROR: 'p%x' appears in more than one data-sharing clause on the same OpenACC directive
   !$acc parallel loop private(p) firstprivate(p%x)
   do i = 1, 10
     p%x = real(i)

--- a/flang/test/Semantics/OpenACC/acc-component-ref-dsa.f90
+++ b/flang/test/Semantics/OpenACC/acc-component-ref-dsa.f90
@@ -123,6 +123,13 @@ subroutine test_same_object_incompatible_different_components()
     p%y = p%x
   end do
   !$acc end parallel loop
+
+  !$acc parallel loop firstprivate(p%y) private(p%x)
+  do i = 1, 10
+    p%x = real(i)
+    p%y = p%x
+  end do
+  !$acc end parallel loop
 end subroutine
 
 subroutine test_contained_component_same_dsa()
@@ -196,11 +203,19 @@ subroutine test_distinct_objects_same_type_same_component()
   !$acc end parallel loop
 end subroutine
 
-subroutine test_indexed_component_refs_are_not_conflicts()
+subroutine test_indexed_component_refs_conflict()
   use component_ref_types, only: vec_t
   type(vec_t) :: v
   integer :: i
+  !ERROR: 'v%arr(6:10)' appears in more than one data-sharing clause on the same OpenACC directive
   !$acc parallel loop private(v%arr(1:5)) firstprivate(v%arr(6:10))
+  do i = 1, 10
+    v%arr(i) = real(i)
+  end do
+  !$acc end parallel loop
+
+  !ERROR: 'v%arr(1:5)' appears in more than one data-sharing clause on the same OpenACC directive
+  !$acc parallel loop firstprivate(v%arr(6:10)) private(v%arr(1:5))
   do i = 1, 10
     v%arr(i) = real(i)
   end do

--- a/flang/test/Semantics/OpenACC/acc-copy-reduction.f90
+++ b/flang/test/Semantics/OpenACC/acc-copy-reduction.f90
@@ -1,0 +1,77 @@
+! RUN: %python %S/../test_errors.py %s %flang -fopenacc
+
+subroutine copy_then_reduction()
+  integer :: x
+  !$acc parallel copy(x) reduction(+:x)
+  x = x + 1
+  !$acc end parallel
+end subroutine
+
+subroutine reduction_then_copy()
+  integer :: x
+  !$acc parallel reduction(+:x) copy(x)
+  x = x + 1
+  !$acc end parallel
+end subroutine
+
+subroutine parallel_data_clauses_with_reduction()
+  integer :: copy_var, copyin_var, copyout_var, create_var, no_create_var
+  integer :: present_var
+  !$acc parallel copy(copy_var) copyin(copyin_var) &
+  !$acc& copyout(copyout_var) create(create_var) &
+  !$acc& no_create(no_create_var) present(present_var) &
+  !$acc& reduction(+:copy_var, copyin_var, copyout_var, create_var, &
+  !$acc& no_create_var, present_var)
+  copy_var = copy_var + 1
+  copyin_var = copyin_var + 1
+  copyout_var = copyout_var + 1
+  create_var = create_var + 1
+  no_create_var = no_create_var + 1
+  present_var = present_var + 1
+  !$acc end parallel
+end subroutine
+
+subroutine serial_reduction_then_data_clauses()
+  integer :: copy_var, present_var
+  !$acc serial reduction(+:copy_var, present_var) &
+  !$acc& copy(copy_var) present(present_var)
+  copy_var = copy_var + 1
+  present_var = present_var + 1
+  !$acc end serial
+end subroutine
+
+subroutine combined_copy_reduction()
+  integer :: i, x
+  !$acc parallel loop copy(x) reduction(+:x)
+  do i = 1, 10
+    x = x + i
+  end do
+
+  !$acc serial loop reduction(+:x) copy(x)
+  do i = 1, 10
+    x = x + i
+  end do
+
+  !$acc kernels loop copy(x) reduction(+:x)
+  do i = 1, 10
+    x = x + i
+  end do
+end subroutine
+
+subroutine combined_present_reduction()
+  integer :: i, x
+  !$acc parallel loop present(x) reduction(+:x)
+  do i = 1, 10
+    x = x + i
+  end do
+
+  !$acc serial loop reduction(+:x) present(x)
+  do i = 1, 10
+    x = x + i
+  end do
+
+  !$acc kernels loop present(x) reduction(+:x)
+  do i = 1, 10
+    x = x + i
+  end do
+end subroutine

--- a/flang/test/Semantics/OpenACC/acc-data-action-overlap.f90
+++ b/flang/test/Semantics/OpenACC/acc-data-action-overlap.f90
@@ -1,0 +1,94 @@
+! RUN: %python %S/../test_errors.py %s %flang -fopenacc
+
+! Data-action clauses may overlap data-sharing clauses. Only two overlapping
+! data-sharing clauses conflict.
+
+subroutine data_actions_then_private(deviceptr_var)
+  integer :: deviceptr_var
+  integer :: copy_var, copyin_var, copyout_var, create_var, no_create_var
+  integer :: present_var
+  integer, pointer :: attach_var
+  !$acc parallel copy(copy_var) copyin(copyin_var) copyout(copyout_var) &
+  !$acc& create(create_var) no_create(no_create_var) present(present_var) &
+  !$acc& deviceptr(deviceptr_var) attach(attach_var) &
+  !$acc& private(copy_var, copyin_var, copyout_var, create_var, &
+  !$acc& no_create_var, present_var, deviceptr_var, attach_var)
+  copy_var = 1
+  !$acc end parallel
+end subroutine
+
+subroutine firstprivate_then_data_actions(deviceptr_var)
+  integer :: deviceptr_var
+  integer :: copy_var, copyin_var, copyout_var, create_var, no_create_var
+  integer :: present_var
+  integer, pointer :: attach_var
+  !$acc serial firstprivate(copy_var, copyin_var, copyout_var, create_var, &
+  !$acc& no_create_var, present_var, deviceptr_var, attach_var) &
+  !$acc& copy(copy_var) copyin(copyin_var) copyout(copyout_var) &
+  !$acc& create(create_var) no_create(no_create_var) present(present_var) &
+  !$acc& deviceptr(deviceptr_var) attach(attach_var)
+  copy_var = 1
+  !$acc end serial
+end subroutine
+
+subroutine reduction_with_data_actions(deviceptr_var)
+  integer :: deviceptr_var
+  integer :: copy_var, copyin_var, copyout_var, create_var, no_create_var
+  integer :: present_var
+  integer, allocatable :: attach_var
+  !$acc parallel reduction(+:copy_var, copyin_var, copyout_var, create_var, &
+  !$acc& no_create_var, present_var, deviceptr_var, attach_var) &
+  !$acc& copy(copy_var) copyin(copyin_var) copyout(copyout_var) &
+  !$acc& create(create_var) no_create(no_create_var) present(present_var) &
+  !$acc& deviceptr(deviceptr_var) attach(attach_var)
+  copy_var = copy_var + 1
+  !$acc end parallel
+end subroutine
+
+subroutine overlapping_data_actions(deviceptr_var)
+  integer :: deviceptr_var
+  integer :: x
+  integer, pointer :: p
+  !$acc kernels copy(x) copyin(x) copyout(x) create(x) no_create(x) present(x)
+  x = 1
+  !$acc end kernels
+
+  !$acc kernels deviceptr(deviceptr_var) copy(deviceptr_var)
+  deviceptr_var = 1
+  !$acc end kernels
+
+  !$acc kernels attach(p) copy(p) present(p)
+  p = 1
+  !$acc end kernels
+end subroutine
+
+subroutine combined_data_action_private()
+  integer :: i, x
+  !$acc parallel loop copy(x) private(x)
+  do i = 1, 10
+    x = i
+  end do
+
+  !$acc serial loop private(x) present(x)
+  do i = 1, 10
+    x = i
+  end do
+
+  !$acc kernels loop create(x) private(x)
+  do i = 1, 10
+    x = i
+  end do
+end subroutine
+
+subroutine common_block_data_action_private()
+  integer :: a, b
+  common /overlap_common/ a, b
+  !$acc declare link(/overlap_common/)
+  !$acc parallel copy(/overlap_common/) private(/overlap_common/)
+  a = 1
+  !$acc end parallel
+
+  !$acc serial firstprivate(/overlap_common/) copyin(/overlap_common/)
+  b = 1
+  !$acc end serial
+end subroutine

--- a/flang/test/Semantics/OpenACC/acc-dataclause-dedup.f90
+++ b/flang/test/Semantics/OpenACC/acc-dataclause-dedup.f90
@@ -64,6 +64,30 @@ program test_dataclause_dedup
   do i = 1, 10
   end do
 
+  ! A reduction still conflicts with explicit privatization on the same
+  ! directive.
+  !ERROR: 'x' appears in more than one data-sharing clause on the same OpenACC directive
+  !$acc parallel private(x) reduction(+:x)
+  x = x + 1
+  !$acc end parallel
+
+  !ERROR: 'x' appears in more than one data-sharing clause on the same OpenACC directive
+  !$acc serial firstprivate(x) reduction(+:x)
+  x = x + 1
+  !$acc end serial
+
+  !ERROR: 'x' appears in more than one data-sharing clause on the same OpenACC directive
+  !$acc parallel loop private(x) reduction(+:x)
+  do i = 1, 10
+    x = x + i
+  end do
+
+  !ERROR: 'x' appears in more than one data-sharing clause on the same OpenACC directive
+  !$acc serial loop firstprivate(x) reduction(+:x)
+  do i = 1, 10
+    x = x + i
+  end do
+
   ! Reduction is excluded from the benign case: same-flag duplicates may
   ! differ in operator, which is a real conflict.
   !ERROR: 'x' appears in more than one data-sharing clause on the same OpenACC directive
@@ -71,11 +95,13 @@ program test_dataclause_dedup
   do i = 1, 10
   end do
 
-  ! Regression coverage for non-bare designators: the dedup machinery only
-  ! examines simple-Name DataRefs, so distinct array elements and array
-  ! sections must pass through untouched, with no warning and no erasure.
+  ! Regression coverage for non-bare designators: distinct array elements and
+  ! sections must pass through untouched, while exact duplicates are diagnosed
+  ! precisely rather than by the base array symbol.
   block
     integer :: arr(10)
+    integer :: lo, mid, hi, idx
+    integer, parameter :: left = 1, split = 5, right = 10
     integer, target :: t1, t2
     integer, pointer :: p
     type :: pt
@@ -94,15 +120,136 @@ program test_dataclause_dedup
     do i = 1, 10
     end do
 
-    ! Same array element listed twice -- not deduped, since GetDesignatorName-
-    ! IfDataRef returns null for ArrayElement and CheckMultipleAppearances
-    ! is never invoked. Compiles without diagnostics.
+    ! Different array elements in different data-sharing clauses -- not
+    ! duplicates.
+    !$acc parallel loop private(arr(1)) firstprivate(arr(2))
+    do i = 1, 10
+    end do
+
+    ! Different array sections in different data-sharing clauses -- not
+    ! duplicates.
+    !$acc parallel loop private(arr(1:5)) firstprivate(arr(6:10))
+    do i = 1, 10
+    end do
+
+    ! A literal element outside a literal section is disjoint across
+    ! data-sharing kinds.
+    !$acc parallel loop private(arr(1:5)) firstprivate(arr(6))
+    do i = 1, 10
+    end do
+
+    ! Named constant sections that fold to disjoint ranges are not conflicts.
+    !$acc parallel loop private(arr(left:split)) firstprivate(arr(split+1:right))
+    do i = 1, 10
+    end do
+
+    ! Same array element listed twice in the same data-sharing clause.
+    !WARNING: 'arr(1)' appears more than once in the same kind of data-sharing clause on an OpenACC directive; duplicate ignored [-Wopenacc-usage]
     !$acc parallel loop private(arr(1), arr(1))
     do i = 1, 10
     end do
 
-    ! Same array section listed twice -- same reasoning, no diagnostic.
+    ! Same array element with different source spelling.
+    !WARNING: 'arr(01)' appears more than once in the same kind of data-sharing clause on an OpenACC directive; duplicate ignored [-Wopenacc-usage]
+    !$acc parallel loop private(arr(1), arr(01))
+    do i = 1, 10
+    end do
+
+    ! Same array element listed in conflicting data-sharing clauses.
+    !ERROR: 'arr(1)' appears in more than one data-sharing clause on the same OpenACC directive
+    !$acc parallel loop private(arr(1)) firstprivate(arr(1))
+    do i = 1, 10
+    end do
+
+    ! Same array section listed twice in the same data-sharing clause.
+    !WARNING: 'arr(1:5)' appears more than once in the same kind of data-sharing clause on an OpenACC directive; duplicate ignored [-Wopenacc-usage]
     !$acc parallel loop private(arr(1:5), arr(1:5))
+    do i = 1, 10
+    end do
+
+    ! Same array section listed in conflicting data-sharing clauses.
+    !ERROR: 'arr(1:5)' appears in more than one data-sharing clause on the same OpenACC directive
+    !$acc parallel loop private(arr(1:5)) firstprivate(arr(1:5))
+    do i = 1, 10
+    end do
+
+    ! Same array section with different source spelling.
+    !WARNING: 'arr(01:05)' appears more than once in the same kind of data-sharing clause on an OpenACC directive; duplicate ignored [-Wopenacc-usage]
+    !$acc parallel loop private(arr(1:5), arr(01:05))
+    do i = 1, 10
+    end do
+
+    ! Equivalent array sections with different source spelling in conflicting
+    ! data-sharing clauses.
+    !ERROR: 'arr(01:05)' appears in more than one data-sharing clause on the same OpenACC directive
+    !$acc parallel loop private(arr(1:5)) firstprivate(arr(01:05))
+    do i = 1, 10
+    end do
+
+    ! Non-identical sections that overlap in the same data-sharing kind are
+    ! rejected until precise overlap support is implemented.
+    !ERROR: 'arr(5:10)' overlaps another object in the same kind of data-sharing clause on the same OpenACC directive
+    !$acc parallel loop private(arr(1:5), arr(5:10))
+    do i = 1, 10
+    end do
+
+    ! Overlapping literal sections in different data-sharing kinds conflict.
+    !ERROR: 'arr(5:10)' appears in more than one data-sharing clause on the same OpenACC directive
+    !$acc parallel loop private(arr(1:5)) firstprivate(arr(5:10))
+    do i = 1, 10
+    end do
+
+    ! A section and its contained element are likewise rejected in either
+    ! order until precise containment support is implemented.
+    !ERROR: 'arr(3)' overlaps another object in the same kind of data-sharing clause on the same OpenACC directive
+    !$acc parallel loop private(arr(1:5), arr(3))
+    do i = 1, 10
+    end do
+
+    !ERROR: 'arr(1:5)' overlaps another object in the same kind of data-sharing clause on the same OpenACC directive
+    !$acc parallel loop private(arr(3), arr(1:5))
+    do i = 1, 10
+    end do
+
+    ! An element contained in a section conflicts across data-sharing kinds.
+    !ERROR: 'arr(3)' appears in more than one data-sharing clause on the same OpenACC directive
+    !$acc parallel loop private(arr(1:5)) firstprivate(arr(3))
+    do i = 1, 10
+    end do
+
+    ! Variable index/section containment cannot yet be proven, so it is treated
+    ! as disjoint.
+    !$acc parallel loop private(arr(idx), arr(lo:hi))
+    do i = 1, 10
+    end do
+
+    ! Variable index/section overlap is ambiguous, so assume disjoint across
+    ! data-sharing kinds unless overlap can be proven.
+    !$acc parallel loop private(arr(lo:hi)) firstprivate(arr(idx))
+    do i = 1, 10
+    end do
+
+    ! Identical variable indices conflict across data-sharing kinds.
+    !ERROR: 'arr(idx)' appears in more than one data-sharing clause on the same OpenACC directive
+    !$acc parallel loop private(arr(idx)) firstprivate(arr(idx))
+    do i = 1, 10
+    end do
+
+    ! Variable section overlap cannot yet be proven, so it is treated as
+    ! disjoint.
+    !$acc parallel loop private(arr(lo:hi), arr(mid:hi))
+    do i = 1, 10
+    end do
+
+    ! Variable section overlap is ambiguous, so assume disjoint across
+    ! data-sharing kinds unless overlap can be proven.
+    !$acc parallel loop private(arr(lo:hi)) firstprivate(arr(mid:hi))
+    do i = 1, 10
+    end do
+
+    ! Identical variable sections conflict across data-sharing kinds.
+    !ERROR: 'arr(lo:hi)' appears in more than one data-sharing clause on the same OpenACC directive
+    !$acc parallel loop private(arr(lo:hi)) firstprivate(arr(lo:hi))
     do i = 1, 10
     end do
 
@@ -111,9 +258,8 @@ program test_dataclause_dedup
     do i = 1, 10
     end do
 
-    ! Mixing a bare-name designator and an array-element designator on the
-    ! same symbol must not trigger dedup -- the array element doesn't go
-    ! through the duplicate check at all.
+    ! A whole array and an element are not distinct data-sharing objects.
+    !ERROR: 'arr(1)' overlaps another object in the same kind of data-sharing clause on the same OpenACC directive
     !$acc parallel loop private(arr, arr(1))
     do i = 1, 10
     end do

--- a/flang/test/Semantics/OpenACC/acc-dataclause-dedup.f90
+++ b/flang/test/Semantics/OpenACC/acc-dataclause-dedup.f90
@@ -110,35 +110,49 @@ program test_dataclause_dedup
     end type
     type(pt) :: s
 
-    ! Different array elements -- not duplicates.
+    ! Distinct elements of one array still represent the same data-sharing
+    ! entity and cannot be lowered as separate private operands.
+    !ERROR: 'arr(2)' is a different part of an object that already appears in the same kind of data-sharing clause on the same OpenACC directive
     !$acc parallel loop private(arr(1), arr(2))
     do i = 1, 10
     end do
 
-    ! Different array sections -- not duplicates.
+    !ERROR: 'arr(6:10)' is a different part of an object that already appears in the same kind of data-sharing clause on the same OpenACC directive
     !$acc parallel loop private(arr(1:5), arr(6:10))
     do i = 1, 10
     end do
 
-    ! Different array elements in different data-sharing clauses -- not
-    ! duplicates.
+    ! Different array elements in different data-sharing clauses conflict.
+    !ERROR: 'arr(2)' appears in more than one data-sharing clause on the same OpenACC directive
     !$acc parallel loop private(arr(1)) firstprivate(arr(2))
     do i = 1, 10
     end do
 
-    ! Different array sections in different data-sharing clauses -- not
-    ! duplicates.
+    ! Reversing the clause order does not change the entity-level conflict.
+    !ERROR: 'arr(1)' appears in more than one data-sharing clause on the same OpenACC directive
+    !$acc parallel loop firstprivate(arr(2)) private(arr(1))
+    do i = 1, 10
+    end do
+
+    !ERROR: 'arr(6:10)' appears in more than one data-sharing clause on the same OpenACC directive
     !$acc parallel loop private(arr(1:5)) firstprivate(arr(6:10))
     do i = 1, 10
     end do
 
+    !ERROR: 'arr(1:5)' appears in more than one data-sharing clause on the same OpenACC directive
+    !$acc parallel loop firstprivate(arr(6:10)) private(arr(1:5))
+    do i = 1, 10
+    end do
+
     ! A literal element outside a literal section is disjoint across
-    ! data-sharing kinds.
+    ! data-sharing kinds but still belongs to the same array entity.
+    !ERROR: 'arr(6)' appears in more than one data-sharing clause on the same OpenACC directive
     !$acc parallel loop private(arr(1:5)) firstprivate(arr(6))
     do i = 1, 10
     end do
 
-    ! Named constant sections that fold to disjoint ranges are not conflicts.
+    ! Named constant sections that fold to disjoint ranges still conflict.
+    !ERROR: 'arr(split+1:right)' appears in more than one data-sharing clause on the same OpenACC directive
     !$acc parallel loop private(arr(left:split)) firstprivate(arr(split+1:right))
     do i = 1, 10
     end do
@@ -217,14 +231,15 @@ program test_dataclause_dedup
     do i = 1, 10
     end do
 
-    ! Variable index/section containment cannot yet be proven, so it is treated
-    ! as disjoint.
+    ! Variable index/section containment cannot be proven, so separate
+    ! appearances of the same array entity are rejected.
+    !ERROR: 'arr(lo:hi)' is a different part of an object that already appears in the same kind of data-sharing clause on the same OpenACC directive
     !$acc parallel loop private(arr(idx), arr(lo:hi))
     do i = 1, 10
     end do
 
-    ! Variable index/section overlap is ambiguous, so assume disjoint across
-    ! data-sharing kinds unless overlap can be proven.
+    ! Variable index/section overlap is ambiguous across data-sharing kinds.
+    !ERROR: 'arr(idx)' appears in more than one data-sharing clause on the same OpenACC directive
     !$acc parallel loop private(arr(lo:hi)) firstprivate(arr(idx))
     do i = 1, 10
     end do
@@ -235,15 +250,21 @@ program test_dataclause_dedup
     do i = 1, 10
     end do
 
-    ! Variable section overlap cannot yet be proven, so it is treated as
-    ! disjoint.
+    ! Variable section overlap cannot be proven, so separate appearances of
+    ! the same array entity are rejected.
+    !ERROR: 'arr(mid:hi)' is a different part of an object that already appears in the same kind of data-sharing clause on the same OpenACC directive
     !$acc parallel loop private(arr(lo:hi), arr(mid:hi))
     do i = 1, 10
     end do
 
-    ! Variable section overlap is ambiguous, so assume disjoint across
-    ! data-sharing kinds unless overlap can be proven.
+    ! Variable section overlap is ambiguous across data-sharing kinds.
+    !ERROR: 'arr(mid:hi)' appears in more than one data-sharing clause on the same OpenACC directive
     !$acc parallel loop private(arr(lo:hi)) firstprivate(arr(mid:hi))
+    do i = 1, 10
+    end do
+
+    !ERROR: 'arr(lo:hi)' appears in more than one data-sharing clause on the same OpenACC directive
+    !$acc parallel loop firstprivate(arr(mid:hi)) private(arr(lo:hi))
     do i = 1, 10
     end do
 

--- a/flang/test/Semantics/OpenACC/acc-default-none-arrays.f90
+++ b/flang/test/Semantics/OpenACC/acc-default-none-arrays.f90
@@ -1,10 +1,9 @@
 ! RUN: %python %S/../test_errors.py %s %flang -fopenacc -fno-openacc-default-none-scalars-strict -Wno-openacc-default-none-scalars-strict
 
 ! Verify that array sections explicitly listed in OpenACC data clauses are
-! correctly registered as having a DSA, so DEFAULT(NONE) does not produce
-! spurious errors.  This does not implement section-level overlap
-! detection or deduplication; duplicate/conflict diagnostics only apply to bare
-! names.  This also covers the substring-in-clause error.
+! correctly registered as having a DSA, so DEFAULT(NONE) uses path containment
+! rather than treating a listed array section as covering every reference to the
+! base array.  This also covers the substring-in-clause error.
 
 ! 1. Data-mapping clauses with array sections: no DEFAULT(NONE) errors.
 subroutine test_data_mapping_sections(n)
@@ -24,6 +23,62 @@ subroutine test_data_mapping_sections(n)
     c(i) = temp
   enddo
   !$acc end kernels
+end subroutine
+
+subroutine test_default_none_literal_section_contains_element()
+  implicit none
+  real :: a(10)
+  !$acc parallel default(none) copy(a(1:5))
+  a(3) = 1.0
+  !$acc end parallel
+end subroutine
+
+subroutine test_default_none_literal_section_rejects_disjoint_element()
+  implicit none
+  real :: a(10)
+  !$acc parallel default(none) copy(a(1:5))
+  !ERROR: The DEFAULT(NONE) clause requires that 'a' must be listed in a data-mapping clause
+  a(6) = 1.0
+  !$acc end parallel
+end subroutine
+
+subroutine test_default_none_literal_section_rejects_partially_overlapping_section()
+  implicit none
+  real :: a(10)
+  !$acc parallel default(none) copy(a(1:5))
+  !ERROR: The DEFAULT(NONE) clause requires that 'a' must be listed in a data-mapping clause
+  a(5:10) = 1.0
+  !$acc end parallel
+end subroutine
+
+subroutine test_default_none_literal_section_rejects_full_section()
+  implicit none
+  real :: a(10)
+  !$acc parallel default(none) copy(a(1:5))
+  !ERROR: The DEFAULT(NONE) clause requires that 'a' must be listed in a data-mapping clause
+  a(:) = 1.0
+  !$acc end parallel
+end subroutine
+
+subroutine test_default_none_full_section_contains_element()
+  implicit none
+  real :: a(10)
+  !$acc parallel default(none) copy(a(:))
+  a = 0.0
+  a(10) = 1.0
+  !$acc end parallel
+end subroutine
+
+subroutine test_default_none_variable_section_lenient(n, lo, hi, i, j, mid)
+  implicit none
+  integer, intent(in) :: n, lo, hi, i, j, mid
+  real :: a(n), b(n), c(n)
+  !$acc parallel default(none) copy(a(lo:hi), b(i), c(1:5))
+  a(i) = 1.0
+  a(mid:hi) = 2.0
+  b(j) = 3.0
+  c(j) = 4.0
+  !$acc end parallel
 end subroutine
 
 ! 2. Private clause with array section: no DEFAULT(NONE) error.
@@ -65,9 +120,8 @@ subroutine test_unlisted_array(n)
 end subroutine
 
 ! 5. Duplicate bare-name under the same data-sharing clause: warn and dedup.
-!    (Array sections like private(a(1:5), a(6:10)) are not deduplicated or
-!    checked for overlap because base-name comparison cannot distinguish
-!    different sections of the same array.)
+!    Exact section duplicates are also diagnosed, but overlapping or distinct
+!    sections like private(a(1:5), a(6:10)) are not treated as duplicates.
 subroutine test_duplicate_private_bare(n)
   implicit none
   integer, intent(in) :: n
@@ -95,7 +149,20 @@ subroutine test_cross_kind_bare(n)
   !$acc end parallel loop
 end subroutine
 
-! 7. Substring in an OpenACC clause is disallowed.
+! 7. Data-sharing entries are scoped to one directive.  Reusing an object in a
+!    later, sequential region must not be diagnosed as a duplicate.
+subroutine test_sequential_regions_have_independent_data_sharing_entries()
+  implicit none
+  real :: a(10)
+  !$acc parallel copy(a)
+  a = 1.0
+  !$acc end parallel
+  !$acc parallel copy(a)
+  a = 2.0
+  !$acc end parallel
+end subroutine
+
+! 8. Substring in an OpenACC clause is disallowed.
 subroutine test_substring()
   implicit none
   character(len=10) :: str
@@ -104,9 +171,37 @@ subroutine test_substring()
   !$acc end parallel
 end subroutine
 
-! 8. Same array section in conflicting private and copy clauses.
-! TODO: cross-kind detection for array sections is not implemented; no error
-!       produced for 'a(1:n)' appearing in both copy and private.
+! 8a. A coindexed object is not an OpenACC data-clause var.
+subroutine test_coindexed_object()
+  implicit none
+  integer, save :: coarray[*]
+  !ERROR: Coindexed objects are not allowed on OpenACC directives or clauses
+  !$acc parallel default(none) copyin(coarray[1])
+  !$acc end parallel
+end subroutine
+
+! 8b. Invalid objects must retain their ordinary Fortran semantic errors;
+!     they must not be mistaken for a resolved OpenACC object that happens
+!     not to have a DesignatorPath.
+subroutine test_unresolved_clause_objects()
+  implicit none
+  type :: t
+    integer :: present
+  end type
+  type(t) :: x
+  !ERROR: Component 'missing' not found in derived type 't'
+  !$acc parallel copyin(x%missing)
+  !$acc end parallel
+  !ERROR: No explicit type declared for 'missing_substring'
+  !$acc parallel copyin(missing_substring(1:5))
+  !$acc end parallel
+  !ERROR: No explicit type declared for 'missing_coarray'
+  !$acc parallel copyin(missing_coarray[1])
+  !$acc end parallel
+end subroutine
+
+! 9. The same array section may appear in a data-action clause and a
+! data-sharing clause.
 subroutine test_cross_kind_sections(n)
   implicit none
   integer, intent(in) :: n
@@ -119,9 +214,8 @@ subroutine test_cross_kind_sections(n)
   !$acc end parallel loop
 end subroutine
 
-! 9. Different sections of the same array in conflicting copy and private clauses.
-! TODO: cross-kind detection for array sections is not implemented; no error
-!       produced for 'a' appearing in both copy and private.
+! 10. Different sections may likewise appear in data-action and data-sharing
+! clauses.
 subroutine test_cross_kind_sections2(n)
   implicit none
   integer, intent(in) :: n

--- a/flang/test/Semantics/OpenACC/acc-default-none-object-refs.f90
+++ b/flang/test/Semantics/OpenACC/acc-default-none-object-refs.f90
@@ -1,0 +1,73 @@
+! RUN: %python %S/../test_errors.py %s %flang -fopenacc
+
+! DEFAULT(NONE) must also diagnose references to variables that appear in the
+! parse tree as a bare object rather than as an Expr, Variable, or ArrayElement:
+! the objects of ALLOCATE/DEALLOCATE/NULLIFY and the pointer target of a pointer
+! assignment.  These reach the parse-tree walk as a Name or StructureComponent,
+! not wrapped in an Expr/Variable/ArrayElement, so they need dedicated handling.
+
+! 1. Unlisted objects of allocate/deallocate/nullify are diagnosed.
+subroutine test_object_refs_unlisted()
+  implicit none
+  real, allocatable :: q(:)
+  real, pointer :: p(:)
+  !$acc parallel default(none)
+  !ERROR: The DEFAULT(NONE) clause requires that 'q' must be listed in a data-mapping clause
+  allocate(q(10))
+  !ERROR: The DEFAULT(NONE) clause requires that 'q' must be listed in a data-mapping clause
+  deallocate(q)
+  !ERROR: The DEFAULT(NONE) clause requires that 'p' must be listed in a data-mapping clause
+  nullify(p)
+  !$acc end parallel
+end subroutine
+
+! 2. Unlisted pointer target and pointee of a pointer assignment are diagnosed.
+!    The left-hand side (the pointer) is the reference the parse tree exposes as
+!    a bare DataRef; the right-hand side is an Expr and was already checked.
+subroutine test_pointer_assign_unlisted()
+  implicit none
+  real, pointer :: p(:), tg(:)
+  !$acc parallel default(none)
+  !ERROR: The DEFAULT(NONE) clause requires that 'p' must be listed in a data-mapping clause
+  !ERROR: The DEFAULT(NONE) clause requires that 'tg' must be listed in a data-mapping clause
+  p => tg
+  !$acc end parallel
+end subroutine
+
+! 3. A structure-component object still reports its base variable.
+subroutine test_object_ref_component()
+  implicit none
+  type t
+    real, pointer :: p(:)
+  end type
+  type(t) :: a
+  !$acc parallel default(none)
+  !ERROR: The DEFAULT(NONE) clause requires that 'a' must be listed in a data-mapping clause
+  nullify(a%p)
+  !$acc end parallel
+end subroutine
+
+! 4. Listed objects do not error.
+subroutine test_object_refs_listed()
+  implicit none
+  real, allocatable :: q(:)
+  real, pointer :: p(:)
+  !$acc parallel default(none) create(q) copyin(p)
+  allocate(q(10))
+  deallocate(q)
+  nullify(p)
+  !$acc end parallel
+end subroutine
+
+! 5. Without DEFAULT(NONE) the object references are not flagged.
+subroutine test_object_refs_no_default_none()
+  implicit none
+  real, allocatable :: q(:)
+  real, pointer :: p(:), tg(:)
+  !$acc parallel
+  allocate(q(10))
+  deallocate(q)
+  nullify(p)
+  p => tg
+  !$acc end parallel
+end subroutine

--- a/flang/test/Semantics/OpenACC/acc-invalid-clause-placement.f90
+++ b/flang/test/Semantics/OpenACC/acc-invalid-clause-placement.f90
@@ -1,0 +1,36 @@
+! RUN: %python %S/../test_errors.py %s %flang -fopenacc
+
+subroutine data_clauses_on_loop(a, p)
+  real :: a(10)
+  real, pointer :: p
+  integer :: i
+
+  !ERROR: COPY clause is not allowed on the LOOP directive
+  !ERROR: COPYIN clause is not allowed on the LOOP directive
+  !ERROR: COPYOUT clause is not allowed on the LOOP directive
+  !ERROR: CREATE clause is not allowed on the LOOP directive
+  !ERROR: NO_CREATE clause is not allowed on the LOOP directive
+  !ERROR: PRESENT clause is not allowed on the LOOP directive
+  !$acc loop copy(a) copyin(a) copyout(a) create(a) no_create(a) present(a)
+  do i = 1, 10
+    a(i) = real(i)
+  end do
+
+  !ERROR: DEVICEPTR clause is not allowed on the LOOP directive
+  !ERROR: ATTACH clause is not allowed on the LOOP directive
+  !ERROR: DELETE clause is not allowed on the LOOP directive
+  !ERROR: DETACH clause is not allowed on the LOOP directive
+  !$acc loop deviceptr(p) attach(p) delete(a) detach(p)
+  do i = 1, 10
+    a(i) = real(i)
+  end do
+end subroutine
+
+subroutine reduction_on_kernels(x)
+  integer :: x
+
+  !ERROR: REDUCTION clause is not allowed on the KERNELS directive
+  !$acc kernels reduction(+:x)
+  x = x + 1
+  !$acc end kernels
+end subroutine

--- a/flang/unittests/Evaluate/CMakeLists.txt
+++ b/flang/unittests/Evaluate/CMakeLists.txt
@@ -20,6 +20,14 @@ add_flang_nongtest_unittest(expression
   FortranParser
 )
 
+add_flang_nongtest_unittest(designator-path
+  FortranSupport
+  NonGTestTesting
+  FortranEvaluate
+  FortranSemantics
+  FortranParser
+)
+
 add_flang_nongtest_unittest(integer
   NonGTestTesting
   FortranEvaluate

--- a/flang/unittests/Evaluate/designator-path.cpp
+++ b/flang/unittests/Evaluate/designator-path.cpp
@@ -1,0 +1,392 @@
+//===-- flang/unittests/Evaluate/designator-path.cpp ---------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "flang/Evaluate/designator-path.h"
+#include "flang/Evaluate/expression.h"
+#include "flang/Parser/provenance.h"
+#include "flang/Semantics/scope.h"
+#include "flang/Semantics/semantics.h"
+#include "flang/Semantics/symbol.h"
+#include "flang/Support/Fortran-features.h"
+#include "flang/Support/LangOptions.h"
+#include "flang/Support/default-kinds.h"
+#include "flang/Testing/testing.h"
+
+using namespace Fortran::evaluate;
+
+namespace {
+namespace common = Fortran::common;
+namespace parser = Fortran::parser;
+namespace semantics = Fortran::semantics;
+using IntExpr = Expr<SubscriptInteger>;
+
+IntExpr Int(int n) { return IntExpr{n}; }
+
+Subscript Scalar(int n) { return Subscript{Int(n)}; }
+
+Triplet TripletSubscript(
+    std::optional<int> lower, std::optional<int> upper, int stride = 1) {
+  return Triplet{lower ? std::optional<IntExpr>{Int(*lower)} : std::nullopt,
+      upper ? std::optional<IntExpr>{Int(*upper)} : std::nullopt, Int(stride)};
+}
+
+Subscript Section(
+    std::optional<int> lower, std::optional<int> upper, int stride = 1) {
+  return Subscript{TripletSubscript(lower, upper, stride)};
+}
+
+Subscript FullSection() {
+  return Subscript{Triplet{std::nullopt, std::nullopt, Int(1)}};
+}
+
+DesignatorPath PathWithSubscripts(std::vector<Subscript> subscripts) {
+  DesignatorPath path;
+  path.AddSubscripts(std::move(subscripts));
+  return path;
+}
+
+DesignatorPath PathWithComponent(const semantics::Symbol *symbol) {
+  DesignatorPath path;
+  path.AddComponent(*symbol);
+  return path;
+}
+
+void CheckRelation(const DesignatorPath &x, const DesignatorPath &y,
+    DesignatorRelation relation) {
+  TEST(x.Compare(y) == relation);
+}
+
+class SymbolFixture {
+public:
+  const semantics::Symbol &MakeSymbol(const char *name) {
+    return scope_.MakeSymbol(parser::CharBlock{name}, semantics::Attrs{},
+        semantics::UnknownDetails{});
+  }
+
+private:
+  parser::AllSources allSources_;
+  parser::AllCookedSources allCookedSources_{allSources_};
+  common::IntrinsicTypeDefaultKinds defaultKinds_;
+  common::LanguageFeatureControl languageFeatures_;
+  common::LangOptions langOptions_;
+  semantics::SemanticsContext context_{
+      defaultKinds_, languageFeatures_, langOptions_, allCookedSources_};
+  semantics::Scope &scope_{
+      context_.globalScope().MakeScope(semantics::Scope::Kind::MainProgram)};
+};
+
+void TestGetConstantSubscriptRange() {
+  auto scalarRange{DesignatorPath::GetConstantSubscriptRange(Scalar(4))};
+  TEST(scalarRange.has_value());
+  TEST(scalarRange->lower == 4);
+  TEST(scalarRange->upper == 4);
+
+  auto sectionRange{DesignatorPath::GetConstantSubscriptRange(Section(2, 7))};
+  TEST(sectionRange.has_value());
+  TEST(sectionRange->lower == 2);
+  TEST(sectionRange->upper == 7);
+
+  TEST(!DesignatorPath::GetConstantSubscriptRange(Section(2, 7, 2)));
+  TEST(!DesignatorPath::GetConstantSubscriptRange(FullSection()));
+}
+
+void TestFullTripletDetection() {
+  TEST(DesignatorPath::IsFullTriplet(TripletSubscript({}, {})));
+  TEST(!DesignatorPath::IsFullTriplet(TripletSubscript(1, {})));
+  TEST(!DesignatorPath::IsFullTriplet(TripletSubscript({}, 10)));
+  TEST(!DesignatorPath::IsFullTriplet(TripletSubscript({}, {}, 2)));
+}
+
+void TestCompareSubscripts() {
+  TEST(DesignatorPath::CompareSubscripts(Scalar(3), Scalar(3)) ==
+      DesignatorRelation::Equal);
+  TEST(DesignatorPath::CompareSubscripts(FullSection(), Scalar(3)) ==
+      DesignatorRelation::Contains);
+  TEST(DesignatorPath::CompareSubscripts(FullSection(), FullSection()) ==
+      DesignatorRelation::Equal);
+  TEST(DesignatorPath::CompareSubscripts(Scalar(3), FullSection()) ==
+      DesignatorRelation::ContainedBy);
+  TEST(DesignatorPath::CompareSubscripts(Section(1, 5), Section(6, 10)) ==
+      DesignatorRelation::Disjoint);
+  TEST(DesignatorPath::CompareSubscripts(Section(1, 5), Section(1, 5)) ==
+      DesignatorRelation::Equal);
+  TEST(DesignatorPath::CompareSubscripts(Section(1, 10), Section(3, 5)) ==
+      DesignatorRelation::Contains);
+  TEST(DesignatorPath::CompareSubscripts(Section(3, 5), Section(1, 10)) ==
+      DesignatorRelation::ContainedBy);
+  TEST(DesignatorPath::CompareSubscripts(Section(1, 5), Section(5, 10)) ==
+      DesignatorRelation::Overlaps);
+  TEST(DesignatorPath::CompareSubscripts(Section(1, 5, 2), Section(1, 5)) ==
+      DesignatorRelation::Disjoint);
+}
+
+void TestCompareSubscriptLists() {
+  TEST(DesignatorPath::CompareSubscriptLists({}, {FullSection()}) ==
+      DesignatorRelation::Equal);
+  TEST(DesignatorPath::CompareSubscriptLists({FullSection()}, {}) ==
+      DesignatorRelation::Equal);
+  TEST(DesignatorPath::CompareSubscriptLists({FullSection()},
+           {FullSection(), FullSection()}) == DesignatorRelation::Disjoint);
+  TEST(DesignatorPath::CompareSubscriptLists({Scalar(1)},
+           {Scalar(1), Scalar(2)}) == DesignatorRelation::Disjoint);
+  TEST(DesignatorPath::CompareSubscriptLists({Scalar(1), Scalar(2)},
+           {Scalar(1), Scalar(2)}) == DesignatorRelation::Equal);
+  TEST(DesignatorPath::CompareSubscriptLists({Section(1, 10), Scalar(2)},
+           {Section(3, 5), Scalar(2)}) == DesignatorRelation::Contains);
+  TEST(DesignatorPath::CompareSubscriptLists({Section(3, 5), Scalar(2)},
+           {Section(1, 10), Scalar(2)}) == DesignatorRelation::ContainedBy);
+  TEST(DesignatorPath::CompareSubscriptLists({Section(1, 10), Scalar(2)},
+           {Section(3, 5), FullSection()}) == DesignatorRelation::Overlaps);
+  TEST(DesignatorPath::CompareSubscriptLists({Section(1, 5), Scalar(2)},
+           {Section(6, 10), Scalar(2)}) == DesignatorRelation::Disjoint);
+}
+
+void TestCompareParts() {
+  SymbolFixture symbols;
+  const semantics::Symbol &symbol1{symbols.MakeSymbol("a")};
+  const semantics::Symbol &symbol2{symbols.MakeSymbol("b")};
+  DesignatorPath::Part component1{{}, &symbol1};
+  DesignatorPath::Part component1Again{{}, &symbol1};
+  DesignatorPath::Part component2{{}, &symbol2};
+  DesignatorPath::Part subscripts{{Section(1, 5)}, nullptr};
+  DesignatorPath::Part subscriptedComponent{{Scalar(3)}, &symbol1};
+
+  TEST(DesignatorPath::CompareParts(component1, component1Again) ==
+      DesignatorRelation::Equal);
+  TEST(DesignatorPath::CompareParts(component1, component2) ==
+      DesignatorRelation::Disjoint);
+  TEST(DesignatorPath::CompareParts(component1, subscripts) ==
+      DesignatorRelation::Overlaps);
+  TEST(DesignatorPath::CompareParts(subscripts, subscriptedComponent) ==
+      DesignatorRelation::Contains);
+}
+
+void TestCombineRelations() {
+  TEST(DesignatorPath::CombineRelations(false, false, false) ==
+      DesignatorRelation::Equal);
+  TEST(DesignatorPath::CombineRelations(true, false, false) ==
+      DesignatorRelation::Contains);
+  TEST(DesignatorPath::CombineRelations(false, true, false) ==
+      DesignatorRelation::ContainedBy);
+  TEST(DesignatorPath::CombineRelations(false, false, true) ==
+      DesignatorRelation::Overlaps);
+  TEST(DesignatorPath::CombineRelations(true, true, false) ==
+      DesignatorRelation::Overlaps);
+}
+
+void TestComparePaths() {
+  DesignatorPath empty;
+  CheckRelation(empty, empty, DesignatorRelation::Equal);
+  CheckRelation(
+      empty, PathWithSubscripts({Scalar(1)}), DesignatorRelation::Disjoint);
+
+  CheckRelation(PathWithSubscripts({Scalar(1)}),
+      PathWithSubscripts({Scalar(1)}), DesignatorRelation::Equal);
+  CheckRelation(PathWithSubscripts({Section(1, 10)}),
+      PathWithSubscripts({Scalar(5)}), DesignatorRelation::Contains);
+  CheckRelation(PathWithSubscripts({Scalar(5)}),
+      PathWithSubscripts({Section(1, 10)}), DesignatorRelation::ContainedBy);
+  CheckRelation(PathWithSubscripts({Section(1, 5)}),
+      PathWithSubscripts({Section(5, 10)}), DesignatorRelation::Overlaps);
+  CheckRelation(PathWithSubscripts({Section(1, 5)}),
+      PathWithSubscripts({Section(6, 10)}), DesignatorRelation::Disjoint);
+
+  SymbolFixture symbols;
+  const semantics::Symbol &symbol{symbols.MakeSymbol("c")};
+  DesignatorPath parent{PathWithComponent(&symbol)};
+  DesignatorPath child{PathWithComponent(&symbol)};
+  child.AddSubscripts({Scalar(1)});
+  CheckRelation(parent, child, DesignatorRelation::Contains);
+  CheckRelation(child, parent, DesignatorRelation::ContainedBy);
+}
+
+void TestMayContainSubscripts() {
+  TEST(DesignatorPath::SubscriptMayContain(Scalar(1), Scalar(1)));
+  TEST(DesignatorPath::SubscriptMayContain(FullSection(), Scalar(7)));
+  TEST(!DesignatorPath::SubscriptMayContain(Scalar(7), FullSection()));
+  TEST(!DesignatorPath::SubscriptMayContain(Section(1, 5), FullSection()));
+  TEST(DesignatorPath::SubscriptMayContain(Section(1, 10), Scalar(7)));
+  TEST(!DesignatorPath::SubscriptMayContain(Section(1, 5), Scalar(7)));
+  TEST(DesignatorPath::SubscriptMayContain(Section(1, 5, 2), Scalar(7)));
+  TEST(!DesignatorPath::SubscriptListMayContain(
+      {Scalar(1)}, {Scalar(1), Scalar(2)}));
+  TEST(DesignatorPath::SubscriptListMayContain({FullSection()}, {}));
+  TEST(!DesignatorPath::SubscriptListMayContain(
+      {FullSection()}, {Scalar(1), Scalar(2)}));
+  TEST(DesignatorPath::SubscriptListMayContain(
+      {FullSection(), Section(1, 10)}, {Scalar(2), Scalar(5)}));
+}
+
+void TestMayContainPartsAndPaths() {
+  SymbolFixture symbols;
+  const semantics::Symbol &symbol1{symbols.MakeSymbol("d")};
+  const semantics::Symbol &symbol2{symbols.MakeSymbol("e")};
+  DesignatorPath::Part component1{{}, &symbol1};
+  DesignatorPath::Part component2{{}, &symbol2};
+  DesignatorPath::Part subscripts{{Section(1, 10)}, nullptr};
+  DesignatorPath::Part scalarSubscript{{Scalar(5)}, nullptr};
+  DesignatorPath::Part scalarComponent{{Scalar(5)}, &symbol1};
+
+  TEST(DesignatorPath::PartMayContain(component1, component1));
+  TEST(!DesignatorPath::PartMayContain(component1, component2));
+  TEST(DesignatorPath::PartMayContain(subscripts, scalarComponent));
+  TEST(DesignatorPath::PartMayContain(subscripts, scalarSubscript));
+
+  DesignatorPath empty;
+  DesignatorPath parent{PathWithComponent(&symbol1)};
+  DesignatorPath child{PathWithComponent(&symbol1)};
+  child.AddSubscripts({Scalar(1)});
+  DesignatorPath sibling{PathWithComponent(&symbol2)};
+
+  TEST(empty.MayContain(parent));
+  TEST(parent.MayContain(parent));
+  TEST(parent.MayContain(child));
+  TEST(!parent.MayContain(empty));
+  TEST(!child.MayContain(parent));
+  TEST(!parent.MayContain(sibling));
+}
+
+void TestAddFunctionsAndMap() {
+  SymbolFixture symbols;
+  const semantics::Symbol &symbol{symbols.MakeSymbol("f")};
+  DesignatorPath path;
+  TEST(path.empty());
+  path.AddComponent(symbol);
+  path.AddSubscripts({Scalar(1), Scalar(2)});
+  TEST(path.Parts().size() == 2);
+  TEST(path.Parts()[0].subscripts.empty());
+  TEST(path.Parts()[0].symbol == &symbol);
+  TEST(path.Parts()[1].subscripts.size() == 2);
+  TEST(path.Parts()[1].symbol == nullptr);
+
+  DesignatorPathMap<int> map;
+  TEST(map.empty());
+  map.push_back(path, 42);
+  TEST(!map.empty());
+  TEST(map.begin()->value == 42);
+  map.erase(map.begin());
+  TEST(map.empty());
+  map.push_back(DesignatorPath{}, 7);
+  map.clear();
+  TEST(map.empty());
+}
+
+void TestSubscriptsPrecedeComponentWithinPart() {
+  SymbolFixture symbols;
+  const semantics::Symbol &base{symbols.MakeSymbol("g")};
+  const semantics::Symbol &y{symbols.MakeSymbol("h")};
+  const semantics::Symbol &z{symbols.MakeSymbol("i")};
+
+  DesignatorPath x;
+  x.SetBase(NamedEntity{base});
+  TEST(x.Base().has_value());
+  TEST(x.Parts().empty());
+
+  DesignatorPath differentBase;
+  differentBase.SetBase(NamedEntity{y});
+
+  DesignatorPath xFull;
+  xFull.SetBase(NamedEntity{base});
+  xFull.AddSubscripts({FullSection()});
+  TEST(xFull.Parts().size() == 1);
+  TEST(xFull.Parts()[0].subscripts.size() == 1);
+  TEST(xFull.Parts()[0].subscripts[0] == FullSection());
+  const auto *fullTriplet{
+      std::get_if<Triplet>(&xFull.Parts()[0].subscripts[0].u)};
+  TEST(fullTriplet != nullptr);
+  if (fullTriplet) {
+    TEST(!fullTriplet->GetLower());
+    TEST(!fullTriplet->GetUpper());
+    TEST(DesignatorPath::IsFullTriplet(*fullTriplet));
+  }
+  TEST(xFull.Parts()[0].symbol == nullptr);
+  TEST(!(xFull == x));
+  TEST(x.Compare(xFull) == DesignatorRelation::Equal);
+  TEST(xFull.Compare(x) == DesignatorRelation::Equal);
+  TEST(x.MayContain(xFull));
+  TEST(xFull.MayContain(x));
+  TEST(!xFull.MayContain(differentBase));
+
+  DesignatorPath xSection;
+  xSection.SetBase(NamedEntity{base});
+  xSection.AddSubscripts({Section(1, 10)});
+  TEST(xSection.Base().has_value());
+  TEST(xSection.Parts().size() == 1);
+  TEST(xSection.Parts()[0].subscripts.size() == 1);
+  TEST(xSection.Parts()[0].symbol == nullptr);
+
+  DesignatorPath xSectionY;
+  xSectionY.SetBase(NamedEntity{base});
+  xSectionY.AddSubscripts({Section(1, 10)});
+  xSectionY.AddComponent(y);
+  TEST(xSectionY.Parts().size() == 1);
+  TEST(xSectionY.Parts()[0].subscripts.size() == 1);
+  TEST(xSectionY.Parts()[0].symbol == &y);
+
+  DesignatorPath xSectionYFull{xSectionY};
+  xSectionYFull.AddSubscripts({FullSection()});
+  TEST(xSectionYFull.Parts().size() == 2);
+  TEST(xSectionYFull.Parts()[0].subscripts.size() == 1);
+  TEST(xSectionYFull.Parts()[0].symbol == &y);
+  TEST(xSectionYFull.Parts()[1].subscripts.size() == 1);
+  TEST(xSectionYFull.Parts()[1].subscripts[0] == FullSection());
+  TEST(xSectionYFull.Parts()[1].symbol == nullptr);
+  TEST(!(xSectionYFull == xSectionY));
+  TEST(xSectionYFull.Compare(xSectionY) == DesignatorRelation::Equal);
+  TEST(xSectionY.Compare(xSectionYFull) == DesignatorRelation::Equal);
+  TEST(xSectionYFull.MayContain(xSectionY));
+  TEST(xSectionY.MayContain(xSectionYFull));
+
+  DesignatorPath xSectionYFullZ;
+  xSectionYFullZ.SetBase(NamedEntity{base});
+  xSectionYFullZ.AddSubscripts({Section(1, 10)});
+  xSectionYFullZ.AddComponent(y);
+  xSectionYFullZ.AddSubscripts({FullSection()});
+  xSectionYFullZ.AddComponent(z);
+  TEST(xSectionYFullZ.Parts().size() == 2);
+  TEST(xSectionYFullZ.Parts()[0].subscripts.size() == 1);
+  TEST(xSectionYFullZ.Parts()[0].symbol == &y);
+  TEST(xSectionYFullZ.Parts()[1].subscripts.size() == 1);
+  TEST(xSectionYFullZ.Parts()[1].subscripts[0] == FullSection());
+  TEST(xSectionYFullZ.Parts()[1].symbol == &z);
+}
+
+void TestAsFortran() {
+  SymbolFixture symbols;
+  const semantics::Symbol &a{symbols.MakeSymbol("a")};
+  const semantics::Symbol &x{symbols.MakeSymbol("x")};
+  const semantics::Symbol &y{symbols.MakeSymbol("y")};
+  DesignatorPath path;
+  path.SetBase(NamedEntity{a});
+  TEST(path.AsFortran() == "a");
+  path.AddSubscripts({Scalar(1), Section(2, 4)});
+  TEST(path.AsFortran() == "a(1_8,2_8:4_8:1_8)");
+  path.AddComponent(x);
+  TEST(path.AsFortran() == "a(1_8,2_8:4_8:1_8)%x");
+  path.AddSubscripts({FullSection()});
+  path.AddComponent(y);
+  TEST(path.AsFortran() == "a(1_8,2_8:4_8:1_8)%x(::1_8)%y");
+}
+
+} // namespace
+
+int main() {
+  TestGetConstantSubscriptRange();
+  TestFullTripletDetection();
+  TestCompareSubscripts();
+  TestCompareSubscriptLists();
+  TestCompareParts();
+  TestCombineRelations();
+  TestComparePaths();
+  TestMayContainSubscripts();
+  TestMayContainPartsAndPaths();
+  TestAddFunctionsAndMap();
+  TestSubscriptsPrecedeComponentWithinPart();
+  TestAsFortran();
+  return testing::Complete();
+}


### PR DESCRIPTION
Reland #211606, #218204, and #218588, which were reverted by #218741 after downstream failures exposed an incompatibility with expression analysis. This incompatibility is now resolved in the PR too.

The failure occurred when an implied-DO name was analyzed without its enclosing expression context, allowing the cached expression to retain the wrong symbol identity. This change preserves the implied-DO index identity while restoring the original OpenACC work:
- represent array sections and component references as structural designator paths;
- improve `DEFAULT(NONE)` and data-clause overlap checking;
- allow supported data-action/data-sharing clause overlap;
- preserve exact duplicate mappings and distinct sibling components;
- reject incompatible repeated array mappings, including disjoint sections whose lowering could otherwise select an undersized mapping operand;
- add coverage for invalid clause placement on standalone `loop` and `kernels` constructs.