### PR TITLE
[clang][bytecode] Remove Record::VirtualBaseMap

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -5896,7 +5896,7 @@ bool Compiler<Emitter>::visitAPValue(const APValue &Val, PrimType ValType,
                 return false;
             } else {
               // Must be a virtual base.
-              assert(EntryRecord->getVirtualBase(Base));
+              assert(EntryRecord->findVirtualBase(Base));
               if (!this->emitGetPtrVirtBasePop(Base, Info))
                 return false;
             }
@@ -7449,7 +7449,7 @@ bool Compiler<Emitter>::compileConstructor(const CXXConstructorDecl *Ctor) {
           Base && Init->isBaseVirtual()) {
         const auto *BaseDecl = Base->getAsCXXRecordDecl();
         assert(BaseDecl);
-        assert(R->getVirtualBase(BaseDecl));
+        assert(R->findVirtualBase(BaseDecl));
         if (!this->emitGetPtrThisVirtBase(BaseDecl, Ctor))
           return false;
         if (!this->visitInitializerPop(Init->getInit()))

--- a/clang/lib/AST/ByteCode/Disasm.cpp
+++ b/clang/lib/AST/ByteCode/Disasm.cpp
@@ -349,8 +349,7 @@ LLVM_DUMP_METHOD void Program::dump(llvm::raw_ostream &OS) const {
 
     // All Records.
     for (const Record *R : Records.values()) {
-      Bytes += sizeof(Record) + R->BaseMap.getMemorySize() +
-               R->VirtualBaseMap.getMemorySize();
+      Bytes += sizeof(Record) + R->BaseMap.getMemorySize();
       Bytes += R->Fields.capacity_in_bytes() + R->Bases.capacity_in_bytes() +
                R->VirtualBases.capacity_in_bytes();
     }

--- a/clang/lib/AST/ByteCode/Interp.h
+++ b/clang/lib/AST/ByteCode/Interp.h
@@ -2160,7 +2160,7 @@ inline bool VirtBaseHelper(InterpState &S, const RecordDecl *Decl,
   if (!Ptr.getFieldDesc()->isRecord())
     return false;
   Pointer Base = Ptr.stripBaseCasts();
-  const Record::Base *VirtBase = Base.getRecord()->getVirtualBase(Decl);
+  const Record::Base *VirtBase = Base.getRecord()->findVirtualBase(Decl);
   if (!VirtBase)
     return false;
   S.Stk.push<Pointer>(Base.atField(VirtBase->Offset));

--- a/clang/lib/AST/ByteCode/Record.cpp
+++ b/clang/lib/AST/ByteCode/Record.cpp
@@ -28,7 +28,6 @@ Record::Record(const RecordDecl *Decl, BaseList &&SrcBases,
       this->HasPtrField |= B.R->hasPtrField();
   }
   for (Base &V : VirtualBases) {
-    VirtualBaseMap[V.Decl] = &V;
     if (!this->HasPtrField)
       this->HasPtrField |= V.R->hasPtrField();
   }
@@ -83,9 +82,11 @@ const Record::Base *Record::findBase(unsigned Offset) const {
   return nullptr;
 }
 
-const Record::Base *Record::getVirtualBase(const RecordDecl *FD) const {
-  auto It = VirtualBaseMap.find(FD);
-  if (It == VirtualBaseMap.end())
-    return nullptr;
-  return It->second;
+const Record::Base *Record::findVirtualBase(const RecordDecl *FD) const {
+  if (auto *It = llvm::find_if(
+          VirtualBases,
+          [=](const Record::Base &B) -> bool { return B.Decl == FD; });
+      It != Bases.end())
+    return &*It;
+  return nullptr;
 }

--- a/clang/lib/AST/ByteCode/Record.h
+++ b/clang/lib/AST/ByteCode/Record.h
@@ -126,7 +126,7 @@ public:
   unsigned getNumVirtualBases() const { return VirtualBases.size(); }
   const Base *getVirtualBase(unsigned I) const { return &VirtualBases[I]; }
   /// Returns a virtual base descriptor.
-  const Base *getVirtualBase(const RecordDecl *RD) const;
+  const Base *findVirtualBase(const RecordDecl *RD) const;
 
   void dump(llvm::raw_ostream &OS, unsigned Indentation = 0,
             unsigned Offset = 0) const;
@@ -152,8 +152,6 @@ private:
 
   /// Mapping from declarations to bases.
   llvm::DenseMap<const RecordDecl *, const Base *> BaseMap;
-  /// Mapping from declarations to virtual bases.
-  llvm::DenseMap<const RecordDecl *, Base *> VirtualBaseMap;
   /// Size of the structure.
   unsigned BaseSize;
   /// Size of all virtual bases.


### PR DESCRIPTION
Virtual bases are so rarely used that I don't think having a dedicated map for them in every record is worth it.