### PR TITLE
[ELF] Discard an SHF_LINK_ORDER section whose linked-to section is discarded

### DIFF
--- a/lld/ELF/InputFiles.cpp
+++ b/lld/ELF/InputFiles.cpp
@@ -881,6 +881,33 @@ void ObjFile<ELFT>::initializeSections(bool ignoreComdats,
     }
   }
 
+  // Discard a SHF_LINK_ORDER section whose linked-to section is already
+  // discarded, by comdat group selection or SHF_EXCLUDE. Repeat until a fixed
+  // point, as a linked-to section may itself be SHF_LINK_ORDER; a section is
+  // only ever discarded, never restored, so this terminates. An sh_link that is
+  // out of range or does not designate an input section is diagnosed by the
+  // loop below.
+  //
+  // Do this before that loop, which would otherwise create a relocation section
+  // for a section discarded here, and push onto the dependentSections of the
+  // shared InputSection::discarded, a data race since
+  // initSectionsAndLocalSyms() runs under parallelForEach().
+  for (bool changed = true; changed;) {
+    changed = false;
+    for (size_t i = 0; i != size; ++i) {
+      if (!this->sections[i] || this->sections[i] == &InputSection::discarded)
+        continue;
+      const Elf_Shdr &sec = objSections[i];
+      if (!(sec.sh_flags & SHF_LINK_ORDER) || !sec.sh_link ||
+          sec.sh_link >= size)
+        continue;
+      if (this->sections[sec.sh_link] == &InputSection::discarded) {
+        this->sections[i] = &InputSection::discarded;
+        changed = true;
+      }
+    }
+  }
+
   // We have a second loop. It is used to:
   // 1) handle SHF_LINK_ORDER sections.
   // 2) create relocation sections. In some cases the section header index of a
@@ -951,8 +978,11 @@ void ObjFile<ELFT>::initializeSections(bool ignoreComdats,
       continue;
     }
 
-    // A SHF_LINK_ORDER section is discarded if its linked-to section is
-    // discarded.
+    // Record the dependency so that the section is discarded along with its
+    // linked-to section if that is discarded later by /DISCARD/ or
+    // --gc-sections. A linked-to section that was already discarded was
+    // handled by the loop above.
+    assert(linkSec != &InputSection::discarded);
     InputSection *isec = cast<InputSection>(this->sections[i]);
     linkSec->dependentSections.push_back(isec);
     if (!isa<InputSection>(linkSec))

