### PR TITLE
Reapply "[SimplifyCFG] Fix profcheck failure from #213302" (#220932)

### DIFF
--- a/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -5158,7 +5158,11 @@ bool SimplifyCFGOpt::simplifySwitchOnSelectRemap(SwitchInst *SI,
       setFittedBranchWeights(*SI, NewSwitchWeights, /*IsExpected=*/false);
     } else if (SwitchHasBranchWeights) {
       // If we only have branch weights on the switch, we cannot reconstruct
-      // branch weights correctly, so mark them as unknown.
+      // branch weights correctly, so mark them as unknown if the function has
+      // a profile count. Reset the branch weights first to ensure we remove
+      // the now invalid branch weights if the function is not otherwise
+      // profiled.
+      SI->setMetadata(LLVMContext::MD_prof, nullptr);
       setExplicitlyUnknownBranchWeightsIfProfiled(*SI, DEBUG_TYPE);
     }
   }

--- a/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -5098,8 +5098,6 @@ bool SimplifyCFGOpt::simplifySwitchOnSelectRemap(SwitchInst *SI,
   BasicBlock *BB = SI->getParent();
 
   if (OldDest != DestFork) {
-    // Case list is changing so we should drop stale profile weights.
-    SI->setMetadata(LLVMContext::MD_prof, nullptr);
     if (!IsDefault)
       OldDest->removePredecessor(BB);
     if (IsDefault)
@@ -5116,6 +5114,35 @@ bool SimplifyCFGOpt::simplifySwitchOnSelectRemap(SwitchInst *SI,
           successors(SI), [&](BasicBlock *Succ) { return Succ == OldDest; });
       if (DTU && !OldDestStillTargeted)
         DTU->applyUpdates({{DominatorTree::Delete, BB, OldDest}});
+    }
+
+    // Update the profile information on the switch if we had a profile
+    // for both it and the select instruction. We only need to do this
+    // in the case where we add a case to the switch.
+    if (IsDefault) {
+      SmallVector<uint32_t> SwitchWeights;
+      bool SwitchHasBranchWeights = extractBranchWeights(*SI, SwitchWeights);
+      SmallVector<uint32_t> SelectWeights;
+      bool SelectHasBranchWeights =
+          extractBranchWeights(*Select, SelectWeights);
+      if (SwitchHasBranchWeights && SelectHasBranchWeights &&
+          !ProfcheckDisableMetadataFixes) {
+        // Update the branch weights of the switch by multiplying all of them by
+        // the weight of the false branch of the select. Then add the new switch
+        // case at the end by multiplying the weight of the true branch of the
+        // select by the total weight of the switch.
+        uint64_t SwitchTotalWeight = sum_of(SwitchWeights, uint64_t{0});
+        SmallVector<uint64_t> NewSwitchWeights;
+        NewSwitchWeights.reserve(SwitchWeights.size() + 1);
+        for (uint32_t SwitchWeight : SwitchWeights)
+          NewSwitchWeights.push_back(SwitchWeight * SelectWeights[1]);
+        NewSwitchWeights.push_back(SwitchTotalWeight * SelectWeights[0]);
+        setFittedBranchWeights(*SI, NewSwitchWeights, false);
+      } else if (SwitchHasBranchWeights) {
+        // If we only have branch weights on the switch, we cannot reconstruct
+        // branch weights correctly, so mark them as unknown.
+        setExplicitlyUnknownBranchWeightsIfProfiled(*SI, DEBUG_TYPE);
+      }
     }
   }
 

