### PR TITLE
[InstCombine] Don't assume a trunc with nsw is never poison

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
@@ -3726,8 +3726,11 @@ static bool impliesPoisonOrCond(const Value *ValAssumedPoison, const Value *V,
                       *RHSC2);
     }
   }
+  // For non-poison X in [0, 1], `trunc nuw X to i1` is not poison, but an
+  // additional `nsw` flag makes it poison for X == 1.
   Value *A;
   if (match(ValAssumedPoison, m_NUWTrunc(m_Value(A))) &&
+      !cast<TruncInst>(ValAssumedPoison)->hasNoSignedWrap() &&
       isGuaranteedNotToBePoison(A)) {
     assert(ValAssumedPoison->getType()->isIntOrIntVectorTy(1));
     return computeKnownBits(

--- a/llvm/test/Transforms/InstCombine/logical-select.ll
+++ b/llvm/test/Transforms/InstCombine/logical-select.ll
@@ -1693,11 +1693,10 @@ define i1 @neg_test_logical_and_trunc_nuw_no_noundef(i1 %c, i8 range(i8 0,2) %x)
   ret i1 %and
 }
 
-; FIXME: The nsw flag can still make the trunc poison, for %x == 1.
 define i1 @neg_test_logical_and_trunc_nsw(i1 %c, i8 noundef range(i8 0,2) %x) {
 ; CHECK-LABEL: @neg_test_logical_and_trunc_nsw(
 ; CHECK-NEXT:    [[TRUNC:%.*]] = trunc nuw nsw i8 [[X:%.*]] to i1
-; CHECK-NEXT:    [[AND:%.*]] = and i1 [[C:%.*]], [[TRUNC]]
+; CHECK-NEXT:    [[AND:%.*]] = select i1 [[C:%.*]], i1 [[TRUNC]], i1 false
 ; CHECK-NEXT:    ret i1 [[AND]]
 ;
   %trunc = trunc nsw i8 %x to i1
@@ -1705,11 +1704,10 @@ define i1 @neg_test_logical_and_trunc_nsw(i1 %c, i8 noundef range(i8 0,2) %x) {
   ret i1 %and
 }
 
-; FIXME: The nsw flag can still make the trunc poison, for %x == 1.
 define i1 @neg_test_logical_or_trunc_nsw(i1 %c, i8 noundef range(i8 0,2) %x) {
 ; CHECK-LABEL: @neg_test_logical_or_trunc_nsw(
 ; CHECK-NEXT:    [[TRUNC:%.*]] = trunc nuw nsw i8 [[X:%.*]] to i1
-; CHECK-NEXT:    [[OR:%.*]] = or i1 [[C:%.*]], [[TRUNC]]
+; CHECK-NEXT:    [[OR:%.*]] = select i1 [[C:%.*]], i1 true, i1 [[TRUNC]]
 ; CHECK-NEXT:    ret i1 [[OR]]
 ;
   %trunc = trunc nsw i8 %x to i1
@@ -1717,11 +1715,10 @@ define i1 @neg_test_logical_or_trunc_nsw(i1 %c, i8 noundef range(i8 0,2) %x) {
   ret i1 %or
 }
 
-; FIXME: The nsw flag can still make the trunc poison, for %x == 1.
 define <2 x i1> @neg_test_logical_and_trunc_nuw_nsw_vec(<2 x i1> %c, <2 x i8> noundef range(i8 0,2) %x) {
 ; CHECK-LABEL: @neg_test_logical_and_trunc_nuw_nsw_vec(
 ; CHECK-NEXT:    [[TRUNC:%.*]] = trunc nuw nsw <2 x i8> [[X:%.*]] to <2 x i1>
-; CHECK-NEXT:    [[AND:%.*]] = and <2 x i1> [[C:%.*]], [[TRUNC]]
+; CHECK-NEXT:    [[AND:%.*]] = select <2 x i1> [[C:%.*]], <2 x i1> [[TRUNC]], <2 x i1> zeroinitializer
 ; CHECK-NEXT:    ret <2 x i1> [[AND]]
 ;
   %trunc = trunc nuw nsw <2 x i8> %x to <2 x i1>

--- a/llvm/test/Transforms/InstCombine/logical-select.ll
+++ b/llvm/test/Transforms/InstCombine/logical-select.ll
@@ -1692,3 +1692,39 @@ define i1 @neg_test_logical_and_trunc_nuw_no_noundef(i1 %c, i8 range(i8 0,2) %x)
   %and = select i1 %c, i1 %trunc, i1 false
   ret i1 %and
 }
+
+; FIXME: The nsw flag can still make the trunc poison, for %x == 1.
+define i1 @neg_test_logical_and_trunc_nsw(i1 %c, i8 noundef range(i8 0,2) %x) {
+; CHECK-LABEL: @neg_test_logical_and_trunc_nsw(
+; CHECK-NEXT:    [[TRUNC:%.*]] = trunc nuw nsw i8 [[X:%.*]] to i1
+; CHECK-NEXT:    [[AND:%.*]] = and i1 [[C:%.*]], [[TRUNC]]
+; CHECK-NEXT:    ret i1 [[AND]]
+;
+  %trunc = trunc nsw i8 %x to i1
+  %and = select i1 %c, i1 %trunc, i1 false
+  ret i1 %and
+}
+
+; FIXME: The nsw flag can still make the trunc poison, for %x == 1.
+define i1 @neg_test_logical_or_trunc_nsw(i1 %c, i8 noundef range(i8 0,2) %x) {
+; CHECK-LABEL: @neg_test_logical_or_trunc_nsw(
+; CHECK-NEXT:    [[TRUNC:%.*]] = trunc nuw nsw i8 [[X:%.*]] to i1
+; CHECK-NEXT:    [[OR:%.*]] = or i1 [[C:%.*]], [[TRUNC]]
+; CHECK-NEXT:    ret i1 [[OR]]
+;
+  %trunc = trunc nsw i8 %x to i1
+  %or = select i1 %c, i1 true, i1 %trunc
+  ret i1 %or
+}
+
+; FIXME: The nsw flag can still make the trunc poison, for %x == 1.
+define <2 x i1> @neg_test_logical_and_trunc_nuw_nsw_vec(<2 x i1> %c, <2 x i8> noundef range(i8 0,2) %x) {
+; CHECK-LABEL: @neg_test_logical_and_trunc_nuw_nsw_vec(
+; CHECK-NEXT:    [[TRUNC:%.*]] = trunc nuw nsw <2 x i8> [[X:%.*]] to <2 x i1>
+; CHECK-NEXT:    [[AND:%.*]] = and <2 x i1> [[C:%.*]], [[TRUNC]]
+; CHECK-NEXT:    ret <2 x i1> [[AND]]
+;
+  %trunc = trunc nuw nsw <2 x i8> %x to <2 x i1>
+  %and = select <2 x i1> %c, <2 x i1> %trunc, <2 x i1> zeroinitializer
+  ret <2 x i1> %and
+}


### PR DESCRIPTION
`impliesPoisonOrCond()` treats `trunc nuw X to i1` as never poison when `X` is known to be in `[0, 1]`, which makes the assumed-poison premise vacuously true and folds a logical and/or into a bitwise one.

`m_NUWTrunc()` matches on a flag subset, so it also matches `trunc nuw nsw`. Such a trunc is still poison for `X == 1`, because `nsw` requires the truncated bits to equal the top bit of the result, and they are zero while the result is one. For `%c = false` and `%x = 1` the source returns `false` while the folded form returns `poison`: https://alive2.llvm.org/ce/z/Q6G5-v

None of the remaining `m_NUWTrunc()` users assumes that the matched trunc is non-poison, so they are unaffected.

Fixes #220487.