### PR TITLE
[flang-rt] Fix missing omp_lib symbols in static runtime archive

### DIFF
--- a/flang-rt/lib/runtime/CMakeLists.txt
+++ b/flang-rt/lib/runtime/CMakeLists.txt
@@ -325,9 +325,16 @@ endif ()
 # Include the Fortran OpenMP module implementation (omp_lib.o) in
 # libflang_rt.runtime when the OpenMP runtime is also being built.
 # Skip for GPU-default targets: omp_lib is a host-side Fortran module.
+set(_flang_rt_libomp_mod_objects "")
 if (TARGET libomp-mod AND NOT "${LLVM_DEFAULT_TARGET_TRIPLE}" MATCHES "^amdgcn|^nvptx"
     AND NOT FLANG_RT_EXPERIMENTAL_OFFLOAD_SUPPORT STREQUAL "CUDA")
-  list(APPEND sources "$<TARGET_OBJECTS:libomp-mod>")
+  set(_flang_rt_libomp_mod_objects "$<TARGET_OBJECTS:libomp-mod>")
+  # When both static and shared are built, sources go through
+  # obj.flang_rt.runtime and nested $<TARGET_OBJECTS:libomp-mod> does not
+  # end up in libflang_rt.runtime.a.
+  if (NOT (FLANG_RT_ENABLE_STATIC AND FLANG_RT_ENABLE_SHARED))
+    list(APPEND sources "${_flang_rt_libomp_mod_objects}")
+  endif ()
 endif ()
 
 
@@ -340,6 +347,15 @@ if (NOT WIN32)
   )
 
   enable_cuda_compilation(flang_rt.runtime "${sources}")
+
+  if (_flang_rt_libomp_mod_objects AND FLANG_RT_ENABLE_STATIC AND FLANG_RT_ENABLE_SHARED)
+    if (TARGET flang_rt.runtime.static)
+      target_sources(flang_rt.runtime.static PRIVATE ${_flang_rt_libomp_mod_objects})
+    endif ()
+    if (TARGET flang_rt.runtime.shared)
+      target_sources(flang_rt.runtime.shared PRIVATE ${_flang_rt_libomp_mod_objects})
+    endif ()
+  endif ()
 
   if (TARGET libomp-mod AND TARGET flang_rt.runtime.shared AND TARGET omp)
     # Resolve bind(c) references from omp_lib when building the shared runtime.


### PR DESCRIPTION
When both FLANG_RT_ENABLE_STATIC and FLANG_RT_ENABLE_SHARED are enabled, runtime sources are built through an intermediate object library. Nested $<TARGET_OBJECTS:libomp-mod> in that object library does not reliably end up in libflang_rt.runtime.a,so omp_lib Fortran module symbols are missing from the static archive.  This causes undefined reference errors for symbols defined in omp_lib_impl.F90 file.

Attached libomp-mod object files directly to flang_rt.runtime.static and flang_rt.runtime.shared instead of routing them through obj.flang_rt.runtime.

Assisted by Cursor to find the root cause.