### PR TITLE
[CIR] Print cir.global's TLS model without naked angle brackets

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -3402,7 +3402,7 @@ def CIR_GlobalOp : CIR_Op<"global", [
     (`constant` $constant^)?
     $linkage
     (`comdat` $comdat^)?
-    (`tls_model` `=` $tls_model^)?
+    (`tls_model` `=` enum($tls_model)^)?
     (`tls_refs` `=` $tls_refs^)?
     (`dso_local` $dso_local^)?
     (`static_local_guard` `` $static_local_guard^)?

--- a/clang/test/CIR/CodeGen/global-temp-dtor.cpp
+++ b/clang/test/CIR/CodeGen/global-temp-dtor.cpp
@@ -47,7 +47,7 @@ thread_local const NonTrivialArr &thread_arr_ref = NonTrivialArr{};
 // CIR:   cir.call @__cxa_atexit
 // CIR: cir.global "private" internal @_ZGR10static_ref_ = #cir.zero : !rec_NonTrivial
 
-// CIR-BEFORE: cir.global external tls_model = <tls_dyn> tls_refs = <"_ZTW10thread_ref", "_ZTH10thread_ref"> @thread_ref = ctor : !cir.ptr<!rec_NonTrivial> {
+// CIR-BEFORE: cir.global external tls_model = tls_dyn tls_refs = <"_ZTW10thread_ref", "_ZTH10thread_ref"> @thread_ref = ctor : !cir.ptr<!rec_NonTrivial> {
 // CIR-BEFORE:   %[[THREAD_REF:.*]] = cir.get_global thread_local @thread_ref
 // CIR-BEFORE:   %[[REF_TEMP:.*]] = cir.get_global @_ZGR10thread_ref_
 // CIR-BEFORE:   cir.call @_ZN10NonTrivialC1Ev(%[[REF_TEMP]])
@@ -56,9 +56,9 @@ thread_local const NonTrivialArr &thread_arr_ref = NonTrivialArr{};
 // CIR-BEFORE:   %[[REF_TEMP_DTOR:.*]] = cir.get_global @_ZGR10thread_ref_
 // CIR-BEFORE:   cir.call @_ZN10NonTrivialD1Ev(%[[REF_TEMP_DTOR]])
 // CIR-BEFORE: }
-// CIR-BEFORE: cir.global "private" internal tls_model = <tls_dyn> @_ZGR10thread_ref_ = #cir.zero : !rec_NonTrivial
+// CIR-BEFORE: cir.global "private" internal tls_model = tls_dyn @_ZGR10thread_ref_ = #cir.zero : !rec_NonTrivial
 
-// CIR: cir.global external tls_model = <tls_dyn> tls_refs = <"_ZTW10thread_ref", "_ZTH10thread_ref"> @thread_ref = #cir.ptr<null> : !cir.ptr<!rec_NonTrivial>
+// CIR: cir.global external tls_model = tls_dyn tls_refs = <"_ZTW10thread_ref", "_ZTH10thread_ref"> @thread_ref = #cir.ptr<null> : !cir.ptr<!rec_NonTrivial>
 // CIR: cir.func internal private @__cxx_global_var_init.1()
 // CIR:   cir.get_global thread_local @thread_ref
 // CIR:   cir.get_global @_ZGR10thread_ref_
@@ -68,7 +68,7 @@ thread_local const NonTrivialArr &thread_arr_ref = NonTrivialArr{};
 // CIR:   cir.get_global @_ZN10NonTrivialD1Ev
 // CIR:   cir.get_global @__dso_handle
 // CIR:   cir.call @__cxa_thread_atexit
-// CIR: cir.global "private" internal tls_model = <tls_dyn> @_ZGR10thread_ref_ = #cir.zero : !rec_NonTrivial
+// CIR: cir.global "private" internal tls_model = tls_dyn @_ZGR10thread_ref_ = #cir.zero : !rec_NonTrivial
 
 // CIR-BEFORE: cir.global external @static_arr_ref = ctor : !cir.ptr<!cir.array<!rec_NonTrivial x 2>> {
 // CIR-BEFORE:   %[[ARRAY_INIT_TEMP:.*]] = cir.alloca {{.*}}"arrayinit.temp"
@@ -108,7 +108,7 @@ thread_local const NonTrivialArr &thread_arr_ref = NonTrivialArr{};
 // CIR:   cir.call @__cxa_atexit
 // CIR: cir.global "private" internal @_ZGR14static_arr_ref_ = #cir.zero : !cir.array<!rec_NonTrivial x 2>
 
-// CIR-BEFORE: cir.global external tls_model = <tls_dyn> tls_refs = <"_ZTW14thread_arr_ref", "_ZTH14thread_arr_ref"> @thread_arr_ref = ctor : !cir.ptr<!cir.array<!rec_NonTrivial x 2>> {
+// CIR-BEFORE: cir.global external tls_model = tls_dyn tls_refs = <"_ZTW14thread_arr_ref", "_ZTH14thread_arr_ref"> @thread_arr_ref = ctor : !cir.ptr<!cir.array<!rec_NonTrivial x 2>> {
 // CIR-BEFORE:   %[[ARRAY_INIT_TEMP:.*]] = cir.alloca {{.*}}"arrayinit.temp"
 // CIR-BEFORE:   %[[THREAD_ARR_REF:.*]] = cir.get_global thread_local @thread_arr_ref
 // CIR-BEFORE:   %[[THREAD_ARR_REF_TEMP:.*]] = cir.get_global @_ZGR14thread_arr_ref_
@@ -129,9 +129,9 @@ thread_local const NonTrivialArr &thread_arr_ref = NonTrivialArr{};
 // CIR-BEFORE:     cir.call @_ZN10NonTrivialD1Ev(%[[ELEMENT]])
 // CIR-BEFORE:   }
 // CIR-BEFORE: }
-// CIR-BEFORE: cir.global "private" internal tls_model = <tls_dyn> @_ZGR14thread_arr_ref_ = #cir.zero : !cir.array<!rec_NonTrivial x 2>
+// CIR-BEFORE: cir.global "private" internal tls_model = tls_dyn @_ZGR14thread_arr_ref_ = #cir.zero : !cir.array<!rec_NonTrivial x 2>
 
-// CIR: cir.global external tls_model = <tls_dyn> tls_refs = <"_ZTW14thread_arr_ref", "_ZTH14thread_arr_ref"> @thread_arr_ref = #cir.ptr<null> : !cir.ptr<!cir.array<!rec_NonTrivial x 2>>
+// CIR: cir.global external tls_model = tls_dyn tls_refs = <"_ZTW14thread_arr_ref", "_ZTH14thread_arr_ref"> @thread_arr_ref = #cir.ptr<null> : !cir.ptr<!cir.array<!rec_NonTrivial x 2>>
 // CIR: cir.func internal private @__cxx_global_array_dtor.1(
 // CIR:   cir.do {
 // CIR:     cir.call @_ZN10NonTrivialD1Ev
@@ -144,7 +144,7 @@ thread_local const NonTrivialArr &thread_arr_ref = NonTrivialArr{};
 // CIR:   cir.get_global @__cxx_global_array_dtor.1
 // CIR:   cir.get_global @__dso_handle
 // CIR:   cir.call @__cxa_thread_atexit
-// CIR: cir.global "private" internal tls_model = <tls_dyn> @_ZGR14thread_arr_ref_ = #cir.zero : !cir.array<!rec_NonTrivial x 2>
+// CIR: cir.global "private" internal tls_model = tls_dyn @_ZGR14thread_arr_ref_ = #cir.zero : !cir.array<!rec_NonTrivial x 2>
 
 // LLVM-DAG: @static_ref = global ptr null
 // LLVM-DAG: @_ZGR10static_ref_ = internal global %struct.NonTrivial zeroinitializer

--- a/clang/test/CIR/CodeGen/global-tls-dyn-init.cpp
+++ b/clang/test/CIR/CodeGen/global-tls-dyn-init.cpp
@@ -23,7 +23,7 @@ struct CtorDtor {
 // LLVM-BOTH-DAG: @_ZTH6tls_cd = alias void (), ptr @__tls_init
 
 // Wrappers & aliases.
-// CIR:       cir.global internal tls_model = <tls_dyn> @__tls_guard = #cir.int<0> : !s8i {alignment = 1 : i64}
+// CIR:       cir.global internal tls_model = tls_dyn @__tls_guard = #cir.int<0> : !s8i {alignment = 1 : i64}
 // CIR-LABEL: cir.func comdat weak_odr private hidden @_ZTW19tls_cd_dyn_not_used() -> !cir.ptr<!rec_CtorDtor> {
 // CIR: cir.call @_ZTH19tls_cd_dyn_not_used() : () -> ()
 // CIR: %[[GET_GLOB:.*]] = cir.get_global thread_local @tls_cd_dyn_not_used : !cir.ptr<!rec_CtorDtor>
@@ -100,11 +100,11 @@ struct CtorDtor {
 // LLVM:   call void @[[TLS_CD_DYN_NOT_USED_INIT:.*]]()
 
 thread_local CtorDtor tls_cd = 5;
-// CIR-BEFORE-LPP: cir.global external tls_model = <tls_dyn> tls_refs = <"_ZTW6tls_cd", "_ZTH6tls_cd"> @tls_cd = #cir.const_record<{#cir.int<5> : !s32i}> : !rec_CtorDtor dtor {
+// CIR-BEFORE-LPP: cir.global external tls_model = tls_dyn tls_refs = <"_ZTW6tls_cd", "_ZTH6tls_cd"> @tls_cd = #cir.const_record<{#cir.int<5> : !s32i}> : !rec_CtorDtor dtor {
 // CIR-BEFORE-LPP:   %[[GET_GLOB:.*]] = cir.get_global thread_local @tls_cd : !cir.ptr<!rec_CtorDtor>
 // CIR-BEFORE-LPP:   cir.call @_ZN8CtorDtorD1Ev(%[[GET_GLOB]]) : (!cir.ptr<!rec_CtorDtor>) -> ()
 // CIR-BEFORE-LPP: }
-// CIR: cir.global external tls_model = <tls_dyn> tls_refs = <"_ZTW6tls_cd", "_ZTH6tls_cd"> @tls_cd = #cir.const_record<{#cir.int<5> : !s32i}> : !rec_CtorDtor
+// CIR: cir.global external tls_model = tls_dyn tls_refs = <"_ZTW6tls_cd", "_ZTH6tls_cd"> @tls_cd = #cir.const_record<{#cir.int<5> : !s32i}> : !rec_CtorDtor
 // CIR: cir.func internal private @[[TLS_CD_INIT]]() {
 // CIR:   %[[GET_GLOB:.*]] = cir.get_global thread_local @tls_cd : !cir.ptr<!rec_CtorDtor>
 // CIR:   %[[GET_DTOR:.*]] = cir.get_global @_ZN8CtorDtorD1Ev : !cir.ptr<!cir.func<(!cir.ptr<!rec_CtorDtor>)>>
@@ -122,7 +122,7 @@ thread_local CtorDtor tls_cd = 5;
 // LLVM-BOTH:   ret void
 
 thread_local CtorDtor tls_cd_dyn = get_i();
-// CIR-BEFORE-LPP:  cir.global external tls_model = <tls_dyn> tls_refs = <"_ZTW10tls_cd_dyn", "_ZTH10tls_cd_dyn"> @tls_cd_dyn = ctor : !rec_CtorDtor {
+// CIR-BEFORE-LPP:  cir.global external tls_model = tls_dyn tls_refs = <"_ZTW10tls_cd_dyn", "_ZTH10tls_cd_dyn"> @tls_cd_dyn = ctor : !rec_CtorDtor {
 // CIR-BEFORE-LPP:    %[[GET_GLOB:.*]] = cir.get_global thread_local @tls_cd_dyn : !cir.ptr<!rec_CtorDtor>
 // CIR-BEFORE-LPP:    %[[CALL:.*]] = cir.call @_Z5get_iv() : () -> (!s32i {llvm.noundef})
 // CIR-BEFORE-LPP:    cir.call @_ZN8CtorDtorC1Ei(%[[GET_GLOB]], %[[CALL]]) : (!cir.ptr<!rec_CtorDtor>
@@ -130,7 +130,7 @@ thread_local CtorDtor tls_cd_dyn = get_i();
 // CIR-BEFORE-LPP:    %[[GET_GLOB:.*]] = cir.get_global thread_local @tls_cd_dyn : !cir.ptr<!rec_CtorDtor>
 // CIR-BEFORE-LPP:    cir.call @_ZN8CtorDtorD1Ev(%[[GET_GLOB]]) : (!cir.ptr<!rec_CtorDtor>) -> ()
 // CIR-BEFORE-LPP:  }
-// CIR: cir.global external tls_model = <tls_dyn> tls_refs = <"_ZTW10tls_cd_dyn", "_ZTH10tls_cd_dyn"> @tls_cd_dyn = #cir.zero : !rec_CtorDtor
+// CIR: cir.global external tls_model = tls_dyn tls_refs = <"_ZTW10tls_cd_dyn", "_ZTH10tls_cd_dyn"> @tls_cd_dyn = #cir.zero : !rec_CtorDtor
 // CIR: cir.func internal private @[[TLS_CD_DYN_INIT]]() {
 // CIR:   %[[GET_GLOB:.*]] = cir.get_global thread_local @tls_cd_dyn : !cir.ptr<!rec_CtorDtor>
 // CIR:   %[[CALL:.*]] = cir.call @_Z5get_iv() : () -> (!s32i {llvm.noundef})
@@ -155,12 +155,12 @@ thread_local CtorDtor tls_cd_dyn = get_i();
 // LLVM-BOTH:   ret void
 
 thread_local CtorDtor &tls_cd_ref = tls_cd_dyn;
-// CIR-BEFORE-LPP: cir.global external tls_model = <tls_dyn> tls_refs = <"_ZTW10tls_cd_ref", "_ZTH10tls_cd_ref"> @tls_cd_ref = ctor : !cir.ptr<!rec_CtorDtor> {
+// CIR-BEFORE-LPP: cir.global external tls_model = tls_dyn tls_refs = <"_ZTW10tls_cd_ref", "_ZTH10tls_cd_ref"> @tls_cd_ref = ctor : !cir.ptr<!rec_CtorDtor> {
 // CIR-BEFORE-LPP:   %[[GET_GLOB:.*]] = cir.get_global thread_local @tls_cd_ref : !cir.ptr<!cir.ptr<!rec_CtorDtor>>
 // CIR-BEFORE-LPP:   %[[CALL:.*]] = cir.get_global thread_local @tls_cd_dyn : !cir.ptr<!rec_CtorDtor>
 // CIR-BEFORE-LPP:   cir.store {{.*}}%[[CALL]], %[[GET_GLOB]] : !cir.ptr<!rec_CtorDtor>, !cir.ptr<!cir.ptr<!rec_CtorDtor>>
 // CIR-BEFORE-LPP: }
-// CIR: cir.global external tls_model = <tls_dyn> tls_refs = <"_ZTW10tls_cd_ref", "_ZTH10tls_cd_ref"> @tls_cd_ref = #cir.ptr<null> : !cir.ptr<!rec_CtorDtor>
+// CIR: cir.global external tls_model = tls_dyn tls_refs = <"_ZTW10tls_cd_ref", "_ZTH10tls_cd_ref"> @tls_cd_ref = #cir.ptr<null> : !cir.ptr<!rec_CtorDtor>
 // CIR: cir.func internal private @[[TLS_CD_REF_INIT]]() {
 // CIR:   %[[GET_GLOB:.*]] = cir.get_global thread_local @tls_cd_ref : !cir.ptr<!cir.ptr<!rec_CtorDtor>>
 // CIR:   %[[GET_DYN:.*]] = cir.call @_ZTW10tls_cd_dyn() : () -> !cir.ptr<!rec_CtorDtor>
@@ -182,7 +182,7 @@ thread_local CtorDtor &tls_cd_ref = tls_cd_dyn;
 // OGCG: }
 
 thread_local CtorDtor tls_cd_dyn_not_used = get_i();
-// CIR-BEFORE-LPP: cir.global external tls_model = <tls_dyn> tls_refs = <"_ZTW19tls_cd_dyn_not_used", "_ZTH19tls_cd_dyn_not_used"> @tls_cd_dyn_not_used = ctor : !rec_CtorDtor {
+// CIR-BEFORE-LPP: cir.global external tls_model = tls_dyn tls_refs = <"_ZTW19tls_cd_dyn_not_used", "_ZTH19tls_cd_dyn_not_used"> @tls_cd_dyn_not_used = ctor : !rec_CtorDtor {
 // CIR-BEFORE-LPP:   %[[GET_GLOB:.*]] = cir.get_global thread_local @tls_cd_dyn_not_used : !cir.ptr<!rec_CtorDtor>
 // CIR-BEFORE-LPP:   %[[CALL:.*]] = cir.call @_Z5get_iv() : () -> (!s32i {llvm.noundef})
 // CIR-BEFORE-LPP:   cir.call @_ZN8CtorDtorC1Ei(%[[GET_GLOB]], %[[CALL]])
@@ -190,7 +190,7 @@ thread_local CtorDtor tls_cd_dyn_not_used = get_i();
 // CIR-BEFORE-LPP:   %[[GET_GLOB:.*]] = cir.get_global thread_local @tls_cd_dyn_not_used : !cir.ptr<!rec_CtorDtor>
 // CIR-BEFORE-LPP:   cir.call @_ZN8CtorDtorD1Ev(%[[GET_GLOB]]) : (!cir.ptr<!rec_CtorDtor>) -> ()
 // CIR-BEFORE-LPP: }
-// CIR: cir.global external tls_model = <tls_dyn> tls_refs = <"_ZTW19tls_cd_dyn_not_used", "_ZTH19tls_cd_dyn_not_used"> @tls_cd_dyn_not_used = #cir.zero : !rec_CtorDtor
+// CIR: cir.global external tls_model = tls_dyn tls_refs = <"_ZTW19tls_cd_dyn_not_used", "_ZTH19tls_cd_dyn_not_used"> @tls_cd_dyn_not_used = #cir.zero : !rec_CtorDtor
 // CIR: cir.func internal private @[[TLS_CD_DYN_NOT_USED_INIT]]() {
 // CIR:   %[[GET_GLOB:.*]] = cir.get_global thread_local @tls_cd_dyn_not_used : !cir.ptr<!rec_CtorDtor>
 // CIR:   %[[CALL:.*]] = cir.call @_Z5get_iv() : () -> (!s32i {llvm.noundef})

--- a/clang/test/CIR/CodeGen/global-tls-dynamic-vs-static.cpp
+++ b/clang/test/CIR/CodeGen/global-tls-dynamic-vs-static.cpp
@@ -9,23 +9,23 @@ _Thread_local int b = 5;
 thread_local  int c = 5;
 thread_local  int d = f();
 
-// CIR-BEFORE-LPP: cir.global external tls_model = <tls_dyn> @a = #cir.int<5> : !s32i
-// CIR-BEFORE-LPP: cir.global external tls_model = <tls_dyn> @b = #cir.int<5> : !s32i
-// CIR-BEFORE-LPP: cir.global external tls_model = <tls_dyn> tls_refs = <"_ZTW1c", "_ZTH1c"> @c = #cir.int<5> : !s32i
-// CIR-BEFORE-LPP: cir.global external tls_model = <tls_dyn> tls_refs = <"_ZTW1d", "_ZTH1d"> @d = ctor
+// CIR-BEFORE-LPP: cir.global external tls_model = tls_dyn @a = #cir.int<5> : !s32i
+// CIR-BEFORE-LPP: cir.global external tls_model = tls_dyn @b = #cir.int<5> : !s32i
+// CIR-BEFORE-LPP: cir.global external tls_model = tls_dyn tls_refs = <"_ZTW1c", "_ZTH1c"> @c = #cir.int<5> : !s32i
+// CIR-BEFORE-LPP: cir.global external tls_model = tls_dyn tls_refs = <"_ZTW1d", "_ZTH1d"> @d = ctor
 
-// CIR-DAG: cir.global external tls_model = <tls_dyn> @a = #cir.int<5> : !s32i
-// CIR-DAG: cir.global external tls_model = <tls_dyn> @b = #cir.int<5> : !s32i
+// CIR-DAG: cir.global external tls_model = tls_dyn @a = #cir.int<5> : !s32i
+// CIR-DAG: cir.global external tls_model = tls_dyn @b = #cir.int<5> : !s32i
 
-// CIR-DAG: cir.global internal tls_model = <tls_dyn> @__tls_guard = #cir.int<0> : !s8i
+// CIR-DAG: cir.global internal tls_model = tls_dyn @__tls_guard = #cir.int<0> : !s8i
 // CIR-DAG: cir.func internal private @__tls_init()
 // CIR-DAG: cir.func internal private @__cxx_global_var_init()
 
-// CIR-DAG: cir.global external tls_model = <tls_dyn> tls_refs = <"_ZTW1c", "_ZTH1c"> @c = #cir.int<5> : !s32i
+// CIR-DAG: cir.global external tls_model = tls_dyn tls_refs = <"_ZTW1c", "_ZTH1c"> @c = #cir.int<5> : !s32i
 // CIR-DAG: cir.func comdat weak_odr private hidden @_ZTW1c()
 // Note: C doesn't get an alias since it doesn't have an init function.
 
-// CIR-DAG: cir.global external tls_model = <tls_dyn> tls_refs = <"_ZTW1d", "_ZTH1d"> @d = #cir.int<0> : !s32i
+// CIR-DAG: cir.global external tls_model = tls_dyn tls_refs = <"_ZTW1d", "_ZTH1d"> @d = #cir.int<0> : !s32i
 // CIR-DAG: cir.func comdat weak_odr private hidden @_ZTW1d() -> !cir.ptr<!s32i>
 // CIR-DAG: cir.func @_ZTH1d() alias(@__tls_init)
 

--- a/clang/test/CIR/CodeGen/global-tls-simple-init.cpp
+++ b/clang/test/CIR/CodeGen/global-tls-simple-init.cpp
@@ -140,16 +140,16 @@ struct CtorDtor {
 
 
 thread_local int tls_int = 5;
-// CIR-BEFORE-LPP: cir.global external tls_model = <tls_dyn> tls_refs = <"_ZTW7tls_int", "_ZTH7tls_int"> @tls_int = #cir.int<5> : !s32i
-// CIR: cir.global external tls_model = <tls_dyn> tls_refs = <"_ZTW7tls_int", "_ZTH7tls_int"> @tls_int = #cir.int<5> : !s32i
+// CIR-BEFORE-LPP: cir.global external tls_model = tls_dyn tls_refs = <"_ZTW7tls_int", "_ZTH7tls_int"> @tls_int = #cir.int<5> : !s32i
+// CIR: cir.global external tls_model = tls_dyn tls_refs = <"_ZTW7tls_int", "_ZTH7tls_int"> @tls_int = #cir.int<5> : !s32i
 
 thread_local int tls_int_dyn = get_i();
-// CIR-BEFORE-LPP: cir.global external tls_model = <tls_dyn> tls_refs = <"_ZTW11tls_int_dyn", "_ZTH11tls_int_dyn"> @tls_int_dyn = ctor : !s32i {
+// CIR-BEFORE-LPP: cir.global external tls_model = tls_dyn tls_refs = <"_ZTW11tls_int_dyn", "_ZTH11tls_int_dyn"> @tls_int_dyn = ctor : !s32i {
 // CIR-BEFORE-LPP:   %[[GET_GLOB:.*]] = cir.get_global thread_local @tls_int_dyn : !cir.ptr<!s32i>
 // CIR-BEFORE-LPP:   %[[CALL:.*]] = cir.call @_Z5get_iv() : () -> (!s32i {llvm.noundef})
 // CIR-BEFORE-LPP:   cir.store {{.*}}%[[CALL]], %[[GET_GLOB]] : !s32i, !cir.ptr<!s32i>
 // CIR-BEFORE-LPP: }
-// CIR: cir.global external tls_model = <tls_dyn> tls_refs = <"_ZTW11tls_int_dyn", "_ZTH11tls_int_dyn"> @tls_int_dyn = #cir.int<0> : !s32i 
+// CIR: cir.global external tls_model = tls_dyn tls_refs = <"_ZTW11tls_int_dyn", "_ZTH11tls_int_dyn"> @tls_int_dyn = #cir.int<0> : !s32i
 // CIR: cir.func internal private @[[TLS_INT_DYN_INIT]]() {
 // CIR:   %[[GET_GLOB:.*]] = cir.get_global thread_local @tls_int_dyn : !cir.ptr<!s32i>
 // CIR:   %[[CALL:.*]] = cir.call @_Z5get_iv() : () -> (!s32i {llvm.noundef})
@@ -164,12 +164,12 @@ thread_local int tls_int_dyn = get_i();
 // LLVM-BOTH:   ret void
 
 thread_local int &tls_int_ref = tls_int_dyn;
-// CIR-BEFORE-LPP: cir.global external tls_model = <tls_dyn> tls_refs = <"_ZTW11tls_int_ref", "_ZTH11tls_int_ref"> @tls_int_ref = ctor : !cir.ptr<!s32i> {
+// CIR-BEFORE-LPP: cir.global external tls_model = tls_dyn tls_refs = <"_ZTW11tls_int_ref", "_ZTH11tls_int_ref"> @tls_int_ref = ctor : !cir.ptr<!s32i> {
 // CIR-BEFORE-LPP:   %[[GET_GLOB:.*]] = cir.get_global thread_local @tls_int_ref : !cir.ptr<!cir.ptr<!s32i>>
 // CIR-BEFORE-LPP:   %[[GET_OTHER:.*]] = cir.get_global thread_local @tls_int_dyn : !cir.ptr<!s32i>
 // CIR-BEFORE-LPP:   cir.store {{.*}}%[[GET_OTHER]], %[[GET_GLOB]] : !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>
 // CIR-BEFORE-LPP: }
-// CIR: cir.global external tls_model = <tls_dyn> tls_refs = <"_ZTW11tls_int_ref", "_ZTH11tls_int_ref"> @tls_int_ref = #cir.ptr<null> : !cir.ptr<!s32i>
+// CIR: cir.global external tls_model = tls_dyn tls_refs = <"_ZTW11tls_int_ref", "_ZTH11tls_int_ref"> @tls_int_ref = #cir.ptr<null> : !cir.ptr<!s32i>
 // CIR: cir.func internal private @[[TLS_INT_REF_INIT]]() {
 // CIR:   %[[GET_GLOB:.*]] = cir.get_global thread_local @tls_int_ref : !cir.ptr<!cir.ptr<!s32i>>
 // CIR:   %[[GET_REF:.*]] = cir.call @_ZTW11tls_int_dyn() : () -> !cir.ptr<!s32i>
@@ -189,7 +189,7 @@ thread_local int &tls_int_ref = tls_int_dyn;
 // OGCG:   ret ptr %[[GET_GLOB]]
 
 thread_local int tls_int_self_init = tls_int_self_init + get_i();
-// CIR-BEFORE-LPP:  cir.global external tls_model = <tls_dyn> tls_refs = <"_ZTW17tls_int_self_init", "_ZTH17tls_int_self_init"> @tls_int_self_init = ctor : !s32i {
+// CIR-BEFORE-LPP:  cir.global external tls_model = tls_dyn tls_refs = <"_ZTW17tls_int_self_init", "_ZTH17tls_int_self_init"> @tls_int_self_init = ctor : !s32i {
 // CIR-BEFORE-LPP:    %[[GET_GLOB:.*]] = cir.get_global thread_local @tls_int_self_init : !cir.ptr<!s32i>
 // CIR-BEFORE-LPP:    %[[GET_SELF:.*]] = cir.get_global thread_local @tls_int_self_init : !cir.ptr<!s32i>
 // CIR-BEFORE-LPP:    %[[LOAD_SELF:.*]] = cir.load {{.*}}%[[GET_SELF]] : !cir.ptr<!s32i>, !s32i
@@ -197,7 +197,7 @@ thread_local int tls_int_self_init = tls_int_self_init + get_i();
 // CIR-BEFORE-LPP:    %[[ADD:.*]] = cir.add nsw %[[LOAD_SELF]], %[[CALL]] : !s32i
 // CIR-BEFORE-LPP:    cir.store {{.*}}%[[ADD]], %[[GET_GLOB]] : !s32i, !cir.ptr<!s32i>
 // CIR-BEFORE-LPP:  }
-// CIR: cir.global external tls_model = <tls_dyn> tls_refs = <"_ZTW17tls_int_self_init", "_ZTH17tls_int_self_init"> @tls_int_self_init = #cir.int<0> : !s32i
+// CIR: cir.global external tls_model = tls_dyn tls_refs = <"_ZTW17tls_int_self_init", "_ZTH17tls_int_self_init"> @tls_int_self_init = #cir.int<0> : !s32i
 // CIR: cir.func internal private @[[TLS_INT_SELF_REF_INIT]]() {
 // CIR:   %[[GET_GLOB:.*]] = cir.get_global thread_local @tls_int_self_init : !cir.ptr<!s32i>
 // CIR:   %[[GET_SELF_FROM_WRAPPER:.*]] = cir.call @_ZTW17tls_int_self_init() : () -> !cir.ptr<!s32i>
@@ -223,16 +223,16 @@ thread_local int tls_int_self_init = tls_int_self_init + get_i();
 // OGCG:   ret ptr %[[GET_GLOB]]
 
 extern thread_local int definitely_inited = 5;
-// CIR-BEFORE-LPP: cir.global external tls_model = <tls_dyn> tls_refs = <"_ZTW17definitely_inited", "_ZTH17definitely_inited"> @definitely_inited = #cir.int<5> : !s32i
-// CIR: cir.global external tls_model = <tls_dyn> tls_refs = <"_ZTW17definitely_inited", "_ZTH17definitely_inited"> @definitely_inited = #cir.int<5> : !s32i
+// CIR-BEFORE-LPP: cir.global external tls_model = tls_dyn tls_refs = <"_ZTW17definitely_inited", "_ZTH17definitely_inited"> @definitely_inited = #cir.int<5> : !s32i
+// CIR: cir.global external tls_model = tls_dyn tls_refs = <"_ZTW17definitely_inited", "_ZTH17definitely_inited"> @definitely_inited = #cir.int<5> : !s32i
 
 extern thread_local int definitely_inited_dyn = get_i();
-// CIR-BEFORE-LPP: cir.global external tls_model = <tls_dyn> tls_refs = <"_ZTW21definitely_inited_dyn", "_ZTH21definitely_inited_dyn"> @definitely_inited_dyn = ctor : !s32i {
+// CIR-BEFORE-LPP: cir.global external tls_model = tls_dyn tls_refs = <"_ZTW21definitely_inited_dyn", "_ZTH21definitely_inited_dyn"> @definitely_inited_dyn = ctor : !s32i {
 // CIR-BEFORE-LPP:   %[[GET_GLOB:.*]] = cir.get_global thread_local @definitely_inited_dyn : !cir.ptr<!s32i>
 // CIR-BEFORE-LPP:   %[[CALL:.*]] = cir.call @_Z5get_iv() : () -> (!s32i {llvm.noundef})
 // CIR-BEFORE-LPP:   cir.store {{.*}}%[[CALL]], %[[GET_GLOB]] : !s32i, !cir.ptr<!s32i>
 // CIR-BEFORE-LPP: }
-// CIR: cir.global external tls_model = <tls_dyn> tls_refs = <"_ZTW21definitely_inited_dyn", "_ZTH21definitely_inited_dyn"> @definitely_inited_dyn = #cir.int<0> : !s32i
+// CIR: cir.global external tls_model = tls_dyn tls_refs = <"_ZTW21definitely_inited_dyn", "_ZTH21definitely_inited_dyn"> @definitely_inited_dyn = #cir.int<0> : !s32i
 // CIR: cir.func internal private @[[DEF_INITED_DYN]]() {
 // CIR:   %[[GET_GLOB:.*]] = cir.get_global thread_local @definitely_inited_dyn : !cir.ptr<!s32i>
 // CIR:   %[[CALL:.*]] = cir.call @_Z5get_iv() : () -> (!s32i {llvm.noundef})
@@ -247,8 +247,8 @@ extern thread_local int definitely_inited_dyn = get_i();
 // LLVM-BOTH:   ret void
 
 extern thread_local int maybe_inited;
-// CIR-BEFORE-LPP: cir.global "private" external tls_model = <tls_dyn> tls_refs = <"_ZTW12maybe_inited", "_ZTH12maybe_inited"> @maybe_inited : !s32i
-// CIR: cir.global "private" external tls_model = <tls_dyn> tls_refs = <"_ZTW12maybe_inited", "_ZTH12maybe_inited"> @maybe_inited : !s32i
+// CIR-BEFORE-LPP: cir.global "private" external tls_model = tls_dyn tls_refs = <"_ZTW12maybe_inited", "_ZTH12maybe_inited"> @maybe_inited : !s32i
+// CIR: cir.global "private" external tls_model = tls_dyn tls_refs = <"_ZTW12maybe_inited", "_ZTH12maybe_inited"> @maybe_inited : !s32i
 
 void uses() {
   auto a = tls_int;

--- a/clang/test/CIR/CodeGen/global-tls-templates.cpp
+++ b/clang/test/CIR/CodeGen/global-tls-templates.cpp
@@ -13,13 +13,13 @@ struct CtorDtor {
 template<typename T>
 thread_local T tls_templ = {get_i()};
 
-// CIR-BEFORE-LPP-LABEL:  cir.global linkonce_odr comdat tls_model = <tls_dyn> tls_refs = <"_ZTW9tls_templIiE", "_ZTH9tls_templIiE", "_ZGV9tls_templIiE"> @_Z9tls_templIiE = ctor : !s32i {
+// CIR-BEFORE-LPP-LABEL:  cir.global linkonce_odr comdat tls_model = tls_dyn tls_refs = <"_ZTW9tls_templIiE", "_ZTH9tls_templIiE", "_ZGV9tls_templIiE"> @_Z9tls_templIiE = ctor : !s32i {
 // CIR-BEFORE-LPP:    %[[GET_GLOB:.*]] = cir.get_global thread_local @_Z9tls_templIiE : !cir.ptr<!s32i>
 // CIR-BEFORE-LPP:    %[[CALL:.*]] = cir.call @_Z5get_iv() : () -> (!s32i {llvm.noundef})
 // CIR-BEFORE-LPP:    cir.store{{.*}} %[[CALL]], %[[GET_GLOB]] : !s32i, !cir.ptr<!s32i>
 // CIR-BEFORE-LPP:  }
 //
-// CIR-BEFORE-LPP-LABEL:  cir.global linkonce_odr comdat tls_model = <tls_dyn> tls_refs = <"_ZTW9tls_templI8CtorDtorE", "_ZTH9tls_templI8CtorDtorE", "_ZGV9tls_templI8CtorDtorE"> @_Z9tls_templI8CtorDtorE = ctor : !rec_CtorDtor {
+// CIR-BEFORE-LPP-LABEL:  cir.global linkonce_odr comdat tls_model = tls_dyn tls_refs = <"_ZTW9tls_templI8CtorDtorE", "_ZTH9tls_templI8CtorDtorE", "_ZGV9tls_templI8CtorDtorE"> @_Z9tls_templI8CtorDtorE = ctor : !rec_CtorDtor {
 // CIR-BEFORE-LPP:    %[[GET_GLOB:.*]] = cir.get_global thread_local @_Z9tls_templI8CtorDtorE : !cir.ptr<!rec_CtorDtor>
 // CIR-BEFORE-LPP:    %[[CALL:.*]] = cir.call @_Z5get_iv() : () -> (!s32i {llvm.noundef})
 // CIR-BEFORE-LPP:    cir.call @_ZN8CtorDtorC1Ei(%[[GET_GLOB]], %[[CALL]]) : (!cir.ptr<!rec_CtorDtor>
@@ -38,7 +38,7 @@ thread_local T tls_templ = {get_i()};
 // Alias: Ctor/Dtor: 
 // CIR: cir.func linkonce_odr @_ZTH9tls_templI8CtorDtorE() alias(@[[CTOR_DTOR_INIT:[^)]*]])
 // TLS Guard: Ctor/Dtor:
-// CIR: cir.global "private" linkonce_odr comdat tls_model = <tls_dyn> @_ZGV9tls_templI8CtorDtorE = #cir.int<0> : !s64i
+// CIR: cir.global "private" linkonce_odr comdat tls_model = tls_dyn @_ZGV9tls_templI8CtorDtorE = #cir.int<0> : !s64i
 
 // Wrapper: int
 // CIR-LABEL: cir.func comdat weak_odr private hidden @_ZTW9tls_templIiE() -> !cir.ptr<!s32i>
@@ -50,10 +50,10 @@ thread_local T tls_templ = {get_i()};
 // Alias: int
 // CIR: cir.func linkonce_odr @_ZTH9tls_templIiE() alias(@[[INT_INIT:[^)]*]])
 // TLS Guard: int
-// CIR: cir.global "private" linkonce_odr comdat tls_model = <tls_dyn> @_ZGV9tls_templIiE = #cir.int<0> : !s64i
+// CIR: cir.global "private" linkonce_odr comdat tls_model = tls_dyn @_ZGV9tls_templIiE = #cir.int<0> : !s64i
 
 // Global: int
-// CIR: cir.global linkonce_odr comdat tls_model = <tls_dyn> tls_refs = <"_ZTW9tls_templIiE", "_ZTH9tls_templIiE", "_ZGV9tls_templIiE"> @_Z9tls_templIiE = #cir.int<0> : !s32i
+// CIR: cir.global linkonce_odr comdat tls_model = tls_dyn tls_refs = <"_ZTW9tls_templIiE", "_ZTH9tls_templIiE", "_ZGV9tls_templIiE"> @_Z9tls_templIiE = #cir.int<0> : !s32i
 
 // Init Func: int
 // CIR:  cir.func internal private @[[INT_INIT]]() {
@@ -74,7 +74,7 @@ thread_local T tls_templ = {get_i()};
 
 
 // Global: Ctor/Dotr:
-// CIR: cir.global linkonce_odr comdat tls_model = <tls_dyn> tls_refs = <"_ZTW9tls_templI8CtorDtorE", "_ZTH9tls_templI8CtorDtorE", "_ZGV9tls_templI8CtorDtorE"> @_Z9tls_templI8CtorDtorE = #cir.zero : !rec_CtorDtor
+// CIR: cir.global linkonce_odr comdat tls_model = tls_dyn tls_refs = <"_ZTW9tls_templI8CtorDtorE", "_ZTH9tls_templI8CtorDtorE", "_ZGV9tls_templI8CtorDtorE"> @_Z9tls_templI8CtorDtorE = #cir.zero : !rec_CtorDtor
 
 // Init Func: Ctor/Dtor:
 // CIR: cir.func internal private @[[CTOR_DTOR_INIT]]() {

--- a/clang/test/CIR/CodeGen/thread-local-in-func.cpp
+++ b/clang/test/CIR/CodeGen/thread-local-in-func.cpp
@@ -4,32 +4,32 @@
 // RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o - | FileCheck %s --check-prefix=OGCG,LLVM-BOTH
 
 // Guard variables.
-// CIR-DAG: cir.global "private" internal tls_model = <tls_dyn> dso_local @_ZGVZ13test_ctordtoriE4init = #cir.int<0> : !s8i
+// CIR-DAG: cir.global "private" internal tls_model = tls_dyn dso_local @_ZGVZ13test_ctordtoriE4init = #cir.int<0> : !s8i
 // LLVM-BOTH-DAG: @_ZGVZ13test_ctordtoriE4init = internal thread_local global i8 0
-// CIR-DAG: cir.global "private" internal tls_model = <tls_dyn> dso_local @_ZGVZ13test_ctordtoriE10const_init = #cir.int<0> : !s8i
+// CIR-DAG: cir.global "private" internal tls_model = tls_dyn dso_local @_ZGVZ13test_ctordtoriE10const_init = #cir.int<0> : !s8i
 // LLVM-BOTH-DAG: @_ZGVZ13test_ctordtoriE10const_init = internal thread_local global i8 0
-// CIR-DAG: cir.global "private" internal tls_model = <tls_dyn> dso_local @_ZGVZ9test_dtoriE10const_init = #cir.int<0> : !s8i
+// CIR-DAG: cir.global "private" internal tls_model = tls_dyn dso_local @_ZGVZ9test_dtoriE10const_init = #cir.int<0> : !s8i
 // LLVM-BOTH-DAG: @_ZGVZ9test_dtoriE10const_init = internal thread_local global i8 0
-// CIR-DAG: cir.global "private" internal tls_model = <tls_dyn> dso_local @_ZGVZ9test_ctoriE4init = #cir.int<0> : !s8i
+// CIR-DAG: cir.global "private" internal tls_model = tls_dyn dso_local @_ZGVZ9test_ctoriE4init = #cir.int<0> : !s8i
 // LLVM-BOTH-DAG: @_ZGVZ9test_ctoriE4init = internal thread_local global i8 0
-// CIR-DAG: cir.global "private" internal tls_model = <tls_dyn> dso_local @_ZGVZ9test_ctoriE10const_init = #cir.int<0> : !s8i
+// CIR-DAG: cir.global "private" internal tls_model = tls_dyn dso_local @_ZGVZ9test_ctoriE10const_init = #cir.int<0> : !s8i
 // LLVM-BOTH-DAG: @_ZGVZ9test_ctoriE10const_init = internal thread_local global i8 0
-// CIR-DAG: cir.global "private" internal tls_model = <tls_dyn> dso_local @_ZGVZ8test_intiE4init = #cir.int<0> : !s8i
+// CIR-DAG: cir.global "private" internal tls_model = tls_dyn dso_local @_ZGVZ8test_intiE4init = #cir.int<0> : !s8i
 // LLVM-BOTH-DAG: @_ZGVZ8test_intiE4init = internal thread_local global i8 0
 
-// CIR-BOTH-DAG: cir.global "private" internal tls_model = <tls_dyn> dso_local static_local_guard<"_ZGVZ13test_ctordtoriE4init"> @_ZZ13test_ctordtoriE4init = #cir.zero : !rec_CtorDtor
+// CIR-BOTH-DAG: cir.global "private" internal tls_model = tls_dyn dso_local static_local_guard<"_ZGVZ13test_ctordtoriE4init"> @_ZZ13test_ctordtoriE4init = #cir.zero : !rec_CtorDtor
 // LLVM-BOTH-DAG: @_ZZ13test_ctordtoriE4init = internal thread_local global %struct.CtorDtor zeroinitializer
-// CIR-BOTH-DAG: cir.global "private" internal tls_model = <tls_dyn> dso_local static_local_guard<"_ZGVZ13test_ctordtoriE10const_init"> @_ZZ13test_ctordtoriE10const_init = #cir.zero : !rec_CtorDtor
+// CIR-BOTH-DAG: cir.global "private" internal tls_model = tls_dyn dso_local static_local_guard<"_ZGVZ13test_ctordtoriE10const_init"> @_ZZ13test_ctordtoriE10const_init = #cir.zero : !rec_CtorDtor
 // LLVM-BOTH-DAG: @_ZZ13test_ctordtoriE10const_init = internal thread_local global %struct.CtorDtor zeroinitializer
-// CIR-BOTH-DAG: cir.global "private" internal tls_model = <tls_dyn> dso_local static_local_guard<"_ZGVZ9test_dtoriE10const_init"> @_ZZ9test_dtoriE10const_init = #cir.zero : !rec_Dtor
+// CIR-BOTH-DAG: cir.global "private" internal tls_model = tls_dyn dso_local static_local_guard<"_ZGVZ9test_dtoriE10const_init"> @_ZZ9test_dtoriE10const_init = #cir.zero : !rec_Dtor
 // LLVM-BOTH-DAG: @_ZZ9test_dtoriE10const_init = internal thread_local global %struct.Dtor zeroinitializer
-// CIR-BOTH-DAG: cir.global "private" internal tls_model = <tls_dyn> dso_local static_local_guard<"_ZGVZ9test_ctoriE4init"> @_ZZ9test_ctoriE4init = #cir.zero : !rec_Ctor
+// CIR-BOTH-DAG: cir.global "private" internal tls_model = tls_dyn dso_local static_local_guard<"_ZGVZ9test_ctoriE4init"> @_ZZ9test_ctoriE4init = #cir.zero : !rec_Ctor
 // LLVM-BOTH-DAG: @_ZZ9test_ctoriE4init = internal thread_local global %struct.Ctor zeroinitializer
-// CIR-BOTH-DAG: cir.global "private" internal tls_model = <tls_dyn> dso_local static_local_guard<"_ZGVZ9test_ctoriE10const_init"> @_ZZ9test_ctoriE10const_init = #cir.zero : !rec_Ctor
+// CIR-BOTH-DAG: cir.global "private" internal tls_model = tls_dyn dso_local static_local_guard<"_ZGVZ9test_ctoriE10const_init"> @_ZZ9test_ctoriE10const_init = #cir.zero : !rec_Ctor
 // LLVM-BOTH-DAG: @_ZZ9test_ctoriE10const_init = internal thread_local global %struct.Ctor zeroinitializer
-// CIR-BOTH-DAG: cir.global "private" internal tls_model = <tls_dyn> dso_local static_local_guard<"_ZGVZ8test_intiE4init"> @_ZZ8test_intiE4init = #cir.int<0> : !s32i
+// CIR-BOTH-DAG: cir.global "private" internal tls_model = tls_dyn dso_local static_local_guard<"_ZGVZ8test_intiE4init"> @_ZZ8test_intiE4init = #cir.int<0> : !s32i
 // LLVM-BOTH-DAG: @_ZZ8test_intiE4init = internal thread_local global i32 0
-// CIR-BOTH-DAG: cir.global "private" internal tls_model = <tls_dyn> dso_local @_ZZ8test_intiE10const_init = #cir.int<5> : !s32i
+// CIR-BOTH-DAG: cir.global "private" internal tls_model = tls_dyn dso_local @_ZZ8test_intiE10const_init = #cir.int<5> : !s32i
 // LLVM-BOTH-DAG: @_ZZ8test_intiE10const_init = internal thread_local global i32 5
 int get_i();
 

--- a/clang/test/CIR/CodeGen/tls-model-func-scope.cpp
+++ b/clang/test/CIR/CodeGen/tls-model-func-scope.cpp
@@ -32,10 +32,10 @@ void func() {
 }
 // CIR-GD: module {{.*}} attributes
 // CIR-GD-SAME: cir.default_tls_model = #cir.tls_model<tls_dyn>
-// CIR-GD: cir.global "private" internal tls_model = <tls_init_exec> dso_local @_ZGVZ4funcvE17override_tls_mode = #cir.int<0> : !s8i
-// CIR-GD: cir.global "private" internal tls_model = <tls_dyn> dso_local @_ZGVZ4funcvE16default_tls_mode = #cir.int<0> : !s8i
-// CIR-GD: cir.global "private" internal tls_model = <tls_init_exec> dso_local static_local_guard<"_ZGVZ4funcvE17override_tls_mode"> @_ZZ4funcvE17override_tls_mode = #cir.int<0> : !s32i
-// CIR-GD: cir.global "private" internal tls_model = <tls_dyn> dso_local static_local_guard<"_ZGVZ4funcvE16default_tls_mode"> @_ZZ4funcvE16default_tls_mode = #cir.int<0> : !s32i
+// CIR-GD: cir.global "private" internal tls_model = tls_init_exec dso_local @_ZGVZ4funcvE17override_tls_mode = #cir.int<0> : !s8i
+// CIR-GD: cir.global "private" internal tls_model = tls_dyn dso_local @_ZGVZ4funcvE16default_tls_mode = #cir.int<0> : !s8i
+// CIR-GD: cir.global "private" internal tls_model = tls_init_exec dso_local static_local_guard<"_ZGVZ4funcvE17override_tls_mode"> @_ZZ4funcvE17override_tls_mode = #cir.int<0> : !s32i
+// CIR-GD: cir.global "private" internal tls_model = tls_dyn dso_local static_local_guard<"_ZGVZ4funcvE16default_tls_mode"> @_ZZ4funcvE16default_tls_mode = #cir.int<0> : !s32i
 
 // LLVM-GD-DAG: @_ZGVZ4funcvE17override_tls_mode = internal thread_local(initialexec) global i8 0
 // LLVM-GD-DAG: @_ZGVZ4funcvE16default_tls_mode = internal thread_local global i8 0
@@ -44,10 +44,10 @@ void func() {
 
 // CIR-LD: module {{.*}} attributes
 // CIR-LD-SAME: cir.default_tls_model = #cir.tls_model<tls_local_dyn>
-// CIR-LD: cir.global "private" internal tls_model = <tls_init_exec> dso_local @_ZGVZ4funcvE17override_tls_mode = #cir.int<0> : !s8i
-// CIR-LD: cir.global "private" internal tls_model = <tls_local_dyn> dso_local @_ZGVZ4funcvE16default_tls_mode = #cir.int<0> : !s8i
-// CIR-LD: cir.global "private" internal tls_model = <tls_init_exec> dso_local static_local_guard<"_ZGVZ4funcvE17override_tls_mode"> @_ZZ4funcvE17override_tls_mode = #cir.int<0> : !s32i
-// CIR-LD: cir.global "private" internal tls_model = <tls_local_dyn> dso_local static_local_guard<"_ZGVZ4funcvE16default_tls_mode"> @_ZZ4funcvE16default_tls_mode = #cir.int<0> : !s32i
+// CIR-LD: cir.global "private" internal tls_model = tls_init_exec dso_local @_ZGVZ4funcvE17override_tls_mode = #cir.int<0> : !s8i
+// CIR-LD: cir.global "private" internal tls_model = tls_local_dyn dso_local @_ZGVZ4funcvE16default_tls_mode = #cir.int<0> : !s8i
+// CIR-LD: cir.global "private" internal tls_model = tls_init_exec dso_local static_local_guard<"_ZGVZ4funcvE17override_tls_mode"> @_ZZ4funcvE17override_tls_mode = #cir.int<0> : !s32i
+// CIR-LD: cir.global "private" internal tls_model = tls_local_dyn dso_local static_local_guard<"_ZGVZ4funcvE16default_tls_mode"> @_ZZ4funcvE16default_tls_mode = #cir.int<0> : !s32i
 
 // LLVM-LD-DAG: @_ZGVZ4funcvE17override_tls_mode = internal thread_local(initialexec) global i8 0
 // LLVM-LD-DAG: @_ZGVZ4funcvE16default_tls_mode = internal thread_local(localdynamic) global i8 0
@@ -56,10 +56,10 @@ void func() {
 
 // CIR-IE: module {{.*}} attributes
 // CIR-IE-SAME: cir.default_tls_model = #cir.tls_model<tls_init_exec>
-// CIR-IE: cir.global "private" internal tls_model = <tls_init_exec> dso_local @_ZGVZ4funcvE17override_tls_mode = #cir.int<0> : !s8i
-// CIR-IE: cir.global "private" internal tls_model = <tls_init_exec> dso_local @_ZGVZ4funcvE16default_tls_mode = #cir.int<0> : !s8i
-// CIR-IE: cir.global "private" internal tls_model = <tls_init_exec> dso_local static_local_guard<"_ZGVZ4funcvE17override_tls_mode"> @_ZZ4funcvE17override_tls_mode = #cir.int<0> : !s32i
-// CIR-IE: cir.global "private" internal tls_model = <tls_init_exec> dso_local static_local_guard<"_ZGVZ4funcvE16default_tls_mode"> @_ZZ4funcvE16default_tls_mode = #cir.int<0> : !s32i
+// CIR-IE: cir.global "private" internal tls_model = tls_init_exec dso_local @_ZGVZ4funcvE17override_tls_mode = #cir.int<0> : !s8i
+// CIR-IE: cir.global "private" internal tls_model = tls_init_exec dso_local @_ZGVZ4funcvE16default_tls_mode = #cir.int<0> : !s8i
+// CIR-IE: cir.global "private" internal tls_model = tls_init_exec dso_local static_local_guard<"_ZGVZ4funcvE17override_tls_mode"> @_ZZ4funcvE17override_tls_mode = #cir.int<0> : !s32i
+// CIR-IE: cir.global "private" internal tls_model = tls_init_exec dso_local static_local_guard<"_ZGVZ4funcvE16default_tls_mode"> @_ZZ4funcvE16default_tls_mode = #cir.int<0> : !s32i
 
 // LLVM-IE-DAG: @_ZGVZ4funcvE17override_tls_mode = internal thread_local(initialexec) global i8 0
 // LLVM-IE-DAG: @_ZGVZ4funcvE16default_tls_mode = internal thread_local(initialexec) global i8 0
@@ -68,10 +68,10 @@ void func() {
 
 // CIR-LE: module {{.*}} attributes
 // CIR-LE-SAME: cir.default_tls_model = #cir.tls_model<tls_local_exec>
-// CIR-LE: cir.global "private" internal tls_model = <tls_init_exec> dso_local @_ZGVZ4funcvE17override_tls_mode = #cir.int<0> : !s8i
-// CIR-LE: cir.global "private" internal tls_model = <tls_local_exec> dso_local @_ZGVZ4funcvE16default_tls_mode = #cir.int<0> : !s8i
-// CIR-LE: cir.global "private" internal tls_model = <tls_init_exec> dso_local static_local_guard<"_ZGVZ4funcvE17override_tls_mode"> @_ZZ4funcvE17override_tls_mode = #cir.int<0> : !s32i
-// CIR-LE: cir.global "private" internal tls_model = <tls_local_exec> dso_local static_local_guard<"_ZGVZ4funcvE16default_tls_mode"> @_ZZ4funcvE16default_tls_mode = #cir.int<0> : !s32i
+// CIR-LE: cir.global "private" internal tls_model = tls_init_exec dso_local @_ZGVZ4funcvE17override_tls_mode = #cir.int<0> : !s8i
+// CIR-LE: cir.global "private" internal tls_model = tls_local_exec dso_local @_ZGVZ4funcvE16default_tls_mode = #cir.int<0> : !s8i
+// CIR-LE: cir.global "private" internal tls_model = tls_init_exec dso_local static_local_guard<"_ZGVZ4funcvE17override_tls_mode"> @_ZZ4funcvE17override_tls_mode = #cir.int<0> : !s32i
+// CIR-LE: cir.global "private" internal tls_model = tls_local_exec dso_local static_local_guard<"_ZGVZ4funcvE16default_tls_mode"> @_ZZ4funcvE16default_tls_mode = #cir.int<0> : !s32i
 
 // LLVM-LE-DAG: @_ZGVZ4funcvE17override_tls_mode = internal thread_local(initialexec) global i8 0
 // LLVM-LE-DAG: @_ZGVZ4funcvE16default_tls_mode = internal thread_local(localexec) global i8 0

--- a/clang/test/CIR/CodeGen/tls-model.cpp
+++ b/clang/test/CIR/CodeGen/tls-model.cpp
@@ -49,12 +49,12 @@ struct T thread_local t1;
 // CIR-GD-SAME: cir.default_tls_model = #cir.tls_model<tls_dyn>
 // CIR-GD-DAG: cir.global external @z1 = #cir.int<0> : !s32i {alignment = 4 : i64}
 // CIR-GD-DAG: cir.global external @z2 = #cir.int<0> : !s32i {alignment = 4 : i64}
-// CIR-GD-DAG: cir.global external tls_model = <tls_dyn> @x = #cir.int<0> : !s32i {alignment = 4 : i64}
-// CIR-GD-DAG: cir.global "private" internal tls_model = <tls_dyn> dso_local @_ZZ1fvE1y = #cir.int<0> : !s32i {alignment = 4 : i64}
-// CIR-GD-DAG: cir.global external tls_model = <tls_init_exec> @z = #cir.int<0> : !s32i {alignment = 4 : i64}
-// CIR-GD-DAG: cir.global external tls_model = <tls_dyn> tls_refs = <"_ZTW2s1", "_ZTH2s1"> @s1 = #cir.zero : !rec_S {alignment = 1 : i64, ast = #cir.var.decl.ast}
-// CIR-GD-DAG: cir.global external tls_model = <tls_dyn> tls_refs = <"_ZTW2t1", "_ZTH2t1"> @t1 = #cir.zero : !rec_T {alignment = 1 : i64, ast = #cir.var.decl.ast}
-// CIR-GD-DAG: cir.global internal tls_model = <tls_dyn> @__tls_guard = #cir.int<0> : !s8i {alignment = 1 : i64}
+// CIR-GD-DAG: cir.global external tls_model = tls_dyn @x = #cir.int<0> : !s32i {alignment = 4 : i64}
+// CIR-GD-DAG: cir.global "private" internal tls_model = tls_dyn dso_local @_ZZ1fvE1y = #cir.int<0> : !s32i {alignment = 4 : i64}
+// CIR-GD-DAG: cir.global external tls_model = tls_init_exec @z = #cir.int<0> : !s32i {alignment = 4 : i64}
+// CIR-GD-DAG: cir.global external tls_model = tls_dyn tls_refs = <"_ZTW2s1", "_ZTH2s1"> @s1 = #cir.zero : !rec_S {alignment = 1 : i64, ast = #cir.var.decl.ast}
+// CIR-GD-DAG: cir.global external tls_model = tls_dyn tls_refs = <"_ZTW2t1", "_ZTH2t1"> @t1 = #cir.zero : !rec_T {alignment = 1 : i64, ast = #cir.var.decl.ast}
+// CIR-GD-DAG: cir.global internal tls_model = tls_dyn @__tls_guard = #cir.int<0> : !s8i {alignment = 1 : i64}
 
 // LLVM-GD-DAG: @z1 ={{.*}} global i32 0
 // LLVM-GD-DAG: @z2 ={{.*}} global i32 0
@@ -73,12 +73,12 @@ struct T thread_local t1;
 // CIR-LD-SAME: cir.default_tls_model = #cir.tls_model<tls_local_dyn>
 // CIR-LD-DAG: cir.global external @z1 = #cir.int<0> : !s32i {alignment = 4 : i64}
 // CIR-LD-DAG: cir.global external @z2 = #cir.int<0> : !s32i {alignment = 4 : i64}
-// CIR-LD-DAG: cir.global external tls_model = <tls_local_dyn> @x = #cir.int<0> : !s32i {alignment = 4 : i64}
-// CIR-LD-DAG: cir.global "private" internal tls_model = <tls_local_dyn> dso_local @_ZZ1fvE1y = #cir.int<0> : !s32i {alignment = 4 : i64}
-// CIR-LD-DAG: cir.global external tls_model = <tls_init_exec> @z = #cir.int<0> : !s32i {alignment = 4 : i64}
-// CIR-LD-DAG: cir.global external tls_model = <tls_local_dyn> tls_refs = <"_ZTW2s1", "_ZTH2s1"> @s1 = #cir.zero : !rec_S {alignment = 1 : i64, ast = #cir.var.decl.ast}
-// CIR-LD-DAG: cir.global external tls_model = <tls_local_dyn> tls_refs = <"_ZTW2t1", "_ZTH2t1"> @t1 = #cir.zero : !rec_T {alignment = 1 : i64, ast = #cir.var.decl.ast}
-// CIR-LD-DAG: cir.global internal tls_model = <tls_local_dyn> @__tls_guard = #cir.int<0> : !s8i {alignment = 1 : i64}
+// CIR-LD-DAG: cir.global external tls_model = tls_local_dyn @x = #cir.int<0> : !s32i {alignment = 4 : i64}
+// CIR-LD-DAG: cir.global "private" internal tls_model = tls_local_dyn dso_local @_ZZ1fvE1y = #cir.int<0> : !s32i {alignment = 4 : i64}
+// CIR-LD-DAG: cir.global external tls_model = tls_init_exec @z = #cir.int<0> : !s32i {alignment = 4 : i64}
+// CIR-LD-DAG: cir.global external tls_model = tls_local_dyn tls_refs = <"_ZTW2s1", "_ZTH2s1"> @s1 = #cir.zero : !rec_S {alignment = 1 : i64, ast = #cir.var.decl.ast}
+// CIR-LD-DAG: cir.global external tls_model = tls_local_dyn tls_refs = <"_ZTW2t1", "_ZTH2t1"> @t1 = #cir.zero : !rec_T {alignment = 1 : i64, ast = #cir.var.decl.ast}
+// CIR-LD-DAG: cir.global internal tls_model = tls_local_dyn @__tls_guard = #cir.int<0> : !s8i {alignment = 1 : i64}
 
 // LLVM-LD-DAG: @z1 ={{.*}} global i32 0
 // LLVM-LD-DAG: @z2 ={{.*}} global i32 0
@@ -97,12 +97,12 @@ struct T thread_local t1;
 // CIR-IE-SAME: cir.default_tls_model = #cir.tls_model<tls_init_exec>
 // CIR-IE-DAG: cir.global external @z1 = #cir.int<0> : !s32i {alignment = 4 : i64}
 // CIR-IE-DAG: cir.global external @z2 = #cir.int<0> : !s32i {alignment = 4 : i64}
-// CIR-IE-DAG: cir.global external tls_model = <tls_init_exec> @x = #cir.int<0> : !s32i {alignment = 4 : i64}
-// CIR-IE-DAG: cir.global "private" internal tls_model = <tls_init_exec> dso_local @_ZZ1fvE1y = #cir.int<0> : !s32i {alignment = 4 : i64}
-// CIR-IE-DAG: cir.global external tls_model = <tls_init_exec> @z = #cir.int<0> : !s32i {alignment = 4 : i64}
-// CIR-IE-DAG: cir.global external tls_model = <tls_init_exec> tls_refs = <"_ZTW2s1", "_ZTH2s1"> @s1 = #cir.zero : !rec_S {alignment = 1 : i64, ast = #cir.var.decl.ast}
-// CIR-IE-DAG: cir.global external tls_model = <tls_init_exec> tls_refs = <"_ZTW2t1", "_ZTH2t1"> @t1 = #cir.zero : !rec_T {alignment = 1 : i64, ast = #cir.var.decl.ast}
-// CIR-IE-DAG: cir.global internal tls_model = <tls_init_exec> @__tls_guard = #cir.int<0> : !s8i {alignment = 1 : i64}
+// CIR-IE-DAG: cir.global external tls_model = tls_init_exec @x = #cir.int<0> : !s32i {alignment = 4 : i64}
+// CIR-IE-DAG: cir.global "private" internal tls_model = tls_init_exec dso_local @_ZZ1fvE1y = #cir.int<0> : !s32i {alignment = 4 : i64}
+// CIR-IE-DAG: cir.global external tls_model = tls_init_exec @z = #cir.int<0> : !s32i {alignment = 4 : i64}
+// CIR-IE-DAG: cir.global external tls_model = tls_init_exec tls_refs = <"_ZTW2s1", "_ZTH2s1"> @s1 = #cir.zero : !rec_S {alignment = 1 : i64, ast = #cir.var.decl.ast}
+// CIR-IE-DAG: cir.global external tls_model = tls_init_exec tls_refs = <"_ZTW2t1", "_ZTH2t1"> @t1 = #cir.zero : !rec_T {alignment = 1 : i64, ast = #cir.var.decl.ast}
+// CIR-IE-DAG: cir.global internal tls_model = tls_init_exec @__tls_guard = #cir.int<0> : !s8i {alignment = 1 : i64}
 
 // LLVM-IE-DAG: @z1 ={{.*}} global i32 0
 // LLVM-IE-DAG: @z2 ={{.*}} global i32 0
@@ -121,12 +121,12 @@ struct T thread_local t1;
 // CIR-LE-SAME: cir.default_tls_model = #cir.tls_model<tls_local_exec>
 // CIR-LE-DAG: cir.global external @z1 = #cir.int<0> : !s32i {alignment = 4 : i64}
 // CIR-LE-DAG: cir.global external @z2 = #cir.int<0> : !s32i {alignment = 4 : i64}
-// CIR-LE-DAG: cir.global external tls_model = <tls_local_exec> @x = #cir.int<0> : !s32i {alignment = 4 : i64}
-// CIR-LE-DAG: cir.global "private" internal tls_model = <tls_local_exec> dso_local @_ZZ1fvE1y = #cir.int<0> : !s32i {alignment = 4 : i64}
-// CIR-LE-DAG: cir.global external tls_model = <tls_init_exec> @z = #cir.int<0> : !s32i {alignment = 4 : i64}
-// CIR-LE-DAG: cir.global external tls_model = <tls_local_exec> tls_refs = <"_ZTW2s1", "_ZTH2s1"> @s1 = #cir.zero : !rec_S {alignment = 1 : i64, ast = #cir.var.decl.ast}
-// CIR-LE-DAG: cir.global external tls_model = <tls_local_exec> tls_refs = <"_ZTW2t1", "_ZTH2t1"> @t1 = #cir.zero : !rec_T {alignment = 1 : i64, ast = #cir.var.decl.ast}
-// CIR-LE-DAG: cir.global internal tls_model = <tls_local_exec> @__tls_guard = #cir.int<0> : !s8i {alignment = 1 : i64}
+// CIR-LE-DAG: cir.global external tls_model = tls_local_exec @x = #cir.int<0> : !s32i {alignment = 4 : i64}
+// CIR-LE-DAG: cir.global "private" internal tls_model = tls_local_exec dso_local @_ZZ1fvE1y = #cir.int<0> : !s32i {alignment = 4 : i64}
+// CIR-LE-DAG: cir.global external tls_model = tls_init_exec @z = #cir.int<0> : !s32i {alignment = 4 : i64}
+// CIR-LE-DAG: cir.global external tls_model = tls_local_exec tls_refs = <"_ZTW2s1", "_ZTH2s1"> @s1 = #cir.zero : !rec_S {alignment = 1 : i64, ast = #cir.var.decl.ast}
+// CIR-LE-DAG: cir.global external tls_model = tls_local_exec tls_refs = <"_ZTW2t1", "_ZTH2t1"> @t1 = #cir.zero : !rec_T {alignment = 1 : i64, ast = #cir.var.decl.ast}
+// CIR-LE-DAG: cir.global internal tls_model = tls_local_exec @__tls_guard = #cir.int<0> : !s8i {alignment = 1 : i64}
 
 // LLVM-LE-DAG: @z1 ={{.*}} global i32 0
 // LLVM-LE-DAG: @z2 ={{.*}} global i32 0

--- a/clang/test/CIR/CodeGen/tls.c
+++ b/clang/test/CIR/CodeGen/tls.c
@@ -6,10 +6,10 @@
 // RUN: FileCheck --check-prefix=OGCG --input-file=%t.ogcg.ll %s
 
 extern __thread int b;
-// CIR: cir.global "private" external tls_model = <tls_dyn> @b : !s32i
+// CIR: cir.global "private" external tls_model = tls_dyn @b : !s32i
 
 __thread int a;
-// CIR: cir.global external tls_model = <tls_dyn> @a = #cir.int<0> : !s32i
+// CIR: cir.global external tls_model = tls_dyn @a = #cir.int<0> : !s32i
 
 int c(void) { return *&b; }
 // CIR: cir.func no_inline dso_local @c() -> !s32i

--- a/clang/test/CIR/IR/global.cir
+++ b/clang/test/CIR/IR/global.cir
@@ -49,10 +49,10 @@ module attributes {cir.triple = "x86_64-unknown-linux-gnu"} {
   cir.global external @fp = #cir.ptr<null> : !cir.ptr<!cir.func<()>>
   cir.global external @fpii = #cir.ptr<null> : !cir.ptr<!cir.func<(!s32i) -> !s32i>>
   cir.global external @fpvar = #cir.ptr<null> : !cir.ptr<!cir.func<(!s32i, ...)>>
-  cir.global external tls_model = <tls_dyn> @tls1 = #cir.int<0> : !s8i
-  cir.global external tls_model = <tls_local_dyn> @tls2 = #cir.int<0> : !s8i
-  cir.global external tls_model = <tls_init_exec> @tls3 = #cir.int<0> : !s8i
-  cir.global external tls_model = <tls_local_exec> @tls4 = #cir.int<0> : !s8i
+  cir.global external tls_model = tls_dyn @tls1 = #cir.int<0> : !s8i
+  cir.global external tls_model = tls_local_dyn @tls2 = #cir.int<0> : !s8i
+  cir.global external tls_model = tls_init_exec @tls3 = #cir.int<0> : !s8i
+  cir.global external tls_model = tls_local_exec @tls4 = #cir.int<0> : !s8i
   cir.global external @gi = #cir.int<0> : !s32i
   cir.global external @gi_past_end = #cir.global_offset<@gi, 4> : !cir.ptr<!s32i>
   cir.global external @gi_before = #cir.global_offset<@gi, -4> : !cir.ptr<!s32i>
@@ -94,10 +94,10 @@ module attributes {cir.triple = "x86_64-unknown-linux-gnu"} {
 // CHECK: cir.global external @fp = #cir.ptr<null> : !cir.ptr<!cir.func<()>>
 // CHECK: cir.global external @fpii = #cir.ptr<null> : !cir.ptr<!cir.func<(!s32i) -> !s32i>>
 // CHECK: cir.global external @fpvar = #cir.ptr<null> : !cir.ptr<!cir.func<(!s32i, ...)>>
-// CHECK: cir.global external tls_model = <tls_dyn> @tls1 = #cir.int<0> : !s8i
-// CHECK: cir.global external tls_model = <tls_local_dyn> @tls2 = #cir.int<0> : !s8i
-// CHECK: cir.global external tls_model = <tls_init_exec> @tls3 = #cir.int<0> : !s8i
-// CHECK: cir.global external tls_model = <tls_local_exec> @tls4 = #cir.int<0> : !s8i
+// CHECK: cir.global external tls_model = tls_dyn @tls1 = #cir.int<0> : !s8i
+// CHECK: cir.global external tls_model = tls_local_dyn @tls2 = #cir.int<0> : !s8i
+// CHECK: cir.global external tls_model = tls_init_exec @tls3 = #cir.int<0> : !s8i
+// CHECK: cir.global external tls_model = tls_local_exec @tls4 = #cir.int<0> : !s8i
 // CHECK: cir.global external @gi = #cir.int<0> : !s32i
 // CHECK: cir.global external @gi_past_end = #cir.global_offset<@gi, 4> : !cir.ptr<!s32i>
 // CHECK: cir.global external @gi_before = #cir.global_offset<@gi, -4> : !cir.ptr<!s32i>

--- a/clang/test/CIR/IR/invalid-tls.cir
+++ b/clang/test/CIR/IR/invalid-tls.cir
@@ -17,7 +17,7 @@ module {
 
 module {
   // expected-error@+1{{op cannot have both static local and tls references}}
-cir.global "private" internal tls_model = <tls_dyn> tls_refs = <"asdf", "asdf", "asdf"> static_local_guard<"asdf"> @_ZZ1fvE1y : !s32i
+cir.global "private" internal tls_model = tls_dyn tls_refs = <"asdf", "asdf", "asdf"> static_local_guard<"asdf"> @_ZZ1fvE1y : !s32i
 }
 
 // -----
@@ -34,7 +34,6 @@ cir.global "private" internal tls_refs = <"asdf", "asdf", "asdf"> @_ZZ1fvE1y : !
 !s32i = !cir.int<s, 32>
 
 module {
-  // expected-error@+2{{custom op 'cir.global' expected ::cir::TLSModel to be one of: tls_dyn, tls_local_dyn, tls_init_exec, tls_local_exec}}
-  // expected-error@+1{{custom op 'cir.global' failed to parse CIR_TLSModelAttr parameter 'value' which is to be a `::cir::TLSModel}}
-cir.global "private" internal tls_model = <invalid_tls_dyn> tls_refs = <"asdf", "asdf", "asdf"> @_ZZ1fvE1y : !s32i
+  // expected-error@+1{{custom op 'cir.global' expected string or keyword containing one of the following enum values for attribute 'tls_model' [tls_dyn, tls_local_dyn, tls_init_exec, tls_local_exec]}}
+cir.global "private" internal tls_model = invalid_tls_dyn tls_refs = <"asdf", "asdf", "asdf"> @_ZZ1fvE1y : !s32i
 }


### PR DESCRIPTION
`cir.global` printed `tls_model = <tls_dyn>`. Those brackets were the
leftover delimiters of `#cir.tls_model<tls_dyn>` after the printer stripped
the dialect prefix and mnemonic, so one enum had two spellings and the
per-global one was not something anyone would write by hand.

Wrapping the argument in the `enum` directive prints the symbolic value on
its own:

  cir.global external tls_model = tls_dyn @a = #cir.int<5> : !s32i

The standalone attribute is unchanged.
