### PR TITLE
Reland "[lldb][test] Disable two breakpoint tests for debugserver"

### DIFF
--- a/lldb/test/API/functionalities/breakpoint/hardware_breakpoints/write_memory_with_hw_breakpoint/TestWriteMemoryWithHWBreakpoint.py
+++ b/lldb/test/API/functionalities/breakpoint/hardware_breakpoints/write_memory_with_hw_breakpoint/TestWriteMemoryWithHWBreakpoint.py
@@ -14,6 +14,8 @@ from functionalities.breakpoint.hardware_breakpoints.base import *
 class WriteMemoryWithHWBreakpoint(HardwareBreakpointTestBase):
 
     @skipTestIfFn(HardwareBreakpointTestBase.hw_breakpoints_unsupported)
+    # Fails with a sanitized build of debugserver.
+    @llgs_test
     def test_write_memory_with_hw_break(self):
         self.build()
         exe = self.getBuildArtifact("a.out")

--- a/lldb/test/API/functionalities/breakpoint/hardware_breakpoints/write_memory_with_hw_breakpoint/TestWriteMemoryWithHWBreakpoint.py
+++ b/lldb/test/API/functionalities/breakpoint/hardware_breakpoints/write_memory_with_hw_breakpoint/TestWriteMemoryWithHWBreakpoint.py
@@ -14,7 +14,7 @@ from functionalities.breakpoint.hardware_breakpoints.base import *
 class WriteMemoryWithHWBreakpoint(HardwareBreakpointTestBase):
 
     @skipTestIfFn(HardwareBreakpointTestBase.hw_breakpoints_unsupported)
-    # Fails with a sanitized build of debugserver.
+    # Fails with a sanitized build of debugserver. https://github.com/llvm/llvm-project/issues/220844
     @llgs_test
     def test_write_memory_with_hw_break(self):
         self.build()

--- a/lldb/test/API/functionalities/breakpoint/write_over_software_breakpoint/TestWriteOverSoftwareBreakpoint.py
+++ b/lldb/test/API/functionalities/breakpoint/write_over_software_breakpoint/TestWriteOverSoftwareBreakpoint.py
@@ -15,6 +15,8 @@ class WriteOverSoftwareBreakpoint(TestBase):
 
     # Could not find a way to make place_break_here visible to lldb on Windows.
     @skipIfWindows
+    # Fails with a sanitized build of debugserver.
+    @llgs_test
     def test_write_over_breakpoint(self):
         TestBase.setUp(self)
         self.line = line_number("main.c", "// break here")

--- a/lldb/test/API/functionalities/breakpoint/write_over_software_breakpoint/TestWriteOverSoftwareBreakpoint.py
+++ b/lldb/test/API/functionalities/breakpoint/write_over_software_breakpoint/TestWriteOverSoftwareBreakpoint.py
@@ -15,7 +15,7 @@ class WriteOverSoftwareBreakpoint(TestBase):
 
     # Could not find a way to make place_break_here visible to lldb on Windows.
     @skipIfWindows
-    # Fails with a sanitized build of debugserver.
+    # Fails with a sanitized build of debugserver. https://github.com/llvm/llvm-project/issues/220844
     @llgs_test
     def test_write_over_breakpoint(self):
         TestBase.setUp(self)


### PR DESCRIPTION
Reverts llvm/llvm-project#220615

These tests are still failing in Swift CI despite apparently working at desk: https://ci.swift.org/view/all/job/llvm.org/job/lldb-cmake-sanitized/1529/

Tracking this in https://github.com/llvm/llvm-project/issues/220844.