### PR TITLE
[libc++] Fix make_from_tuple for reference types

### DIFF
--- a/libcxx/include/tuple
+++ b/libcxx/include/tuple
@@ -1398,7 +1398,7 @@ make_from_tuple(_Tuple&& __tuple) noexcept(__can_nothrow_make_from_tuple_v<_Tp, 
                   "Attempted construction of reference element binds to a temporary whose lifetime has ended");
   }
 #      endif // _LIBCPP_STD_VER >= 23
-  return std::apply([]<class... _Args>(_Args&&... __args) { return _Tp(std::forward<_Args>(__args)...); },
+  return std::apply([]<class... _Args>(_Args&&... __args) -> _Tp { return _Tp(std::forward<_Args>(__args)...); },
                     std::forward<_Tuple>(__tuple));
 }
 

--- a/libcxx/test/std/utilities/tuple/tuple.tuple/tuple.apply/make_from_tuple.pass.cpp
+++ b/libcxx/test/std/utilities/tuple/tuple.tuple/tuple.apply/make_from_tuple.pass.cpp
@@ -255,5 +255,10 @@ int main(int, char**)
     test_perfect_forwarding();
     test_noexcept();
 
+  { // Test that constructing a T& returns the same object
+    int i;
+    assert(&std::make_from_tuple<const int&>(std::tuple<int&>(i)) == &i);
+  }
+
   return 0;
 }


### PR DESCRIPTION
#215067 refactored `make_from_tuple`, which introduced a regression when trying to construct reference types with it.
