### PR TITLE
[flang][OpenMP] Fix crash in defaultmap(none) on structure constructors

### DIFF
--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -3183,6 +3183,10 @@ static bool IsOpenMPAggregate(const Symbol &symbol) {
     return false;
 
   const auto *type{symbol.GetType()};
+  // Symbols without a declared type (e.g. a derived-type name) are not
+  // variables and belong to no defaultmap category.
+  if (!type)
+    return false;
   // OpenMP categorizes Fortran characters as aggregates.
   if (type->category() == Fortran::semantics::DeclTypeSpec::Category::Character)
     return true;
@@ -3206,6 +3210,8 @@ static bool IsOpenMPScalar(const Symbol &symbol) {
       IsAllocatable(symbol))
     return false;
   const auto *type{symbol.GetType()};
+  if (!type)
+    return false;
   if ((!symbol.GetShape() || symbol.GetShape()->empty()) &&
       (type->category() ==
               Fortran::semantics::DeclTypeSpec::Category::Numeric ||

--- a/flang/test/Semantics/OpenMP/defaultmap-clause-none.f90
+++ b/flang/test/Semantics/OpenMP/defaultmap-clause-none.f90
@@ -130,4 +130,18 @@ subroutine defaultmap_func_and_procedure_pointer()
         i = test_procedure()
     !$omp end target
 end subroutine defaultmap_func_and_procedure_pointer
+
+! Verify we do not crash on a derived-type name in a structure constructor,
+! which has no declared type of its own, in defaultmap(none)
+subroutine defaultmap_structure_constructor_none
+    implicit none
+    type t
+    end type
+    type(t) :: x
+
+    !$omp target defaultmap(none: aggregate)
+!ERROR: The DEFAULTMAP(NONE) clause requires that 'x' must be listed in a data-sharing attribute, data-mapping attribute, or is_device_ptr clause
+        x = t()
+    !$omp end target
+end subroutine defaultmap_structure_constructor_none
 end module


### PR DESCRIPTION
Fixes :  [https://github.com/llvm/llvm-project/issues/218929](https://github.com/llvm/llvm-project/issues/218929)
Flang was crashing when a target defaultmap(none:...) region contained a structure constructor, like this:
```
program p
  type t
  end type
  type(t) :: x

  !$omp target defaultmap(none:aggregate)
  x = t()
  !$omp end target
end
```
The problem is in `IsOpenMPAggregate` and `IsOpenMPScalar`. When the OpenMP attribute visitor walks the names in the region, it hits the t in t(), which resolves to the derived-type definition symbol rather than a variable. `Symbol::GetType() `returns nullptr for such a symbol, and both helpers dereferenced that pointer directly `(type->category())` without checking, causing a segfault. The fix adds a null check to both helpers returning false since a symbol with no declared type belongs to no defaultmap category. 
