### PR TITLE
[lldb] Update decorator in write-over-breakpoint tests

### DIFF
--- a/lldb/test/API/functionalities/breakpoint/hardware_breakpoints/write_memory_with_hw_breakpoint/TestWriteMemoryWithHWBreakpoint.py
+++ b/lldb/test/API/functionalities/breakpoint/hardware_breakpoints/write_memory_with_hw_breakpoint/TestWriteMemoryWithHWBreakpoint.py
@@ -14,8 +14,7 @@ from functionalities.breakpoint.hardware_breakpoints.base import *
 class WriteMemoryWithHWBreakpoint(HardwareBreakpointTestBase):
 
     @skipTestIfFn(HardwareBreakpointTestBase.hw_breakpoints_unsupported)
-    # Fails with a sanitized build of debugserver. https://github.com/llvm/llvm-project/issues/220844
-    @llgs_test
+    @skipIfOutOfTreeDebugserver
     def test_write_memory_with_hw_break(self):
         self.build()
         exe = self.getBuildArtifact("a.out")

--- a/lldb/test/API/functionalities/breakpoint/write_over_software_breakpoint/TestWriteOverSoftwareBreakpoint.py
+++ b/lldb/test/API/functionalities/breakpoint/write_over_software_breakpoint/TestWriteOverSoftwareBreakpoint.py
@@ -15,8 +15,7 @@ class WriteOverSoftwareBreakpoint(TestBase):
 
     # Could not find a way to make place_break_here visible to lldb on Windows.
     @skipIfWindows
-    # Fails with a sanitized build of debugserver. https://github.com/llvm/llvm-project/issues/220844
-    @llgs_test
+    @skipIfOutOfTreeDebugserver
     def test_write_over_breakpoint(self):
         TestBase.setUp(self)
         self.line = line_number("main.c", "// break here")


### PR DESCRIPTION
sanitized bots don't use the just-built debugserver, so any tests exercising new debugserver features won't work on them.