### PR TITLE
[AArch64] Cost vector.match intrinsics that require type legalization

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64TargetTransformInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64TargetTransformInfo.cpp
@@ -1154,23 +1154,30 @@ AArch64TTIImpl::getIntrinsicInstrCost(const IntrinsicCostAttributes &ICA,
     break;
   }
   case Intrinsic::experimental_vector_match: {
-    auto *NeedleTy = cast<FixedVectorType>(ICA.getArgTypes()[1]);
-    EVT SearchVT = getTLI()->getValueType(DL, ICA.getArgTypes()[0]);
-    unsigned SearchSize = NeedleTy->getNumElements();
-    auto IsSupportedTypeAndSearchSize = [&]() {
-      if (SearchVT == MVT::nxv8i16 || SearchVT == MVT::v8i16)
-        return SearchSize == 8;
-
-      if (SearchVT == MVT::nxv16i8 || SearchVT == MVT::v16i8 ||
-          SearchVT == MVT::v8i8)
-        return SearchSize == 8 || SearchSize == 16;
-
-      return false;
-    };
-
-    if (!ST->hasSVE2() || !ST->isSVEAvailable() ||
-        !IsSupportedTypeAndSearchSize())
+    if (!ST->hasSVE2() || !ST->isSVEAvailable())
       break;
+
+    auto *NeedleTy = cast<FixedVectorType>(ICA.getArgTypes()[1]);
+
+    // We expand vector.matches with <= 2 elements to a chain of compares.
+    unsigned SearchSize = NeedleTy->getNumElements();
+    if (SearchSize <= 2)
+      break;
+
+    auto SearchLT = getTypeLegalizationCost(ICA.getArgTypes()[0]);
+    if (!is_contained(
+            {MVT::nxv8i16, MVT::nxv16i8, MVT::v8i16, MVT::v16i8, MVT::v8i8},
+            SearchLT.second.SimpleTy))
+      break;
+
+    unsigned ElementSizeInBits = SearchLT.second.getScalarSizeInBits();
+
+    // Number of needle elements we can compare per `match` instruction.
+    unsigned NeedleEltsPerMatch = AArch64::SVEBitsPerBlock / ElementSizeInBits;
+
+    // How many `match` instructions we need to match `SearchSize` elements.
+    unsigned MatchesRequiredForNeedle =
+        llvm::divideCeil(SearchSize, NeedleEltsPerMatch);
 
     // Base cost for MATCH instructions. At least on the Neoverse V2 and
     // Neoverse V3, these are cheap operations with the same latency as a
@@ -1180,7 +1187,8 @@ AArch64TTIImpl::getIntrinsicInstrCost(const IntrinsicCostAttributes &ICA,
     InstructionCost Cost = 4;
     if (isa<FixedVectorType>(RetTy))
       Cost += 10;
-    return Cost;
+
+    return Cost * SearchLT.first * MatchesRequiredForNeedle;
   }
   case Intrinsic::cttz: {
     auto LT = getTypeLegalizationCost(ICA.getArgTypes()[0]);

--- a/llvm/lib/Target/AArch64/AArch64TargetTransformInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64TargetTransformInfo.cpp
@@ -1164,13 +1164,13 @@ AArch64TTIImpl::getIntrinsicInstrCost(const IntrinsicCostAttributes &ICA,
     if (SearchSize <= 2)
       break;
 
-    auto SearchLT = getTypeLegalizationCost(ICA.getArgTypes()[0]);
+    auto [LegalParts, SearchVT] = getTypeLegalizationCost(ICA.getArgTypes()[0]);
     if (!is_contained(
             {MVT::nxv8i16, MVT::nxv16i8, MVT::v8i16, MVT::v16i8, MVT::v8i8},
-            SearchLT.second.SimpleTy))
+            SearchVT.SimpleTy))
       break;
 
-    unsigned ElementSizeInBits = SearchLT.second.getScalarSizeInBits();
+    unsigned ElementSizeInBits = SearchVT.getScalarSizeInBits();
 
     // Number of needle elements we can compare per `match` instruction.
     unsigned NeedleEltsPerMatch = AArch64::SVEBitsPerBlock / ElementSizeInBits;
@@ -1188,7 +1188,7 @@ AArch64TTIImpl::getIntrinsicInstrCost(const IntrinsicCostAttributes &ICA,
     if (isa<FixedVectorType>(RetTy))
       Cost += 10;
 
-    return Cost * SearchLT.first * MatchesRequiredForNeedle;
+    return Cost * LegalParts * MatchesRequiredForNeedle;
   }
   case Intrinsic::cttz: {
     auto LT = getTypeLegalizationCost(ICA.getArgTypes()[0]);

--- a/llvm/test/Analysis/CostModel/AArch64/sve-intrinsics.ll
+++ b/llvm/test/Analysis/CostModel/AArch64/sve-intrinsics.ll
@@ -1397,10 +1397,22 @@ define void @match() #3 {
 ; CHECK-VSCALE-1-NEXT:  Cost Model: Found costs of 4 for: %match_nxv8i16_v8i16 = call <vscale x 8 x i1> @llvm.experimental.vector.match.nxv8i16.v8i16(<vscale x 8 x i16> poison, <8 x i16> poison, <vscale x 8 x i1> poison)
 ; CHECK-VSCALE-1-NEXT:  Cost Model: Found costs of RThru:29 CodeSize:21 Lat:29 SizeLat:29 for: %match_nxv4i32_v4i32 = call <vscale x 4 x i1> @llvm.experimental.vector.match.nxv4i32.v4i32(<vscale x 4 x i32> poison, <4 x i32> poison, <vscale x 4 x i1> poison)
 ; CHECK-VSCALE-1-NEXT:  Cost Model: Found costs of RThru:15 CodeSize:11 Lat:15 SizeLat:15 for: %match_nxv2i64_v2i64 = call <vscale x 2 x i1> @llvm.experimental.vector.match.nxv2i64.v2i64(<vscale x 2 x i64> poison, <2 x i64> poison, <vscale x 2 x i1> poison)
+; CHECK-VSCALE-1-NEXT:  Cost Model: Found costs of 4 for: %match_nxv16i8_v4i8 = call <vscale x 16 x i1> @llvm.experimental.vector.match.nxv16i8.v4i8(<vscale x 16 x i8> poison, <4 x i8> poison, <vscale x 16 x i1> poison)
+; CHECK-VSCALE-1-NEXT:  Cost Model: Found costs of 8 for: %match_nxv16i8_v32i8 = call <vscale x 16 x i1> @llvm.experimental.vector.match.nxv16i8.v32i8(<vscale x 16 x i8> poison, <32 x i8> poison, <vscale x 16 x i1> poison)
+; CHECK-VSCALE-1-NEXT:  Cost Model: Found costs of 8 for: %match_nxv32i8_v16i8 = call <vscale x 32 x i1> @llvm.experimental.vector.match.nxv32i8.v16i8(<vscale x 32 x i8> poison, <16 x i8> poison, <vscale x 32 x i1> poison)
+; CHECK-VSCALE-1-NEXT:  Cost Model: Found costs of 4 for: %match_nxv8i16_v4i16 = call <vscale x 8 x i1> @llvm.experimental.vector.match.nxv8i16.v4i16(<vscale x 8 x i16> poison, <4 x i16> poison, <vscale x 8 x i1> poison)
+; CHECK-VSCALE-1-NEXT:  Cost Model: Found costs of 8 for: %match_nxv8i16_v16i16 = call <vscale x 8 x i1> @llvm.experimental.vector.match.nxv8i16.v16i16(<vscale x 8 x i16> poison, <16 x i16> poison, <vscale x 8 x i1> poison)
+; CHECK-VSCALE-1-NEXT:  Cost Model: Found costs of 16 for: %match_nxv16i16_v16i16 = call <vscale x 16 x i1> @llvm.experimental.vector.match.nxv16i16.v16i16(<vscale x 16 x i16> poison, <16 x i16> poison, <vscale x 16 x i1> poison)
 ; CHECK-VSCALE-1-NEXT:  Cost Model: Found costs of 14 for: %match_v16i8_v16i8 = call <16 x i1> @llvm.experimental.vector.match.v16i8.v16i8(<16 x i8> poison, <16 x i8> poison, <16 x i1> poison)
 ; CHECK-VSCALE-1-NEXT:  Cost Model: Found costs of 14 for: %match_v8i16_v8i16 = call <8 x i1> @llvm.experimental.vector.match.v8i16.v8i16(<8 x i16> poison, <8 x i16> poison, <8 x i1> poison)
 ; CHECK-VSCALE-1-NEXT:  Cost Model: Found costs of RThru:29 CodeSize:21 Lat:29 SizeLat:29 for: %match_v4i32_v4i32 = call <4 x i1> @llvm.experimental.vector.match.v4i32.v4i32(<4 x i32> poison, <4 x i32> poison, <4 x i1> poison)
 ; CHECK-VSCALE-1-NEXT:  Cost Model: Found costs of RThru:15 CodeSize:11 Lat:15 SizeLat:15 for: %match_v2i64_v2i64 = call <2 x i1> @llvm.experimental.vector.match.v2i64.v2i64(<2 x i64> poison, <2 x i64> poison, <2 x i1> poison)
+; CHECK-VSCALE-1-NEXT:  Cost Model: Found costs of 14 for: %match_v16i8_v4i8 = call <16 x i1> @llvm.experimental.vector.match.v16i8.v4i8(<16 x i8> poison, <4 x i8> poison, <16 x i1> poison)
+; CHECK-VSCALE-1-NEXT:  Cost Model: Found costs of 28 for: %match_v16i8_v32i8 = call <16 x i1> @llvm.experimental.vector.match.v16i8.v32i8(<16 x i8> poison, <32 x i8> poison, <16 x i1> poison)
+; CHECK-VSCALE-1-NEXT:  Cost Model: Found costs of 28 for: %match_v32i8_v16i8 = call <32 x i1> @llvm.experimental.vector.match.v32i8.v16i8(<32 x i8> poison, <16 x i8> poison, <32 x i1> poison)
+; CHECK-VSCALE-1-NEXT:  Cost Model: Found costs of 14 for: %match_v8i16_v4i16 = call <8 x i1> @llvm.experimental.vector.match.v8i16.v4i16(<8 x i16> poison, <4 x i16> poison, <8 x i1> poison)
+; CHECK-VSCALE-1-NEXT:  Cost Model: Found costs of 28 for: %match_v8i16_v16i16 = call <8 x i1> @llvm.experimental.vector.match.v8i16.v16i16(<8 x i16> poison, <16 x i16> poison, <8 x i1> poison)
+; CHECK-VSCALE-1-NEXT:  Cost Model: Found costs of 56 for: %match_v16i16_v16i16 = call <16 x i1> @llvm.experimental.vector.match.v16i16.v16i16(<16 x i16> poison, <16 x i16> poison, <16 x i1> poison)
 ; CHECK-VSCALE-1-NEXT:  Cost Model: Found costs of RThru:0 CodeSize:1 Lat:1 SizeLat:1 for: ret void
 ;
 ; CHECK-VSCALE-2-LABEL: 'match'
@@ -1408,10 +1420,22 @@ define void @match() #3 {
 ; CHECK-VSCALE-2-NEXT:  Cost Model: Found costs of 4 for: %match_nxv8i16_v8i16 = call <vscale x 8 x i1> @llvm.experimental.vector.match.nxv8i16.v8i16(<vscale x 8 x i16> poison, <8 x i16> poison, <vscale x 8 x i1> poison)
 ; CHECK-VSCALE-2-NEXT:  Cost Model: Found costs of RThru:29 CodeSize:21 Lat:29 SizeLat:29 for: %match_nxv4i32_v4i32 = call <vscale x 4 x i1> @llvm.experimental.vector.match.nxv4i32.v4i32(<vscale x 4 x i32> poison, <4 x i32> poison, <vscale x 4 x i1> poison)
 ; CHECK-VSCALE-2-NEXT:  Cost Model: Found costs of RThru:15 CodeSize:11 Lat:15 SizeLat:15 for: %match_nxv2i64_v2i64 = call <vscale x 2 x i1> @llvm.experimental.vector.match.nxv2i64.v2i64(<vscale x 2 x i64> poison, <2 x i64> poison, <vscale x 2 x i1> poison)
+; CHECK-VSCALE-2-NEXT:  Cost Model: Found costs of 4 for: %match_nxv16i8_v4i8 = call <vscale x 16 x i1> @llvm.experimental.vector.match.nxv16i8.v4i8(<vscale x 16 x i8> poison, <4 x i8> poison, <vscale x 16 x i1> poison)
+; CHECK-VSCALE-2-NEXT:  Cost Model: Found costs of 8 for: %match_nxv16i8_v32i8 = call <vscale x 16 x i1> @llvm.experimental.vector.match.nxv16i8.v32i8(<vscale x 16 x i8> poison, <32 x i8> poison, <vscale x 16 x i1> poison)
+; CHECK-VSCALE-2-NEXT:  Cost Model: Found costs of 8 for: %match_nxv32i8_v16i8 = call <vscale x 32 x i1> @llvm.experimental.vector.match.nxv32i8.v16i8(<vscale x 32 x i8> poison, <16 x i8> poison, <vscale x 32 x i1> poison)
+; CHECK-VSCALE-2-NEXT:  Cost Model: Found costs of 4 for: %match_nxv8i16_v4i16 = call <vscale x 8 x i1> @llvm.experimental.vector.match.nxv8i16.v4i16(<vscale x 8 x i16> poison, <4 x i16> poison, <vscale x 8 x i1> poison)
+; CHECK-VSCALE-2-NEXT:  Cost Model: Found costs of 8 for: %match_nxv8i16_v16i16 = call <vscale x 8 x i1> @llvm.experimental.vector.match.nxv8i16.v16i16(<vscale x 8 x i16> poison, <16 x i16> poison, <vscale x 8 x i1> poison)
+; CHECK-VSCALE-2-NEXT:  Cost Model: Found costs of 16 for: %match_nxv16i16_v16i16 = call <vscale x 16 x i1> @llvm.experimental.vector.match.nxv16i16.v16i16(<vscale x 16 x i16> poison, <16 x i16> poison, <vscale x 16 x i1> poison)
 ; CHECK-VSCALE-2-NEXT:  Cost Model: Found costs of 14 for: %match_v16i8_v16i8 = call <16 x i1> @llvm.experimental.vector.match.v16i8.v16i8(<16 x i8> poison, <16 x i8> poison, <16 x i1> poison)
 ; CHECK-VSCALE-2-NEXT:  Cost Model: Found costs of 14 for: %match_v8i16_v8i16 = call <8 x i1> @llvm.experimental.vector.match.v8i16.v8i16(<8 x i16> poison, <8 x i16> poison, <8 x i1> poison)
 ; CHECK-VSCALE-2-NEXT:  Cost Model: Found costs of RThru:29 CodeSize:21 Lat:29 SizeLat:29 for: %match_v4i32_v4i32 = call <4 x i1> @llvm.experimental.vector.match.v4i32.v4i32(<4 x i32> poison, <4 x i32> poison, <4 x i1> poison)
 ; CHECK-VSCALE-2-NEXT:  Cost Model: Found costs of RThru:15 CodeSize:11 Lat:15 SizeLat:15 for: %match_v2i64_v2i64 = call <2 x i1> @llvm.experimental.vector.match.v2i64.v2i64(<2 x i64> poison, <2 x i64> poison, <2 x i1> poison)
+; CHECK-VSCALE-2-NEXT:  Cost Model: Found costs of 14 for: %match_v16i8_v4i8 = call <16 x i1> @llvm.experimental.vector.match.v16i8.v4i8(<16 x i8> poison, <4 x i8> poison, <16 x i1> poison)
+; CHECK-VSCALE-2-NEXT:  Cost Model: Found costs of 28 for: %match_v16i8_v32i8 = call <16 x i1> @llvm.experimental.vector.match.v16i8.v32i8(<16 x i8> poison, <32 x i8> poison, <16 x i1> poison)
+; CHECK-VSCALE-2-NEXT:  Cost Model: Found costs of 28 for: %match_v32i8_v16i8 = call <32 x i1> @llvm.experimental.vector.match.v32i8.v16i8(<32 x i8> poison, <16 x i8> poison, <32 x i1> poison)
+; CHECK-VSCALE-2-NEXT:  Cost Model: Found costs of 14 for: %match_v8i16_v4i16 = call <8 x i1> @llvm.experimental.vector.match.v8i16.v4i16(<8 x i16> poison, <4 x i16> poison, <8 x i1> poison)
+; CHECK-VSCALE-2-NEXT:  Cost Model: Found costs of 28 for: %match_v8i16_v16i16 = call <8 x i1> @llvm.experimental.vector.match.v8i16.v16i16(<8 x i16> poison, <16 x i16> poison, <8 x i1> poison)
+; CHECK-VSCALE-2-NEXT:  Cost Model: Found costs of 56 for: %match_v16i16_v16i16 = call <16 x i1> @llvm.experimental.vector.match.v16i16.v16i16(<16 x i16> poison, <16 x i16> poison, <16 x i1> poison)
 ; CHECK-VSCALE-2-NEXT:  Cost Model: Found costs of RThru:0 CodeSize:1 Lat:1 SizeLat:1 for: ret void
 ;
 ; TYPE_BASED_ONLY-LABEL: 'match'
@@ -1419,10 +1443,22 @@ define void @match() #3 {
 ; TYPE_BASED_ONLY-NEXT:  Cost Model: Found costs of 4 for: %match_nxv8i16_v8i16 = call <vscale x 8 x i1> @llvm.experimental.vector.match.nxv8i16.v8i16(<vscale x 8 x i16> poison, <8 x i16> poison, <vscale x 8 x i1> poison)
 ; TYPE_BASED_ONLY-NEXT:  Cost Model: Found costs of RThru:29 CodeSize:21 Lat:29 SizeLat:29 for: %match_nxv4i32_v4i32 = call <vscale x 4 x i1> @llvm.experimental.vector.match.nxv4i32.v4i32(<vscale x 4 x i32> poison, <4 x i32> poison, <vscale x 4 x i1> poison)
 ; TYPE_BASED_ONLY-NEXT:  Cost Model: Found costs of RThru:15 CodeSize:11 Lat:15 SizeLat:15 for: %match_nxv2i64_v2i64 = call <vscale x 2 x i1> @llvm.experimental.vector.match.nxv2i64.v2i64(<vscale x 2 x i64> poison, <2 x i64> poison, <vscale x 2 x i1> poison)
+; TYPE_BASED_ONLY-NEXT:  Cost Model: Found costs of 4 for: %match_nxv16i8_v4i8 = call <vscale x 16 x i1> @llvm.experimental.vector.match.nxv16i8.v4i8(<vscale x 16 x i8> poison, <4 x i8> poison, <vscale x 16 x i1> poison)
+; TYPE_BASED_ONLY-NEXT:  Cost Model: Found costs of 8 for: %match_nxv16i8_v32i8 = call <vscale x 16 x i1> @llvm.experimental.vector.match.nxv16i8.v32i8(<vscale x 16 x i8> poison, <32 x i8> poison, <vscale x 16 x i1> poison)
+; TYPE_BASED_ONLY-NEXT:  Cost Model: Found costs of 8 for: %match_nxv32i8_v16i8 = call <vscale x 32 x i1> @llvm.experimental.vector.match.nxv32i8.v16i8(<vscale x 32 x i8> poison, <16 x i8> poison, <vscale x 32 x i1> poison)
+; TYPE_BASED_ONLY-NEXT:  Cost Model: Found costs of 4 for: %match_nxv8i16_v4i16 = call <vscale x 8 x i1> @llvm.experimental.vector.match.nxv8i16.v4i16(<vscale x 8 x i16> poison, <4 x i16> poison, <vscale x 8 x i1> poison)
+; TYPE_BASED_ONLY-NEXT:  Cost Model: Found costs of 8 for: %match_nxv8i16_v16i16 = call <vscale x 8 x i1> @llvm.experimental.vector.match.nxv8i16.v16i16(<vscale x 8 x i16> poison, <16 x i16> poison, <vscale x 8 x i1> poison)
+; TYPE_BASED_ONLY-NEXT:  Cost Model: Found costs of 16 for: %match_nxv16i16_v16i16 = call <vscale x 16 x i1> @llvm.experimental.vector.match.nxv16i16.v16i16(<vscale x 16 x i16> poison, <16 x i16> poison, <vscale x 16 x i1> poison)
 ; TYPE_BASED_ONLY-NEXT:  Cost Model: Found costs of 14 for: %match_v16i8_v16i8 = call <16 x i1> @llvm.experimental.vector.match.v16i8.v16i8(<16 x i8> poison, <16 x i8> poison, <16 x i1> poison)
 ; TYPE_BASED_ONLY-NEXT:  Cost Model: Found costs of 14 for: %match_v8i16_v8i16 = call <8 x i1> @llvm.experimental.vector.match.v8i16.v8i16(<8 x i16> poison, <8 x i16> poison, <8 x i1> poison)
 ; TYPE_BASED_ONLY-NEXT:  Cost Model: Found costs of RThru:29 CodeSize:21 Lat:29 SizeLat:29 for: %match_v4i32_v4i32 = call <4 x i1> @llvm.experimental.vector.match.v4i32.v4i32(<4 x i32> poison, <4 x i32> poison, <4 x i1> poison)
 ; TYPE_BASED_ONLY-NEXT:  Cost Model: Found costs of RThru:15 CodeSize:11 Lat:15 SizeLat:15 for: %match_v2i64_v2i64 = call <2 x i1> @llvm.experimental.vector.match.v2i64.v2i64(<2 x i64> poison, <2 x i64> poison, <2 x i1> poison)
+; TYPE_BASED_ONLY-NEXT:  Cost Model: Found costs of 14 for: %match_v16i8_v4i8 = call <16 x i1> @llvm.experimental.vector.match.v16i8.v4i8(<16 x i8> poison, <4 x i8> poison, <16 x i1> poison)
+; TYPE_BASED_ONLY-NEXT:  Cost Model: Found costs of 28 for: %match_v16i8_v32i8 = call <16 x i1> @llvm.experimental.vector.match.v16i8.v32i8(<16 x i8> poison, <32 x i8> poison, <16 x i1> poison)
+; TYPE_BASED_ONLY-NEXT:  Cost Model: Found costs of 28 for: %match_v32i8_v16i8 = call <32 x i1> @llvm.experimental.vector.match.v32i8.v16i8(<32 x i8> poison, <16 x i8> poison, <32 x i1> poison)
+; TYPE_BASED_ONLY-NEXT:  Cost Model: Found costs of 14 for: %match_v8i16_v4i16 = call <8 x i1> @llvm.experimental.vector.match.v8i16.v4i16(<8 x i16> poison, <4 x i16> poison, <8 x i1> poison)
+; TYPE_BASED_ONLY-NEXT:  Cost Model: Found costs of 28 for: %match_v8i16_v16i16 = call <8 x i1> @llvm.experimental.vector.match.v8i16.v16i16(<8 x i16> poison, <16 x i16> poison, <8 x i1> poison)
+; TYPE_BASED_ONLY-NEXT:  Cost Model: Found costs of 56 for: %match_v16i16_v16i16 = call <16 x i1> @llvm.experimental.vector.match.v16i16.v16i16(<16 x i16> poison, <16 x i16> poison, <16 x i1> poison)
 ; TYPE_BASED_ONLY-NEXT:  Cost Model: Found costs of RThru:0 CodeSize:1 Lat:1 SizeLat:1 for: ret void
 ;
 
@@ -1431,10 +1467,26 @@ define void @match() #3 {
   %match_nxv4i32_v4i32 = call <vscale x 4 x i1> @llvm.experimental.vector.match.nxv4i32.v4i32(<vscale x 4 x i32> poison, <4 x i32> poison, <vscale x 4 x i1> poison)
   %match_nxv2i64_v2i64 = call <vscale x 2 x i1> @llvm.experimental.vector.match.nxv2i64.v2i64(<vscale x 2 x i64> poison, <2 x i64> poison, <vscale x 2 x i1> poison)
 
+  %match_nxv16i8_v4i8 = call <vscale x 16 x i1> @llvm.experimental.vector.match(<vscale x 16 x i8> poison, <4 x i8> poison, <vscale x 16 x i1> poison)
+  %match_nxv16i8_v32i8 = call <vscale x 16 x i1> @llvm.experimental.vector.match(<vscale x 16 x i8> poison, <32 x i8> poison, <vscale x 16 x i1> poison)
+  %match_nxv32i8_v16i8 = call <vscale x 32 x i1> @llvm.experimental.vector.match(<vscale x 32 x i8> poison, <16 x i8> poison, <vscale x 32 x i1> poison)
+
+  %match_nxv8i16_v4i16 = call <vscale x 8 x i1> @llvm.experimental.vector.match(<vscale x 8 x i16> poison, <4 x i16> poison, <vscale x 8 x i1> poison)
+  %match_nxv8i16_v16i16 = call <vscale x 8 x i1> @llvm.experimental.vector.match(<vscale x 8 x i16> poison, <16 x i16> poison, <vscale x 8 x i1> poison)
+  %match_nxv16i16_v16i16 = call <vscale x 16 x i1> @llvm.experimental.vector.match(<vscale x 16 x i16> poison, <16 x i16> poison, <vscale x 16 x i1> poison)
+
   %match_v16i8_v16i8 = call <16 x i1> @llvm.experimental.vector.match.v16i8.v16i8(<16 x i8> poison, <16 x i8> poison, <16 x i1> poison)
   %match_v8i16_v8i16 = call <8 x i1> @llvm.experimental.vector.match.v8i16.v8i16(<8 x i16> poison, <8 x i16> poison, <8 x i1> poison)
   %match_v4i32_v4i32 = call <4 x i1> @llvm.experimental.vector.match.v4i32.v4i32(<4 x i32> poison, <4 x i32> poison, <4 x i1> poison)
   %match_v2i64_v2i64 = call <2 x i1> @llvm.experimental.vector.match.v2i64.v2i64(<2 x i64> poison, <2 x i64> poison, <2 x i1> poison)
+
+  %match_v16i8_v4i8 = call <16 x i1> @llvm.experimental.vector.match(<16 x i8> poison, <4 x i8> poison, <16 x i1> poison)
+  %match_v16i8_v32i8 = call <16 x i1> @llvm.experimental.vector.match(<16 x i8> poison, <32 x i8> poison, <16 x i1> poison)
+  %match_v32i8_v16i8 = call <32 x i1> @llvm.experimental.vector.match(<32 x i8> poison, <16 x i8> poison, <32 x i1> poison)
+
+  %match_v8i16_v4i16 = call <8 x i1> @llvm.experimental.vector.match(<8 x i16> poison, <4 x i16> poison, <8 x i1> poison)
+  %match_v8i16_v16i16 = call <8 x i1> @llvm.experimental.vector.match(<8 x i16> poison, <16 x i16> poison, <8 x i1> poison)
+  %match_v16i16_v16i16 = call <16 x i1> @llvm.experimental.vector.match(<16 x i16> poison, <16 x i16> poison, <16 x i1> poison)
 
   ret void
 }


### PR DESCRIPTION
Recent patches (#218972, #218972) have added type-legalization support for vector.match. This allows us to remove the exact type and search size requirements from the intrinsic cost. This in turn will simplify the combine in #212456.