### PR TITLE
[lldb][test] Rerun tests that hit a known flaky failure

### DIFF
--- a/lldb/test/API/lit.cfg.py
+++ b/lldb/test/API/lit.cfg.py
@@ -382,6 +382,7 @@ if is_configured("dotest_lit_args_str"):
     dotest_cmd.extend(shlex.split(config.dotest_lit_args_str))
 
 # Load LLDB test format.
+sys.path.append(os.path.join(config.lldb_src_root, "test"))
 sys.path.append(os.path.join(config.lldb_src_root, "test", "API"))
 import lldbtest
 

--- a/lldb/test/API/lldbtest.py
+++ b/lldb/test/API/lldbtest.py
@@ -8,6 +8,8 @@ import lit.TestRunner
 import lit.util
 from lit.formats.base import TestFormat
 
+import lldbflakes
+
 
 class LLDBTest(TestFormat):
     def __init__(self, dotest_cmd):
@@ -33,6 +35,11 @@ class LLDBTest(TestFormat):
                     )
 
     def execute(self, test, litConfig):
+        return lldbflakes.execute_with_reruns(
+            lambda: lit.Test.Result(*self._execute_once(test, litConfig))
+        )
+
+    def _execute_once(self, test, litConfig):
         if litConfig.noExecute:
             return lit.Test.PASS, ""
 

--- a/lldb/test/Shell/helper/toolchain.py
+++ b/lldb/test/Shell/helper/toolchain.py
@@ -11,6 +11,8 @@ from lit.llvm import llvm_config
 from lit.llvm.subst import FindTool
 from lit.llvm.subst import ToolSubst
 
+import lldbflakes
+
 import posixpath
 
 def _get_lldb_init_path(config):
@@ -84,7 +86,9 @@ class ShTestLldb(ShTest):
                         cmd.replace(args_def, args_unique),
                     )
                 break
-        return super().execute(test, litConfig)
+        return lldbflakes.execute_with_reruns(
+            lambda: ShTest.execute(self, test, litConfig)
+        )
 
 
 def use_lldb_substitutions(config):

--- a/lldb/test/Shell/lit.cfg.py
+++ b/lldb/test/Shell/lit.cfg.py
@@ -14,6 +14,7 @@ from lit.llvm import llvm_config
 from lit.llvm.subst import FindTool
 from lit.llvm.subst import ToolSubst
 
+sys.path.append(os.path.join(config.lldb_src_root, "test"))
 site.addsitedir(os.path.dirname(__file__))
 from helper import toolchain
 

--- a/lldb/test/lldbflakes.py
+++ b/lldb/test/lldbflakes.py
@@ -1,0 +1,40 @@
+"""Rerun policy shared by the API and Shell test formats."""
+
+import re
+
+import lit.Test
+
+# Failures that come from flaky infrastructure rather than from the test
+# itself. Rerunning masks real bugs, so this is deliberately not a blanket
+# retry of every failure. Adding an entry is a last resort, reserved for a
+# defect outside LLDB's control that cannot be worked around any other way.
+KNOWN_FLAKES = [
+    # macOS 26.3 denies debugserver permission to attach when too many debug
+    # sessions start at once, which surfaces as an immediate process exit.
+    re.compile(r"process exited with status -1"),
+]
+
+MAX_ATTEMPTS = 3
+
+
+def _hit_known_flake(output):
+    return any(flake.search(output) for flake in KNOWN_FLAKES)
+
+
+def execute_with_reruns(execute_once):
+    """Run execute_once, which returns a lit.Test.Result, until it stops
+    failing with a known flake."""
+    for attempt in range(MAX_ATTEMPTS):
+        result = execute_once()
+        if result.code != lit.Test.FAIL or not _hit_known_flake(result.output):
+            break
+
+    # A pass that needed a rerun is reported apart from a clean pass so that
+    # the flakiness stays visible.
+    if attempt > 0:
+        if result.code == lit.Test.PASS:
+            result.code = lit.Test.FLAKYPASS
+        result.attempts = attempt + 1
+        result.max_allowed_attempts = MAX_ATTEMPTS
+
+    return result


### PR DESCRIPTION
macOS 26.3 denies debugserver permission to attach when too many debug sessions start at once, which surfaces as a test failing with "process exited with status -1". The denial is intermittent and a rerun normally gets through.

Gate the rerun on a list of known flake signatures rather than retrying every failure, because a blanket retry masks real bugs. Adding to that list is a last resort for defects outside LLDB's control.