### PR TITLE
[MLIR][XeGPU] Optimize instruction granularity for elemwise

### DIFF
--- a/mlir/lib/Dialect/XeGPU/Transforms/XeGPUPropagateLayout.cpp
+++ b/mlir/lib/Dialect/XeGPU/Transforms/XeGPUPropagateLayout.cpp
@@ -13,6 +13,7 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/Utils/IndexingUtils.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/Dialect/XeGPU/IR/XeGPU.h"
 #include "mlir/Dialect/XeGPU/Transforms/Passes.h"
@@ -33,6 +34,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/TypeSwitch.h"
@@ -1567,6 +1569,7 @@ private:
   LogicalResult resolveTensorDescConsumer(OpOperand &operand);
   LogicalResult resolveVectorConsumer(OpOperand &operand);
   LogicalResult assignResultLayout(OpResult &result);
+  void sinkElementwiseConversions();
 };
 
 } // namespace
@@ -1626,12 +1629,132 @@ LogicalResult ResolveLayoutConflicts::run() {
     return WalkResult::advance();
   });
 
+  if (r.wasInterrupted())
+    return failure();
+
+  sinkElementwiseConversions();
+
   LLVM_DEBUG({
     DBGS() << "IR after resolving layout conflicts:\n";
     parentOp->dump();
   });
 
