### PR TITLE
[GlobalISel] Add G_INSERT_VECTOR_ELT to computeNumSignBits

### DIFF
--- a/llvm/lib/CodeGen/GlobalISel/GISelValueTracking.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/GISelValueTracking.cpp
@@ -2714,6 +2714,37 @@ unsigned GISelValueTracking::computeNumSignBits(Register R,
     }
     break;
   }
+  case TargetOpcode::G_INSERT_VECTOR_ELT: {
+    GInsertVectorElement &Insert = cast<GInsertVectorElement>(MI);
+    Register InVec = Insert.getVectorReg();
+    Register InVal = Insert.getElementReg();
+    Register EltNo = Insert.getIndexReg();
+    LLT VecVT = MRI.getType(InVec);
+    LLT ValTy = MRI.getType(InVal);
+    if (VecVT.isScalableVector()) {
+      unsigned VecSignBits = computeNumSignBits(InVec, APInt(1, 1), Depth + 1);
+      if (ValTy.getScalarSizeInBits() != TyBits)
+        return VecSignBits;
+      unsigned ValSignBits = computeNumSignBits(InVal, APInt(1, 1), Depth + 1);
+      return std::min(VecSignBits, ValSignBits);
+    }
+    std::optional<APInt> ConstEltNo = getIConstantVRegVal(EltNo, MRI);
+    unsigned NumElts = VecVT.getNumElements();
+    bool DemandedVal = true;
+    APInt DemandedVecElts = DemandedElts;
+    if (ConstEltNo && ConstEltNo->ult(NumElts)) {
+      unsigned EltIdx = ConstEltNo->getZExtValue();
+      DemandedVal = !!DemandedElts[EltIdx];
+      DemandedVecElts.clearBit(EltIdx);
+    }
+    unsigned MinSignBits = std::numeric_limits<unsigned>::max();
+    if (DemandedVal && ValTy.getScalarSizeInBits() == TyBits)
+      MinSignBits = computeNumSignBits(InVal, APInt(1, 1), Depth + 1);
+    if (!!DemandedVecElts)
+      MinSignBits = std::min(
+          MinSignBits, computeNumSignBits(InVec, DemandedVecElts, Depth + 1));
+    return MinSignBits;
+  }
   case TargetOpcode::G_EXTRACT_VECTOR_ELT: {
     GExtractVectorElement &Extract = cast<GExtractVectorElement>(MI);
     Register InVec = Extract.getVectorReg();

--- a/llvm/test/CodeGen/AArch64/GlobalISel/knownbits-insert-vector.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/knownbits-insert-vector.mir
@@ -154,3 +154,37 @@ body: |
     %3:_(i64) = G_CONSTANT i64 10
     %4:_(<4 x i16>) = G_INSERT_VECTOR_ELT %2, %1, %3
 ...
+---
+# computeNumSignBits: scalable vector - conservatively checks both operands
+name: signbits_scalable
+body: |
+  bb.0:
+  ; CHECK-LABEL: name: @signbits_scalable
+  ; CHECK-NEXT: %0:_ KnownBits:???????? SignBits:1 IsKnownNeverZero:0
+  ; CHECK-NEXT: %1:_ KnownBits:???????????????? SignBits:9 IsKnownNeverZero:0
+  ; CHECK-NEXT: %2:_ KnownBits:???????????????? SignBits:1 IsKnownNeverZero:0
+  ; CHECK-NEXT: %3:_ KnownBits:0000000000000000000000000000000000000000000000000000000000000000 SignBits:64 IsKnownNeverZero:0
+  ; CHECK-NEXT: %4:_ KnownBits:???????????????? SignBits:1 IsKnownNeverZero:0
+    %0:_(i8) = COPY $b0
+    %1:_(i16) = G_SEXT %0
+    %2:_(<vscale x 4 x i16>) = COPY $z0
+    %3:_(i64) = G_CONSTANT i64 0
+    %4:_(<vscale x 4 x i16>) = G_INSERT_VECTOR_ELT %2, %1, %3
+...
+---
+# computeNumSignBits: scalable vector with sext source - min of both
+name: signbits_scalable_sext_src
+body: |
+  bb.0:
+  ; CHECK-LABEL: name: @signbits_scalable_sext_src
+  ; CHECK-NEXT: %0:_ KnownBits:???????? SignBits:1 IsKnownNeverZero:0
+  ; CHECK-NEXT: %1:_ KnownBits:???????????????? SignBits:9 IsKnownNeverZero:0
+  ; CHECK-NEXT: %2:_ KnownBits:???????????????? SignBits:9 IsKnownNeverZero:0
+  ; CHECK-NEXT: %3:_ KnownBits:0000000000000000000000000000000000000000000000000000000000000000 SignBits:64 IsKnownNeverZero:0
+  ; CHECK-NEXT: %4:_ KnownBits:???????????????? SignBits:9 IsKnownNeverZero:0
+    %0:_(i8) = COPY $b0
+    %1:_(i16) = G_SEXT %0
+    %2:_(<vscale x 4 x i16>) = G_SPLAT_VECTOR %1
+    %3:_(i64) = G_CONSTANT i64 0
+    %4:_(<vscale x 4 x i16>) = G_INSERT_VECTOR_ELT %2, %1, %3
+...

--- a/llvm/test/CodeGen/AArch64/GlobalISel/knownbits-insert-vector.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/knownbits-insert-vector.mir
@@ -97,3 +97,60 @@ body: |
     %4:_(i8) = G_CONSTANT i8 6
     %5:_(<2 x i8>) = G_INSERT_VECTOR_ELT %3, %4, %idx
 ...
+---
+# computeNumSignBits: both source and inserted element are sext -> SignBits:9
+name: signbits_both_sext
+body: |
+  bb.0:
+  ; CHECK-LABEL: name: @signbits_both_sext
+  ; CHECK-NEXT: %0:_ KnownBits:???????? SignBits:1 IsKnownNeverZero:0
+  ; CHECK-NEXT: %1:_ KnownBits:???????????????? SignBits:9 IsKnownNeverZero:0
+  ; CHECK-NEXT: %2:_ KnownBits:???????? SignBits:1 IsKnownNeverZero:0
+  ; CHECK-NEXT: %3:_ KnownBits:???????????????? SignBits:9 IsKnownNeverZero:0
+  ; CHECK-NEXT: %4:_ KnownBits:???????????????? SignBits:9 IsKnownNeverZero:0
+  ; CHECK-NEXT: %5:_ KnownBits:0000000000000000000000000000000000000000000000000000000000000010 SignBits:62 IsKnownNeverZero:1
+  ; CHECK-NEXT: %6:_ KnownBits:???????????????? SignBits:9 IsKnownNeverZero:0
+    %0:_(i8) = COPY $b0
+    %1:_(i16) = G_SEXT %0
+    %2:_(i8) = COPY $b1
+    %3:_(i16) = G_SEXT %2
+    %4:_(<4 x i16>) = G_BUILD_VECTOR %1, %1, %1, %1
+    %5:_(i64) = G_CONSTANT i64 2
+    %6:_(<4 x i16>) = G_INSERT_VECTOR_ELT %4, %3, %5
+...
+---
+# computeNumSignBits: unknown source, sext inserted -> min = 1
+name: signbits_unknown_src
+body: |
+  bb.0:
+  ; CHECK-LABEL: name: @signbits_unknown_src
+  ; CHECK-NEXT: %0:_ KnownBits:???????? SignBits:1 IsKnownNeverZero:0
+  ; CHECK-NEXT: %1:_ KnownBits:???????????????? SignBits:9 IsKnownNeverZero:0
+  ; CHECK-NEXT: %2:_ KnownBits:???????????????? SignBits:1 IsKnownNeverZero:0
+  ; CHECK-NEXT: %3:_ KnownBits:???????????????? SignBits:1 IsKnownNeverZero:0
+  ; CHECK-NEXT: %4:_ KnownBits:0000000000000000000000000000000000000000000000000000000000000000 SignBits:64 IsKnownNeverZero:0
+  ; CHECK-NEXT: %5:_ KnownBits:???????????????? SignBits:1 IsKnownNeverZero:0
+    %0:_(i8) = COPY $b0
+    %1:_(i16) = G_SEXT %0
+    %2:_(i16) = COPY $h1
+    %3:_(<4 x i16>) = G_BUILD_VECTOR %2, %2, %2, %2
+    %4:_(i64) = G_CONSTANT i64 0
+    %5:_(<4 x i16>) = G_INSERT_VECTOR_ELT %3, %1, %4
+...
+---
+# computeNumSignBits: out of bounds index demands all elements
+name: signbits_oob_idx
+body: |
+  bb.0:
+  ; CHECK-LABEL: name: @signbits_oob_idx
+  ; CHECK-NEXT: %0:_ KnownBits:???????? SignBits:1 IsKnownNeverZero:0
+  ; CHECK-NEXT: %1:_ KnownBits:???????????????? SignBits:9 IsKnownNeverZero:0
+  ; CHECK-NEXT: %2:_ KnownBits:???????????????? SignBits:9 IsKnownNeverZero:0
+  ; CHECK-NEXT: %3:_ KnownBits:0000000000000000000000000000000000000000000000000000000000001010 SignBits:60 IsKnownNeverZero:1
+  ; CHECK-NEXT: %4:_ KnownBits:???????????????? SignBits:9 IsKnownNeverZero:0
+    %0:_(i8) = COPY $b0
+    %1:_(i16) = G_SEXT %0
+    %2:_(<4 x i16>) = G_BUILD_VECTOR %1, %1, %1, %1
+    %3:_(i64) = G_CONSTANT i64 10
+    %4:_(<4 x i16>) = G_INSERT_VECTOR_ELT %2, %1, %3
+...


### PR DESCRIPTION
Port the SDAG INSERT_VECTOR_ELT computeNumSignBits handling to GlobalISel. If the element index is known and in bounds, split the demand between the source vector and the inserted element and return the minimum sign bits.
For unknown or out-of-bounds indices, demand both conservatively. For scalable vectors, conservatively check both operands.

Part of #150515.

CC: @davemgreen @arsenm 