### PR TITLE
[Sparc] Fix instruction size for delay slot with UNIMP

### DIFF
--- a/llvm/lib/Target/Sparc/DelaySlotFiller.cpp
+++ b/llvm/lib/Target/Sparc/DelaySlotFiller.cpp
@@ -80,8 +80,6 @@ namespace {
     MachineBasicBlock::iterator
     findDelayInstr(MachineBasicBlock &MBB, MachineBasicBlock::iterator slot);
 
-    bool needsUnimp(MachineBasicBlock::iterator I, unsigned &StructSize);
-
     bool tryCombineRestoreWithPrevInst(MachineBasicBlock &MBB,
                                        MachineBasicBlock::iterator MBBI);
 
@@ -103,7 +101,7 @@ FunctionPass *llvm::createSparcDelaySlotFillerPass() {
 bool Filler::runOnMachineBasicBlock(MachineBasicBlock &MBB) {
   bool Changed = false;
   Subtarget = &MBB.getParent()->getSubtarget<SparcSubtarget>();
-  const TargetInstrInfo *TII = Subtarget->getInstrInfo();
+  const SparcInstrInfo *TII = Subtarget->getInstrInfo();
 
   for (MachineBasicBlock::iterator I = MBB.begin(); I != MBB.end(); ) {
     MachineBasicBlock::iterator MI = I;
@@ -145,7 +143,7 @@ bool Filler::runOnMachineBasicBlock(MachineBasicBlock &MBB) {
       MBB.splice(I, &MBB, D);
 
     unsigned structSize = 0;
-    if (needsUnimp(MI, structSize)) {
+    if (TII->needsUnimp(*MI, structSize)) {
       MachineBasicBlock::iterator J = MI;
       ++J; // skip the delay filler.
       assert (J != MBB.end() && "MI needs a delay instruction.");
@@ -366,37 +364,6 @@ bool Filler::IsRegInSet(SmallSet<unsigned, 32>& RegSet, unsigned Reg)
     if (RegSet.count(*AI))
       return true;
   return false;
-}
-
-bool Filler::needsUnimp(MachineBasicBlock::iterator I, unsigned &StructSize)
-{
-  if (!I->isCall())
-    return false;
-
-  unsigned structSizeOpNum = 0;
-  switch (I->getOpcode()) {
-  default: llvm_unreachable("Unknown call opcode.");
-  case SP::CALL:
-    structSizeOpNum = 1;
-    break;
-  case SP::CALLrr:
-  case SP::CALLri:
-    structSizeOpNum = 2;
-    break;
-  case SP::TLS_CALL: return false;
-  case SP::TAIL_CALLri:
-  case SP::TAIL_CALL: return false;
-  }
-
-  const MachineOperand &MO = I->getOperand(structSizeOpNum);
-  if (!MO.isImm())
-    return false;
-
-  // A zero-sized return value has nothing for the callee to copy, so GCC emits
-  // no unimp for it and returns to the instruction right after the delay slot.
-  // We replicate this behavior here.
-  StructSize = MO.getImm();
-  return StructSize != 0;
 }
 
 static bool combineRestoreADD(MachineBasicBlock &MBB,

--- a/llvm/lib/Target/Sparc/SparcInstrInfo.cpp
+++ b/llvm/lib/Target/Sparc/SparcInstrInfo.cpp
@@ -656,6 +656,40 @@ Register SparcInstrInfo::getGlobalBaseReg(MachineFunction *MF) const {
   return GlobalBaseReg;
 }
 
+bool SparcInstrInfo::needsUnimp(const MachineInstr &MI,
+                                unsigned &StructSize) const {
+  if (!MI.isCall())
+    return false;
+
+  unsigned StructSizeOpNum = 0;
+  switch (MI.getOpcode()) {
+  default:
+    llvm_unreachable("Unknown call opcode.");
+  case SP::CALL:
+    StructSizeOpNum = 1;
+    break;
+  case SP::CALLrr:
+  case SP::CALLri:
+    StructSizeOpNum = 2;
+    break;
+  case SP::TLS_CALL:
+    return false;
+  case SP::TAIL_CALLri:
+  case SP::TAIL_CALL:
+    return false;
+  }
+
+  const MachineOperand &MO = MI.getOperand(StructSizeOpNum);
+  if (!MO.isImm())
+    return false;
+
+  // A zero-sized return value has nothing for the callee to copy, so GCC emits
+  // no unimp for it and returns to the instruction right after the delay slot.
+  // We replicate this behavior here.
+  StructSize = MO.getImm();
+  return StructSize != 0;
+}
+
 unsigned SparcInstrInfo::getInstSizeInBytes(const MachineInstr &MI) const {
   unsigned Opcode = MI.getOpcode();
 
@@ -687,8 +721,10 @@ unsigned SparcInstrInfo::getInstSizeInBytes(const MachineInstr &MI) const {
   // If the instruction has a delay slot, be conservative and also include
   // it for sizing purposes. This is done so that the BranchRelaxation pass
   // will not mistakenly mark out-of-range branches as in-range.
-  if (MI.hasDelaySlot())
-    return get(Opcode).getSize() * 2;
+  if (MI.hasDelaySlot()) {
+    unsigned StructSize = 0;
+    return get(Opcode).getSize() * (2 + needsUnimp(MI, StructSize));
+  }
   return get(Opcode).getSize();
 }
 

--- a/llvm/lib/Target/Sparc/SparcInstrInfo.h
+++ b/llvm/lib/Target/Sparc/SparcInstrInfo.h
@@ -117,6 +117,10 @@ public:
 
   // Lower pseudo instructions after register allocation.
   bool expandPostRAPseudo(MachineInstr &MI) const override;
+
+  // Whether this is a call that needs unimp. Populates \p StructSize with
+  // the size of the returned struct.
+  bool needsUnimp(const MachineInstr &MI, unsigned &StructSize) const;
 };
 
 }


### PR DESCRIPTION
Sparc currently reports all instructions with delay slots as having twice the size. However, there is a special case for struct returns, where there is an extra UNIMP instruction. Move needsUnimp() into SparcInstrInfo, and account for it in the instruction size calculation.

Part of enabling instruction size verification by default.