### PR TITLE
[libc] Make File::FileLock public in File data structure

### DIFF
--- a/libc/src/__support/File/file.h
+++ b/libc/src/__support/File/file.h
@@ -92,6 +92,19 @@ public:
     EXCLUSIVE = 0x100,
   };
 
+  // This is a convenience RAII class to lock and unlock file objects.
+  class FileLock {
+    File *file;
+
+  public:
+    explicit FileLock(File *f) : file(f) { file->lock(); }
+
+    ~FileLock() { file->unlock(); }
+
+    FileLock(const FileLock &) = delete;
+    FileLock(FileLock &&) = delete;
+  };
+
 private:
   enum class FileOp : uint8_t { NONE, READ, WRITE, SEEK };
 
@@ -139,19 +152,6 @@ private:
 
   Orientation orientation;
   internal::mbstate mbstate;
-
-  // This is a convenience RAII class to lock and unlock file objects.
-  class FileLock {
-    File *file;
-
-  public:
-    explicit FileLock(File *f) : file(f) { file->lock(); }
-
-    ~FileLock() { file->unlock(); }
-
-    FileLock(const FileLock &) = delete;
-    FileLock(FileLock &&) = delete;
-  };
 
 protected:
   constexpr bool write_allowed() const {

--- a/libc/src/__support/File/linux/file.cpp
+++ b/libc/src/__support/File/linux/file.cpp
@@ -311,11 +311,8 @@ int get_fileno(File *f) {
 }
 
 int reopenfile(File *f, const char *path, const char *mode) {
-  f->lock();
-  int ret = reopenfile_unlocked(f, path, mode);
-  f->unlock();
-
-  return ret;
+  File::FileLock lock(f);
+  return reopenfile_unlocked(f, path, mode);
 }
 
 int reopenfile_unlocked(File *f, const char *path, const char *mode) {

--- a/libc/src/pwd/flat_file_db.h
+++ b/libc/src/pwd/flat_file_db.h
@@ -55,17 +55,15 @@ private:
     if (!f || buf.size() < 2)
       return Error(EINVAL);
 
-    f->lock();
+    File::FileLock lock(f);
     size_t bytes_read = 0;
     FileIOResult result(0);
     bool truncated = false;
 
     for (char &ch : buf.first(buf.size() - 1)) {
       result = f->read_unlocked(&ch, 1);
-      if (result.has_error()) {
-        f->unlock();
+      if (result.has_error())
         return Error(result.error);
-      }
       if (result.value != 1)
         break;
       ++bytes_read;
@@ -79,19 +77,14 @@ private:
       char c = '\0';
       while (true) {
         result = f->read_unlocked(&c, 1);
-        if (result.has_error()) {
-          f->unlock();
+        if (result.has_error())
           return Error(result.error);
-        }
         if (result.value != 1 || c == '\n')
           break;
       }
     }
 
-    bool has_error = f->error_unlocked();
-    f->unlock();
-
-    if (has_error)
+    if (f->error_unlocked())
       return Error(EIO);
 
     // If the line ended with a newline, strip it.

--- a/libc/src/stdio/generic/fgets.cpp
+++ b/libc/src/stdio/generic/fgets.cpp
@@ -24,7 +24,7 @@ LLVM_LIBC_FUNCTION(char *, fgets,
 
   unsigned char c = '\0';
   auto stream = reinterpret_cast<LIBC_NAMESPACE::File *__restrict>(raw_stream);
-  stream->lock();
+  File::FileLock lock(stream);
 
   // i is an int because it's frequently compared to count, which is also int.
   int i = 0;
@@ -44,7 +44,6 @@ LLVM_LIBC_FUNCTION(char *, fgets,
 
   bool has_error = stream->error_unlocked();
   bool has_eof = stream->iseof_unlocked();
-  stream->unlock();
 
   // If the requested read size makes no sense, an error occurred, or no bytes
   // were read due to an EOF, then return nullptr and don't write the null byte.

--- a/libc/src/stdio/generic/perror.cpp
+++ b/libc/src/stdio/generic/perror.cpp
@@ -78,9 +78,8 @@ LLVM_LIBC_FUNCTION(void, perror, (const char *str)) {
 
   // We need to lock the stream to ensure the newline is always appended.
   LIBC_NAMESPACE::File *file = reinterpret_cast<File *>(stderr);
-  file->lock();
+  File::FileLock lock(file);
   write_sequence(str_view, err_str);
-  file->unlock();
 }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/stdio/generic/puts.cpp
+++ b/libc/src/stdio/generic/puts.cpp
@@ -18,25 +18,12 @@
 
 namespace LIBC_NAMESPACE_DECL {
 
-namespace {
-
-// Simple helper to unlock the file once destroyed.
-struct ScopedLock {
-  ScopedLock(LIBC_NAMESPACE::File *stream) : stream(stream) { stream->lock(); }
-  ~ScopedLock() { stream->unlock(); }
-
-private:
-  LIBC_NAMESPACE::File *stream;
-};
-
-} // namespace
-
 LLVM_LIBC_FUNCTION(int, puts, (const char *__restrict str)) {
   cpp::string_view str_view(str);
 
-  LIBC_NAMESPACE::File *file = reinterpret_cast<File *>(stdout);
+  File *file = reinterpret_cast<File *>(stdout);
   // We need to lock the stream to ensure the newline is always appended.
-  ScopedLock lock(file);
+  File::FileLock lock(file);
 
   auto result = file->write_unlocked(str, str_view.size());
   if (result.has_error())

--- a/libc/src/wchar/fgetws.cpp
+++ b/libc/src/wchar/fgetws.cpp
@@ -39,7 +39,7 @@ LLVM_LIBC_FUNCTION(wchar_t *, fgetws,
     return ws;
   }
 
-  f->lock();
+  File::FileLock lock(f);
 
   wchar_t *result = ws;
   int chars_read = 0;
@@ -62,7 +62,6 @@ LLVM_LIBC_FUNCTION(wchar_t *, fgetws,
   if (result != nullptr)
     ws[chars_read] = L'\0';
 
-  f->unlock();
   return result;
 }
 

--- a/libc/test/src/__support/File/file_test.cpp
+++ b/libc/test/src/__support/File/file_test.cpp
@@ -866,3 +866,18 @@ TEST(LlvmLibcFileTest, PartialWideCharWriteDetected) {
 
   ASSERT_EQ(f->close(), 0);
 }
+
+TEST(LlvmLibcFileTest, FileLockRAII) {
+  StringFile *f = new_string_file(nullptr, 0, _IONBF, false, "w+");
+  ASSERT_FALSE(f == nullptr);
+
+  {
+    File::FileLock lock(f);
+    ASSERT_EQ(f->write_unlocked("abc", 3).value, size_t(3));
+  }
+
+  // After FileLock is destroyed, operations under lock still acquire and
+  // release cleanly.
+  ASSERT_EQ(f->write("def", 3).value, size_t(3));
+  ASSERT_EQ(f->close(), 0);
+}


### PR DESCRIPTION
Commit 9db0037bf1b3 moved FileLock from namespace scope into class File so internal methods could use RAII locking, but placed it in the private section.

Move FileLock to the public section of class File so that external callers operating on File streams can use RAII locking instead of manual lock and unlock calls.

Port callers in puts, fgets, perror, fgetws, reopenfile, and the pwd flat file database parser to use File::FileLock, and add a unit test verifying RAII locking on File streams.

Assisted-by: Automated tooling, human reviewed.