--- a/lld/test/ELF/linkorder-discard.s
+++ b/lld/test/ELF/linkorder-discard.s
@@ -1,0 +1,234 @@
+# REQUIRES: x86
+## A SHF_LINK_ORDER section whose linked-to section is discarded is discarded
+## with it. Without that, the section is emitted with an sh_link that no longer
+## designates an output section and the link fails.
+
+# RUN: rm -rf %t && split-file %s %t && cd %t
+# RUN: llvm-mc -filetype=obj -triple=x86_64 a.s -o a.o
+# RUN: llvm-mc -filetype=obj -triple=x86_64 b.s -o b.o
+# RUN: llvm-mc -filetype=obj -triple=x86_64 main.s -o main.o
+
+## b.o's group is discarded, and so is the __patchable_function_entries section
+## that points into it. Only a.o's entry is left, with an sh_link
+## to the surviving .text.
+# RUN: ld.lld main.o a.o b.o -o out
+# RUN: llvm-readelf -S out | FileCheck %s \
+# RUN:     --implicit-check-not='{{ }}__patchable_function_entries '
+# CHECK: [[#%u,TEXT:]]] .text PROGBITS
+# CHECK: {{ }}__patchable_function_entries PROGBITS {{.*}} 000008 00 WAL [[#%u,TEXT]]
+
+## Same in a relocatable link and with --emit-relocs, where the relocation
+## sections are copied to the output and must not be left with a dangling
+## sh_info. Exactly one of each survives, and the surviving relocation section
+## points at the surviving __patchable_function_entries.
+# RUN: ld.lld -r main.o a.o b.o -o out.ro
+# RUN: llvm-readelf -S out.ro | FileCheck %s --check-prefix=REL \
+# RUN:     --implicit-check-not='{{ }}__patchable_function_entries ' \
+# RUN:     --implicit-check-not='{{ }}.rela__patchable_function_entries '
+# REL: [[#%u,PFE:]]] __patchable_function_entries PROGBITS
+# REL: {{ }}.rela__patchable_function_entries RELA {{.*}} I {{[0-9]+}} [[#%u,PFE]]
+
+# RUN: ld.lld --emit-relocs main.o a.o b.o -o out.er
+# RUN: llvm-readelf -S out.er | FileCheck %s --check-prefix=REL \
+# RUN:     --implicit-check-not='{{ }}__patchable_function_entries ' \
+# RUN:     --implicit-check-not='{{ }}.rela__patchable_function_entries '
+
+## A relocation section that precedes the SHF_LINK_ORDER section it relocates
+## must be dropped along with it. yaml2obj is used because assemblers place
+## relocation sections last.
+# RUN: yaml2obj rev.yaml -o rev.o
+# RUN: ld.lld -r main.o a.o rev.o -o out.rev
+# RUN: llvm-readelf -S out.rev | FileCheck %s --check-prefix=REL \
+# RUN:     --implicit-check-not='{{ }}__patchable_function_entries ' \
+# RUN:     --implicit-check-not='{{ }}.rela__patchable_function_entries '
+
+## A relocation section has no input section yet at this point, and the loop
+## uses sh_link, while a relocation section names its target with sh_info.
+## Discarding one on sh_link would silently drop its relocations.
+## .rela.data.live has SHF_LINK_ORDER and an sh_link to the discarded group,
+## but relocates the live .data.live, which must still get its relocation.
+# RUN: yaml2obj reloc.yaml -o reloc.o
+# RUN: ld.lld main.o a.o reloc.o -o out.reloc
+# RUN: llvm-readelf -x .data out.reloc | FileCheck %s --check-prefix=RELOC
+# RELOC:     Hex dump of section '.data':
+# RELOC-NOT: 00000000 00000000
+
+## A linked-to section may itself be SHF_LINK_ORDER. lo_a links to lo_b, which
+## links to lo_c, which links to a discarded section, so all three go. Handling
+## only one level fails the link with "sh_link points to discarded section
+## <internal>:()". GNU ld follows the chain as well.
+##
+## The same object has a cycle and a self-link, which no rewrite of the loop may
+## hang on. No member of a cycle reaches a discarded section, so all three stay.
+# RUN: yaml2obj chain.yaml -o chain.o
+# RUN: ld.lld main.o a.o chain.o -o out.chain
+# RUN: llvm-readelf -S out.chain | FileCheck %s --check-prefix=CHAIN \
+# RUN:     --implicit-check-not='{{ }}lo_a ' \
+# RUN:     --implicit-check-not='{{ }}lo_b ' \
+# RUN:     --implicit-check-not='{{ }}lo_c '
+# CHAIN-DAG: {{ }}lo_self PROGBITS
+# CHAIN-DAG: {{ }}lo_x PROGBITS
+# CHAIN-DAG: {{ }}lo_y PROGBITS
+
+#--- a.s
+.globl fa
+fa:
+  retq
+
+.section .text.P,"axG",@progbits,P,comdat
+.globl P
+P:
+  retq
+
+.section __patchable_function_entries,"awo",@progbits,.text.P
+  .quad P
+
+#--- b.s
+.globl fb
+fb:
+  retq
+
+.section .text.P,"axG",@progbits,P,comdat
+.globl P
+P:
+  retq
+
+.section __patchable_function_entries,"awo",@progbits,.text.P
+  .quad P
+
+#--- main.s
+.globl _start
+_start:
+  callq P
+  callq fa
+  retq
+
+#--- rev.yaml
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_REL
+  Machine: EM_X86_64
+Sections:
+  - Name:    .text.P
+    Type:    SHT_PROGBITS
+    Flags:   [ SHF_ALLOC, SHF_EXECINSTR, SHF_GROUP ]
+    Size:    1
+  - Name:    .group
+    Type:    SHT_GROUP
+    Link:    .symtab
+    Info:    P
+    Members:
+      - SectionOrType: GRP_COMDAT
+      - SectionOrType: .text.P
+  - Name:    .rela__patchable_function_entries
+    Type:    SHT_RELA
+    Link:    .symtab
+    Info:    __patchable_function_entries
+    Relocations:
+      - Offset: 0
+        Symbol: P
+        Type:   R_X86_64_64
+  - Name:    __patchable_function_entries
+    Type:    SHT_PROGBITS
+    Flags:   [ SHF_ALLOC, SHF_WRITE, SHF_LINK_ORDER ]
+    Link:    .text.P
+    Size:    8
+Symbols:
+  - Name:    P
+    Section: .text.P
+    Binding: STB_GLOBAL
+
+#--- reloc.yaml
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_REL
+  Machine: EM_X86_64
+Sections:
+  - Name:    .text.P
+    Type:    SHT_PROGBITS
+    Flags:   [ SHF_ALLOC, SHF_EXECINSTR, SHF_GROUP ]
+    Size:    1
+  - Name:    .group
+    Type:    SHT_GROUP
+    Link:    .symtab
+    Info:    P
+    Members:
+      - SectionOrType: GRP_COMDAT
+      - SectionOrType: .text.P
+  - Name:    .data.live
+    Type:    SHT_PROGBITS
+    Flags:   [ SHF_ALLOC, SHF_WRITE ]
+    Size:    8
+  - Name:    .rela.data.live
+    Type:    SHT_RELA
+    Flags:   [ SHF_LINK_ORDER ]
+    Link:    .text.P
+    Info:    .data.live
+    Relocations:
+      - Offset: 0
+        Symbol: fa
+        Type:   R_X86_64_64
+Symbols:
+  - Name:    P
+    Section: .text.P
+    Binding: STB_GLOBAL
+  - Name:    fa
+    Binding: STB_GLOBAL
+
+#--- chain.yaml
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_REL
+  Machine: EM_X86_64
+Sections:
+  - Name:    .text.P
+    Type:    SHT_PROGBITS
+    Flags:   [ SHF_ALLOC, SHF_EXECINSTR, SHF_GROUP ]
+    Size:    1
+  - Name:    .group
+    Type:    SHT_GROUP
+    Link:    .symtab
+    Info:    P
+    Members:
+      - SectionOrType: GRP_COMDAT
+      - SectionOrType: .text.P
+  - Name:    lo_a
+    Type:    SHT_PROGBITS
+    Flags:   [ SHF_ALLOC, SHF_LINK_ORDER ]
+    Link:    lo_b
+    Size:    8
+  - Name:    lo_b
+    Type:    SHT_PROGBITS
+    Flags:   [ SHF_ALLOC, SHF_LINK_ORDER ]
+    Link:    lo_c
+    Size:    8
+  - Name:    lo_c
+    Type:    SHT_PROGBITS
+    Flags:   [ SHF_ALLOC, SHF_LINK_ORDER ]
+    Link:    .text.P
+    Size:    8
+  - Name:    lo_self
+    Type:    SHT_PROGBITS
+    Flags:   [ SHF_ALLOC, SHF_LINK_ORDER ]
+    Link:    lo_self
+    Size:    8
+  - Name:    lo_x
+    Type:    SHT_PROGBITS
+    Flags:   [ SHF_ALLOC, SHF_LINK_ORDER ]
+    Link:    lo_y
+    Size:    8
+  - Name:    lo_y
+    Type:    SHT_PROGBITS
+    Flags:   [ SHF_ALLOC, SHF_LINK_ORDER ]
+    Link:    lo_x
+    Size:    8
+Symbols:
+  - Name:    P
+    Section: .text.P
+    Binding: STB_GLOBAL

