### PR TITLE
[offload][nfc] Return an explicit error from createInterop

### DIFF
--- a/offload/plugins-nextgen/common/include/PluginInterface.h
+++ b/offload/plugins-nextgen/common/include/PluginInterface.h
@@ -1300,7 +1300,8 @@ struct GenericDeviceTy : public DeviceAllocatorTy {
 
   virtual Expected<omp_interop_val_t *>
   createInterop(int32_t InteropType, interop_spec_t &InteropSpec) {
-    return nullptr;
+    return Plugin::error(error::ErrorCode::UNSUPPORTED,
+                         "%s not supported by platform", __func__);
   }
 
   virtual Error releaseInterop(omp_interop_val_t *Interop) {


### PR DESCRIPTION
The return type is Expected<omp_interop_val_t *> so a nullptr can be incorrectly interpreted as a success and subsequently the nullptr could get dereferenced. Make the error explicit.