### PR TITLE
[SPIRV] Add matrix type legalization for many float global opcodes

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVPostLegalizer.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVPostLegalizer.cpp
@@ -197,6 +197,7 @@ static SPIRVTypeInst deduceTypeFromUses(Register Reg, MachineFunction &MF,
     case TargetOpcode::COPY:
     case TargetOpcode::G_STRICT_FMA:
     case TargetOpcode::G_INTRINSIC_TRUNC:
+    case TargetOpcode::G_INTRINSIC_ROUNDEVEN:
       ResType = deduceTypeFromResultRegister(&Use, Reg, GR, MIB);
       break;
     case TargetOpcode::G_LOAD:

--- a/llvm/lib/Target/SPIRV/SPIRVPostLegalizer.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVPostLegalizer.cpp
@@ -21,7 +21,6 @@
 #include "llvm/CodeGen/MachineFunction.h"
 #include "llvm/CodeGen/MachineFunctionAnalysisManager.h"
 #include "llvm/CodeGen/MachinePassManager.h"
-#include "llvm/CodeGen/TargetOpcodes.h"
 #include "llvm/IR/Analysis.h"
 #include "llvm/IR/IntrinsicsSPIRV.h"
 #include "llvm/Support/Debug.h"
@@ -197,7 +196,7 @@ static SPIRVTypeInst deduceTypeFromUses(Register Reg, MachineFunction &MF,
     case TargetOpcode::G_FSQRT:
     case TargetOpcode::COPY:
     case TargetOpcode::G_STRICT_FMA:
-    case TargetOpcode::G_TRUNC:
+    case TargetOpcode::G_INTRINSIC_TRUNC:
       ResType = deduceTypeFromResultRegister(&Use, Reg, GR, MIB);
       break;
     case TargetOpcode::G_LOAD:

--- a/llvm/lib/Target/SPIRV/SPIRVPostLegalizer.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVPostLegalizer.cpp
@@ -21,6 +21,7 @@
 #include "llvm/CodeGen/MachineFunction.h"
 #include "llvm/CodeGen/MachineFunctionAnalysisManager.h"
 #include "llvm/CodeGen/MachinePassManager.h"
+#include "llvm/CodeGen/TargetOpcodes.h"
 #include "llvm/IR/Analysis.h"
 #include "llvm/IR/IntrinsicsSPIRV.h"
 #include "llvm/Support/Debug.h"
@@ -170,15 +171,33 @@ static SPIRVTypeInst deduceTypeFromUses(Register Reg, MachineFunction &MF,
     case TargetOpcode::G_FADD:
     case TargetOpcode::G_FSUB:
     case TargetOpcode::G_FMUL:
+    case TargetOpcode::G_FCEIL:
     case TargetOpcode::G_FDIV:
+    case TargetOpcode::G_FEXP:
+    case TargetOpcode::G_FEXP2:
+    case TargetOpcode::G_FFLOOR:
     case TargetOpcode::G_FREM:
     case TargetOpcode::G_FMA:
+    case TargetOpcode::G_FACOS:
+    case TargetOpcode::G_FASIN:
+    case TargetOpcode::G_FATAN:
     case TargetOpcode::G_FATAN2:
+    case TargetOpcode::G_FCOS:
+    case TargetOpcode::G_FSIN:
+    case TargetOpcode::G_FTAN:
+    case TargetOpcode::G_FCOSH:
+    case TargetOpcode::G_FSINH:
+    case TargetOpcode::G_FTANH:
+    case TargetOpcode::G_FLOG:
+    case TargetOpcode::G_FLOG2:
+    case TargetOpcode::G_FLOG10:
     case TargetOpcode::G_FPOW:
     case TargetOpcode::G_FMINNUM:
     case TargetOpcode::G_FMAXNUM:
+    case TargetOpcode::G_FSQRT:
     case TargetOpcode::COPY:
     case TargetOpcode::G_STRICT_FMA:
+    case TargetOpcode::G_TRUNC:
       ResType = deduceTypeFromResultRegister(&Use, Reg, GR, MIB);
       break;
     case TargetOpcode::G_LOAD:

--- a/llvm/lib/Target/SPIRV/SPIRVPostLegalizer.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVPostLegalizer.cpp
@@ -170,10 +170,10 @@ static SPIRVTypeInst deduceTypeFromUses(Register Reg, MachineFunction &MF,
     case TargetOpcode::G_FADD:
     case TargetOpcode::G_FSUB:
     case TargetOpcode::G_FMUL:
-    case TargetOpcode::G_FCEIL:
     case TargetOpcode::G_FDIV:
     case TargetOpcode::G_FEXP:
     case TargetOpcode::G_FEXP2:
+    case TargetOpcode::G_FCEIL:
     case TargetOpcode::G_FFLOOR:
     case TargetOpcode::G_FREM:
     case TargetOpcode::G_FMA:

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/acos_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/acos_mat.ll
@@ -2,14 +2,14 @@
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
 
 ; CHECK-NOT: OpCapability Vector16
-; CHECK: OpCapability Float16
-; CHECK: %[[#ext:]] = OpExtInstImport "GLSL.std.450"
-; CHECK: %[[#void:]] = OpTypeVoid
-; CHECK: %[[#f32:]] = OpTypeFloat 32
-; CHECK: %[[#vec4f32:]] = OpTypeVector %[[#f32]] 4
-; CHECK: %[[#vec2f32:]] = OpTypeVector %[[#f32]] 2
-; CHECK: %[[#f16:]] = OpTypeFloat 16
-; CHECK: %[[#vec4f16:]] = OpTypeVector %[[#f16]] 4
+; CHECK-DAG: OpCapability Float16
+; CHECK-DAG: %[[#ext:]] = OpExtInstImport "GLSL.std.450"
+; CHECK-DAG: %[[#void:]] = OpTypeVoid
+; CHECK-DAG: %[[#f32:]] = OpTypeFloat 32
+; CHECK-DAG: %[[#vec4f32:]] = OpTypeVector %[[#f32]] 4
+; CHECK-DAG: %[[#vec2f32:]] = OpTypeVector %[[#f32]] 2
+; CHECK-DAG: %[[#f16:]] = OpTypeFloat 16
+; CHECK-DAG: %[[#vec4f16:]] = OpTypeVector %[[#f16]] 4
 
 @wide_f32_6 = internal addrspace(10) global [6 x float] zeroinitializer
 @wide_f16_9 = internal addrspace(10) global [9 x half] zeroinitializer

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/acos_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/acos_mat.ll
@@ -1,0 +1,67 @@
+; RUN: llc -O0 -verify-machineinstrs -mtriple=spirv-unknown-vulkan %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
+
+; CHECK-NOT: OpCapability Vector16
+; CHECK: OpCapability Float16
+; CHECK: %[[#ext:]] = OpExtInstImport "GLSL.std.450"
+; CHECK: %[[#void:]] = OpTypeVoid
+; CHECK: %[[#f32:]] = OpTypeFloat 32
+; CHECK: %[[#vec4f32:]] = OpTypeVector %[[#f32]] 4
+; CHECK: %[[#vec2f32:]] = OpTypeVector %[[#f32]] 2
+; CHECK: %[[#f16:]] = OpTypeFloat 16
+; CHECK: %[[#vec4f16:]] = OpTypeVector %[[#f16]] 4
+
+@wide_f32_6 = internal addrspace(10) global [6 x float] zeroinitializer
+@wide_f16_9 = internal addrspace(10) global [9 x half] zeroinitializer
+@wide_f32_16 = internal addrspace(10) global [16 x float] zeroinitializer
+@shuffle_f32_4 = internal addrspace(10) global <4 x float> zeroinitializer
+
+define internal void @acos_float6_from_shuffle() {
+entry:
+  ; CHECK-LABEL: %[[#func6:]] = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function acos_float6_from_shuffle
+  ; CHECK: %{{[0-9]+}} = OpLoad %[[#vec4f32]]
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f32]] %[[#ext]] Acos
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec2f32]] %[[#ext]] Acos
+  %vec = load <4 x float>, ptr addrspace(10) @shuffle_f32_4
+  %va = shufflevector <4 x float> %vec, <4 x float> %vec,
+            <6 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5>
+  %r = call <6 x float> @llvm.acos.v6f32(<6 x float> %va)
+  store <6 x float> %r, ptr addrspace(10) @wide_f32_6
+  ret void
+}
+
+define internal void @acos_half9() {
+entry:
+  ; CHECK-LABEL: %[[#func9:]] = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function acos_half9
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Acos
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Acos
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#f16]] %[[#ext]] Acos
+  %va = load <9 x half>, ptr addrspace(10) @wide_f16_9
+  %r = call <9 x half> @llvm.acos.v9f16(<9 x half> %va)
+  store <9 x half> %r, ptr addrspace(10) @wide_f16_9
+  ret void
+}
+
+define internal void @acos_float16() {
+entry:
+  ; CHECK-LABEL: %[[#func16:]] = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function acos_float16
+  ; CHECK-COUNT-4: %{{[0-9]+}} = OpExtInst %[[#vec4f32]] %[[#ext]] Acos
+  %va = load <16 x float>, ptr addrspace(10) @wide_f32_16
+  %r = call <16 x float> @llvm.acos.v16f32(<16 x float> %va)
+  store <16 x float> %r, ptr addrspace(10) @wide_f32_16
+  ret void
+}
+
+define void @main() #0 {
+entry:
+  call void @acos_float6_from_shuffle()
+  call void @acos_half9()
+  call void @acos_float16()
+  ret void
+}
+
+declare <6 x float> @llvm.acos.v6f32(<6 x float>)
+declare <9 x half> @llvm.acos.v9f16(<9 x half>)
+declare <16 x float> @llvm.acos.v16f32(<16 x float>)
+
+attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/acos_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/acos_mat.ll
@@ -33,8 +33,7 @@ entry:
 define internal void @acos_half9() {
 entry:
   ; CHECK-LABEL: %[[#func9:]] = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function acos_half9
-  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Acos
-  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Acos
+  ; CHECK-COUNT-2: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Acos
   ; CHECK: %{{[0-9]+}} = OpExtInst %[[#f16]] %[[#ext]] Acos
   %va = load <9 x half>, ptr addrspace(10) @wide_f16_9
   %r = call <9 x half> @llvm.acos.v9f16(<9 x half> %va)

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/asin_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/asin_mat.ll
@@ -2,14 +2,14 @@
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
 
 ; CHECK-NOT: OpCapability Vector16
-; CHECK: OpCapability Float16
-; CHECK: %[[#ext:]] = OpExtInstImport "GLSL.std.450"
-; CHECK: %[[#void:]] = OpTypeVoid
-; CHECK: %[[#f32:]] = OpTypeFloat 32
-; CHECK: %[[#vec4f32:]] = OpTypeVector %[[#f32]] 4
-; CHECK: %[[#vec2f32:]] = OpTypeVector %[[#f32]] 2
-; CHECK: %[[#f16:]] = OpTypeFloat 16
-; CHECK: %[[#vec4f16:]] = OpTypeVector %[[#f16]] 4
+; CHECK-DAG: OpCapability Float16
+; CHECK-DAG: %[[#ext:]] = OpExtInstImport "GLSL.std.450"
+; CHECK-DAG: %[[#void:]] = OpTypeVoid
+; CHECK-DAG: %[[#f32:]] = OpTypeFloat 32
+; CHECK-DAG: %[[#vec4f32:]] = OpTypeVector %[[#f32]] 4
+; CHECK-DAG: %[[#vec2f32:]] = OpTypeVector %[[#f32]] 2
+; CHECK-DAG: %[[#f16:]] = OpTypeFloat 16
+; CHECK-DAG: %[[#vec4f16:]] = OpTypeVector %[[#f16]] 4
 
 @wide_f32_6 = internal addrspace(10) global [6 x float] zeroinitializer
 @wide_f16_9 = internal addrspace(10) global [9 x half] zeroinitializer

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/asin_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/asin_mat.ll
@@ -1,0 +1,67 @@
+; RUN: llc -O0 -verify-machineinstrs -mtriple=spirv-unknown-vulkan %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
+
+; CHECK-NOT: OpCapability Vector16
+; CHECK: OpCapability Float16
+; CHECK: %[[#ext:]] = OpExtInstImport "GLSL.std.450"
+; CHECK: %[[#void:]] = OpTypeVoid
+; CHECK: %[[#f32:]] = OpTypeFloat 32
+; CHECK: %[[#vec4f32:]] = OpTypeVector %[[#f32]] 4
+; CHECK: %[[#vec2f32:]] = OpTypeVector %[[#f32]] 2
+; CHECK: %[[#f16:]] = OpTypeFloat 16
+; CHECK: %[[#vec4f16:]] = OpTypeVector %[[#f16]] 4
+
+@wide_f32_6 = internal addrspace(10) global [6 x float] zeroinitializer
+@wide_f16_9 = internal addrspace(10) global [9 x half] zeroinitializer
+@wide_f32_16 = internal addrspace(10) global [16 x float] zeroinitializer
+@shuffle_f32_4 = internal addrspace(10) global <4 x float> zeroinitializer
+
+define internal void @asin_float6_from_shuffle() {
+entry:
+  ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function asin_float6_from_shuffle
+  ; CHECK: %{{[0-9]+}} = OpLoad %[[#vec4f32]]
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f32]] %[[#ext]] Asin
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec2f32]] %[[#ext]] Asin
+  %vec = load <4 x float>, ptr addrspace(10) @shuffle_f32_4
+  %va = shufflevector <4 x float> %vec, <4 x float> %vec,
+            <6 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5>
+  %r = call <6 x float> @llvm.asin.v6f32(<6 x float> %va)
+  store <6 x float> %r, ptr addrspace(10) @wide_f32_6
+  ret void
+}
+
+define internal void @asin_half9() {
+entry:
+  ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function asin_half9
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Asin
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Asin
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#f16]] %[[#ext]] Asin
+  %va = load <9 x half>, ptr addrspace(10) @wide_f16_9
+  %r = call <9 x half> @llvm.asin.v9f16(<9 x half> %va)
+  store <9 x half> %r, ptr addrspace(10) @wide_f16_9
+  ret void
+}
+
+define internal void @asin_float16() {
+entry:
+  ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function asin_float16
+  ; CHECK-COUNT-4: %{{[0-9]+}} = OpExtInst %[[#vec4f32]] %[[#ext]] Asin
+  %va = load <16 x float>, ptr addrspace(10) @wide_f32_16
+  %r = call <16 x float> @llvm.asin.v16f32(<16 x float> %va)
+  store <16 x float> %r, ptr addrspace(10) @wide_f32_16
+  ret void
+}
+
+define void @main() #0 {
+entry:
+  call void @asin_float6_from_shuffle()
+  call void @asin_half9()
+  call void @asin_float16()
+  ret void
+}
+
+declare <6 x float> @llvm.asin.v6f32(<6 x float>)
+declare <9 x half> @llvm.asin.v9f16(<9 x half>)
+declare <16 x float> @llvm.asin.v16f32(<16 x float>)
+
+attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/asin_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/asin_mat.ll
@@ -33,8 +33,7 @@ entry:
 define internal void @asin_half9() {
 entry:
   ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function asin_half9
-  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Asin
-  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Asin
+  ; CHECK-COUNT-2: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Asin
   ; CHECK: %{{[0-9]+}} = OpExtInst %[[#f16]] %[[#ext]] Asin
   %va = load <9 x half>, ptr addrspace(10) @wide_f16_9
   %r = call <9 x half> @llvm.asin.v9f16(<9 x half> %va)

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/atan_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/atan_mat.ll
@@ -2,14 +2,14 @@
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
 
 ; CHECK-NOT: OpCapability Vector16
-; CHECK: OpCapability Float16
-; CHECK: %[[#ext:]] = OpExtInstImport "GLSL.std.450"
-; CHECK: %[[#void:]] = OpTypeVoid
-; CHECK: %[[#f32:]] = OpTypeFloat 32
-; CHECK: %[[#vec4f32:]] = OpTypeVector %[[#f32]] 4
-; CHECK: %[[#vec2f32:]] = OpTypeVector %[[#f32]] 2
-; CHECK: %[[#f16:]] = OpTypeFloat 16
-; CHECK: %[[#vec4f16:]] = OpTypeVector %[[#f16]] 4
+; CHECK-DAG: OpCapability Float16
+; CHECK-DAG: %[[#ext:]] = OpExtInstImport "GLSL.std.450"
+; CHECK-DAG: %[[#void:]] = OpTypeVoid
+; CHECK-DAG: %[[#f32:]] = OpTypeFloat 32
+; CHECK-DAG: %[[#vec4f32:]] = OpTypeVector %[[#f32]] 4
+; CHECK-DAG: %[[#vec2f32:]] = OpTypeVector %[[#f32]] 2
+; CHECK-DAG: %[[#f16:]] = OpTypeFloat 16
+; CHECK-DAG: %[[#vec4f16:]] = OpTypeVector %[[#f16]] 4
 
 @wide_f32_6 = internal addrspace(10) global [6 x float] zeroinitializer
 @wide_f16_9 = internal addrspace(10) global [9 x half] zeroinitializer

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/atan_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/atan_mat.ll
@@ -1,0 +1,67 @@
+; RUN: llc -O0 -verify-machineinstrs -mtriple=spirv-unknown-vulkan %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
+
+; CHECK-NOT: OpCapability Vector16
+; CHECK: OpCapability Float16
+; CHECK: %[[#ext:]] = OpExtInstImport "GLSL.std.450"
+; CHECK: %[[#void:]] = OpTypeVoid
+; CHECK: %[[#f32:]] = OpTypeFloat 32
+; CHECK: %[[#vec4f32:]] = OpTypeVector %[[#f32]] 4
+; CHECK: %[[#vec2f32:]] = OpTypeVector %[[#f32]] 2
+; CHECK: %[[#f16:]] = OpTypeFloat 16
+; CHECK: %[[#vec4f16:]] = OpTypeVector %[[#f16]] 4
+
+@wide_f32_6 = internal addrspace(10) global [6 x float] zeroinitializer
+@wide_f16_9 = internal addrspace(10) global [9 x half] zeroinitializer
+@wide_f32_16 = internal addrspace(10) global [16 x float] zeroinitializer
+@shuffle_f32_4 = internal addrspace(10) global <4 x float> zeroinitializer
+
+define internal void @atan_float6_from_shuffle() {
+entry:
+  ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function atan_float6_from_shuffle
+  ; CHECK: %{{[0-9]+}} = OpLoad %[[#vec4f32]]
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f32]] %[[#ext]] Atan
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec2f32]] %[[#ext]] Atan
+  %vec = load <4 x float>, ptr addrspace(10) @shuffle_f32_4
+  %va = shufflevector <4 x float> %vec, <4 x float> %vec,
+            <6 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5>
+  %r = call <6 x float> @llvm.atan.v6f32(<6 x float> %va)
+  store <6 x float> %r, ptr addrspace(10) @wide_f32_6
+  ret void
+}
+
+define internal void @atan_half9() {
+entry:
+  ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function atan_half9
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Atan
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Atan
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#f16]] %[[#ext]] Atan
+  %va = load <9 x half>, ptr addrspace(10) @wide_f16_9
+  %r = call <9 x half> @llvm.atan.v9f16(<9 x half> %va)
+  store <9 x half> %r, ptr addrspace(10) @wide_f16_9
+  ret void
+}
+
+define internal void @atan_float16() {
+entry:
+  ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function atan_float16
+  ; CHECK-COUNT-4: %{{[0-9]+}} = OpExtInst %[[#vec4f32]] %[[#ext]] Atan
+  %va = load <16 x float>, ptr addrspace(10) @wide_f32_16
+  %r = call <16 x float> @llvm.atan.v16f32(<16 x float> %va)
+  store <16 x float> %r, ptr addrspace(10) @wide_f32_16
+  ret void
+}
+
+define void @main() #0 {
+entry:
+  call void @atan_float6_from_shuffle()
+  call void @atan_half9()
+  call void @atan_float16()
+  ret void
+}
+
+declare <6 x float> @llvm.atan.v6f32(<6 x float>)
+declare <9 x half> @llvm.atan.v9f16(<9 x half>)
+declare <16 x float> @llvm.atan.v16f32(<16 x float>)
+
+attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/atan_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/atan_mat.ll
@@ -33,8 +33,7 @@ entry:
 define internal void @atan_half9() {
 entry:
   ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function atan_half9
-  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Atan
-  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Atan
+  ; CHECK-COUNT-2: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Atan
   ; CHECK: %{{[0-9]+}} = OpExtInst %[[#f16]] %[[#ext]] Atan
   %va = load <9 x half>, ptr addrspace(10) @wide_f16_9
   %r = call <9 x half> @llvm.atan.v9f16(<9 x half> %va)

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/ceil_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/ceil_mat.ll
@@ -2,14 +2,14 @@
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
 
 ; CHECK-NOT: OpCapability Vector16
-; CHECK: OpCapability Float16
-; CHECK: %[[#ext:]] = OpExtInstImport "GLSL.std.450"
-; CHECK: %[[#void:]] = OpTypeVoid
-; CHECK: %[[#f32:]] = OpTypeFloat 32
-; CHECK: %[[#vec4f32:]] = OpTypeVector %[[#f32]] 4
-; CHECK: %[[#vec2f32:]] = OpTypeVector %[[#f32]] 2
-; CHECK: %[[#f16:]] = OpTypeFloat 16
-; CHECK: %[[#vec4f16:]] = OpTypeVector %[[#f16]] 4
+; CHECK-DAG: OpCapability Float16
+; CHECK-DAG: %[[#ext:]] = OpExtInstImport "GLSL.std.450"
+; CHECK-DAG: %[[#void:]] = OpTypeVoid
+; CHECK-DAG: %[[#f32:]] = OpTypeFloat 32
+; CHECK-DAG: %[[#vec4f32:]] = OpTypeVector %[[#f32]] 4
+; CHECK-DAG: %[[#vec2f32:]] = OpTypeVector %[[#f32]] 2
+; CHECK-DAG: %[[#f16:]] = OpTypeFloat 16
+; CHECK-DAG: %[[#vec4f16:]] = OpTypeVector %[[#f16]] 4
 
 @wide_f32_6 = internal addrspace(10) global [6 x float] zeroinitializer
 @wide_f16_9 = internal addrspace(10) global [9 x half] zeroinitializer

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/ceil_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/ceil_mat.ll
@@ -1,0 +1,67 @@
+; RUN: llc -O0 -verify-machineinstrs -mtriple=spirv-unknown-vulkan %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
+
+; CHECK-NOT: OpCapability Vector16
+; CHECK: OpCapability Float16
+; CHECK: %[[#ext:]] = OpExtInstImport "GLSL.std.450"
+; CHECK: %[[#void:]] = OpTypeVoid
+; CHECK: %[[#f32:]] = OpTypeFloat 32
+; CHECK: %[[#vec4f32:]] = OpTypeVector %[[#f32]] 4
+; CHECK: %[[#vec2f32:]] = OpTypeVector %[[#f32]] 2
+; CHECK: %[[#f16:]] = OpTypeFloat 16
+; CHECK: %[[#vec4f16:]] = OpTypeVector %[[#f16]] 4
+
+@wide_f32_6 = internal addrspace(10) global [6 x float] zeroinitializer
+@wide_f16_9 = internal addrspace(10) global [9 x half] zeroinitializer
+@wide_f32_16 = internal addrspace(10) global [16 x float] zeroinitializer
+@shuffle_f32_4 = internal addrspace(10) global <4 x float> zeroinitializer
+
+define internal void @ceil_float6_from_shuffle() {
+entry:
+  ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function ceil_float6_from_shuffle
+  ; CHECK: %{{[0-9]+}} = OpLoad %[[#vec4f32]]
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f32]] %[[#ext]] Ceil
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec2f32]] %[[#ext]] Ceil
+  %vec = load <4 x float>, ptr addrspace(10) @shuffle_f32_4
+  %va = shufflevector <4 x float> %vec, <4 x float> %vec,
+            <6 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5>
+  %r = call <6 x float> @llvm.ceil.v6f32(<6 x float> %va)
+  store <6 x float> %r, ptr addrspace(10) @wide_f32_6
+  ret void
+}
+
+define internal void @ceil_half9() {
+entry:
+  ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function ceil_half9
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Ceil
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Ceil
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#f16]] %[[#ext]] Ceil
+  %va = load <9 x half>, ptr addrspace(10) @wide_f16_9
+  %r = call <9 x half> @llvm.ceil.v9f16(<9 x half> %va)
+  store <9 x half> %r, ptr addrspace(10) @wide_f16_9
+  ret void
+}
+
+define internal void @ceil_float16() {
+entry:
+  ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function ceil_float16
+  ; CHECK-COUNT-4: %{{[0-9]+}} = OpExtInst %[[#vec4f32]] %[[#ext]] Ceil
+  %va = load <16 x float>, ptr addrspace(10) @wide_f32_16
+  %r = call <16 x float> @llvm.ceil.v16f32(<16 x float> %va)
+  store <16 x float> %r, ptr addrspace(10) @wide_f32_16
+  ret void
+}
+
+define void @main() #0 {
+entry:
+  call void @ceil_float6_from_shuffle()
+  call void @ceil_half9()
+  call void @ceil_float16()
+  ret void
+}
+
+declare <6 x float> @llvm.ceil.v6f32(<6 x float>)
+declare <9 x half> @llvm.ceil.v9f16(<9 x half>)
+declare <16 x float> @llvm.ceil.v16f32(<16 x float>)
+
+attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/ceil_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/ceil_mat.ll
@@ -33,8 +33,7 @@ entry:
 define internal void @ceil_half9() {
 entry:
   ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function ceil_half9
-  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Ceil
-  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Ceil
+  ; CHECK-COUNT-2: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Ceil
   ; CHECK: %{{[0-9]+}} = OpExtInst %[[#f16]] %[[#ext]] Ceil
   %va = load <9 x half>, ptr addrspace(10) @wide_f16_9
   %r = call <9 x half> @llvm.ceil.v9f16(<9 x half> %va)

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/cos_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/cos_mat.ll
@@ -2,14 +2,14 @@
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
 
 ; CHECK-NOT: OpCapability Vector16
-; CHECK: OpCapability Float16
-; CHECK: %[[#ext:]] = OpExtInstImport "GLSL.std.450"
-; CHECK: %[[#void:]] = OpTypeVoid
-; CHECK: %[[#f32:]] = OpTypeFloat 32
-; CHECK: %[[#vec4f32:]] = OpTypeVector %[[#f32]] 4
-; CHECK: %[[#vec2f32:]] = OpTypeVector %[[#f32]] 2
-; CHECK: %[[#f16:]] = OpTypeFloat 16
-; CHECK: %[[#vec4f16:]] = OpTypeVector %[[#f16]] 4
+; CHECK-DAG: OpCapability Float16
+; CHECK-DAG: %[[#ext:]] = OpExtInstImport "GLSL.std.450"
+; CHECK-DAG: %[[#void:]] = OpTypeVoid
+; CHECK-DAG: %[[#f32:]] = OpTypeFloat 32
+; CHECK-DAG: %[[#vec4f32:]] = OpTypeVector %[[#f32]] 4
+; CHECK-DAG: %[[#vec2f32:]] = OpTypeVector %[[#f32]] 2
+; CHECK-DAG: %[[#f16:]] = OpTypeFloat 16
+; CHECK-DAG: %[[#vec4f16:]] = OpTypeVector %[[#f16]] 4
 
 @wide_f32_6 = internal addrspace(10) global [6 x float] zeroinitializer
 @wide_f16_9 = internal addrspace(10) global [9 x half] zeroinitializer

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/cos_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/cos_mat.ll
@@ -1,0 +1,67 @@
+; RUN: llc -O0 -verify-machineinstrs -mtriple=spirv-unknown-vulkan %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
+
+; CHECK-NOT: OpCapability Vector16
+; CHECK: OpCapability Float16
+; CHECK: %[[#ext:]] = OpExtInstImport "GLSL.std.450"
+; CHECK: %[[#void:]] = OpTypeVoid
+; CHECK: %[[#f32:]] = OpTypeFloat 32
+; CHECK: %[[#vec4f32:]] = OpTypeVector %[[#f32]] 4
+; CHECK: %[[#vec2f32:]] = OpTypeVector %[[#f32]] 2
+; CHECK: %[[#f16:]] = OpTypeFloat 16
+; CHECK: %[[#vec4f16:]] = OpTypeVector %[[#f16]] 4
+
+@wide_f32_6 = internal addrspace(10) global [6 x float] zeroinitializer
+@wide_f16_9 = internal addrspace(10) global [9 x half] zeroinitializer
+@wide_f32_16 = internal addrspace(10) global [16 x float] zeroinitializer
+@shuffle_f32_4 = internal addrspace(10) global <4 x float> zeroinitializer
+
+define internal void @cos_float6_from_shuffle() {
+entry:
+  ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function cos_float6_from_shuffle
+  ; CHECK: %{{[0-9]+}} = OpLoad %[[#vec4f32]]
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f32]] %[[#ext]] Cos
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec2f32]] %[[#ext]] Cos
+  %vec = load <4 x float>, ptr addrspace(10) @shuffle_f32_4
+  %va = shufflevector <4 x float> %vec, <4 x float> %vec,
+            <6 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5>
+  %r = call <6 x float> @llvm.cos.v6f32(<6 x float> %va)
+  store <6 x float> %r, ptr addrspace(10) @wide_f32_6
+  ret void
+}
+
+define internal void @cos_half9() {
+entry:
+  ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function cos_half9
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Cos
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Cos
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#f16]] %[[#ext]] Cos
+  %va = load <9 x half>, ptr addrspace(10) @wide_f16_9
+  %r = call <9 x half> @llvm.cos.v9f16(<9 x half> %va)
+  store <9 x half> %r, ptr addrspace(10) @wide_f16_9
+  ret void
+}
+
+define internal void @cos_float16() {
+entry:
+  ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function cos_float16
+  ; CHECK-COUNT-4: %{{[0-9]+}} = OpExtInst %[[#vec4f32]] %[[#ext]] Cos
+  %va = load <16 x float>, ptr addrspace(10) @wide_f32_16
+  %r = call <16 x float> @llvm.cos.v16f32(<16 x float> %va)
+  store <16 x float> %r, ptr addrspace(10) @wide_f32_16
+  ret void
+}
+
+define void @main() #0 {
+entry:
+  call void @cos_float6_from_shuffle()
+  call void @cos_half9()
+  call void @cos_float16()
+  ret void
+}
+
+declare <6 x float> @llvm.cos.v6f32(<6 x float>)
+declare <9 x half> @llvm.cos.v9f16(<9 x half>)
+declare <16 x float> @llvm.cos.v16f32(<16 x float>)
+
+attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/cos_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/cos_mat.ll
@@ -33,8 +33,7 @@ entry:
 define internal void @cos_half9() {
 entry:
   ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function cos_half9
-  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Cos
-  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Cos
+  ; CHECK-COUNT-2: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Cos
   ; CHECK: %{{[0-9]+}} = OpExtInst %[[#f16]] %[[#ext]] Cos
   %va = load <9 x half>, ptr addrspace(10) @wide_f16_9
   %r = call <9 x half> @llvm.cos.v9f16(<9 x half> %va)

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/cosh_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/cosh_mat.ll
@@ -2,14 +2,14 @@
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
 
 ; CHECK-NOT: OpCapability Vector16
-; CHECK: OpCapability Float16
-; CHECK: %[[#ext:]] = OpExtInstImport "GLSL.std.450"
-; CHECK: %[[#void:]] = OpTypeVoid
-; CHECK: %[[#f32:]] = OpTypeFloat 32
-; CHECK: %[[#vec4f32:]] = OpTypeVector %[[#f32]] 4
-; CHECK: %[[#vec2f32:]] = OpTypeVector %[[#f32]] 2
-; CHECK: %[[#f16:]] = OpTypeFloat 16
-; CHECK: %[[#vec4f16:]] = OpTypeVector %[[#f16]] 4
+; CHECK-DAG: OpCapability Float16
+; CHECK-DAG: %[[#ext:]] = OpExtInstImport "GLSL.std.450"
+; CHECK-DAG: %[[#void:]] = OpTypeVoid
+; CHECK-DAG: %[[#f32:]] = OpTypeFloat 32
+; CHECK-DAG: %[[#vec4f32:]] = OpTypeVector %[[#f32]] 4
+; CHECK-DAG: %[[#vec2f32:]] = OpTypeVector %[[#f32]] 2
+; CHECK-DAG: %[[#f16:]] = OpTypeFloat 16
+; CHECK-DAG: %[[#vec4f16:]] = OpTypeVector %[[#f16]] 4
 
 @wide_f32_6 = internal addrspace(10) global [6 x float] zeroinitializer
 @wide_f16_9 = internal addrspace(10) global [9 x half] zeroinitializer

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/cosh_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/cosh_mat.ll
@@ -1,0 +1,67 @@
+; RUN: llc -O0 -verify-machineinstrs -mtriple=spirv-unknown-vulkan %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
+
+; CHECK-NOT: OpCapability Vector16
+; CHECK: OpCapability Float16
+; CHECK: %[[#ext:]] = OpExtInstImport "GLSL.std.450"
+; CHECK: %[[#void:]] = OpTypeVoid
+; CHECK: %[[#f32:]] = OpTypeFloat 32
+; CHECK: %[[#vec4f32:]] = OpTypeVector %[[#f32]] 4
+; CHECK: %[[#vec2f32:]] = OpTypeVector %[[#f32]] 2
+; CHECK: %[[#f16:]] = OpTypeFloat 16
+; CHECK: %[[#vec4f16:]] = OpTypeVector %[[#f16]] 4
+
+@wide_f32_6 = internal addrspace(10) global [6 x float] zeroinitializer
+@wide_f16_9 = internal addrspace(10) global [9 x half] zeroinitializer
+@wide_f32_16 = internal addrspace(10) global [16 x float] zeroinitializer
+@shuffle_f32_4 = internal addrspace(10) global <4 x float> zeroinitializer
+
+define internal void @cosh_float6_from_shuffle() {
+entry:
+  ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function cosh_float6_from_shuffle
+  ; CHECK: %{{[0-9]+}} = OpLoad %[[#vec4f32]]
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f32]] %[[#ext]] Cosh
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec2f32]] %[[#ext]] Cosh
+  %vec = load <4 x float>, ptr addrspace(10) @shuffle_f32_4
+  %va = shufflevector <4 x float> %vec, <4 x float> %vec,
+            <6 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5>
+  %r = call <6 x float> @llvm.cosh.v6f32(<6 x float> %va)
+  store <6 x float> %r, ptr addrspace(10) @wide_f32_6
+  ret void
+}
+
+define internal void @cosh_half9() {
+entry:
+  ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function cosh_half9
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Cosh
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Cosh
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#f16]] %[[#ext]] Cosh
+  %va = load <9 x half>, ptr addrspace(10) @wide_f16_9
+  %r = call <9 x half> @llvm.cosh.v9f16(<9 x half> %va)
+  store <9 x half> %r, ptr addrspace(10) @wide_f16_9
+  ret void
+}
+
+define internal void @cosh_float16() {
+entry:
+  ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function cosh_float16
+  ; CHECK-COUNT-4: %{{[0-9]+}} = OpExtInst %[[#vec4f32]] %[[#ext]] Cosh
+  %va = load <16 x float>, ptr addrspace(10) @wide_f32_16
+  %r = call <16 x float> @llvm.cosh.v16f32(<16 x float> %va)
+  store <16 x float> %r, ptr addrspace(10) @wide_f32_16
+  ret void
+}
+
+define void @main() #0 {
+entry:
+  call void @cosh_float6_from_shuffle()
+  call void @cosh_half9()
+  call void @cosh_float16()
+  ret void
+}
+
+declare <6 x float> @llvm.cosh.v6f32(<6 x float>)
+declare <9 x half> @llvm.cosh.v9f16(<9 x half>)
+declare <16 x float> @llvm.cosh.v16f32(<16 x float>)
+
+attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/cosh_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/cosh_mat.ll
@@ -33,8 +33,7 @@ entry:
 define internal void @cosh_half9() {
 entry:
   ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function cosh_half9
-  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Cosh
-  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Cosh
+  ; CHECK-COUNT-2: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Cosh
   ; CHECK: %{{[0-9]+}} = OpExtInst %[[#f16]] %[[#ext]] Cosh
   %va = load <9 x half>, ptr addrspace(10) @wide_f16_9
   %r = call <9 x half> @llvm.cosh.v9f16(<9 x half> %va)

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/exp2_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/exp2_mat.ll
@@ -2,14 +2,14 @@
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
 
 ; CHECK-NOT: OpCapability Vector16
-; CHECK: OpCapability Float16
-; CHECK: %[[#ext:]] = OpExtInstImport "GLSL.std.450"
-; CHECK: %[[#void:]] = OpTypeVoid
-; CHECK: %[[#f32:]] = OpTypeFloat 32
-; CHECK: %[[#vec4f32:]] = OpTypeVector %[[#f32]] 4
-; CHECK: %[[#vec2f32:]] = OpTypeVector %[[#f32]] 2
-; CHECK: %[[#f16:]] = OpTypeFloat 16
-; CHECK: %[[#vec4f16:]] = OpTypeVector %[[#f16]] 4
+; CHECK-DAG: OpCapability Float16
+; CHECK-DAG: %[[#ext:]] = OpExtInstImport "GLSL.std.450"
+; CHECK-DAG: %[[#void:]] = OpTypeVoid
+; CHECK-DAG: %[[#f32:]] = OpTypeFloat 32
+; CHECK-DAG: %[[#vec4f32:]] = OpTypeVector %[[#f32]] 4
+; CHECK-DAG: %[[#vec2f32:]] = OpTypeVector %[[#f32]] 2
+; CHECK-DAG: %[[#f16:]] = OpTypeFloat 16
+; CHECK-DAG: %[[#vec4f16:]] = OpTypeVector %[[#f16]] 4
 
 @wide_f32_6 = internal addrspace(10) global [6 x float] zeroinitializer
 @wide_f16_9 = internal addrspace(10) global [9 x half] zeroinitializer

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/exp2_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/exp2_mat.ll
@@ -1,0 +1,67 @@
+; RUN: llc -O0 -verify-machineinstrs -mtriple=spirv-unknown-vulkan %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
+
+; CHECK-NOT: OpCapability Vector16
+; CHECK: OpCapability Float16
+; CHECK: %[[#ext:]] = OpExtInstImport "GLSL.std.450"
+; CHECK: %[[#void:]] = OpTypeVoid
+; CHECK: %[[#f32:]] = OpTypeFloat 32
+; CHECK: %[[#vec4f32:]] = OpTypeVector %[[#f32]] 4
+; CHECK: %[[#vec2f32:]] = OpTypeVector %[[#f32]] 2
+; CHECK: %[[#f16:]] = OpTypeFloat 16
+; CHECK: %[[#vec4f16:]] = OpTypeVector %[[#f16]] 4
+
+@wide_f32_6 = internal addrspace(10) global [6 x float] zeroinitializer
+@wide_f16_9 = internal addrspace(10) global [9 x half] zeroinitializer
+@wide_f32_16 = internal addrspace(10) global [16 x float] zeroinitializer
+@shuffle_f32_4 = internal addrspace(10) global <4 x float> zeroinitializer
+
+define internal void @exp2_float6_from_shuffle() {
+entry:
+  ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function exp2_float6_from_shuffle
+  ; CHECK: %{{[0-9]+}} = OpLoad %[[#vec4f32]]
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f32]] %[[#ext]] Exp2
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec2f32]] %[[#ext]] Exp2
+  %vec = load <4 x float>, ptr addrspace(10) @shuffle_f32_4
+  %va = shufflevector <4 x float> %vec, <4 x float> %vec,
+            <6 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5>
+  %r = call <6 x float> @llvm.exp2.v6f32(<6 x float> %va)
+  store <6 x float> %r, ptr addrspace(10) @wide_f32_6
+  ret void
+}
+
+define internal void @exp2_half9() {
+entry:
+  ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function exp2_half9
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Exp2
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Exp2
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#f16]] %[[#ext]] Exp2
+  %va = load <9 x half>, ptr addrspace(10) @wide_f16_9
+  %r = call <9 x half> @llvm.exp2.v9f16(<9 x half> %va)
+  store <9 x half> %r, ptr addrspace(10) @wide_f16_9
+  ret void
+}
+
+define internal void @exp2_float16() {
+entry:
+  ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function exp2_float16
+  ; CHECK-COUNT-4: %{{[0-9]+}} = OpExtInst %[[#vec4f32]] %[[#ext]] Exp2
+  %va = load <16 x float>, ptr addrspace(10) @wide_f32_16
+  %r = call <16 x float> @llvm.exp2.v16f32(<16 x float> %va)
+  store <16 x float> %r, ptr addrspace(10) @wide_f32_16
+  ret void
+}
+
+define void @main() #0 {
+entry:
+  call void @exp2_float6_from_shuffle()
+  call void @exp2_half9()
+  call void @exp2_float16()
+  ret void
+}
+
+declare <6 x float> @llvm.exp2.v6f32(<6 x float>)
+declare <9 x half> @llvm.exp2.v9f16(<9 x half>)
+declare <16 x float> @llvm.exp2.v16f32(<16 x float>)
+
+attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/exp2_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/exp2_mat.ll
@@ -33,8 +33,7 @@ entry:
 define internal void @exp2_half9() {
 entry:
   ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function exp2_half9
-  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Exp2
-  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Exp2
+  ; CHECK-COUNT-2: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Exp2
   ; CHECK: %{{[0-9]+}} = OpExtInst %[[#f16]] %[[#ext]] Exp2
   %va = load <9 x half>, ptr addrspace(10) @wide_f16_9
   %r = call <9 x half> @llvm.exp2.v9f16(<9 x half> %va)

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/exp_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/exp_mat.ll
@@ -2,14 +2,14 @@
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
 
 ; CHECK-NOT: OpCapability Vector16
-; CHECK: OpCapability Float16
-; CHECK: %[[#ext:]] = OpExtInstImport "GLSL.std.450"
-; CHECK: %[[#void:]] = OpTypeVoid
-; CHECK: %[[#f32:]] = OpTypeFloat 32
-; CHECK: %[[#vec4f32:]] = OpTypeVector %[[#f32]] 4
-; CHECK: %[[#vec2f32:]] = OpTypeVector %[[#f32]] 2
-; CHECK: %[[#f16:]] = OpTypeFloat 16
-; CHECK: %[[#vec4f16:]] = OpTypeVector %[[#f16]] 4
+; CHECK-DAG: OpCapability Float16
+; CHECK-DAG: %[[#ext:]] = OpExtInstImport "GLSL.std.450"
+; CHECK-DAG: %[[#void:]] = OpTypeVoid
+; CHECK-DAG: %[[#f32:]] = OpTypeFloat 32
+; CHECK-DAG: %[[#vec4f32:]] = OpTypeVector %[[#f32]] 4
+; CHECK-DAG: %[[#vec2f32:]] = OpTypeVector %[[#f32]] 2
+; CHECK-DAG: %[[#f16:]] = OpTypeFloat 16
+; CHECK-DAG: %[[#vec4f16:]] = OpTypeVector %[[#f16]] 4
 
 @wide_f32_6 = internal addrspace(10) global [6 x float] zeroinitializer
 @wide_f16_9 = internal addrspace(10) global [9 x half] zeroinitializer

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/exp_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/exp_mat.ll
@@ -1,0 +1,67 @@
+; RUN: llc -O0 -verify-machineinstrs -mtriple=spirv-unknown-vulkan %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
+
+; CHECK-NOT: OpCapability Vector16
+; CHECK: OpCapability Float16
+; CHECK: %[[#ext:]] = OpExtInstImport "GLSL.std.450"
+; CHECK: %[[#void:]] = OpTypeVoid
+; CHECK: %[[#f32:]] = OpTypeFloat 32
+; CHECK: %[[#vec4f32:]] = OpTypeVector %[[#f32]] 4
+; CHECK: %[[#vec2f32:]] = OpTypeVector %[[#f32]] 2
+; CHECK: %[[#f16:]] = OpTypeFloat 16
+; CHECK: %[[#vec4f16:]] = OpTypeVector %[[#f16]] 4
+
+@wide_f32_6 = internal addrspace(10) global [6 x float] zeroinitializer
+@wide_f16_9 = internal addrspace(10) global [9 x half] zeroinitializer
+@wide_f32_16 = internal addrspace(10) global [16 x float] zeroinitializer
+@shuffle_f32_4 = internal addrspace(10) global <4 x float> zeroinitializer
+
+define internal void @exp_float6_from_shuffle() {
+entry:
+  ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function exp_float6_from_shuffle
+  ; CHECK: %{{[0-9]+}} = OpLoad %[[#vec4f32]]
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f32]] %[[#ext]] Exp
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec2f32]] %[[#ext]] Exp
+  %vec = load <4 x float>, ptr addrspace(10) @shuffle_f32_4
+  %va = shufflevector <4 x float> %vec, <4 x float> %vec,
+            <6 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5>
+  %r = call <6 x float> @llvm.exp.v6f32(<6 x float> %va)
+  store <6 x float> %r, ptr addrspace(10) @wide_f32_6
+  ret void
+}
+
+define internal void @exp_half9() {
+entry:
+  ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function exp_half9
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Exp
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Exp
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#f16]] %[[#ext]] Exp
+  %va = load <9 x half>, ptr addrspace(10) @wide_f16_9
+  %r = call <9 x half> @llvm.exp.v9f16(<9 x half> %va)
+  store <9 x half> %r, ptr addrspace(10) @wide_f16_9
+  ret void
+}
+
+define internal void @exp_float16() {
+entry:
+  ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function exp_float16
+  ; CHECK-COUNT-4: %{{[0-9]+}} = OpExtInst %[[#vec4f32]] %[[#ext]] Exp
+  %va = load <16 x float>, ptr addrspace(10) @wide_f32_16
+  %r = call <16 x float> @llvm.exp.v16f32(<16 x float> %va)
+  store <16 x float> %r, ptr addrspace(10) @wide_f32_16
+  ret void
+}
+
+define void @main() #0 {
+entry:
+  call void @exp_float6_from_shuffle()
+  call void @exp_half9()
+  call void @exp_float16()
+  ret void
+}
+
+declare <6 x float> @llvm.exp.v6f32(<6 x float>)
+declare <9 x half> @llvm.exp.v9f16(<9 x half>)
+declare <16 x float> @llvm.exp.v16f32(<16 x float>)
+
+attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/exp_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/exp_mat.ll
@@ -33,8 +33,7 @@ entry:
 define internal void @exp_half9() {
 entry:
   ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function exp_half9
-  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Exp
-  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Exp
+  ; CHECK-COUNT-2: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Exp
   ; CHECK: %{{[0-9]+}} = OpExtInst %[[#f16]] %[[#ext]] Exp
   %va = load <9 x half>, ptr addrspace(10) @wide_f16_9
   %r = call <9 x half> @llvm.exp.v9f16(<9 x half> %va)

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/floor_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/floor_mat.ll
@@ -1,0 +1,67 @@
+; RUN: llc -O0 -verify-machineinstrs -mtriple=spirv-unknown-vulkan %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
+
+; CHECK-NOT: OpCapability Vector16
+; CHECK: OpCapability Float16
+; CHECK: %[[#ext:]] = OpExtInstImport "GLSL.std.450"
+; CHECK: %[[#void:]] = OpTypeVoid
+; CHECK: %[[#f32:]] = OpTypeFloat 32
+; CHECK: %[[#vec4f32:]] = OpTypeVector %[[#f32]] 4
+; CHECK: %[[#vec2f32:]] = OpTypeVector %[[#f32]] 2
+; CHECK: %[[#f16:]] = OpTypeFloat 16
+; CHECK: %[[#vec4f16:]] = OpTypeVector %[[#f16]] 4
+
+@wide_f32_6 = internal addrspace(10) global [6 x float] zeroinitializer
+@wide_f16_9 = internal addrspace(10) global [9 x half] zeroinitializer
+@wide_f32_16 = internal addrspace(10) global [16 x float] zeroinitializer
+@shuffle_f32_4 = internal addrspace(10) global <4 x float> zeroinitializer
+
+define internal void @floor_float6_from_shuffle() {
+entry:
+  ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function floor_float6_from_shuffle
+  ; CHECK: %{{[0-9]+}} = OpLoad %[[#vec4f32]]
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f32]] %[[#ext]] Floor
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec2f32]] %[[#ext]] Floor
+  %vec = load <4 x float>, ptr addrspace(10) @shuffle_f32_4
+  %va = shufflevector <4 x float> %vec, <4 x float> %vec,
+            <6 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5>
+  %r = call <6 x float> @llvm.floor.v6f32(<6 x float> %va)
+  store <6 x float> %r, ptr addrspace(10) @wide_f32_6
+  ret void
+}
+
+define internal void @floor_half9() {
+entry:
+  ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function floor_half9
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Floor
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Floor
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#f16]] %[[#ext]] Floor
+  %va = load <9 x half>, ptr addrspace(10) @wide_f16_9
+  %r = call <9 x half> @llvm.floor.v9f16(<9 x half> %va)
+  store <9 x half> %r, ptr addrspace(10) @wide_f16_9
+  ret void
+}
+
+define internal void @floor_float16() {
+entry:
+  ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function floor_float16
+  ; CHECK-COUNT-4: %{{[0-9]+}} = OpExtInst %[[#vec4f32]] %[[#ext]] Floor
+  %va = load <16 x float>, ptr addrspace(10) @wide_f32_16
+  %r = call <16 x float> @llvm.floor.v16f32(<16 x float> %va)
+  store <16 x float> %r, ptr addrspace(10) @wide_f32_16
+  ret void
+}
+
+define void @main() #0 {
+entry:
+  call void @floor_float6_from_shuffle()
+  call void @floor_half9()
+  call void @floor_float16()
+  ret void
+}
+
+declare <6 x float> @llvm.floor.v6f32(<6 x float>)
+declare <9 x half> @llvm.floor.v9f16(<9 x half>)
+declare <16 x float> @llvm.floor.v16f32(<16 x float>)
+
+attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/floor_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/floor_mat.ll
@@ -2,14 +2,14 @@
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
 
 ; CHECK-NOT: OpCapability Vector16
-; CHECK: OpCapability Float16
-; CHECK: %[[#ext:]] = OpExtInstImport "GLSL.std.450"
-; CHECK: %[[#void:]] = OpTypeVoid
-; CHECK: %[[#f32:]] = OpTypeFloat 32
-; CHECK: %[[#vec4f32:]] = OpTypeVector %[[#f32]] 4
-; CHECK: %[[#vec2f32:]] = OpTypeVector %[[#f32]] 2
-; CHECK: %[[#f16:]] = OpTypeFloat 16
-; CHECK: %[[#vec4f16:]] = OpTypeVector %[[#f16]] 4
+; CHECK-DAG: OpCapability Float16
+; CHECK-DAG: %[[#ext:]] = OpExtInstImport "GLSL.std.450"
+; CHECK-DAG: %[[#void:]] = OpTypeVoid
+; CHECK-DAG: %[[#f32:]] = OpTypeFloat 32
+; CHECK-DAG: %[[#vec4f32:]] = OpTypeVector %[[#f32]] 4
+; CHECK-DAG: %[[#vec2f32:]] = OpTypeVector %[[#f32]] 2
+; CHECK-DAG: %[[#f16:]] = OpTypeFloat 16
+; CHECK-DAG: %[[#vec4f16:]] = OpTypeVector %[[#f16]] 4
 
 @wide_f32_6 = internal addrspace(10) global [6 x float] zeroinitializer
 @wide_f16_9 = internal addrspace(10) global [9 x half] zeroinitializer

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/floor_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/floor_mat.ll
@@ -33,8 +33,7 @@ entry:
 define internal void @floor_half9() {
 entry:
   ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function floor_half9
-  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Floor
-  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Floor
+  ; CHECK-COUNT-2: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Floor
   ; CHECK: %{{[0-9]+}} = OpExtInst %[[#f16]] %[[#ext]] Floor
   %va = load <9 x half>, ptr addrspace(10) @wide_f16_9
   %r = call <9 x half> @llvm.floor.v9f16(<9 x half> %va)

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/log10_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/log10_mat.ll
@@ -2,14 +2,14 @@
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
 
 ; CHECK-NOT: OpCapability Vector16
-; CHECK: OpCapability Float16
-; CHECK: %[[#ext:]] = OpExtInstImport "GLSL.std.450"
-; CHECK: %[[#void:]] = OpTypeVoid
-; CHECK: %[[#f32:]] = OpTypeFloat 32
-; CHECK: %[[#vec4f32:]] = OpTypeVector %[[#f32]] 4
-; CHECK: %[[#vec2f32:]] = OpTypeVector %[[#f32]] 2
-; CHECK: %[[#f16:]] = OpTypeFloat 16
-; CHECK: %[[#vec4f16:]] = OpTypeVector %[[#f16]] 4
+; CHECK-DAG: OpCapability Float16
+; CHECK-DAG: %[[#ext:]] = OpExtInstImport "GLSL.std.450"
+; CHECK-DAG: %[[#void:]] = OpTypeVoid
+; CHECK-DAG: %[[#f32:]] = OpTypeFloat 32
+; CHECK-DAG: %[[#vec4f32:]] = OpTypeVector %[[#f32]] 4
+; CHECK-DAG: %[[#vec2f32:]] = OpTypeVector %[[#f32]] 2
+; CHECK-DAG: %[[#f16:]] = OpTypeFloat 16
+; CHECK-DAG: %[[#vec4f16:]] = OpTypeVector %[[#f16]] 4
 
 @wide_f32_6 = internal addrspace(10) global [6 x float] zeroinitializer
 @wide_f16_9 = internal addrspace(10) global [9 x half] zeroinitializer

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/log10_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/log10_mat.ll
@@ -1,0 +1,72 @@
+; RUN: llc -O0 -verify-machineinstrs -mtriple=spirv-unknown-vulkan %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
+
+; CHECK-NOT: OpCapability Vector16
+; CHECK: OpCapability Float16
+; CHECK: %[[#ext:]] = OpExtInstImport "GLSL.std.450"
+; CHECK: %[[#void:]] = OpTypeVoid
+; CHECK: %[[#f32:]] = OpTypeFloat 32
+; CHECK: %[[#vec4f32:]] = OpTypeVector %[[#f32]] 4
+; CHECK: %[[#vec2f32:]] = OpTypeVector %[[#f32]] 2
+; CHECK: %[[#f16:]] = OpTypeFloat 16
+; CHECK: %[[#vec4f16:]] = OpTypeVector %[[#f16]] 4
+
+@wide_f32_6 = internal addrspace(10) global [6 x float] zeroinitializer
+@wide_f16_9 = internal addrspace(10) global [9 x half] zeroinitializer
+@wide_f32_16 = internal addrspace(10) global [16 x float] zeroinitializer
+@shuffle_f32_4 = internal addrspace(10) global <4 x float> zeroinitializer
+
+define internal void @log10_float6_from_shuffle() {
+entry:
+  ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function log10_float6_from_shuffle
+  ; CHECK: %{{[0-9]+}} = OpLoad %[[#vec4f32]]
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f32]] %[[#ext]] Log2
+  ; CHECK: OpVectorTimesScalar
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec2f32]] %[[#ext]] Log2
+  ; CHECK: OpVectorTimesScalar
+  %vec = load <4 x float>, ptr addrspace(10) @shuffle_f32_4
+  %va = shufflevector <4 x float> %vec, <4 x float> %vec,
+            <6 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5>
+  %r = call <6 x float> @llvm.log10.v6f32(<6 x float> %va)
+  store <6 x float> %r, ptr addrspace(10) @wide_f32_6
+  ret void
+}
+
+define internal void @log10_half9() {
+entry:
+  ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function log10_half9
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Log2
+  ; CHECK: OpVectorTimesScalar
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Log2
+  ; CHECK: OpVectorTimesScalar
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#f16]] %[[#ext]] Log2
+  ; CHECK: OpFMul
+  %va = load <9 x half>, ptr addrspace(10) @wide_f16_9
+  %r = call <9 x half> @llvm.log10.v9f16(<9 x half> %va)
+  store <9 x half> %r, ptr addrspace(10) @wide_f16_9
+  ret void
+}
+
+define internal void @log10_float16() {
+entry:
+  ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function log10_float16
+  ; CHECK-COUNT-4: %{{[0-9]+}} = OpExtInst %[[#vec4f32]] %[[#ext]] Log2
+  %va = load <16 x float>, ptr addrspace(10) @wide_f32_16
+  %r = call <16 x float> @llvm.log10.v16f32(<16 x float> %va)
+  store <16 x float> %r, ptr addrspace(10) @wide_f32_16
+  ret void
+}
+
+define void @main() #0 {
+entry:
+  call void @log10_float6_from_shuffle()
+  call void @log10_half9()
+  call void @log10_float16()
+  ret void
+}
+
+declare <6 x float> @llvm.log10.v6f32(<6 x float>)
+declare <9 x half> @llvm.log10.v9f16(<9 x half>)
+declare <16 x float> @llvm.log10.v16f32(<16 x float>)
+
+attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/log2_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/log2_mat.ll
@@ -2,14 +2,14 @@
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
 
 ; CHECK-NOT: OpCapability Vector16
-; CHECK: OpCapability Float16
-; CHECK: %[[#ext:]] = OpExtInstImport "GLSL.std.450"
-; CHECK: %[[#void:]] = OpTypeVoid
-; CHECK: %[[#f32:]] = OpTypeFloat 32
-; CHECK: %[[#vec4f32:]] = OpTypeVector %[[#f32]] 4
-; CHECK: %[[#vec2f32:]] = OpTypeVector %[[#f32]] 2
-; CHECK: %[[#f16:]] = OpTypeFloat 16
-; CHECK: %[[#vec4f16:]] = OpTypeVector %[[#f16]] 4
+; CHECK-DAG: OpCapability Float16
+; CHECK-DAG: %[[#ext:]] = OpExtInstImport "GLSL.std.450"
+; CHECK-DAG: %[[#void:]] = OpTypeVoid
+; CHECK-DAG: %[[#f32:]] = OpTypeFloat 32
+; CHECK-DAG: %[[#vec4f32:]] = OpTypeVector %[[#f32]] 4
+; CHECK-DAG: %[[#vec2f32:]] = OpTypeVector %[[#f32]] 2
+; CHECK-DAG: %[[#f16:]] = OpTypeFloat 16
+; CHECK-DAG: %[[#vec4f16:]] = OpTypeVector %[[#f16]] 4
 
 @wide_f32_6 = internal addrspace(10) global [6 x float] zeroinitializer
 @wide_f16_9 = internal addrspace(10) global [9 x half] zeroinitializer

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/log2_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/log2_mat.ll
@@ -1,0 +1,67 @@
+; RUN: llc -O0 -verify-machineinstrs -mtriple=spirv-unknown-vulkan %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
+
+; CHECK-NOT: OpCapability Vector16
+; CHECK: OpCapability Float16
+; CHECK: %[[#ext:]] = OpExtInstImport "GLSL.std.450"
+; CHECK: %[[#void:]] = OpTypeVoid
+; CHECK: %[[#f32:]] = OpTypeFloat 32
+; CHECK: %[[#vec4f32:]] = OpTypeVector %[[#f32]] 4
+; CHECK: %[[#vec2f32:]] = OpTypeVector %[[#f32]] 2
+; CHECK: %[[#f16:]] = OpTypeFloat 16
+; CHECK: %[[#vec4f16:]] = OpTypeVector %[[#f16]] 4
+
+@wide_f32_6 = internal addrspace(10) global [6 x float] zeroinitializer
+@wide_f16_9 = internal addrspace(10) global [9 x half] zeroinitializer
+@wide_f32_16 = internal addrspace(10) global [16 x float] zeroinitializer
+@shuffle_f32_4 = internal addrspace(10) global <4 x float> zeroinitializer
+
+define internal void @log2_float6_from_shuffle() {
+entry:
+  ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function log2_float6_from_shuffle
+  ; CHECK: %{{[0-9]+}} = OpLoad %[[#vec4f32]]
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f32]] %[[#ext]] Log2
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec2f32]] %[[#ext]] Log2
+  %vec = load <4 x float>, ptr addrspace(10) @shuffle_f32_4
+  %va = shufflevector <4 x float> %vec, <4 x float> %vec,
+            <6 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5>
+  %r = call <6 x float> @llvm.log2.v6f32(<6 x float> %va)
+  store <6 x float> %r, ptr addrspace(10) @wide_f32_6
+  ret void
+}
+
+define internal void @log2_half9() {
+entry:
+  ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function log2_half9
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Log2
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Log2
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#f16]] %[[#ext]] Log2
+  %va = load <9 x half>, ptr addrspace(10) @wide_f16_9
+  %r = call <9 x half> @llvm.log2.v9f16(<9 x half> %va)
+  store <9 x half> %r, ptr addrspace(10) @wide_f16_9
+  ret void
+}
+
+define internal void @log2_float16() {
+entry:
+  ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function log2_float16
+  ; CHECK-COUNT-4: %{{[0-9]+}} = OpExtInst %[[#vec4f32]] %[[#ext]] Log2
+  %va = load <16 x float>, ptr addrspace(10) @wide_f32_16
+  %r = call <16 x float> @llvm.log2.v16f32(<16 x float> %va)
+  store <16 x float> %r, ptr addrspace(10) @wide_f32_16
+  ret void
+}
+
+define void @main() #0 {
+entry:
+  call void @log2_float6_from_shuffle()
+  call void @log2_half9()
+  call void @log2_float16()
+  ret void
+}
+
+declare <6 x float> @llvm.log2.v6f32(<6 x float>)
+declare <9 x half> @llvm.log2.v9f16(<9 x half>)
+declare <16 x float> @llvm.log2.v16f32(<16 x float>)
+
+attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/log2_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/log2_mat.ll
@@ -33,8 +33,7 @@ entry:
 define internal void @log2_half9() {
 entry:
   ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function log2_half9
-  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Log2
-  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Log2
+  ; CHECK-COUNT-2: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Log2
   ; CHECK: %{{[0-9]+}} = OpExtInst %[[#f16]] %[[#ext]] Log2
   %va = load <9 x half>, ptr addrspace(10) @wide_f16_9
   %r = call <9 x half> @llvm.log2.v9f16(<9 x half> %va)

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/log_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/log_mat.ll
@@ -2,14 +2,14 @@
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
 
 ; CHECK-NOT: OpCapability Vector16
-; CHECK: OpCapability Float16
-; CHECK: %[[#ext:]] = OpExtInstImport "GLSL.std.450"
-; CHECK: %[[#void:]] = OpTypeVoid
-; CHECK: %[[#f32:]] = OpTypeFloat 32
-; CHECK: %[[#vec4f32:]] = OpTypeVector %[[#f32]] 4
-; CHECK: %[[#vec2f32:]] = OpTypeVector %[[#f32]] 2
-; CHECK: %[[#f16:]] = OpTypeFloat 16
-; CHECK: %[[#vec4f16:]] = OpTypeVector %[[#f16]] 4
+; CHECK-DAG: OpCapability Float16
+; CHECK-DAG: %[[#ext:]] = OpExtInstImport "GLSL.std.450"
+; CHECK-DAG: %[[#void:]] = OpTypeVoid
+; CHECK-DAG: %[[#f32:]] = OpTypeFloat 32
+; CHECK-DAG: %[[#vec4f32:]] = OpTypeVector %[[#f32]] 4
+; CHECK-DAG: %[[#vec2f32:]] = OpTypeVector %[[#f32]] 2
+; CHECK-DAG: %[[#f16:]] = OpTypeFloat 16
+; CHECK-DAG: %[[#vec4f16:]] = OpTypeVector %[[#f16]] 4
 
 @wide_f32_6 = internal addrspace(10) global [6 x float] zeroinitializer
 @wide_f16_9 = internal addrspace(10) global [9 x half] zeroinitializer

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/log_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/log_mat.ll
@@ -1,0 +1,67 @@
+; RUN: llc -O0 -verify-machineinstrs -mtriple=spirv-unknown-vulkan %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
+
+; CHECK-NOT: OpCapability Vector16
+; CHECK: OpCapability Float16
+; CHECK: %[[#ext:]] = OpExtInstImport "GLSL.std.450"
+; CHECK: %[[#void:]] = OpTypeVoid
+; CHECK: %[[#f32:]] = OpTypeFloat 32
+; CHECK: %[[#vec4f32:]] = OpTypeVector %[[#f32]] 4
+; CHECK: %[[#vec2f32:]] = OpTypeVector %[[#f32]] 2
+; CHECK: %[[#f16:]] = OpTypeFloat 16
+; CHECK: %[[#vec4f16:]] = OpTypeVector %[[#f16]] 4
+
+@wide_f32_6 = internal addrspace(10) global [6 x float] zeroinitializer
+@wide_f16_9 = internal addrspace(10) global [9 x half] zeroinitializer
+@wide_f32_16 = internal addrspace(10) global [16 x float] zeroinitializer
+@shuffle_f32_4 = internal addrspace(10) global <4 x float> zeroinitializer
+
+define internal void @log_float6_from_shuffle() {
+entry:
+  ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function log_float6_from_shuffle
+  ; CHECK: %{{[0-9]+}} = OpLoad %[[#vec4f32]]
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f32]] %[[#ext]] Log
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec2f32]] %[[#ext]] Log
+  %vec = load <4 x float>, ptr addrspace(10) @shuffle_f32_4
+  %va = shufflevector <4 x float> %vec, <4 x float> %vec,
+            <6 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5>
+  %r = call <6 x float> @llvm.log.v6f32(<6 x float> %va)
+  store <6 x float> %r, ptr addrspace(10) @wide_f32_6
+  ret void
+}
+
+define internal void @log_half9() {
+entry:
+  ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function log_half9
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Log
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Log
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#f16]] %[[#ext]] Log
+  %va = load <9 x half>, ptr addrspace(10) @wide_f16_9
+  %r = call <9 x half> @llvm.log.v9f16(<9 x half> %va)
+  store <9 x half> %r, ptr addrspace(10) @wide_f16_9
+  ret void
+}
+
+define internal void @log_float16() {
+entry:
+  ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function log_float16
+  ; CHECK-COUNT-4: %{{[0-9]+}} = OpExtInst %[[#vec4f32]] %[[#ext]] Log
+  %va = load <16 x float>, ptr addrspace(10) @wide_f32_16
+  %r = call <16 x float> @llvm.log.v16f32(<16 x float> %va)
+  store <16 x float> %r, ptr addrspace(10) @wide_f32_16
+  ret void
+}
+
+define void @main() #0 {
+entry:
+  call void @log_float6_from_shuffle()
+  call void @log_half9()
+  call void @log_float16()
+  ret void
+}
+
+declare <6 x float> @llvm.log.v6f32(<6 x float>)
+declare <9 x half> @llvm.log.v9f16(<9 x half>)
+declare <16 x float> @llvm.log.v16f32(<16 x float>)
+
+attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/log_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/log_mat.ll
@@ -33,8 +33,7 @@ entry:
 define internal void @log_half9() {
 entry:
   ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function log_half9
-  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Log
-  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Log
+  ; CHECK-COUNT-2: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Log
   ; CHECK: %{{[0-9]+}} = OpExtInst %[[#f16]] %[[#ext]] Log
   %va = load <9 x half>, ptr addrspace(10) @wide_f16_9
   %r = call <9 x half> @llvm.log.v9f16(<9 x half> %va)

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/roundeven_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/roundeven_mat.ll
@@ -1,0 +1,67 @@
+; RUN: llc -O0 -verify-machineinstrs -mtriple=spirv-unknown-vulkan %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
+
+; CHECK-NOT: OpCapability Vector16
+; CHECK-DAG: OpCapability Float16
+; CHECK-DAG: %[[#ext:]] = OpExtInstImport "GLSL.std.450"
+; CHECK-DAG: %[[#void:]] = OpTypeVoid
+; CHECK-DAG: %[[#f32:]] = OpTypeFloat 32
+; CHECK-DAG: %[[#vec4f32:]] = OpTypeVector %[[#f32]] 4
+; CHECK-DAG: %[[#vec2f32:]] = OpTypeVector %[[#f32]] 2
+; CHECK-DAG: %[[#f16:]] = OpTypeFloat 16
+; CHECK-DAG: %[[#vec4f16:]] = OpTypeVector %[[#f16]] 4
+
+@wide_f32_6 = internal addrspace(10) global [6 x float] zeroinitializer
+@wide_f16_9 = internal addrspace(10) global [9 x half] zeroinitializer
+@wide_f32_16 = internal addrspace(10) global [16 x float] zeroinitializer
+@shuffle_f32_4 = internal addrspace(10) global <4 x float> zeroinitializer
+
+define internal void @roundeven_float6_from_shuffle() {
+entry:
+  ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function roundeven_float6_from_shuffle
+  ; CHECK: %{{[0-9]+}} = OpLoad %[[#vec4f32]]
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f32]] %[[#ext]] RoundEven
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec2f32]] %[[#ext]] RoundEven
+  %vec = load <4 x float>, ptr addrspace(10) @shuffle_f32_4
+  %va = shufflevector <4 x float> %vec, <4 x float> %vec,
+            <6 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5>
+  %r = call <6 x float> @llvm.roundeven.v6f32(<6 x float> %va)
+  store <6 x float> %r, ptr addrspace(10) @wide_f32_6
+  ret void
+}
+
+define internal void @roundeven_half9() {
+entry:
+  ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function roundeven_half9
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] RoundEven
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] RoundEven
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#f16]] %[[#ext]] RoundEven
+  %va = load <9 x half>, ptr addrspace(10) @wide_f16_9
+  %r = call <9 x half> @llvm.roundeven.v9f16(<9 x half> %va)
+  store <9 x half> %r, ptr addrspace(10) @wide_f16_9
+  ret void
+}
+
+define internal void @roundeven_float16() {
+entry:
+  ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function roundeven_float16
+  ; CHECK-COUNT-4: %{{[0-9]+}} = OpExtInst %[[#vec4f32]] %[[#ext]] RoundEven
+  %va = load <16 x float>, ptr addrspace(10) @wide_f32_16
+  %r = call <16 x float> @llvm.roundeven.v16f32(<16 x float> %va)
+  store <16 x float> %r, ptr addrspace(10) @wide_f32_16
+  ret void
+}
+
+define void @main() #0 {
+entry:
+  call void @roundeven_float6_from_shuffle()
+  call void @roundeven_half9()
+  call void @roundeven_float16()
+  ret void
+}
+
+declare <6 x float> @llvm.roundeven.v6f32(<6 x float>)
+declare <9 x half> @llvm.roundeven.v9f16(<9 x half>)
+declare <16 x float> @llvm.roundeven.v16f32(<16 x float>)
+
+attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/roundeven_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/roundeven_mat.ll
@@ -33,8 +33,7 @@ entry:
 define internal void @roundeven_half9() {
 entry:
   ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function roundeven_half9
-  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] RoundEven
-  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] RoundEven
+  ; CHECK-COUNT-2: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] RoundEven
   ; CHECK: %{{[0-9]+}} = OpExtInst %[[#f16]] %[[#ext]] RoundEven
   %va = load <9 x half>, ptr addrspace(10) @wide_f16_9
   %r = call <9 x half> @llvm.roundeven.v9f16(<9 x half> %va)

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/sin_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/sin_mat.ll
@@ -2,14 +2,14 @@
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
 
 ; CHECK-NOT: OpCapability Vector16
-; CHECK: OpCapability Float16
-; CHECK: %[[#ext:]] = OpExtInstImport "GLSL.std.450"
-; CHECK: %[[#void:]] = OpTypeVoid
-; CHECK: %[[#f32:]] = OpTypeFloat 32
-; CHECK: %[[#vec4f32:]] = OpTypeVector %[[#f32]] 4
-; CHECK: %[[#vec2f32:]] = OpTypeVector %[[#f32]] 2
-; CHECK: %[[#f16:]] = OpTypeFloat 16
-; CHECK: %[[#vec4f16:]] = OpTypeVector %[[#f16]] 4
+; CHECK-DAG: OpCapability Float16
+; CHECK-DAG: %[[#ext:]] = OpExtInstImport "GLSL.std.450"
+; CHECK-DAG: %[[#void:]] = OpTypeVoid
+; CHECK-DAG: %[[#f32:]] = OpTypeFloat 32
+; CHECK-DAG: %[[#vec4f32:]] = OpTypeVector %[[#f32]] 4
+; CHECK-DAG: %[[#vec2f32:]] = OpTypeVector %[[#f32]] 2
+; CHECK-DAG: %[[#f16:]] = OpTypeFloat 16
+; CHECK-DAG: %[[#vec4f16:]] = OpTypeVector %[[#f16]] 4
 
 @wide_f32_6 = internal addrspace(10) global [6 x float] zeroinitializer
 @wide_f16_9 = internal addrspace(10) global [9 x half] zeroinitializer

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/sin_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/sin_mat.ll
@@ -1,0 +1,67 @@
+; RUN: llc -O0 -verify-machineinstrs -mtriple=spirv-unknown-vulkan %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
+
+; CHECK-NOT: OpCapability Vector16
+; CHECK: OpCapability Float16
+; CHECK: %[[#ext:]] = OpExtInstImport "GLSL.std.450"
+; CHECK: %[[#void:]] = OpTypeVoid
+; CHECK: %[[#f32:]] = OpTypeFloat 32
+; CHECK: %[[#vec4f32:]] = OpTypeVector %[[#f32]] 4
+; CHECK: %[[#vec2f32:]] = OpTypeVector %[[#f32]] 2
+; CHECK: %[[#f16:]] = OpTypeFloat 16
+; CHECK: %[[#vec4f16:]] = OpTypeVector %[[#f16]] 4
+
+@wide_f32_6 = internal addrspace(10) global [6 x float] zeroinitializer
+@wide_f16_9 = internal addrspace(10) global [9 x half] zeroinitializer
+@wide_f32_16 = internal addrspace(10) global [16 x float] zeroinitializer
+@shuffle_f32_4 = internal addrspace(10) global <4 x float> zeroinitializer
+
+define internal void @sin_float6_from_shuffle() {
+entry:
+  ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function sin_float6_from_shuffle
+  ; CHECK: %{{[0-9]+}} = OpLoad %[[#vec4f32]]
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f32]] %[[#ext]] Sin
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec2f32]] %[[#ext]] Sin
+  %vec = load <4 x float>, ptr addrspace(10) @shuffle_f32_4
+  %va = shufflevector <4 x float> %vec, <4 x float> %vec,
+            <6 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5>
+  %r = call <6 x float> @llvm.sin.v6f32(<6 x float> %va)
+  store <6 x float> %r, ptr addrspace(10) @wide_f32_6
+  ret void
+}
+
+define internal void @sin_half9() {
+entry:
+  ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function sin_half9
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Sin
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Sin
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#f16]] %[[#ext]] Sin
+  %va = load <9 x half>, ptr addrspace(10) @wide_f16_9
+  %r = call <9 x half> @llvm.sin.v9f16(<9 x half> %va)
+  store <9 x half> %r, ptr addrspace(10) @wide_f16_9
+  ret void
+}
+
+define internal void @sin_float16() {
+entry:
+  ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function sin_float16
+  ; CHECK-COUNT-4: %{{[0-9]+}} = OpExtInst %[[#vec4f32]] %[[#ext]] Sin
+  %va = load <16 x float>, ptr addrspace(10) @wide_f32_16
+  %r = call <16 x float> @llvm.sin.v16f32(<16 x float> %va)
+  store <16 x float> %r, ptr addrspace(10) @wide_f32_16
+  ret void
+}
+
+define void @main() #0 {
+entry:
+  call void @sin_float6_from_shuffle()
+  call void @sin_half9()
+  call void @sin_float16()
+  ret void
+}
+
+declare <6 x float> @llvm.sin.v6f32(<6 x float>)
+declare <9 x half> @llvm.sin.v9f16(<9 x half>)
+declare <16 x float> @llvm.sin.v16f32(<16 x float>)
+
+attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/sin_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/sin_mat.ll
@@ -33,8 +33,7 @@ entry:
 define internal void @sin_half9() {
 entry:
   ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function sin_half9
-  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Sin
-  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Sin
+  ; CHECK-COUNT-2: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Sin
   ; CHECK: %{{[0-9]+}} = OpExtInst %[[#f16]] %[[#ext]] Sin
   %va = load <9 x half>, ptr addrspace(10) @wide_f16_9
   %r = call <9 x half> @llvm.sin.v9f16(<9 x half> %va)

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/sinh_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/sinh_mat.ll
@@ -2,14 +2,14 @@
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
 
 ; CHECK-NOT: OpCapability Vector16
-; CHECK: OpCapability Float16
-; CHECK: %[[#ext:]] = OpExtInstImport "GLSL.std.450"
-; CHECK: %[[#void:]] = OpTypeVoid
-; CHECK: %[[#f32:]] = OpTypeFloat 32
-; CHECK: %[[#vec4f32:]] = OpTypeVector %[[#f32]] 4
-; CHECK: %[[#vec2f32:]] = OpTypeVector %[[#f32]] 2
-; CHECK: %[[#f16:]] = OpTypeFloat 16
-; CHECK: %[[#vec4f16:]] = OpTypeVector %[[#f16]] 4
+; CHECK-DAG: OpCapability Float16
+; CHECK-DAG: %[[#ext:]] = OpExtInstImport "GLSL.std.450"
+; CHECK-DAG: %[[#void:]] = OpTypeVoid
+; CHECK-DAG: %[[#f32:]] = OpTypeFloat 32
+; CHECK-DAG: %[[#vec4f32:]] = OpTypeVector %[[#f32]] 4
+; CHECK-DAG: %[[#vec2f32:]] = OpTypeVector %[[#f32]] 2
+; CHECK-DAG: %[[#f16:]] = OpTypeFloat 16
+; CHECK-DAG: %[[#vec4f16:]] = OpTypeVector %[[#f16]] 4
 
 @wide_f32_6 = internal addrspace(10) global [6 x float] zeroinitializer
 @wide_f16_9 = internal addrspace(10) global [9 x half] zeroinitializer

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/sinh_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/sinh_mat.ll
@@ -1,0 +1,67 @@
+; RUN: llc -O0 -verify-machineinstrs -mtriple=spirv-unknown-vulkan %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
+
+; CHECK-NOT: OpCapability Vector16
+; CHECK: OpCapability Float16
+; CHECK: %[[#ext:]] = OpExtInstImport "GLSL.std.450"
+; CHECK: %[[#void:]] = OpTypeVoid
+; CHECK: %[[#f32:]] = OpTypeFloat 32
+; CHECK: %[[#vec4f32:]] = OpTypeVector %[[#f32]] 4
+; CHECK: %[[#vec2f32:]] = OpTypeVector %[[#f32]] 2
+; CHECK: %[[#f16:]] = OpTypeFloat 16
+; CHECK: %[[#vec4f16:]] = OpTypeVector %[[#f16]] 4
+
+@wide_f32_6 = internal addrspace(10) global [6 x float] zeroinitializer
+@wide_f16_9 = internal addrspace(10) global [9 x half] zeroinitializer
+@wide_f32_16 = internal addrspace(10) global [16 x float] zeroinitializer
+@shuffle_f32_4 = internal addrspace(10) global <4 x float> zeroinitializer
+
+define internal void @sinh_float6_from_shuffle() {
+entry:
+  ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function sinh_float6_from_shuffle
+  ; CHECK: %{{[0-9]+}} = OpLoad %[[#vec4f32]]
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f32]] %[[#ext]] Sinh
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec2f32]] %[[#ext]] Sinh
+  %vec = load <4 x float>, ptr addrspace(10) @shuffle_f32_4
+  %va = shufflevector <4 x float> %vec, <4 x float> %vec,
+            <6 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5>
+  %r = call <6 x float> @llvm.sinh.v6f32(<6 x float> %va)
+  store <6 x float> %r, ptr addrspace(10) @wide_f32_6
+  ret void
+}
+
+define internal void @sinh_half9() {
+entry:
+  ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function sinh_half9
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Sinh
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Sinh
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#f16]] %[[#ext]] Sinh
+  %va = load <9 x half>, ptr addrspace(10) @wide_f16_9
+  %r = call <9 x half> @llvm.sinh.v9f16(<9 x half> %va)
+  store <9 x half> %r, ptr addrspace(10) @wide_f16_9
+  ret void
+}
+
+define internal void @sinh_float16() {
+entry:
+  ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function sinh_float16
+  ; CHECK-COUNT-4: %{{[0-9]+}} = OpExtInst %[[#vec4f32]] %[[#ext]] Sinh
+  %va = load <16 x float>, ptr addrspace(10) @wide_f32_16
+  %r = call <16 x float> @llvm.sinh.v16f32(<16 x float> %va)
+  store <16 x float> %r, ptr addrspace(10) @wide_f32_16
+  ret void
+}
+
+define void @main() #0 {
+entry:
+  call void @sinh_float6_from_shuffle()
+  call void @sinh_half9()
+  call void @sinh_float16()
+  ret void
+}
+
+declare <6 x float> @llvm.sinh.v6f32(<6 x float>)
+declare <9 x half> @llvm.sinh.v9f16(<9 x half>)
+declare <16 x float> @llvm.sinh.v16f32(<16 x float>)
+
+attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/sinh_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/sinh_mat.ll
@@ -33,8 +33,7 @@ entry:
 define internal void @sinh_half9() {
 entry:
   ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function sinh_half9
-  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Sinh
-  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Sinh
+  ; CHECK-COUNT-2: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Sinh
   ; CHECK: %{{[0-9]+}} = OpExtInst %[[#f16]] %[[#ext]] Sinh
   %va = load <9 x half>, ptr addrspace(10) @wide_f16_9
   %r = call <9 x half> @llvm.sinh.v9f16(<9 x half> %va)

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/sqrt_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/sqrt_mat.ll
@@ -2,14 +2,14 @@
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
 
 ; CHECK-NOT: OpCapability Vector16
-; CHECK: OpCapability Float16
-; CHECK: %[[#ext:]] = OpExtInstImport "GLSL.std.450"
-; CHECK: %[[#void:]] = OpTypeVoid
-; CHECK: %[[#f32:]] = OpTypeFloat 32
-; CHECK: %[[#vec4f32:]] = OpTypeVector %[[#f32]] 4
-; CHECK: %[[#vec2f32:]] = OpTypeVector %[[#f32]] 2
-; CHECK: %[[#f16:]] = OpTypeFloat 16
-; CHECK: %[[#vec4f16:]] = OpTypeVector %[[#f16]] 4
+; CHECK-DAG: OpCapability Float16
+; CHECK-DAG: %[[#ext:]] = OpExtInstImport "GLSL.std.450"
+; CHECK-DAG: %[[#void:]] = OpTypeVoid
+; CHECK-DAG: %[[#f32:]] = OpTypeFloat 32
+; CHECK-DAG: %[[#vec4f32:]] = OpTypeVector %[[#f32]] 4
+; CHECK-DAG: %[[#vec2f32:]] = OpTypeVector %[[#f32]] 2
+; CHECK-DAG: %[[#f16:]] = OpTypeFloat 16
+; CHECK-DAG: %[[#vec4f16:]] = OpTypeVector %[[#f16]] 4
 
 @wide_f32_6 = internal addrspace(10) global [6 x float] zeroinitializer
 @wide_f16_9 = internal addrspace(10) global [9 x half] zeroinitializer

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/sqrt_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/sqrt_mat.ll
@@ -1,0 +1,67 @@
+; RUN: llc -O0 -verify-machineinstrs -mtriple=spirv-unknown-vulkan %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
+
+; CHECK-NOT: OpCapability Vector16
+; CHECK: OpCapability Float16
+; CHECK: %[[#ext:]] = OpExtInstImport "GLSL.std.450"
+; CHECK: %[[#void:]] = OpTypeVoid
+; CHECK: %[[#f32:]] = OpTypeFloat 32
+; CHECK: %[[#vec4f32:]] = OpTypeVector %[[#f32]] 4
+; CHECK: %[[#vec2f32:]] = OpTypeVector %[[#f32]] 2
+; CHECK: %[[#f16:]] = OpTypeFloat 16
+; CHECK: %[[#vec4f16:]] = OpTypeVector %[[#f16]] 4
+
+@wide_f32_6 = internal addrspace(10) global [6 x float] zeroinitializer
+@wide_f16_9 = internal addrspace(10) global [9 x half] zeroinitializer
+@wide_f32_16 = internal addrspace(10) global [16 x float] zeroinitializer
+@shuffle_f32_4 = internal addrspace(10) global <4 x float> zeroinitializer
+
+define internal void @sqrt_float6_from_shuffle() {
+entry:
+  ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function sqrt_float6_from_shuffle
+  ; CHECK: %{{[0-9]+}} = OpLoad %[[#vec4f32]]
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f32]] %[[#ext]] Sqrt
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec2f32]] %[[#ext]] Sqrt
+  %vec = load <4 x float>, ptr addrspace(10) @shuffle_f32_4
+  %va = shufflevector <4 x float> %vec, <4 x float> %vec,
+            <6 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5>
+  %r = call <6 x float> @llvm.sqrt.v6f32(<6 x float> %va)
+  store <6 x float> %r, ptr addrspace(10) @wide_f32_6
+  ret void
+}
+
+define internal void @sqrt_half9() {
+entry:
+  ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function sqrt_half9
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Sqrt
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Sqrt
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#f16]] %[[#ext]] Sqrt
+  %va = load <9 x half>, ptr addrspace(10) @wide_f16_9
+  %r = call <9 x half> @llvm.sqrt.v9f16(<9 x half> %va)
+  store <9 x half> %r, ptr addrspace(10) @wide_f16_9
+  ret void
+}
+
+define internal void @sqrt_float16() {
+entry:
+  ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function sqrt_float16
+  ; CHECK-COUNT-4: %{{[0-9]+}} = OpExtInst %[[#vec4f32]] %[[#ext]] Sqrt
+  %va = load <16 x float>, ptr addrspace(10) @wide_f32_16
+  %r = call <16 x float> @llvm.sqrt.v16f32(<16 x float> %va)
+  store <16 x float> %r, ptr addrspace(10) @wide_f32_16
+  ret void
+}
+
+define void @main() #0 {
+entry:
+  call void @sqrt_float6_from_shuffle()
+  call void @sqrt_half9()
+  call void @sqrt_float16()
+  ret void
+}
+
+declare <6 x float> @llvm.sqrt.v6f32(<6 x float>)
+declare <9 x half> @llvm.sqrt.v9f16(<9 x half>)
+declare <16 x float> @llvm.sqrt.v16f32(<16 x float>)
+
+attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/sqrt_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/sqrt_mat.ll
@@ -33,8 +33,7 @@ entry:
 define internal void @sqrt_half9() {
 entry:
   ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function sqrt_half9
-  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Sqrt
-  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Sqrt
+  ; CHECK-COUNT-2: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Sqrt
   ; CHECK: %{{[0-9]+}} = OpExtInst %[[#f16]] %[[#ext]] Sqrt
   %va = load <9 x half>, ptr addrspace(10) @wide_f16_9
   %r = call <9 x half> @llvm.sqrt.v9f16(<9 x half> %va)

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/tan_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/tan_mat.ll
@@ -2,14 +2,14 @@
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
 
 ; CHECK-NOT: OpCapability Vector16
-; CHECK: OpCapability Float16
-; CHECK: %[[#ext:]] = OpExtInstImport "GLSL.std.450"
-; CHECK: %[[#void:]] = OpTypeVoid
-; CHECK: %[[#f32:]] = OpTypeFloat 32
-; CHECK: %[[#vec4f32:]] = OpTypeVector %[[#f32]] 4
-; CHECK: %[[#vec2f32:]] = OpTypeVector %[[#f32]] 2
-; CHECK: %[[#f16:]] = OpTypeFloat 16
-; CHECK: %[[#vec4f16:]] = OpTypeVector %[[#f16]] 4
+; CHECK-DAG: OpCapability Float16
+; CHECK-DAG: %[[#ext:]] = OpExtInstImport "GLSL.std.450"
+; CHECK-DAG: %[[#void:]] = OpTypeVoid
+; CHECK-DAG: %[[#f32:]] = OpTypeFloat 32
+; CHECK-DAG: %[[#vec4f32:]] = OpTypeVector %[[#f32]] 4
+; CHECK-DAG: %[[#vec2f32:]] = OpTypeVector %[[#f32]] 2
+; CHECK-DAG: %[[#f16:]] = OpTypeFloat 16
+; CHECK-DAG: %[[#vec4f16:]] = OpTypeVector %[[#f16]] 4
 
 @wide_f32_6 = internal addrspace(10) global [6 x float] zeroinitializer
 @wide_f16_9 = internal addrspace(10) global [9 x half] zeroinitializer

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/tan_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/tan_mat.ll
@@ -1,0 +1,67 @@
+; RUN: llc -O0 -verify-machineinstrs -mtriple=spirv-unknown-vulkan %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
+
+; CHECK-NOT: OpCapability Vector16
+; CHECK: OpCapability Float16
+; CHECK: %[[#ext:]] = OpExtInstImport "GLSL.std.450"
+; CHECK: %[[#void:]] = OpTypeVoid
+; CHECK: %[[#f32:]] = OpTypeFloat 32
+; CHECK: %[[#vec4f32:]] = OpTypeVector %[[#f32]] 4
+; CHECK: %[[#vec2f32:]] = OpTypeVector %[[#f32]] 2
+; CHECK: %[[#f16:]] = OpTypeFloat 16
+; CHECK: %[[#vec4f16:]] = OpTypeVector %[[#f16]] 4
+
+@wide_f32_6 = internal addrspace(10) global [6 x float] zeroinitializer
+@wide_f16_9 = internal addrspace(10) global [9 x half] zeroinitializer
+@wide_f32_16 = internal addrspace(10) global [16 x float] zeroinitializer
+@shuffle_f32_4 = internal addrspace(10) global <4 x float> zeroinitializer
+
+define internal void @tan_float6_from_shuffle() {
+entry:
+  ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function tan_float6_from_shuffle
+  ; CHECK: %{{[0-9]+}} = OpLoad %[[#vec4f32]]
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f32]] %[[#ext]] Tan
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec2f32]] %[[#ext]] Tan
+  %vec = load <4 x float>, ptr addrspace(10) @shuffle_f32_4
+  %va = shufflevector <4 x float> %vec, <4 x float> %vec,
+            <6 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5>
+  %r = call <6 x float> @llvm.tan.v6f32(<6 x float> %va)
+  store <6 x float> %r, ptr addrspace(10) @wide_f32_6
+  ret void
+}
+
+define internal void @tan_half9() {
+entry:
+  ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function tan_half9
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Tan
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Tan
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#f16]] %[[#ext]] Tan
+  %va = load <9 x half>, ptr addrspace(10) @wide_f16_9
+  %r = call <9 x half> @llvm.tan.v9f16(<9 x half> %va)
+  store <9 x half> %r, ptr addrspace(10) @wide_f16_9
+  ret void
+}
+
+define internal void @tan_float16() {
+entry:
+  ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function tan_float16
+  ; CHECK-COUNT-4: %{{[0-9]+}} = OpExtInst %[[#vec4f32]] %[[#ext]] Tan
+  %va = load <16 x float>, ptr addrspace(10) @wide_f32_16
+  %r = call <16 x float> @llvm.tan.v16f32(<16 x float> %va)
+  store <16 x float> %r, ptr addrspace(10) @wide_f32_16
+  ret void
+}
+
+define void @main() #0 {
+entry:
+  call void @tan_float6_from_shuffle()
+  call void @tan_half9()
+  call void @tan_float16()
+  ret void
+}
+
+declare <6 x float> @llvm.tan.v6f32(<6 x float>)
+declare <9 x half> @llvm.tan.v9f16(<9 x half>)
+declare <16 x float> @llvm.tan.v16f32(<16 x float>)
+
+attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/tan_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/tan_mat.ll
@@ -33,8 +33,7 @@ entry:
 define internal void @tan_half9() {
 entry:
   ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function tan_half9
-  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Tan
-  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Tan
+  ; CHECK-COUNT-2: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Tan
   ; CHECK: %{{[0-9]+}} = OpExtInst %[[#f16]] %[[#ext]] Tan
   %va = load <9 x half>, ptr addrspace(10) @wide_f16_9
   %r = call <9 x half> @llvm.tan.v9f16(<9 x half> %va)

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/tanh_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/tanh_mat.ll
@@ -2,14 +2,14 @@
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
 
 ; CHECK-NOT: OpCapability Vector16
-; CHECK: OpCapability Float16
-; CHECK: %[[#ext:]] = OpExtInstImport "GLSL.std.450"
-; CHECK: %[[#void:]] = OpTypeVoid
-; CHECK: %[[#f32:]] = OpTypeFloat 32
-; CHECK: %[[#vec4f32:]] = OpTypeVector %[[#f32]] 4
-; CHECK: %[[#vec2f32:]] = OpTypeVector %[[#f32]] 2
-; CHECK: %[[#f16:]] = OpTypeFloat 16
-; CHECK: %[[#vec4f16:]] = OpTypeVector %[[#f16]] 4
+; CHECK-DAG: OpCapability Float16
+; CHECK-DAG: %[[#ext:]] = OpExtInstImport "GLSL.std.450"
+; CHECK-DAG: %[[#void:]] = OpTypeVoid
+; CHECK-DAG: %[[#f32:]] = OpTypeFloat 32
+; CHECK-DAG: %[[#vec4f32:]] = OpTypeVector %[[#f32]] 4
+; CHECK-DAG: %[[#vec2f32:]] = OpTypeVector %[[#f32]] 2
+; CHECK-DAG: %[[#f16:]] = OpTypeFloat 16
+; CHECK-DAG: %[[#vec4f16:]] = OpTypeVector %[[#f16]] 4
 
 @wide_f32_6 = internal addrspace(10) global [6 x float] zeroinitializer
 @wide_f16_9 = internal addrspace(10) global [9 x half] zeroinitializer

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/tanh_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/tanh_mat.ll
@@ -1,0 +1,67 @@
+; RUN: llc -O0 -verify-machineinstrs -mtriple=spirv-unknown-vulkan %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
+
+; CHECK-NOT: OpCapability Vector16
+; CHECK: OpCapability Float16
+; CHECK: %[[#ext:]] = OpExtInstImport "GLSL.std.450"
+; CHECK: %[[#void:]] = OpTypeVoid
+; CHECK: %[[#f32:]] = OpTypeFloat 32
+; CHECK: %[[#vec4f32:]] = OpTypeVector %[[#f32]] 4
+; CHECK: %[[#vec2f32:]] = OpTypeVector %[[#f32]] 2
+; CHECK: %[[#f16:]] = OpTypeFloat 16
+; CHECK: %[[#vec4f16:]] = OpTypeVector %[[#f16]] 4
+
+@wide_f32_6 = internal addrspace(10) global [6 x float] zeroinitializer
+@wide_f16_9 = internal addrspace(10) global [9 x half] zeroinitializer
+@wide_f32_16 = internal addrspace(10) global [16 x float] zeroinitializer
+@shuffle_f32_4 = internal addrspace(10) global <4 x float> zeroinitializer
+
+define internal void @tanh_float6_from_shuffle() {
+entry:
+  ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function tanh_float6_from_shuffle
+  ; CHECK: %{{[0-9]+}} = OpLoad %[[#vec4f32]]
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f32]] %[[#ext]] Tanh
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec2f32]] %[[#ext]] Tanh
+  %vec = load <4 x float>, ptr addrspace(10) @shuffle_f32_4
+  %va = shufflevector <4 x float> %vec, <4 x float> %vec,
+            <6 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5>
+  %r = call <6 x float> @llvm.tanh.v6f32(<6 x float> %va)
+  store <6 x float> %r, ptr addrspace(10) @wide_f32_6
+  ret void
+}
+
+define internal void @tanh_half9() {
+entry:
+  ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function tanh_half9
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Tanh
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Tanh
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#f16]] %[[#ext]] Tanh
+  %va = load <9 x half>, ptr addrspace(10) @wide_f16_9
+  %r = call <9 x half> @llvm.tanh.v9f16(<9 x half> %va)
+  store <9 x half> %r, ptr addrspace(10) @wide_f16_9
+  ret void
+}
+
+define internal void @tanh_float16() {
+entry:
+  ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function tanh_float16
+  ; CHECK-COUNT-4: %{{[0-9]+}} = OpExtInst %[[#vec4f32]] %[[#ext]] Tanh
+  %va = load <16 x float>, ptr addrspace(10) @wide_f32_16
+  %r = call <16 x float> @llvm.tanh.v16f32(<16 x float> %va)
+  store <16 x float> %r, ptr addrspace(10) @wide_f32_16
+  ret void
+}
+
+define void @main() #0 {
+entry:
+  call void @tanh_float6_from_shuffle()
+  call void @tanh_half9()
+  call void @tanh_float16()
+  ret void
+}
+
+declare <6 x float> @llvm.tanh.v6f32(<6 x float>)
+declare <9 x half> @llvm.tanh.v9f16(<9 x half>)
+declare <16 x float> @llvm.tanh.v16f32(<16 x float>)
+
+attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/tanh_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/tanh_mat.ll
@@ -33,8 +33,7 @@ entry:
 define internal void @tanh_half9() {
 entry:
   ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function tanh_half9
-  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Tanh
-  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Tanh
+  ; CHECK-COUNT-2: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Tanh
   ; CHECK: %{{[0-9]+}} = OpExtInst %[[#f16]] %[[#ext]] Tanh
   %va = load <9 x half>, ptr addrspace(10) @wide_f16_9
   %r = call <9 x half> @llvm.tanh.v9f16(<9 x half> %va)

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/trunc_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/trunc_mat.ll
@@ -2,14 +2,14 @@
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
 
 ; CHECK-NOT: OpCapability Vector16
-; CHECK: OpCapability Float16
-; CHECK: %[[#ext:]] = OpExtInstImport "GLSL.std.450"
-; CHECK: %[[#void:]] = OpTypeVoid
-; CHECK: %[[#f32:]] = OpTypeFloat 32
-; CHECK: %[[#vec4f32:]] = OpTypeVector %[[#f32]] 4
-; CHECK: %[[#vec2f32:]] = OpTypeVector %[[#f32]] 2
-; CHECK: %[[#f16:]] = OpTypeFloat 16
-; CHECK: %[[#vec4f16:]] = OpTypeVector %[[#f16]] 4
+; CHECK-DAG: OpCapability Float16
+; CHECK-DAG: %[[#ext:]] = OpExtInstImport "GLSL.std.450"
+; CHECK-DAG: %[[#void:]] = OpTypeVoid
+; CHECK-DAG: %[[#f32:]] = OpTypeFloat 32
+; CHECK-DAG: %[[#vec4f32:]] = OpTypeVector %[[#f32]] 4
+; CHECK-DAG: %[[#vec2f32:]] = OpTypeVector %[[#f32]] 2
+; CHECK-DAG: %[[#f16:]] = OpTypeFloat 16
+; CHECK-DAG: %[[#vec4f16:]] = OpTypeVector %[[#f16]] 4
 
 @wide_f32_6 = internal addrspace(10) global [6 x float] zeroinitializer
 @wide_f16_9 = internal addrspace(10) global [9 x half] zeroinitializer

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/trunc_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/trunc_mat.ll
@@ -1,0 +1,67 @@
+; RUN: llc -O0 -verify-machineinstrs -mtriple=spirv-unknown-vulkan %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
+
+; CHECK-NOT: OpCapability Vector16
+; CHECK: OpCapability Float16
+; CHECK: %[[#ext:]] = OpExtInstImport "GLSL.std.450"
+; CHECK: %[[#void:]] = OpTypeVoid
+; CHECK: %[[#f32:]] = OpTypeFloat 32
+; CHECK: %[[#vec4f32:]] = OpTypeVector %[[#f32]] 4
+; CHECK: %[[#vec2f32:]] = OpTypeVector %[[#f32]] 2
+; CHECK: %[[#f16:]] = OpTypeFloat 16
+; CHECK: %[[#vec4f16:]] = OpTypeVector %[[#f16]] 4
+
+@wide_f32_6 = internal addrspace(10) global [6 x float] zeroinitializer
+@wide_f16_9 = internal addrspace(10) global [9 x half] zeroinitializer
+@wide_f32_16 = internal addrspace(10) global [16 x float] zeroinitializer
+@shuffle_f32_4 = internal addrspace(10) global <4 x float> zeroinitializer
+
+define internal void @trunc_float6_from_shuffle() {
+entry:
+  ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function trunc_float6_from_shuffle
+  ; CHECK: %{{[0-9]+}} = OpLoad %[[#vec4f32]]
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f32]] %[[#ext]] Trunc
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec2f32]] %[[#ext]] Trunc
+  %vec = load <4 x float>, ptr addrspace(10) @shuffle_f32_4
+  %va = shufflevector <4 x float> %vec, <4 x float> %vec,
+            <6 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5>
+  %r = call <6 x float> @llvm.trunc.v6f32(<6 x float> %va)
+  store <6 x float> %r, ptr addrspace(10) @wide_f32_6
+  ret void
+}
+
+define internal void @trunc_half9() {
+entry:
+  ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function trunc_half9
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Trunc
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Trunc
+  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#f16]] %[[#ext]] Trunc
+  %va = load <9 x half>, ptr addrspace(10) @wide_f16_9
+  %r = call <9 x half> @llvm.trunc.v9f16(<9 x half> %va)
+  store <9 x half> %r, ptr addrspace(10) @wide_f16_9
+  ret void
+}
+
+define internal void @trunc_float16() {
+entry:
+  ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function trunc_float16
+  ; CHECK-COUNT-4: %{{[0-9]+}} = OpExtInst %[[#vec4f32]] %[[#ext]] Trunc
+  %va = load <16 x float>, ptr addrspace(10) @wide_f32_16
+  %r = call <16 x float> @llvm.trunc.v16f32(<16 x float> %va)
+  store <16 x float> %r, ptr addrspace(10) @wide_f32_16
+  ret void
+}
+
+define void @main() #0 {
+entry:
+  call void @trunc_float6_from_shuffle()
+  call void @trunc_half9()
+  call void @trunc_float16()
+  ret void
+}
+
+declare <6 x float> @llvm.trunc.v6f32(<6 x float>)
+declare <9 x half> @llvm.trunc.v9f16(<9 x half>)
+declare <16 x float> @llvm.trunc.v16f32(<16 x float>)
+
+attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/trunc_mat.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/trunc_mat.ll
@@ -33,8 +33,7 @@ entry:
 define internal void @trunc_half9() {
 entry:
   ; CHECK-LABEL: %{{[0-9]+}} = OpFunction %{{[0-9]+}} None %{{[0-9]+}} ; -- Begin function trunc_half9
-  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Trunc
-  ; CHECK: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Trunc
+  ; CHECK-COUNT-2: %{{[0-9]+}} = OpExtInst %[[#vec4f16]] %[[#ext]] Trunc
   ; CHECK: %{{[0-9]+}} = OpExtInst %[[#f16]] %[[#ext]] Trunc
   %va = load <9 x half>, ptr addrspace(10) @wide_f16_9
   %r = call <9 x half> @llvm.trunc.v9f16(<9 x half> %va)


### PR DESCRIPTION
fixes #220723

The issue in #220723 is that the global opcodes can not deduce the element type when the input is a shuffle vector. This is the same issue as #213783. All we have to do to fix this is to have deduceTypeFromUses in the SPIRVPostLegalizer know that we need to look up the type from the results register for these opcodes.

The secondary issue is that there were no matrix tests for any of these global opcodes so I added them. I did not follow the template started by the atan2 tests because those are overkill and testing way to much stuff not related to opcode legalization.

Assisted on the tests by MAI-Code-1.1-Flash