### PR TITLE
[ADT] Invalidate iterators on move and swap in SmallPtrSet and StringMap

### DIFF
--- a/llvm/include/llvm/ADT/StringMap.h
+++ b/llvm/include/llvm/ADT/StringMap.h
@@ -49,6 +49,7 @@ protected:
     RHS.TheTable = nullptr;
     RHS.NumBuckets = 0;
     RHS.NumItems = 0;
+    RHS.incrementEpoch();
   }
 
   LLVM_ABI StringMapImpl(unsigned InitSize, unsigned ItemSize);

--- a/llvm/lib/Support/SmallPtrSet.cpp
+++ b/llvm/lib/Support/SmallPtrSet.cpp
@@ -198,6 +198,8 @@ void SmallPtrSetImplBase::moveHelper(const void **SmallStorage,
                                      const void **RHSSmallStorage,
                                      SmallPtrSetImplBase &&RHS) {
   assert(&RHS != this && "Self-move should be handled by the caller.");
+  incrementEpoch();
+  RHS.incrementEpoch();
 
   if (RHS.isSmall()) {
     // Copy a small RHS rather than moving.
@@ -223,6 +225,8 @@ void SmallPtrSetImplBase::swap(const void **SmallStorage,
                                const void **RHSSmallStorage,
                                SmallPtrSetImplBase &RHS) {
   if (this == &RHS) return;
+  incrementEpoch();
+  RHS.incrementEpoch();
 
   // We can only avoid copying elements if neither set is small.
   if (!this->isSmall() && !RHS.isSmall()) {

--- a/llvm/unittests/ADT/DenseMapTest.cpp
+++ b/llvm/unittests/ADT/DenseMapTest.cpp
@@ -1176,6 +1176,23 @@ TEST(DenseMapCustomTest, InsertInvalidatesIteratorComparison) {
   Map.try_emplace(2, 20);
   EXPECT_DEATH((void)(It == Map.end()), "incomparable iterators");
 }
+
+TEST(DenseMapCustomTest, MoveConstructInvalidatesIterators) {
+  DenseMap<int, int> M;
+  M.try_emplace(1, 10);
+  auto It = M.find(1);
+  DenseMap<int, int> Other = std::move(M);
+  EXPECT_DEATH((void)It->second, "invalid iterator access");
+}
+
+TEST(DenseMapCustomTest, MoveAssignInvalidatesIterators) {
+  DenseMap<int, int> M;
+  M.try_emplace(1, 10);
+  auto It = M.find(1);
+  DenseMap<int, int> Other;
+  Other = std::move(M);
+  EXPECT_DEATH((void)It->second, "invalid iterator access");
+}
 #endif
 
 } // namespace

--- a/llvm/unittests/ADT/SmallPtrSetTest.cpp
+++ b/llvm/unittests/ADT/SmallPtrSetTest.cpp
@@ -481,3 +481,34 @@ TEST(SmallPtrSetTest, Reserve) {
   Set.reserve(192);
   EXPECT_EQ(Set.capacity(), 512u);
 }
+
+#if LLVM_ENABLE_ABI_BREAKING_CHECKS
+TEST(SmallPtrSetTest, SwapInvalidatesIterators) {
+  int buf[1];
+  SmallPtrSet<int *, 2> Set;
+  Set.insert(&buf[0]);
+  auto It = Set.begin();
+  SmallPtrSet<int *, 2> Other;
+  Set.swap(Other);
+  EXPECT_DEATH((void)*It, "invalid iterator access");
+}
+
+TEST(SmallPtrSetTest, MoveConstructInvalidatesIterators) {
+  int buf[1];
+  SmallPtrSet<int *, 2> Set;
+  Set.insert(&buf[0]);
+  auto It = Set.begin();
+  SmallPtrSet<int *, 2> Other = std::move(Set);
+  EXPECT_DEATH((void)*It, "invalid iterator access");
+}
+
+TEST(SmallPtrSetTest, MoveAssignInvalidatesIterators) {
+  int buf[1];
+  SmallPtrSet<int *, 2> Set;
+  Set.insert(&buf[0]);
+  auto It = Set.begin();
+  SmallPtrSet<int *, 2> Other;
+  Other = std::move(Set);
+  EXPECT_DEATH((void)*It, "invalid iterator access");
+}
+#endif

--- a/llvm/unittests/ADT/StringMapTest.cpp
+++ b/llvm/unittests/ADT/StringMapTest.cpp
@@ -890,6 +890,23 @@ TEST(StringMapCustomTest, SwapInvalidatesIterators) {
   EXPECT_DEATH((void)It->second, "invalid iterator access");
 }
 
+TEST(StringMapCustomTest, MoveConstructInvalidatesIterators) {
+  StringMap<int> Map;
+  Map["a"] = 1;
+  auto It = Map.find("a");
+  StringMap<int> Other = std::move(Map);
+  EXPECT_DEATH((void)It->second, "invalid iterator access");
+}
+
+TEST(StringMapCustomTest, MoveAssignInvalidatesIterators) {
+  StringMap<int> Map;
+  Map["a"] = 1;
+  auto It = Map.find("a");
+  StringMap<int> Other;
+  Other = std::move(Map);
+  EXPECT_DEATH((void)It->second, "invalid iterator access");
+}
+
 TEST(StringMapCustomTest, IteratorComparability) {
   StringMap<int>::iterator I1, I2;
   EXPECT_EQ(I1, I2);


### PR DESCRIPTION
This patch adds missing incrementEpoch() calls to:

- StringMapImpl's move constructor.
- SmallPtrSetImplBase's moveHelper() (move construction and assignment).
- SmallPtrSetImplBase's swap().

This ensures that existing iterators pointing into moved-from or
swapped containers are properly invalidated in debug mode.

Assisted-by: Antigravity
