### PR TITLE
[ELF] Remove --fortran-common

### DIFF
--- a/lld/ELF/Config.h
+++ b/lld/ELF/Config.h
@@ -364,7 +364,6 @@ struct Config {
   bool fixCortexA53Errata843419;
   bool fixCortexA8;
   bool formatBinary = false;
-  bool fortranCommon;
   bool gcSections;
   bool gdbIndex;
   bool gnuHash = false;

--- a/lld/ELF/Driver.cpp
+++ b/lld/ELF/Driver.cpp
@@ -1460,8 +1460,6 @@ static void readConfigs(Ctx &ctx, opt::InputArgList &args) {
   ctx.arg.cmseOutputLib = args.getLastArgValue(OPT_out_implib);
   ctx.arg.fixCortexA8 =
       args.hasArg(OPT_fix_cortex_a8) && !args.hasArg(OPT_relocatable);
-  ctx.arg.fortranCommon =
-      args.hasFlag(OPT_fortran_common, OPT_no_fortran_common, false);
   ctx.arg.gcSections = args.hasFlag(OPT_gc_sections, OPT_no_gc_sections, false);
   ctx.arg.gnuUnique = args.hasFlag(OPT_gnu_unique, OPT_no_gnu_unique, true);
   ctx.arg.gdbIndex = args.hasFlag(OPT_gdb_index, OPT_no_gdb_index, false);

--- a/lld/ELF/InputFiles.cpp
+++ b/lld/ELF/InputFiles.cpp
@@ -1365,73 +1365,6 @@ template <class ELFT> void ObjFile<ELFT>::postParse() {
   }
 }
 
-// The handling of tentative definitions (COMMON symbols) in archives is murky.
-// A tentative definition will be promoted to a global definition if there are
-// no non-tentative definitions to dominate it. When we hold a tentative
-// definition to a symbol and are inspecting archive members for inclusion
-// there are 2 ways we can proceed:
-//
-// 1) Consider the tentative definition a 'real' definition (ie promotion from
-//    tentative to real definition has already happened) and not inspect
-//    archive members for Global/Weak definitions to replace the tentative
-//    definition. An archive member would only be included if it satisfies some
-//    other undefined symbol. This is the behavior Gold uses.
-//
-// 2) Consider the tentative definition as still undefined (ie the promotion to
-//    a real definition happens only after all symbol resolution is done).
-//    The linker searches archive members for STB_GLOBAL definitions to
-//    replace the tentative definition with. This is the behavior used by
-//    GNU ld.
-//
-//  The second behavior is inherited from SysVR4, which based it on the FORTRAN
-//  COMMON BLOCK model. This behavior is needed for proper initialization in old
-//  (pre F90) FORTRAN code that is packaged into an archive.
-//
-//  The following functions search archive members for definitions to replace
-//  tentative definitions (implementing behavior 2).
-static bool isBitcodeNonCommonDef(MemoryBufferRef mb, StringRef symName,
-                                  StringRef archiveName) {
-  IRSymtabFile symtabFile = check(readIRSymtab(mb));
-  for (const irsymtab::Reader::SymbolRef &sym :
-       symtabFile.TheReader.symbols()) {
-    if (sym.isGlobal() && sym.getName() == symName)
-      return !sym.isUndefined() && !sym.isWeak() && !sym.isCommon();
-  }
-  return false;
-}
-
-template <class ELFT>
-static bool isNonCommonDef(Ctx &ctx, ELFKind ekind, MemoryBufferRef mb,
-                           StringRef symName, StringRef archiveName) {
-  ObjFile<ELFT> *obj = make<ObjFile<ELFT>>(ctx, ekind, mb, archiveName);
-  obj->init();
-  StringRef stringtable = obj->getStringTable();
-
-  for (auto sym : obj->template getGlobalELFSyms<ELFT>()) {
-    Expected<StringRef> name = sym.getName(stringtable);
-    if (name && name.get() == symName)
-      return sym.isDefined() && sym.getBinding() == STB_GLOBAL &&
-             !sym.isCommon();
-  }
-  return false;
-}
-
-static bool isNonCommonDef(Ctx &ctx, MemoryBufferRef mb, StringRef symName,
-                           StringRef archiveName) {
-  switch (getELFKind(ctx, mb, archiveName)) {
-  case ELF32LEKind:
-    return isNonCommonDef<ELF32LE>(ctx, ELF32LEKind, mb, symName, archiveName);
-  case ELF32BEKind:
-    return isNonCommonDef<ELF32BE>(ctx, ELF32BEKind, mb, symName, archiveName);
-  case ELF64LEKind:
-    return isNonCommonDef<ELF64LE>(ctx, ELF64LEKind, mb, symName, archiveName);
-  case ELF64BEKind:
-    return isNonCommonDef<ELF64BE>(ctx, ELF64BEKind, mb, symName, archiveName);
-  default:
-    llvm_unreachable("getELFKind");
-  }
-}
-
 SharedFile::SharedFile(Ctx &ctx, MemoryBufferRef m, StringRef defaultSoName)
     : ELFFileBase(ctx, SharedKind, getELFKind(ctx, m, ""), m),
       soName(defaultSoName), isNeeded(!ctx.arg.asNeeded) {}
@@ -2029,13 +1962,6 @@ template <class ELFT> void ObjFile<ELFT>::parseLazy() {
     if (!lazy)
       break;
   }
-}
-
-bool InputFile::shouldExtractForCommon(StringRef name) const {
-  if (isa<BitcodeFile>(this))
-    return isBitcodeNonCommonDef(mb, name, archiveName);
-
-  return isNonCommonDef(ctx, mb, name, archiveName);
 }
 
 std::string elf::replaceThinLTOSuffix(Ctx &ctx, StringRef path) {

--- a/lld/ELF/InputFiles.h
+++ b/lld/ELF/InputFiles.h
@@ -115,10 +115,6 @@ public:
   // Get filename to use for linker script processing.
   StringRef getNameForScript() const;
 
-  // Check if a non-common symbol should be extracted to override a common
-  // definition.
-  bool shouldExtractForCommon(StringRef name) const;
-
   // .got2 in the current file. This is used by PPC32 -fPIC/-fPIE to compute
   // offsets in PLT call stubs.
   InputSection *ppc32Got2 = nullptr;

--- a/lld/ELF/Options.td
+++ b/lld/ELF/Options.td
@@ -83,10 +83,6 @@ defm optimize_bb_jumps: BB<"optimize-bb-jumps",
     "Remove direct jumps at the end to the next basic block",
     "Do not remove any direct jumps at the end to the next basic block (default)">;
 
-defm fortran_common : BB<"fortran-common",
-    "Search archive members for definitions to override COMMON symbols (default)",
-    "Do not search archive members for definitions to override COMMON symbols">;
-
 defm split_stack_adjust_size
     : Eq<"split-stack-adjust-size",
          "Specify adjustment to stack size when a split-stack function calls a "

--- a/lld/ELF/Symbols.cpp
+++ b/lld/ELF/Symbols.cpp
@@ -657,16 +657,8 @@ void Symbol::resolve(Ctx &ctx, const LazySymbol &other) {
 
   if (LLVM_UNLIKELY(!isUndefined())) {
     // See the comment in resolve(Ctx &, const Undefined &).
-    if (isDefined()) {
+    if (isDefined())
       ctx.backwardReferences.erase(this);
-    } else if (isCommon() && ctx.arg.fortranCommon &&
-               other.file->shouldExtractForCommon(getName())) {
-      // For common objects, we want to look for global or weak definitions that
-      // should be extracted as the canonical definition instead.
-      ctx.backwardReferences.erase(this);
-      other.overwrite(*this);
-      other.extract(ctx);
-    }
     return;
   }
 

--- a/lld/docs/ld.lld.1
+++ b/lld/docs/ld.lld.1
@@ -378,8 +378,6 @@ Do not demangle symbol names.
 Inhibit output of an
 .Li .interp
 section.
-.It Fl -no-fortran-common
-Do not search archive members for definitions to override COMMON symbols.
 .It Fl -no-gc-sections
 Disable garbage collection of unused sections.
 .It Fl -no-gnu-unique

--- a/lld/test/ELF/common-archive-lookup.s
+++ b/lld/test/ELF/common-archive-lookup.s
@@ -25,12 +25,6 @@
 ## Bitcode archive.
 # RUN: llvm-ar crs 4.a 1.bc 2.bc
 
-# RUN: ld.lld -o 1 main.o 1.a --fortran-common
-# RUN: llvm-objdump -D -j .data 1 | FileCheck --check-prefix=TEST1 %s
-
-# RUN: ld.lld -o 2 main.o --start-lib 1.o strong_data_only.o --end-lib --fortran-common
-# RUN: llvm-objdump -D -j .data 2 | FileCheck --check-prefix=TEST1 %s
-
 # RUN: ld.lld -o 3 main.o 2.a
 # RUN: llvm-objdump -t 3 | FileCheck --check-prefix=BSS %s
 
@@ -45,28 +39,13 @@
 # RUN: ld.lld -o 7 main.o 2.o --start-lib 1.o strong_data_only.o --end-lib
 # RUN: llvm-objdump -D -j .data 7 | FileCheck --check-prefix=TEST2 %s
 
-# RUN: not ld.lld -o 8 main.o 1.a strong_data_only.o --fortran-common 2>&1 | \
-# RUN:   FileCheck --check-prefix=ERR %s
-
-# RUN: not ld.lld -o 9 main.o --start-lib 1.o 2.o --end-lib  strong_data_only.o --fortran-common 2>&1 | \
-# RUN:   FileCheck --check-prefix=ERR %s
-
 # ERR: ld.lld: error: duplicate symbol: block
 
-# RUN: ld.lld --no-fortran-common -o 10 main.o 1.a
-# RUN: llvm-readobj --syms 10 | FileCheck --check-prefix=NFC %s
 # RUN: ld.lld -o 10 main.o 1.a
 # RUN: llvm-readobj --syms 10 | FileCheck --check-prefix=NFC %s
 
-# RUN: ld.lld --no-fortran-common -o 11 main.o --start-lib 1.o strong_data_only.o --end-lib
+# RUN: ld.lld -o 11 main.o --start-lib 1.o strong_data_only.o --end-lib
 # RUN: llvm-readobj --syms 11 | FileCheck --check-prefix=NFC %s
-
-# RUN: ld.lld -o out main.o 4.a --fortran-common --lto-emit-asm
-# RUN: FileCheck --check-prefix=ASM %s < out.lto.s
-
-# RUN: rm out.lto.s
-# RUN: ld.lld -o out main.o --start-lib 1.bc 2.bc --end-lib --fortran-common --lto-emit-asm
-# RUN: FileCheck --check-prefix=ASM %s < out.lto.s
 
 ## COMMON overrides weak. Don't extract 3.bc which provides a weak definition.
 # RUN: ld.lld main.o --start-lib 1.bc 3.bc --end-lib -y block | FileCheck --check-prefix=LTO_WEAK %s

--- a/lld/test/ELF/warn-backrefs.s
+++ b/lld/test/ELF/warn-backrefs.s
@@ -77,8 +77,6 @@
 # RUN: llvm-ar rcs %tcomm.a %tcomm.o
 # RUN: llvm-ar rcs %tstrong.a %tstrong.o
 # RUN: ld.lld --warn-backrefs %tcomm.a %t1.o %t5.o 2>&1 -o /dev/null | FileCheck --check-prefix=COMM %s
-# RUN: ld.lld --fatal-warnings --fortran-common --warn-backrefs %tcomm.a %t1.o %t5.o %tstrong.a 2>&1 -o /dev/null
-# RUN: ld.lld --warn-backrefs --no-fortran-common %tcomm.a %t1.o %t5.o %tstrong.a 2>&1 -o /dev/null | FileCheck --check-prefix=COMM %s
 
 # COMM: ld.lld: warning: backward reference detected: obj in {{.*}}5.o refers to {{.*}}comm.a
 


### PR DESCRIPTION
--fortran-common implements a legacy linker rule that lets a COMMON
symbol extract an archive member providing a STB_GLOBAL definition,
departing from the rule that only an undefined symbol extracts a member.

The option has defaulted to off since LLVM 15, complicates parallel
symbol resolution, and is deemed unneeded.

Close: #205015
Link: https://discourse.llvm.org/t/removal-of-fortran-common-option/91553
