### PR TITLE
[flang][test] Expect a single -rpath in fveclib.f90 ArmPL check

### DIFF
--- a/flang/test/Driver/fveclib.f90
+++ b/flang/test/Driver/fveclib.f90
@@ -54,6 +54,4 @@
 
 ! RUN: %flang -### --target=aarch64-linux-gnu -resource-dir=%S/../../../clang/test/Driver/Inputs/resource_dir_with_arch_subdir -frtlib-add-rpath -fveclib=ArmPL %s 2>&1 | FileCheck --check-prefix=CHECK-RPATH-ARMPL %s
 ! CHECK-RPATH-ARMPL: "--push-state" "--as-needed" "-lm" "-lamath" "-lm" "--pop-state"
-! We need to see "-rpath" at least twice, one for veclib, one for the Fortran runtime
-! CHECK-RPATH-ARMPL-SAME: "-rpath"
 ! CHECK-RPATH-ARMPL-SAME: "-rpath"


### PR DESCRIPTION
Fixes a `check-flang` failure on main: `Flang :: Driver/fveclib.f90`.

#220697 consolidated `tools::addArchSpecificRPath()` down to a single call site — it was removed from `ToolChain::addFlangRTLibPath()` and from the `-fveclib=ArmPL` block in `tools::AddLinkerInputs()`, and one unconditional call was hoisted to the end of `AddLinkerInputs()`. A link line can therefore emit each candidate rpath at most once, so `CHECK-RPATH-ARMPL` fails on its second `-rpath` match:

```
flang/test/Driver/fveclib.f90:59:27: error: CHECK-RPATH-ARMPL-SAME: expected string not found in input
! CHECK-RPATH-ARMPL-SAME: "-rpath"
                          ^
```

The two matches only ever passed because `addArchSpecificRPath()` is a pure function of the toolchain and the argument list, so the two former call sites emitted identical paths. The test was matching a duplicate rpath, not the separate veclib and Fortran-runtime entries that its comment described. The arch-specific runtime directory — which is where `flang_rt` lives — is still emitted once, so no rpath is actually lost:

```
$ flang -### -frtlib-add-rpath hello.f90
"-rpath" ".../lib/clang/24/lib/x86_64-unknown-linux-gnu"
```

Assisted-by: AI