### PR TITLE
[alpha.webkit.UncheckedCallArgsChecker] Treat copyRef() in a call argument as safe

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/ASTUtils.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/ASTUtils.cpp
@@ -104,6 +104,9 @@ bool tryToFindPtrOrigin(
         }
       }
 
+      if (isSafePtrType(call->getType()))
+        return callback(E, true);
+
       if (auto *memberCall = dyn_cast<CXXMemberCallExpr>(call)) {
         if (auto *decl = memberCall->getMethodDecl()) {
           std::optional<bool> IsGetterOfRefCt = isGetterOfSafePtr(decl);

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -219,6 +219,9 @@ static bool isPtrOfType(const clang::QualType T, Predicate Pred) {
     } else if (auto *DTS = type->getAs<DeducedTemplateSpecializationType>()) {
       auto *Decl = DTS->getTemplateName().getAsTemplateDecl();
       return Decl && Pred(Decl->getNameAsString());
+    } else if (auto *RD = type->getAs<RecordType>()) {
+      auto *Decl = RD->getDecl();
+      return Decl && Pred(Decl->getNameAsString());
     } else
       break;
   }

--- a/clang/test/Analysis/Checkers/WebKit/mock-types.h
+++ b/clang/test/Analysis/Checkers/WebKit/mock-types.h
@@ -318,6 +318,7 @@ template <typename T, typename PtrTraits = RawPtrTraits<T>, typename RefDerefTra
   T *operator->() const { return PtrTraits::unwrap(t); }
   operator T &() const { return *PtrTraits::unwrap(t); }
   T* leakRef() { return PtrTraits::exchange(t, nullptr); }
+  [[nodiscard]] Ref copyRef() const { return Ref(*t); }
 };
 
 template <typename T> Ref<T> adoptRef(T& t) {

--- a/clang/test/Analysis/Checkers/WebKit/unchecked-call-arg.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/unchecked-call-arg.cpp
@@ -1,5 +1,7 @@
 // RUN: %clang_analyze_cc1 -analyzer-checker=alpha.webkit.UncheckedCallArgsChecker -verify %s
 
+#include "mock-types.h"
+
 void WTFCrash(void);
 
 enum class Tag : bool { Value };
@@ -37,3 +39,24 @@ void doWorkWithObject(const CheckedObject&);
 void bar() {
   doWorkWithObject(CheckedObject());
 }
+
+namespace refptr_checked_ptr_capable {
+
+class CheckedRefCounted {
+public:
+  void ref() const;
+  void deref() const;
+  void incrementCheckedPtrCount() const;
+  void decrementCheckedPtrCount() const;
+};
+
+void receive(CheckedRefCounted&);
+struct Foo {
+  Ref<CheckedRefCounted> m_obj;
+
+  void foo() {
+    receive(m_obj.copyRef());
+  }
+};
+
+} // namespace refptr_checked_ptr_capable


### PR DESCRIPTION
Treat calling a non-trivial function with the result of copyRef() or any other function which returns a safe pointer type as an argument as safe.