--- a/lld/test/ELF/linkorder-exclude.s
+++ b/lld/test/ELF/linkorder-exclude.s
@@ -1,0 +1,32 @@
+# REQUIRES: x86
+## A SHF_LINK_ORDER section linked to an SHF_EXCLUDE'd section is discarded
+## along with it in a final link, and kept, as SHF_EXCLUDE itself is, in a
+## relocatable link. GNU ld does the same.
+
+# RUN: rm -rf %t && split-file %s %t && cd %t
+# RUN: llvm-mc -filetype=obj -triple=x86_64 excl.s -o excl.o
+# RUN: llvm-mc -filetype=obj -triple=x86_64 main.s -o main.o
+
+# RUN: ld.lld main.o excl.o -o out
+# RUN: llvm-readelf -S out | FileCheck %s \
+# RUN:     --implicit-check-not='{{ }}__patchable_function_entries ' \
+# RUN:     --implicit-check-not='{{ }}.text.X '
+# CHECK: {{ }}.text PROGBITS
+
+# RUN: ld.lld -r main.o excl.o -o out.ro
+# RUN: llvm-readelf -S out.ro | FileCheck %s --check-prefix=REL
+# REL: [[#%u,X:]]] .text.X PROGBITS {{.*}} AXE
+# REL: {{ }}__patchable_function_entries PROGBITS {{.*}} WAL [[#%u,X]]
+
+#--- excl.s
+.section .text.X,"axe",@progbits
+X:
+  retq
+
+.section __patchable_function_entries,"awo",@progbits,.text.X
+  .quad X
+
+#--- main.s
+.globl _start
+_start:
+  retq


### PR DESCRIPTION
`initializeSections()` records a `SHF_LINK_ORDER` section in its linked-to
section's `dependentSections`, so that `/DISCARD/` or `--gc-sections` later
discards the two together. It had no handling for a linked-to section that was
already discarded when it runs, by comdat group selection or by `SHF_EXCLUDE`.
Such a section was pushed onto the `dependentSections` of the shared
`InputSection::discarded`, a data race since `initSectionsAndLocalSyms()` runs
under `parallelForEach()`, and was kept with an `sh_link` that no longer
designated an output section, so `Writer.cpp` failed the link with `sh_link
points to discarded section <internal>:()`.

Discard such a section in a loop of its own ahead of the loop that creates
relocation sections, which would otherwise create one for a section discarded
here. Repeat to a fixed point, as a linked-to section may itself be
`SHF_LINK_ORDER`.

A section linked to an `SHF_EXCLUDE`'d section is now discarded rather than
failing the link, and is kept in a relocatable link, as `SHF_EXCLUDE` sections
are. GNU ld does the same in both cases.

Found while adding `.gnu.linkonce` support, where a discarded copy of a section
is the common way to reach this. It is reachable without it: gcc and clang place
`__patchable_function_entries` for a COMDAT function inside its group, but
nothing requires that, and one placed outside the group points at a function in
a discarded group, which GNU ld links.

---

This is independent of #219816, which happens to touch the same function. This
is the work that led me to that site; the `assert` added here only becomes
meaningful if #219816 lands.

Assisted-by: Claude Code