### PR TITLE
[CIR] Drop dead ceremony around the CIR enum attributes

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIREnumAttr.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIREnumAttr.td
@@ -47,11 +47,6 @@ class CIR_EnumAttr<EnumInfo info, string name = "", list<Trait> traits = []>
   let assemblyFormat = "`<` $value `>`";
 }
 
-class CIR_DefaultValuedEnumParameter<EnumAttrInfo info, string value = "">
-    : EnumParameter<info> {
-  let defaultValue = value;
-}
-
 def CIR_LangAddressSpace : CIR_I32Enum<
   "LangAddressSpace", "language address space kind", [
   I32EnumAttrCase<"Default", 0, "default">,

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -1369,21 +1369,6 @@ def CIR_CleanupKind : CIR_I32Enum<"CleanupKind", "cleanup kind", [
 ]>;
 
 def CIR_CleanupKindAttr : CIR_EnumAttr<CIR_CleanupKind, "cleanup"> {
-  let summary = "Cleanup kind attribute";
-  let description = [{
-    Cleanup kind attributes.
-  }];
-
-  let cppClassName = "CleanupKindAttr";
-
-  let skipDefaultBuilders = 1;
-  let builders = [
-    AttrBuilder<(ins CArg<"CleanupKind",
-                          "cir::CleanupKind::All">:$value), [{
-      return $_get($_ctxt, value);
-    }]>
-  ];
-
   let extraClassDeclaration = [{
     bool isNormal() const {
       return getValue() == CleanupKind::Normal ||
@@ -3348,7 +3333,6 @@ def CIR_TLSModel : CIR_I32Enum<"TLSModel", "TLS model", [
 ]>;
 
 def CIR_TLSModelAttr: CIR_EnumAttr<CIR_TLSModel, "tls_model"> {
-  let summary = "TLS Model attribute";
   let description = [{
      The TLS mode for the global, which comes from either the
     `tls_model` attribute, or `-ftls-model` flag.

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -6967,14 +6967,6 @@ def FPClassTestEnum
   FPClass_Sub, FPClass_Zero, FPClass_PosFin, FPClass_NegFin, FPClass_Fin,
   FPClass_Pos, FPClass_Neg, FPClass_All]> {
   let printBitEnumPrimaryGroups = 1;
-
-  // I32BitEnumAttr turns this on for backwards compatibility, which makes the
-  // operation printer quote every value that is not a single bit. Turning it
-  // off, together with the `enum` directive on cir.is_fp_class, gets a
-  // separator-aware parser and printer that spell every value unquoted.
-  let printBitEnumQuoted = 0;
-
-  let genSpecializedAttr = 0;
 }
 
 def CIR_FPClassTestAttr : CIR_EnumAttr<FPClassTestEnum, "fp_class">;

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -6967,6 +6967,14 @@ def FPClassTestEnum
   FPClass_Sub, FPClass_Zero, FPClass_PosFin, FPClass_NegFin, FPClass_Fin,
   FPClass_Pos, FPClass_Neg, FPClass_All]> {
   let printBitEnumPrimaryGroups = 1;
+
+  // I32BitEnumAttr turns this on for backwards compatibility, which makes the
+  // operation printer quote every value that is not a single bit. Turning it
+  // off, together with the `enum` directive on cir.is_fp_class, gets a
+  // separator-aware parser and printer that spell every value unquoted.
+  let printBitEnumQuoted = 0;
+
+  let genSpecializedAttr = 0;
 }
 
 def CIR_FPClassTestAttr : CIR_EnumAttr<FPClassTestEnum, "fp_class">;


### PR DESCRIPTION
Five things that no longer earn their place in the CIR enum attribute
machinery.

CIR_CleanupKindAttr carried three. Its cppClassName restated the default
AttrDef already derives. Its skipDefaultBuilders plus hand-written
AttrBuilder existed only to default $value to CleanupKind::All, which no
caller relies on, so the generated builders stayed suppressed for nothing.
And its summary and description restated the name, overriding the enum's own
"cleanup kind" that EnumAttr would otherwise inherit. The isNormal, isEH and
isNormalAndEH helpers stay.

CIR_TLSModelAttr's summary restated its name the same way, so only that goes.
CIR_DefaultValuedEnumParameter has never had a user.
