### PR TITLE
[lldb][test] Disable TestBreakOnLambdaCapture.py on Windows on Arm

### DIFF
--- a/lldb/test/API/functionalities/breakpoint/breakpoint_on_lambda_capture/TestBreakOnLambdaCapture.py
+++ b/lldb/test/API/functionalities/breakpoint/breakpoint_on_lambda_capture/TestBreakOnLambdaCapture.py
@@ -11,6 +11,8 @@ from lldbsuite.test.lldbtest import *
 
 
 @requireThreadSupport
+# Flakey and stalls locally - https://github.com/llvm/llvm-project/issues/220942.
+@skipIf(oslist=["windows"], archs=["aarch64"])
 class TestBreakOnLambdaCapture(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 


### PR DESCRIPTION
Something is wrong with the breakpoint handling which makes it flakey on our bot.

https://github.com/llvm/llvm-project/issues/220942