### PR TITLE
[Comment] Fix @method/@methodgroup/@callback false positives

### DIFF
--- a/clang/lib/AST/CommentSema.cpp
+++ b/clang/lib/AST/CommentSema.cpp
@@ -111,13 +111,16 @@ void Sema::checkFunctionDeclVerbatimLine(const BlockCommandComment *Comment) {
         DiagSelect = diag::CallableKind::FunctionGroup;
       break;
     case CommandTraits::KCI_method:
-      DiagSelect = diag::CallableKind::Method;
+      if (!isObjCMethodDecl())
+        DiagSelect = diag::CallableKind::Method;
       break;
     case CommandTraits::KCI_methodgroup:
-      DiagSelect = diag::CallableKind::MethodGroup;
+      if (!isObjCMethodDecl())
+        DiagSelect = diag::CallableKind::MethodGroup;
       break;
     case CommandTraits::KCI_callback:
-      DiagSelect = diag::CallableKind::Callback;
+      if (!isFunctionPointerVarDecl())
+        DiagSelect = diag::CallableKind::Callback;
       break;
   }
   if (DiagSelect)

--- a/clang/test/Sema/warn-documentation.cpp
+++ b/clang/test/Sema/warn-documentation.cpp
@@ -834,6 +834,12 @@ unsigned test_function(Base64Flags inFlags);
 typedef unsigned int BaseFlags;
 unsigned (*test_callback)(BaseFlags inFlags);
 
+// @callback should not warn when the comment is directly attached to a
+// pointer to function declaration.
+/*! @callback test_callback_attached
+*/
+unsigned (*test_callback_attached)(BaseFlags inFlags);
+
 // expected-warning@+1 {{'\endverbatim' command does not terminate a verbatim text block}}
 /// \endverbatim
 int test_verbatim_1();

--- a/clang/test/Sema/warn-documentation.m
+++ b/clang/test/Sema/warn-documentation.m
@@ -135,6 +135,18 @@ typedef unsigned int NSTimeInterval;
 - (id)initWithTimeout:(NSTimeInterval)timeout;
 @end
 
+// @method and @methodgroup should not warn when the comment is directly
+// attached to an Objective-C method declaration.
+@interface TestMethodAndMethodgroupAttached
+/*!
+ @methodgroup Creating a request
+*/
+/*!
+ @method doSomething
+*/
+- (id)doSomething;
+@end
+
 // expected-warning@+2 {{'@protocol' command should not be used in a comment attached to a non-protocol declaration}}
 /*!
 @protocol PROTO


### PR DESCRIPTION
76af74004e8b (#181769) refactored the DiagSelect computation in checkFunctionDeclVerbatimLine to use named enum constants instead of magic numbers. The checks for whether the comment was attached to an Objective-C method, a method group, or a pointer to a function declaration were removed for the @method, @methodgroup, and @callback cases, which caused warn_doc_function_method_decl_mismatch to be emitted even when the comments were attached to matching declarations.

Restore the dropped checks.

rdar://184264978