### PR TITLE
[libc] Add <sys/user.h> for Linux-x86_64

### DIFF
--- a/libc/config/linux/x86_64/headers.txt
+++ b/libc/config/linux/x86_64/headers.txt
@@ -81,6 +81,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.sys_uio
     libc.include.sys_un
     libc.include.sys_unistd
+    libc.include.sys_user
     libc.include.sys_utsname
     libc.include.sys_vfs
     libc.include.sys_wait

--- a/libc/include/CMakeLists.txt
+++ b/libc/include/CMakeLists.txt
@@ -1047,6 +1047,15 @@ add_header_macro(
 )
 
 add_header_macro(
+  sys_user
+  ../libc/include/sys/user.yaml
+  sys/user.h
+  DEPENDS
+    .llvm_libc_common_h
+    .llvm-libc-types.struct_user_regs_struct
+)
+
+add_header_macro(
   sys_vfs
   ../libc/include/sys/vfs.yaml
   sys/vfs.h

--- a/libc/include/llvm-libc-types/CMakeLists.txt
+++ b/libc/include/llvm-libc-types/CMakeLists.txt
@@ -619,6 +619,7 @@ endif()
 
 add_type_header(mcontext_t HDR mcontext_t.h)
 add_type_header(ucontext_t HDR ucontext_t.h)
+add_type_header(struct_user_regs_struct HDR struct_user_regs_struct.h)
 
 # UEFI
 add_header(EFI_GUID HDR EFI_GUID.h DEPENDS libc.include.llvm-libc-macros.stdint_macros)

--- a/libc/include/llvm-libc-types/struct_user_regs_struct.h
+++ b/libc/include/llvm-libc-types/struct_user_regs_struct.h
@@ -1,0 +1,23 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Definition of type struct user_regs_struct.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TYPES_STRUCT_USER_REGS_STRUCT_H
+#define LLVM_LIBC_TYPES_STRUCT_USER_REGS_STRUCT_H
+
+#if defined(__x86_64__)
+#include "x86_64/struct_user_regs_struct.h"
+#else
+#error "struct user_regs_struct not available for your target architecture."
+#endif
+
+#endif // LLVM_LIBC_TYPES_STRUCT_USER_REGS_STRUCT_H

--- a/libc/include/llvm-libc-types/x86_64/CMakeLists.txt
+++ b/libc/include/llvm-libc-types/x86_64/CMakeLists.txt
@@ -5,6 +5,12 @@ add_header(
 )
 
 add_header(
+  struct_user_regs_struct
+  HDR
+    struct_user_regs_struct.h
+)
+
+add_header(
   ucontext_t
   HDR
     ucontext_t.h

--- a/libc/include/llvm-libc-types/x86_64/struct_user_regs_struct.h
+++ b/libc/include/llvm-libc-types/x86_64/struct_user_regs_struct.h
@@ -1,0 +1,47 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Definition of struct user_regs_struct for x86_64.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TYPES_X86_64_STRUCT_USER_REGS_STRUCT_H
+#define LLVM_LIBC_TYPES_X86_64_STRUCT_USER_REGS_STRUCT_H
+
+struct user_regs_struct {
+  unsigned long long r15;
+  unsigned long long r14;
+  unsigned long long r13;
+  unsigned long long r12;
+  unsigned long long rbp;
+  unsigned long long rbx;
+  unsigned long long r11;
+  unsigned long long r10;
+  unsigned long long r9;
+  unsigned long long r8;
+  unsigned long long rax;
+  unsigned long long rcx;
+  unsigned long long rdx;
+  unsigned long long rsi;
+  unsigned long long rdi;
+  unsigned long long orig_rax;
+  unsigned long long rip;
+  unsigned long long cs;
+  unsigned long long eflags;
+  unsigned long long rsp;
+  unsigned long long ss;
+  unsigned long long fs_base;
+  unsigned long long gs_base;
+  unsigned long long ds;
+  unsigned long long es;
+  unsigned long long fs;
+  unsigned long long gs;
+};
+
+#endif // LLVM_LIBC_TYPES_X86_64_STRUCT_USER_REGS_STRUCT_H

--- a/libc/include/sys/user.yaml
+++ b/libc/include/sys/user.yaml
@@ -1,0 +1,5 @@
+header: sys/user.h
+standards:
+  - linux
+types:
+  - type_name: struct_user_regs_struct


### PR DESCRIPTION
This is a non-POSIX header, which is nevertheless provided in some environments to give access to arch-specific information, such as register sets. Linux `ptrace` man page for `PTRACE_GETREGS` flags references
`<sys/user.h>` explcitly : https://man7.org/linux/man-pages/man2/ptrace.2.html 

Users get to rely on that to explore the thread/process state
e.g. LeakSanitizer does it to collect live pointers that can be present in the registers:
https://github.com/llvm/llvm-project/blob/3993ccd4f07a5feee69764efa5bc9b53a0ce19ae/compiler-rt/lib/sanitizer_common/sanitizer_stoptheworld_linux_libcdep.cpp#L41

Provide this header and define `user_regs_struct` struct on Linux x86_64.