### PR TITLE
[CIR] Record why the CUDA registration attribute parses itself

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRCUDAAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRCUDAAttrs.td
@@ -92,6 +92,11 @@ def CIR_CUDAVarRegistrationInfoAttr : CIR_Attr<"CUDAVarRegistrationInfo", "cu.va
     "bool":$isManaged
   );
 
+  // Not expressible as a declarative assemblyFormat. The three flags print as
+  // presence-only keywords and parse in any order, whereas an optional group
+  // anchored on a `bool` parameter parses and prints a value, so `extern`
+  // would have to spell `extern true`. struct(params) round-trips but costs
+  // the compact syntax.
   let hasCustomAssemblyFormat = 1;
 }
 


### PR DESCRIPTION
hasCustomAssemblyFormat with no explanation invites the question of whether a
declarative assemblyFormat would do. It would not. The three flags print as
presence-only keywords and parse in any order, while an optional group
anchored on a `bool` parameter parses and prints a value, so the group would
spell `extern true`. MLIR has no presence-only flag for `bool` in an
attribute format, unlike UnitAttr in an operation format. struct(params)
round-trips but spells the attribute
`<device_side_name = "i", kind = Variable, isExtern = true>` instead of
`<i, Variable, extern>`.

NFC.
