### PR TITLE
[MC][AArch64][LFI] Preserve policy options across .arch and .cpu

### DIFF
--- a/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
+++ b/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
@@ -2518,6 +2518,22 @@ public:
   }
 };
 
+/// Preserves assembler policy features that are independent of the selected
+/// architecture or CPU across calls to MCSubtargetInfo::setDefaultFeatures().
+class PolicyFeaturePreserver {
+  // List of assembler policies that must survive .arch and .cpu directives.
+  static constexpr FeatureBitset ToPreserve = {AArch64::FeatureNoLFILoads,
+                                               AArch64::FeatureNoLFIStores};
+  FeatureBitset SavedFeatures;
+
+public:
+  explicit PolicyFeaturePreserver(const MCSubtargetInfo &STI)
+      : SavedFeatures(STI.getFeatureBits() & ToPreserve) {}
+  void restore(MCSubtargetInfo &STI) const {
+    STI.SetFeatureBitsTransitively(SavedFeatures);
+  }
+};
+
 } // end anonymous namespace.
 
 void AArch64Operand::print(raw_ostream &OS, const MCAsmInfo &MAI) const {
@@ -7252,10 +7268,13 @@ bool AArch64AsmParser::parseDirectiveArch(SMLoc L) {
   AArch64Features.push_back(AArch64::StrTab[ArchInfo->ArchFeature]);
   AArch64::getExtensionFeatures(ArchInfo->DefaultExts, AArch64Features);
 
+  PolicyFeaturePreserver PolicyPreserver(getSTI());
   MCSubtargetInfo &STI = copySTI();
-  std::vector<std::string> ArchFeatures(AArch64Features.begin(), AArch64Features.end());
+  std::vector<std::string> ArchFeatures(AArch64Features.begin(),
+                                        AArch64Features.end());
   STI.setDefaultFeatures("generic", /*TuneCPU*/ "generic",
                          join(ArchFeatures.begin(), ArchFeatures.end(), ","));
+  PolicyPreserver.restore(STI);
 
   SmallVector<StringRef, 4> RequestedExtensions;
   if (!ExtensionString.empty())
@@ -7349,8 +7368,10 @@ bool AArch64AsmParser::parseDirectiveCPU(SMLoc L) {
   }
   ExpandCryptoAEK(*CpuArch, RequestedExtensions);
 
+  PolicyFeaturePreserver PolicyPreserver(getSTI());
   MCSubtargetInfo &STI = copySTI();
   STI.setDefaultFeatures(CPU, /*TuneCPU*/ CPU, "");
+  PolicyPreserver.restore(STI);
   CurLoc = incrementLoc(CurLoc, CPU.size());
 
   for (auto Name : RequestedExtensions) {

--- a/llvm/test/MC/AArch64/LFI/preserve-no-lfi-loads.s
+++ b/llvm/test/MC/AArch64/LFI/preserve-no-lfi-loads.s
@@ -1,0 +1,17 @@
+// RUN: llvm-mc -triple aarch64_lfi -mattr=+no-lfi-loads %s | FileCheck %s
+
+// .arch and .cpu replace the subtarget feature set. They must preserve the
+// +no-lfi-loads assembler policy supplied through -mattr.
+
+ldr x0, [x1]
+// CHECK: ldr x0, [x1]
+
+.arch armv8-a
+
+ldr x2, [x3]
+// CHECK: ldr x2, [x3]
+
+.cpu cortex-a53
+
+ldr x4, [x5]
+// CHECK: ldr x4, [x5]

--- a/llvm/test/MC/AArch64/LFI/preserve-no-lfi-stores.s
+++ b/llvm/test/MC/AArch64/LFI/preserve-no-lfi-stores.s
@@ -1,0 +1,17 @@
+// RUN: llvm-mc -triple aarch64_lfi -mattr=+no-lfi-stores %s | FileCheck %s
+
+// .arch and .cpu replace the subtarget feature set. They must preserve the
+// +no-lfi-stores assembler policy supplied through -mattr.
+
+str x0, [x1]
+// CHECK: str x0, [x1]
+
+.arch armv8-a
+
+str x2, [x3]
+// CHECK: str x2, [x3]
+
+.cpu cortex-a53
+
+str x4, [x5]
+// CHECK: str x4, [x5]


### PR DESCRIPTION
`+no-lfi-loads` and `+no-lfi-stores` are configuration options specified via `-mattr=` and represented internally as subtarget feature flags. The `.arch` and `.cpu` directives replace the complete feature set using `setDefaultFeatures()`, clearing these options and affecting the rewriting of subsequent instructions.

The patch resolves the issue by preserving a limited set of LFI policy feature flags and restoring them after calling `setDefaultFeatures()`.

Assisted-by: Codex