### PR TITLE
[mlir][GPUToSPIRV] Avoid copying the target environment (NFC)

### DIFF
--- a/mlir/lib/Conversion/GPUToSPIRV/GPUToSPIRV.cpp
+++ b/mlir/lib/Conversion/GPUToSPIRV/GPUToSPIRV.cpp
@@ -537,7 +537,8 @@ LogicalResult GPUShuffleConversion::matchAndRewrite(
   // Require the shuffle width to be the same as the target's subgroup size,
   // given that for SPIR-V non-uniform subgroup ops, we cannot select
   // participating invocations.
-  auto targetEnv = getTypeConverter<SPIRVTypeConverter>()->getTargetEnv();
+  const spirv::TargetEnv &targetEnv =
+      getTypeConverter<SPIRVTypeConverter>()->getTargetEnv();
   unsigned subgroupSize =
       targetEnv.getAttr().getResourceLimits().getSubgroupSize();
   IntegerAttr widthAttr;


### PR DESCRIPTION
Keep a const reference to the target environment returned by the type converter. The conversion only reads the environment to obtain the subgroup size, so copying it is unnecessary.

Found by Coverity.

Assisted-by: Codex