### PR TITLE
Remove unused MachineBlockFrequencyInfo::isIrrLoopHeader. NFC

### DIFF
--- a/llvm/include/llvm/CodeGen/MachineBlockFrequencyInfo.h
+++ b/llvm/include/llvm/CodeGen/MachineBlockFrequencyInfo.h
@@ -80,8 +80,6 @@ public:
   LLVM_ABI std::optional<uint64_t>
   getProfileCountFromFreq(BlockFrequency Freq) const;
 
-  LLVM_ABI bool isIrrLoopHeader(const MachineBasicBlock *MBB) const;
-
   /// incrementally calculate block frequencies when we split edges, to avoid
   /// full CFG traversal.
   LLVM_ABI void onEdgeSplit(const MachineBasicBlock &NewPredecessor,

--- a/llvm/lib/CodeGen/MachineBlockFrequencyInfo.cpp
+++ b/llvm/lib/CodeGen/MachineBlockFrequencyInfo.cpp
@@ -281,12 +281,6 @@ MachineBlockFrequencyInfo::getProfileCountFromFreq(BlockFrequency Freq) const {
   return MBFI->getProfileCountFromFreq(F, Freq);
 }
 
-bool MachineBlockFrequencyInfo::isIrrLoopHeader(
-    const MachineBasicBlock *MBB) const {
-  assert(MBFI && "Expected analysis to be available");
-  return MBFI->isIrrLoopHeader(MBB);
-}
-
 void MachineBlockFrequencyInfo::onEdgeSplit(
     const MachineBasicBlock &NewPredecessor,
     const MachineBasicBlock &NewSuccessor,


### PR DESCRIPTION
The only consumer used to be PGOInstrumentation, which now reads it
through the IR-level BlockFrequencyInfo.