### PR TITLE
[mlir][tblgen] Avoid copies when iterating symbols (NFC)

### DIFF
--- a/mlir/tools/mlir-tblgen/RewriterGen.cpp
+++ b/mlir/tools/mlir-tblgen/RewriterGen.cpp
@@ -430,10 +430,8 @@ void PatternEmitter::emitStaticMatchCall(DagNode tree, StringRef opName) {
   SymbolInfoMap localSymbolMap(loc);
   pattern.collectBoundSymbols(tree, localSymbolMap, /*isSrcPattern=*/true);
 
-  for (const auto &info : localSymbolMap) {
-    auto name = info.first;
-    auto symboInfo = info.second;
-    auto ret = symbolInfoMap.findBoundSymbol(name, symboInfo);
+  for (const auto &[name, symbolInfo] : localSymbolMap) {
+    auto ret = symbolInfoMap.findBoundSymbol(name, symbolInfo);
     os << formatv(", {0}", ret->second.getVarName(name));
   }
 


### PR DESCRIPTION
Use a const structured binding when looking up locally bound symbols. The symbol name and SymbolInfo remain owned by localSymbolMap for the duration of the lookup, so copying both values is unnecessary.

Found by Coverity.

Assisted-by: Codex