-  return r.wasInterrupted() ? failure() : success();
+  return success();
+}
+
+/// Optimize elementwise operations by sinking costly layout conversion.
+///
+///   %m  = vector.create_mask ...                        {L1}
+///   %d  = arith.mulf ...                                {L1}
+///   %cm = xegpu.convert_layout %m : L1 -> L2
+///   %cd = xegpu.convert_layout %d : L1 -> L2
+///   %s  = arith.select %cm, %cd, %splat                 {L2}
+///
+/// becomes
+///
+///   %s' = arith.select %m, %d, %splat                   {L1}
+///   %s  = xegpu.convert_layout %s' : L1 -> L2
+///
+/// We only sink if a coarser layout applies to an elementwise op
+///
+void ResolveLayoutConflicts::sinkElementwiseConversions() {
+  llvm::SmallSetVector<xegpu::ConvertLayoutOp, 8> deadConverts;
+  parentOp->walk([&](Operation *op) {
+    if (!OpTrait::hasElementwiseMappableTraits(op) || op->getNumResults() != 1)
+      return;
+    OpResult result = op->getResult(0);
+    if (!isa<VectorType>(result.getType()))
+      return;
+    xegpu::DistributeLayoutAttr resultLayout =
+        xegpu::getDistributeLayoutAttr(result);
+    if (!resultLayout)
+      return;
+
+    // Ensure that all feeding conversions have the same layout.
+    SmallVector<std::pair<OpOperand *, xegpu::ConvertLayoutOp>> conversions;
+    xegpu::DistributeLayoutAttr uniformConvSrcLayout;
+    for (OpOperand &operand : op->getOpOperands()) {
+      Value operandValue = operand.get();
+      if (!isa<VectorType>(operandValue.getType()))
+        continue;
+      auto operandConversionOp =
+          operandValue.getDefiningOp<xegpu::ConvertLayoutOp>();
+      // Those that are not a conversion should be easily materializable with
+      // another layout.
+      if (!operandConversionOp) {
+        Operation *definingOp = operandValue.getDefiningOp();
+        if (!definingOp || !xegpu::isTriviallyRematerializable(definingOp))
+          return;
+        continue;
+      }
+      xegpu::DistributeLayoutAttr input =
+          operandConversionOp.getEffectiveInputLayout();
+      if (!input)
+        return;
+      if (!uniformConvSrcLayout)
+        uniformConvSrcLayout = input;
+      else if (!uniformConvSrcLayout.isEqualTo(input))
+        return;
+      conversions.emplace_back(&operand, operandConversionOp);
+    }
+
+    if (!uniformConvSrcLayout)
+      return;
+
+    // Sink only when it leaves the op coarser.
+    // Conversion's source layout must be larger than the elemwise result
+    // layout.
+    SmallVector<int64_t> resultLayoutInstData =
+        resultLayout.getEffectiveInstDataAsInt();
+    SmallVector<int64_t> sourceInstData =
+        uniformConvSrcLayout.getEffectiveInstDataAsInt();
+    if (resultLayoutInstData.empty() || sourceInstData.empty() ||
+        computeProduct(sourceInstData) <= computeProduct(resultLayoutInstData))
+      return;
+
+    // Rewire the conversions, then rematerialize the remaining operands in the
+    // source layout.
+    llvm::SmallDenseSet<unsigned> rewiredOpIdxs;
+    for (auto [operand, convert] : conversions) {
+      operand->set(convert.getSource());
+      rewiredOpIdxs.insert(operand->getOperandNumber());
+    }
+    for (OpOperand &operand : op->getOpOperands()) {
+      Value operandValue = operand.get();
+      if (!isa<VectorType>(operandValue.getType()))
+        continue;
+      if (rewiredOpIdxs.contains(operand.getOperandNumber()))
+        continue;
+      Operation *definingOp = operandValue.getDefiningOp();
+      assert(definingOp && xegpu::isTriviallyRematerializable(definingOp) &&
+             "operand should have been rejected above");
+      // Rematerialize with uniform source layout.
+      builder.setInsertionPointAfter(definingOp);
+      Operation *clone = builder.clone(*definingOp);
+      OpResult cloneResult = clone->getResult(0);
+      xegpu::removeLayoutAttr(cloneResult);
+      xegpu::setDistributeLayoutAttr(cloneResult, uniformConvSrcLayout);
+      operand.set(cloneResult);
+    }
+
+    // Run the op in the source layout and bridge its result back, so that
+    // `getConsumerLayoutAt` now reports the source layout for every operand.
+    builder.setInsertionPointAfterValue(result);
+    auto newConvOp = xegpu::ConvertLayoutOp::create(
+        builder, op->getLoc(), result.getType(), result, uniformConvSrcLayout,
+        resultLayout);
+    result.replaceAllUsesExcept(newConvOp.getResult(), newConvOp);
+    xegpu::removeLayoutAttr(result);
+    xegpu::setDistributeLayoutAttr(result, uniformConvSrcLayout);
+
+    for (auto [operand, convert] : conversions)
+      if (convert.getResult().use_empty())
+        deadConverts.insert(convert);
+  });
+
+  // Memory effects block dce
+  for (xegpu::ConvertLayoutOp convert : deadConverts)
+    convert.erase();
 }
 
 LogicalResult ResolveLayoutConflicts::assignResultLayout(OpResult &result) {

--- a/mlir/test/Dialect/XeGPU/resolve-layout-conflicts.mlir
+++ b/mlir/test/Dialect/XeGPU/resolve-layout-conflicts.mlir
@@ -315,11 +315,11 @@ func.func @conflict_while_pass_through(%cond: i1) {
 // CHECK-SAME:        {layout_result_0 = #xegpu.layout<inst_data = [16, 16]>} : vector<16x16xf16>
 // CHECK:           scf.yield %[[ADD]] : vector<16x16xf16>
 // CHECK:         }
-// CHECK:         %[[CVT:.*]] = xegpu.convert_layout %[[FOR]]
+// CHECK:         %[[EXP:.*]] = math.exp %[[FOR]]
+// CHECK-SAME:      {layout_result_0 = #xegpu.layout<inst_data = [16, 16]>} : vector<16x16xf16>
+// CHECK:         %[[CVT:.*]] = xegpu.convert_layout %[[EXP]]
 // CHECK-SAME:      <{input_layout = #xegpu.layout<inst_data = [16, 16]>, target_layout = #xegpu.layout<inst_data = [8, 16]>}>
 // CHECK-SAME:      : vector<16x16xf16>
-// CHECK:         %[[EXP:.*]] = math.exp %[[CVT]]
-// CHECK-SAME:      {layout_result_0 = #xegpu.layout<inst_data = [8, 16]>} : vector<16x16xf16>
 // CHECK:         return
 func.func @conflict_postop() {
   %c0 = arith.constant 0 : index
@@ -442,6 +442,85 @@ func.func @convert_layout_bridge_input_mismatch() {
      <{input_layout = #xegpu.layout<inst_data = [16, 16]>,
        target_layout = #xegpu.layout<inst_data = [32, 16]>}>
      : vector<32x32xf16>
+  return
+}
+}
+
+// -----
+
+// CHECK-LABEL: func.func @sink_conversion_out_of_elementwise
+// CHECK-DAG:     %[[MASK:.*]] = "some_op"() {layout_result_0 = #xegpu.layout<inst_data = [8, 16]>} : () -> vector<16x64xi1>
+// CHECK-DAG:     %[[DATA:.*]] = "some_op"() {layout_result_0 = #xegpu.layout<inst_data = [8, 16]>} : () -> vector<16x64xf32>
+// CHECK-DAG:     %[[PAD:.*]] = arith.constant {layout_result_0 = #xegpu.layout<inst_data = [8, 16]>} dense<0xFF800000> : vector<16x64xf32>
+// CHECK:         %[[SEL:.*]] = arith.select %[[MASK]], %[[DATA]], %[[PAD]]
+// CHECK-SAME:      {layout_result_0 = #xegpu.layout<inst_data = [8, 16]>} : vector<16x64xi1>, vector<16x64xf32>
+// CHECK:         %[[CVT:.*]] = xegpu.convert_layout %[[SEL]]
+// CHECK-SAME:      <{input_layout = #xegpu.layout<inst_data = [8, 16]>, target_layout = #xegpu.layout<inst_data = [1, 16]>}>
+// CHECK-SAME:      : vector<16x64xf32>
+// CHECK:         %{{.*}} = vector.multi_reduction <maximumf>, %[[CVT]], %{{.*}}
+// CHECK-NOT:     xegpu.convert_layout
+gpu.module @test_sink_conversion {
+func.func @sink_conversion_out_of_elementwise() {
+  %mask = "some_op"() {
+    layout_result_0 = #xegpu.layout<inst_data = [8, 16]>
+  } : () -> vector<16x64xi1>
+  %data = "some_op"() {
+    layout_result_0 = #xegpu.layout<inst_data = [8, 16]>
+  } : () -> vector<16x64xf32>
+  %pad = arith.constant {
+    layout_result_0 = #xegpu.layout<inst_data = [1, 16]>
+  } dense<0xFF800000> : vector<16x64xf32>
+  %acc = arith.constant {
+    layout_result_0 = #xegpu.slice<#xegpu.layout<inst_data = [1, 16]>, dims = [1]>
+  } dense<0xFF800000> : vector<16xf32>
+  %sel = arith.select %mask, %data, %pad {
+    layout_result_0 = #xegpu.layout<inst_data = [1, 16]>
+  } : vector<16x64xi1>, vector<16x64xf32>
+  %red = vector.multi_reduction <maximumf>, %sel, %acc {
+    layout_result_0 = #xegpu.slice<#xegpu.layout<inst_data = [1, 16]>, dims = [1]>
+  } [1] : vector<16x64xf32> to vector<16xf32>
+  return
+}
+}
+
+// -----
+
+// CHECK-LABEL: func.func @conflicting_operands_disagree_not_sunk
+// CHECK:         %[[V0:.*]] = "some_op"() {layout_result_0 = #xegpu.layout<inst_data = [8, 16]>} : () -> vector<32x32xf16>
+// CHECK:         %[[CVT0:.*]] = xegpu.convert_layout %[[V0]]
+// CHECK-SAME:      <{input_layout = #xegpu.layout<inst_data = [8, 16]>, target_layout = #xegpu.layout<inst_data = [16, 16]>}>
+// CHECK:         %[[V1:.*]] = "some_op"() {layout_result_0 = #xegpu.layout<inst_data = [32, 16]>} : () -> vector<32x32xf16>
+// CHECK:         %[[CVT1:.*]] = xegpu.convert_layout %[[V1]]
+// CHECK-SAME:      <{input_layout = #xegpu.layout<inst_data = [32, 16]>, target_layout = #xegpu.layout<inst_data = [16, 16]>}>
+// CHECK:         %{{.*}} = arith.addf %[[CVT0]], %[[CVT1]]
+// CHECK-SAME:      {layout_result_0 = #xegpu.layout<inst_data = [16, 16]>} : vector<32x32xf16>
+gpu.module @test_no_sink_on_disagreement {
+func.func @conflicting_operands_disagree_not_sunk() {
+  %0 = "some_op"() {layout_result_0 = #xegpu.layout<inst_data = [8, 16]>} : () -> vector<32x32xf16>
+  %1 = "some_op"() {layout_result_0 = #xegpu.layout<inst_data = [32, 16]>} : () -> vector<32x32xf16>
+  %2 = arith.addf %0, %1 {layout_result_0 = #xegpu.layout<inst_data = [16, 16]>} : vector<32x32xf16>
+  return
+}
+}
+
+// -----
+
+// CHECK-LABEL: func.func @finer_operands_not_sunk
+// CHECK:         %[[V0:.*]] = "some_op"() {layout_result_0 = #xegpu.layout<inst_data = [1, 16]>} : () -> vector<16x64xf32>
+// CHECK:         %[[CVT0:.*]] = xegpu.convert_layout %[[V0]]
+// CHECK-SAME:      <{input_layout = #xegpu.layout<inst_data = [1, 16]>, target_layout = #xegpu.layout<inst_data = [8, 16]>}>
+// CHECK:         %[[V1:.*]] = "some_op"() {layout_result_0 = #xegpu.layout<inst_data = [1, 16]>} : () -> vector<16x64xf32>
+// CHECK:         %[[CVT1:.*]] = xegpu.convert_layout %[[V1]]
+// CHECK-SAME:      <{input_layout = #xegpu.layout<inst_data = [1, 16]>, target_layout = #xegpu.layout<inst_data = [8, 16]>}>
+// CHECK:         %{{.*}} = arith.addf %[[CVT0]], %[[CVT1]]
+// CHECK-SAME:      {layout_result_0 = #xegpu.layout<inst_data = [8, 16]>} : vector<16x64xf32>
+// CHECK-NOT:     xegpu.convert_layout
+gpu.module @test_no_sink_to_finer {
+func.func @finer_operands_not_sunk() {
+  %a = "some_op"() {layout_result_0 = #xegpu.layout<inst_data = [1, 16]>} : () -> vector<16x64xf32>
+  %b = "some_op"() {layout_result_0 = #xegpu.layout<inst_data = [1, 16]>} : () -> vector<16x64xf32>
+  %r = arith.addf %a, %b {layout_result_0 = #xegpu.layout<inst_data = [8, 16]>}
+    : vector<16x64xf32>
   return
 }
 }


### PR DESCRIPTION
This PR enables the following layout optimization:
```
elementwise(convert(a), convert(b)) → convert(elementwise(a,b))
```
It applies only if the result granularity is larger, leading to fewer ops after blocking.
For example, instead of extracting 8 `[1,16]` vectors for each operand to do 8 `[1,16]` elemwise ops, we do one `[8,16]` elemwise and 8 extract `[1,16]` afterwards. 