### PR TITLE
[lldb][debugserver] Don't overwrite the attach error with a hint

### DIFF
--- a/lldb/tools/debugserver/source/RNBRemote.cpp
+++ b/lldb/tools/debugserver/source/RNBRemote.cpp
@@ -4228,19 +4228,19 @@ rnb_err_t RNBRemote::HandlePacket_v(const char *p) {
 
       std::string error_explainer = "attach failed";
       if (err_str[0] != '\0') {
-        // This is not a super helpful message for end users
-        if (strcmp (err_str, "unable to start the exception thread") == 0) {
-          snprintf (err_str, sizeof (err_str) - 1,
-                    "Not allowed to attach to process.  Look in the console "
-                    "messages (Console.app), near the debugserver entries, "
-                    "when the attach failed.  The subsystem that denied "
-                    "the attach permission will likely have logged an "
-                    "informative message about why it was denied.");
-          err_str[sizeof (err_str) - 1] = '\0';
-        }
         error_explainer += " (";
         error_explainer += err_str;
         error_explainer += ")";
+        // This is not a super helpful message for end users
+        if (strcmp(err_str, "unable to start the exception thread") == 0) {
+          error_explainer += ".  ";
+          error_explainer += "Not allowed to attach to process.  Look in the "
+                             "console messages (Console.app), near the "
+                             "debugserver entries, when the attach failed.  "
+                             "The subsystem that denied the attach permission "
+                             "will likely have logged an informative message "
+                             "about why it was denied.";
+        }
       }
       DNBLogError("Attach failed: \"%s\".", err_str);
       return SendErrorPacket("E96", error_explainer);


### PR DESCRIPTION
When the attach fails with "unable to start the exception thread", debugserver snprintf'd advice about checking Console.app over err_str, destroying the real error before it reached both the packet sent to lldb and the DNBLogError below it. That step can fail for reasons other than a denied attach, so the hint replaced an authoritative error with a guess.