### PR TITLE
[libc++][NFC] Simplify __to_gcc_order by avoiding constexprness

### DIFF
--- a/libcxx/include/__atomic/to_gcc_order.h
+++ b/libcxx/include/__atomic/to_gcc_order.h
@@ -11,6 +11,7 @@
 
 #include <__atomic/memory_order.h>
 #include <__config>
+#include <__utility/unreachable.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
@@ -21,30 +22,40 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if defined(__ATOMIC_RELAXED) && defined(__ATOMIC_CONSUME) && defined(__ATOMIC_ACQUIRE) &&                             \
     defined(__ATOMIC_RELEASE) && defined(__ATOMIC_ACQ_REL) && defined(__ATOMIC_SEQ_CST)
 
-_LIBCPP_HIDE_FROM_ABI inline _LIBCPP_CONSTEXPR int __to_gcc_order(memory_order __order) {
-  // Avoid switch statement to make this a constexpr.
-  return __order == memory_order_relaxed
-           ? __ATOMIC_RELAXED
-           : (__order == memory_order_acquire
-                  ? __ATOMIC_ACQUIRE
-                  : (__order == memory_order_release
-                         ? __ATOMIC_RELEASE
-                         : (__order == memory_order_seq_cst
-                                ? __ATOMIC_SEQ_CST
-                                : (__order == memory_order_acq_rel ? __ATOMIC_ACQ_REL : __ATOMIC_CONSUME))));
+_LIBCPP_HIDE_FROM_ABI inline int __to_gcc_order(memory_order __order) {
+  switch (__order) {
+  case memory_order_relaxed:
+    return __ATOMIC_RELAXED;
+  case memory_order_acquire:
+    return __ATOMIC_ACQUIRE;
+  case memory_order_release:
+    return __ATOMIC_RELEASE;
+  case memory_order_acq_rel:
+    return __ATOMIC_ACQ_REL;
+  case memory_order_seq_cst:
+    return __ATOMIC_SEQ_CST;
+  case memory_order_consume:
+    return __ATOMIC_CONSUME;
+  }
+  std::__libcpp_unreachable();
 }
 
-_LIBCPP_HIDE_FROM_ABI inline _LIBCPP_CONSTEXPR int __to_gcc_failure_order(memory_order __order) {
-  // Avoid switch statement to make this a constexpr.
-  return __order == memory_order_relaxed
-           ? __ATOMIC_RELAXED
-           : (__order == memory_order_acquire
-                  ? __ATOMIC_ACQUIRE
-                  : (__order == memory_order_release
-                         ? __ATOMIC_RELAXED
-                         : (__order == memory_order_seq_cst
-                                ? __ATOMIC_SEQ_CST
-                                : (__order == memory_order_acq_rel ? __ATOMIC_ACQUIRE : __ATOMIC_CONSUME))));
+_LIBCPP_HIDE_FROM_ABI inline int __to_gcc_failure_order(memory_order __order) {
+  switch (__order) {
+  case memory_order_relaxed:
+    return __ATOMIC_RELAXED;
+  case memory_order_acquire:
+    return __ATOMIC_ACQUIRE;
+  case memory_order_release:
+    return __ATOMIC_RELAXED;
+  case memory_order_seq_cst:
+    return __ATOMIC_SEQ_CST;
+  case memory_order_acq_rel:
+    return __ATOMIC_ACQUIRE;
+  case memory_order_consume:
+    return __ATOMIC_CONSUME;
+  }
+  std::__libcpp_unreachable();
 }
 
 #endif


### PR DESCRIPTION
We never make use of the fact that these functions are `constexpr`, so we might as well avoid complicating them for it. Even if we need them to be `constexpr` at some point, we likely won't require them to be `constexpr` in C++11, which is the only language mode with the single statement restriction that caused this to be more complicated.