### PR TITLE
[ORC] Add host-jit-triple lit feature, gate some JIT tests

### DIFF
--- a/llvm/test/ExecutionEngine/Orc/throw-catch-merged-compact-unwind.ll
+++ b/llvm/test/ExecutionEngine/Orc/throw-catch-merged-compact-unwind.ll
@@ -1,4 +1,8 @@
 ; REQUIRES: system-darwin && host-unwind-supports-jit
+;
+; Unwinding through JIT'd frames is not yet supported on arm64e.
+; UNSUPPORTED: host-jit-triple={{arm64e-.*}}
+;
 ; RUN: lli -jit-kind=orc %s
 ;
 ; Check that the compact-unwind index terminator covers the final function when

--- a/llvm/test/ExecutionEngine/Orc/throw-catch-minimal.ll
+++ b/llvm/test/ExecutionEngine/Orc/throw-catch-minimal.ll
@@ -1,4 +1,8 @@
 ; REQUIRES: system-darwin && host-unwind-supports-jit
+;
+; Unwinding through JIT'd frames is not yet supported on arm64e.
+; UNSUPPORTED: host-jit-triple={{arm64e-.*}}
+;
 ; RUN: lli -jit-kind=orc %s
 ;
 ; Basic correctness testing for eh-frame processing and registration.

--- a/llvm/test/ExecutionEngine/Orc/throw-catch-no-frame-pointer.ll
+++ b/llvm/test/ExecutionEngine/Orc/throw-catch-no-frame-pointer.ll
@@ -1,4 +1,8 @@
 ; REQUIRES: system-darwin && host-unwind-supports-jit
+;
+; Unwinding through JIT'd frames is not yet supported on arm64e.
+; UNSUPPORTED: host-jit-triple={{arm64e-.*}}
+;
 ; RUN: lli -jit-kind=orc %s
 ;
 ; Check that we can throw exceptions from no-fp functions. On systems that

--- a/llvm/test/ExecutionEngine/OrcLazy/global-ctors-and-dtors.ll
+++ b/llvm/test/ExecutionEngine/OrcLazy/global-ctors-and-dtors.ll
@@ -1,3 +1,6 @@
+; Calling JIT'd atexit destructors is not yet supported on arm64e.
+; UNSUPPORTED: host-jit-triple={{arm64e-.*}}
+;
 ; Test that global constructors and destructors are run:
 ;
 ; RUN: lli -jit-kind=orc-lazy -orc-lazy-debug=funcs-to-stdout -extra-module %s \

--- a/llvm/test/ExecutionEngine/OrcLazy/minimal-throw-catch.ll
+++ b/llvm/test/ExecutionEngine/OrcLazy/minimal-throw-catch.ll
@@ -1,4 +1,8 @@
 ; REQUIRES: system-darwin && host-unwind-supports-jit
+;
+; Unwinding through JIT'd frames is not yet supported on arm64e.
+; UNSUPPORTED: host-jit-triple={{arm64e-.*}}
+;
 ; RUN: lli -jit-kind=orc-lazy %s
 ;
 ; Basic correctness testing for eh-frame processing and registration.

--- a/llvm/test/lit.cfg.py
+++ b/llvm/test/lit.cfg.py
@@ -760,6 +760,25 @@ def host_unwind_supports_jit():
 if host_unwind_supports_jit():
     config.available_features.add("host-unwind-supports-jit")
 
+
+# The triple that lli's JIT will target. This can be more specific than either
+# the host or the default target triple: e.g. an arm64e build of lli reports
+# arm64e-apple-darwin, while both CMake triples describe the machine as arm64.
+def host_jit_triple():
+    lli = lit.util.which("lli", config.llvm_tools_dir)
+    if not lli:
+        return None
+    try:
+        return subprocess.check_output([lli, "-host-jit-triple"], text=True).strip()
+    except (OSError, subprocess.CalledProcessError):
+        lit_config.warning("could not determine host JIT triple from lli")
+        return None
+
+
+config.host_jit_triple = host_jit_triple()
+if config.host_jit_triple:
+    config.available_features.add("host-jit-triple=" + config.host_jit_triple)
+
 # Ask llvm-config about asserts
 llvm_config.feature_config(
     [

--- a/llvm/tools/lli/lli.cpp
+++ b/llvm/tools/lli/lli.cpp
@@ -67,6 +67,7 @@
 #include "llvm/Support/ToolOutputFile.h"
 #include "llvm/Support/WithColor.h"
 #include "llvm/Support/raw_ostream.h"
+#include "llvm/TargetParser/Host.h"
 #include "llvm/TargetParser/Triple.h"
 #include <cerrno>
 #include <optional>
@@ -176,6 +177,10 @@ static cl::opt<char>
              cl::desc("Optimization level. [-O0, -O1, -O2, or -O3] "
                       "(default = '-O2')"),
              cl::Prefix, cl::init('2'));
+
+static cl::opt<bool> HostJITTriple("host-jit-triple",
+                                   cl::desc("Print process triple and exit"),
+                                   cl::init(false));
 
 static cl::opt<std::string>
     TargetTriple("mtriple", cl::desc("Override target triple for module"));
@@ -429,6 +434,11 @@ int main(int argc, char **argv, char * const *envp) {
 
   cl::ParseCommandLineOptions(argc, argv,
                               "llvm interpreter & dynamic compiler\n");
+
+  if (HostJITTriple) {
+    outs() << sys::getProcessTriple() << "\n";
+    return 0;
+  }
 
   // If the user doesn't want core files, disable them.
   if (DisableCoreFiles)


### PR DESCRIPTION
The JIT does not support throwing exceptions on Darwin/arm64e yet. Add an llvm-lit feature flag, "host-jit-triple", that reports the process triple as detected by `lli` so that we can mark exception-throwing tests as unsupported when they would be run as arm64e. (Feature flags based on build settings, e.g. host-triple and target-triple, don't reliably report arm64e).

Adds a -host-jit-triple option to lli to print the value for the feature-flag.

rdar://185482009