### PR TITLE
[clang][bytecode] Check strcmp input for unknown-size arrays

### DIFF
--- a/clang/lib/AST/ByteCode/InterpBuiltin.cpp
+++ b/clang/lib/AST/ByteCode/InterpBuiltin.cpp
@@ -306,7 +306,9 @@ static bool interp__builtin_strcmp(InterpState &S, CodePtr OpPC,
 
   if (!A.isReadablePointerType() || !B.isReadablePointerType())
     return false;
-  if (A.isDummy() || B.isDummy())
+
+  if (A.isDummy() || B.isDummy() || A.isUnknownSizeArray() ||
+      B.isUnknownSizeArray())
     return false;
 
   bool IsWide = ID == Builtin::BIwcscmp || ID == Builtin::BIwcsncmp ||

--- a/clang/test/AST/ByteCode/builtin-functions.cpp
+++ b/clang/test/AST/ByteCode/builtin-functions.cpp
@@ -132,6 +132,12 @@ namespace strcmp {
   static_assert(__builtin_strncmp("abaa", "abba", 0) == 0);
   static_assert(__builtin_strncmp(0, 0, 0) == 0);
   static_assert(__builtin_strncmp("abab\0banana", "abab\0canada", 100) == 0);
+
+
+  constexpr char missingInit[] = bar__; // both-error {{use of undeclared identifier 'bar__'}} \
+                                        // ref-note {{declared here}}
+  static_assert(__builtin_strcmp(missingInit, "bar") == 0, ""); // both-error {{not an integral constant expression}} \
+                                                                // ref-note {{initializer of 'missingInit' is unknown}}
 }
 
 namespace WcsCmp {


### PR DESCRIPTION
The later calls to getNumElems() will fail for them.