### PR TITLE
[IPSCCP] Do not delete non-replaceable constants during globals cleanup

### DIFF
--- a/llvm/lib/Transforms/IPO/SCCP.cpp
+++ b/llvm/lib/Transforms/IPO/SCCP.cpp
@@ -327,9 +327,10 @@ static bool runIPSCCP(
 
   // If we inferred constant or undef values for globals variables, we can
   // delete the global and any stores that remain to it.
-  for (const auto &I : make_early_inc_range(Solver.getTrackedGlobals())) {
-    GlobalVariable *GV = I.first;
-    if (SCCPSolver::isOverdefined(I.second))
+  for (const auto &[GV, LV] : Solver.getTrackedGlobals()) {
+    // We may have inferred a constant that is not replaceable (e.g., due to
+    // different pointer provenance), so skip deleting the global in this case.
+    if (!SCCPSolver::isReplaceableConstant(LV) && !LV.isUnknownOrUndef())
       continue;
     LLVM_DEBUG(dbgs() << "Found that GV '" << GV->getName()
                       << "' is constant!\n");

--- a/llvm/test/Transforms/SCCP/assume-equality-pointers.ll
+++ b/llvm/test/Transforms/SCCP/assume-equality-pointers.ll
@@ -135,7 +135,6 @@ define ptr @assume_pointers_equality_maybe_different_provenance_5(ptr %x) {
 @g_outer = internal global ptr @g_inner
 @g_inner = external global ptr
 
-; FIXME: This is a miscompilation.
 define ptr @assume_pointers_equality_maybe_different_provenance_6(ptr %p) {
 ; CHECK-LABEL: define ptr @assume_pointers_equality_maybe_different_provenance_6(
 ; CHECK-SAME: ptr [[P:%.*]]) {

--- a/llvm/test/Transforms/SCCP/assume-equality-pointers.ll
+++ b/llvm/test/Transforms/SCCP/assume-equality-pointers.ll
@@ -132,6 +132,34 @@ define ptr @assume_pointers_equality_maybe_different_provenance_5(ptr %x) {
   ret ptr %gep
 }
 
+@g_outer = internal global ptr @g_inner
+@g_inner = external global ptr
+
+; FIXME: This is a miscompilation.
+define ptr @assume_pointers_equality_maybe_different_provenance_6(ptr %p) {
+; CHECK-LABEL: define ptr @assume_pointers_equality_maybe_different_provenance_6(
+; CHECK-SAME: ptr [[P:%.*]]) {
+; CHECK-NEXT:  [[ENTRY:.*:]]
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq ptr [[P]], @g_inner
+; CHECK-NEXT:    br i1 [[CMP]], label %[[IF:.*]], label %[[ELSE:.*]]
+; CHECK:       [[IF]]:
+; CHECK-NEXT:    ret ptr null
+; CHECK:       [[ELSE]]:
+; CHECK-NEXT:    ret ptr poison
+;
+entry:
+  %cmp = icmp eq ptr %p, @g_inner
+  br i1 %cmp, label %if, label %else
+
+if:
+  store ptr %p, ptr @g_outer, align 8
+  ret ptr null
+
+else:
+  %res = load ptr, ptr @g_outer, align 8
+  ret ptr %res
+}
+
 define i1 @assume_pointers_equality_can_replace_valid(ptr %x, ptr %y) {
 ; CHECK-LABEL: define i1 @assume_pointers_equality_can_replace_valid(
 ; CHECK-SAME: ptr [[X:%.*]], ptr [[Y:%.*]]) {

--- a/llvm/test/Transforms/SCCP/assume-equality-pointers.ll
+++ b/llvm/test/Transforms/SCCP/assume-equality-pointers.ll
@@ -143,9 +143,11 @@ define ptr @assume_pointers_equality_maybe_different_provenance_6(ptr %p) {
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp eq ptr [[P]], @g_inner
 ; CHECK-NEXT:    br i1 [[CMP]], label %[[IF:.*]], label %[[ELSE:.*]]
 ; CHECK:       [[IF]]:
+; CHECK-NEXT:    store ptr [[P]], ptr @g_outer, align 8
 ; CHECK-NEXT:    ret ptr null
 ; CHECK:       [[ELSE]]:
-; CHECK-NEXT:    ret ptr poison
+; CHECK-NEXT:    [[RES:%.*]] = load ptr, ptr @g_outer, align 8
+; CHECK-NEXT:    ret ptr [[RES]]
 ;
 entry:
   %cmp = icmp eq ptr %p, @g_inner


### PR DESCRIPTION
Following up on #160083, a tracked global's value may be inferred to be a constant which is however not replaceable, due to different pointer provenance. Such a substitution is already prevented by `tryToReplaceWithConstant`. Ensure these globals, and their users, are not deleted when this happens to be the case.

Fixes: https://github.com/llvm/llvm-project/issues/220793.