### PR TITLE
[mlir][Tosa] Avoid copying inferred shape components (NFC)

### DIFF
--- a/mlir/include/mlir/Dialect/Tosa/Utils/ConversionUtils.h
+++ b/mlir/include/mlir/Dialect/Tosa/Utils/ConversionUtils.h
@@ -113,7 +113,7 @@ TosaOp createOpAndInferShape(ImplicitLocOpBuilder &builder, Type resultTy,
   // different bit-width types and does not have a TypeAttr to define the
   // target type.
   auto result = op->getResult(0);
-  auto predictedShape = returnedShapes[0];
+  const auto &predictedShape = returnedShapes[0];
   auto currentKnowledge = ValueKnowledge::getKnowledgeFromType(resultTy);
 
   // Compute the knowledge based on the inferred type.


### PR DESCRIPTION
Bind the inferred shape by const reference while it remains owned by the local result vector. The helper only reads the shape components, so copying their shape storage is unnecessary.

Found by Coverity.

Assisted-by: Codex