### PR TITLE
[flang] Collapse execution-part statement error flood into one error message

### DIFF
--- a/flang/lib/Parser/executable-parsers.cpp
+++ b/flang/lib/Parser/executable-parsers.cpp
@@ -69,18 +69,21 @@ constexpr auto obsoleteExecutionPartConstruct{recovery(ignoredStatementPrefix >>
 TYPE_PARSER(!consumedAllInput >>
     recovery(
         CONTEXT_PARSER("execution part construct"_en_US,
-            first(construct<ExecutionPartConstruct>(executableConstruct),
-                construct<ExecutionPartConstruct>(
-                    statement(indirect(formatStmt))),
-                construct<ExecutionPartConstruct>(
-                    statement(indirect(entryStmt))),
-                construct<ExecutionPartConstruct>(
-                    statement(indirect(dataStmt))),
-                extension<LanguageFeature::ExecutionPartNamelist>(
-                    "nonstandard usage: NAMELIST in execution part"_port_en_US,
-                    construct<ExecutionPartConstruct>(
-                        statement(indirect(Parser<NamelistStmt>{})))),
-                obsoleteExecutionPartConstruct,
+            first(
+                withMessage("expected an executable statement"_err_en_US,
+                    first(
+                        construct<ExecutionPartConstruct>(executableConstruct),
+                        construct<ExecutionPartConstruct>(
+                            statement(indirect(formatStmt))),
+                        construct<ExecutionPartConstruct>(
+                            statement(indirect(entryStmt))),
+                        construct<ExecutionPartConstruct>(
+                            statement(indirect(dataStmt))),
+                        extension<LanguageFeature::ExecutionPartNamelist>(
+                            "nonstandard usage: NAMELIST in execution part"_port_en_US,
+                            construct<ExecutionPartConstruct>(
+                                statement(indirect(Parser<NamelistStmt>{})))),
+                        obsoleteExecutionPartConstruct)),
                 lookAhead(declarationConstruct) >> SkipTo<'\n'>{} >>
                     fail<ExecutionPartConstruct>(
                         "misplaced declaration in the execution part"_err_en_US))),

--- a/flang/test/Parser/recovery10.f90
+++ b/flang/test/Parser/recovery10.f90
@@ -1,0 +1,21 @@
+! RUN: not %flang_fc1 -fsyntax-only %s 2>&1 | FileCheck %s \
+! RUN:   --implicit-check-not="expected 'CALL'" \
+! RUN:   --implicit-check-not="expected 'DATA'" \
+! RUN:   --implicit-check-not="expected 'NAMELIST'" \
+! RUN:   --implicit-check-not="expected 'GO TO'" \
+! RUN:   --implicit-check-not="expected 'ALLOCATE ('" \
+! RUN:   --implicit-check-not="obsolete legacy extension"
+
+! Verify that an unrecognizable statement in the execution part produces a
+! single clear "expected an executable statement" diagnostic instead of a
+! flood of "expected 'KEYWORD'" messages for every possible statement, one
+! for each execution-part-construct alternative.  The --implicit-check-not
+! options assert, across the whole output, that none of those spurious
+! messages reappear.
+
+program p
+  x = 1 ;  + y
+! CHECK: error: expected an executable statement
+! CHECK-NEXT: {{.*}}x = 1 ;  + y
+! CHECK: in the context: execution part
+end


### PR DESCRIPTION
An unrecognizable statement in the execution part of a source file produced
one "expected 'KEYWORD'" error for every possible statement because each
execution-part-construct alternative failed at the same source position and
the alternative combinator merges the messages of same-position ties.

Wrapped the keyword-led alternatives in `withMessage` so that when none
of them matches a token, the flood is discarded in favor of a single "expected an
executable statement" diagnostic.

This fixes the problem identified in Issue: https://github.com/llvm/llvm-project/issues/220696

Assisted-by: Claude