### PR TITLE
[orc-rt] Make ExecutorProcessInfo platform-generic

### DIFF
--- a/orc-rt/include/orc-rt-internal/bedrock/sys/CPUFeatures.h
+++ b/orc-rt/include/orc-rt-internal/bedrock/sys/CPUFeatures.h
@@ -1,0 +1,28 @@
+//===- CPUFeatures.h - Host CPU feature detection ---------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Exactly one implementation is compiled into the runtime, chosen by the
+// build: see lib/bedrock/sys/darwin/CPUFeatures.cpp and its siblings.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ORC_RT_INTERNAL_BEDROCK_SYS_CPUFEATURES_H
+#define ORC_RT_INTERNAL_BEDROCK_SYS_CPUFEATURES_H
+
+#include <string_view>
+#include <vector>
+
+namespace orc_rt::sys {
+
+/// Returns the host's CPU feature names, using LLVM's SubtargetFeatures
+/// naming (see orc-rt-internal/bedrock/TargetDetails.h).
+std::vector<std::string_view> detectTargetCPUFeatures();
+
+} // namespace orc_rt::sys
+
+#endif // ORC_RT_INTERNAL_BEDROCK_SYS_CPUFEATURES_H

--- a/orc-rt/include/orc-rt-internal/bedrock/sys/PageSize.h
+++ b/orc-rt/include/orc-rt-internal/bedrock/sys/PageSize.h
@@ -1,0 +1,29 @@
+//===- PageSize.h - Host page-size detection ---------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Exactly one implementation is compiled into the runtime, chosen by the
+// build: see lib/bedrock/sys/posix/PageSize.cpp and its siblings.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ORC_RT_INTERNAL_BEDROCK_SYS_PAGESIZE_H
+#define ORC_RT_INTERNAL_BEDROCK_SYS_PAGESIZE_H
+
+#include "orc-rt/support/Error.h"
+
+#include <cstddef>
+
+namespace orc_rt::sys {
+
+/// Returns the host process's page size, or an error if it could not be
+/// determined.
+Expected<size_t> detectPageSize() noexcept;
+
+} // namespace orc_rt::sys
+
+#endif // ORC_RT_INTERNAL_BEDROCK_SYS_PAGESIZE_H

--- a/orc-rt/include/orc-rt-internal/bedrock/sys/PageSize.h
+++ b/orc-rt/include/orc-rt-internal/bedrock/sys/PageSize.h
@@ -1,4 +1,4 @@
-//===- PageSize.h - Host page-size detection ---------------------*- C++ -*-===//
+//===- PageSize.h - Host page-size detection --------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/orc-rt/include/orc-rt-internal/bedrock/sys/TargetTriple.h
+++ b/orc-rt/include/orc-rt-internal/bedrock/sys/TargetTriple.h
@@ -1,0 +1,27 @@
+//===- TargetTriple.h - Host target-triple detection ------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Exactly one implementation is compiled into the runtime, chosen by the
+// build: see lib/bedrock/sys/darwin/TargetTriple.cpp and its siblings.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ORC_RT_INTERNAL_BEDROCK_SYS_TARGETTRIPLE_H
+#define ORC_RT_INTERNAL_BEDROCK_SYS_TARGETTRIPLE_H
+
+#include <string>
+
+namespace orc_rt::sys {
+
+/// Returns a target-triple string for the host process. Detection may
+/// involve system calls, so the result is cached.
+std::string detectTargetTriple() noexcept;
+
+} // namespace orc_rt::sys
+
+#endif // ORC_RT_INTERNAL_BEDROCK_SYS_TARGETTRIPLE_H

--- a/orc-rt/include/orc-rt-internal/support/sys/DynamicLibrary.h
+++ b/orc-rt/include/orc-rt-internal/support/sys/DynamicLibrary.h
@@ -9,8 +9,8 @@
 // The host dynamic-library operations that NativeDylibManager is built on.
 //
 // Exactly one implementation is compiled into the runtime, chosen by the build:
-// see lib/bedrock/posix/DynamicLibrary.cpp and its siblings. A target with no
-// dynamic loader has no native dylib manager.
+// see lib/bedrock/sys/posix/DynamicLibrary.cpp and its siblings. A target with
+// no dynamic loader has no native dylib manager.
 //
 //===----------------------------------------------------------------------===//
 

