### PR TITLE
[flang][OpenMP] Fix predetermined variables with default(none)

### DIFF
--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -591,6 +591,8 @@ public:
   bool Pre(const parser::OpenMPInvalidDirective &x) { return false; }
 
   bool Pre(const parser::DoConstruct &);
+  bool Pre(const parser::InputImpliedDo &);
+  bool Pre(const parser::OutputImpliedDo &);
 
   bool Pre(const parser::OpenMPSectionsConstruct &);
   void Post(const parser::OpenMPSectionsConstruct &) { PopContext(); }
@@ -2216,6 +2218,28 @@ bool OmpAttributeVisitor::Pre(const parser::DoConstruct &x) {
   return true;
 }
 
+bool OmpAttributeVisitor::Pre(const parser::InputImpliedDo &x) {
+  if (WithinConstruct()) {
+    const auto &iv{parser::UnwrapRef<parser::Name>(
+        std::get<parser::IoImpliedDoControl>(x.t).Name())};
+    if (iv.symbol) {
+      ResolveSeqLoopIndexInParallelOrTaskConstruct(iv);
+    }
+  }
+  return true;
+}
+
+bool OmpAttributeVisitor::Pre(const parser::OutputImpliedDo &x) {
+  if (WithinConstruct()) {
+    const auto &iv{parser::UnwrapRef<parser::Name>(
+        std::get<parser::IoImpliedDoControl>(x.t).Name())};
+    if (iv.symbol) {
+      ResolveSeqLoopIndexInParallelOrTaskConstruct(iv);
+    }
+  }
+  return true;
+}
+
 // 2.15.1.1 Data-sharing Attribute Rules - Predetermined
 //   - The loop iteration variable(s) in the associated do-loop(s) of a do,
 //     parallel do, taskloop, or distribute construct is (are) private.
@@ -2651,6 +2675,13 @@ void OmpAttributeVisitor::CreateImplicitSymbols(
       }
     };
     initSymbolDSA(symbol, dsa);
+
+    // A predetermined symbol in a nested construct does not acquire an
+    // implicit DSA from an enclosing DEFAULT(NONE) construct.
+    if (symbol->test(Symbol::Flag::OmpPreDetermined) && dsa.none() &&
+        prevDSA.none() && dirContext.defaultDSA == Symbol::Flag::OmpNone) {
+      continue;
+    }
 
     // When handling each implicit rule for a given symbol, one of the
     // following actions may be taken:

--- a/flang/test/Semantics/OpenMP/resolve05.f90
+++ b/flang/test/Semantics/OpenMP/resolve05.f90
@@ -29,6 +29,71 @@ subroutine default_none_seq_loop
   enddo
 end subroutine
 
+! I/O implied-DO variables are predetermined private in the innermost
+! enclosing parallel construct. See https://github.com/llvm/llvm-project/issues/197396.
+subroutine default_none_output_implied_do
+  integer :: ido
+
+  call omp_set_num_threads(2)
+  !$omp parallel default(none)
+  print *, (ido, ido=1,2)
+  !$omp end parallel
+  print *, 'pass'
+end subroutine
+
+subroutine default_none_output_implied_do_arrays
+  use omp_lib
+  implicit none
+  integer, parameter :: n = 10
+  integer :: a(n) = 0, i = 0, b(n) = 0
+
+  !$omp parallel default(none) private(a) shared(b)
+  a = omp_get_thread_num()
+  !$omp critical
+  b = b + a
+  print *, (b(i), a(i), i=2,4)
+  !$omp end critical
+  !$omp end parallel
+end subroutine
+
+subroutine default_none_input_implied_do
+  implicit none
+  integer, parameter :: n = 10
+  integer :: a(n), i
+
+  !$omp parallel default(none) shared(a)
+  read *, (a(i), i=1,n)
+  !$omp end parallel
+end subroutine
+
+subroutine default_none_simd_loop(n)
+  implicit none
+  integer, intent(in) :: n
+  integer :: i
+
+  !$omp parallel default(none) shared(n)
+  !$omp simd
+  do i = 1, n
+  end do
+  !$omp end simd
+  !$omp end parallel
+end subroutine
+
+subroutine default_none_simd_loop_outer_reference(n)
+  implicit none
+  integer, intent(in) :: n
+  integer :: i
+
+  !$omp parallel default(none) shared(n)
+  !$omp simd
+  do i = 1, n
+  end do
+  !$omp end simd
+  !ERROR: The DEFAULT(NONE) clause requires that 'i' must be listed in a data-sharing attribute clause
+  print *, i
+  !$omp end parallel
+end subroutine
+
 ! Test that DEFAULT(NONE) error check sees implicit references
 subroutine default_none_nested()
   integer :: a

--- a/flang/test/Semantics/OpenMP/symbol08.f90
+++ b/flang/test/Semantics/OpenMP/symbol08.f90
@@ -249,3 +249,30 @@ subroutine test_seq_loop
   !REF: /test_seq_loop/j
   print *, i, j
 end subroutine test_seq_loop
+
+! I/O implied-DO variables are private in the innermost enclosing parallel
+! or task generating construct.
+!DEF: /test_output_implied_do (Subroutine) Subprogram
+subroutine test_output_implied_do
+  implicit none
+  !DEF: /test_output_implied_do/i ObjectEntity INTEGER(4)
+  integer i
+  !$omp parallel default(none)
+  !DEF: /test_output_implied_do/OtherConstruct1/i (OmpPrivate, OmpPreDetermined) HostAssoc INTEGER(4)
+  print *, (i, i=1,2)
+  !$omp end parallel
+end subroutine test_output_implied_do
+
+!DEF: /test_input_implied_do (Subroutine) Subprogram
+!DEF: /test_input_implied_do/a ObjectEntity INTEGER(4)
+subroutine test_input_implied_do(a)
+  implicit none
+  !REF: /test_input_implied_do/a
+  !DEF: /test_input_implied_do/i ObjectEntity INTEGER(4)
+  integer a(2), i
+  !$omp parallel default(none) shared(a)
+  !DEF: /test_input_implied_do/OtherConstruct1/a (OmpShared, OmpExplicit) HostAssoc INTEGER(4)
+  !DEF: /test_input_implied_do/OtherConstruct1/i (OmpPrivate, OmpPreDetermined) HostAssoc INTEGER(4)
+  read *, (a(i), i=1,2)
+  !$omp end parallel
+end subroutine test_input_implied_do


### PR DESCRIPTION
Treat input and output implied-DO indices as predetermined private variables when they occur inside OpenMP parallel or task-generating constructs.

Also prevent variables with predetermined attributes in nested constructs from incorrectly acquiring an implicit data-sharing attribute from an enclosing `default(none)` construct.

Add semantic and symbol-resolution coverage for:
- Input and output implied-DO indices
- Array I/O implied-DOs
- Loop variables in nested `simd` constructs
- References to loop variables outside the construct where `default(none)` should still require an explicit data-sharing attribute

Fixes #197396.