### PR TITLE
[Mips] Fix instruction size for unfinalized bundles

### DIFF
--- a/llvm/lib/Target/Mips/MipsInstrInfo.cpp
+++ b/llvm/lib/Target/Mips/MipsInstrInfo.cpp
@@ -708,6 +708,9 @@ bool MipsInstrInfo::isAsCheapAsAMove(const MachineInstr &MI) const {
 unsigned MipsInstrInfo::getInstSizeInBytes(const MachineInstr &MI) const {
   switch (MI.getOpcode()) {
   default:
+    // Handle non-finalized bundle.
+    if (MI.isBundledWithSucc())
+      return MI.getDesc().getSize() + getInstBundleSize(MI);
     if (MI.hasDelaySlot()) {
       // instr + 1 nop
       return MI.getDesc().getSize() + 4;


### PR DESCRIPTION
It looks like Mips uses unfinalized bundles (i.e. there is no leading BUNDLE) for delay slots. While proper delay slots are covered by the hasDelaySlot() case, things like forbidden slots and load delay slots are not. Make sure we report the correct size for these.

Part of enabling instruction size verification by default.