--- a/orc-rt/include/orc-rt-internal/support/sys/Memory.h
+++ b/orc-rt/include/orc-rt-internal/support/sys/Memory.h
@@ -9,7 +9,7 @@
 // The host memory operations that SimpleNativeMemoryMap is built on.
 //
 // Exactly one implementation is compiled into the runtime, chosen by the build:
-// see lib/bedrock/posix/Memory.cpp and its siblings. A target that
+// see lib/bedrock/sys/posix/Memory.cpp and its siblings. A target that
 // cannot provide these has no native memory map.
 //
 //===----------------------------------------------------------------------===//

--- a/orc-rt/include/orc-rt/bedrock/ExecutorProcessInfo.h
+++ b/orc-rt/include/orc-rt/bedrock/ExecutorProcessInfo.h
@@ -16,10 +16,7 @@
 
 #include "orc-rt/support/Error.h"
 
-#include <initializer_list>
 #include <string>
-#include <string_view>
-#include <vector>
 
 namespace orc_rt {
 
@@ -43,29 +40,7 @@ public:
   /// Returns the host process's page size.
   size_t pageSize() const noexcept { return PageSize; }
 
-  /// This will return a string that can be forwarded to SubtargetFeatures
-  /// It will only return "+" turning off features, is left to caller.
-  /// This calls syscalls so result is cached
-  static std::string detectCPUFeatures() noexcept;
-  /// This calls syscalls so result is cached
-  static std::string detectTargetTriple() noexcept;
-
-  static Expected<size_t> detectPageSize() noexcept;
-
 private:
-  friend struct ExecutorProcessInfoTestAccess;
-
-  // Storage of string_views is static, so will last the lifetime of the runtime
-  static std::vector<std::string_view> detectTargetCPUFeatures();
-
-  /// Formats vector of feature names as an SubtargetFeatures valid string, e.g.
-  /// "+avx,+avx2".
-  static std::string
-  formatCPUFeatures(const std::vector<std::string_view> &Features);
-
-  static std::string
-  makeTargetTriple(std::initializer_list<std::string_view> Components);
-
   std::string Triple;
   size_t PageSize;
   std::string CPUFeatures;

--- a/orc-rt/lib/bedrock/CMakeLists.txt
+++ b/orc-rt/lib/bedrock/CMakeLists.txt
@@ -48,6 +48,7 @@ set(ORC_RT_POSIX_SOURCES
   sys/posix/DynamicLibrary.cpp
   sys/posix/Errno.cpp
   sys/posix/Memory.cpp
+  sys/posix/PageSize.cpp
 )
 
 set(ORC_RT_DARWIN_SOURCES

--- a/orc-rt/lib/bedrock/ExecutorProcessInfo.cpp
+++ b/orc-rt/lib/bedrock/ExecutorProcessInfo.cpp
@@ -12,13 +12,13 @@
 //===----------------------------------------------------------------------===//
 
 #include "orc-rt/bedrock/ExecutorProcessInfo.h"
+#include "orc-rt-internal/bedrock/sys/CPUFeatures.h"
+#include "orc-rt-internal/bedrock/sys/PageSize.h"
+#include "orc-rt-internal/bedrock/sys/TargetTriple.h"
 #include "orc-rt-internal/support/StringExtras.h"
-#include "orc-rt-internal/support/sys/Errno.h"
 #include "orc-rt/support/bit.h"
 
 #include <cassert>
-#include <cstring>
-#include <unistd.h>
 
 namespace orc_rt {
 
@@ -32,59 +32,19 @@ ExecutorProcessInfo::ExecutorProcessInfo(std::string Triple, size_t PageSize,
 
 /// Create an ExecutorProcessInfo, auto-detecting property values.
 Expected<ExecutorProcessInfo> ExecutorProcessInfo::Detect() noexcept {
-  auto CPUFeatures = detectCPUFeatures();
-  auto Triple = detectTargetTriple();
-  auto PageSize = detectPageSize();
+  auto Features = sys::detectTargetCPUFeatures();
+  std::string CPUFeatures;
+  if (!Features.empty()) {
+    // Every feature is emitted with a '+' prefix, so the separator carries
+    // the prefix for all but the first.
+    CPUFeatures = "+" + join(Features, ",+");
+  }
+  auto Triple = sys::detectTargetTriple();
+  auto PageSize = sys::detectPageSize();
   if (!PageSize)
     return PageSize.takeError();
   return ExecutorProcessInfo(std::move(Triple), std::move(*PageSize),
                              std::move(CPUFeatures));
-}
-
-std::string ExecutorProcessInfo::formatCPUFeatures(
-    const std::vector<std::string_view> &Features) {
-  if (Features.empty())
-    return {};
-
-  // Every feature is emitted with a '+' prefix, so the separator carries the
-  // prefix for all but the first.
-  return "+" + join(Features, ",+");
-}
-
-std::string ExecutorProcessInfo::detectCPUFeatures() noexcept {
-  // Detection involves system calls, so cache the result. Function-local
-  // static initialization is thread safe.
-  static const std::string Cache = formatCPUFeatures(detectTargetCPUFeatures());
-  return Cache;
-}
-
-std::string ExecutorProcessInfo::makeTargetTriple(
-    std::initializer_list<std::string_view> Components) {
-  const std::string_view *First = Components.begin();
-  const std::string_view *Last = Components.end();
-
-  // Trailing empty components have to be dropped
-  // Empty parts in the middle results in "--"
-  // this matches llvm behaviour
-  while (Last != First && (Last - 1)->empty())
-    --Last;
-
-  return join(First, Last, "-");
-}
-
-Expected<size_t> ExecutorProcessInfo::detectPageSize() noexcept {
-  long PageSize = sysconf(_SC_PAGESIZE);
-  if (PageSize == -1)
-    return make_error<StringError>((StringOutputStream()
-                                    << "sysconf did not return a page size: "
-                                    << sys::strError(errno))
-                                       .str());
-  if (PageSize <= 0 || !has_single_bit(static_cast<size_t>(PageSize)))
-    return make_error<StringError>((StringOutputStream()
-                                    << "reported page size " << PageSize
-                                    << " is not a power of two")
-                                       .str());
-  return static_cast<size_t>(PageSize);
 }
 
 } // namespace orc_rt

--- a/orc-rt/lib/bedrock/sys/darwin/CPUFeatures.cpp
+++ b/orc-rt/lib/bedrock/sys/darwin/CPUFeatures.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-#include "orc-rt/bedrock/ExecutorProcessInfo.h"
+#include "orc-rt-internal/bedrock/sys/CPUFeatures.h"
 
 #include "orc-rt-internal/bedrock/TargetDetails.h"
 
@@ -13,7 +13,7 @@
 #include <sys/sysctl.h>
 #include <sys/types.h>
 
-namespace orc_rt {
+namespace orc_rt::sys {
 
 namespace {
 
@@ -25,36 +25,44 @@ bool sysctlFlag(const char *Name) noexcept {
 }
 
 } // namespace
-std::vector<std::string_view> ExecutorProcessInfo::detectTargetCPUFeatures() {
-  using namespace orc_rt::target_detail;
-  std::vector<std::string_view> Features;
+
+std::vector<std::string_view> detectTargetCPUFeatures() {
+  // Detection involves system calls, so cache the result. Function-local
+  // static initialization is thread safe.
+  static const std::vector<std::string_view> Cache = [] {
+    using namespace orc_rt::target_detail;
+    std::vector<std::string_view> Features;
 
 #if defined(__x86_64__) || defined(__i386__)
-  // The hw.optional flags already account for kernel support of the extended
-  // register state, so no OSXSAVE / XCR0 check is required here unlike linux
-  // this is why we diverge from using the compiler intrinsics here.
-  if (sysctlFlag("hw.optional.sse4_1"))
-    Features.push_back(feature::x86::sse4_1);
-  if (sysctlFlag("hw.optional.sse4_2"))
-    Features.push_back(feature::x86::sse4_2);
-  if (sysctlFlag("hw.optional.avx1_0"))
-    Features.push_back(feature::x86::avx);
-  if (sysctlFlag("hw.optional.avx2_0"))
-    Features.push_back(feature::x86::avx2);
+    // The hw.optional flags already account for kernel support of the
+    // extended register state, so no OSXSAVE / XCR0 check is required here
+    // unlike linux this is why we diverge from using the compiler intrinsics
+    // here.
+    if (sysctlFlag("hw.optional.sse4_1"))
+      Features.push_back(feature::x86::sse4_1);
+    if (sysctlFlag("hw.optional.sse4_2"))
+      Features.push_back(feature::x86::sse4_2);
+    if (sysctlFlag("hw.optional.avx1_0"))
+      Features.push_back(feature::x86::avx);
+    if (sysctlFlag("hw.optional.avx2_0"))
+      Features.push_back(feature::x86::avx2);
 
 #elif defined(__arm64__) || defined(__aarch64__)
-  // NEON is mandatory on all Apple AArch64 hardware.
-  Features.push_back(feature::aarch64::neon);
+    // NEON is mandatory on all Apple AArch64 hardware.
+    Features.push_back(feature::aarch64::neon);
 
-  if (sysctlFlag("hw.optional.arm.FEAT_DotProd"))
-    Features.push_back(feature::aarch64::dotprod);
-  if (sysctlFlag("hw.optional.arm.FEAT_FP16"))
-    Features.push_back(feature::aarch64::fullfp16);
-  if (sysctlFlag("hw.optional.arm.FEAT_SHA3"))
-    Features.push_back(feature::aarch64::sha3);
+    if (sysctlFlag("hw.optional.arm.FEAT_DotProd"))
+      Features.push_back(feature::aarch64::dotprod);
+    if (sysctlFlag("hw.optional.arm.FEAT_FP16"))
+      Features.push_back(feature::aarch64::fullfp16);
+    if (sysctlFlag("hw.optional.arm.FEAT_SHA3"))
+      Features.push_back(feature::aarch64::sha3);
 #endif
 
-  return Features;
+    return Features;
+  }();
+
+  return Cache;
 }
 
-} // namespace orc_rt
+} // namespace orc_rt::sys

--- a/orc-rt/lib/bedrock/sys/darwin/TargetTriple.cpp
+++ b/orc-rt/lib/bedrock/sys/darwin/TargetTriple.cpp
@@ -10,8 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "orc-rt-internal/bedrock/sys/TargetTriple.h"
+
 #include "orc-rt-internal/bedrock/TargetDetails.h"
-#include "orc-rt/bedrock/ExecutorProcessInfo.h"
+#include "orc-rt-internal/support/StringExtras.h"
 
 #include <TargetConditionals.h>
 #include <cstdlib>
@@ -19,7 +21,7 @@
 #include <sys/sysctl.h>
 #include <sys/types.h>
 
-namespace orc_rt {
+namespace orc_rt::sys {
 
 namespace {
 // FIXME: jared - Add in error handling rather than an empty string.
@@ -39,7 +41,7 @@ std::string sysctlString(const char *Name) noexcept {
 
 } // namespace
 
-std::string ExecutorProcessInfo::detectTargetTriple() noexcept {
+std::string detectTargetTriple() noexcept {
   // Detection may involve system calls, so cache the result.
   static const std::string Cache = [] {
     using namespace target_detail;
@@ -98,10 +100,12 @@ std::string ExecutorProcessInfo::detectTargetTriple() noexcept {
     if (Version.empty())
       Version = sysctlString(VersionSysctl);
 
-    return makeTargetTriple(
-        {Arch, vendor::apple, std::string(Platform) + Version, Environment});
+    std::string PlatformVersion = std::string(Platform) + Version;
+    if (Environment.empty())
+      return join({Arch, vendor::apple, PlatformVersion}, "-");
+    return join({Arch, vendor::apple, PlatformVersion, Environment}, "-");
   }();
   return Cache;
 }
 
-} // namespace orc_rt
+} // namespace orc_rt::sys

--- a/orc-rt/lib/bedrock/sys/linux/CPUFeatures.cpp
+++ b/orc-rt/lib/bedrock/sys/linux/CPUFeatures.cpp
@@ -1,9 +1,7 @@
-#include "orc-rt/bedrock/ExecutorProcessInfo.h"
+#include "orc-rt-internal/bedrock/sys/CPUFeatures.h"
 
-namespace orc_rt {
+namespace orc_rt::sys {
 
-std::vector<std::string_view> ExecutorProcessInfo::detectTargetCPUFeatures() {
-  return {};
-}
+std::vector<std::string_view> detectTargetCPUFeatures() { return {}; }
 
-} // namespace orc_rt
+} // namespace orc_rt::sys

--- a/orc-rt/lib/bedrock/sys/linux/TargetTriple.cpp
+++ b/orc-rt/lib/bedrock/sys/linux/TargetTriple.cpp
@@ -6,13 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "orc-rt/bedrock/ExecutorProcessInfo.h"
+#include "orc-rt-internal/bedrock/sys/TargetTriple.h"
 
 #include "orc-rt-internal/bedrock/TargetDetails.h"
+#include "orc-rt-internal/support/StringExtras.h"
 
-namespace orc_rt {
+namespace orc_rt::sys {
 
-std::string ExecutorProcessInfo::detectTargetTriple() noexcept {
+std::string detectTargetTriple() noexcept {
   static const std::string Cache = [] {
     using namespace target_detail;
 
@@ -35,13 +36,13 @@ std::string ExecutorProcessInfo::detectTargetTriple() noexcept {
 #endif
 
 #if defined(__GLIBC__)
-    return makeTargetTriple({Arch, Vendor, "linux", "gnu"});
+    return join({Arch, Vendor, "linux", "gnu"}, "-");
 #else
-    return makeTargetTriple({Arch, Vendor, "linux"});
+    return join({Arch, Vendor, "linux"}, "-");
 #endif
   }();
 
   return Cache;
 }
 
-} // namespace orc_rt
+} // namespace orc_rt::sys

--- a/orc-rt/lib/bedrock/sys/posix/PageSize.cpp
+++ b/orc-rt/lib/bedrock/sys/posix/PageSize.cpp
@@ -1,0 +1,38 @@
+//===- PageSize.cpp - POSIX page-size detection -----------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Page-size detection on POSIX systems, in terms of sysconf.
+//
+//===----------------------------------------------------------------------===//
+
+#include "orc-rt-internal/bedrock/sys/PageSize.h"
+#include "orc-rt-internal/support/StringExtras.h"
+#include "orc-rt-internal/support/sys/Errno.h"
+#include "orc-rt/support/bit.h"
+
+#include <cerrno>
+#include <unistd.h>
+
+namespace orc_rt::sys {
+
+Expected<size_t> detectPageSize() noexcept {
+  long PageSize = sysconf(_SC_PAGESIZE);
+  if (PageSize == -1)
+    return make_error<StringError>((StringOutputStream()
+                                    << "sysconf did not return a page size: "
+                                    << strError(errno))
+                                       .str());
+  if (PageSize <= 0 || !has_single_bit(static_cast<size_t>(PageSize)))
+    return make_error<StringError>((StringOutputStream()
+                                    << "reported page size " << PageSize
+                                    << " is not a power of two")
+                                       .str());
+  return static_cast<size_t>(PageSize);
+}
+
+} // namespace orc_rt::sys

--- a/orc-rt/lib/bedrock/sys/windows/CPUFeatures.cpp
+++ b/orc-rt/lib/bedrock/sys/windows/CPUFeatures.cpp
@@ -1,9 +1,7 @@
-#include "orc-rt/bedrock/ExecutorProcessInfo.h"
+#include "orc-rt-internal/bedrock/sys/CPUFeatures.h"
 
-namespace orc_rt {
+namespace orc_rt::sys {
 
-std::vector<std::string_view> ExecutorProcessInfo::detectTargetCPUFeatures() {
-  return {};
-}
+std::vector<std::string_view> detectTargetCPUFeatures() { return {}; }
 
-} // namespace orc_rt
+} // namespace orc_rt::sys

--- a/orc-rt/lib/bedrock/sys/windows/TargetTriple.cpp
+++ b/orc-rt/lib/bedrock/sys/windows/TargetTriple.cpp
@@ -6,10 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "orc-rt/bedrock/ExecutorProcessInfo.h"
+#include "orc-rt-internal/bedrock/sys/TargetTriple.h"
 
-namespace orc_rt {
+namespace orc_rt::sys {
 
-std::string ExecutorProcessInfo::detectTargetTriple() noexcept { return {}; }
+std::string detectTargetTriple() noexcept { return {}; }
 
-} // namespace orc_rt
+} // namespace orc_rt::sys

--- a/orc-rt/test/unit/CMakeLists.txt
+++ b/orc-rt/test/unit/CMakeLists.txt
@@ -67,6 +67,9 @@ add_orc_rt_unittest(CoreTests
   bedrock/sps/SimpleNativeMemoryMapSPSCITest.cpp
   bedrock/sps/SimpleRemoteCATest.cpp
 
+  bedrock/sys/CPUFeaturesTest.cpp
+  bedrock/sys/TargetTripleTest.cpp
+
   tools/OptionParserTest.cpp
 
   DISABLE_LLVM_LINK_LLVM_DYLIB

--- a/orc-rt/test/unit/bedrock/ExecutorProcessInfoTest.cpp
+++ b/orc-rt/test/unit/bedrock/ExecutorProcessInfoTest.cpp
@@ -11,35 +11,12 @@
 //===----------------------------------------------------------------------===//
 
 #include "orc-rt/bedrock/ExecutorProcessInfo.h"
-#include "orc-rt-internal/bedrock/TargetDetails.h"
 #include "orc-rt/support/bit.h"
 #include "gtest/gtest.h"
 
-#include <algorithm>
 #include <unistd.h>
 
 using namespace orc_rt;
-using namespace orc_rt::target_detail;
-
-namespace orc_rt {
-/// Friend of ExecutorProcessInfo; forwards to the private helpers so the
-/// tests below can exercise them without widening the public API.
-struct ExecutorProcessInfoTestAccess {
-  static std::vector<std::string_view> detectTargetCPUFeatures() {
-    return ExecutorProcessInfo::detectTargetCPUFeatures();
-  }
-  static std::string
-  formatCPUFeatures(const std::vector<std::string_view> &Features) {
-    return ExecutorProcessInfo::formatCPUFeatures(Features);
-  }
-  static std::string
-  makeTargetTriple(std::initializer_list<std::string_view> Components) {
-    return ExecutorProcessInfo::makeTargetTriple(Components);
-  }
-};
-} // namespace orc_rt
-
-using TestAccess = orc_rt::ExecutorProcessInfoTestAccess;
 
 TEST(ExecutorProcessInfoTest, DetectSucceeds) {
   auto EPI = ExecutorProcessInfo::Detect();
@@ -62,119 +39,9 @@ TEST(ExecutorProcessInfoTest, DetectPageSizeMatchesSysconf) {
   EXPECT_EQ(EPI.pageSize(), static_cast<size_t>(sysconf(_SC_PAGESIZE)));
 }
 
-TEST(ExecutorProcessInfoTest, DetectTargetTripleNotEmpty) {
-  auto EPI = cantFail(ExecutorProcessInfo::Detect());
-  EXPECT_FALSE(EPI.targetTriple().empty());
-}
-
-TEST(ExecutorProcessInfoTest, DetectTargetTripleHasValidStructure) {
-  auto EPI = cantFail(ExecutorProcessInfo::Detect());
-  // A valid triple has 2 hyphens (arch-vendor-os) or 3 (arch-vendor-os-env).
-  auto NumHyphens =
-      std::count(EPI.targetTriple().begin(), EPI.targetTriple().end(), '-');
-  EXPECT_GE(NumHyphens, 2);
-  EXPECT_LE(NumHyphens, 3);
-}
-
-TEST(ExecutorProcessInfoTest, DetectTargetTripleArchMatchesCompileTarget) {
-  auto EPI = cantFail(ExecutorProcessInfo::Detect());
-#if defined(__arm64e__)
-  EXPECT_EQ(EPI.targetTriple().substr(0, 7), "arm64e-");
-#elif defined(__APPLE__) && (defined(__arm64__) || defined(__aarch64__))
-  EXPECT_EQ(EPI.targetTriple().substr(0, 6), "arm64-");
-#elif defined(__aarch64__) || defined(_M_ARM64)
-  EXPECT_EQ(EPI.targetTriple().substr(0, 8), "aarch64-");
-#elif defined(__x86_64h__)
-  EXPECT_EQ(EPI.targetTriple().substr(0, 8), "x86_64h-");
-#elif defined(__x86_64__) || defined(_M_X64)
-  EXPECT_EQ(EPI.targetTriple().substr(0, 7), "x86_64-");
-#endif
-}
-
-TEST(ExecutorProcessInfoTest, DetectTargetTripleOSMatchesCompileTarget) {
-  auto EPI = cantFail(ExecutorProcessInfo::Detect());
-#if defined(__APPLE__)
-  EXPECT_NE(EPI.targetTriple().find("-apple-"), std::string::npos);
-#elif defined(__linux__)
-  EXPECT_NE(EPI.targetTriple().find("-linux-"), std::string::npos);
-#endif
-}
-
 TEST(ExecutorProcessInfoTest, ConstructWithExplicitValues) {
   ExecutorProcessInfo EPI("x86_64-unknown-linux-gnu", 4096, "+x,+a,+b");
   EXPECT_EQ(EPI.targetTriple(), "x86_64-unknown-linux-gnu");
   EXPECT_EQ(EPI.pageSize(), 4096U);
   EXPECT_EQ(EPI.targetCPUFeatures(), "+x,+a,+b");
-}
-
-TEST(ExecutorProcessInfoTest, FormatEmptyFeatures) {
-  std::vector<std::string_view> V;
-
-  EXPECT_EQ(TestAccess::formatCPUFeatures(V), "");
-}
-
-TEST(ExecutorProcessInfoTest, FormatSingleFeature) {
-  std::vector<std::string_view> V = {feature::x86::avx2};
-
-  EXPECT_EQ(TestAccess::formatCPUFeatures(V), "+avx2");
-}
-
-TEST(ExecutorProcessInfoTest, FormatMultipleFeatures) {
-  std::vector<std::string_view> V = {feature::aarch64::neon,
-                                     feature::aarch64::dotprod,
-                                     feature::aarch64::fullfp16};
-
-  EXPECT_EQ(TestAccess::formatCPUFeatures(V), "+neon,+dotprod,+fullfp16");
-}
-
-TEST(ExecutorProcessInfoTest, DetectDoesNotCrash) {
-  [[maybe_unused]] auto _ = TestAccess::detectTargetCPUFeatures();
-  SUCCEED();
-}
-
-// this test should catch any issues that arise from out of order tests
-// hopefully.
-TEST(ExecutorProcessInfoTest, CachedCPUFeaturesResultIsIdempotent) {
-  EXPECT_EQ(ExecutorProcessInfo::detectCPUFeatures(),
-            ExecutorProcessInfo::detectCPUFeatures());
-}
-
-TEST(ExecutorProcessInfoTest, CachedStringMatchesFormatted) {
-  std::string F =
-      TestAccess::formatCPUFeatures(TestAccess::detectTargetCPUFeatures());
-  std::string C = ExecutorProcessInfo::detectCPUFeatures();
-
-  EXPECT_EQ(F, C);
-}
-
-TEST(ExecutorProcessInfoTest, MakeTargetTripleAllComponents) {
-  EXPECT_EQ(
-      TestAccess::makeTargetTriple({"arm64", "apple", "ios26.0", "macabi"}),
-      "arm64-apple-ios26.0-macabi");
-}
-
-TEST(ExecutorProcessInfoTest, MakeTargetTripleDropsTrailingEmpty) {
-  EXPECT_EQ(TestAccess::makeTargetTriple({"arm64", "apple", "macosx26.1", ""}),
-            "arm64-apple-macosx26.1");
-}
-
-TEST(ExecutorProcessInfoTest, MakeTargetTripleDoubleDashMiddleEmpty) {
-  EXPECT_EQ(TestAccess::makeTargetTriple({"x86_64", "", "linux", "gnu"}),
-            "x86_64--linux-gnu");
-  EXPECT_EQ(TestAccess::makeTargetTriple({"x86_64", "", "linux", ""}),
-            "x86_64--linux");
-}
-
-TEST(ExecutorProcessInfoTest, MakeTargetTripleEmpty) {
-  EXPECT_EQ(TestAccess::makeTargetTriple({}), "");
-}
-
-TEST(ExecutorProcessInfoTest, MakeTargetTripleExtraComponents) {
-  EXPECT_EQ(TestAccess::makeTargetTriple({"a", "b", "c", "d", "e"}),
-            "a-b-c-d-e");
-}
-
-TEST(ExecutorProcessInfoTest, CachedTargetTripleResultIsIdempotent) {
-  EXPECT_EQ(ExecutorProcessInfo::detectTargetTriple(),
-            ExecutorProcessInfo::detectTargetTriple());
 }

--- a/orc-rt/test/unit/bedrock/sys/CPUFeaturesTest.cpp
+++ b/orc-rt/test/unit/bedrock/sys/CPUFeaturesTest.cpp
@@ -1,0 +1,27 @@
+//===- CPUFeaturesTest.cpp ------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Tests for orc-rt's bedrock/sys/CPUFeatures.h APIs.
+//
+//===----------------------------------------------------------------------===//
+
+#include "orc-rt-internal/bedrock/sys/CPUFeatures.h"
+#include "gtest/gtest.h"
+
+using namespace orc_rt;
+
+TEST(CPUFeaturesTest, DetectDoesNotCrash) {
+  [[maybe_unused]] auto _ = sys::detectTargetCPUFeatures();
+  SUCCEED();
+}
+
+// this test should catch any issues that arise from out of order tests
+// hopefully.
+TEST(CPUFeaturesTest, CachedResultIsIdempotent) {
+  EXPECT_EQ(sys::detectTargetCPUFeatures(), sys::detectTargetCPUFeatures());
+}

--- a/orc-rt/test/unit/bedrock/sys/TargetTripleTest.cpp
+++ b/orc-rt/test/unit/bedrock/sys/TargetTripleTest.cpp
@@ -1,0 +1,58 @@
+//===- TargetTripleTest.cpp -----------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Tests for orc-rt's bedrock/sys/TargetTriple.h APIs.
+//
+//===----------------------------------------------------------------------===//
+
+#include "orc-rt-internal/bedrock/sys/TargetTriple.h"
+#include "gtest/gtest.h"
+
+#include <algorithm>
+
+using namespace orc_rt;
+
+TEST(TargetTripleTest, NotEmpty) {
+  EXPECT_FALSE(sys::detectTargetTriple().empty());
+}
+
+TEST(TargetTripleTest, HasValidStructure) {
+  auto Triple = sys::detectTargetTriple();
+  // A valid triple has 2 hyphens (arch-vendor-os) or 3 (arch-vendor-os-env).
+  auto NumHyphens = std::count(Triple.begin(), Triple.end(), '-');
+  EXPECT_GE(NumHyphens, 2);
+  EXPECT_LE(NumHyphens, 3);
+}
+
+TEST(TargetTripleTest, ArchMatchesCompileTarget) {
+  auto Triple = sys::detectTargetTriple();
+#if defined(__arm64e__)
+  EXPECT_EQ(Triple.substr(0, 7), "arm64e-");
+#elif defined(__APPLE__) && (defined(__arm64__) || defined(__aarch64__))
+  EXPECT_EQ(Triple.substr(0, 6), "arm64-");
+#elif defined(__aarch64__) || defined(_M_ARM64)
+  EXPECT_EQ(Triple.substr(0, 8), "aarch64-");
+#elif defined(__x86_64h__)
+  EXPECT_EQ(Triple.substr(0, 8), "x86_64h-");
+#elif defined(__x86_64__) || defined(_M_X64)
+  EXPECT_EQ(Triple.substr(0, 7), "x86_64-");
+#endif
+}
+
+TEST(TargetTripleTest, OSMatchesCompileTarget) {
+  auto Triple = sys::detectTargetTriple();
+#if defined(__APPLE__)
+  EXPECT_NE(Triple.find("-apple-"), std::string::npos);
+#elif defined(__linux__)
+  EXPECT_NE(Triple.find("-linux-"), std::string::npos);
+#endif
+}
+
+TEST(TargetTripleTest, CachedResultIsIdempotent) {
+  EXPECT_EQ(sys::detectTargetTriple(), sys::detectTargetTriple());
+}


### PR DESCRIPTION
ExecutorProcessInfo was part generic, part system-specific: some of its methods were implemented directly in its own .cpp, others only existed as out-of-line definitions in per-OS files under lib/bedrock/sys/.

Move the system-specific pieces into free functions under orc_rt::sys (mirroring the existing support/sys/ convention), and have ExecutorProcessInfo consume them like any other client. The class itself is now fully generic, with no system-specific code of its own.

No functional change, except that page-size detection (previously hardcoded to POSIX sysconf) now goes through the same per-OS split as the rest of ExecutorProcessInfo; a Windows implementation is left for a follow-up.