### PR TITLE
[Docs] Document persistent metadata printing

### DIFF
--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -57,10 +57,13 @@ Makes programs 10x faster by doing Special New Thing.
   numbering and ordering compared with earlier releases. Standalone metadata
   printing now uses numbered definitions such as `!1 = !DIFile(...)` instead
   of pointer-based forms such as `<0x...> = !DIFile(...)`. Tools and tests that
-  compare such output may need updating. Before a complete module is emitted
-  as LLVM IR, its metadata IDs are renumbered into a contiguous sequence in
-  canonical order, so normal complete-module LLVM IR output remains unchanged
-  from earlier releases.
+  compare such output may need updating. LLVM's standard final-output paths
+  renumber metadata IDs into a contiguous sequence in canonical order before
+  emitting a complete module. C++ clients that call `Module::print()` directly
+  do not renumber automatically and may see different metadata numbering and
+  definition ordering compared with earlier releases. Such clients can call
+  `Module::renumberMetadataForAssembly()` immediately before final output when
+  canonical numbering is required.
 
 * Added `llvm.vector.reduce.fmaximumnum` and `llvm.vector.reduce.fminimumnum`
   intrinsics, the reduction variants of `llvm.maximumnum` and

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -57,8 +57,10 @@ Makes programs 10x faster by doing Special New Thing.
   numbering and ordering compared with earlier releases. Standalone metadata
   printing now uses numbered definitions such as `!1 = !DIFile(...)` instead
   of pointer-based forms such as `<0x...> = !DIFile(...)`. Tools and tests that
-  compare such output may need updating. Final assembly output is still
-  renumbered into canonical order.
+  compare such output may need updating. Before a complete module is emitted
+  as LLVM IR, its metadata IDs are renumbered into a contiguous sequence in
+  canonical order, so normal complete-module LLVM IR output remains unchanged
+  from earlier releases.
 
 * Added `llvm.vector.reduce.fmaximumnum` and `llvm.vector.reduce.fminimumnum`
   intrinsics, the reduction variants of `llvm.maximumnum` and

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -52,6 +52,14 @@ Makes programs 10x faster by doing Special New Thing.
 
 ### Changes to the LLVM IR
 
+* LLVM now assigns persistent print IDs to metadata nodes. This keeps metadata
+  IDs stable across repeated debug and pass output, but can change their
+  numbering and ordering compared with earlier releases. Standalone metadata
+  printing now uses numbered definitions such as `!1 = !DIFile(...)` instead
+  of pointer-based forms such as `<0x...> = !DIFile(...)`. Tools and tests that
+  compare such output may need updating. Final assembly output is still
+  renumbered into canonical order.
+
 * Added `llvm.vector.reduce.fmaximumnum` and `llvm.vector.reduce.fminimumnum`
   intrinsics, the reduction variants of `llvm.maximumnum` and
   `llvm.minimumnum`. 

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -52,11 +52,13 @@ Makes programs 10x faster by doing Special New Thing.
 
 ### Changes to the LLVM IR
 
-* LLVM now assigns persistent print IDs to metadata nodes. Keeping these IDs
-  stable across repeated debug and pass output makes changes easier to follow:
-  unchanged metadata keeps the same number as passes modify the module. The
-  numbering and definition order can differ from earlier releases, so tests
-  of intermediate output may need updated expectations.
+* LLVM now assigns persistent print IDs to metadata nodes. Reusing these IDs
+  avoids repeated module-wide scans to rebuild metadata numbering, which can
+  significantly speed up debug and pass printing on large modules. Keeping
+  the IDs stable also makes repeated output easier to compare: unchanged
+  metadata keeps the same number as passes modify the module. The numbering
+  and definition order can differ from earlier releases, so tests of
+  intermediate output may need updated expectations.
 
   LLVM's standard final-output paths renumber metadata in canonical order.
   This gives consecutive IDs with no gaps and makes the final IR easier to

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -52,18 +52,23 @@ Makes programs 10x faster by doing Special New Thing.
 
 ### Changes to the LLVM IR
 
-* LLVM now assigns persistent print IDs to metadata nodes. This keeps metadata
-  IDs stable across repeated debug and pass output, but can change their
-  numbering and ordering compared with earlier releases. Standalone metadata
-  printing now uses numbered definitions such as `!1 = !DIFile(...)` instead
-  of pointer-based forms such as `<0x...> = !DIFile(...)`. Tools and tests that
-  compare such output may need updating. LLVM's standard final-output paths
-  renumber metadata IDs into a contiguous sequence in canonical order before
-  emitting a complete module. C++ clients that call `Module::print()` directly
-  do not renumber automatically and may see different metadata numbering and
-  definition ordering compared with earlier releases. Such clients can call
-  `Module::renumberMetadataForAssembly()` immediately before final output when
-  canonical numbering is required.
+* LLVM now assigns persistent print IDs to metadata nodes. Keeping these IDs
+  stable across repeated debug and pass output makes changes easier to follow:
+  unchanged metadata keeps the same number as passes modify the module. The
+  numbering and definition order can differ from earlier releases, so tests
+  of intermediate output may need updated expectations.
+
+  LLVM's standard final-output paths renumber metadata in canonical order.
+  This gives consecutive IDs with no gaps and makes the final IR easier to
+  read. C++ clients that call `Module::print()` directly do not renumber
+  automatically. For final IR output, these clients should call
+  `Module::renumberMetadataForAssembly()` immediately before printing. Keep
+  persistent IDs for intermediate dumps so their numbering remains stable.
+
+  Standalone metadata printing now uses numbered definitions such as
+  `!1 = !DIFile(...)` instead of pointer-based forms such as
+  `<0x...> = !DIFile(...)`. Tools and tests that compare such output may need
+  updating.
 
 * Added `llvm.vector.reduce.fmaximumnum` and `llvm.vector.reduce.fminimumnum`
   intrinsics, the reduction variants of `llvm.maximumnum` and


### PR DESCRIPTION
Document how persistent metadata IDs affect intermediate and standalone
textual output. Final assembly output remains canonically renumbered.

Follow-up to #220390.

