### PR TITLE
[Offload] Update skip list for level_zero Offload API tests

### DIFF
--- a/offload/unittests/OffloadAPI/kernel/olLaunchKernel.cpp
+++ b/offload/unittests/OffloadAPI/kernel/olLaunchKernel.cpp
@@ -250,8 +250,6 @@ TEST_P(olLaunchKernelLocalMemReductionTest, Success) {
 }
 
 TEST_P(olLaunchKernelLocalMemStaticTest, Success) {
-  SKIP_KNOWN_FAILURE(LevelZero{"unsupported DynSharedMemory"});
-
   LaunchArgs.NumGroups.x = 4;
   LaunchArgs.DynSharedMemory = 0;
 

--- a/offload/unittests/OffloadAPI/kernel/olLaunchKernel.cpp
+++ b/offload/unittests/OffloadAPI/kernel/olLaunchKernel.cpp
@@ -80,8 +80,6 @@ TEST_P(olLaunchKernelFooTest, Success) {
 }
 
 TEST_P(olLaunchKernelFooTest, SuccessThreaded) {
-  SKIP_KNOWN_FAILURE(LevelZero{"thread-safety issues"});
-
   threadify([&](size_t) {
     void *DevAlloc, *HstAlloc;
     size_t Size = LaunchArgs.GroupSize.x * sizeof(uint32_t);

--- a/offload/unittests/OffloadAPI/memory/olMemFill.cpp
+++ b/offload/unittests/OffloadAPI/memory/olMemFill.cpp
@@ -154,7 +154,6 @@ TEST_P(olMemFillTest, SuccessLargeByteAligned) {
 }
 
 TEST_P(olMemFillTest, SuccessLargeByteAlignedEnqueue) {
-  SKIP_KNOWN_FAILURE(LevelZero{"unsupported feature"});
   constexpr size_t Size = 17 * 64;
   void *Alloc;
   ManuallyTriggeredTask Manual;

--- a/offload/unittests/OffloadAPI/queue/olDestroyQueue.cpp
+++ b/offload/unittests/OffloadAPI/queue/olDestroyQueue.cpp
@@ -19,8 +19,6 @@ TEST_P(olDestroyQueueTest, Success) {
 }
 
 TEST_P(olDestroyQueueTest, SuccessDelayedResolution) {
-  SKIP_KNOWN_FAILURE(LevelZero{"implicit synchronization issues"});
-
   ManuallyTriggeredTask Manual;
   ASSERT_SUCCESS(Manual.enqueue(Queue));
   ASSERT_SUCCESS(olDestroyQueue(Queue));


### PR DESCRIPTION
olDestroyQueueTest.SuccessDelayedResolution - passes
olLaunchKernelFooTest.SuccessThreaded - ran 1000 times, all passed
olMemFillTest.SuccessLargeByteAlignedEnqueue - passes after fixes from @311Volt
olLaunchKernelLocalMemStaticTest - it's not using dynamic shared memory, just a static array which is valid