### PR TITLE
[LowerTypeTests] Keep imported CFI functions inlinable in the ThinLTO backend

### DIFF
--- a/llvm/lib/Transforms/IPO/LowerTypeTests.cpp
+++ b/llvm/lib/Transforms/IPO/LowerTypeTests.cpp
@@ -540,11 +540,10 @@ class LowerTypeTestsModule {
   void createJumpTable(Function *F, ArrayRef<GlobalTypeMember *> Functions,
                        Triple::ArchType JumpTableArch);
 
-  /// replaceCfiUses - Go through the uses list for this definition
-  /// and make each use point to "V" instead of "this" when the use is outside
-  /// the block. 'This's use list is expected to have at least one element.
-  /// Unlike replaceAllUsesWith this function skips blockaddr and direct call
-  /// uses.
+  /// replaceCfiUses - Go through the uses list for this definition and make
+  /// each use point to "New" instead of "Old" when the use is outside the
+  /// block. 'Old's use list is expected to have at least one element.  Unlike
+  /// replaceAllUsesWith this function skips blockaddr and direct call uses.
   void replaceCfiUses(Function *Old, Value *New, bool IsJumpTableCanonical);
 
   /// replaceDirectCalls - Go through the uses list for this definition and
@@ -1090,15 +1089,26 @@ void LowerTypeTestsModule::importFunction(Function *F,
   if (F->isDeclarationForLinker() && isJumpTableCanonical) {
     // Non-dso_local functions may be overriden at run time,
     // don't short curcuit them
-    if (F->isDSOLocal()) {
+    if (!F->isDSOLocal())
+      return;
+    if (F->isDeclaration()) {
+      // Direct calls do not need the type check, so let them skip the jump
+      // table and call the real function directly.
       Function *RealF = Function::Create(F->getFunctionType(),
                                          GlobalValue::ExternalLinkage,
                                          F->getAddressSpace(),
                                          Name + ".cfi", &M);
       RealF->setVisibility(GlobalVariable::HiddenVisibility);
       replaceDirectCalls(F, RealF);
+      return;
     }
-    return;
+    // Otherwise F is an available_externally definition imported from
+    // another module. Handle it like a local definition below: the body is
+    // renamed to Name.cfi and stays the target of direct calls, so it remains
+    // inlinable, while address-taken uses are redirected to the jump table
+    // entry. If the body is not inlined and is dropped later, the reference
+    // to Name.cfi resolves to the real function at link time, exactly as for
+    // a declaration.
   }
 
   Function *FDecl;
@@ -2034,7 +2044,7 @@ void LowerTypeTestsModule::replaceCfiUses(Function *Old, Value *New,
     if (isa<NoCFIValue>(U.getUser()))
       continue;
 
-    // Skip direct calls to externally defined or non-dso_local functions.
+    // Skip direct calls to externally defined or dso_local functions.
     if (isDirectCall(U) && (Old->isDSOLocal() || !IsJumpTableCanonical))
       continue;
 

--- a/llvm/test/ThinLTO/X86/cfi-icall-import-inline.ll
+++ b/llvm/test/ThinLTO/X86/cfi-icall-import-inline.ll
@@ -1,0 +1,78 @@
+; Check that a function imported by ThinLTO which is also a CFI jump table
+; member can still be inlined in the importing module. LowerTypeTests must keep
+; direct calls pointing at the imported body (renamed to hot.cfi) rather than
+; redirecting them to a declaration of the real function.
+
+; REQUIRES: x86-registered-target
+
+; RUN: rm -rf %t.dir && split-file %s %t.dir
+; RUN: opt -thinlto-bc -thinlto-split-lto-unit %t.dir/a.ll -o %t.dir/a.bc
+; RUN: opt -thinlto-bc -thinlto-split-lto-unit %t.dir/b.ll -o %t.dir/b.bc
+; RUN: llvm-lto2 run -save-temps %t.dir/a.bc %t.dir/b.bc -o %t.dir/out \
+; RUN:   -r=%t.dir/a.bc,hot,plx \
+; RUN:   -r=%t.dir/a.bc,indirect,plx \
+; RUN:   -r=%t.dir/a.bc,get,plx \
+; RUN:   -r=%t.dir/b.bc,hot,l \
+; RUN:   -r=%t.dir/b.bc,caller,plx
+; RUN: llvm-dis %t.dir/out.2.3.import.bc -o - | FileCheck %s --check-prefix=IMPORT
+; RUN: llvm-dis %t.dir/out.2.4.opt.bc -o - | FileCheck %s --check-prefix=OPT
+; RUN: llvm-dis %t.dir/out.0.4.opt.bc -o - | FileCheck %s --check-prefix=JT
+
+; @hot is imported into b.ll as an available_externally definition.
+; IMPORT: define available_externally hidden i32 @hot(i32 %x)
+
+; After optimization the imported body has been inlined into @caller.
+; OPT-LABEL: define hidden {{.*}}i32 @caller(i32
+; OPT-NOT: call
+; OPT: mul {{.*}}i32 %x, 3
+; OPT-NEXT: ret i32
+
+; In the regular-LTO module, @hot aliases the jump table trampoline to @hot.cfi.
+; JT-DAG: @hot = {{.*}}alias {{.*}}ptr @.cfi.jumptable
+; JT-DAG: @__typeid__ZTSFiiE_global_addr = {{.*}}alias {{.*}}ptr @.cfi.jumptable
+; JT-DAG: declare {{.*}}void @hot.cfi()
+; JT: define private void @.cfi.jumptable()
+; JT: call void asm sideeffect "jmp {{.*}}@plt{{.*}}"{{.*}}(ptr @hot.cfi)
+
+;--- a.ll
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+define hidden i32 @hot(i32 %x) !type !0 {
+  %r = mul i32 %x, 3
+  ret i32 %r
+}
+
+; An indirect call through the type of @hot puts @hot into a jump table.
+define hidden i32 @indirect(ptr %f, i32 %x) {
+  %t = call i1 @llvm.type.test(ptr %f, metadata !"_ZTSFiiE")
+  br i1 %t, label %cont, label %trap
+
+trap:
+  call void @llvm.ubsantrap(i8 2)
+  unreachable
+
+cont:
+  %r = call i32 %f(i32 %x)
+  ret i32 %r
+}
+
+define hidden ptr @get() {
+  ret ptr @hot
+}
+
+declare i1 @llvm.type.test(ptr, metadata)
+declare void @llvm.ubsantrap(i8)
+
+!0 = !{i64 0, !"_ZTSFiiE"}
+
+;--- b.ll
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+declare hidden i32 @hot(i32)
+
+define hidden i32 @caller(i32 %x) {
+  %r = call i32 @hot(i32 %x)
+  ret i32 %r
+}

--- a/llvm/test/Transforms/LowerTypeTests/Inputs/import-icall.yaml
+++ b/llvm/test/Transforms/LowerTypeTests/Inputs/import-icall.yaml
@@ -16,6 +16,10 @@ CfiFunctionDefs:
   GUID: 3388953113786086079
 - Name: does_not_exist
   GUID: 3974636296533007648
+- Name: imported_a
+  GUID: 3911367325508726226
+- Name: imported_b
+  GUID: 6352548445926811250
 CfiFunctionDecls:
 - Name: external
   GUID: 5224464028922159466

--- a/llvm/test/Transforms/LowerTypeTests/import-icall.ll
+++ b/llvm/test/Transforms/LowerTypeTests/import-icall.ll
@@ -29,6 +29,33 @@ define ptr @local_decl() {
   ret ptr @local_decl
 }
 
+; An available_externally function imported from another module. Its body must
+; remain the target of direct calls so that the inliner can still see it; only
+; address-taken uses are redirected to the jump table entry.
+define available_externally dso_local i8 @imported_a() {
+  ret i8 3
+}
+
+define i8 @use_imported_a() {
+  %x = call i8 @imported_a()
+  ret i8 %x
+}
+
+define ptr @addr_imported_a() {
+  ret ptr @imported_a
+}
+
+; A non-dso_local available_externally function may be preempted at run time,
+; so it is left alone.
+define available_externally i8 @imported_b() {
+  ret i8 4
+}
+
+define i8 @use_imported_b() {
+  %x = call i8 @imported_b()
+  ret i8 %x
+}
+
 declare void @external()
 declare extern_weak void @external_weak()
 
@@ -48,8 +75,24 @@ declare extern_weak void @external_weak()
 ; CHECK-NEXT:   call ptr @local_decl()
 ; CHECK-NEXT:   ret ptr @local_decl.cfi_jt
 
+; CHECK:      define available_externally hidden i8 @imported_a.cfi()
+; CHECK-NEXT:   ret i8 3
+
+; CHECK:      define i8 @use_imported_a()
+; CHECK-NEXT:   call i8 @imported_a.cfi()
+
+; CHECK:      define ptr @addr_imported_a()
+; CHECK-NEXT:   ret ptr @imported_a
+
+; CHECK:      define available_externally i8 @imported_b()
+; CHECK-NEXT:   ret i8 4
+
+; CHECK:      define i8 @use_imported_b()
+; CHECK-NEXT:   call i8 @imported_b()
+
 ; CHECK: declare void @external()
 ; CHECK: declare extern_weak void @external_weak()
 ; CHECK: declare i8 @local_a()
+; CHECK: declare dso_local i8 @imported_a()
 ; CHECK: declare hidden void @external.cfi_jt()
 ; CHECK: declare hidden void @external_weak.cfi_jt()


### PR DESCRIPTION
In the ThinLTO backend, importFunction() treated imported available_externally definitions like declarations: it created a bodiless declaration of the real function (foo.cfi) and redirected all direct calls to it so that they skip the jump table. Since LowerTypeTests runs at the start of the backend pipeline, this happened before the inliner ever saw the call, and the imported body became unreferenced. As a result, with -fsanitize=cfi-icall and ThinLTO, no function that is a member of a jump table (i.e. whose type is checked by any indirect call in the program) could be inlined across modules, which defeats the main purpose of importing it.

Handle imported definitions the same way as local definitions instead: rename the body to foo.cfi, keep direct calls pointing at it, and redirect only address-taken uses to the jump table entry.

Assisted-by: Claude Code