### PR TITLE
[analyzer] Chain checkers in runCheckersForEndFunction

### DIFF
--- a/clang/lib/StaticAnalyzer/Core/CheckerManager.cpp
+++ b/clang/lib/StaticAnalyzer/Core/CheckerManager.cpp
@@ -536,38 +536,46 @@ void CheckerManager::runCheckersForBeginFunction(ExplodedNodeSet &Dst,
   expandGraphWithCheckers(C, Dst, Src);
 }
 
+namespace {
+
+struct CheckEndFunctionContext {
+  using CheckersTy = std::vector<CheckerManager::CheckEndFunctionFunc>;
+
+  const CheckersTy &Checkers;
+  const ReturnStmt *RS;
+  ExprEngine &Eng;
+
+  CheckEndFunctionContext(const CheckersTy &Checkers, const ReturnStmt *RS,
+                          ExprEngine &Eng)
+      : Checkers(Checkers), RS(RS), Eng(Eng) {}
+
+  CheckersTy::const_iterator checkers_begin() { return Checkers.begin(); }
+  CheckersTy::const_iterator checkers_end() { return Checkers.end(); }
+
+  void runChecker(CheckerManager::CheckEndFunctionFunc checkFn,
+                  ExplodedNode *Pred, ExplodedNodeSet &Dst) {
+    llvm::TimeTraceScope TimeScope(checkerScopeName("End", checkFn.Checker));
+    const ProgramPoint &L =
+        FunctionExitPoint(RS, Pred->getStackFrame(), checkFn.Checker);
+    CheckerContext C(Eng, Pred, Dst, L);
+
+    checkFn(RS, C);
+  }
+};
+
+} // namespace
+
 /// Run checkers for end of a function (either the entrypoint or another
-/// function that was inlined). Note that this function places the
-/// checker activations on separate execution paths:
-///        /-[checker1]-> N1 ...
-///   Pred --[checker2]-> N2 ...
-///        \-[checker3]-> N3 ...
-/// (If none of the checkers produce a transition, we continue with 'Pred'.)
-///
-/// This differs from the handling of all the other checker callbacks, where
-/// the checker activations are chained sequentially on a single path:
-///   Pred --[checker1]-> N1 --[checker2]-> N2 --[checker3]-> N3 ...
-///
-/// This difference has historical reasons: originally this callback was called
-/// 'EndPath' and only activated at the end of an execution paths, and
-/// (according to an old comment) those 'EndPath' checkers expected that they
-/// create an "end of path" node which will be final.
-/// TODO: Check whether this exceptional behavior is still justified.
+/// function that was inlined).
 void CheckerManager::runCheckersForEndFunction(ExplodedNodeSet &Dst,
                                                ExplodedNode *Pred,
                                                ExprEngine &Eng,
                                                const ReturnStmt *RS) {
-  // By default, continue from 'Pred' -- this will be removed from 'Dst' if any
-  // checker generates a transition from it.
-  Dst.insert(Pred);
-
-  for (const auto &checkFn : EndFunctionCheckers) {
-    const ProgramPoint &L =
-        FunctionExitPoint(RS, Pred->getStackFrame(), checkFn.Checker);
-    CheckerContext C(Eng, Pred, Dst, L);
-    llvm::TimeTraceScope TimeScope(checkerScopeName("End", checkFn.Checker));
-    checkFn(RS, C);
-  }
+  ExplodedNodeSet Src;
+  Src.insert(Pred);
+  CheckEndFunctionContext C(EndFunctionCheckers, RS, Eng);
+  llvm::TimeTraceScope TimeScope("CheckerManager::runCheckersForEndFunction");
+  expandGraphWithCheckers(C, Dst, Src);
 }
 
 namespace {


### PR DESCRIPTION
The function `runCheckersForEndFunction` had an unusual behavior that it invoked the callbacks in parallel (introducing a new execution path for each checker callback that produced a transition), unlike all other analogous functions, which "chained" the checkers, executing them after each other.

This behavior was introduced before 2011, when this callback was called `check::EndPath`, to ensure that the `EndPath` callbacks are _final_ and nodes created by them end up at the end of the execution path. When interprocedural analysis (inlining functions) was introduced in 2013, the callback was renamed to `EndFunction` (to reflect that it also activates at the end of inlined functions), but the unusual behavior was preserved.

There were 8 "real" checkers with `check::EndFunction` callbacks, but most of them only created error nodes or did "nice to have" cleanup, so the irregular behavior of this callback did not cause visible trouble.

However, none of the checkers actually _relies_ on the parallel execution of the callbacks and the unusual transition pattern seriously violates the established patterns of the analyzer; so this commit rewrites `runCheckersForEndFunction` to follow the standard logic.

This may slightly perturb the analysis results (because it changes the "shape" of the exploded graph), but -- based on my review of the upstream EndFunction checkers -- should not cause any directed functional changes.

For more background details see also the github review comments at https://github.com/llvm/llvm-project/pull/217319#discussion_r3812950071