### PR TITLE
[AMDGPU] Restrict pending resource preferences near unified VGPR occupancy boundaries

### DIFF
--- a/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
@@ -84,6 +84,9 @@ static cl::opt<unsigned> PendingQueueLimit(
         "Max (Available+Pending) size to inspect pending queue (0 disables)"),
     cl::init(256));
 
+// Heuristic maximum VGPR pressure increase used near register limits.
+static constexpr unsigned MaxVGPRPressureInc = 16;
+
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 #define DUMP_MAX_REG_PRESSURE
 static cl::opt<bool> PrintMaxRPRegUsageBeforeScheduler(
@@ -386,7 +389,6 @@ void GCNSchedStrategy::initCandidate(SchedCandidate &Cand, SUnit *SU,
   // only for VGPRs or only for SGPRs.
 
   // FIXME: Better heuristics to determine whether to prefer SGPRs or VGPRs.
-  const unsigned MaxVGPRPressureInc = 16;
   bool ShouldTrackVGPRs = VGPRPressure + MaxVGPRPressureInc >= VGPRExcessLimit;
   bool ShouldTrackSGPRs = !ShouldTrackVGPRs && SGPRPressure >= SGPRExcessLimit;
 
@@ -442,10 +444,13 @@ static bool shouldCheckPending(SchedBoundary &Zone,
 }
 
 static SUnit *pickOnlyChoice(SchedBoundary &Zone,
-                             const TargetSchedModel *SchedModel) {
-  // pickOnlyChoice() releases pending instructions and checks for new hazards.
+                             const TargetSchedModel *SchedModel,
+                             bool AllowPendingCandidates) {
+  // Keep queue maintenance and hazard checks active when nodes still in
+  // Pending are excluded from candidate selection.
   SUnit *OnlyChoice = Zone.pickOnlyChoice();
-  if (!shouldCheckPending(Zone, SchedModel) || Zone.Pending.empty())
+  if (!AllowPendingCandidates || !shouldCheckPending(Zone, SchedModel) ||
+      Zone.Pending.empty())
     return OnlyChoice;
 
   return nullptr;
@@ -512,7 +517,7 @@ void GCNSchedStrategy::pickNodeFromQueue(SchedBoundary &Zone,
     }
   }
 
-  if (!shouldCheckPending(Zone, SchedModel))
+  if (!AllowPendingCandidates || !shouldCheckPending(Zone, SchedModel))
     return;
 
   LLVM_DEBUG(dbgs() << "Pending Q:\n");
@@ -544,11 +549,11 @@ SUnit *GCNSchedStrategy::pickNodeBidirectional(bool &IsTopNode,
                                                bool &PickedPending) {
   // Schedule as far as possible in the direction of no choice. This is most
   // efficient, but also provides the best heuristics for CriticalPSets.
-  if (SUnit *SU = pickOnlyChoice(Bot, SchedModel)) {
+  if (SUnit *SU = pickOnlyChoice(Bot, SchedModel, AllowPendingCandidates)) {
     IsTopNode = false;
     return SU;
   }
-  if (SUnit *SU = pickOnlyChoice(Top, SchedModel)) {
+  if (SUnit *SU = pickOnlyChoice(Top, SchedModel, AllowPendingCandidates)) {
     IsTopNode = true;
     return SU;
   }
@@ -648,7 +653,7 @@ SUnit *GCNSchedStrategy::pickNode(bool &IsTopNode) {
   do {
     PickedPending = false;
     if (RegionPolicy.OnlyTopDown) {
-      SU = pickOnlyChoice(Top, SchedModel);
+      SU = pickOnlyChoice(Top, SchedModel, AllowPendingCandidates);
       if (!SU) {
         CandPolicy NoPolicy;
         TopCand.reset(NoPolicy);
@@ -660,7 +665,7 @@ SUnit *GCNSchedStrategy::pickNode(bool &IsTopNode) {
       }
       IsTopNode = true;
     } else if (RegionPolicy.OnlyBottomUp) {
-      SU = pickOnlyChoice(Bot, SchedModel);
+      SU = pickOnlyChoice(Bot, SchedModel, AllowPendingCandidates);
       if (!SU) {
         CandPolicy NoPolicy;
         BotCand.reset(NoPolicy);
@@ -1831,6 +1836,32 @@ bool GCNSchedStage::initGCNRegion() {
   }
 
   PressureBefore = DAG.Pressure[RegionIdx];
+
+  S.AllowPendingCandidates = true;
+
+  // Only adjust the initial max-occupancy schedule, and do not override the
+  // explicit scheduling policy of an IGLP region.
+  if (StageID == GCNSchedStageID::OccInitialSchedule && ST.hasGFX90AInsts() &&
+      !DAG.RegionsWithIGLPInstrs[RegionIdx]) {
+    unsigned DynamicVGPRBlockSize = MFI.getDynamicVGPRBlockSize();
+    unsigned RegionOccupancy =
+        std::min(DAG.MinOccupancy,
+                 PressureBefore.getOccupancy(ST, DynamicVGPRBlockSize));
+
+    // Pending candidates may extend live ranges. Round the estimate to the
+    // hardware allocation granule and keep the final block for the current
+    // occupancy in reserve. At one wave there is no lower occupancy to protect.
+    if (RegionOccupancy > 1) {
+      unsigned UnifiedVGPRPressure =
+          PressureBefore.getVGPRNum(/*UnifiedVGPRFile=*/true);
+      unsigned EstimatedUnifiedVGPRPressure =
+          alignTo(UnifiedVGPRPressure + MaxVGPRPressureInc + S.ErrorMargin,
+                  ST.getVGPRAllocGranule(DynamicVGPRBlockSize));
+      unsigned MaxVGPRs =
+          ST.getMaxNumVGPRs(RegionOccupancy, DynamicVGPRBlockSize);
+      S.AllowPendingCandidates = EstimatedUnifiedVGPRPressure < MaxVGPRs;
+    }
+  }
 
   LLVM_DEBUG(
       dbgs() << "Pressure before scheduling:\nRegion live-ins:"

--- a/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
@@ -84,7 +84,7 @@ static cl::opt<unsigned> PendingQueueLimit(
         "Max (Available+Pending) size to inspect pending queue (0 disables)"),
     cl::init(256));
 
-// Heuristic maximum VGPR pressure increase used near register limits.
+// Heuristic VGPR pressure lookahead used near register limits.
 static constexpr unsigned MaxVGPRPressureInc = 16;
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
@@ -444,13 +444,10 @@ static bool shouldCheckPending(SchedBoundary &Zone,
 }
 
 static SUnit *pickOnlyChoice(SchedBoundary &Zone,
-                             const TargetSchedModel *SchedModel,
-                             bool AllowPendingCandidates) {
-  // Keep queue maintenance and hazard checks active when nodes still in
-  // Pending are excluded from candidate selection.
+                             const TargetSchedModel *SchedModel) {
+  // pickOnlyChoice() releases pending instructions and checks for new hazards.
   SUnit *OnlyChoice = Zone.pickOnlyChoice();
-  if (!AllowPendingCandidates || !shouldCheckPending(Zone, SchedModel) ||
-      Zone.Pending.empty())
+  if (!shouldCheckPending(Zone, SchedModel) || Zone.Pending.empty())
     return OnlyChoice;
 
   return nullptr;
@@ -517,7 +514,7 @@ void GCNSchedStrategy::pickNodeFromQueue(SchedBoundary &Zone,
     }
   }
 
-  if (!AllowPendingCandidates || !shouldCheckPending(Zone, SchedModel))
+  if (!shouldCheckPending(Zone, SchedModel))
     return;
 
   LLVM_DEBUG(dbgs() << "Pending Q:\n");
@@ -549,11 +546,11 @@ SUnit *GCNSchedStrategy::pickNodeBidirectional(bool &IsTopNode,
                                                bool &PickedPending) {
   // Schedule as far as possible in the direction of no choice. This is most
   // efficient, but also provides the best heuristics for CriticalPSets.
-  if (SUnit *SU = pickOnlyChoice(Bot, SchedModel, AllowPendingCandidates)) {
+  if (SUnit *SU = pickOnlyChoice(Bot, SchedModel)) {
     IsTopNode = false;
     return SU;
   }
-  if (SUnit *SU = pickOnlyChoice(Top, SchedModel, AllowPendingCandidates)) {
+  if (SUnit *SU = pickOnlyChoice(Top, SchedModel)) {
     IsTopNode = true;
     return SU;
   }
@@ -653,7 +650,7 @@ SUnit *GCNSchedStrategy::pickNode(bool &IsTopNode) {
   do {
     PickedPending = false;
     if (RegionPolicy.OnlyTopDown) {
-      SU = pickOnlyChoice(Top, SchedModel, AllowPendingCandidates);
+      SU = pickOnlyChoice(Top, SchedModel);
       if (!SU) {
         CandPolicy NoPolicy;
         TopCand.reset(NoPolicy);
@@ -665,7 +662,7 @@ SUnit *GCNSchedStrategy::pickNode(bool &IsTopNode) {
       }
       IsTopNode = true;
     } else if (RegionPolicy.OnlyBottomUp) {
-      SU = pickOnlyChoice(Bot, SchedModel, AllowPendingCandidates);
+      SU = pickOnlyChoice(Bot, SchedModel);
       if (!SU) {
         CandPolicy NoPolicy;
         BotCand.reset(NoPolicy);
@@ -767,6 +764,13 @@ bool GCNSchedStrategy::tryPendingCandidate(SchedCandidate &Cand,
       tryPressure(TryCand.RPDelta.CriticalMax, Cand.RPDelta.CriticalMax,
                   TryCand, Cand, RegCritical, TRI, DAG->MF))
     return TryCand.Reason != NoCand;
+
+  // Near a unified VGPR occupancy boundary, retain the existing pressure and
+  // physical-register preferences, but avoid selecting pending nodes solely
+  // for resource heuristics while candidate costs do not fully model unified
+  // VGPR/AGPR allocation.
+  if (!AllowPendingResourceHeuristics)
+    return false;
 
   bool SameBoundary = Zone != nullptr;
   if (SameBoundary) {
@@ -1837,7 +1841,7 @@ bool GCNSchedStage::initGCNRegion() {
 
   PressureBefore = DAG.Pressure[RegionIdx];
 
-  S.AllowPendingCandidates = true;
+  S.AllowPendingResourceHeuristics = true;
 
   // Only adjust the initial max-occupancy schedule, and do not override the
   // explicit scheduling policy of an IGLP region.
@@ -1848,9 +1852,13 @@ bool GCNSchedStage::initGCNRegion() {
         std::min(DAG.MinOccupancy,
                  PressureBefore.getOccupancy(ST, DynamicVGPRBlockSize));
 
-    // Pending candidates may extend live ranges. Round the estimate to the
-    // hardware allocation granule and keep the final block for the current
-    // occupancy in reserve. At one wave there is no lower occupancy to protect.
+    // Pending describes resource readiness; selecting a pending node can raise
+    // or lower pressure. In the motivating gfx950 case, resource-based pending
+    // selection lengthened a result's live range and worsened final allocation.
+    // Conservatively restrict those resource preferences near an occupancy
+    // boundary. Round the estimate to the hardware allocation granule and keep
+    // the final block for the current occupancy in reserve. At one wave there
+    // is no lower occupancy to protect.
     if (RegionOccupancy > 1) {
       unsigned UnifiedVGPRPressure =
           PressureBefore.getVGPRNum(/*UnifiedVGPRFile=*/true);
@@ -1859,7 +1867,8 @@ bool GCNSchedStage::initGCNRegion() {
                   ST.getVGPRAllocGranule(DynamicVGPRBlockSize));
       unsigned MaxVGPRs =
           ST.getMaxNumVGPRs(RegionOccupancy, DynamicVGPRBlockSize);
-      S.AllowPendingCandidates = EstimatedUnifiedVGPRPressure < MaxVGPRs;
+      S.AllowPendingResourceHeuristics =
+          EstimatedUnifiedVGPRPressure < MaxVGPRs;
     }
   }
 

--- a/llvm/lib/Target/AMDGPU/GCNSchedStrategy.h
+++ b/llvm/lib/Target/AMDGPU/GCNSchedStrategy.h
@@ -121,6 +121,10 @@ public:
   // increasing ILP and preserving VGPRs.
   bool KnownExcessRP = false;
 
+  // Whether nodes still in Pending may be selected in the current region.
+  // Queue maintenance remains enabled.
+  bool AllowPendingCandidates = true;
+
   // An error margin is necessary because of poor performance of the generic RP
   // tracker and can be adjusted up for tuning heuristics to try and more
   // aggressively reduce register pressure.

--- a/llvm/lib/Target/AMDGPU/GCNSchedStrategy.h
+++ b/llvm/lib/Target/AMDGPU/GCNSchedStrategy.h
@@ -121,9 +121,9 @@ public:
   // increasing ILP and preserving VGPRs.
   bool KnownExcessRP = false;
 
-  // Whether nodes still in Pending may be selected in the current region.
-  // Queue maintenance remains enabled.
-  bool AllowPendingCandidates = true;
+  // Whether resource heuristics may favor pending nodes in the current region.
+  // Pressure and physical-register preferences remain enabled.
+  bool AllowPendingResourceHeuristics = true;
 
   // An error margin is necessary because of poor performance of the generic RP
   // tracker and can be adjusted up for tuning heuristics to try and more

--- a/llvm/test/CodeGen/AMDGPU/schedule-pending-queue-pressure.mir
+++ b/llvm/test/CodeGen/AMDGPU/schedule-pending-queue-pressure.mir
@@ -1,0 +1,53 @@
+# RUN: llc -mtriple=amdgpu9.50-amd-amdhsa -run-pass=machine-scheduler -misched-prera-direction=topdown -verify-machineinstrs -verify-misched -debug-only=machine-scheduler -o /dev/null %s 2>&1 | FileCheck %s
+# REQUIRES: asserts
+
+# A pending MFMA ends both matrix-input live ranges. Waiting for that MFMA
+# before scheduling the independent LDS load preserves occupancy in this region.
+# The 42 VGPRs kept live across the region make its original peak 62 VGPRs.
+# Suppressing all pending candidates instead creates a 66-VGPR schedule, which
+# the scheduler must revert. Check the initial schedule to expose this loss of
+# a pressure-reducing candidate even when the final instruction order is restored.
+
+# CHECK-LABEL: pending_reduces_pressure:%bb.1
+# CHECK: Region register pressure: VGPRs: 62 AGPRs: 0
+# CHECK: Scheduling SU(0) %r0:
+# CHECK-NEXT: Top Pressure: VGPR_32=58
+# CHECK: hazard:  SU(1) HWXDL[0]=4c, is later than CurrCycle = 1c
+# CHECK: Queue TopQ.P: 1
+# CHECK: Pending Q:
+# CHECK: Cand SU(1) REG-CRIT
+# CHECK: Cycle: 4 TopQ.A
+# CHECK: Scheduling SU(1) %r1:
+# CHECK-NEXT: Top Pressure: VGPR_32=50
+# CHECK: Scheduling SU(2) %load:
+# CHECK: Pressure after scheduling: VGPRs: 62 AGPRs: 0
+# CHECK: Occupancy before scheduling: 8, after 8.
+# CHECK-NEXT: Ending scheduling stage: Max Occupancy Initial Schedule
+--- |
+  define amdgpu_kernel void @pending_reduces_pressure() #0 { ret void }
+  attributes #0 = { "amdgpu-flat-work-group-size"="1,256" "target-cpu"="gfx950" }
+...
+---
+name: pending_reduces_pressure
+tracksRegLiveness: true
+machineFunctionInfo:
+  isEntryFunction: true
+  occupancy: 8
+body: |
+  bb.0:
+    %a:vreg_128_align2 = IMPLICIT_DEF
+    %b:vreg_128_align2 = IMPLICIT_DEF
+    %c0:vreg_128_align2 = IMPLICIT_DEF
+    %c1:vreg_128_align2 = IMPLICIT_DEF
+    %keep0:vreg_512 = IMPLICIT_DEF
+    %keep1:vreg_512 = IMPLICIT_DEF
+    %keep2:vreg_256 = IMPLICIT_DEF
+    %addr:vreg_64 = IMPLICIT_DEF
+    S_BRANCH %bb.1
+
+  bb.1:
+    %r0:vreg_128_align2 = V_MFMA_F32_16X16X32_BF16_vgprcd_e64 %a, %b, %c0, 0, 0, 0, implicit $mode, implicit $exec
+    %r1:vreg_128_align2 = V_MFMA_F32_16X16X32_BF16_vgprcd_e64 %a, %b, %c1, 0, 0, 0, implicit $mode, implicit $exec
+    %load:vreg_128_align2 = DS_READ_B128_gfx9 %addr.sub0, 0, 0, implicit $exec
+    S_ENDPGM 0, implicit %r0, implicit %r1, implicit %load, implicit %keep0, implicit %keep1, implicit %keep2, implicit %addr
+...

--- a/llvm/test/CodeGen/AMDGPU/schedule-unified-vgpr-occupancy.ll
+++ b/llvm/test/CodeGen/AMDGPU/schedule-unified-vgpr-occupancy.ll
@@ -1,0 +1,76 @@
+; NOTE: Do not autogenerate. This test intentionally checks only resource usage.
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx950 -verify-machineinstrs < %s | FileCheck %s
+
+; Regression test for https://github.com/llvm/llvm-project/issues/219377#issuecomment-5510810499.
+; The loop's original pressure is 45 VGPRs. With an 8-register allocation
+; granule, alignTo(45 + 16 + 3, 8) equals the 64-register occupancy boundary.
+; Reserving that final granule stops pending nodes from extending live ranges.
+
+; CHECK-LABEL: avoid_unified_vgpr_occupancy_cliff:
+; CHECK:      ; NumVgprs: 64{{$}}
+; CHECK-NEXT: ; NumAgprs: 0{{$}}
+; CHECK-NEXT: ; TotalNumVgprs: 64{{$}}
+; CHECK-NEXT: ; ScratchSize: 0{{$}}
+; CHECK:      ; Occupancy: 8{{$}}
+
+define amdgpu_kernel void @avoid_unified_vgpr_occupancy_cliff(<8 x bfloat> %matrix0, <8 x bfloat> %matrix1, <8 x bfloat> %matrix2) {
+entry:
+  br label %loop
+
+loop:                                             ; preds = %loop, %entry
+  %acc0 = phi float [ 0.000000e+00, %entry ], [ %next.acc0, %loop ]
+  %acc1 = phi float [ 0.000000e+00, %entry ], [ %next.acc1, %loop ]
+  %acc2 = phi float [ 0.000000e+00, %entry ], [ %next.acc2, %loop ]
+  %acc3 = phi float [ 0.000000e+00, %entry ], [ %next.acc3, %loop ]
+  %acc0.insert0 = insertelement <4 x float> zeroinitializer, float %acc0, i64 0
+  %acc0.insert1 = insertelement <4 x float> %acc0.insert0, float %acc0, i64 1
+  %acc0.seed = insertelement <4 x float> %acc0.insert1, float 0.000000e+00, i64 0
+  %chain0.0 = tail call <4 x float> @llvm.amdgcn.mfma.f32.16x16x32.bf16(<8 x bfloat> zeroinitializer, <8 x bfloat> zeroinitializer, <4 x float> %acc0.seed, i32 0, i32 0, i32 0)
+  %acc1.insert0 = insertelement <4 x float> zeroinitializer, float %acc1, i64 0
+  %acc1.insert1 = insertelement <4 x float> %acc1.insert0, float %acc1, i64 1
+  %acc1.seed = insertelement <4 x float> %acc1.insert1, float 0.000000e+00, i64 0
+  %chain1.0 = tail call <4 x float> @llvm.amdgcn.mfma.f32.16x16x32.bf16(<8 x bfloat> %matrix0, <8 x bfloat> zeroinitializer, <4 x float> %acc1.seed, i32 0, i32 0, i32 0)
+  %acc2.insert0 = insertelement <4 x float> zeroinitializer, float %acc2, i64 0
+  %acc2.seed = insertelement <4 x float> %acc2.insert0, float %acc2, i64 0
+  %acc3.insert0 = insertelement <4 x float> zeroinitializer, float %acc3, i64 0
+  %acc3.seed = insertelement <4 x float> %acc3.insert0, float %acc3, i64 0
+  %chain3.0 = tail call <4 x float> @llvm.amdgcn.mfma.f32.16x16x32.bf16(<8 x bfloat> %matrix1, <8 x bfloat> zeroinitializer, <4 x float> %acc3.seed, i32 0, i32 0, i32 0)
+  %chain0.1 = tail call <4 x float> @llvm.amdgcn.mfma.f32.16x16x32.bf16(<8 x bfloat> zeroinitializer, <8 x bfloat> zeroinitializer, <4 x float> %chain0.0, i32 0, i32 0, i32 0)
+  %chain1.1 = tail call <4 x float> @llvm.amdgcn.mfma.f32.16x16x32.bf16(<8 x bfloat> %matrix2, <8 x bfloat> zeroinitializer, <4 x float> %chain1.0, i32 0, i32 0, i32 0)
+  %chain2.0 = tail call <4 x float> @llvm.amdgcn.mfma.f32.16x16x32.bf16(<8 x bfloat> <bfloat 0.000000e+00, bfloat 0.000000e+00, bfloat 0.000000e+00, bfloat 0.000000e+00, bfloat 1.000000e+00, bfloat 1.000000e+00, bfloat 1.000000e+00, bfloat 1.000000e+00>, <8 x bfloat> zeroinitializer, <4 x float> %acc2.seed, i32 0, i32 0, i32 0)
+  %chain2.1 = tail call <4 x float> @llvm.amdgcn.mfma.f32.16x16x32.bf16(<8 x bfloat> splat (bfloat 1.000000e+00), <8 x bfloat> zeroinitializer, <4 x float> %chain2.0, i32 0, i32 0, i32 0)
+  ; Preserve the scheduling-region boundary and reserve low VGPRs so the
+  ; allocation difference straddles the 64-register occupancy boundary.
+  tail call void asm sideeffect "", "~{v[0:15]},~{v[16:23]}"()
+  %chain0.2 = tail call <4 x float> @llvm.amdgcn.mfma.f32.16x16x32.bf16(<8 x bfloat> zeroinitializer, <8 x bfloat> zeroinitializer, <4 x float> %chain0.1, i32 0, i32 0, i32 0)
+  %chain0.3 = tail call <4 x float> @llvm.amdgcn.mfma.f32.16x16x32.bf16(<8 x bfloat> zeroinitializer, <8 x bfloat> zeroinitializer, <4 x float> %chain0.2, i32 0, i32 0, i32 0)
+  %chain0.4 = tail call <4 x float> @llvm.amdgcn.mfma.f32.16x16x32.bf16(<8 x bfloat> zeroinitializer, <8 x bfloat> zeroinitializer, <4 x float> %chain0.3, i32 0, i32 0, i32 0)
+  %chain0.5 = tail call <4 x float> @llvm.amdgcn.mfma.f32.16x16x32.bf16(<8 x bfloat> zeroinitializer, <8 x bfloat> zeroinitializer, <4 x float> %chain0.4, i32 0, i32 0, i32 0)
+  %chain0.6 = tail call <4 x float> @llvm.amdgcn.mfma.f32.16x16x32.bf16(<8 x bfloat> zeroinitializer, <8 x bfloat> zeroinitializer, <4 x float> %chain0.5, i32 0, i32 0, i32 0)
+  %chain0.7 = tail call <4 x float> @llvm.amdgcn.mfma.f32.16x16x32.bf16(<8 x bfloat> zeroinitializer, <8 x bfloat> zeroinitializer, <4 x float> %chain0.6, i32 0, i32 0, i32 0)
+  %next.acc0 = extractelement <4 x float> %chain0.7, i64 0
+  %chain1.2 = tail call <4 x float> @llvm.amdgcn.mfma.f32.16x16x32.bf16(<8 x bfloat> zeroinitializer, <8 x bfloat> zeroinitializer, <4 x float> %chain1.1, i32 0, i32 0, i32 0)
+  %chain1.3 = tail call <4 x float> @llvm.amdgcn.mfma.f32.16x16x32.bf16(<8 x bfloat> zeroinitializer, <8 x bfloat> zeroinitializer, <4 x float> %chain1.2, i32 0, i32 0, i32 0)
+  %chain1.4 = tail call <4 x float> @llvm.amdgcn.mfma.f32.16x16x32.bf16(<8 x bfloat> zeroinitializer, <8 x bfloat> zeroinitializer, <4 x float> %chain1.3, i32 0, i32 0, i32 0)
+  %chain1.5 = tail call <4 x float> @llvm.amdgcn.mfma.f32.16x16x32.bf16(<8 x bfloat> zeroinitializer, <8 x bfloat> zeroinitializer, <4 x float> %chain1.4, i32 0, i32 0, i32 0)
+  %chain1.6 = tail call <4 x float> @llvm.amdgcn.mfma.f32.16x16x32.bf16(<8 x bfloat> zeroinitializer, <8 x bfloat> zeroinitializer, <4 x float> %chain1.5, i32 0, i32 0, i32 0)
+  %chain1.7 = tail call <4 x float> @llvm.amdgcn.mfma.f32.16x16x32.bf16(<8 x bfloat> zeroinitializer, <8 x bfloat> zeroinitializer, <4 x float> %chain1.6, i32 0, i32 0, i32 0)
+  %next.acc1 = extractelement <4 x float> %chain1.7, i64 0
+  %chain2.2 = tail call <4 x float> @llvm.amdgcn.mfma.f32.16x16x32.bf16(<8 x bfloat> zeroinitializer, <8 x bfloat> zeroinitializer, <4 x float> %chain2.1, i32 0, i32 0, i32 0)
+  %chain2.3 = tail call <4 x float> @llvm.amdgcn.mfma.f32.16x16x32.bf16(<8 x bfloat> zeroinitializer, <8 x bfloat> zeroinitializer, <4 x float> %chain2.2, i32 0, i32 0, i32 0)
+  %chain2.4 = tail call <4 x float> @llvm.amdgcn.mfma.f32.16x16x32.bf16(<8 x bfloat> zeroinitializer, <8 x bfloat> zeroinitializer, <4 x float> %chain2.3, i32 0, i32 0, i32 0)
+  %chain2.5 = tail call <4 x float> @llvm.amdgcn.mfma.f32.16x16x32.bf16(<8 x bfloat> zeroinitializer, <8 x bfloat> zeroinitializer, <4 x float> %chain2.4, i32 0, i32 0, i32 0)
+  %chain2.6 = tail call <4 x float> @llvm.amdgcn.mfma.f32.16x16x32.bf16(<8 x bfloat> zeroinitializer, <8 x bfloat> zeroinitializer, <4 x float> %chain2.5, i32 0, i32 0, i32 0)
+  %chain2.7 = tail call <4 x float> @llvm.amdgcn.mfma.f32.16x16x32.bf16(<8 x bfloat> zeroinitializer, <8 x bfloat> zeroinitializer, <4 x float> %chain2.6, i32 0, i32 0, i32 0)
+  %next.acc2 = extractelement <4 x float> %chain2.7, i64 0
+  %chain3.1 = tail call <4 x float> @llvm.amdgcn.mfma.f32.16x16x32.bf16(<8 x bfloat> zeroinitializer, <8 x bfloat> zeroinitializer, <4 x float> %chain3.0, i32 0, i32 0, i32 0)
+  %chain3.2 = tail call <4 x float> @llvm.amdgcn.mfma.f32.16x16x32.bf16(<8 x bfloat> zeroinitializer, <8 x bfloat> zeroinitializer, <4 x float> %chain3.1, i32 0, i32 0, i32 0)
+  %chain3.3 = tail call <4 x float> @llvm.amdgcn.mfma.f32.16x16x32.bf16(<8 x bfloat> zeroinitializer, <8 x bfloat> zeroinitializer, <4 x float> %chain3.2, i32 0, i32 0, i32 0)
+  %chain3.4 = tail call <4 x float> @llvm.amdgcn.mfma.f32.16x16x32.bf16(<8 x bfloat> zeroinitializer, <8 x bfloat> zeroinitializer, <4 x float> %chain3.3, i32 0, i32 0, i32 0)
+  %chain3.5 = tail call <4 x float> @llvm.amdgcn.mfma.f32.16x16x32.bf16(<8 x bfloat> zeroinitializer, <8 x bfloat> zeroinitializer, <4 x float> %chain3.4, i32 0, i32 0, i32 0)
+  %chain3.6 = tail call <4 x float> @llvm.amdgcn.mfma.f32.16x16x32.bf16(<8 x bfloat> zeroinitializer, <8 x bfloat> zeroinitializer, <4 x float> %chain3.5, i32 0, i32 0, i32 0)
+  %next.acc3 = extractelement <4 x float> %chain3.6, i64 0
+  br label %loop
+}
+
+declare <4 x float> @llvm.amdgcn.mfma.f32.16x16x32.bf16(<8 x bfloat>, <8 x bfloat>, <4 x float>, i32 immarg, i32 immarg, i32 immarg)

--- a/llvm/test/CodeGen/AMDGPU/schedule-unified-vgpr-occupancy.ll
+++ b/llvm/test/CodeGen/AMDGPU/schedule-unified-vgpr-occupancy.ll
@@ -1,10 +1,12 @@
 ; NOTE: Do not autogenerate. This test intentionally checks only resource usage.
-; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx950 -verify-machineinstrs < %s | FileCheck %s
+; RUN: llc -mtriple=amdgpu9.50-amd-amdhsa -verify-machineinstrs < %s | FileCheck %s
 
 ; Regression test for https://github.com/llvm/llvm-project/issues/219377#issuecomment-5510810499.
 ; The loop's original pressure is 45 VGPRs. With an 8-register allocation
 ; granule, alignTo(45 + 16 + 3, 8) equals the 64-register occupancy boundary.
-; Reserving that final granule stops pending nodes from extending live ranges.
+; In this case, selecting pending MFMAs for resource demand lengthens live ranges
+; and worsens final allocation. Restrict those resource preferences near the
+; boundary; other pending selections can lower pressure and remain eligible.
 
 ; CHECK-LABEL: avoid_unified_vgpr_occupancy_cliff:
 ; CHECK:      ; NumVgprs: 64{{$}}
@@ -39,8 +41,8 @@ loop:                                             ; preds = %loop, %entry
   %chain1.1 = tail call <4 x float> @llvm.amdgcn.mfma.f32.16x16x32.bf16(<8 x bfloat> %matrix2, <8 x bfloat> zeroinitializer, <4 x float> %chain1.0, i32 0, i32 0, i32 0)
   %chain2.0 = tail call <4 x float> @llvm.amdgcn.mfma.f32.16x16x32.bf16(<8 x bfloat> <bfloat 0.000000e+00, bfloat 0.000000e+00, bfloat 0.000000e+00, bfloat 0.000000e+00, bfloat 1.000000e+00, bfloat 1.000000e+00, bfloat 1.000000e+00, bfloat 1.000000e+00>, <8 x bfloat> zeroinitializer, <4 x float> %acc2.seed, i32 0, i32 0, i32 0)
   %chain2.1 = tail call <4 x float> @llvm.amdgcn.mfma.f32.16x16x32.bf16(<8 x bfloat> splat (bfloat 1.000000e+00), <8 x bfloat> zeroinitializer, <4 x float> %chain2.0, i32 0, i32 0, i32 0)
-  ; Preserve the scheduling-region boundary and reserve low VGPRs so the
-  ; allocation difference straddles the 64-register occupancy boundary.
+  ; Clobber low VGPRs so the allocation difference straddles the 64-register
+  ; occupancy boundary.
   tail call void asm sideeffect "", "~{v[0:15]},~{v[16:23]}"()
   %chain0.2 = tail call <4 x float> @llvm.amdgcn.mfma.f32.16x16x32.bf16(<8 x bfloat> zeroinitializer, <8 x bfloat> zeroinitializer, <4 x float> %chain0.1, i32 0, i32 0, i32 0)
   %chain0.3 = tail call <4 x float> @llvm.amdgcn.mfma.f32.16x16x32.bf16(<8 x bfloat> zeroinitializer, <8 x bfloat> zeroinitializer, <4 x float> %chain0.2, i32 0, i32 0, i32 0)


### PR DESCRIPTION
The original gfx950 reproducer in #219377 loses occupancy when pending MFMAs are selected for resource demand. The resulting schedule lengthens a result's live range and changes final VGPR/AGPR allocation across an occupancy boundary.

Restrict pending selections based solely on resource heuristics near unified VGPR occupancy limits. Keep the existing physical-register, excess-pressure, and critical-pressure preferences enabled, since pending candidates can also reduce pressure. The guard applies to the initial max-occupancy stage on gfx90a-family targets, excludes IGLP regions, and skips the one-wave case. Queue maintenance and hazard waits remain active.

Results for the original kernel and its reduced regression test:

| Input | Before: VGPR / AGPR / total / occupancy | With guard: VGPR / AGPR / total / occupancy |
| --- | --- | --- |
| Original direct SSA | 254 / 4 / 260 / 1 | 254 / 0 / 254 / 2 |
| Reduced test | 64 / 4 / 68 / 7 | 64 / 0 / 64 / 8 |

All four outputs have zero scratch allocation. The original inline-assembly control remains at 240 VGPR, 0 AGPR, occupancy 2.

Pending status does not classify live-range behavior. This is a conservative scheduling heuristic, and candidate pressure costs still do not fully model unified VGPR/AGPR allocation. In the reduced case, both schedules report 45 VGPR and 0 AGPR before allocation despite their different final resource usage.

Validation includes the end-to-end occupancy regression, the pending hazard test, and a new gfx950 MIR test in which a pending MFMA reduces pressure from 58 to 50. Suppressing all pending candidates produces a 66-VGPR initial schedule that must be reverted; retaining the pressure preference keeps the region peak at 62 and occupancy at 8. The AMDGPU CodeGen suite reports 5,019 passes and 6 expected failures, with no unexpected failures.