--- a/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -5126,6 +5126,8 @@ bool SimplifyCFGOpt::simplifySwitchOnSelectRemap(SwitchInst *SI,
       uint64_t SelectFalseWeight;
       bool SelectHasBranchWeights =
           extractBranchWeights(*Select, SelectTrueWeight, SelectFalseWeight);
+      if (Negate)
+        std::swap(SelectTrueWeight, SelectFalseWeight);
       if (SwitchHasBranchWeights && SelectHasBranchWeights &&
           !ProfcheckDisableMetadataFixes) {
         // Update the branch weights of the switch by multiplying all of them by

--- a/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -5117,35 +5117,49 @@ bool SimplifyCFGOpt::simplifySwitchOnSelectRemap(SwitchInst *SI,
     }
 
     // Update the profile information on the switch if we had a profile
-    // for both it and the select instruction. We only need to do this
-    // in the case where we add a case to the switch.
-    if (IsDefault) {
-      SmallVector<uint32_t> SwitchWeights;
-      bool SwitchHasBranchWeights = extractBranchWeights(*SI, SwitchWeights);
-      uint64_t SelectTrueWeight;
-      uint64_t SelectFalseWeight;
-      bool SelectHasBranchWeights =
-          extractBranchWeights(*Select, SelectTrueWeight, SelectFalseWeight);
-      if (Negate)
-        std::swap(SelectTrueWeight, SelectFalseWeight);
-      if (SwitchHasBranchWeights && SelectHasBranchWeights &&
-          !ProfcheckDisableMetadataFixes) {
+    // for both it and the select instruction.
+    SmallVector<uint32_t> SwitchWeights;
+    bool SwitchHasBranchWeights = extractBranchWeights(*SI, SwitchWeights);
+    uint64_t SelectTrueWeight;
+    uint64_t SelectFalseWeight;
+    bool SelectHasBranchWeights =
+        extractBranchWeights(*Select, SelectTrueWeight, SelectFalseWeight);
+    if (Negate)
+      std::swap(SelectTrueWeight, SelectFalseWeight);
+    if (SwitchHasBranchWeights && SelectHasBranchWeights &&
+        !ProfcheckDisableMetadataFixes) {
+      uint64_t SwitchTotalWeight = sum_of(SwitchWeights, uint64_t{0});
+      SmallVector<uint64_t> NewSwitchWeights;
+      if (IsDefault) {
         // Update the branch weights of the switch by multiplying all of them by
         // the weight of the false branch of the select. Then add the new switch
         // case at the end by multiplying the weight of the true branch of the
         // select by the total weight of the switch.
-        uint64_t SwitchTotalWeight = sum_of(SwitchWeights, uint64_t{0});
-        SmallVector<uint64_t> NewSwitchWeights;
         NewSwitchWeights.reserve(SwitchWeights.size() + 1);
         for (uint32_t SwitchWeight : SwitchWeights)
           NewSwitchWeights.push_back(SwitchWeight * SelectFalseWeight);
         NewSwitchWeights.push_back(SwitchTotalWeight * SelectTrueWeight);
-        setFittedBranchWeights(*SI, NewSwitchWeights, /*IsExpected=*/false);
-      } else if (SwitchHasBranchWeights) {
-        // If we only have branch weights on the switch, we cannot reconstruct
-        // branch weights correctly, so mark them as unknown.
-        setExplicitlyUnknownBranchWeightsIfProfiled(*SI, DEBUG_TYPE);
+      } else {
+        // Similar scaling as the above, except we scale the existing switch
+        // entry for the comparison constant by the true weight of the select.
+        // We have to treat the default case (the first entry in the weights
+        // array specially) as it does not have a case value.
+        NewSwitchWeights.reserve(SwitchWeights.size());
+        NewSwitchWeights.push_back(SwitchWeights[0] * SelectFalseWeight);
+        for (const auto &[SwitchCase, SwitchWeight] :
+             zip(SI->cases(), drop_begin(SwitchWeights))) {
+          if (SwitchCase.getCaseValue() == C) {
+            NewSwitchWeights.push_back(SwitchTotalWeight * SelectTrueWeight);
+          } else {
+            NewSwitchWeights.push_back(SwitchWeight * SelectFalseWeight);
+          }
+        }
       }
+      setFittedBranchWeights(*SI, NewSwitchWeights, /*IsExpected=*/false);
+    } else if (SwitchHasBranchWeights) {
+      // If we only have branch weights on the switch, we cannot reconstruct
+      // branch weights correctly, so mark them as unknown.
+      setExplicitlyUnknownBranchWeightsIfProfiled(*SI, DEBUG_TYPE);
     }
   }
 

--- a/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -5122,9 +5122,10 @@ bool SimplifyCFGOpt::simplifySwitchOnSelectRemap(SwitchInst *SI,
     if (IsDefault) {
       SmallVector<uint32_t> SwitchWeights;
       bool SwitchHasBranchWeights = extractBranchWeights(*SI, SwitchWeights);
-      SmallVector<uint32_t> SelectWeights;
+      uint64_t SelectTrueWeight;
+      uint64_t SelectFalseWeight;
       bool SelectHasBranchWeights =
-          extractBranchWeights(*Select, SelectWeights);
+          extractBranchWeights(*Select, SelectTrueWeight, SelectFalseWeight);
       if (SwitchHasBranchWeights && SelectHasBranchWeights &&
           !ProfcheckDisableMetadataFixes) {
         // Update the branch weights of the switch by multiplying all of them by
@@ -5135,9 +5136,9 @@ bool SimplifyCFGOpt::simplifySwitchOnSelectRemap(SwitchInst *SI,
         SmallVector<uint64_t> NewSwitchWeights;
         NewSwitchWeights.reserve(SwitchWeights.size() + 1);
         for (uint32_t SwitchWeight : SwitchWeights)
-          NewSwitchWeights.push_back(SwitchWeight * SelectWeights[1]);
-        NewSwitchWeights.push_back(SwitchTotalWeight * SelectWeights[0]);
-        setFittedBranchWeights(*SI, NewSwitchWeights, false);
+          NewSwitchWeights.push_back(SwitchWeight * SelectFalseWeight);
+        NewSwitchWeights.push_back(SwitchTotalWeight * SelectTrueWeight);
+        setFittedBranchWeights(*SI, NewSwitchWeights, /*IsExpected=*/false);
       } else if (SwitchHasBranchWeights) {
         // If we only have branch weights on the switch, we cannot reconstruct
         // branch weights correctly, so mark them as unknown.

--- a/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -5120,39 +5120,32 @@ bool SimplifyCFGOpt::simplifySwitchOnSelectRemap(SwitchInst *SI,
     // for both it and the select instruction.
     SmallVector<uint32_t> SwitchWeights;
     bool SwitchHasBranchWeights = extractBranchWeights(*SI, SwitchWeights);
+    if (IsDefault)
+      SwitchWeights.push_back(0);
     uint64_t SelectTrueWeight;
     uint64_t SelectFalseWeight;
     bool SelectHasBranchWeights =
         extractBranchWeights(*Select, SelectTrueWeight, SelectFalseWeight);
+    uint64_t SelectTotalWeight = SelectTrueWeight + SelectFalseWeight;
     if (Negate)
       std::swap(SelectTrueWeight, SelectFalseWeight);
     if (SwitchHasBranchWeights && SelectHasBranchWeights &&
         !ProfcheckDisableMetadataFixes) {
       uint64_t SwitchTotalWeight = sum_of(SwitchWeights, uint64_t{0});
       SmallVector<uint64_t> NewSwitchWeights;
-      if (IsDefault) {
-        // Update the branch weights of the switch by multiplying all of them by
-        // the weight of the false branch of the select. Then add the new switch
-        // case at the end by multiplying the weight of the true branch of the
-        // select by the total weight of the switch.
-        NewSwitchWeights.reserve(SwitchWeights.size() + 1);
-        for (uint32_t SwitchWeight : SwitchWeights)
-          NewSwitchWeights.push_back(SwitchWeight * SelectFalseWeight);
-        NewSwitchWeights.push_back(SwitchTotalWeight * SelectTrueWeight);
-      } else {
-        // Similar scaling as the above, except we scale the existing switch
-        // entry for the comparison constant by the true weight of the select.
-        // We have to treat the default case (the first entry in the weights
-        // array specially) as it does not have a case value.
-        NewSwitchWeights.reserve(SwitchWeights.size());
-        NewSwitchWeights.push_back(SwitchWeights[0] * SelectFalseWeight);
-        for (const auto &[SwitchCase, SwitchWeight] :
-             zip(SI->cases(), drop_begin(SwitchWeights))) {
-          if (SwitchCase.getCaseValue() == C) {
-            NewSwitchWeights.push_back(SwitchTotalWeight * SelectTrueWeight);
-          } else {
-            NewSwitchWeights.push_back(SwitchWeight * SelectFalseWeight);
-          }
+      NewSwitchWeights.reserve(SwitchWeights.size() + IsDefault);
+      NewSwitchWeights.push_back(SwitchWeights[0] * SelectTotalWeight);
+      for (const auto &[SwitchCase, SwitchWeight] :
+            zip(SI->cases(), drop_begin(SwitchWeights))) {
+        if (SwitchCase.getCaseValue() == C) {
+          NewSwitchWeights.push_back(SwitchTotalWeight * SelectTrueWeight);
+        } else if (SwitchCase.getCaseValue() == K) {
+          // TODO(boomanaiden154): Check if this would be negative to prevent
+          // underflow.
+          NewSwitchWeights.push_back(SwitchWeight * SelectTotalWeight -
+                                      SelectTrueWeight * SwitchTotalWeight);
+        } else {
+          NewSwitchWeights.push_back(SwitchWeight * SelectTotalWeight);
         }
       }
       setFittedBranchWeights(*SI, NewSwitchWeights, /*IsExpected=*/false);

--- a/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -5140,7 +5140,7 @@ bool SimplifyCFGOpt::simplifySwitchOnSelectRemap(SwitchInst *SI,
       // denominator.
       uint64_t SwitchTotalWeight = sum_of(SwitchWeights, uint64_t{0});
       SmallVector<uint64_t> NewSwitchWeights;
-      NewSwitchWeights.reserve(SwitchWeights.size() + IsDefault);
+      NewSwitchWeights.reserve(SwitchWeights.size());
       NewSwitchWeights.push_back(SwitchWeights[0] * SelectTotalWeight);
       for (const auto &[SwitchCase, SwitchWeight] :
            zip(SI->cases(), drop_begin(SwitchWeights))) {

--- a/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -5120,6 +5120,8 @@ bool SimplifyCFGOpt::simplifySwitchOnSelectRemap(SwitchInst *SI,
     // for both it and the select instruction.
     SmallVector<uint32_t> SwitchWeights;
     bool SwitchHasBranchWeights = extractBranchWeights(*SI, SwitchWeights);
+    // If we add a case, ensure the length of the branch weights list matches
+    // to make iterating over them easier later.
     if (IsDefault)
       SwitchWeights.push_back(0);
     uint64_t SelectTrueWeight;
@@ -5131,19 +5133,30 @@ bool SimplifyCFGOpt::simplifySwitchOnSelectRemap(SwitchInst *SI,
       std::swap(SelectTrueWeight, SelectFalseWeight);
     if (SwitchHasBranchWeights && SelectHasBranchWeights &&
         !ProfcheckDisableMetadataFixes) {
+      // We update the branch weights by subtracting P(x=C) from the probability
+      // of case K in the switch (what C redirect to before the transformation),
+      // plugging the probability for case C into the switch (which we derive
+      // from the select), and ensuring everything is scaled to have a common
+      // denominator.
       uint64_t SwitchTotalWeight = sum_of(SwitchWeights, uint64_t{0});
       SmallVector<uint64_t> NewSwitchWeights;
       NewSwitchWeights.reserve(SwitchWeights.size() + IsDefault);
       NewSwitchWeights.push_back(SwitchWeights[0] * SelectTotalWeight);
       for (const auto &[SwitchCase, SwitchWeight] :
-            zip(SI->cases(), drop_begin(SwitchWeights))) {
+           zip(SI->cases(), drop_begin(SwitchWeights))) {
         if (SwitchCase.getCaseValue() == C) {
           NewSwitchWeights.push_back(SwitchTotalWeight * SelectTrueWeight);
         } else if (SwitchCase.getCaseValue() == K) {
-          // TODO(boomanaiden154): Check if this would be negative to prevent
-          // underflow.
-          NewSwitchWeights.push_back(SwitchWeight * SelectTotalWeight -
-                                      SelectTrueWeight * SwitchTotalWeight);
+          // In reality, P(key=K) > P(x=C) should always hold, but explicitly
+          // guard against bad profiles here to prevent underflow by saturating
+          // to zero.
+          uint64_t ProbabilityKeyEqualsK = SwitchWeight * SelectTotalWeight;
+          uint64_t ProbabilityXEqualsC = SelectTrueWeight * SwitchTotalWeight;
+          uint64_t ProbabilityXEqualsK =
+              ProbabilityKeyEqualsK > ProbabilityXEqualsC
+                  ? ProbabilityKeyEqualsK - ProbabilityXEqualsC
+                  : 0;
+          NewSwitchWeights.push_back(ProbabilityXEqualsK);
         } else {
           NewSwitchWeights.push_back(SwitchWeight * SelectTotalWeight);
         }

--- a/llvm/test/Transforms/SimplifyCFG/switch-select-remap.ll
+++ b/llvm/test/Transforms/SimplifyCFG/switch-select-remap.ll
@@ -4,14 +4,50 @@
 ; The compared value 4 has no explicit case, and the remapped value 6 maps to
 ; a real (non-default) case, so switching on %x needs a new explicit case for
 ; 4 pointing to bb2.
-define void @test_remap_add_case(i8 %x) {
+define void @test_remap_add_case(i8 %x) !prof !0 {
 ; CHECK-LABEL: define void @test_remap_add_case(
-; CHECK-SAME: i8 [[X:%.*]]) {
+; CHECK-SAME: i8 [[X:%.*]]) !prof [[PROF0:![0-9]+]] {
 ; CHECK-NEXT:    switch i8 [[X]], label %[[BB1:.*]] [
 ; CHECK-NEXT:      i8 6, label %[[BB2:.*]]
 ; CHECK-NEXT:      i8 10, label %[[BB3:.*]]
 ; CHECK-NEXT:      i8 4, label %[[BB2]]
-; CHECK-NEXT:    ]
+; CHECK-NEXT:    ], !prof [[PROF1:![0-9]+]]
+; CHECK:       [[BB1]]:
+; CHECK-NEXT:    call void @func1()
+; CHECK-NEXT:    unreachable
+; CHECK:       [[BB2]]:
+; CHECK-NEXT:    call void @func2()
+; CHECK-NEXT:    unreachable
+; CHECK:       [[BB3]]:
+; CHECK-NEXT:    call void @func3()
+; CHECK-NEXT:    unreachable
+;
+  %cmp = icmp eq i8 %x, 4
+  %key = select i1 %cmp, i8 6, i8 %x, !prof !1
+  switch i8 %key, label %bb1 [
+  i8 6, label %bb2
+  i8 10, label %bb3
+  ], !prof !2
+
+bb1:
+  call void @func1()
+  unreachable
+bb2:
+  call void @func2()
+  unreachable
+bb3:
+  call void @func3()
+  unreachable
+}
+
+define void @test_remap_only_switch_profile(i8 %x) !prof !0 {
+; CHECK-LABEL: define void @test_remap_only_switch_profile(
+; CHECK-SAME: i8 [[X:%.*]]) !prof [[PROF0]] {
+; CHECK-NEXT:    switch i8 [[X]], label %[[BB1:.*]] [
+; CHECK-NEXT:      i8 6, label %[[BB2:.*]]
+; CHECK-NEXT:      i8 10, label %[[BB3:.*]]
+; CHECK-NEXT:      i8 4, label %[[BB2]]
+; CHECK-NEXT:    ], !prof [[PROF2:![0-9]+]]
 ; CHECK:       [[BB1]]:
 ; CHECK-NEXT:    call void @func1()
 ; CHECK-NEXT:    unreachable
@@ -27,7 +63,7 @@ define void @test_remap_add_case(i8 %x) {
   switch i8 %key, label %bb1 [
   i8 6, label %bb2
   i8 10, label %bb3
-  ]
+  ], !prof !2
 
 bb1:
   call void @func1()
@@ -47,14 +83,14 @@ bb3:
 ; body are removed in the same run: this pass edits the CFG through a
 ; DomTreeUpdater, so a follow-up SimplifyCFG iteration cleans it up
 ; immediately instead of needing a separate pass.
-define void @test_remap_retarget_case(i8 %x) {
+define void @test_remap_retarget_case(i8 %x) !prof !0 {
 ; CHECK-LABEL: define void @test_remap_retarget_case(
-; CHECK-SAME: i8 [[X:%.*]]) {
+; CHECK-SAME: i8 [[X:%.*]]) !prof [[PROF0]] {
 ; CHECK-NEXT:    switch i8 [[X]], label %[[BB1:.*]] [
 ; CHECK-NEXT:      i8 4, label %[[BB2:.*]]
 ; CHECK-NEXT:      i8 6, label %[[BB2]]
 ; CHECK-NEXT:      i8 10, label %[[BB3:.*]]
-; CHECK-NEXT:    ]
+; CHECK-NEXT:    ], !prof [[PROF3:![0-9]+]]
 ; CHECK:       [[BB1]]:
 ; CHECK-NEXT:    call void @func1()
 ; CHECK-NEXT:    unreachable
@@ -66,12 +102,12 @@ define void @test_remap_retarget_case(i8 %x) {
 ; CHECK-NEXT:    unreachable
 ;
   %cmp = icmp eq i8 %x, 4
-  %key = select i1 %cmp, i8 6, i8 %x
+  %key = select i1 %cmp, i8 6, i8 %x, !prof !1
   switch i8 %key, label %bb1 [
   i8 4, label %bb4
   i8 6, label %bb2
   i8 10, label %bb3
-  ]
+  ], !prof !3
 
 bb1:
   call void @func1()
@@ -295,45 +331,6 @@ default:
   unreachable
 }
 
-; The fold changes the case list (a case may be added, or retargeted to a
-; different successor), so any existing branch-weight metadata would
-; mislabel the new layout - it must be dropped rather than kept stale.
-define void @test_remap_drops_branch_weights(i8 %x) {
-; CHECK-LABEL: define void @test_remap_drops_branch_weights(
-; CHECK-SAME: i8 [[X:%.*]]) {
-; CHECK-NEXT:    switch i8 [[X]], label %[[BB1:.*]] [
-; CHECK-NEXT:      i8 6, label %[[BB2:.*]]
-; CHECK-NEXT:      i8 10, label %[[BB3:.*]]
-; CHECK-NEXT:      i8 4, label %[[BB2]]
-; CHECK-NEXT:    ]
-; CHECK:       [[BB1]]:
-; CHECK-NEXT:    call void @func1()
-; CHECK-NEXT:    unreachable
-; CHECK:       [[BB2]]:
-; CHECK-NEXT:    call void @func2()
-; CHECK-NEXT:    unreachable
-; CHECK:       [[BB3]]:
-; CHECK-NEXT:    call void @func3()
-; CHECK-NEXT:    unreachable
-;
-  %cmp = icmp eq i8 %x, 4
-  %key = select i1 %cmp, i8 6, i8 %x
-  switch i8 %key, label %bb1 [
-  i8 6, label %bb2
-  i8 10, label %bb3
-  ], !prof !0
-
-bb1:
-  call void @func1()
-  unreachable
-bb2:
-  call void @func2()
-  unreachable
-bb3:
-  call void @func3()
-  unreachable
-}
-
 ; Negative test: %key (the select) is used by more than just the switch, so
 ; folding it away wouldn't actually remove the compare/select sequence -
 ; leave it alone.
@@ -464,4 +461,13 @@ declare void @func3()
 declare void @func4()
 declare void @use(i32)
 
-!0 = !{!"branch_weights", i32 1, i32 2, i32 3}
+!0 = !{!"function_entry_count", i32 10}
+!1 = !{!"branch_weights", i32 2, i32 3}
+!2 = !{!"branch_weights", i32 5, i32 7, i32 11}
+!3 = !{!"branch_weights", i32 5, i32 7, i32 11, i32 13}
+;.
+; CHECK: [[PROF0]] = !{!"function_entry_count", i32 10}
+; CHECK: [[PROF1]] = !{!"branch_weights", i32 15, i32 21, i32 33, i32 46}
+; CHECK: [[PROF2]] = !{!"unknown", !"simplifycfg"}
+; CHECK: [[PROF3]] = !{!"branch_weights", i32 5, i32 7, i32 11, i32 13}
+;.

--- a/llvm/test/Transforms/SimplifyCFG/switch-select-remap.ll
+++ b/llvm/test/Transforms/SimplifyCFG/switch-select-remap.ll
@@ -76,6 +76,42 @@ bb3:
   unreachable
 }
 
+define void @test_remap_only_switch_profile_unprofiled_function(i8 %x) {
+; CHECK-LABEL: define void @test_remap_only_switch_profile_unprofiled_function(
+; CHECK-SAME: i8 [[X:%.*]]) {
+; CHECK-NEXT:    switch i8 [[X]], label %[[BB1:.*]] [
+; CHECK-NEXT:      i8 6, label %[[BB2:.*]]
+; CHECK-NEXT:      i8 10, label %[[BB3:.*]]
+; CHECK-NEXT:      i8 4, label %[[BB2]]
+; CHECK-NEXT:    ]
+; CHECK:       [[BB1]]:
+; CHECK-NEXT:    call void @func1()
+; CHECK-NEXT:    unreachable
+; CHECK:       [[BB2]]:
+; CHECK-NEXT:    call void @func2()
+; CHECK-NEXT:    unreachable
+; CHECK:       [[BB3]]:
+; CHECK-NEXT:    call void @func3()
+; CHECK-NEXT:    unreachable
+;
+  %cmp = icmp eq i8 %x, 4
+  %key = select i1 %cmp, i8 6, i8 %x
+  switch i8 %key, label %bb1 [
+  i8 6, label %bb2
+  i8 10, label %bb3
+  ], !prof !2
+
+bb1:
+  call void @func1()
+  unreachable
+bb2:
+  call void @func2()
+  unreachable
+bb3:
+  call void @func3()
+  unreachable
+}
+
 ; The value 4 already has an explicit case pointing to bb4, but %key can never
 ; actually be 4 (it's remapped to 6 whenever %x is 4), so that case is really
 ; dead and should be retargeted to wherever the remapped value 6 dispatches to

--- a/llvm/test/Transforms/SimplifyCFG/switch-select-remap.ll
+++ b/llvm/test/Transforms/SimplifyCFG/switch-select-remap.ll
@@ -464,11 +464,11 @@ declare void @use(i32)
 !0 = !{!"function_entry_count", i32 10}
 !1 = !{!"branch_weights", i32 2, i32 3}
 !2 = !{!"branch_weights", i32 5, i32 7, i32 11}
-!3 = !{!"branch_weights", i32 5, i32 7, i32 11, i32 13}
+!3 = !{!"branch_weights", i32 5, i32 0, i32 11, i32 13}
 ;.
 ; CHECK: [[PROF0]] = !{!"function_entry_count", i32 10}
 ; CHECK: [[PROF1]] = !{!"branch_weights", i32 15, i32 21, i32 33, i32 46}
 ; CHECK: [[PROF2]] = !{!"unknown", !"simplifycfg"}
-; CHECK: [[PROF3]] = !{!"branch_weights", i32 5, i32 7, i32 11, i32 13}
+; CHECK: [[PROF3]] = !{!"branch_weights", i32 15, i32 58, i32 33, i32 39}
 ; CHECK: [[PROF4]] = !{!"branch_weights", i32 10, i32 14, i32 22, i32 69}
 ;.

--- a/llvm/test/Transforms/SimplifyCFG/switch-select-remap.ll
+++ b/llvm/test/Transforms/SimplifyCFG/switch-select-remap.ll
@@ -126,14 +126,14 @@ bb4:
 ; Same remap expressed with icmp ne / select(cond, %x, 6). The remapped value 6
 ; maps to a real (non-default) case, so switching on %x needs a new explicit
 ; case for 4 pointing to bb2, same as test_remap_add_case but via the NE arm.
-define void @test_remap_ne_add_case(i8 %x) {
+define void @test_remap_ne_add_case(i8 %x) !prof !0 {
 ; CHECK-LABEL: define void @test_remap_ne_add_case(
-; CHECK-SAME: i8 [[X:%.*]]) {
+; CHECK-SAME: i8 [[X:%.*]]) !prof [[PROF0]] {
 ; CHECK-NEXT:    switch i8 [[X]], label %[[BB1:.*]] [
 ; CHECK-NEXT:      i8 6, label %[[BB2:.*]]
 ; CHECK-NEXT:      i8 10, label %[[BB3:.*]]
 ; CHECK-NEXT:      i8 4, label %[[BB2]]
-; CHECK-NEXT:    ]
+; CHECK-NEXT:    ], !prof [[PROF4:![0-9]+]]
 ; CHECK:       [[BB1]]:
 ; CHECK-NEXT:    call void @func1()
 ; CHECK-NEXT:    unreachable
@@ -145,11 +145,11 @@ define void @test_remap_ne_add_case(i8 %x) {
 ; CHECK-NEXT:    unreachable
 ;
   %cmp = icmp ne i8 %x, 4
-  %key = select i1 %cmp, i8 %x, i8 6
+  %key = select i1 %cmp, i8 %x, i8 6, !prof !1
   switch i8 %key, label %bb1 [
   i8 6, label %bb2
   i8 10, label %bb3
-  ]
+  ], !prof !2
 
 bb1:
   call void @func1()
@@ -470,4 +470,5 @@ declare void @use(i32)
 ; CHECK: [[PROF1]] = !{!"branch_weights", i32 15, i32 21, i32 33, i32 46}
 ; CHECK: [[PROF2]] = !{!"unknown", !"simplifycfg"}
 ; CHECK: [[PROF3]] = !{!"branch_weights", i32 5, i32 7, i32 11, i32 13}
+; CHECK: [[PROF4]] = !{!"branch_weights", i32 10, i32 14, i32 22, i32 69}
 ;.

--- a/llvm/test/Transforms/SimplifyCFG/switch-select-remap.ll
+++ b/llvm/test/Transforms/SimplifyCFG/switch-select-remap.ll
@@ -169,7 +169,7 @@ define void @test_remap_ne_add_case(i8 %x) !prof !0 {
 ; CHECK-NEXT:      i8 6, label %[[BB2:.*]]
 ; CHECK-NEXT:      i8 10, label %[[BB3:.*]]
 ; CHECK-NEXT:      i8 4, label %[[BB2]]
-; CHECK-NEXT:    ], !prof [[PROF4:![0-9]+]]
+; CHECK-NEXT:    ], !prof [[PROF1]]
 ; CHECK:       [[BB1]]:
 ; CHECK-NEXT:    call void @func1()
 ; CHECK-NEXT:    unreachable
@@ -181,7 +181,7 @@ define void @test_remap_ne_add_case(i8 %x) !prof !0 {
 ; CHECK-NEXT:    unreachable
 ;
   %cmp = icmp ne i8 %x, 4
-  %key = select i1 %cmp, i8 %x, i8 6, !prof !1
+  %key = select i1 %cmp, i8 %x, i8 6, !prof !4
   switch i8 %key, label %bb1 [
   i8 6, label %bb2
   i8 10, label %bb3
@@ -295,13 +295,13 @@ bb4:
 ; K (the remapped-to value) has no explicit case of its own, so it already
 ; dispatches to the default destination - same as the (also absent) compared
 ; value C would. %x can be switched on directly with no case-list change.
-define void @test_remap_k_default_add(i8 %x) {
+define void @test_remap_k_default_add(i8 %x) !prof !0 {
 ; CHECK-LABEL: define void @test_remap_k_default_add(
-; CHECK-SAME: i8 [[X:%.*]]) {
+; CHECK-SAME: i8 [[X:%.*]]) !prof [[PROF0]] {
 ; CHECK-NEXT:    switch i8 [[X]], label %[[DEFAULT:.*]] [
 ; CHECK-NEXT:      i8 1, label %[[BB1:.*]]
 ; CHECK-NEXT:      i8 2, label %[[BB2:.*]]
-; CHECK-NEXT:    ]
+; CHECK-NEXT:    ], !prof [[PROF4:![0-9]+]]
 ; CHECK:       [[BB1]]:
 ; CHECK-NEXT:    call void @func1()
 ; CHECK-NEXT:    unreachable
@@ -313,11 +313,11 @@ define void @test_remap_k_default_add(i8 %x) {
 ; CHECK-NEXT:    unreachable
 ;
   %cmp = icmp eq i8 %x, 4
-  %key = select i1 %cmp, i8 6, i8 %x
+  %key = select i1 %cmp, i8 6, i8 %x, !prof !1
   switch i8 %key, label %default [
   i8 1, label %bb1
   i8 2, label %bb2
-  ]
+  ], !prof !2
 
 bb1:
   call void @func1()
@@ -499,12 +499,13 @@ declare void @use(i32)
 
 !0 = !{!"function_entry_count", i32 10}
 !1 = !{!"branch_weights", i32 2, i32 3}
-!2 = !{!"branch_weights", i32 5, i32 7, i32 11}
-!3 = !{!"branch_weights", i32 5, i32 0, i32 11, i32 13}
+!2 = !{!"branch_weights", i32 5, i32 11, i32 7}
+!3 = !{!"branch_weights", i32 5, i32 0, i32 11, i32 7}
+!4 = !{!"branch_weights", i32 3, i32 2}
 ;.
 ; CHECK: [[PROF0]] = !{!"function_entry_count", i32 10}
-; CHECK: [[PROF1]] = !{!"branch_weights", i32 15, i32 21, i32 33, i32 46}
+; CHECK: [[PROF1]] = !{!"branch_weights", i32 25, i32 9, i32 35, i32 46}
 ; CHECK: [[PROF2]] = !{!"unknown", !"simplifycfg"}
-; CHECK: [[PROF3]] = !{!"branch_weights", i32 15, i32 58, i32 33, i32 39}
-; CHECK: [[PROF4]] = !{!"branch_weights", i32 10, i32 14, i32 22, i32 69}
+; CHECK: [[PROF3]] = !{!"branch_weights", i32 15, i32 46, i32 9, i32 35}
+; CHECK: [[PROF4]] = !{!"branch_weights", i32 5, i32 11, i32 7}
 ;.

--- a/llvm/test/Transforms/SimplifyCFG/switch-select-remap.ll
+++ b/llvm/test/Transforms/SimplifyCFG/switch-select-remap.ll
@@ -40,6 +40,42 @@ bb3:
   unreachable
 }
 
+define void @test_remap_profile_undeflow(i8 %x) !prof !0 {
+; CHECK-LABEL: define void @test_remap_profile_undeflow(
+; CHECK-SAME: i8 [[X:%.*]]) !prof [[PROF0]] {
+; CHECK-NEXT:    switch i8 [[X]], label %[[BB1:.*]] [
+; CHECK-NEXT:      i8 6, label %[[BB2:.*]]
+; CHECK-NEXT:      i8 10, label %[[BB3:.*]]
+; CHECK-NEXT:      i8 4, label %[[BB2]]
+; CHECK-NEXT:    ], !prof [[PROF2:![0-9]+]]
+; CHECK:       [[BB1]]:
+; CHECK-NEXT:    call void @func1()
+; CHECK-NEXT:    unreachable
+; CHECK:       [[BB2]]:
+; CHECK-NEXT:    call void @func2()
+; CHECK-NEXT:    unreachable
+; CHECK:       [[BB3]]:
+; CHECK-NEXT:    call void @func3()
+; CHECK-NEXT:    unreachable
+;
+  %cmp = icmp eq i8 %x, 4
+  %key = select i1 %cmp, i8 6, i8 %x, !prof !1
+  switch i8 %key, label %bb1 [
+  i8 6, label %bb2
+  i8 10, label %bb3
+  ], !prof !5
+
+bb1:
+  call void @func1()
+  unreachable
+bb2:
+  call void @func2()
+  unreachable
+bb3:
+  call void @func3()
+  unreachable
+}
+
 define void @test_remap_only_switch_profile(i8 %x) !prof !0 {
 ; CHECK-LABEL: define void @test_remap_only_switch_profile(
 ; CHECK-SAME: i8 [[X:%.*]]) !prof [[PROF0]] {
@@ -47,7 +83,7 @@ define void @test_remap_only_switch_profile(i8 %x) !prof !0 {
 ; CHECK-NEXT:      i8 6, label %[[BB2:.*]]
 ; CHECK-NEXT:      i8 10, label %[[BB3:.*]]
 ; CHECK-NEXT:      i8 4, label %[[BB2]]
-; CHECK-NEXT:    ], !prof [[PROF2:![0-9]+]]
+; CHECK-NEXT:    ], !prof [[PROF3:![0-9]+]]
 ; CHECK:       [[BB1]]:
 ; CHECK-NEXT:    call void @func1()
 ; CHECK-NEXT:    unreachable
@@ -126,7 +162,7 @@ define void @test_remap_retarget_case(i8 %x) !prof !0 {
 ; CHECK-NEXT:      i8 4, label %[[BB2:.*]]
 ; CHECK-NEXT:      i8 6, label %[[BB2]]
 ; CHECK-NEXT:      i8 10, label %[[BB3:.*]]
-; CHECK-NEXT:    ], !prof [[PROF3:![0-9]+]]
+; CHECK-NEXT:    ], !prof [[PROF4:![0-9]+]]
 ; CHECK:       [[BB1]]:
 ; CHECK-NEXT:    call void @func1()
 ; CHECK-NEXT:    unreachable
@@ -301,7 +337,7 @@ define void @test_remap_k_default_add(i8 %x) !prof !0 {
 ; CHECK-NEXT:    switch i8 [[X]], label %[[DEFAULT:.*]] [
 ; CHECK-NEXT:      i8 1, label %[[BB1:.*]]
 ; CHECK-NEXT:      i8 2, label %[[BB2:.*]]
-; CHECK-NEXT:    ], !prof [[PROF4:![0-9]+]]
+; CHECK-NEXT:    ], !prof [[PROF5:![0-9]+]]
 ; CHECK:       [[BB1]]:
 ; CHECK-NEXT:    call void @func1()
 ; CHECK-NEXT:    unreachable
@@ -502,10 +538,12 @@ declare void @use(i32)
 !2 = !{!"branch_weights", i32 5, i32 11, i32 7}
 !3 = !{!"branch_weights", i32 5, i32 0, i32 11, i32 7}
 !4 = !{!"branch_weights", i32 3, i32 2}
+!5 = !{!"branch_weights", i32 5, i32 7, i32 11}
 ;.
 ; CHECK: [[PROF0]] = !{!"function_entry_count", i32 10}
 ; CHECK: [[PROF1]] = !{!"branch_weights", i32 25, i32 9, i32 35, i32 46}
-; CHECK: [[PROF2]] = !{!"unknown", !"simplifycfg"}
-; CHECK: [[PROF3]] = !{!"branch_weights", i32 15, i32 46, i32 9, i32 35}
-; CHECK: [[PROF4]] = !{!"branch_weights", i32 5, i32 11, i32 7}
+; CHECK: [[PROF2]] = !{!"branch_weights", i32 25, i32 0, i32 55, i32 46}
+; CHECK: [[PROF3]] = !{!"unknown", !"simplifycfg"}
+; CHECK: [[PROF4]] = !{!"branch_weights", i32 25, i32 46, i32 9, i32 35}
+; CHECK: [[PROF5]] = !{!"branch_weights", i32 5, i32 11, i32 7}
 ;.

--- a/llvm/utils/profcheck-xfail.txt
+++ b/llvm/utils/profcheck-xfail.txt
@@ -111,7 +111,6 @@ Transforms/PreISelIntrinsicLowering/AArch64/expand-exp.ll
 Transforms/PreISelIntrinsicLowering/AArch64/expand-fp-math.ll
 Transforms/PreISelIntrinsicLowering/AArch64/expand-fp-math-binary.ll
 Transforms/PreISelIntrinsicLowering/AArch64/expand-log.ll
-Transforms/SimplifyCFG/switch-select-remap.ll
 Transforms/StackProtector/cross-dso-cfi-stack-chk-fail.ll
 Transforms/TailCallElim/2010-06-26-MultipleReturnValues.ll
 Transforms/TailCallElim/accum_recursion.ll


### PR DESCRIPTION
This reverts commit 02d1fabd22d599bad38b2b926c7bcaaf41aff6e0.

Rerequesting review as I merged prematurely. This fixes a newly introduced SimplifyCFG profcheck failure by correctly propagating branch weight information.