### PR TITLE
[MachineScheduler] Fix the acyclic-latency estimate and skip pressure heuristics where they cannot pay

### DIFF
--- a/llvm/include/llvm/CodeGen/MachineScheduler.h
+++ b/llvm/include/llvm/CodeGen/MachineScheduler.h
@@ -1321,7 +1321,13 @@ protected:
   /// Candidate last picked from Bot boundary.
   SchedCandidate BotCand;
 
+  /// True unless the region is one where no schedule can bring register
+  /// pressure back under the limit, so the pressure heuristics have nothing
+  /// to win. See GenericScheduler::checkPressureIsActionable().
+  bool PressureActionable = true;
+
   void checkAcyclicLatency();
+  void checkPressureIsActionable();
 
   void initCandidate(SchedCandidate &Cand, SUnit *SU, bool AtTop,
                      const RegPressureTracker &RPTracker,

--- a/llvm/lib/CodeGen/MachineScheduler.cpp
+++ b/llvm/lib/CodeGen/MachineScheduler.cpp
@@ -248,6 +248,20 @@ static cl::opt<unsigned> SchedOnlyBlock("misched-only-block", cl::Hidden,
 static cl::opt<unsigned> ReadyListLimit("misched-limit", cl::Hidden,
   cl::desc("Limit ready list to N instructions"), cl::init(256));
 
+static cl::opt<unsigned> PressureGateWindows(
+    "misched-pressure-gate-windows", cl::Hidden,
+    cl::desc("Skip the RegExcess/RegCritical heuristics in regions at least "
+             "this many out-of-order windows long whose pressure is already "
+             "over the limit and whose issue time already covers their "
+             "critical path (0 disables)"),
+    cl::init(2));
+
+static cl::opt<unsigned> PressureGateMinInstrs(
+    "misched-pressure-gate-min-instrs", cl::Hidden,
+    cl::desc("Never skip the RegExcess/RegCritical heuristics in regions "
+             "smaller than this, whatever the out-of-order window says"),
+    cl::init(600));
+
 static cl::opt<bool> EnableRegPressure("misched-regpressure", cl::Hidden,
   cl::desc("Enable register pressure scheduling."), cl::init(true));
 
@@ -3764,7 +3778,14 @@ void GenericScheduler::checkAcyclicLatency() {
   // is covered by the iteration's own issue time and no cross-iteration
   // overlap is needed to hide it.
   //
-  // Only refine the estimate where it models a real reorder buffer. For
+  // Without this check the test degenerates for any loop body larger than the
+  // micro-op buffer: for an issue-bound loop IterCount == RemIssueCount, so
+  // InFlightCount collapses to AcyclicCount and the condition reduces to
+  // "acyclic critical path > MicroOpBufferSize / IssueWidth" - a threshold of
+  // a few tens of cycles, which every large loop exceeds whether or not
+  // latency is what limits it.
+  //
+  // Only refine the estimate where it models a real reorder buffer.  For
   // MicroOpBufferSize <= 1 the value is a sentinel for an in-order target
   // rather than a size, BufferLimit is degenerate, and treating such loops as
   // latency limited is the deliberate policy for those targets.
@@ -3781,6 +3802,73 @@ void GenericScheduler::checkAcyclicLatency() {
              << " InFlight=" << InFlightCount / SchedModel->getMicroOpFactor()
              << "m BufferLim=" << SchedModel->getMicroOpBufferSize() << "m\n";
       if (Rem.IsAcyclicLatencyLimited) dbgs() << "  ACYCLIC LATENCY LIMIT\n");
+}
+
+/// Decide whether scheduling this region for register pressure can achieve
+/// anything.
+///
+/// RegExcess and RegCritical are consulted before clustering, resource
+/// balancing, latency and source order in tryCandidate(), so whenever either
+/// fires it decides the schedule outright. That ordering is right when a
+/// different order could keep the region inside the register file, because
+/// then avoiding a spill is worth more than any of those.
+///
+/// It is not right when the region is already over the limit and is issue
+/// bound. Then some values have to be spilled whichever order is chosen, and
+/// there is no dependence height left to recover by reordering either, so the
+/// heuristics can only replace the incoming order with a greedy minimum-peak
+/// order. That lowers the peak slightly without removing the spills.
+///
+/// The size condition is expressed in multiples of the target's out-of-order
+/// window rather than as a fixed instruction count. A region that fits in the
+/// window is one the hardware reorders for itself, so a poor static order
+/// costs little there. A region many windows long is one the hardware cannot
+/// see across, so the static order is what the machine executes, and a greedy
+/// choice made with no lookahead compounds over all of it.
+void GenericScheduler::checkPressureIsActionable() {
+  PressureActionable = true;
+  if (!PressureGateWindows || !DAG->isTrackingPressure())
+    return;
+
+  // MicroOpBufferSize is 0 or 1 for in-order targets, where it is a sentinel
+  // rather than a window size - isOutOfOrder() is the predicate that means
+  // "the hardware reorders for itself". In-order targets are never gated:
+  // they are the ones that most need the scheduler.
+  if (!SchedModel->getMCSchedModel()->isOutOfOrder())
+    return;
+  // Two conditions, because neither alone is enough. The window ratio is the
+  // argument for the gate, but MicroOpBufferSize varies by a factor of two
+  // across models, so a ratio that is right for a large buffer is far too
+  // permissive on a small one and starts catching mid-size regions where the
+  // pressure heuristics do pay. The absolute floor keeps the gate to regions
+  // that are large in their own right.
+  unsigned Window = SchedModel->getMicroOpBufferSize();
+  if (NumRegionInstrs <
+      std::max(PressureGateWindows * Window, PressureGateMinInstrs.getValue()))
+    return;
+
+  // Nothing to gate if the region already fits in the register file.
+  if (DAG->getRegionCriticalPSets().empty())
+    return;
+
+  // Only when throughput, not dependence height, sets the pace. If the
+  // critical path dominates there is still latency to win back by reordering,
+  // and that is worth the risk.
+  //
+  // Compare against the region's critical *resource*, not against
+  // RemIssueCount: the latter measures micro-ops against the front end, which
+  // for a loop bottlenecked on one execution port badly underestimates how
+  // long the region takes and makes an obviously throughput-bound loop look
+  // latency bound.
+  unsigned OtherCritIdx = 0;
+  unsigned CritResCount = Bot.getOtherResourceCount(OtherCritIdx);
+  if (!checkResourceLimit(SchedModel->getLatencyFactor(), CritResCount,
+                          Rem.CriticalPath, /*AfterSchedNode=*/false))
+    return;
+
+  PressureActionable = false;
+  LLVM_DEBUG(dbgs() << "  Pressure heuristics disabled: " << NumRegionInstrs
+                    << " instrs, over the limit, issue bound\n");
 }
 
 void GenericScheduler::registerRoots() {
@@ -3800,6 +3888,8 @@ void GenericScheduler::registerRoots() {
     Rem.CyclicCritPath = DAG->computeCyclicCriticalPath();
     checkAcyclicLatency();
   }
+
+  checkPressureIsActionable();
 }
 
 bool llvm::tryPressure(const PressureChange &TryP, const PressureChange &CandP,
@@ -3976,17 +4066,15 @@ bool GenericScheduler::tryCandidate(SchedCandidate &Cand,
     return TryCand.Reason != NoCand;
 
   // Avoid exceeding the target's limit.
-  if (DAG->isTrackingPressure() && tryPressure(TryCand.RPDelta.Excess,
-                                               Cand.RPDelta.Excess,
-                                               TryCand, Cand, RegExcess, TRI,
-                                               DAG->MF))
+  if (PressureActionable && DAG->isTrackingPressure() &&
+      tryPressure(TryCand.RPDelta.Excess, Cand.RPDelta.Excess, TryCand, Cand,
+                  RegExcess, TRI, DAG->MF))
     return TryCand.Reason != NoCand;
 
   // Avoid increasing the max critical pressure in the scheduled region.
-  if (DAG->isTrackingPressure() && tryPressure(TryCand.RPDelta.CriticalMax,
-                                               Cand.RPDelta.CriticalMax,
-                                               TryCand, Cand, RegCritical, TRI,
-                                               DAG->MF))
+  if (PressureActionable && DAG->isTrackingPressure() &&
+      tryPressure(TryCand.RPDelta.CriticalMax, Cand.RPDelta.CriticalMax,
+                  TryCand, Cand, RegCritical, TRI, DAG->MF))
     return TryCand.Reason != NoCand;
 
   // We only compare a subset of features when comparing nodes between

--- a/llvm/lib/CodeGen/MachineScheduler.cpp
+++ b/llvm/lib/CodeGen/MachineScheduler.cpp
@@ -3739,9 +3739,17 @@ void GenericScheduler::checkAcyclicLatency() {
     return;
 
   // Scaled number of cycles per loop iteration.
-  unsigned IterCount =
-    std::max(Rem.CyclicCritPath * SchedModel->getLatencyFactor(),
-             Rem.RemIssueCount);
+  //
+  // The model above calls for the loop's resource height, so use the critical
+  // resource rather than RemIssueCount. The latter counts micro-ops against
+  // the front end, which for a region bottlenecked on one execution port
+  // underestimates how long an iteration takes - several-fold for wide vector
+  // code that can only issue to a couple of ports - and so overstates how
+  // many iterations must be in flight.
+  unsigned OtherCritIdx = 0;
+  unsigned ResourceHeight = Bot.getOtherResourceCount(OtherCritIdx);
+  unsigned IterCount = std::max(
+      Rem.CyclicCritPath * SchedModel->getLatencyFactor(), ResourceHeight);
   // Scaled acyclic critical path.
   unsigned AcyclicCount = Rem.CriticalPath * SchedModel->getLatencyFactor();
   // InFlightCount = (AcyclicPath / IterCycles) * InstrPerLoop
@@ -3750,7 +3758,20 @@ void GenericScheduler::checkAcyclicLatency() {
   unsigned BufferLimit =
     SchedModel->getMicroOpBufferSize() * SchedModel->getMicroOpFactor();
 
-  Rem.IsAcyclicLatencyLimited = InFlightCount > BufferLimit;
+  // The InFlightCount estimate above only means something once the acyclic
+  // path actually spans more than one iteration. If a single iteration takes
+  // at least as long to issue as the acyclic path takes to complete, that path
+  // is covered by the iteration's own issue time and no cross-iteration
+  // overlap is needed to hide it.
+  //
+  // Only refine the estimate where it models a real reorder buffer. For
+  // MicroOpBufferSize <= 1 the value is a sentinel for an in-order target
+  // rather than a size, BufferLimit is degenerate, and treating such loops as
+  // latency limited is the deliberate policy for those targets.
+  bool SpansIterations = !SchedModel->getMCSchedModel()->isOutOfOrder() ||
+                         AcyclicCount > IterCount;
+
+  Rem.IsAcyclicLatencyLimited = SpansIterations && InFlightCount > BufferLimit;
 
   LLVM_DEBUG(
       dbgs() << "IssueCycles="

--- a/llvm/test/CodeGen/X86/misched-acyclic-latency.ll
+++ b/llvm/test/CodeGen/X86/misched-acyclic-latency.ll
@@ -1,0 +1,576 @@
+; Check that checkAcyclicLatency() flags loops whose acyclic critical path
+; really does span several iterations, and does not flag loops that are limited
+; by throughput instead.
+;
+; RUN: llc < %s -mtriple=x86_64-- -mcpu=x86-64 -debug-only=machine-scheduler \
+; RUN:   -o /dev/null 2>&1 | FileCheck %s
+; RUN: llc < %s -mtriple=x86_64-- -mcpu=skylake-avx512 \
+; RUN:   -debug-only=machine-scheduler -o /dev/null 2>&1 | FileCheck %s
+;
+; REQUIRES: asserts
+
+; @acyclic_limited is a long dependent chain of vector multiplies with only a
+; trivial loop-carried dependency, so its acyclic path genuinely spans several
+; iterations and must be flagged.  This also keeps the CHECK-NOT below honest:
+; it proves the message is still produced and still spelled this way.
+
+; CHECK: ACYCLIC LATENCY LIMIT
+
+; Everything after this point must not be flagged.  The two loops below cover
+; the two ways the old estimate got this wrong.
+;
+; @throughput_loop is a wide, independent chain of 512-bit adds.  Its
+; InFlightCount exceeds the micro-op buffer, but the acyclic path fits inside a
+; single iteration's own issue time (NumIters=1), so there is nothing for
+; cross-iteration overlap to hide.
+;
+; @port_bound_loop is six independent chains of 512-bit multiplies.  It is
+; bound by the vector ports rather than by the front end, so an iteration takes
+; several times longer than its micro-op count suggests.  IterCount must come
+; from the region's critical resource; taking it from the micro-op issue count
+; understates an iteration and overstates how many must be in flight.
+
+; CHECK-NOT: ACYCLIC LATENCY LIMIT
+
+define void @acyclic_limited(ptr %p, ptr %q, i64 %n) {
+entry:
+  br label %loop
+
+loop:
+  %iv = phi i64 [ 0, %entry ], [ %iv.next, %loop ]
+  %g = getelementptr inbounds <16 x float>, ptr %p, i64 %iv
+  %v = load <16 x float>, ptr %g
+  %c0 = fmul <16 x float> %v, %v
+  %c1 = fmul <16 x float> %c0, %c0
+  %c2 = fmul <16 x float> %c1, %c1
+  %c3 = fmul <16 x float> %c2, %c2
+  %c4 = fmul <16 x float> %c3, %c3
+  %c5 = fmul <16 x float> %c4, %c4
+  %c6 = fmul <16 x float> %c5, %c5
+  %c7 = fmul <16 x float> %c6, %c6
+  %c8 = fmul <16 x float> %c7, %c7
+  %c9 = fmul <16 x float> %c8, %c8
+  %c10 = fmul <16 x float> %c9, %c9
+  %c11 = fmul <16 x float> %c10, %c10
+  %c12 = fmul <16 x float> %c11, %c11
+  %c13 = fmul <16 x float> %c12, %c12
+  %c14 = fmul <16 x float> %c13, %c13
+  %c15 = fmul <16 x float> %c14, %c14
+  %c16 = fmul <16 x float> %c15, %c15
+  %c17 = fmul <16 x float> %c16, %c16
+  %c18 = fmul <16 x float> %c17, %c17
+  %c19 = fmul <16 x float> %c18, %c18
+  %c20 = fmul <16 x float> %c19, %c19
+  %c21 = fmul <16 x float> %c20, %c20
+  %c22 = fmul <16 x float> %c21, %c21
+  %c23 = fmul <16 x float> %c22, %c22
+  %c24 = fmul <16 x float> %c23, %c23
+  %c25 = fmul <16 x float> %c24, %c24
+  %c26 = fmul <16 x float> %c25, %c25
+  %c27 = fmul <16 x float> %c26, %c26
+  %c28 = fmul <16 x float> %c27, %c27
+  %c29 = fmul <16 x float> %c28, %c28
+  %c30 = fmul <16 x float> %c29, %c29
+  %c31 = fmul <16 x float> %c30, %c30
+  %c32 = fmul <16 x float> %c31, %c31
+  %c33 = fmul <16 x float> %c32, %c32
+  %c34 = fmul <16 x float> %c33, %c33
+  %c35 = fmul <16 x float> %c34, %c34
+  %c36 = fmul <16 x float> %c35, %c35
+  %c37 = fmul <16 x float> %c36, %c36
+  %c38 = fmul <16 x float> %c37, %c37
+  %c39 = fmul <16 x float> %c38, %c38
+  %c40 = fmul <16 x float> %c39, %c39
+  %c41 = fmul <16 x float> %c40, %c40
+  %c42 = fmul <16 x float> %c41, %c41
+  %c43 = fmul <16 x float> %c42, %c42
+  %c44 = fmul <16 x float> %c43, %c43
+  %c45 = fmul <16 x float> %c44, %c44
+  %c46 = fmul <16 x float> %c45, %c45
+  %c47 = fmul <16 x float> %c46, %c46
+  store <16 x float> %c47, ptr %q
+  %iv.next = add i64 %iv, 1
+  %cc = icmp slt i64 %iv.next, %n
+  br i1 %cc, label %loop, label %exit
+
+exit:
+  ret void
+}
+
+define void @throughput_loop(ptr %p, ptr %q, i64 %n) {
+entry:
+  br label %loop
+
+loop:
+  %iv = phi i64 [ 0, %entry ], [ %iv.next, %loop ]
+  %a0 = getelementptr inbounds <16 x i32>, ptr %p, i64 0
+  %v0 = load <16 x i32>, ptr %a0
+  %a1 = getelementptr inbounds <16 x i32>, ptr %p, i64 1
+  %v1 = load <16 x i32>, ptr %a1
+  %a2 = getelementptr inbounds <16 x i32>, ptr %p, i64 2
+  %v2 = load <16 x i32>, ptr %a2
+  %a3 = getelementptr inbounds <16 x i32>, ptr %p, i64 3
+  %v3 = load <16 x i32>, ptr %a3
+  %a4 = getelementptr inbounds <16 x i32>, ptr %p, i64 4
+  %v4 = load <16 x i32>, ptr %a4
+  %a5 = getelementptr inbounds <16 x i32>, ptr %p, i64 5
+  %v5 = load <16 x i32>, ptr %a5
+  %a6 = getelementptr inbounds <16 x i32>, ptr %p, i64 6
+  %v6 = load <16 x i32>, ptr %a6
+  %a7 = getelementptr inbounds <16 x i32>, ptr %p, i64 7
+  %v7 = load <16 x i32>, ptr %a7
+  %t0 = add <16 x i32> %v0, %v1
+  %t1 = add <16 x i32> %v1, %v2
+  %t2 = add <16 x i32> %v2, %v3
+  %t3 = add <16 x i32> %v3, %v4
+  %t4 = add <16 x i32> %v4, %v5
+  %t5 = add <16 x i32> %v5, %v6
+  %t6 = add <16 x i32> %v6, %v7
+  %t7 = add <16 x i32> %v7, %v0
+  %t8 = add <16 x i32> %t0, %t1
+  %t9 = add <16 x i32> %t1, %t2
+  %t10 = add <16 x i32> %t2, %t3
+  %t11 = add <16 x i32> %t3, %t4
+  %t12 = add <16 x i32> %t4, %t5
+  %t13 = add <16 x i32> %t5, %t6
+  %t14 = add <16 x i32> %t6, %t7
+  %t15 = add <16 x i32> %t7, %t0
+  %t16 = add <16 x i32> %t8, %t9
+  %t17 = add <16 x i32> %t9, %t10
+  %t18 = add <16 x i32> %t10, %t11
+  %t19 = add <16 x i32> %t11, %t12
+  %t20 = add <16 x i32> %t12, %t13
+  %t21 = add <16 x i32> %t13, %t14
+  %t22 = add <16 x i32> %t14, %t15
+  %t23 = add <16 x i32> %t15, %t8
+  %t24 = add <16 x i32> %t16, %t17
+  %t25 = add <16 x i32> %t17, %t18
+  %t26 = add <16 x i32> %t18, %t19
+  %t27 = add <16 x i32> %t19, %t20
+  %t28 = add <16 x i32> %t20, %t21
+  %t29 = add <16 x i32> %t21, %t22
+  %t30 = add <16 x i32> %t22, %t23
+  %t31 = add <16 x i32> %t23, %t16
+  %t32 = add <16 x i32> %t24, %t25
+  %t33 = add <16 x i32> %t25, %t26
+  %t34 = add <16 x i32> %t26, %t27
+  %t35 = add <16 x i32> %t27, %t28
+  %t36 = add <16 x i32> %t28, %t29
+  %t37 = add <16 x i32> %t29, %t30
+  %t38 = add <16 x i32> %t30, %t31
+  %t39 = add <16 x i32> %t31, %t24
+  %t40 = add <16 x i32> %t32, %t33
+  %t41 = add <16 x i32> %t33, %t34
+  %t42 = add <16 x i32> %t34, %t35
+  %t43 = add <16 x i32> %t35, %t36
+  %t44 = add <16 x i32> %t36, %t37
+  %t45 = add <16 x i32> %t37, %t38
+  %t46 = add <16 x i32> %t38, %t39
+  %t47 = add <16 x i32> %t39, %t32
+  %t48 = add <16 x i32> %t40, %t41
+  %t49 = add <16 x i32> %t41, %t42
+  %t50 = add <16 x i32> %t42, %t43
+  %t51 = add <16 x i32> %t43, %t44
+  %t52 = add <16 x i32> %t44, %t45
+  %t53 = add <16 x i32> %t45, %t46
+  %t54 = add <16 x i32> %t46, %t47
+  %t55 = add <16 x i32> %t47, %t40
+  %t56 = add <16 x i32> %t48, %t49
+  %t57 = add <16 x i32> %t49, %t50
+  %t58 = add <16 x i32> %t50, %t51
+  %t59 = add <16 x i32> %t51, %t52
+  %t60 = add <16 x i32> %t52, %t53
+  %t61 = add <16 x i32> %t53, %t54
+  %t62 = add <16 x i32> %t54, %t55
+  %t63 = add <16 x i32> %t55, %t48
+  %t64 = add <16 x i32> %t56, %t57
+  %t65 = add <16 x i32> %t57, %t58
+  %t66 = add <16 x i32> %t58, %t59
+  %t67 = add <16 x i32> %t59, %t60
+  %t68 = add <16 x i32> %t60, %t61
+  %t69 = add <16 x i32> %t61, %t62
+  %t70 = add <16 x i32> %t62, %t63
+  %t71 = add <16 x i32> %t63, %t56
+  %t72 = add <16 x i32> %t64, %t65
+  %t73 = add <16 x i32> %t65, %t66
+  %t74 = add <16 x i32> %t66, %t67
+  %t75 = add <16 x i32> %t67, %t68
+  %t76 = add <16 x i32> %t68, %t69
+  %t77 = add <16 x i32> %t69, %t70
+  %t78 = add <16 x i32> %t70, %t71
+  %t79 = add <16 x i32> %t71, %t64
+  %t80 = add <16 x i32> %t72, %t73
+  %t81 = add <16 x i32> %t73, %t74
+  %t82 = add <16 x i32> %t74, %t75
+  %t83 = add <16 x i32> %t75, %t76
+  %t84 = add <16 x i32> %t76, %t77
+  %t85 = add <16 x i32> %t77, %t78
+  %t86 = add <16 x i32> %t78, %t79
+  %t87 = add <16 x i32> %t79, %t72
+  %t88 = add <16 x i32> %t80, %t81
+  %t89 = add <16 x i32> %t81, %t82
+  %t90 = add <16 x i32> %t82, %t83
+  %t91 = add <16 x i32> %t83, %t84
+  %t92 = add <16 x i32> %t84, %t85
+  %t93 = add <16 x i32> %t85, %t86
+  %t94 = add <16 x i32> %t86, %t87
+  %t95 = add <16 x i32> %t87, %t80
+  %t96 = add <16 x i32> %t88, %t89
+  %t97 = add <16 x i32> %t89, %t90
+  %t98 = add <16 x i32> %t90, %t91
+  %t99 = add <16 x i32> %t91, %t92
+  %t100 = add <16 x i32> %t92, %t93
+  %t101 = add <16 x i32> %t93, %t94
+  %t102 = add <16 x i32> %t94, %t95
+  %t103 = add <16 x i32> %t95, %t88
+  %t104 = add <16 x i32> %t96, %t97
+  %t105 = add <16 x i32> %t97, %t98
+  %t106 = add <16 x i32> %t98, %t99
+  %t107 = add <16 x i32> %t99, %t100
+  %t108 = add <16 x i32> %t100, %t101
+  %t109 = add <16 x i32> %t101, %t102
+  %t110 = add <16 x i32> %t102, %t103
+  %t111 = add <16 x i32> %t103, %t96
+  %t112 = add <16 x i32> %t104, %t105
+  %t113 = add <16 x i32> %t105, %t106
+  %t114 = add <16 x i32> %t106, %t107
+  %t115 = add <16 x i32> %t107, %t108
+  %t116 = add <16 x i32> %t108, %t109
+  %t117 = add <16 x i32> %t109, %t110
+  %t118 = add <16 x i32> %t110, %t111
+  %t119 = add <16 x i32> %t111, %t104
+  %t120 = add <16 x i32> %t112, %t113
+  %t121 = add <16 x i32> %t113, %t114
+  %t122 = add <16 x i32> %t114, %t115
+  %t123 = add <16 x i32> %t115, %t116
+  %t124 = add <16 x i32> %t116, %t117
+  %t125 = add <16 x i32> %t117, %t118
+  %t126 = add <16 x i32> %t118, %t119
+  %t127 = add <16 x i32> %t119, %t112
+  %t128 = add <16 x i32> %t120, %t121
+  %t129 = add <16 x i32> %t121, %t122
+  %t130 = add <16 x i32> %t122, %t123
+  %t131 = add <16 x i32> %t123, %t124
+  %t132 = add <16 x i32> %t124, %t125
+  %t133 = add <16 x i32> %t125, %t126
+  %t134 = add <16 x i32> %t126, %t127
+  %t135 = add <16 x i32> %t127, %t120
+  %t136 = add <16 x i32> %t128, %t129
+  %t137 = add <16 x i32> %t129, %t130
+  %t138 = add <16 x i32> %t130, %t131
+  %t139 = add <16 x i32> %t131, %t132
+  %t140 = add <16 x i32> %t132, %t133
+  %t141 = add <16 x i32> %t133, %t134
+  %t142 = add <16 x i32> %t134, %t135
+  %t143 = add <16 x i32> %t135, %t128
+  %t144 = add <16 x i32> %t136, %t137
+  %t145 = add <16 x i32> %t137, %t138
+  %t146 = add <16 x i32> %t138, %t139
+  %t147 = add <16 x i32> %t139, %t140
+  %t148 = add <16 x i32> %t140, %t141
+  %t149 = add <16 x i32> %t141, %t142
+  %t150 = add <16 x i32> %t142, %t143
+  %t151 = add <16 x i32> %t143, %t136
+  %t152 = add <16 x i32> %t144, %t145
+  %t153 = add <16 x i32> %t145, %t146
+  %t154 = add <16 x i32> %t146, %t147
+  %t155 = add <16 x i32> %t147, %t148
+  %t156 = add <16 x i32> %t148, %t149
+  %t157 = add <16 x i32> %t149, %t150
+  %t158 = add <16 x i32> %t150, %t151
+  %t159 = add <16 x i32> %t151, %t144
+  %t160 = add <16 x i32> %t152, %t153
+  %t161 = add <16 x i32> %t153, %t154
+  %t162 = add <16 x i32> %t154, %t155
+  %t163 = add <16 x i32> %t155, %t156
+  %t164 = add <16 x i32> %t156, %t157
+  %t165 = add <16 x i32> %t157, %t158
+  %t166 = add <16 x i32> %t158, %t159
+  %t167 = add <16 x i32> %t159, %t152
+  %t168 = add <16 x i32> %t160, %t161
+  %t169 = add <16 x i32> %t161, %t162
+  %t170 = add <16 x i32> %t162, %t163
+  %t171 = add <16 x i32> %t163, %t164
+  %t172 = add <16 x i32> %t164, %t165
+  %t173 = add <16 x i32> %t165, %t166
+  %t174 = add <16 x i32> %t166, %t167
+  %t175 = add <16 x i32> %t167, %t160
+  %t176 = add <16 x i32> %t168, %t169
+  %t177 = add <16 x i32> %t169, %t170
+  %t178 = add <16 x i32> %t170, %t171
+  %t179 = add <16 x i32> %t171, %t172
+  %t180 = add <16 x i32> %t172, %t173
+  %t181 = add <16 x i32> %t173, %t174
+  %t182 = add <16 x i32> %t174, %t175
+  %t183 = add <16 x i32> %t175, %t168
+  %t184 = add <16 x i32> %t176, %t177
+  %t185 = add <16 x i32> %t177, %t178
+  %t186 = add <16 x i32> %t178, %t179
+  %t187 = add <16 x i32> %t179, %t180
+  %t188 = add <16 x i32> %t180, %t181
+  %t189 = add <16 x i32> %t181, %t182
+  %t190 = add <16 x i32> %t182, %t183
+  %t191 = add <16 x i32> %t183, %t176
+  %t192 = add <16 x i32> %t184, %t185
+  %t193 = add <16 x i32> %t185, %t186
+  %t194 = add <16 x i32> %t186, %t187
+  %t195 = add <16 x i32> %t187, %t188
+  %t196 = add <16 x i32> %t188, %t189
+  %t197 = add <16 x i32> %t189, %t190
+  %t198 = add <16 x i32> %t190, %t191
+  %t199 = add <16 x i32> %t191, %t184
+  %t200 = add <16 x i32> %t192, %t193
+  %t201 = add <16 x i32> %t193, %t194
+  %t202 = add <16 x i32> %t194, %t195
+  %t203 = add <16 x i32> %t195, %t196
+  %t204 = add <16 x i32> %t196, %t197
+  %t205 = add <16 x i32> %t197, %t198
+  %t206 = add <16 x i32> %t198, %t199
+  %t207 = add <16 x i32> %t199, %t192
+  %t208 = add <16 x i32> %t200, %t201
+  %t209 = add <16 x i32> %t201, %t202
+  %t210 = add <16 x i32> %t202, %t203
+  %t211 = add <16 x i32> %t203, %t204
+  %t212 = add <16 x i32> %t204, %t205
+  %t213 = add <16 x i32> %t205, %t206
+  %t214 = add <16 x i32> %t206, %t207
+  %t215 = add <16 x i32> %t207, %t200
+  %t216 = add <16 x i32> %t208, %t209
+  %t217 = add <16 x i32> %t209, %t210
+  %t218 = add <16 x i32> %t210, %t211
+  %t219 = add <16 x i32> %t211, %t212
+  %t220 = add <16 x i32> %t212, %t213
+  %t221 = add <16 x i32> %t213, %t214
+  %t222 = add <16 x i32> %t214, %t215
+  %t223 = add <16 x i32> %t215, %t208
+  %t224 = add <16 x i32> %t216, %t217
+  %t225 = add <16 x i32> %t217, %t218
+  %t226 = add <16 x i32> %t218, %t219
+  %t227 = add <16 x i32> %t219, %t220
+  %t228 = add <16 x i32> %t220, %t221
+  %t229 = add <16 x i32> %t221, %t222
+  %t230 = add <16 x i32> %t222, %t223
+  %t231 = add <16 x i32> %t223, %t216
+  %t232 = add <16 x i32> %t224, %t225
+  %t233 = add <16 x i32> %t225, %t226
+  %t234 = add <16 x i32> %t226, %t227
+  %t235 = add <16 x i32> %t227, %t228
+  %t236 = add <16 x i32> %t228, %t229
+  %t237 = add <16 x i32> %t229, %t230
+  %t238 = add <16 x i32> %t230, %t231
+  %t239 = add <16 x i32> %t231, %t224
+  %t240 = add <16 x i32> %t232, %t233
+  %t241 = add <16 x i32> %t233, %t234
+  %t242 = add <16 x i32> %t234, %t235
+  %t243 = add <16 x i32> %t235, %t236
+  %t244 = add <16 x i32> %t236, %t237
+  %t245 = add <16 x i32> %t237, %t238
+  %t246 = add <16 x i32> %t238, %t239
+  %t247 = add <16 x i32> %t239, %t232
+  %t248 = add <16 x i32> %t240, %t241
+  %t249 = add <16 x i32> %t241, %t242
+  %t250 = add <16 x i32> %t242, %t243
+  %t251 = add <16 x i32> %t243, %t244
+  %t252 = add <16 x i32> %t244, %t245
+  %t253 = add <16 x i32> %t245, %t246
+  %t254 = add <16 x i32> %t246, %t247
+  %t255 = add <16 x i32> %t247, %t240
+  %t256 = add <16 x i32> %t248, %t249
+  %t257 = add <16 x i32> %t249, %t250
+  %t258 = add <16 x i32> %t250, %t251
+  %t259 = add <16 x i32> %t251, %t252
+  %t260 = add <16 x i32> %t252, %t253
+  %t261 = add <16 x i32> %t253, %t254
+  %t262 = add <16 x i32> %t254, %t255
+  %t263 = add <16 x i32> %t255, %t248
+  %t264 = add <16 x i32> %t256, %t257
+  %t265 = add <16 x i32> %t257, %t258
+  %t266 = add <16 x i32> %t258, %t259
+  %t267 = add <16 x i32> %t259, %t260
+  %t268 = add <16 x i32> %t260, %t261
+  %t269 = add <16 x i32> %t261, %t262
+  %t270 = add <16 x i32> %t262, %t263
+  %t271 = add <16 x i32> %t263, %t256
+  %t272 = add <16 x i32> %t264, %t265
+  %t273 = add <16 x i32> %t265, %t266
+  %t274 = add <16 x i32> %t266, %t267
+  %t275 = add <16 x i32> %t267, %t268
+  %t276 = add <16 x i32> %t268, %t269
+  %t277 = add <16 x i32> %t269, %t270
+  %t278 = add <16 x i32> %t270, %t271
+  %t279 = add <16 x i32> %t271, %t264
+  %t280 = add <16 x i32> %t272, %t273
+  %t281 = add <16 x i32> %t273, %t274
+  %t282 = add <16 x i32> %t274, %t275
+  %t283 = add <16 x i32> %t275, %t276
+  %t284 = add <16 x i32> %t276, %t277
+  %t285 = add <16 x i32> %t277, %t278
+  %t286 = add <16 x i32> %t278, %t279
+  %t287 = add <16 x i32> %t279, %t272
+  %t288 = add <16 x i32> %t280, %t281
+  %t289 = add <16 x i32> %t281, %t282
+  %t290 = add <16 x i32> %t282, %t283
+  %t291 = add <16 x i32> %t283, %t284
+  %t292 = add <16 x i32> %t284, %t285
+  %t293 = add <16 x i32> %t285, %t286
+  %t294 = add <16 x i32> %t286, %t287
+  %t295 = add <16 x i32> %t287, %t280
+  %t296 = add <16 x i32> %t288, %t289
+  %t297 = add <16 x i32> %t289, %t290
+  %t298 = add <16 x i32> %t290, %t291
+  %t299 = add <16 x i32> %t291, %t292
+  %t300 = add <16 x i32> %t292, %t293
+  %t301 = add <16 x i32> %t293, %t294
+  %t302 = add <16 x i32> %t294, %t295
+  %t303 = add <16 x i32> %t295, %t288
+  %t304 = add <16 x i32> %t296, %t297
+  %t305 = add <16 x i32> %t297, %t298
+  %t306 = add <16 x i32> %t298, %t299
+  %t307 = add <16 x i32> %t299, %t300
+  %t308 = add <16 x i32> %t300, %t301
+  %t309 = add <16 x i32> %t301, %t302
+  %t310 = add <16 x i32> %t302, %t303
+  %t311 = add <16 x i32> %t303, %t296
+  %t312 = add <16 x i32> %t304, %t305
+  %t313 = add <16 x i32> %t305, %t306
+  %t314 = add <16 x i32> %t306, %t307
+  %t315 = add <16 x i32> %t307, %t308
+  %t316 = add <16 x i32> %t308, %t309
+  %t317 = add <16 x i32> %t309, %t310
+  %t318 = add <16 x i32> %t310, %t311
+  %t319 = add <16 x i32> %t311, %t304
+  store <16 x i32> %t312, ptr %q
+  %iv.next = add i64 %iv, 1
+  %c = icmp slt i64 %iv.next, %n
+  br i1 %c, label %loop, label %exit
+
+exit:
+  ret void
+}
+
+define void @port_bound_loop(ptr noalias %p, ptr noalias %q, i64 %n) #0 {
+entry:
+  br label %loop
+loop:
+  %i = phi i64 [ 0, %entry ], [ %i.next, %loop ]
+  %g0 = getelementptr <16 x float>, ptr %p, i64 0
+  %v0.0 = load <16 x float>, ptr %g0, align 64
+  %g1 = getelementptr <16 x float>, ptr %p, i64 1
+  %v1.0 = load <16 x float>, ptr %g1, align 64
+  %g2 = getelementptr <16 x float>, ptr %p, i64 2
+  %v2.0 = load <16 x float>, ptr %g2, align 64
+  %g3 = getelementptr <16 x float>, ptr %p, i64 3
+  %v3.0 = load <16 x float>, ptr %g3, align 64
+  %g4 = getelementptr <16 x float>, ptr %p, i64 4
+  %v4.0 = load <16 x float>, ptr %g4, align 64
+  %g5 = getelementptr <16 x float>, ptr %p, i64 5
+  %v5.0 = load <16 x float>, ptr %g5, align 64
+  %v0.1 = fmul <16 x float> %v0.0, splat (float 1.00e+00)
+  %v1.1 = fmul <16 x float> %v1.0, splat (float 1.01e+00)
+  %v2.1 = fmul <16 x float> %v2.0, splat (float 1.02e+00)
+  %v3.1 = fmul <16 x float> %v3.0, splat (float 1.03e+00)
+  %v4.1 = fmul <16 x float> %v4.0, splat (float 1.04e+00)
+  %v5.1 = fmul <16 x float> %v5.0, splat (float 1.05e+00)
+  %v0.2 = fmul <16 x float> %v0.1, splat (float 1.00e+00)
+  %v1.2 = fmul <16 x float> %v1.1, splat (float 1.01e+00)
+  %v2.2 = fmul <16 x float> %v2.1, splat (float 1.02e+00)
+  %v3.2 = fmul <16 x float> %v3.1, splat (float 1.03e+00)
+  %v4.2 = fmul <16 x float> %v4.1, splat (float 1.04e+00)
+  %v5.2 = fmul <16 x float> %v5.1, splat (float 1.05e+00)
+  %v0.3 = fmul <16 x float> %v0.2, splat (float 1.00e+00)
+  %v1.3 = fmul <16 x float> %v1.2, splat (float 1.01e+00)
+  %v2.3 = fmul <16 x float> %v2.2, splat (float 1.02e+00)
+  %v3.3 = fmul <16 x float> %v3.2, splat (float 1.03e+00)
+  %v4.3 = fmul <16 x float> %v4.2, splat (float 1.04e+00)
+  %v5.3 = fmul <16 x float> %v5.2, splat (float 1.05e+00)
+  %v0.4 = fmul <16 x float> %v0.3, splat (float 1.00e+00)
+  %v1.4 = fmul <16 x float> %v1.3, splat (float 1.01e+00)
+  %v2.4 = fmul <16 x float> %v2.3, splat (float 1.02e+00)
+  %v3.4 = fmul <16 x float> %v3.3, splat (float 1.03e+00)
+  %v4.4 = fmul <16 x float> %v4.3, splat (float 1.04e+00)
+  %v5.4 = fmul <16 x float> %v5.3, splat (float 1.05e+00)
+  %v0.5 = fmul <16 x float> %v0.4, splat (float 1.00e+00)
+  %v1.5 = fmul <16 x float> %v1.4, splat (float 1.01e+00)
+  %v2.5 = fmul <16 x float> %v2.4, splat (float 1.02e+00)
+  %v3.5 = fmul <16 x float> %v3.4, splat (float 1.03e+00)
+  %v4.5 = fmul <16 x float> %v4.4, splat (float 1.04e+00)
+  %v5.5 = fmul <16 x float> %v5.4, splat (float 1.05e+00)
+  %v0.6 = fmul <16 x float> %v0.5, splat (float 1.00e+00)
+  %v1.6 = fmul <16 x float> %v1.5, splat (float 1.01e+00)
+  %v2.6 = fmul <16 x float> %v2.5, splat (float 1.02e+00)
+  %v3.6 = fmul <16 x float> %v3.5, splat (float 1.03e+00)
+  %v4.6 = fmul <16 x float> %v4.5, splat (float 1.04e+00)
+  %v5.6 = fmul <16 x float> %v5.5, splat (float 1.05e+00)
+  %v0.7 = fmul <16 x float> %v0.6, splat (float 1.00e+00)
+  %v1.7 = fmul <16 x float> %v1.6, splat (float 1.01e+00)
+  %v2.7 = fmul <16 x float> %v2.6, splat (float 1.02e+00)
+  %v3.7 = fmul <16 x float> %v3.6, splat (float 1.03e+00)
+  %v4.7 = fmul <16 x float> %v4.6, splat (float 1.04e+00)
+  %v5.7 = fmul <16 x float> %v5.6, splat (float 1.05e+00)
+  %v0.8 = fmul <16 x float> %v0.7, splat (float 1.00e+00)
+  %v1.8 = fmul <16 x float> %v1.7, splat (float 1.01e+00)
+  %v2.8 = fmul <16 x float> %v2.7, splat (float 1.02e+00)
+  %v3.8 = fmul <16 x float> %v3.7, splat (float 1.03e+00)
+  %v4.8 = fmul <16 x float> %v4.7, splat (float 1.04e+00)
+  %v5.8 = fmul <16 x float> %v5.7, splat (float 1.05e+00)
+  %v0.9 = fmul <16 x float> %v0.8, splat (float 1.00e+00)
+  %v1.9 = fmul <16 x float> %v1.8, splat (float 1.01e+00)
+  %v2.9 = fmul <16 x float> %v2.8, splat (float 1.02e+00)
+  %v3.9 = fmul <16 x float> %v3.8, splat (float 1.03e+00)
+  %v4.9 = fmul <16 x float> %v4.8, splat (float 1.04e+00)
+  %v5.9 = fmul <16 x float> %v5.8, splat (float 1.05e+00)
+  %v0.10 = fmul <16 x float> %v0.9, splat (float 1.00e+00)
+  %v1.10 = fmul <16 x float> %v1.9, splat (float 1.01e+00)
+  %v2.10 = fmul <16 x float> %v2.9, splat (float 1.02e+00)
+  %v3.10 = fmul <16 x float> %v3.9, splat (float 1.03e+00)
+  %v4.10 = fmul <16 x float> %v4.9, splat (float 1.04e+00)
+  %v5.10 = fmul <16 x float> %v5.9, splat (float 1.05e+00)
+  %v0.11 = fmul <16 x float> %v0.10, splat (float 1.00e+00)
+  %v1.11 = fmul <16 x float> %v1.10, splat (float 1.01e+00)
+  %v2.11 = fmul <16 x float> %v2.10, splat (float 1.02e+00)
+  %v3.11 = fmul <16 x float> %v3.10, splat (float 1.03e+00)
+  %v4.11 = fmul <16 x float> %v4.10, splat (float 1.04e+00)
+  %v5.11 = fmul <16 x float> %v5.10, splat (float 1.05e+00)
+  %v0.12 = fmul <16 x float> %v0.11, splat (float 1.00e+00)
+  %v1.12 = fmul <16 x float> %v1.11, splat (float 1.01e+00)
+  %v2.12 = fmul <16 x float> %v2.11, splat (float 1.02e+00)
+  %v3.12 = fmul <16 x float> %v3.11, splat (float 1.03e+00)
+  %v4.12 = fmul <16 x float> %v4.11, splat (float 1.04e+00)
+  %v5.12 = fmul <16 x float> %v5.11, splat (float 1.05e+00)
+  %v0.13 = fmul <16 x float> %v0.12, splat (float 1.00e+00)
+  %v1.13 = fmul <16 x float> %v1.12, splat (float 1.01e+00)
+  %v2.13 = fmul <16 x float> %v2.12, splat (float 1.02e+00)
+  %v3.13 = fmul <16 x float> %v3.12, splat (float 1.03e+00)
+  %v4.13 = fmul <16 x float> %v4.12, splat (float 1.04e+00)
+  %v5.13 = fmul <16 x float> %v5.12, splat (float 1.05e+00)
+  %v0.14 = fmul <16 x float> %v0.13, splat (float 1.00e+00)
+  %v1.14 = fmul <16 x float> %v1.13, splat (float 1.01e+00)
+  %v2.14 = fmul <16 x float> %v2.13, splat (float 1.02e+00)
+  %v3.14 = fmul <16 x float> %v3.13, splat (float 1.03e+00)
+  %v4.14 = fmul <16 x float> %v4.13, splat (float 1.04e+00)
+  %v5.14 = fmul <16 x float> %v5.13, splat (float 1.05e+00)
+  %v0.15 = fmul <16 x float> %v0.14, splat (float 1.00e+00)
+  %v1.15 = fmul <16 x float> %v1.14, splat (float 1.01e+00)
+  %v2.15 = fmul <16 x float> %v2.14, splat (float 1.02e+00)
+  %v3.15 = fmul <16 x float> %v3.14, splat (float 1.03e+00)
+  %v4.15 = fmul <16 x float> %v4.14, splat (float 1.04e+00)
+  %v5.15 = fmul <16 x float> %v5.14, splat (float 1.05e+00)
+  %s0 = getelementptr <16 x float>, ptr %q, i64 0
+  store <16 x float> %v0.15, ptr %s0, align 64
+  %s1 = getelementptr <16 x float>, ptr %q, i64 1
+  store <16 x float> %v1.15, ptr %s1, align 64
+  %s2 = getelementptr <16 x float>, ptr %q, i64 2
+  store <16 x float> %v2.15, ptr %s2, align 64
+  %s3 = getelementptr <16 x float>, ptr %q, i64 3
+  store <16 x float> %v3.15, ptr %s3, align 64
+  %s4 = getelementptr <16 x float>, ptr %q, i64 4
+  store <16 x float> %v4.15, ptr %s4, align 64
+  %s5 = getelementptr <16 x float>, ptr %q, i64 5
+  store <16 x float> %v5.15, ptr %s5, align 64
+  %i.next = add i64 %i, 1
+  %c = icmp ult i64 %i.next, %n
+  br i1 %c, label %loop, label %exit
+exit:
+  ret void
+}
+attributes #0 = { "target-features"="+avx512f" }

--- a/llvm/test/CodeGen/X86/misched-pressure-gate.ll
+++ b/llvm/test/CodeGen/X86/misched-pressure-gate.ll
@@ -1,0 +1,324 @@
+; Check that GenericScheduler skips the RegExcess/RegCritical heuristics only in
+; regions where they cannot pay: large, already over the register pressure
+; limit, and throughput rather than latency bound.
+;
+; RUN: llc < %s -mtriple=x86_64-- -mcpu=x86-64 -debug-only=machine-scheduler \
+; RUN:   -o /dev/null 2>&1 | FileCheck %s --check-prefix=GATED
+;
+; The gate is off when the option is zero.
+; RUN: llc < %s -mtriple=x86_64-- -mcpu=x86-64 -debug-only=machine-scheduler \
+; RUN:   -misched-pressure-gate-windows=0 -o /dev/null 2>&1 \
+; RUN:   | FileCheck %s --check-prefix=NOGATE
+;
+; The absolute floor alone is enough to hold it off ...
+; RUN: llc < %s -mtriple=x86_64-- -mcpu=x86-64 -debug-only=machine-scheduler \
+; RUN:   -misched-pressure-gate-min-instrs=100000 -o /dev/null 2>&1 \
+; RUN:   | FileCheck %s --check-prefix=NOGATE
+;
+; ... and so is the out-of-order window ratio alone.
+; RUN: llc < %s -mtriple=x86_64-- -mcpu=x86-64 -debug-only=machine-scheduler \
+; RUN:   -misched-pressure-gate-windows=100 -o /dev/null 2>&1 \
+; RUN:   | FileCheck %s --check-prefix=NOGATE
+;
+; REQUIRES: asserts
+
+; The loop below keeps many <16 x i32> values live at once, so register
+; pressure is far above the limit whatever order the scheduler picks, and the
+; work is independent, so throughput and not dependence height sets the pace.
+
+; When the gate fires, the region is announced and neither pressure heuristic
+; may pick a node in it again.  Checking the picks as well as the message
+; matters: the message alone would still be printed if the guards in
+; tryCandidate() were dropped and the analysis left in place.
+
+; GATED: Pressure heuristics disabled
+; GATED-NOT: Pick {{Top|Bot}} REG-
+
+; With the gate held off, the region is not announced and RegExcess does pick.
+
+; NOGATE-NOT: Pressure heuristics disabled
+; NOGATE: Pick {{Top|Bot}} REG-EXCESS
+
+define void @pressure_loop(ptr %p, ptr %q, i64 %n) {
+entry:
+  br label %loop
+
+loop:
+  %iv = phi i64 [ 0, %entry ], [ %iv.next, %loop ]
+  %a0 = getelementptr inbounds <16 x i32>, ptr %p, i64 0
+  %v0 = load <16 x i32>, ptr %a0
+  %a1 = getelementptr inbounds <16 x i32>, ptr %p, i64 1
+  %v1 = load <16 x i32>, ptr %a1
+  %a2 = getelementptr inbounds <16 x i32>, ptr %p, i64 2
+  %v2 = load <16 x i32>, ptr %a2
+  %a3 = getelementptr inbounds <16 x i32>, ptr %p, i64 3
+  %v3 = load <16 x i32>, ptr %a3
+  %a4 = getelementptr inbounds <16 x i32>, ptr %p, i64 4
+  %v4 = load <16 x i32>, ptr %a4
+  %a5 = getelementptr inbounds <16 x i32>, ptr %p, i64 5
+  %v5 = load <16 x i32>, ptr %a5
+  %a6 = getelementptr inbounds <16 x i32>, ptr %p, i64 6
+  %v6 = load <16 x i32>, ptr %a6
+  %a7 = getelementptr inbounds <16 x i32>, ptr %p, i64 7
+  %v7 = load <16 x i32>, ptr %a7
+  %a8 = getelementptr inbounds <16 x i32>, ptr %p, i64 8
+  %v8 = load <16 x i32>, ptr %a8
+  %a9 = getelementptr inbounds <16 x i32>, ptr %p, i64 9
+  %v9 = load <16 x i32>, ptr %a9
+  %a10 = getelementptr inbounds <16 x i32>, ptr %p, i64 10
+  %v10 = load <16 x i32>, ptr %a10
+  %a11 = getelementptr inbounds <16 x i32>, ptr %p, i64 11
+  %v11 = load <16 x i32>, ptr %a11
+  %a12 = getelementptr inbounds <16 x i32>, ptr %p, i64 12
+  %v12 = load <16 x i32>, ptr %a12
+  %a13 = getelementptr inbounds <16 x i32>, ptr %p, i64 13
+  %v13 = load <16 x i32>, ptr %a13
+  %a14 = getelementptr inbounds <16 x i32>, ptr %p, i64 14
+  %v14 = load <16 x i32>, ptr %a14
+  %a15 = getelementptr inbounds <16 x i32>, ptr %p, i64 15
+  %v15 = load <16 x i32>, ptr %a15
+  %a16 = getelementptr inbounds <16 x i32>, ptr %p, i64 16
+  %v16 = load <16 x i32>, ptr %a16
+  %a17 = getelementptr inbounds <16 x i32>, ptr %p, i64 17
+  %v17 = load <16 x i32>, ptr %a17
+  %a18 = getelementptr inbounds <16 x i32>, ptr %p, i64 18
+  %v18 = load <16 x i32>, ptr %a18
+  %a19 = getelementptr inbounds <16 x i32>, ptr %p, i64 19
+  %v19 = load <16 x i32>, ptr %a19
+  %a20 = getelementptr inbounds <16 x i32>, ptr %p, i64 20
+  %v20 = load <16 x i32>, ptr %a20
+  %a21 = getelementptr inbounds <16 x i32>, ptr %p, i64 21
+  %v21 = load <16 x i32>, ptr %a21
+  %a22 = getelementptr inbounds <16 x i32>, ptr %p, i64 22
+  %v22 = load <16 x i32>, ptr %a22
+  %a23 = getelementptr inbounds <16 x i32>, ptr %p, i64 23
+  %v23 = load <16 x i32>, ptr %a23
+  %a24 = getelementptr inbounds <16 x i32>, ptr %p, i64 24
+  %v24 = load <16 x i32>, ptr %a24
+  %a25 = getelementptr inbounds <16 x i32>, ptr %p, i64 25
+  %v25 = load <16 x i32>, ptr %a25
+  %a26 = getelementptr inbounds <16 x i32>, ptr %p, i64 26
+  %v26 = load <16 x i32>, ptr %a26
+  %a27 = getelementptr inbounds <16 x i32>, ptr %p, i64 27
+  %v27 = load <16 x i32>, ptr %a27
+  %a28 = getelementptr inbounds <16 x i32>, ptr %p, i64 28
+  %v28 = load <16 x i32>, ptr %a28
+  %a29 = getelementptr inbounds <16 x i32>, ptr %p, i64 29
+  %v29 = load <16 x i32>, ptr %a29
+  %a30 = getelementptr inbounds <16 x i32>, ptr %p, i64 30
+  %v30 = load <16 x i32>, ptr %a30
+  %a31 = getelementptr inbounds <16 x i32>, ptr %p, i64 31
+  %v31 = load <16 x i32>, ptr %a31
+  %a32 = getelementptr inbounds <16 x i32>, ptr %p, i64 32
+  %v32 = load <16 x i32>, ptr %a32
+  %a33 = getelementptr inbounds <16 x i32>, ptr %p, i64 33
+  %v33 = load <16 x i32>, ptr %a33
+  %a34 = getelementptr inbounds <16 x i32>, ptr %p, i64 34
+  %v34 = load <16 x i32>, ptr %a34
+  %a35 = getelementptr inbounds <16 x i32>, ptr %p, i64 35
+  %v35 = load <16 x i32>, ptr %a35
+  %a36 = getelementptr inbounds <16 x i32>, ptr %p, i64 36
+  %v36 = load <16 x i32>, ptr %a36
+  %a37 = getelementptr inbounds <16 x i32>, ptr %p, i64 37
+  %v37 = load <16 x i32>, ptr %a37
+  %a38 = getelementptr inbounds <16 x i32>, ptr %p, i64 38
+  %v38 = load <16 x i32>, ptr %a38
+  %a39 = getelementptr inbounds <16 x i32>, ptr %p, i64 39
+  %v39 = load <16 x i32>, ptr %a39
+  %a40 = getelementptr inbounds <16 x i32>, ptr %p, i64 40
+  %v40 = load <16 x i32>, ptr %a40
+  %a41 = getelementptr inbounds <16 x i32>, ptr %p, i64 41
+  %v41 = load <16 x i32>, ptr %a41
+  %a42 = getelementptr inbounds <16 x i32>, ptr %p, i64 42
+  %v42 = load <16 x i32>, ptr %a42
+  %a43 = getelementptr inbounds <16 x i32>, ptr %p, i64 43
+  %v43 = load <16 x i32>, ptr %a43
+  %a44 = getelementptr inbounds <16 x i32>, ptr %p, i64 44
+  %v44 = load <16 x i32>, ptr %a44
+  %m0 = add <16 x i32> %v0, %v1
+  %m1 = add <16 x i32> %v1, %v2
+  %m2 = add <16 x i32> %v2, %v3
+  %m3 = add <16 x i32> %v3, %v4
+  %m4 = add <16 x i32> %v4, %v5
+  %m5 = add <16 x i32> %v5, %v6
+  %m6 = add <16 x i32> %v6, %v7
+  %m7 = add <16 x i32> %v7, %v8
+  %m8 = add <16 x i32> %v8, %v9
+  %m9 = add <16 x i32> %v9, %v10
+  %m10 = add <16 x i32> %v10, %v11
+  %m11 = add <16 x i32> %v11, %v12
+  %m12 = add <16 x i32> %v12, %v13
+  %m13 = add <16 x i32> %v13, %v14
+  %m14 = add <16 x i32> %v14, %v15
+  %m15 = add <16 x i32> %v15, %v16
+  %m16 = add <16 x i32> %v16, %v17
+  %m17 = add <16 x i32> %v17, %v18
+  %m18 = add <16 x i32> %v18, %v19
+  %m19 = add <16 x i32> %v19, %v20
+  %m20 = add <16 x i32> %v20, %v21
+  %m21 = add <16 x i32> %v21, %v22
+  %m22 = add <16 x i32> %v22, %v23
+  %m23 = add <16 x i32> %v23, %v24
+  %m24 = add <16 x i32> %v24, %v25
+  %m25 = add <16 x i32> %v25, %v26
+  %m26 = add <16 x i32> %v26, %v27
+  %m27 = add <16 x i32> %v27, %v28
+  %m28 = add <16 x i32> %v28, %v29
+  %m29 = add <16 x i32> %v29, %v30
+  %m30 = add <16 x i32> %v30, %v31
+  %m31 = add <16 x i32> %v31, %v32
+  %m32 = add <16 x i32> %v32, %v33
+  %m33 = add <16 x i32> %v33, %v34
+  %m34 = add <16 x i32> %v34, %v35
+  %m35 = add <16 x i32> %v35, %v36
+  %m36 = add <16 x i32> %v36, %v37
+  %m37 = add <16 x i32> %v37, %v38
+  %m38 = add <16 x i32> %v38, %v39
+  %m39 = add <16 x i32> %v39, %v40
+  %m40 = add <16 x i32> %v40, %v41
+  %m41 = add <16 x i32> %v41, %v42
+  %m42 = add <16 x i32> %v42, %v43
+  %m43 = add <16 x i32> %v43, %v44
+  %m44 = add <16 x i32> %v44, %v0
+  %x0 = xor <16 x i32> %m0, %v2
+  %x1 = xor <16 x i32> %m1, %v3
+  %x2 = xor <16 x i32> %m2, %v4
+  %x3 = xor <16 x i32> %m3, %v5
+  %x4 = xor <16 x i32> %m4, %v6
+  %x5 = xor <16 x i32> %m5, %v7
+  %x6 = xor <16 x i32> %m6, %v8
+  %x7 = xor <16 x i32> %m7, %v9
+  %x8 = xor <16 x i32> %m8, %v10
+  %x9 = xor <16 x i32> %m9, %v11
+  %x10 = xor <16 x i32> %m10, %v12
+  %x11 = xor <16 x i32> %m11, %v13
+  %x12 = xor <16 x i32> %m12, %v14
+  %x13 = xor <16 x i32> %m13, %v15
+  %x14 = xor <16 x i32> %m14, %v16
+  %x15 = xor <16 x i32> %m15, %v17
+  %x16 = xor <16 x i32> %m16, %v18
+  %x17 = xor <16 x i32> %m17, %v19
+  %x18 = xor <16 x i32> %m18, %v20
+  %x19 = xor <16 x i32> %m19, %v21
+  %x20 = xor <16 x i32> %m20, %v22
+  %x21 = xor <16 x i32> %m21, %v23
+  %x22 = xor <16 x i32> %m22, %v24
+  %x23 = xor <16 x i32> %m23, %v25
+  %x24 = xor <16 x i32> %m24, %v26
+  %x25 = xor <16 x i32> %m25, %v27
+  %x26 = xor <16 x i32> %m26, %v28
+  %x27 = xor <16 x i32> %m27, %v29
+  %x28 = xor <16 x i32> %m28, %v30
+  %x29 = xor <16 x i32> %m29, %v31
+  %x30 = xor <16 x i32> %m30, %v32
+  %x31 = xor <16 x i32> %m31, %v33
+  %x32 = xor <16 x i32> %m32, %v34
+  %x33 = xor <16 x i32> %m33, %v35
+  %x34 = xor <16 x i32> %m34, %v36
+  %x35 = xor <16 x i32> %m35, %v37
+  %x36 = xor <16 x i32> %m36, %v38
+  %x37 = xor <16 x i32> %m37, %v39
+  %x38 = xor <16 x i32> %m38, %v40
+  %x39 = xor <16 x i32> %m39, %v41
+  %x40 = xor <16 x i32> %m40, %v42
+  %x41 = xor <16 x i32> %m41, %v43
+  %x42 = xor <16 x i32> %m42, %v44
+  %x43 = xor <16 x i32> %m43, %v0
+  %x44 = xor <16 x i32> %m44, %v1
+  %b0 = getelementptr inbounds <16 x i32>, ptr %q, i64 0
+  store <16 x i32> %x0, ptr %b0
+  %b1 = getelementptr inbounds <16 x i32>, ptr %q, i64 1
+  store <16 x i32> %x1, ptr %b1
+  %b2 = getelementptr inbounds <16 x i32>, ptr %q, i64 2
+  store <16 x i32> %x2, ptr %b2
+  %b3 = getelementptr inbounds <16 x i32>, ptr %q, i64 3
+  store <16 x i32> %x3, ptr %b3
+  %b4 = getelementptr inbounds <16 x i32>, ptr %q, i64 4
+  store <16 x i32> %x4, ptr %b4
+  %b5 = getelementptr inbounds <16 x i32>, ptr %q, i64 5
+  store <16 x i32> %x5, ptr %b5
+  %b6 = getelementptr inbounds <16 x i32>, ptr %q, i64 6
+  store <16 x i32> %x6, ptr %b6
+  %b7 = getelementptr inbounds <16 x i32>, ptr %q, i64 7
+  store <16 x i32> %x7, ptr %b7
+  %b8 = getelementptr inbounds <16 x i32>, ptr %q, i64 8
+  store <16 x i32> %x8, ptr %b8
+  %b9 = getelementptr inbounds <16 x i32>, ptr %q, i64 9
+  store <16 x i32> %x9, ptr %b9
+  %b10 = getelementptr inbounds <16 x i32>, ptr %q, i64 10
+  store <16 x i32> %x10, ptr %b10
+  %b11 = getelementptr inbounds <16 x i32>, ptr %q, i64 11
+  store <16 x i32> %x11, ptr %b11
+  %b12 = getelementptr inbounds <16 x i32>, ptr %q, i64 12
+  store <16 x i32> %x12, ptr %b12
+  %b13 = getelementptr inbounds <16 x i32>, ptr %q, i64 13
+  store <16 x i32> %x13, ptr %b13
+  %b14 = getelementptr inbounds <16 x i32>, ptr %q, i64 14
+  store <16 x i32> %x14, ptr %b14
+  %b15 = getelementptr inbounds <16 x i32>, ptr %q, i64 15
+  store <16 x i32> %x15, ptr %b15
+  %b16 = getelementptr inbounds <16 x i32>, ptr %q, i64 16
+  store <16 x i32> %x16, ptr %b16
+  %b17 = getelementptr inbounds <16 x i32>, ptr %q, i64 17
+  store <16 x i32> %x17, ptr %b17
+  %b18 = getelementptr inbounds <16 x i32>, ptr %q, i64 18
+  store <16 x i32> %x18, ptr %b18
+  %b19 = getelementptr inbounds <16 x i32>, ptr %q, i64 19
+  store <16 x i32> %x19, ptr %b19
+  %b20 = getelementptr inbounds <16 x i32>, ptr %q, i64 20
+  store <16 x i32> %x20, ptr %b20
+  %b21 = getelementptr inbounds <16 x i32>, ptr %q, i64 21
+  store <16 x i32> %x21, ptr %b21
+  %b22 = getelementptr inbounds <16 x i32>, ptr %q, i64 22
+  store <16 x i32> %x22, ptr %b22
+  %b23 = getelementptr inbounds <16 x i32>, ptr %q, i64 23
+  store <16 x i32> %x23, ptr %b23
+  %b24 = getelementptr inbounds <16 x i32>, ptr %q, i64 24
+  store <16 x i32> %x24, ptr %b24
+  %b25 = getelementptr inbounds <16 x i32>, ptr %q, i64 25
+  store <16 x i32> %x25, ptr %b25
+  %b26 = getelementptr inbounds <16 x i32>, ptr %q, i64 26
+  store <16 x i32> %x26, ptr %b26
+  %b27 = getelementptr inbounds <16 x i32>, ptr %q, i64 27
+  store <16 x i32> %x27, ptr %b27
+  %b28 = getelementptr inbounds <16 x i32>, ptr %q, i64 28
+  store <16 x i32> %x28, ptr %b28
+  %b29 = getelementptr inbounds <16 x i32>, ptr %q, i64 29
+  store <16 x i32> %x29, ptr %b29
+  %b30 = getelementptr inbounds <16 x i32>, ptr %q, i64 30
+  store <16 x i32> %x30, ptr %b30
+  %b31 = getelementptr inbounds <16 x i32>, ptr %q, i64 31
+  store <16 x i32> %x31, ptr %b31
+  %b32 = getelementptr inbounds <16 x i32>, ptr %q, i64 32
+  store <16 x i32> %x32, ptr %b32
+  %b33 = getelementptr inbounds <16 x i32>, ptr %q, i64 33
+  store <16 x i32> %x33, ptr %b33
+  %b34 = getelementptr inbounds <16 x i32>, ptr %q, i64 34
+  store <16 x i32> %x34, ptr %b34
+  %b35 = getelementptr inbounds <16 x i32>, ptr %q, i64 35
+  store <16 x i32> %x35, ptr %b35
+  %b36 = getelementptr inbounds <16 x i32>, ptr %q, i64 36
+  store <16 x i32> %x36, ptr %b36
+  %b37 = getelementptr inbounds <16 x i32>, ptr %q, i64 37
+  store <16 x i32> %x37, ptr %b37
+  %b38 = getelementptr inbounds <16 x i32>, ptr %q, i64 38
+  store <16 x i32> %x38, ptr %b38
+  %b39 = getelementptr inbounds <16 x i32>, ptr %q, i64 39
+  store <16 x i32> %x39, ptr %b39
+  %b40 = getelementptr inbounds <16 x i32>, ptr %q, i64 40
+  store <16 x i32> %x40, ptr %b40
+  %b41 = getelementptr inbounds <16 x i32>, ptr %q, i64 41
+  store <16 x i32> %x41, ptr %b41
+  %b42 = getelementptr inbounds <16 x i32>, ptr %q, i64 42
+  store <16 x i32> %x42, ptr %b42
+  %b43 = getelementptr inbounds <16 x i32>, ptr %q, i64 43
+  store <16 x i32> %x43, ptr %b43
+  %b44 = getelementptr inbounds <16 x i32>, ptr %q, i64 44
+  store <16 x i32> %x44, ptr %b44
+  %iv.next = add i64 %iv, 1
+  %c = icmp slt i64 %iv.next, %n
+  br i1 %c, label %loop, label %exit
+
+exit:
+  ret void
+}


### PR DESCRIPTION
I was looking for reasons behind https://github.com/llvm/llvm-project/issues/215149 with the help of LLM and believe I found it.

This PR fixes https://github.com/llvm/llvm-project/issues/215149 by recovering majority of the performance gap between AVX-512 BLAKE3 C implementation and hand-written assembly as well as improving AVX2 version of the same kernel (see the issue for details why that may have not been the case).

Despite LLM wrote most of it under my guidance, I edited, audited and tested the changes to the best of my ability on both Intel and AMD CPUs before opening the PR.

---

Two defects in `GenericScheduler` cost 1.6-2.9% on large AVX-512 loops, depending on target tuning (tested generic and znver4 on Intel Xeon and AMD Threadripper CPUs). Kept as two commits; details and rationale are in the commit messages.

1. `checkAcyclicLatency()` computes something other than the model documented above it. It uses `Rem.RemIssueCount` as the per-iteration cost where the model calls for the loop's resource height, and it applies the in-flight comparison unconditionally, where the comparison only means anything once the acyclic path spans more than one iteration. Without that second condition the test algebraically reduces to "acyclic critical path longer than `MicroOpBufferSize / IssueWidth` cycles" - about 42 on Skylake - which every large loop clears whether or not latency limits it. On BLAKE3's AVX-512 kernel, the current code flags 4 regions as latency-limited; the fixed estimate flags none.

2. `RegExcess` and `RegCritical` outrank clustering, resource balancing, latency and source order, so either one firing decides the schedule outright. That is right when a different order could keep the region inside the register file. It is not right when the region is already over the limit and throughput bound: some values spill whichever order is chosen, and there is no dependence height left to win back either. `checkPressureIsActionable()` skips the two heuristics in exactly that case, subject to a size floor and an out-of-order-window ratio.

### Measurements

BLAKE3's compression kernels built from intrinsics. The same IR for every arm; only the `llc` that produced the object differs. Medians of randomised interleaved rounds pinned to one core; each cell is one complete sweep at the stated working-set size. `assembly` is BLAKE3's hand-written implementation, which the patch does not touch, run in the same sweep as a reference point.

Machines: an Intel Emerald Rapids Xeon (shared 4-vCPU cloud VM, so noisier) and an AMD Ryzen Threadripper 7970X (Zen 4).

**AVX-512 kernel, generic tuning** (`-O2 -mavx512f -mavx512vl -mavx512bw -mavx512dq`)

| arm | Xeon 512 KiB | Xeon 4 MiB | Zen 4 512 KiB | Zen 4 4 MiB |
|---|---|---|---|---|
| commit 1 alone | −0.18% | −0.18% | −0.40% | −0.21% |
| commit 2 alone | +0.06% | −0.16% | +0.44% | +0.74% |
| both | **+2.41%** | **+2.41%** | **+1.42%** | **+1.69%** |
| assembly (unaffected reference) | — | — | +2.78% | +2.65% |

**AVX-512 kernel, znver4 tuning** (`-O2 -march=znver4`, Zen 4)

| arm | 512 KiB | 4 MiB |
|---|---|---|
| commit 1 alone | +0.23% | −0.44% |
| commit 2 alone | +2.80% | +2.00% |
| both | **+2.87%** | **+2.16%** |

**AVX2 kernel, generic tuning** (`-O2 -mavx2`, Zen 4)

| arm | 512 KiB | 4 MiB |
|---|---|---|
| commit 1 alone | +2.56% | +1.25% |
| commit 2 alone | +6.54% | +6.24% |
| both | **+7.21%** | **+5.72%** |
| assembly (unaffected reference) | +16.15% | +14.08% |

The patch closes 51% and 64% of the AVX-512 gap to hand-written assembly, and 41% to 45% of the AVX2 gap.
AVX2 gains considerably more in relative terms (+5.7% to +7.2%) than AVX-512 (+1.4% to +1.7%), because its starting point is further from assembly.

Commit 2 is the most beneficial, and commit 1 looks like a downgrade in isolation on AVX-512.
But it is worth +1.25% to +2.56% on AVX2, and under generic tuning it is what makes commit 2 effective on AVX-512.

Not measured: the AVX2 kernel under znver4 tuning (Clang beats hand-written assembly here because it doesn't limit itself to AVX2-only instructions), and the AVX2 kernel on Intel (was too noisy at the time).

Note that AVX2 still has known (to me) issues with code generation that I'll be looking at separately, so those numbers are not final, just trying to prove it at least doesn't regress.

### Testing

Two regression tests have been added since BLAKE3 workload is larger than anything in the repo (I think), and thus the changes didn't affect any existing code generation tests.
That was kind of the point: targeted fix without affecting the rest of the cases unnecessarily, though I was surprised such workloads were not represented at all on any of the platforms.

Default values of new knobs are the best educated guess after multiple rounds of tests.
