### PR TITLE
[AMDLIBM] Add VF8 mapping for cbrtf (amd_vrs8_cbrtf)

### DIFF
--- a/llvm/include/llvm/Analysis/VecFuncs.def
+++ b/llvm/include/llvm/Analysis/VecFuncs.def
@@ -1931,6 +1931,7 @@ TLI_DEFINE_VECFUNC("llvm.tanh.f32", "amd_vrs16_tanhf", FIXED(16), NOMASK, "_ZGV_
 
 TLI_DEFINE_VECFUNC("cbrt", "amd_vrd2_cbrt", FIXED(2), NOMASK, "_ZGV_LLVM_N2v")
 TLI_DEFINE_VECFUNC("cbrtf", "amd_vrs4_cbrtf", FIXED(4), NOMASK, "_ZGV_LLVM_N4v")
+TLI_DEFINE_VECFUNC("cbrtf", "amd_vrs8_cbrtf", FIXED(8), NOMASK, "_ZGV_LLVM_N8v")
 
 TLI_DEFINE_VECFUNC("sincos", "amd_vrd2_sincos", FIXED(2), NOMASK, "_ZGV_LLVM_N2vl8l8")
 TLI_DEFINE_VECFUNC("sincos", "amd_vrd4_sincos", FIXED(4), NOMASK, "_ZGV_LLVM_N4vl8l8")

--- a/llvm/include/llvm/IR/RuntimeLibcalls.td
+++ b/llvm/include/llvm/IR/RuntimeLibcalls.td
@@ -4576,6 +4576,7 @@ defset list<RuntimeLibcallImpl> AMDLIBM_VECFUNCS = {
   def amd_vrs8_acosf : RuntimeLibcallImpl<ACOS_V8F32>;
   def amd_vrs8_asinf : RuntimeLibcallImpl<ASIN_V8F32>;
   def amd_vrs8_atanf : RuntimeLibcallImpl<ATAN_V8F32>;
+  def amd_vrs8_cbrtf : RuntimeLibcallImpl<CBRT_V8F32>;
   def amd_vrs8_cosf : RuntimeLibcallImpl<COS_V8F32>;
   def amd_vrs8_coshf : RuntimeLibcallImpl<COSH_V8F32>;
   def amd_vrs8_erff : RuntimeLibcallImpl<ERF_V8F32>;

--- a/llvm/test/Transforms/LoopVectorize/X86/amdlibm-calls.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/amdlibm-calls.ll
@@ -2037,6 +2037,34 @@ for.end:
   ret void
 }
 
+; ======================= cbrtf ============================
+define void @cbrtf_f32(ptr nocapture %varray) {
+; CHECK-LABEL: @cbrtf_f32(
+;
+; CHECK-VF2:    {{.*}} = tail call float @cbrtf(float {{.*}})
+; CHECK-VF4:    [[TMP5:%.*]] = call <4 x float> @amd_vrs4_cbrtf(<4 x float> [[TMP4:%.*]])
+; CHECK-VF8:    [[TMP5:%.*]] = call <8 x float> @amd_vrs8_cbrtf(<8 x float> [[TMP4:%.*]])
+; CHECK-VF16:   {{.*}} = tail call float @cbrtf(float {{.*}})
+; CHECK:        ret void
+;
+entry:
+  br label %for.body
+
+for.body:
+  %iv = phi i64 [ 0, %entry ], [ %iv.next, %for.body ]
+  %tmp = trunc i64 %iv to i32
+  %conv = sitofp i32 %tmp to float
+  %call = tail call float @cbrtf(float %conv)
+  %arrayidx = getelementptr inbounds float, ptr %varray, i64 %iv
+  store float %call, ptr %arrayidx, align 4
+  %iv.next = add nuw nsw i64 %iv, 1
+  %exitcond = icmp eq i64 %iv.next, 1000
+  br i1 %exitcond, label %for.end, label %for.body
+
+for.end:
+  ret void
+}
+
 ; ======================= expm1 ============================
 define void @expm1_f64(ptr nocapture %varray) {
 ; CHECK-LABEL: @expm1_f64(
@@ -2109,3 +2137,4 @@ declare double @round(double) #0
 declare float @roundf(float) #0
 declare double @expm1(double) #0
 declare float @expm1f(float) #0
+declare float @cbrtf(float) #0


### PR DESCRIPTION
Map cbrtf loops at VF=8 to amd_vrs8_cbrtf so -vector-library=AMDLIBM matches the vector entry exported by AOCL-LibM.

AOCL repo : [AOCL-LibM](https://github.com/amd/aocl-libm-ose)

As per the latest external supported call in [amdlibm_vec.h](https://github.com/amd/aocl-libm-ose/blob/master/include/external/amdlibm_vec.h)