### PR TITLE
[CIR] Use the modern enum case classes

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -79,10 +79,10 @@ class CIR_UnitAttr<string name, string attrMnemonic, list<Trait> traits = []>
 // TODO: Add cases for other languages that Clang supports.
 
 def CIR_SourceLanguage : CIR_I32Enum<"SourceLanguage", "source language", [
-  I32EnumAttrCase<"C", 1, "c">,
-  I32EnumAttrCase<"CXX", 2, "cxx">,
-  I32EnumAttrCase<"OpenCLC", 3, "opencl_c">,
-  I32EnumAttrCase<"OpenCLCXX", 4, "opencl_cxx">
+  I32EnumCase<"C", 1, "c">,
+  I32EnumCase<"CXX", 2, "cxx">,
+  I32EnumCase<"OpenCLC", 3, "opencl_c">,
+  I32EnumCase<"OpenCLCXX", 4, "opencl_cxx">
 ]>;
 
 def CIR_SourceLanguageAttr : CIR_EnumAttr<CIR_SourceLanguage, "lang"> {
@@ -121,9 +121,9 @@ def CIR_SourceLanguageAttr : CIR_EnumAttr<CIR_SourceLanguage, "lang"> {
 
 def CIR_ArgPassingKind : CIR_I32Enum<
     "ArgPassingKind", "record argument passing eligibility", [
-  I32EnumAttrCase<"CanPassInRegs", 0, "can_pass_in_regs">,
-  I32EnumAttrCase<"CannotPassInRegs", 1, "cannot_pass_in_regs">,
-  I32EnumAttrCase<"CanNeverPassInRegs", 2, "can_never_pass_in_regs">
+  I32EnumCase<"CanPassInRegs", 0, "can_pass_in_regs">,
+  I32EnumCase<"CannotPassInRegs", 1, "cannot_pass_in_regs">,
+  I32EnumCase<"CanNeverPassInRegs", 2, "can_never_pass_in_regs">
 ]>;
 
 def CIR_RecordLayoutAttr : CIR_Attr<"RecordLayout", "record_layout", [
@@ -728,9 +728,9 @@ def CIR_MethodAttr : CIR_ValueLikeAttr<"Method", "method"> {
 
 def CIR_CmpOrdering : CIR_I32Enum<
   "CmpOrdering", "three-way comparison ordering kind", [
-    I32EnumAttrCase<"Strong", 0, "strong">,
-    I32EnumAttrCase<"Weak", 1, "weak">,
-    I32EnumAttrCase<"Partial", 2, "partial">
+    I32EnumCase<"Strong", 0, "strong">,
+    I32EnumCase<"Weak", 1, "weak">,
+    I32EnumCase<"Partial", 2, "partial">
 ]>;
 
 def CIR_CmpThreeWayInfoAttr : CIR_Attr<"CmpThreeWayInfo", "cmp3way_info"> {
@@ -810,12 +810,12 @@ def CIR_CmpThreeWayInfoAttr : CIR_Attr<"CmpThreeWayInfo", "cmp3way_info"> {
 
 def CIR_FPDynamicRoundingMode : CIR_I32Enum<
     "FPDynamicRoundingMode", "floating-point dynamic rounding mode", [
-  I32EnumAttrCase<"ToNearest", 0, "tonearest">,
-  I32EnumAttrCase<"Downward", 1, "downward">,
-  I32EnumAttrCase<"Upward", 2, "upward">,
-  I32EnumAttrCase<"UpwardZero", 3, "upwardzero">,
-  I32EnumAttrCase<"ToNearestAway", 4, "tonearestaway">,
-  I32EnumAttrCase<"Unknown", 7, "unknown">
+  I32EnumCase<"ToNearest", 0, "tonearest">,
+  I32EnumCase<"Downward", 1, "downward">,
+  I32EnumCase<"Upward", 2, "upward">,
+  I32EnumCase<"UpwardZero", 3, "upwardzero">,
+  I32EnumCase<"ToNearestAway", 4, "tonearestaway">,
+  I32EnumCase<"Unknown", 7, "unknown">
 ]> {
   let description = [{
     The known dynamic rounding mode at the point the instruction is executed.
@@ -826,9 +826,9 @@ def CIR_FPDynamicRoundingMode : CIR_I32Enum<
 
 def CIR_FPExceptionMode : CIR_I32Enum<
     "FPExceptionMode", "floating-point exception mode", [
-  I32EnumAttrCase<"Unknown", 0, "unknown">,
-  I32EnumAttrCase<"Masked", 1, "masked">,
-  I32EnumAttrCase<"Unmasked", 2, "unmasked">
+  I32EnumCase<"Unknown", 0, "unknown">,
+  I32EnumCase<"Masked", 1, "masked">,
+  I32EnumCase<"Unmasked", 2, "unmasked">
 ]> {
   let description = [{
     The known floating-point exception mode at the point the instruction is
@@ -1342,9 +1342,9 @@ def CIR_ConstComplexAttr : CIR_ValueLikeAttr<"ConstComplex", "const_complex"> {
 //===----------------------------------------------------------------------===//
 
 def CIR_VisibilityKind : CIR_I32Enum<"VisibilityKind", "C/C++ visibility", [
-  I32EnumAttrCase<"Default", 0, "default">,
-  I32EnumAttrCase<"Hidden", 1, "hidden">,
-  I32EnumAttrCase<"Protected", 2, "protected">
+  I32EnumCase<"Default", 0, "default">,
+  I32EnumCase<"Hidden", 1, "hidden">,
+  I32EnumCase<"Protected", 2, "protected">
 ]>;
 
 //===----------------------------------------------------------------------===//
@@ -1406,10 +1406,10 @@ def CIR_GlobalDtorAttr : CIR_GlobalCtorDtor<"Dtor", "dtor"> {
 //===----------------------------------------------------------------------===//
 
 def CIR_CtorKind : CIR_I32Enum<"CtorKind", "CXX Constructor Kind", [
-  I32EnumAttrCase<"Custom", 0, "custom">,
-  I32EnumAttrCase<"Default", 1, "default">,
-  I32EnumAttrCase<"Copy", 2, "copy">,
-  I32EnumAttrCase<"Move", 3, "move">,
+  I32EnumCase<"Custom", 0, "custom">,
+  I32EnumCase<"Default", 1, "default">,
+  I32EnumCase<"Copy", 2, "copy">,
+  I32EnumCase<"Move", 3, "move">,
 ]>;
 
 def CIR_CXXCtorAttr : CIR_Attr<"CXXCtor", "cxx_ctor"> {
@@ -1472,8 +1472,8 @@ def CIR_CXXDtorAttr : CIR_Attr<"CXXDtor", "cxx_dtor"> {
 }
 
 def CIR_AssignKind : CIR_I32Enum<"AssignKind", "CXX Assignment Operator Kind", [
-  I32EnumAttrCase<"Copy", 0, "copy">,
-  I32EnumAttrCase<"Move", 1, "move">,
+  I32EnumCase<"Copy", 0, "copy">,
+  I32EnumCase<"Move", 1, "move">,
 ]>;
 
 def CIR_CXXAssignAttr : CIR_Attr<"CXXAssign", "cxx_assign"> {
@@ -1512,7 +1512,7 @@ def CIR_CXXAssignAttr : CIR_Attr<"CXXAssign", "cxx_assign"> {
 // pairs with one raised operation in CIRStdOps.td.
 def CIR_KnownFuncKind : CIR_I32Enum<"KnownFuncKind",
     "known standard library entity", [
-  I32EnumAttrCase<"StdFind", 1, "std::find">,
+  I32EnumCase<"StdFind", 1, "std::find">,
 ]>;
 
 def CIR_FuncIdentityAttr : CIR_Attr<"FuncIdentity", "func_identity"> {
@@ -1800,9 +1800,9 @@ def CIR_TypeInfoAttr : CIR_ValueLikeAttr<"TypeInfo", "typeinfo"> {
 //===----------------------------------------------------------------------===//
 
 def CIR_InlineKind : CIR_I32Enum<"InlineKind", "inline kind", [
-  I32EnumAttrCase<"NoInline", 1, "no_inline">,
-  I32EnumAttrCase<"AlwaysInline", 2, "always_inline">,
-  I32EnumAttrCase<"InlineHint", 3, "inline_hint">
+  I32EnumCase<"NoInline", 1, "no_inline">,
+  I32EnumCase<"AlwaysInline", 2, "always_inline">,
+  I32EnumCase<"InlineHint", 3, "inline_hint">
 ]>;
 
 def CIR_InlineKindAttr: CIR_EnumAttr<CIR_InlineKind, "inline"> {
@@ -1914,9 +1914,9 @@ def CIR_BlockAddrDiffAttr
 
 def CIR_SideEffect : CIR_I32Enum<
     "SideEffect", "allowed side effects of a function", [
-      I32EnumAttrCase<"All", 0, "all">,
-      I32EnumAttrCase<"Pure", 1, "pure">,
-      I32EnumAttrCase<"Const", 2, "const">
+      I32EnumCase<"All", 0, "all">,
+      I32EnumCase<"Pure", 1, "pure">,
+      I32EnumCase<"Const", 2, "const">
 ]> {
   let description = [{
     The side effect attribute specifies the possible side effects of a function
@@ -2097,9 +2097,9 @@ def CIR_ASTVarDeclAttr : CIR_AST<"VarDecl", "var.decl", [
 // so CIRGen can map between them, but CIR does not depend on the underlying
 // clang enumerator values.
 def CIR_TLSKind : CIR_I32Enum<"TLSKind", "thread-local storage kind", [
-  I32EnumAttrCase<"None", 0, "none">,          // clang::VarDecl::TLS_None
-  I32EnumAttrCase<"Static", 1, "static">,      // clang::VarDecl::TLS_Static
-  I32EnumAttrCase<"Dynamic", 2, "dynamic">     // clang::VarDecl::TLS_Dynamic
+  I32EnumCase<"None", 0, "none">,          // clang::VarDecl::TLS_None
+  I32EnumCase<"Static", 1, "static">,      // clang::VarDecl::TLS_Static
+  I32EnumCase<"Dynamic", 2, "dynamic">     // clang::VarDecl::TLS_Dynamic
 ]>;
 
 // CIR-native template-specialization kind. Cases mirror
@@ -2108,16 +2108,16 @@ def CIR_TemplateSpecializationKind
     : CIR_I32Enum<"TemplateSpecializationKind",
                       "template specialization kind", [
   // clang::TSK_Undeclared
-  I32EnumAttrCase<"Undeclared", 0, "undeclared">,
+  I32EnumCase<"Undeclared", 0, "undeclared">,
   // clang::TSK_ImplicitInstantiation
-  I32EnumAttrCase<"ImplicitInstantiation", 1, "implicit_instantiation">,
+  I32EnumCase<"ImplicitInstantiation", 1, "implicit_instantiation">,
   // clang::TSK_ExplicitSpecialization
-  I32EnumAttrCase<"ExplicitSpecialization", 2, "explicit_specialization">,
+  I32EnumCase<"ExplicitSpecialization", 2, "explicit_specialization">,
   // clang::TSK_ExplicitInstantiationDeclaration
-  I32EnumAttrCase<"ExplicitInstantiationDeclaration", 3,
+  I32EnumCase<"ExplicitInstantiationDeclaration", 3,
                   "explicit_instantiation_declaration">,
   // clang::TSK_ExplicitInstantiationDefinition
-  I32EnumAttrCase<"ExplicitInstantiationDefinition", 4,
+  I32EnumCase<"ExplicitInstantiationDefinition", 4,
                   "explicit_instantiation_definition">
 ]>;
 

--- a/clang/include/clang/CIR/Dialect/IR/CIRCUDAAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRCUDAAttrs.td
@@ -72,9 +72,9 @@ def CIR_CUDABinaryHandleAttr : CIR_Attr<
 // CIR_CUDAVarRegistrationInfoAttr's own assembly format.
 def CIR_CUDADeviceVarKind : CIR_I32Enum<"CUDADeviceVarKind",
     "CUDA device variable kind", [
-  I32EnumAttrCase<"Variable", 0>,
-  I32EnumAttrCase<"Surface", 1>,   // Future
-  I32EnumAttrCase<"Texture", 2>,   // Future
+  I32EnumCase<"Variable", 0>,
+  I32EnumCase<"Surface", 1>,   // Future
+  I32EnumCase<"Texture", 2>,   // Future
 ]>;
 
 // Attribute carrying device variable registration flags

--- a/clang/include/clang/CIR/Dialect/IR/CIREnumAttr.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIREnumAttr.td
@@ -49,14 +49,14 @@ class CIR_EnumAttr<EnumInfo info, string name = "", list<Trait> traits = []>
 
 def CIR_LangAddressSpace : CIR_I32Enum<
   "LangAddressSpace", "language address space kind", [
-  I32EnumAttrCase<"Default", 0, "default">,
-  I32EnumAttrCase<"OffloadPrivate", 1, "offload_private">,
-  I32EnumAttrCase<"OffloadLocal", 2, "offload_local">,
-  I32EnumAttrCase<"OffloadGlobal", 3, "offload_global">,
-  I32EnumAttrCase<"OffloadConstant", 4, "offload_constant">,
-  I32EnumAttrCase<"OffloadGeneric", 5, "offload_generic">,
-  I32EnumAttrCase<"OffloadGlobalDevice", 6, "offload_global_device">,
-  I32EnumAttrCase<"OffloadGlobalHost", 7, "offload_global_host">
+  I32EnumCase<"Default", 0, "default">,
+  I32EnumCase<"OffloadPrivate", 1, "offload_private">,
+  I32EnumCase<"OffloadLocal", 2, "offload_local">,
+  I32EnumCase<"OffloadGlobal", 3, "offload_global">,
+  I32EnumCase<"OffloadConstant", 4, "offload_constant">,
+  I32EnumCase<"OffloadGeneric", 5, "offload_generic">,
+  I32EnumCase<"OffloadGlobalDevice", 6, "offload_global_device">,
+  I32EnumCase<"OffloadGlobalHost", 7, "offload_global_host">
 ]> {
   let description = [{
     Enumerates language-specific address spaces used by CIR. These represent

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -188,7 +188,7 @@ defvar CIR_DynamicMemoryEffects = 0;
 //===----------------------------------------------------------------------===//
 
 def CIR_CastKind : CIR_I32Enum<"CastKind", "cast kind", [
-  I32EnumAttrCase<"bitcast", 1>,
+  I32EnumCase<"bitcast", 1>,
   // CK_LValueBitCast
   // CK_LValueToRValueBitCast
   // CK_LValueToRValue
@@ -198,49 +198,49 @@ def CIR_CastKind : CIR_I32Enum<"CastKind", "cast kind", [
   // CK_UncheckedDerivedToBase
   // CK_Dynamic
   // CK_ToUnion
-  I32EnumAttrCase<"array_to_ptrdecay", 11>,
+  I32EnumCase<"array_to_ptrdecay", 11>,
   // CK_FunctionToPointerDecay
   // CK_NullToPointer
   // CK_NullToMemberPointer
   // CK_BaseToDerivedMemberPointer
   // CK_DerivedToBaseMemberPointer
-  I32EnumAttrCase<"member_ptr_to_bool", 17>,
+  I32EnumCase<"member_ptr_to_bool", 17>,
   // CK_ReinterpretMemberPointer
   // CK_UserDefinedConversion
   // CK_ConstructorConversion
-  I32EnumAttrCase<"int_to_ptr", 21>,
-  I32EnumAttrCase<"ptr_to_int", 22>,
-  I32EnumAttrCase<"ptr_to_bool", 23>,
+  I32EnumCase<"int_to_ptr", 21>,
+  I32EnumCase<"ptr_to_int", 22>,
+  I32EnumCase<"ptr_to_bool", 23>,
   // CK_ToVoid
   // CK_MatrixCast
   // CK_VectorSplat
-  I32EnumAttrCase<"integral", 27>,
-  I32EnumAttrCase<"int_to_bool", 28>,
-  I32EnumAttrCase<"int_to_float", 29>,
+  I32EnumCase<"integral", 27>,
+  I32EnumCase<"int_to_bool", 28>,
+  I32EnumCase<"int_to_float", 29>,
   // CK_FloatingToFixedPoint
   // CK_FixedPointToFloating
   // CK_FixedPointCast
   // CK_FixedPointToIntegral
   // CK_IntegralToFixedPoint
   // CK_FixedPointToBoolean
-  I32EnumAttrCase<"float_to_int", 36>,
-  I32EnumAttrCase<"float_to_bool", 37>,
-  I32EnumAttrCase<"bool_to_int", 38>,
-  I32EnumAttrCase<"floating", 39>,
+  I32EnumCase<"float_to_int", 36>,
+  I32EnumCase<"float_to_bool", 37>,
+  I32EnumCase<"bool_to_int", 38>,
+  I32EnumCase<"floating", 39>,
   // CK_CPointerToObjCPointerCast
   // CK_BlockPointerToObjCPointerCast
   // CK_AnyPointerToBlockPointerCast
   // CK_ObjCObjectLValueCast
-  I32EnumAttrCase<"float_to_complex", 44>,
-  I32EnumAttrCase<"float_complex_to_real", 45>,
-  I32EnumAttrCase<"float_complex_to_bool", 46>,
-  I32EnumAttrCase<"float_complex", 47>,
-  I32EnumAttrCase<"float_complex_to_int_complex", 48>,
-  I32EnumAttrCase<"int_to_complex", 49>,
-  I32EnumAttrCase<"int_complex_to_real", 50>,
-  I32EnumAttrCase<"int_complex_to_bool", 51>,
-  I32EnumAttrCase<"int_complex", 52>,
-  I32EnumAttrCase<"int_complex_to_float_complex", 53>,
+  I32EnumCase<"float_to_complex", 44>,
+  I32EnumCase<"float_complex_to_real", 45>,
+  I32EnumCase<"float_complex_to_bool", 46>,
+  I32EnumCase<"float_complex", 47>,
+  I32EnumCase<"float_complex_to_int_complex", 48>,
+  I32EnumCase<"int_to_complex", 49>,
+  I32EnumCase<"int_complex_to_real", 50>,
+  I32EnumCase<"int_complex_to_bool", 51>,
+  I32EnumCase<"int_complex", 52>,
+  I32EnumCase<"int_complex_to_float_complex", 53>,
   // CK_ARCProduceObject
   // CK_ARCConsumeObject
   // CK_ARCReclaimReturnedObject
@@ -250,7 +250,7 @@ def CIR_CastKind : CIR_I32Enum<"CastKind", "cast kind", [
   // CK_CopyAndAutoreleaseBlockObject
   // CK_BuiltinFnToFnPtr
   // CK_ZeroToOCLOpaqueType
-  I32EnumAttrCase<"address_space", 63>,
+  I32EnumCase<"address_space", 63>,
   // CK_IntToOCLSampler
   // CK_HLSLVectorTruncation
   // CK_HLSLArrayRValue
@@ -259,7 +259,7 @@ def CIR_CastKind : CIR_I32Enum<"CastKind", "cast kind", [
 
   // Enums below are specific to CIR and don't have a correspondence to classic
   // codegen:
-  I32EnumAttrCase<"bool_to_float", 1000>,
+  I32EnumCase<"bool_to_float", 1000>,
 ]>;
 
 def CIR_CastKindAttr : CIR_EnumAttr<CIR_CastKind, "cast">;
@@ -413,8 +413,8 @@ def CIR_BuiltinIntCastOp : CIR_Op<"builtin_int_cast", [Pure]> {
 
 def CIR_DynamicCastKind : CIR_I32Enum<
   "DynamicCastKind", "dynamic cast kind", [
-    I32EnumAttrCase<"Ptr", 0, "ptr">,
-    I32EnumAttrCase<"Ref", 1, "ref">
+    I32EnumCase<"Ptr", 0, "ptr">,
+    I32EnumCase<"Ref", 1, "ref">
 ]>;
 
 def CIR_DynamicCastKindAttr
@@ -650,12 +650,12 @@ def CIR_SignBitOp : CIR_Op<"signbit", [Pure]> {
 
 def CIR_MemOrder : CIR_I32Enum<
   "MemOrder", "Memory order according to C++11 memory model", [
-    I32EnumAttrCase<"Relaxed", 0, "relaxed">,
-    I32EnumAttrCase<"Consume", 1, "consume">,
-    I32EnumAttrCase<"Acquire", 2, "acquire">,
-    I32EnumAttrCase<"Release", 3, "release">,
-    I32EnumAttrCase<"AcquireRelease", 4, "acq_rel">,
-    I32EnumAttrCase<"SequentiallyConsistent", 5, "seq_cst">
+    I32EnumCase<"Relaxed", 0, "relaxed">,
+    I32EnumCase<"Consume", 1, "consume">,
+    I32EnumCase<"Acquire", 2, "acquire">,
+    I32EnumCase<"Release", 3, "release">,
+    I32EnumCase<"AcquireRelease", 4, "acq_rel">,
+    I32EnumCase<"SequentiallyConsistent", 5, "seq_cst">
 ]>;
 
 def CIR_MemOrderAttr : CIR_EnumAttr<CIR_MemOrder, "mem_order">;
@@ -665,26 +665,26 @@ def CIR_MemOrderAttr : CIR_EnumAttr<CIR_MemOrder, "mem_order">;
 //===----------------------------------------------------------------------===//
 
 def CIR_SyncScopeKind : CIR_I32Enum<"SyncScopeKind", "sync scope kind", [
-  I32EnumAttrCase<"SingleThread", 0, "single_thread">,
-  I32EnumAttrCase<"System", 1, "system">,
-  I32EnumAttrCase<"Device", 2, "device">,
-  I32EnumAttrCase<"Workgroup", 3, "workgroup">,
-  I32EnumAttrCase<"Wavefront", 4, "wavefront">,
-  I32EnumAttrCase<"Cluster", 5, "cluster">,
+  I32EnumCase<"SingleThread", 0, "single_thread">,
+  I32EnumCase<"System", 1, "system">,
+  I32EnumCase<"Device", 2, "device">,
+  I32EnumCase<"Workgroup", 3, "workgroup">,
+  I32EnumCase<"Wavefront", 4, "wavefront">,
+  I32EnumCase<"Cluster", 5, "cluster">,
 
   // HIP sync scopes
-  I32EnumAttrCase<"HIPSingleThread", 6, "hip_single_thread">,
-  I32EnumAttrCase<"HIPSystem", 7, "hip_system">,
-  I32EnumAttrCase<"HIPAgent", 8, "hip_agent">,
-  I32EnumAttrCase<"HIPWorkgroup", 9, "hip_workgroup">,
-  I32EnumAttrCase<"HIPWavefront", 10, "hip_wavefront">,
-  I32EnumAttrCase<"HIPCluster", 11, "hip_cluster">,
+  I32EnumCase<"HIPSingleThread", 6, "hip_single_thread">,
+  I32EnumCase<"HIPSystem", 7, "hip_system">,
+  I32EnumCase<"HIPAgent", 8, "hip_agent">,
+  I32EnumCase<"HIPWorkgroup", 9, "hip_workgroup">,
+  I32EnumCase<"HIPWavefront", 10, "hip_wavefront">,
+  I32EnumCase<"HIPCluster", 11, "hip_cluster">,
 
   // OpenCL sync scopes
-  I32EnumAttrCase<"OpenCLWorkGroup", 12, "opencl_work_group">,
-  I32EnumAttrCase<"OpenCLDevice", 13, "opencl_device">,
-  I32EnumAttrCase<"OpenCLAllSVMDevices", 14, "opencl_all_svm_devices">,
-  I32EnumAttrCase<"OpenCLSubGroup", 15, "opencl_sub_group">,
+  I32EnumCase<"OpenCLWorkGroup", 12, "opencl_work_group">,
+  I32EnumCase<"OpenCLDevice", 13, "opencl_device">,
+  I32EnumCase<"OpenCLAllSVMDevices", 14, "opencl_all_svm_devices">,
+  I32EnumCase<"OpenCLSubGroup", 15, "opencl_sub_group">,
 ]>;
 
 def CIR_SyncScopeKindAttr : CIR_EnumAttr<CIR_SyncScopeKind, "sync_scope">;
@@ -1363,9 +1363,9 @@ def CIR_ScopeOp : CIR_RegionBranchOpBase<"scope", [
 //===----------------------------------------------------------------------===//
 
 def CIR_CleanupKind : CIR_I32Enum<"CleanupKind", "cleanup kind", [
-  I32EnumAttrCase<"Normal", 1, "normal">,
-  I32EnumAttrCase<"EH", 2, "eh">,
-  I32EnumAttrCase<"All", 3, "all">
+  I32EnumCase<"Normal", 1, "normal">,
+  I32EnumCase<"EH", 2, "eh">,
+  I32EnumCase<"All", 3, "all">
 ]>;
 
 def CIR_CleanupKindAttr : CIR_EnumAttr<CIR_CleanupKind, "cleanup"> {
@@ -1516,10 +1516,10 @@ def CIR_CmpThreeWayOp : CIR_Op<"cmp3way", [Pure, SameTypeOperands]> {
 //===----------------------------------------------------------------------===//
 
 def CIR_CaseOpKind : CIR_I32Enum<"CaseOpKind", "case kind", [
-  I32EnumAttrCase<"Default", 0, "default">,
-  I32EnumAttrCase<"Equal", 1, "equal">,
-  I32EnumAttrCase<"Anyof", 2, "anyof">,
-  I32EnumAttrCase<"Range", 3, "range">
+  I32EnumCase<"Default", 0, "default">,
+  I32EnumCase<"Equal", 1, "equal">,
+  I32EnumCase<"Anyof", 2, "anyof">,
+  I32EnumCase<"Range", 3, "range">
 ]>;
 
 def CIR_CaseOpKindAttr : CIR_EnumAttr<CIR_CaseOpKind, "case">;
@@ -2522,14 +2522,14 @@ def CIR_ForOp : CIR_LoopOpBase<"for"> {
 //===----------------------------------------------------------------------===//
 
 def CIR_CmpOpKind : CIR_I32Enum<"CmpOpKind", "compare operation kind", [
-  I32EnumAttrCase<"lt", 0>,
-  I32EnumAttrCase<"le", 1>,
-  I32EnumAttrCase<"gt", 2>,
-  I32EnumAttrCase<"ge", 3>,
-  I32EnumAttrCase<"eq", 4>,
-  I32EnumAttrCase<"ne", 5>,
-  I32EnumAttrCase<"one", 6>,
-  I32EnumAttrCase<"uno", 7>
+  I32EnumCase<"lt", 0>,
+  I32EnumCase<"le", 1>,
+  I32EnumCase<"gt", 2>,
+  I32EnumCase<"ge", 3>,
+  I32EnumCase<"eq", 4>,
+  I32EnumCase<"ne", 5>,
+  I32EnumCase<"one", 6>,
+  I32EnumCase<"uno", 7>
 ]>;
 
 def CIR_CmpOpKindAttr : CIR_EnumAttr<CIR_CmpOpKind, "cmp">;
@@ -3294,28 +3294,28 @@ def CIR_TernaryOp : CIR_RegionBranchOpBase<"ternary", [
 def CIR_GlobalLinkageKind : CIR_I32Enum<
   "GlobalLinkageKind", "linkage kind", [
     // Externally visible function
-    I32EnumAttrCase<"ExternalLinkage", 0, "external">,
+    I32EnumCase<"ExternalLinkage", 0, "external">,
     // Available for inspection, not emission.
-    I32EnumAttrCase<"AvailableExternallyLinkage", 1, "available_externally">,
+    I32EnumCase<"AvailableExternallyLinkage", 1, "available_externally">,
     // Keep one copy of function when linking (inline)
-    I32EnumAttrCase<"LinkOnceAnyLinkage", 2, "linkonce">,
+    I32EnumCase<"LinkOnceAnyLinkage", 2, "linkonce">,
     // Same, but only replaced by something equivalent.
-    I32EnumAttrCase<"LinkOnceODRLinkage", 3, "linkonce_odr">,
+    I32EnumCase<"LinkOnceODRLinkage", 3, "linkonce_odr">,
     // Keep one copy of named function when linking (weak)
-    I32EnumAttrCase<"WeakAnyLinkage", 4, "weak">,
+    I32EnumCase<"WeakAnyLinkage", 4, "weak">,
     // Same, but only replaced by something equivalent.
-    I32EnumAttrCase<"WeakODRLinkage", 5, "weak_odr">,
+    I32EnumCase<"WeakODRLinkage", 5, "weak_odr">,
     // Special purpose, only applies to global arrays
-    I32EnumAttrCase<"AppendingLinkage", 6, "appending">,
+    I32EnumCase<"AppendingLinkage", 6, "appending">,
     // Rename collisions when linking (static functions).
-    I32EnumAttrCase<"InternalLinkage", 7, "internal">,
+    I32EnumCase<"InternalLinkage", 7, "internal">,
     // Like Internal, but omit from symbol table, prefix it with
     // "cir_" to prevent clash with MLIR's symbol "private".
-    I32EnumAttrCase<"PrivateLinkage", 8, "cir_private">,
+    I32EnumCase<"PrivateLinkage", 8, "cir_private">,
     // ExternalWeak linkage description.
-    I32EnumAttrCase<"ExternalWeakLinkage", 9, "extern_weak">,
+    I32EnumCase<"ExternalWeakLinkage", 9, "extern_weak">,
     // Tentative definitions.
-    I32EnumAttrCase<"CommonLinkage", 10, "common">
+    I32EnumCase<"CommonLinkage", 10, "common">
 ]>;
 
 def CIR_GlobalLinkageKindAttr
@@ -3326,10 +3326,10 @@ def CIR_GlobalLinkageKindAttr
 // is upstreamed.
 
 def CIR_TLSModel : CIR_I32Enum<"TLSModel", "TLS model", [
-  I32EnumAttrCase<"GeneralDynamic", 1, "tls_dyn">,
-  I32EnumAttrCase<"LocalDynamic", 2, "tls_local_dyn">,
-  I32EnumAttrCase<"InitialExec", 3, "tls_init_exec">,
-  I32EnumAttrCase<"LocalExec", 4, "tls_local_exec">
+  I32EnumCase<"GeneralDynamic", 1, "tls_dyn">,
+  I32EnumCase<"LocalDynamic", 2, "tls_local_dyn">,
+  I32EnumCase<"InitialExec", 3, "tls_init_exec">,
+  I32EnumCase<"LocalExec", 4, "tls_local_exec">
 ]>;
 
 def CIR_TLSModelAttr: CIR_EnumAttr<CIR_TLSModel, "tls_model"> {
@@ -4168,11 +4168,11 @@ def CIR_OptionalPriorityAttr : OptionalAttr<
 // are CIR-specific and are not in sync with `llvm::CallingConv` or
 // `clang::CallingConv`.
 def CIR_CallingConv : CIR_I32Enum<"CallingConv", "calling convention", [
-  I32EnumAttrCase<"C", 0, "c">,
-  I32EnumAttrCase<"PTXKernel", 1, "ptx_kernel">,
-  I32EnumAttrCase<"SpirFunction", 2, "spir_function">,
-  I32EnumAttrCase<"SpirKernel", 3, "spir_kernel">,
-  I32EnumAttrCase<"AMDGPUKernel", 4, "amdgpu_kernel">
+  I32EnumCase<"C", 0, "c">,
+  I32EnumCase<"PTXKernel", 1, "ptx_kernel">,
+  I32EnumCase<"SpirFunction", 2, "spir_function">,
+  I32EnumCase<"SpirKernel", 3, "spir_kernel">,
+  I32EnumCase<"AMDGPUKernel", 4, "amdgpu_kernel">
 ]>;
 
 def CIR_CallingConvAttr : CIR_EnumAttr<CIR_CallingConv, "calling_conv">;
@@ -4724,10 +4724,10 @@ def CIR_TryCallOp : CIR_CallOpBase<"try_call",[
 //===----------------------------------------------------------------------===//
 
 def CIR_AwaitKind : CIR_I32Enum<"AwaitKind", "await kind", [
-  I32EnumAttrCase<"Init", 0, "init">,
-  I32EnumAttrCase<"User", 1, "user">,
-  I32EnumAttrCase<"Yield", 2, "yield">,
-  I32EnumAttrCase<"Final", 3, "final">
+  I32EnumCase<"Init", 0, "init">,
+  I32EnumCase<"User", 1, "user">,
+  I32EnumCase<"Yield", 2, "yield">,
+  I32EnumCase<"Final", 3, "final">
 ]>;
 
 def CIR_AwaitKindAttr : CIR_EnumAttr<CIR_AwaitKind, "await">;
@@ -5422,8 +5422,8 @@ def CIR_LifetimeEndOp : CIR_Op<"lifetime.end"> {
 //===----------------------------------------------------------------------===//
 
 def CIR_AsmFlavor : CIR_I32Enum<"AsmFlavor", "ATT or Intel",
-                                    [I32EnumAttrCase<"x86_att", 0>,
-                                     I32EnumAttrCase<"x86_intel", 1>]>;
+                                    [I32EnumCase<"x86_att", 0>,
+                                     I32EnumCase<"x86_intel", 1>]>;
 
 def CIR_AsmFlavorAttr : CIR_EnumAttr<CIR_AsmFlavor, "asm_flavor">;
 
@@ -6539,10 +6539,10 @@ def CIR_ComplexSubOp : CIR_ComplexBinOp<"complex.sub"> {
 
 def CIR_ComplexRangeKind : CIR_I32Enum<
   "ComplexRangeKind", "complex multiplication and division implementation", [
-    I32EnumAttrCase<"Full", 0, "full">,
-    I32EnumAttrCase<"Improved", 1, "improved">,
-    I32EnumAttrCase<"Promoted", 2, "promoted">,
-    I32EnumAttrCase<"Basic", 3, "basic">,
+    I32EnumCase<"Full", 0, "full">,
+    I32EnumCase<"Improved", 1, "improved">,
+    I32EnumCase<"Promoted", 2, "promoted">,
+    I32EnumCase<"Basic", 3, "basic">,
 ]>;
 
 def CIR_ComplexRangeKindAttr
@@ -6905,42 +6905,42 @@ def CIR_RotateOp : CIR_Op<"rotate", [Pure, SameOperandsAndResultType]> {
 // Individual floating-point classes, one per bit (positions 0-9), matching
 // LLVM's `FPClassTest` bit layout (`llvm/ADT/FloatingPointMode.h`).  Modeled
 // as a bit-enum so `__builtin_isfpclass` can pass any combination of bits.
-def FPClass_None     : I32BitEnumAttrCaseNone<"None", "fcNone">;
-def FPClass_SNan     : I32BitEnumAttrCaseBit<"SignalingNaN", 0, "fcSNan">;
-def FPClass_QNan     : I32BitEnumAttrCaseBit<"QuietNaN", 1, "fcQNan">;
-def FPClass_NegInf   : I32BitEnumAttrCaseBit<"NegativeInfinity", 2, "fcNegInf">;
-def FPClass_NegNorm  : I32BitEnumAttrCaseBit<"NegativeNormal", 3, "fcNegNormal">;
-def FPClass_NegSub   : I32BitEnumAttrCaseBit<"NegativeSubnormal", 4,
+def FPClass_None     : I32BitEnumCaseNone<"None", "fcNone">;
+def FPClass_SNan     : I32BitEnumCaseBit<"SignalingNaN", 0, "fcSNan">;
+def FPClass_QNan     : I32BitEnumCaseBit<"QuietNaN", 1, "fcQNan">;
+def FPClass_NegInf   : I32BitEnumCaseBit<"NegativeInfinity", 2, "fcNegInf">;
+def FPClass_NegNorm  : I32BitEnumCaseBit<"NegativeNormal", 3, "fcNegNormal">;
+def FPClass_NegSub   : I32BitEnumCaseBit<"NegativeSubnormal", 4,
                                              "fcNegSubnormal">;
-def FPClass_NegZero  : I32BitEnumAttrCaseBit<"NegativeZero", 5, "fcNegZero">;
-def FPClass_PosZero  : I32BitEnumAttrCaseBit<"PositiveZero", 6, "fcPosZero">;
-def FPClass_PosSub   : I32BitEnumAttrCaseBit<"PositiveSubnormal", 7,
+def FPClass_NegZero  : I32BitEnumCaseBit<"NegativeZero", 5, "fcNegZero">;
+def FPClass_PosZero  : I32BitEnumCaseBit<"PositiveZero", 6, "fcPosZero">;
+def FPClass_PosSub   : I32BitEnumCaseBit<"PositiveSubnormal", 7,
                                              "fcPosSubnormal">;
-def FPClass_PosNorm  : I32BitEnumAttrCaseBit<"PositiveNormal", 8, "fcPosNormal">;
-def FPClass_PosInf   : I32BitEnumAttrCaseBit<"PositiveInfinity", 9, "fcPosInf">;
+def FPClass_PosNorm  : I32BitEnumCaseBit<"PositiveNormal", 8, "fcPosNormal">;
+def FPClass_PosInf   : I32BitEnumCaseBit<"PositiveInfinity", 9, "fcPosInf">;
 
 // Composite groups (aliases for combinations of the individual classes).
-def FPClass_Nan      : I32BitEnumAttrCaseGroup<"Nan",
+def FPClass_Nan      : BitEnumCaseGroup<"Nan",
     [FPClass_SNan, FPClass_QNan], "fcNan">;
-def FPClass_Inf      : I32BitEnumAttrCaseGroup<"Infinity",
+def FPClass_Inf      : BitEnumCaseGroup<"Infinity",
     [FPClass_NegInf, FPClass_PosInf], "fcInf">;
-def FPClass_Norm     : I32BitEnumAttrCaseGroup<"Normal",
+def FPClass_Norm     : BitEnumCaseGroup<"Normal",
     [FPClass_NegNorm, FPClass_PosNorm], "fcNormal">;
-def FPClass_Sub      : I32BitEnumAttrCaseGroup<"Subnormal",
+def FPClass_Sub      : BitEnumCaseGroup<"Subnormal",
     [FPClass_NegSub, FPClass_PosSub], "fcSubnormal">;
-def FPClass_Zero     : I32BitEnumAttrCaseGroup<"Zero",
+def FPClass_Zero     : BitEnumCaseGroup<"Zero",
     [FPClass_NegZero, FPClass_PosZero], "fcZero">;
-def FPClass_PosFin   : I32BitEnumAttrCaseGroup<"PositiveFinite",
+def FPClass_PosFin   : BitEnumCaseGroup<"PositiveFinite",
     [FPClass_PosNorm, FPClass_PosSub, FPClass_PosZero], "fcPosFinite">;
-def FPClass_NegFin   : I32BitEnumAttrCaseGroup<"NegativeFinite",
+def FPClass_NegFin   : BitEnumCaseGroup<"NegativeFinite",
     [FPClass_NegNorm, FPClass_NegSub, FPClass_NegZero], "fcNegFinite">;
-def FPClass_Fin      : I32BitEnumAttrCaseGroup<"Finite",
+def FPClass_Fin      : BitEnumCaseGroup<"Finite",
     [FPClass_PosFin, FPClass_NegFin], "fcFinite">;
-def FPClass_Pos      : I32BitEnumAttrCaseGroup<"Positive",
+def FPClass_Pos      : BitEnumCaseGroup<"Positive",
     [FPClass_PosFin, FPClass_PosInf], "fcPositive">;
-def FPClass_Neg      : I32BitEnumAttrCaseGroup<"Negative",
+def FPClass_Neg      : BitEnumCaseGroup<"Negative",
     [FPClass_NegFin, FPClass_NegInf], "fcNegative">;
-def FPClass_All      : I32BitEnumAttrCaseGroup<"All",
+def FPClass_All      : BitEnumCaseGroup<"All",
     [FPClass_Nan, FPClass_Inf, FPClass_Fin], "fcAllFlags">;
 
 def FPClassTestEnum
@@ -6994,10 +6994,10 @@ def CIR_IsFPClassOp : CIR_Op<"is_fp_class", [Pure]> {
 
 def CIR_AssumeBundleKind : CIR_I32Enum<
   "AssumeBundleKind", "kind of cir.assume operand bundle", [
-  I32EnumAttrCase<"None", 0>,
-  I32EnumAttrCase<"Align", 1, "align">,
-  I32EnumAttrCase<"SeparateStorage", 2, "separate_storage">,
-  I32EnumAttrCase<"Dereferenceable", 3, "dereferenceable">
+  I32EnumCase<"None", 0>,
+  I32EnumCase<"Align", 1, "align">,
+  I32EnumCase<"SeparateStorage", 2, "separate_storage">,
+  I32EnumCase<"Dereferenceable", 3, "dereferenceable">
 ]>;
 
 def CIR_AssumeBundleKindAttr
@@ -8745,12 +8745,12 @@ def CIR_EndCatchOp : CIR_Op<"end_catch"> {
 
 def CIR_InitCatchKind : CIR_I32Enum<
   "InitCatchKind", "", [
-    I32EnumAttrCase<"Reference", 0, "reference">,
-    I32EnumAttrCase<"Pointer", 1, "pointer">,
-    I32EnumAttrCase<"Scalar", 2, "scalar">,
-    I32EnumAttrCase<"Objc", 3, "objc">,
-    I32EnumAttrCase<"TrivialCopy", 4, "trivial_copy">,
-    I32EnumAttrCase<"NonTrivialCopy", 5, "non_trivial_copy">,
+    I32EnumCase<"Reference", 0, "reference">,
+    I32EnumCase<"Pointer", 1, "pointer">,
+    I32EnumCase<"Scalar", 2, "scalar">,
+    I32EnumCase<"Objc", 3, "objc">,
+    I32EnumCase<"TrivialCopy", 4, "trivial_copy">,
+    I32EnumCase<"NonTrivialCopy", 5, "non_trivial_copy">,
 ]>;
 
 def CIR_InitCatchKindAttr : CIR_EnumAttr<CIR_InitCatchKind, "init_catch">;
@@ -8868,23 +8868,23 @@ def CIR_TokenNoneOp : CIR_Op<"token.none", [
 
 def CIR_AtomicFetchKind : CIR_I32Enum<
   "AtomicFetchKind", "Binary opcode for atomic fetch-and-update operations", [
-    I32EnumAttrCase<"Add", 0, "add">,
-    I32EnumAttrCase<"Sub", 1, "sub">,
-    I32EnumAttrCase<"And", 2, "and">,
-    I32EnumAttrCase<"Xor", 3, "xor">,
-    I32EnumAttrCase<"Or", 4, "or">,
-    I32EnumAttrCase<"Nand", 5, "nand">,
-    I32EnumAttrCase<"Max", 6, "max">,
-    I32EnumAttrCase<"Min", 7, "min">,
-    I32EnumAttrCase<"UIncWrap", 8, "uinc_wrap">,
-    I32EnumAttrCase<"UDecWrap", 9, "udec_wrap">,
+    I32EnumCase<"Add", 0, "add">,
+    I32EnumCase<"Sub", 1, "sub">,
+    I32EnumCase<"And", 2, "and">,
+    I32EnumCase<"Xor", 3, "xor">,
+    I32EnumCase<"Or", 4, "or">,
+    I32EnumCase<"Nand", 5, "nand">,
+    I32EnumCase<"Max", 6, "max">,
+    I32EnumCase<"Min", 7, "min">,
+    I32EnumCase<"UIncWrap", 8, "uinc_wrap">,
+    I32EnumCase<"UDecWrap", 9, "udec_wrap">,
     // The primary difference between Max, Maximum, and MaximumNum is primarily
     // about how they handle floating-point inputs. See the description of the
     // CIR_AtomicFetchOp for more information.
-    I32EnumAttrCase<"Maximum", 10, "maximum">,
-    I32EnumAttrCase<"Minimum", 11, "minimum">,
-    I32EnumAttrCase<"MaximumNum", 12, "maximum_num">,
-    I32EnumAttrCase<"MinimumNum", 13, "minimum_num">
+    I32EnumCase<"Maximum", 10, "maximum">,
+    I32EnumCase<"Minimum", 11, "minimum">,
+    I32EnumCase<"MaximumNum", 12, "maximum_num">,
+    I32EnumCase<"MinimumNum", 13, "minimum_num">
 ]>;
 
 def CIR_AtomicFetchKindAttr

--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
@@ -747,10 +747,10 @@ def CIR_BitFieldType : CIR_Type<"BitField", "bitfield", [
 
 def CIR_RecordMemberKind : CIR_I32Enum<
     "RecordMemberKind", "what a record member holds", [
-  I32EnumAttrCase<"Data", 0, "data">,
-  I32EnumAttrCase<"Pad", 1, "pad">,
-  I32EnumAttrCase<"Empty", 2, "empty">,
-  I32EnumAttrCase<"BitField", 3, "bitfield">
+  I32EnumCase<"Data", 0, "data">,
+  I32EnumCase<"Pad", 1, "pad">,
+  I32EnumCase<"Empty", 2, "empty">,
+  I32EnumCase<"BitField", 3, "bitfield">
 ]> {
   let description = [{
     `pad` is storage the compiler inserted to place a later member at its


### PR DESCRIPTION
The `I32EnumAttrCase` family carries an `Attr` half, and an `IntegerAttr`
predicate with it, that a CIR enum has no use for now that the enums derive
from `EnumInfo`. Upstream says of those forms that they "are not needed when
using the newer `EnumCase` form".

Rename all of them to `I32EnumCase`, `I32BitEnumCaseNone`,
`I32BitEnumCaseBit` and `BitEnumCaseGroup`. The group class drops its width
prefix because the modern spelling takes the width from its cases.