### PR TITLE
[LLVM][NFC] Use +inf/-inf syntax for float infinity literals

### DIFF
--- a/llvm/test/CodeGen/AArch64/sve-vector-splat.ll
+++ b/llvm/test/CodeGen/AArch64/sve-vector-splat.ll
@@ -610,7 +610,7 @@ define <vscale x 2 x float> @splat_pinf_nxv2f32() {
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    mov z0.s, #0x7f800000
 ; CHECK-NEXT:    ret
-  ret <vscale x 2 x float> splat (float 0x7FF0000000000000)
+  ret <vscale x 2 x float> splat (float +inf)
 }
 
 define <vscale x 4 x float> @splat_pinf_nxv4f32() {
@@ -618,7 +618,7 @@ define <vscale x 4 x float> @splat_pinf_nxv4f32() {
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    mov z0.s, #0x7f800000
 ; CHECK-NEXT:    ret
-  ret <vscale x 4 x float> splat (float 0x7FF0000000000000)
+  ret <vscale x 4 x float> splat (float +inf)
 }
 
 define <vscale x 2 x double> @splat_pinf_nxv2f64() {
@@ -682,7 +682,7 @@ define <vscale x 2 x float> @splat_ninf_nxv2f32() {
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    mov z0.s, #0xff800000
 ; CHECK-NEXT:    ret
-  ret <vscale x 2 x float> splat (float 0xFFF0000000000000)
+  ret <vscale x 2 x float> splat (float -inf)
 }
 
 define <vscale x 4 x float> @splat_ninf_nxv4f32() {
@@ -690,7 +690,7 @@ define <vscale x 4 x float> @splat_ninf_nxv4f32() {
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    mov z0.s, #0xff800000
 ; CHECK-NEXT:    ret
-  ret <vscale x 4 x float> splat (float 0xFFF0000000000000)
+  ret <vscale x 4 x float> splat (float -inf)
 }
 
 define <vscale x 2 x double> @splat_ninf_nxv2f64() {

--- a/llvm/test/CodeGen/AMDGPU/dpp_combine.ll
+++ b/llvm/test/CodeGen/AMDGPU/dpp_combine.ll
@@ -102,13 +102,13 @@ define amdgpu_kernel void @dpp_fadd_f16(ptr addrspace(1) %arg) {
 ; GCN: v_min{{(_num)?}}_f32_dpp v0, v0, v0 row_shr:8 row_mask:0xf bank_mask:0xf{{$}}
 define nofpclass(nan) float @dpp_fmin_f32(float nofpclass(nan) %x) {
 entry:
-  %dpp.shr1 = tail call float @llvm.amdgcn.update.dpp.f32(float 0x7FF0000000000000, float %x, i32 273, i32 15, i32 15, i1 false)
+  %dpp.shr1 = tail call float @llvm.amdgcn.update.dpp.f32(float +inf, float %x, i32 273, i32 15, i32 15, i1 false)
   %min1 = tail call nnan float @llvm.minnum.f32(float %x, float %dpp.shr1)
-  %dpp.shr2 = tail call float @llvm.amdgcn.update.dpp.f32(float 0x7FF0000000000000, float %min1, i32 274, i32 15, i32 15, i1 false)
+  %dpp.shr2 = tail call float @llvm.amdgcn.update.dpp.f32(float +inf, float %min1, i32 274, i32 15, i32 15, i1 false)
   %min2 = tail call nnan float @llvm.minnum.f32(float %min1, float %dpp.shr2)
-  %dpp.shr4 = tail call float @llvm.amdgcn.update.dpp.f32(float 0x7FF0000000000000, float %min2, i32 276, i32 15, i32 15, i1 false)
+  %dpp.shr4 = tail call float @llvm.amdgcn.update.dpp.f32(float +inf, float %min2, i32 276, i32 15, i32 15, i1 false)
   %min3 = tail call nnan float @llvm.minnum.f32(float %min2, float %dpp.shr4)
-  %dpp.shr8 = tail call float @llvm.amdgcn.update.dpp.f32(float 0x7FF0000000000000, float %min3, i32 280, i32 15, i32 15, i1 false)
+  %dpp.shr8 = tail call float @llvm.amdgcn.update.dpp.f32(float +inf, float %min3, i32 280, i32 15, i32 15, i1 false)
   %min4 = tail call nnan float @llvm.minnum.f32(float %min3, float %dpp.shr8)
   ret float %min4
 }
@@ -120,13 +120,13 @@ entry:
 ; GCN: v_max{{(_num)?}}_f32_dpp v0, v0, v0 row_shr:8 row_mask:0xf bank_mask:0xf{{$}}
 define nofpclass(nan) float @dpp_fmax_f32(float nofpclass(nan) %x) #0 {
 entry:
-  %dpp.shr1 = tail call float @llvm.amdgcn.update.dpp.f32(float 0xFFF0000000000000, float %x, i32 273, i32 15, i32 15, i1 false)
+  %dpp.shr1 = tail call float @llvm.amdgcn.update.dpp.f32(float -inf, float %x, i32 273, i32 15, i32 15, i1 false)
   %max1 = tail call nnan float @llvm.maxnum.f32(float %x, float %dpp.shr1)
-  %dpp.shr2 = tail call float @llvm.amdgcn.update.dpp.f32(float 0xFFF0000000000000, float %max1, i32 274, i32 15, i32 15, i1 false)
+  %dpp.shr2 = tail call float @llvm.amdgcn.update.dpp.f32(float -inf, float %max1, i32 274, i32 15, i32 15, i1 false)
   %max2 = tail call nnan float @llvm.maxnum.f32(float %max1, float %dpp.shr2)
-  %dpp.shr4 = tail call float @llvm.amdgcn.update.dpp.f32(float 0xFFF0000000000000, float %max2, i32 276, i32 15, i32 15, i1 false)
+  %dpp.shr4 = tail call float @llvm.amdgcn.update.dpp.f32(float -inf, float %max2, i32 276, i32 15, i32 15, i1 false)
   %max3 = tail call nnan float @llvm.maxnum.f32(float %max2, float %dpp.shr4)
-  %dpp.shr8 = tail call float @llvm.amdgcn.update.dpp.f32(float 0xFFF0000000000000, float %max3, i32 280, i32 15, i32 15, i1 false)
+  %dpp.shr8 = tail call float @llvm.amdgcn.update.dpp.f32(float -inf, float %max3, i32 280, i32 15, i32 15, i1 false)
   %max4 = tail call nnan float @llvm.maxnum.f32(float %max3, float %dpp.shr8)
   ret float %max4
 }
@@ -138,13 +138,13 @@ entry:
 ; GCN: v_min{{(_num)?}}_f32_dpp v0, v0, v0 row_shr:8 row_mask:0xf bank_mask:0xf{{$}}
 define nofpclass(nan) float @dpp_fminimum_f32(float nofpclass(nan) %x) {
 entry:
-  %dpp.shr1 = tail call float @llvm.amdgcn.update.dpp.f32(float 0x7FF0000000000000, float %x, i32 273, i32 15, i32 15, i1 false)
+  %dpp.shr1 = tail call float @llvm.amdgcn.update.dpp.f32(float +inf, float %x, i32 273, i32 15, i32 15, i1 false)
   %min1 = tail call nnan float @llvm.minimumnum.f32(float %x, float %dpp.shr1)
-  %dpp.shr2 = tail call float @llvm.amdgcn.update.dpp.f32(float 0x7FF0000000000000, float %min1, i32 274, i32 15, i32 15, i1 false)
+  %dpp.shr2 = tail call float @llvm.amdgcn.update.dpp.f32(float +inf, float %min1, i32 274, i32 15, i32 15, i1 false)
   %min2 = tail call nnan float @llvm.minimumnum.f32(float %min1, float %dpp.shr2)
-  %dpp.shr4 = tail call float @llvm.amdgcn.update.dpp.f32(float 0x7FF0000000000000, float %min2, i32 276, i32 15, i32 15, i1 false)
+  %dpp.shr4 = tail call float @llvm.amdgcn.update.dpp.f32(float +inf, float %min2, i32 276, i32 15, i32 15, i1 false)
   %min3 = tail call nnan float @llvm.minimumnum.f32(float %min2, float %dpp.shr4)
-  %dpp.shr8 = tail call float @llvm.amdgcn.update.dpp.f32(float 0x7FF0000000000000, float %min3, i32 280, i32 15, i32 15, i1 false)
+  %dpp.shr8 = tail call float @llvm.amdgcn.update.dpp.f32(float +inf, float %min3, i32 280, i32 15, i32 15, i1 false)
   %min4 = tail call nnan float @llvm.minimumnum.f32(float %min3, float %dpp.shr8)
   ret float %min4
 }
@@ -156,13 +156,13 @@ entry:
 ; GCN: v_max{{(_num)?}}_f32_dpp v0, v0, v0 row_shr:8 row_mask:0xf bank_mask:0xf{{$}}
 define nofpclass(nan) float @dpp_fmaximum_f32(float nofpclass(nan) %x) #0 {
 entry:
-  %dpp.shr1 = tail call float @llvm.amdgcn.update.dpp.f32(float 0xFFF0000000000000, float %x, i32 273, i32 15, i32 15, i1 false)
+  %dpp.shr1 = tail call float @llvm.amdgcn.update.dpp.f32(float -inf, float %x, i32 273, i32 15, i32 15, i1 false)
   %max1 = tail call nnan float @llvm.maximumnum.f32(float %x, float %dpp.shr1)
-  %dpp.shr2 = tail call float @llvm.amdgcn.update.dpp.f32(float 0xFFF0000000000000, float %max1, i32 274, i32 15, i32 15, i1 false)
+  %dpp.shr2 = tail call float @llvm.amdgcn.update.dpp.f32(float -inf, float %max1, i32 274, i32 15, i32 15, i1 false)
   %max2 = tail call nnan float @llvm.maximumnum.f32(float %max1, float %dpp.shr2)
-  %dpp.shr4 = tail call float @llvm.amdgcn.update.dpp.f32(float 0xFFF0000000000000, float %max2, i32 276, i32 15, i32 15, i1 false)
+  %dpp.shr4 = tail call float @llvm.amdgcn.update.dpp.f32(float -inf, float %max2, i32 276, i32 15, i32 15, i1 false)
   %max3 = tail call nnan float @llvm.maximumnum.f32(float %max2, float %dpp.shr4)
-  %dpp.shr8 = tail call float @llvm.amdgcn.update.dpp.f32(float 0xFFF0000000000000, float %max3, i32 280, i32 15, i32 15, i1 false)
+  %dpp.shr8 = tail call float @llvm.amdgcn.update.dpp.f32(float -inf, float %max3, i32 280, i32 15, i32 15, i1 false)
   %max4 = tail call nnan float @llvm.maximumnum.f32(float %max3, float %dpp.shr8)
   ret float %max4
 }

--- a/llvm/test/CodeGen/AMDGPU/float-to-arbitrary-fp-e5m3fnu.ll
+++ b/llvm/test/CodeGen/AMDGPU/float-to-arbitrary-fp-e5m3fnu.ll
@@ -95,7 +95,7 @@ define i8 @to_e5m3fnu_inf_saturate() {
 ; CHECK-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; CHECK-NEXT:    v_mov_b32_e32 v0, 0xfe
 ; CHECK-NEXT:    s_setpc_b64 s[30:31]
-  %r = call i8 @llvm.convert.to.arbitrary.fp.i8.f32(float 0x7FF0000000000000, metadata !"Float8E5M3FNU", metadata !"round.tonearest", i1 true)
+  %r = call i8 @llvm.convert.to.arbitrary.fp.i8.f32(float +inf, metadata !"Float8E5M3FNU", metadata !"round.tonearest", i1 true)
   ret i8 %r
 }
 

--- a/llvm/test/CodeGen/AMDGPU/fract-match.ll
+++ b/llvm/test/CodeGen/AMDGPU/fract-match.ll
@@ -273,7 +273,7 @@ define <3 x float> @safe_math_fract_v3f32(<3 x float> %x, ptr addrspace(1) write
   %uno = fcmp uno <3 x float> %x, <float 0.0, float poison, float 0.0>
   %cond = select <3 x i1> %uno, <3 x float> %x, <3 x float> %min
   %fabs = tail call <3 x float> @llvm.fabs.v3f32(<3 x float> %x)
-  %cmpinf = fcmp oeq <3 x float> %fabs, <float 0x7FF0000000000000, float poison, float 0x7FF0000000000000>
+  %cmpinf = fcmp oeq <3 x float> %fabs, <float +inf, float poison, float +inf>
   %cond6 = select <3 x i1> %cmpinf, <3 x float> <float 0.0, float poison, float 0.0>, <3 x float> %cond
   store <3 x float> %floor, ptr addrspace(1) %ip, align 4
   ret <3 x float> %cond6
@@ -408,7 +408,7 @@ define <2 x float> @safe_math_fract_v2f32_const_splat_poison(<2 x float> %x, ptr
   %uno = fcmp uno <2 x float> %x, zeroinitializer
   %cond = select <2 x i1> %uno, <2 x float> %x, <2 x float> %min
   %fabs = tail call <2 x float> @llvm.fabs.v2f32(<2 x float> %x)
-  %cmpinf = fcmp oeq <2 x float> %fabs, splat (float 0x7FF0000000000000)
+  %cmpinf = fcmp oeq <2 x float> %fabs, splat (float +inf)
   %cond6 = select <2 x i1> %cmpinf, <2 x float> zeroinitializer, <2 x float> %cond
   store <2 x float> %floor, ptr addrspace(1) %ip, align 4
   ret <2 x float> %cond6
@@ -2503,7 +2503,7 @@ entry:
   %uno = fcmp uno <2 x float> %x, zeroinitializer
   %cond = select <2 x i1> %uno, <2 x float> %x, <2 x float> %min
   %fabs = tail call <2 x float> @llvm.fabs.v2f32(<2 x float> %x)
-  %cmpinf = fcmp oeq <2 x float> %fabs, <float 0x7FF0000000000000, float 0x7FF0000000000000>
+  %cmpinf = fcmp oeq <2 x float> %fabs, <float +inf, float +inf>
   %cond6 = select <2 x i1> %cmpinf, <2 x float> zeroinitializer, <2 x float> %cond
   store <2 x float> %floor, ptr addrspace(1) %ip, align 4
   ret <2 x float> %cond6
@@ -5381,7 +5381,7 @@ entry:
   %sub = fsub <3 x float> %x, %floor
   %min = call <3 x float> @llvm.minnum.v3f32(<3 x float> %sub, <3 x float> <float 0x3FEFFFFFE0000000, float poison, float 0x3FEFFFFFE0000000>)
   %x.fabs = call <3 x float> @llvm.fabs.v3f32(<3 x float> %x)
-  %not.inf = fcmp une <3 x float> %x.fabs, <float 0x7FF0000000000000, float poison, float 0x7FF0000000000000>
+  %not.inf = fcmp une <3 x float> %x.fabs, <float +inf, float poison, float +inf>
   %cond = select <3 x i1> %not.inf, <3 x float> %min, <3 x float> <float 0.0, float poison, float 0.0>
   %not.nan = fcmp ord <3 x float> %x, <float 0.0, float poison, float 0.0>
   %cond8 = select <3 x i1> %not.nan, <3 x float> %cond, <3 x float> %x

--- a/llvm/test/CodeGen/AMDGPU/frexp-constant-fold.ll
+++ b/llvm/test/CodeGen/AMDGPU/frexp-constant-fold.ll
@@ -207,7 +207,7 @@ define { float, i32 } @frexp_inf() {
 ; CHECK-NEXT:    v_mov_b32_e32 v0, 0x7f800000
 ; CHECK-NEXT:    v_mov_b32_e32 v1, 0
 ; CHECK-NEXT:    s_setpc_b64 s[30:31]
-  %ret = call { float, i32 } @llvm.frexp.f32.i32(float 0x7FF0000000000000)
+  %ret = call { float, i32 } @llvm.frexp.f32.i32(float +inf)
   ret { float, i32 } %ret
 }
 
@@ -218,7 +218,7 @@ define { float, i32 } @frexp_neginf() {
 ; CHECK-NEXT:    v_mov_b32_e32 v0, 0xff800000
 ; CHECK-NEXT:    v_mov_b32_e32 v1, 0
 ; CHECK-NEXT:    s_setpc_b64 s[30:31]
-  %ret = call { float, i32 } @llvm.frexp.f32.i32(float 0xFFF0000000000000)
+  %ret = call { float, i32 } @llvm.frexp.f32.i32(float -inf)
   ret { float, i32 } %ret
 }
 
@@ -301,7 +301,7 @@ define { <2 x float>, <2 x i32> } @frexp_splat_inf() {
 ; CHECK-NEXT:    v_mov_b32_e32 v2, 0
 ; CHECK-NEXT:    v_mov_b32_e32 v3, 0
 ; CHECK-NEXT:    s_setpc_b64 s[30:31]
-  %ret = call { <2 x float>, <2 x i32> } @llvm.frexp.v2f32.v2i32(<2 x float> <float 0x7FF0000000000000, float 0x7FF0000000000000>)
+  %ret = call { <2 x float>, <2 x i32> } @llvm.frexp.v2f32.v2i32(<2 x float> <float +inf, float +inf>)
   ret { <2 x float>, <2 x i32> } %ret
 }
 
@@ -314,7 +314,7 @@ define { <2 x float>, <2 x i32> } @frexp_splat_neginf() {
 ; CHECK-NEXT:    v_mov_b32_e32 v2, 0
 ; CHECK-NEXT:    v_mov_b32_e32 v3, 0
 ; CHECK-NEXT:    s_setpc_b64 s[30:31]
-  %ret = call { <2 x float>, <2 x i32> } @llvm.frexp.v2f32.v2i32(<2 x float> <float 0xFFF0000000000000, float 0xFFF0000000000000>)
+  %ret = call { <2 x float>, <2 x i32> } @llvm.frexp.v2f32.v2i32(<2 x float> <float -inf, float -inf>)
   ret { <2 x float>, <2 x i32> } %ret
 }
 
@@ -327,6 +327,6 @@ define { <2 x float>, <2 x i32> } @frexp_splat_undef_inf() {
 ; CHECK-NEXT:    v_mov_b32_e32 v1, 0x7f800000
 ; CHECK-NEXT:    v_mov_b32_e32 v3, 0
 ; CHECK-NEXT:    s_setpc_b64 s[30:31]
-  %ret = call { <2 x float>, <2 x i32> } @llvm.frexp.v2f32.v2i32(<2 x float> <float undef, float 0x7FF0000000000000>)
+  %ret = call { <2 x float>, <2 x i32> } @llvm.frexp.v2f32.v2i32(<2 x float> <float undef, float +inf>)
   ret { <2 x float>, <2 x i32> } %ret
 }

--- a/llvm/test/CodeGen/AMDGPU/known-never-nan.ll
+++ b/llvm/test/CodeGen/AMDGPU/known-never-nan.ll
@@ -35,9 +35,9 @@ define float @fma_not_fmaxnm_maybe_nan(i32 %i1, i32 %i2, i32 %i3) #0 {
   %f1 = uitofp i32 %i1 to float
   %f2 = uitofp i32 %i2 to float
   %f3 = uitofp i32 %i2 to float
-  %fma = tail call float @llvm.fma.f32(float %f2, float %f1, float 0xfff0000000000000)
+  %fma = tail call float @llvm.fma.f32(float %f2, float %f1, float -inf)
   %cmp = fcmp ugt float %fma, 0xfff0000000000000
-  %val = select i1 %cmp, float %fma, float 0xfff0000000000000
+  %val = select i1 %cmp, float %fma, float -inf
   ret float %val
 }
 

--- a/llvm/test/CodeGen/AMDGPU/modf-constant-fold.ll
+++ b/llvm/test/CodeGen/AMDGPU/modf-constant-fold.ll
@@ -89,7 +89,7 @@ define { float, float } @modf_inf() {
 ; CHECK-NEXT:    v_mov_b32_e32 v0, 0
 ; CHECK-NEXT:    v_mov_b32_e32 v1, 0x7f800000
 ; CHECK-NEXT:    s_setpc_b64 s[30:31]
-  %ret = call { float, float } @llvm.modf.f32(float 0x7FF0000000000000)
+  %ret = call { float, float } @llvm.modf.f32(float +inf)
   ret { float, float } %ret
 }
 
@@ -100,7 +100,7 @@ define { float, float } @modf_neginf() {
 ; CHECK-NEXT:    v_bfrev_b32_e32 v0, 1
 ; CHECK-NEXT:    v_mov_b32_e32 v1, 0xff800000
 ; CHECK-NEXT:    s_setpc_b64 s[30:31]
-  %ret = call { float, float } @llvm.modf.f32(float 0xFFF0000000000000)
+  %ret = call { float, float } @llvm.modf.f32(float -inf)
   ret { float, float } %ret
 }
 
@@ -315,7 +315,7 @@ define { <2 x float>, <2 x float> } @modf_splat_inf() {
 ; CHECK-NEXT:    v_mov_b32_e32 v2, 0x7f800000
 ; CHECK-NEXT:    v_mov_b32_e32 v3, 0x7f800000
 ; CHECK-NEXT:    s_setpc_b64 s[30:31]
-  %ret = call { <2 x float>, <2 x float> } @llvm.modf.v2f32(<2 x float> <float 0x7FF0000000000000, float 0x7FF0000000000000>)
+  %ret = call { <2 x float>, <2 x float> } @llvm.modf.v2f32(<2 x float> <float +inf, float +inf>)
   ret { <2 x float>, <2 x float> } %ret
 }
 
@@ -328,7 +328,7 @@ define { <2 x float>, <2 x float> } @modf_splat_neginf() {
 ; CHECK-NEXT:    v_mov_b32_e32 v2, 0xff800000
 ; CHECK-NEXT:    v_mov_b32_e32 v3, 0xff800000
 ; CHECK-NEXT:    s_setpc_b64 s[30:31]
-  %ret = call { <2 x float>, <2 x float> } @llvm.modf.v2f32(<2 x float> <float 0xFFF0000000000000, float 0xFFF0000000000000>)
+  %ret = call { <2 x float>, <2 x float> } @llvm.modf.v2f32(<2 x float> <float -inf, float -inf>)
   ret { <2 x float>, <2 x float> } %ret
 }
 
@@ -342,6 +342,6 @@ define { <2 x float>, <2 x float> } @modf_splat_poison_inf() {
 ; CHECK-NEXT:    v_mov_b32_e32 v1, 0
 ; CHECK-NEXT:    v_mov_b32_e32 v3, 0x7f800000
 ; CHECK-NEXT:    s_setpc_b64 s[30:31]
-  %ret = call { <2 x float>, <2 x float> } @llvm.modf.v2f32(<2 x float> <float poison, float 0x7FF0000000000000>)
+  %ret = call { <2 x float>, <2 x float> } @llvm.modf.v2f32(<2 x float> <float poison, float +inf>)
   ret { <2 x float>, <2 x float> } %ret
 }

--- a/llvm/test/CodeGen/AMDGPU/select-cmp-shared-constant-fp.ll
+++ b/llvm/test/CodeGen/AMDGPU/select-cmp-shared-constant-fp.ll
@@ -335,7 +335,7 @@ define float @fcmp_select_no_fold_posinf_oeq_f32(float %arg, float %other) {
 ; GFX1010-NEXT:    s_setpc_b64 s[30:31]
 entry:
   %cmp = fcmp oeq float %arg, 0x7FF0000000000000
-  %sel = select i1 %cmp, float 0x7FF0000000000000, float %other
+  %sel = select i1 %cmp, float +inf, float %other
   ret float %sel
 }
 
@@ -358,8 +358,8 @@ define float @fcmp_select_no_fold_neginf_f32_one(float %arg, float %other) {
 ; GFX1010-NEXT:    v_cndmask_b32_e32 v0, 0xff800000, v1, vcc_lo
 ; GFX1010-NEXT:    s_setpc_b64 s[30:31]
 entry:
-  %cmp = fcmp one float 0xFFF0000000000000, %arg
-  %sel = select i1 %cmp, float %other, float 0xFFF0000000000000
+  %cmp = fcmp one float -inf, %arg
+  %sel = select i1 %cmp, float %other, float -inf
   ret float %sel
 }
 

--- a/llvm/test/CodeGen/ARM/fminmax-folds.ll
+++ b/llvm/test/CodeGen/ARM/fminmax-folds.ll
@@ -58,7 +58,7 @@ define float @test_minnum_const_inf(float %x) {
 ; CHECK-NEXT:  @ %bb.1:
 ; CHECK-NEXT:  .LCPI4_0:
 ; CHECK-NEXT:    .long 0x7f800000 @ float +Inf
-  %r = call float @llvm.minnum.f32(float %x, float 0x7ff0000000000000)
+  %r = call float @llvm.minnum.f32(float %x, float +inf)
   ret float %r
 }
 
@@ -68,7 +68,7 @@ define float @test_maxnum_const_inf(float %x) {
 ; CHECK-NEXT:    movw r0, #0
 ; CHECK-NEXT:    movt r0, #32640
 ; CHECK-NEXT:    bx lr
-  %r = call float @llvm.maxnum.f32(float %x, float 0x7ff0000000000000)
+  %r = call float @llvm.maxnum.f32(float %x, float +inf)
   ret float %r
 }
 
@@ -84,7 +84,7 @@ define float @test_maximum_const_inf(float %x) {
 ; CHECK-NEXT:  @ %bb.1:
 ; CHECK-NEXT:  .LCPI6_0:
 ; CHECK-NEXT:    .long 0x7f800000 @ float +Inf
-  %r = call float @llvm.maximum.f32(float %x, float 0x7ff0000000000000)
+  %r = call float @llvm.maximum.f32(float %x, float +inf)
   ret float %r
 }
 
@@ -92,7 +92,7 @@ define float @test_minimum_const_inf(float %x) {
 ; CHECK-LABEL: test_minimum_const_inf:
 ; CHECK:       @ %bb.0:
 ; CHECK-NEXT:    bx lr
-  %r = call float @llvm.minimum.f32(float %x, float 0x7ff0000000000000)
+  %r = call float @llvm.minimum.f32(float %x, float +inf)
   ret float %r
 }
 
@@ -102,7 +102,7 @@ define float @test_minnum_const_neg_inf(float %x) {
 ; CHECK-NEXT:    movw r0, #0
 ; CHECK-NEXT:    movt r0, #65408
 ; CHECK-NEXT:    bx lr
-  %r = call float @llvm.minnum.f32(float %x, float 0xfff0000000000000)
+  %r = call float @llvm.minnum.f32(float %x, float -inf)
   ret float %r
 }
 
@@ -118,7 +118,7 @@ define float @test_maxnum_const_neg_inf(float %x) {
 ; CHECK-NEXT:  @ %bb.1:
 ; CHECK-NEXT:  .LCPI9_0:
 ; CHECK-NEXT:    .long 0xff800000 @ float -Inf
-  %r = call float @llvm.maxnum.f32(float %x, float 0xfff0000000000000)
+  %r = call float @llvm.maxnum.f32(float %x, float -inf)
   ret float %r
 }
 
@@ -126,7 +126,7 @@ define float @test_maximum_const_neg_inf(float %x) {
 ; CHECK-LABEL: test_maximum_const_neg_inf:
 ; CHECK:       @ %bb.0:
 ; CHECK-NEXT:    bx lr
-  %r = call float @llvm.maximum.f32(float %x, float 0xfff0000000000000)
+  %r = call float @llvm.maximum.f32(float %x, float -inf)
   ret float %r
 }
 
@@ -142,7 +142,7 @@ define float @test_minimum_const_neg_inf(float %x) {
 ; CHECK-NEXT:  @ %bb.1:
 ; CHECK-NEXT:  .LCPI11_0:
 ; CHECK-NEXT:    .long 0xff800000 @ float -Inf
-  %r = call float @llvm.minimum.f32(float %x, float 0xfff0000000000000)
+  %r = call float @llvm.minimum.f32(float %x, float -inf)
   ret float %r
 }
 
@@ -150,7 +150,7 @@ define float @test_minnum_const_inf_nnan(float %x) {
 ; CHECK-LABEL: test_minnum_const_inf_nnan:
 ; CHECK:       @ %bb.0:
 ; CHECK-NEXT:    bx lr
-  %r = call nnan float @llvm.minnum.f32(float %x, float 0x7ff0000000000000)
+  %r = call nnan float @llvm.minnum.f32(float %x, float +inf)
   ret float %r
 }
 
@@ -160,7 +160,7 @@ define float @test_maxnum_const_inf_nnan(float %x) {
 ; CHECK-NEXT:    movw r0, #0
 ; CHECK-NEXT:    movt r0, #32640
 ; CHECK-NEXT:    bx lr
-  %r = call nnan float @llvm.maxnum.f32(float %x, float 0x7ff0000000000000)
+  %r = call nnan float @llvm.maxnum.f32(float %x, float +inf)
   ret float %r
 }
 
@@ -170,7 +170,7 @@ define float @test_maximum_const_inf_nnan(float %x) {
 ; CHECK-NEXT:    movw r0, #0
 ; CHECK-NEXT:    movt r0, #32640
 ; CHECK-NEXT:    bx lr
-  %r = call nnan float @llvm.maximum.f32(float %x, float 0x7ff0000000000000)
+  %r = call nnan float @llvm.maximum.f32(float %x, float +inf)
   ret float %r
 }
 
@@ -178,7 +178,7 @@ define float @test_minimum_const_inf_nnan(float %x) {
 ; CHECK-LABEL: test_minimum_const_inf_nnan:
 ; CHECK:       @ %bb.0:
 ; CHECK-NEXT:    bx lr
-  %r = call nnan float @llvm.minimum.f32(float %x, float 0x7ff0000000000000)
+  %r = call nnan float @llvm.minimum.f32(float %x, float +inf)
   ret float %r
 }
 
@@ -186,7 +186,7 @@ define float @test_minnum_const_inf_nnan_comm(float %x) {
 ; CHECK-LABEL: test_minnum_const_inf_nnan_comm:
 ; CHECK:       @ %bb.0:
 ; CHECK-NEXT:    bx lr
-  %r = call nnan float @llvm.minnum.f32(float 0x7ff0000000000000, float %x)
+  %r = call nnan float @llvm.minnum.f32(float +inf, float %x)
   ret float %r
 }
 
@@ -196,7 +196,7 @@ define float @test_maxnum_const_inf_nnan_comm(float %x) {
 ; CHECK-NEXT:    movw r0, #0
 ; CHECK-NEXT:    movt r0, #32640
 ; CHECK-NEXT:    bx lr
-  %r = call nnan float @llvm.maxnum.f32(float 0x7ff0000000000000, float %x)
+  %r = call nnan float @llvm.maxnum.f32(float +inf, float %x)
   ret float %r
 }
 
@@ -206,7 +206,7 @@ define float @test_maximum_const_inf_nnan_comm(float %x) {
 ; CHECK-NEXT:    movw r0, #0
 ; CHECK-NEXT:    movt r0, #32640
 ; CHECK-NEXT:    bx lr
-  %r = call nnan float @llvm.maximum.f32(float 0x7ff0000000000000, float %x)
+  %r = call nnan float @llvm.maximum.f32(float +inf, float %x)
   ret float %r
 }
 
@@ -214,7 +214,7 @@ define float @test_minimum_const_inf_nnan_comm(float %x) {
 ; CHECK-LABEL: test_minimum_const_inf_nnan_comm:
 ; CHECK:       @ %bb.0:
 ; CHECK-NEXT:    bx lr
-  %r = call nnan float @llvm.minimum.f32(float 0x7ff0000000000000, float %x)
+  %r = call nnan float @llvm.minimum.f32(float +inf, float %x)
   ret float %r
 }
 
@@ -222,7 +222,7 @@ define <2 x float> @test_minnum_const_inf_nnan_comm_vec(<2 x float> %x) {
 ; CHECK-LABEL: test_minnum_const_inf_nnan_comm_vec:
 ; CHECK:       @ %bb.0:
 ; CHECK-NEXT:    bx lr
-  %r = call nnan <2 x float> @llvm.minnum.v2f32(<2 x float> <float 0x7ff0000000000000, float 0x7ff0000000000000>, <2 x float> %x)
+  %r = call nnan <2 x float> @llvm.minnum.v2f32(<2 x float> <float +inf, float +inf>, <2 x float> %x)
   ret <2 x float> %r
 }
 
@@ -237,7 +237,7 @@ define <2 x float> @test_maxnum_const_inf_nnan_comm_vec(<2 x float> %x) {
 ; CHECK-NEXT:  .LCPI21_0:
 ; CHECK-NEXT:    .long 0x7f800000 @ float +Inf
 ; CHECK-NEXT:    .long 0x7f800000 @ float +Inf
-  %r = call nnan <2 x float> @llvm.maxnum.v2f32(<2 x float> <float 0x7ff0000000000000, float 0x7ff0000000000000>, <2 x float> %x)
+  %r = call nnan <2 x float> @llvm.maxnum.v2f32(<2 x float> <float +inf, float +inf>, <2 x float> %x)
   ret <2 x float> %r
 }
 
@@ -252,7 +252,7 @@ define <2 x float> @test_maximum_const_inf_nnan_comm_vec(<2 x float> %x) {
 ; CHECK-NEXT:  .LCPI22_0:
 ; CHECK-NEXT:    .long 0x7f800000 @ float +Inf
 ; CHECK-NEXT:    .long 0x7f800000 @ float +Inf
-  %r = call nnan <2 x float> @llvm.maximum.v2f32(<2 x float> <float 0x7ff0000000000000, float 0x7ff0000000000000>, <2 x float> %x)
+  %r = call nnan <2 x float> @llvm.maximum.v2f32(<2 x float> <float +inf, float +inf>, <2 x float> %x)
   ret <2 x float> %r
 }
 
@@ -260,7 +260,7 @@ define <2 x float> @test_minimum_const_inf_nnan_comm_vec(<2 x float> %x) {
 ; CHECK-LABEL: test_minimum_const_inf_nnan_comm_vec:
 ; CHECK:       @ %bb.0:
 ; CHECK-NEXT:    bx lr
-  %r = call nnan <2 x float> @llvm.minimum.v2f32(<2 x float> <float 0x7ff0000000000000, float 0x7ff0000000000000>, <2 x float> %x)
+  %r = call nnan <2 x float> @llvm.minimum.v2f32(<2 x float> <float +inf, float +inf>, <2 x float> %x)
   ret <2 x float> %r
 }
 
@@ -270,7 +270,7 @@ define float @test_minnum_const_neg_inf_nnan(float %x) {
 ; CHECK-NEXT:    movw r0, #0
 ; CHECK-NEXT:    movt r0, #65408
 ; CHECK-NEXT:    bx lr
-  %r = call nnan float @llvm.minnum.f32(float %x, float 0xfff0000000000000)
+  %r = call nnan float @llvm.minnum.f32(float %x, float -inf)
   ret float %r
 }
 
@@ -278,7 +278,7 @@ define float @test_maxnum_const_neg_inf_nnan(float %x) {
 ; CHECK-LABEL: test_maxnum_const_neg_inf_nnan:
 ; CHECK:       @ %bb.0:
 ; CHECK-NEXT:    bx lr
-  %r = call nnan float @llvm.maxnum.f32(float %x, float 0xfff0000000000000)
+  %r = call nnan float @llvm.maxnum.f32(float %x, float -inf)
   ret float %r
 }
 
@@ -286,7 +286,7 @@ define float @test_maximum_const_neg_inf_nnan(float %x) {
 ; CHECK-LABEL: test_maximum_const_neg_inf_nnan:
 ; CHECK:       @ %bb.0:
 ; CHECK-NEXT:    bx lr
-  %r = call nnan float @llvm.maximum.f32(float %x, float 0xfff0000000000000)
+  %r = call nnan float @llvm.maximum.f32(float %x, float -inf)
   ret float %r
 }
 
@@ -296,7 +296,7 @@ define float @test_minimum_const_neg_inf_nnan(float %x) {
 ; CHECK-NEXT:    movw r0, #0
 ; CHECK-NEXT:    movt r0, #65408
 ; CHECK-NEXT:    bx lr
-  %r = call nnan float @llvm.minimum.f32(float %x, float 0xfff0000000000000)
+  %r = call nnan float @llvm.minimum.f32(float %x, float -inf)
   ret float %r
 }
 

--- a/llvm/test/CodeGen/PowerPC/fp-classify.ll
+++ b/llvm/test/CodeGen/PowerPC/fp-classify.ll
@@ -178,7 +178,7 @@ define <4 x i1> @abs_isinfv4f32(<4 x float> %x) {
 ; P9-NEXT:    blr
 entry:
   %0 = tail call <4 x float> @llvm.fabs.v4f32(<4 x float> %x)
-  %cmpinf = fcmp oeq <4 x float> %0, <float 0x7FF0000000000000, float 0x7FF0000000000000, float 0x7FF0000000000000, float 0x7FF0000000000000>
+  %cmpinf = fcmp oeq <4 x float> %0, <float +inf, float +inf, float +inf, float +inf>
   ret <4 x i1> %cmpinf
 }
 

--- a/llvm/test/CodeGen/RISCV/combine-is_fpclass.ll
+++ b/llvm/test/CodeGen/RISCV/combine-is_fpclass.ll
@@ -297,7 +297,7 @@ define i1 @copysign_inf_mag_isfinite_or_nan(float %y) nounwind {
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    li a0, 0
 ; CHECK-NEXT:    ret
-  %r = call float @llvm.copysign.f32(float 0x7FF0000000000000, float %y)
+  %r = call float @llvm.copysign.f32(float +inf, float %y)
   %res = call i1 @llvm.is.fpclass.f32(float %r, i32 507) ; 0x1FB = finite (0x1F8) | nan (0x3)
   ret i1 %res
 }

--- a/llvm/test/CodeGen/RISCV/float-zfa.ll
+++ b/llvm/test/CodeGen/RISCV/float-zfa.ll
@@ -49,7 +49,7 @@ define float @loadfpimm6() {
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    fli.s fa0, inf
 ; CHECK-NEXT:    ret
-  ret float 0x7FF0000000000000
+  ret float +inf
 }
 
 define float @loadfpimm7() {

--- a/llvm/test/CodeGen/SPIRV/literals.ll
+++ b/llvm/test/CodeGen/SPIRV/literals.ll
@@ -28,9 +28,9 @@ entry:
   %hexf = alloca float, align 4
   store float 0x37D5C73200000000, ptr %hexf, align 4
   %inf = alloca float, align 4
-  store float 0x7FF0000000000000, ptr %inf, align 4
+  store float +inf, ptr %inf, align 4
   %ninf = alloca float, align 4
-  store float 0xFFF0000000000000, ptr %ninf, align 4
+  store float -inf, ptr %ninf, align 4
   %nan = alloca float, align 4
   store float 0x7FF8000000000000, ptr %nan, align 4
   %nnan = alloca float, align 4

--- a/llvm/test/CodeGen/SPIRV/validate/triton-tut-softmax-kernel.ll
+++ b/llvm/test/CodeGen/SPIRV/validate/triton-tut-softmax-kernel.ll
@@ -59,7 +59,7 @@ define spir_kernel void @softmax_kernel(ptr addrspace(1) nocapture writeonly %0,
   br label %49
 
 49:                                               ; preds = %46, %38
-  %50 = phi <1 x float> [ %48, %46 ], [ splat (float 0xFFF0000000000000), %38 ]
+  %50 = phi <1 x float> [ %48, %46 ], [ splat (float -inf), %38 ]
   %51 = extractelement <1 x float> %50, i64 0
   br i1 %19, label %52, label %54
 
@@ -68,7 +68,7 @@ define spir_kernel void @softmax_kernel(ptr addrspace(1) nocapture writeonly %0,
   br label %54
 
 54:                                               ; preds = %52, %49
-  %55 = phi <1 x float> [ %53, %52 ], [ splat (float 0xFFF0000000000000), %49 ]
+  %55 = phi <1 x float> [ %53, %52 ], [ splat (float -inf), %49 ]
   %56 = extractelement <1 x float> %55, i64 0
   br i1 %20, label %57, label %59
 
@@ -77,7 +77,7 @@ define spir_kernel void @softmax_kernel(ptr addrspace(1) nocapture writeonly %0,
   br label %59
 
 59:                                               ; preds = %57, %54
-  %60 = phi <1 x float> [ %58, %57 ], [ splat (float 0xFFF0000000000000), %54 ]
+  %60 = phi <1 x float> [ %58, %57 ], [ splat (float -inf), %54 ]
   %61 = extractelement <1 x float> %60, i64 0
   br i1 %21, label %62, label %64
 
@@ -86,7 +86,7 @@ define spir_kernel void @softmax_kernel(ptr addrspace(1) nocapture writeonly %0,
   br label %64
 
 64:                                               ; preds = %62, %59
-  %65 = phi <1 x float> [ %63, %62 ], [ splat (float 0xFFF0000000000000), %59 ]
+  %65 = phi <1 x float> [ %63, %62 ], [ splat (float -inf), %59 ]
   %66 = extractelement <1 x float> %65, i64 0
   tail call spir_func void @_Z7barrierj(i32 1)
   %67 = tail call float @llvm.maxnum.f32(float %51, float %56)

--- a/llvm/test/CodeGen/SystemZ/tdc-08.ll
+++ b/llvm/test/CodeGen/SystemZ/tdc-08.ll
@@ -47,7 +47,7 @@ define <4 x float> @f1(<4 x float> %x, <4 x float> %a, <4 x float> %b) {
 ; CHECK-NEXT:    le %f6, 0(%r1)
 ; CHECK-NEXT:    br %r14
   %abs = call <4 x float> @llvm.fabs.v4f32(<4 x float> %x)
-  %cmp = fcmp ult <4 x float> %abs, splat (float 0x7FF0000000000000)
+  %cmp = fcmp ult <4 x float> %abs, splat (float +inf)
   %sel = select <4 x i1> %cmp, <4 x float> %a, <4 x float> %b
   ret <4 x float> %sel
 }

--- a/llvm/test/CodeGen/SystemZ/vector-constrained-fp-intrinsics.ll
+++ b/llvm/test/CodeGen/SystemZ/vector-constrained-fp-intrinsics.ll
@@ -574,7 +574,7 @@ define <1 x float> @constrained_vector_fmul_v1f32() #0 {
 ; SZ13-NEXT:    br %r14
 entry:
   %mul = call <1 x float> @llvm.experimental.constrained.fmul.v1f32(
-           <1 x float> <float 0x7FF0000000000000>,
+           <1 x float> <float +inf>,
            <1 x float> <float 2.000000e+00>,
            metadata !"round.dynamic",
            metadata !"fpexcept.strict") #0
@@ -641,8 +641,8 @@ define <3 x float> @constrained_vector_fmul_v3f32() #0 {
 ; SZ13-NEXT:    br %r14
 entry:
   %mul = call <3 x float> @llvm.experimental.constrained.fmul.v3f32(
-           <3 x float> <float 0x7FF0000000000000, float 0x7FF0000000000000,
-                        float 0x7FF0000000000000>,
+           <3 x float> <float +inf, float +inf,
+                        float +inf>,
            <3 x float> <float 1.000000e+00, float 1.000000e+01, float 1.000000e+02>,
            metadata !"round.dynamic",
            metadata !"fpexcept.strict") #0
@@ -746,7 +746,7 @@ define <1 x float> @constrained_vector_fadd_v1f32() #0 {
 ; SZ13-NEXT:    br %r14
 entry:
   %add = call <1 x float> @llvm.experimental.constrained.fadd.v1f32(
-           <1 x float> <float 0x7FF0000000000000>,
+           <1 x float> <float +inf>,
            <1 x float> <float 1.0>,
            metadata !"round.dynamic",
            metadata !"fpexcept.strict") #0
@@ -916,7 +916,7 @@ define <1 x float> @constrained_vector_fsub_v1f32() #0 {
 ; SZ13-NEXT:    br %r14
 entry:
   %sub = call <1 x float> @llvm.experimental.constrained.fsub.v1f32(
-           <1 x float> <float 0x7FF0000000000000>,
+           <1 x float> <float +inf>,
            <1 x float> <float 1.000000e+00>,
            metadata !"round.dynamic",
            metadata !"fpexcept.strict") #0

--- a/llvm/test/CodeGen/Thumb2/LowOverheadLoops/predicated-liveout-unknown-lanes.ll
+++ b/llvm/test/CodeGen/Thumb2/LowOverheadLoops/predicated-liveout-unknown-lanes.ll
@@ -22,7 +22,7 @@ entry:
 
 do.body:                                          ; preds = %do.body, %entry
   %blockSize.addr.0 = phi i32 [ %blockSize, %entry ], [ %sub, %do.body ]
-  %curExtremValVec.0 = phi <4 x float> [ <float 0xFFF0000000000000, float 0xFFF0000000000000, float 0xFFF0000000000000, float 0xFFF0000000000000>, %entry ], [ %3, %do.body ]
+  %curExtremValVec.0 = phi <4 x float> [ <float -inf, float -inf, float -inf, float -inf>, %entry ], [ %3, %do.body ]
   %pSrc.addr.0 = phi ptr [ %pSrc, %entry ], [ %add.ptr, %do.body ]
   %0 = tail call <4 x i1> @llvm.arm.mve.vctp32(i32 %blockSize.addr.0)
   %1 = bitcast ptr %pSrc.addr.0 to ptr

--- a/llvm/test/CodeGen/WebAssembly/immediates.ll
+++ b/llvm/test/CodeGen/WebAssembly/immediates.ll
@@ -121,7 +121,7 @@ define float @negnan_f32() {
 ; CHECK-NEXT: f32.const $push[[NUM:[0-9]+]]=, infinity{{$}}
 ; CHECK-NEXT: return $pop[[NUM]]{{$}}
 define float @inf_f32() {
-  ret float 0x7FF0000000000000
+  ret float +inf
 }
 
 ; CHECK-LABEL: neginf_f32:
@@ -129,7 +129,7 @@ define float @inf_f32() {
 ; CHECK-NEXT: f32.const $push[[NUM:[0-9]+]]=, -infinity{{$}}
 ; CHECK-NEXT: return $pop[[NUM]]{{$}}
 define float @neginf_f32() {
-  ret float 0xFFF0000000000000
+  ret float -inf
 }
 
 ; CHECK-LABEL: custom_nan_f32:

--- a/llvm/test/CodeGen/X86/2010-05-25-DotDebugLoc.ll
+++ b/llvm/test/CodeGen/X86/2010-05-25-DotDebugLoc.ll
@@ -71,7 +71,7 @@ bb6:                                              ; preds = %bb4
   br i1 %or.cond94, label %bb9, label %bb8, !dbg !29
 
 bb8:                                              ; preds = %bb6
-  %27 = tail call float @copysignf(float 0x7FF0000000000000, float %c) nounwind readnone, !dbg !30 ; <float> [#uses=2]
+  %27 = tail call float @copysignf(float +inf, float %c) nounwind readnone, !dbg !30 ; <float> [#uses=2]
   %28 = fmul float %27, %a, !dbg !30              ; <float> [#uses=1]
   tail call void @llvm.dbg.value(metadata float %28, i64 0, metadata !17, metadata !DIExpression()), !dbg !30
   %29 = fmul float %27, %b, !dbg !31              ; <float> [#uses=1]

--- a/llvm/test/CodeGen/X86/avx512-intrinsics-fast-isel.ll
+++ b/llvm/test/CodeGen/X86/avx512-intrinsics-fast-isel.ll
@@ -8138,7 +8138,7 @@ define float @test_mm512_mask_reduce_max_ps(i16 zeroext %__M, <16 x float> %__W)
 ; X64-NEXT:    retq
 entry:
   %0 = bitcast i16 %__M to <16 x i1>
-  %1 = select <16 x i1> %0, <16 x float> %__W, <16 x float> <float 0xFFF0000000000000, float 0xFFF0000000000000, float 0xFFF0000000000000, float 0xFFF0000000000000, float 0xFFF0000000000000, float 0xFFF0000000000000, float 0xFFF0000000000000, float 0xFFF0000000000000, float 0xFFF0000000000000, float 0xFFF0000000000000, float 0xFFF0000000000000, float 0xFFF0000000000000, float 0xFFF0000000000000, float 0xFFF0000000000000, float 0xFFF0000000000000, float 0xFFF0000000000000>
+  %1 = select <16 x i1> %0, <16 x float> %__W, <16 x float> <float -inf, float -inf, float -inf, float -inf, float -inf, float -inf, float -inf, float -inf, float -inf, float -inf, float -inf, float -inf, float -inf, float -inf, float -inf, float -inf>
   %vecext.i = call nnan float @llvm.vector.reduce.fmax.v16f32(<16 x float> %1)
   ret float %vecext.i
 }
@@ -8268,7 +8268,7 @@ define float @test_mm512_mask_reduce_min_ps(i16 zeroext %__M, <16 x float> %__W)
 ; X64-NEXT:    retq
 entry:
   %0 = bitcast i16 %__M to <16 x i1>
-  %1 = select <16 x i1> %0, <16 x float> %__W, <16 x float> <float 0x7FF0000000000000, float 0x7FF0000000000000, float 0x7FF0000000000000, float 0x7FF0000000000000, float 0x7FF0000000000000, float 0x7FF0000000000000, float 0x7FF0000000000000, float 0x7FF0000000000000, float 0x7FF0000000000000, float 0x7FF0000000000000, float 0x7FF0000000000000, float 0x7FF0000000000000, float 0x7FF0000000000000, float 0x7FF0000000000000, float 0x7FF0000000000000, float 0x7FF0000000000000>
+  %1 = select <16 x i1> %0, <16 x float> %__W, <16 x float> <float +inf, float +inf, float +inf, float +inf, float +inf, float +inf, float +inf, float +inf, float +inf, float +inf, float +inf, float +inf, float +inf, float +inf, float +inf, float +inf>
   %vecext.i = call nnan float @llvm.vector.reduce.fmin.v16f32(<16 x float> %1)
   ret float %vecext.i
 }

--- a/llvm/test/CodeGen/X86/avx512-masked-op-fusion.ll
+++ b/llvm/test/CodeGen/X86/avx512-masked-op-fusion.ll
@@ -32,8 +32,8 @@ entry:
 
 loop:
   %iv = phi i64 [ 0, %entry ], [ %iv.next, %loop ]
-  %acc_min = phi <16 x float> [ splat (float 0x7FF0000000000000), %entry ], [ %res_min, %loop ]
-  %acc_max = phi <16 x float> [ splat (float 0xFFF0000000000000), %entry ], [ %res_max, %loop ]
+  %acc_min = phi <16 x float> [ splat (float +inf), %entry ], [ %res_min, %loop ]
+  %acc_max = phi <16 x float> [ splat (float -inf), %entry ], [ %res_max, %loop ]
   %msk_ptr = getelementptr inbounds i8, ptr %pMsk, i64 %iv
   %msk_bytes = load <16 x i8>, ptr %msk_ptr, align 1
   %cmp = icmp eq <16 x i8> %msk_bytes, zeroinitializer

--- a/llvm/test/CodeGen/X86/coff-fp-section-name.ll
+++ b/llvm/test/CodeGen/X86/coff-fp-section-name.ll
@@ -33,7 +33,7 @@ entry:
   store float 0x3E212E0BE0000000, ptr %h, align 4
   store float 8.000000e+00, ptr %i, align 4
   store float 0x7FF8000000000000, ptr %j, align 4
-  store float 0x7FF0000000000000, ptr %k, align 4
+  store float +inf, ptr %k, align 4
   store double 1.000000e+00, ptr %l, align 8
   store double 8.000000e+00, ptr %m, align 8
   store double 0x7FF8000000000000, ptr %n, align 8

--- a/llvm/test/CodeGen/X86/fmaxnum.ll
+++ b/llvm/test/CodeGen/X86/fmaxnum.ll
@@ -654,7 +654,7 @@ define float @test_maxnum_neg_inf_nnan(float %x, float %y) nounwind {
 ; AVX:       # %bb.0:
 ; AVX-NEXT:    vmovaps %xmm1, %xmm0
 ; AVX-NEXT:    retq
-  %r = call nnan float @llvm.maxnum.f32(float %y, float 0xfff0000000000000)
+  %r = call nnan float @llvm.maxnum.f32(float %y, float -inf)
   ret float %r
 }
 

--- a/llvm/test/CodeGen/X86/fminimum-fmaximum.ll
+++ b/llvm/test/CodeGen/X86/fminimum-fmaximum.ll
@@ -2869,7 +2869,7 @@ define float @test_fminimum_inf_nnan(float %x, float %y) nounwind {
 ; X86:       # %bb.0:
 ; X86-NEXT:    flds {{[0-9]+}}(%esp)
 ; X86-NEXT:    retl
-  %1 = call nnan float @llvm.minimum.f32(float %y, float 0x7ff0000000000000)
+  %1 = call nnan float @llvm.minimum.f32(float %y, float +inf)
   ret float %1
 }
 
@@ -2894,7 +2894,7 @@ define float @test_fmaximum_neg_inf_nnan(float %x, float %y) nounwind {
 ; X86:       # %bb.0:
 ; X86-NEXT:    flds {{[0-9]+}}(%esp)
 ; X86-NEXT:    retl
-  %1 = call nnan float @llvm.maximum.f32(float %y, float 0xfff0000000000000)
+  %1 = call nnan float @llvm.maximum.f32(float %y, float -inf)
   ret float %1
 }
 

--- a/llvm/test/CodeGen/X86/fminimumnum-fmaximumnum.ll
+++ b/llvm/test/CodeGen/X86/fminimumnum-fmaximumnum.ll
@@ -3505,7 +3505,7 @@ define float @test_fminimumnum_inf_nnan(float %x, float %y) nounwind {
 ; X86:       # %bb.0:
 ; X86-NEXT:    flds {{[0-9]+}}(%esp)
 ; X86-NEXT:    retl
-  %1 = call nnan float @llvm.minimumnum.f32(float %y, float 0x7ff0000000000000)
+  %1 = call nnan float @llvm.minimumnum.f32(float %y, float +inf)
   ret float %1
 }
 
@@ -3530,7 +3530,7 @@ define float @test_fmaximumnum_neg_inf_nnan(float %x, float %y) nounwind {
 ; X86:       # %bb.0:
 ; X86-NEXT:    flds {{[0-9]+}}(%esp)
 ; X86-NEXT:    retl
-  %1 = call nnan float @llvm.maximumnum.f32(float %y, float 0xfff0000000000000)
+  %1 = call nnan float @llvm.maximumnum.f32(float %y, float -inf)
   ret float %1
 }
 

--- a/llvm/test/CodeGen/X86/fminnum.ll
+++ b/llvm/test/CodeGen/X86/fminnum.ll
@@ -654,7 +654,7 @@ define float @test_minnum_inf_nnan(float %x, float %y) nounwind {
 ; AVX:       # %bb.0:
 ; AVX-NEXT:    vmovaps %xmm1, %xmm0
 ; AVX-NEXT:    retq
-  %r = call nnan float @llvm.minnum.f32(float %y, float 0x7ff0000000000000)
+  %r = call nnan float @llvm.minnum.f32(float %y, float +inf)
   ret float %r
 }
 

--- a/llvm/test/CodeGen/X86/pr45443.ll
+++ b/llvm/test/CodeGen/X86/pr45443.ll
@@ -14,7 +14,7 @@ bb:
   %tmp6 = and <16 x i32> %tmp, <i32 16777215, i32 16777215, i32 16777215, i32 16777215, i32 16777215, i32 16777215, i32 16777215, i32 16777215, i32 16777215, i32 16777215, i32 16777215, i32 16777215, i32 16777215, i32 16777215, i32 16777215, i32 16777215>
   %tmp7 = icmp ne <16 x i32> %tmp6, zeroinitializer
   %tmp8 = and <16 x i1> %tmp7, %tmp5
-  %tmp9 = select fast <16 x i1> %tmp8, <16 x float> <float 0xFFF0000000000000, float 0xFFF0000000000000, float 0xFFF0000000000000, float 0xFFF0000000000000, float 0xFFF0000000000000, float 0xFFF0000000000000, float 0xFFF0000000000000, float 0xFFF0000000000000, float 0xFFF0000000000000, float 0xFFF0000000000000, float 0xFFF0000000000000, float 0xFFF0000000000000, float 0xFFF0000000000000, float 0xFFF0000000000000, float 0xFFF0000000000000, float 0xFFF0000000000000>, <16 x float> %tmp4
+  %tmp9 = select fast <16 x i1> %tmp8, <16 x float> <float -inf, float -inf, float -inf, float -inf, float -inf, float -inf, float -inf, float -inf, float -inf, float -inf, float -inf, float -inf, float -inf, float -inf, float -inf, float -inf>, <16 x float> %tmp4
   ret <16 x float> %tmp9
 }
 declare <16 x float> @llvm.fma.v16f32(<16 x float>, <16 x float>, <16 x float>)

--- a/llvm/test/CodeGen/X86/vector-constrained-fp-intrinsics-flags.ll
+++ b/llvm/test/CodeGen/X86/vector-constrained-fp-intrinsics-flags.ll
@@ -7,7 +7,7 @@ define <1 x float> @constrained_vector_fadd_v1f32() #0 {
 ; CHECK: $xmm0 = COPY [[ADDSSrm]]
 ; CHECK: RET 0, $xmm0
 entry:
-  %add = call <1 x float> @llvm.experimental.constrained.fadd.v1f32(<1 x float> <float 0x7FF0000000000000>, <1 x float> <float 1.0>, metadata !"round.dynamic", metadata !"fpexcept.strict") #0
+  %add = call <1 x float> @llvm.experimental.constrained.fadd.v1f32(<1 x float> <float +inf>, <1 x float> <float 1.0>, metadata !"round.dynamic", metadata !"fpexcept.strict") #0
   ret <1 x float> %add
 }
 

--- a/llvm/test/CodeGen/X86/vector-constrained-fp-intrinsics.ll
+++ b/llvm/test/CodeGen/X86/vector-constrained-fp-intrinsics.ll
@@ -415,7 +415,7 @@ define <1 x float> @constrained_vector_fmul_v1f32() #0 {
 ; AVX-NEXT:    retq
 entry:
   %mul = call <1 x float> @llvm.experimental.constrained.fmul.v1f32(
-           <1 x float> <float 0x7FF0000000000000>,
+           <1 x float> <float +inf>,
            <1 x float> <float 2.000000e+00>,
            metadata !"round.dynamic",
            metadata !"fpexcept.strict") #0
@@ -468,8 +468,8 @@ define <3 x float> @constrained_vector_fmul_v3f32() #0 {
 ; AVX-NEXT:    retq
 entry:
   %mul = call <3 x float> @llvm.experimental.constrained.fmul.v3f32(
-           <3 x float> <float 0x7FF0000000000000, float 0x7FF0000000000000,
-                        float 0x7FF0000000000000>,
+           <3 x float> <float +inf, float +inf,
+                        float +inf>,
            <3 x float> <float 1.000000e+00, float 1.000000e+01, float 1.000000e+02>,
            metadata !"round.dynamic",
            metadata !"fpexcept.strict") #0
@@ -548,7 +548,7 @@ define <1 x float> @constrained_vector_fadd_v1f32() #0 {
 ; AVX-NEXT:    retq
 entry:
   %add = call <1 x float> @llvm.experimental.constrained.fadd.v1f32(
-           <1 x float> <float 0x7FF0000000000000>,
+           <1 x float> <float +inf>,
            <1 x float> <float 1.0>,
            metadata !"round.dynamic",
            metadata !"fpexcept.strict") #0
@@ -682,7 +682,7 @@ define <1 x float> @constrained_vector_fsub_v1f32() #0 {
 ; AVX-NEXT:    retq
 entry:
   %sub = call <1 x float> @llvm.experimental.constrained.fsub.v1f32(
-           <1 x float> <float 0x7FF0000000000000>,
+           <1 x float> <float +inf>,
            <1 x float> <float 1.000000e+00>,
            metadata !"round.dynamic",
            metadata !"fpexcept.strict") #0

--- a/llvm/test/Transforms/Attributor/nofpclass-canonicalize.ll
+++ b/llvm/test/Transforms/Attributor/nofpclass-canonicalize.ll
@@ -169,7 +169,7 @@ define float @ret_canonicalize_ieee_constant_pos_inf() denormal_fpenv(ieee|ieee)
 ; CHECK-NEXT:    [[CALL:%.*]] = call noundef nofpclass(nan ninf zero sub norm) float @llvm.canonicalize.f32(float noundef +inf) #[[ATTR12]]
 ; CHECK-NEXT:    ret float [[CALL]]
 ;
-  %call = call float @llvm.canonicalize.f32(float 0x7FF0000000000000)
+  %call = call float @llvm.canonicalize.f32(float +inf)
   ret float %call
 }
 
@@ -179,7 +179,7 @@ define float @ret_canonicalize_ieee_constant_neg_inf() denormal_fpenv(ieee|ieee)
 ; CHECK-NEXT:    [[CALL:%.*]] = call noundef nofpclass(nan pinf zero sub norm) float @llvm.canonicalize.f32(float noundef -inf) #[[ATTR12]]
 ; CHECK-NEXT:    ret float [[CALL]]
 ;
-  %call = call float @llvm.canonicalize.f32(float 0xFFF0000000000000)
+  %call = call float @llvm.canonicalize.f32(float -inf)
   ret float %call
 }
 
@@ -269,7 +269,7 @@ define float @ret_canonicalize_daz_constant_pos_inf() denormal_fpenv(preservesig
 ; CHECK-NEXT:    [[CALL:%.*]] = call noundef nofpclass(nan ninf zero sub norm) float @llvm.canonicalize.f32(float noundef +inf) #[[ATTR12]]
 ; CHECK-NEXT:    ret float [[CALL]]
 ;
-  %call = call float @llvm.canonicalize.f32(float 0x7FF0000000000000)
+  %call = call float @llvm.canonicalize.f32(float +inf)
   ret float %call
 }
 
@@ -279,7 +279,7 @@ define float @ret_canonicalize_daz_constant_neg_inf() denormal_fpenv(preservesig
 ; CHECK-NEXT:    [[CALL:%.*]] = call noundef nofpclass(nan pinf zero sub norm) float @llvm.canonicalize.f32(float noundef -inf) #[[ATTR12]]
 ; CHECK-NEXT:    ret float [[CALL]]
 ;
-  %call = call float @llvm.canonicalize.f32(float 0xFFF0000000000000)
+  %call = call float @llvm.canonicalize.f32(float -inf)
   ret float %call
 }
 
@@ -369,7 +369,7 @@ define float @ret_canonicalize_dapz_constant_pos_inf() denormal_fpenv(positiveze
 ; CHECK-NEXT:    [[CALL:%.*]] = call noundef nofpclass(nan ninf zero sub norm) float @llvm.canonicalize.f32(float noundef +inf) #[[ATTR12]]
 ; CHECK-NEXT:    ret float [[CALL]]
 ;
-  %call = call float @llvm.canonicalize.f32(float 0x7FF0000000000000)
+  %call = call float @llvm.canonicalize.f32(float +inf)
   ret float %call
 }
 
@@ -379,7 +379,7 @@ define float @ret_canonicalize_dapz_constant_neg_inf() denormal_fpenv(positiveze
 ; CHECK-NEXT:    [[CALL:%.*]] = call noundef nofpclass(nan pinf zero sub norm) float @llvm.canonicalize.f32(float noundef -inf) #[[ATTR12]]
 ; CHECK-NEXT:    ret float [[CALL]]
 ;
-  %call = call float @llvm.canonicalize.f32(float 0xFFF0000000000000)
+  %call = call float @llvm.canonicalize.f32(float -inf)
   ret float %call
 }
 
@@ -469,7 +469,7 @@ define float @ret_canonicalize_dynamic_constant_pos_inf() denormal_fpenv(dynamic
 ; CHECK-NEXT:    [[CALL:%.*]] = call noundef nofpclass(nan ninf sub norm) float @llvm.canonicalize.f32(float noundef +inf) #[[ATTR12]]
 ; CHECK-NEXT:    ret float [[CALL]]
 ;
-  %call = call float @llvm.canonicalize.f32(float 0x7FF0000000000000)
+  %call = call float @llvm.canonicalize.f32(float +inf)
   ret float %call
 }
 
@@ -479,7 +479,7 @@ define float @ret_canonicalize_dynamic_constant_neg_inf() denormal_fpenv(dynamic
 ; CHECK-NEXT:    [[CALL:%.*]] = call noundef nofpclass(nan pinf sub norm) float @llvm.canonicalize.f32(float noundef -inf) #[[ATTR12]]
 ; CHECK-NEXT:    ret float [[CALL]]
 ;
-  %call = call float @llvm.canonicalize.f32(float 0xFFF0000000000000)
+  %call = call float @llvm.canonicalize.f32(float -inf)
   ret float %call
 }
 

--- a/llvm/test/Transforms/Attributor/nofpclass-select.ll
+++ b/llvm/test/Transforms/Attributor/nofpclass-select.ll
@@ -300,7 +300,7 @@ define float @clamp_zero_to_inf(float %arg) {
 ; CHECK-NEXT:    ret float [[SELECT]]
 ;
   %is.zero = fcmp oeq float %arg, 0.0
-  %select = select i1 %is.zero, float 0x7FF0000000000000, float %arg
+  %select = select i1 %is.zero, float +inf, float %arg
   ret float %select
 }
 
@@ -312,7 +312,7 @@ define float @clamp_zero_to_only_inf(float %arg) {
 ; CHECK-NEXT:    ret float [[SELECT]]
 ;
   %is.zero = fcmp oeq float %arg, 0.0
-  %select = select i1 %is.zero, float %arg, float 0x7FF0000000000000
+  %select = select i1 %is.zero, float %arg, float +inf
   ret float %select
 }
 

--- a/llvm/test/Transforms/Attributor/nofpclass.ll
+++ b/llvm/test/Transforms/Attributor/nofpclass.ll
@@ -1503,7 +1503,7 @@ define <4 x float> @insertelement_constant_chain() {
   %ins.0 = insertelement <4 x float> poison, float 1.0, i32 0
   %ins.1 = insertelement <4 x float> %ins.0, float 0.0, i32 1
   %ins.2 = insertelement <4 x float> %ins.1, float -9.0, i32 2
-  %ins.3 = insertelement <4 x float> %ins.2, float 0x7FF0000000000000, i32 3
+  %ins.3 = insertelement <4 x float> %ins.2, float +inf, i32 3
   ret <4 x float> %ins.3
 }
 
@@ -1539,7 +1539,7 @@ define <vscale x 4 x float> @insertelement_scalable_constant_chain() {
   %ins.0 = insertelement <vscale x 4 x float> poison, float 1.0, i32 0
   %ins.1 = insertelement <vscale x 4 x float> %ins.0, float 0.0, i32 1
   %ins.2 = insertelement <vscale x 4 x float> %ins.1, float -9.0, i32 2
-  %ins.3 = insertelement <vscale x 4 x float> %ins.2, float 0x7FF0000000000000, i32 3
+  %ins.3 = insertelement <vscale x 4 x float> %ins.2, float +inf, i32 3
   ret <vscale x 4 x float> %ins.3
 }
 
@@ -1600,7 +1600,7 @@ define <4 x float> @insertelement_index_oob_chain() {
 ; CHECK-NEXT:    [[INSERT:%.*]] = insertelement <4 x float> zeroinitializer, float +inf, i32 4
 ; CHECK-NEXT:    ret <4 x float> [[INSERT]]
 ;
-  %insert = insertelement <4 x float> zeroinitializer, float 0x7FF0000000000000, i32 4
+  %insert = insertelement <4 x float> zeroinitializer, float +inf, i32 4
   ret <4 x float> %insert
 }
 

--- a/llvm/test/Transforms/EarlyCSE/atan.ll
+++ b/llvm/test/Transforms/EarlyCSE/atan.ll
@@ -17,7 +17,7 @@ define float @callatanInf() {
 ; CHECK-NEXT:    [[CALL:%.*]] = call float @atanf(float +inf)
 ; CHECK-NEXT:    ret float [[CALL]]
 ;
-  %call = call float @atanf(float 0x7FF0000000000000)
+  %call = call float @atanf(float +inf)
   ret float %call
 }
 
@@ -146,7 +146,7 @@ define float @callatan2_Inf() {
 ; CHECK-LABEL: @callatan2_Inf(
 ; CHECK-NEXT:    ret float f0x3F490FDB
 ;
-  %call = call float @atan2f(float 0x7FF0000000000000, float 0x7FF0000000000000)
+  %call = call float @atan2f(float +inf, float +inf)
   ret float %call
 }
 

--- a/llvm/test/Transforms/InstCombine/2009-01-19-fmod-constant-float-specials.ll
+++ b/llvm/test/Transforms/InstCombine/2009-01-19-fmod-constant-float-specials.ll
@@ -13,7 +13,7 @@ entry:
 	%y = alloca float		; <ptr> [#uses=2]
 	%x = alloca float		; <ptr> [#uses=2]
 	%"alloca point" = bitcast i32 0 to i32		; <i32> [#uses=0]
-	store float 0x7FF0000000000000, ptr %x, align 4
+	store float +inf, ptr %x, align 4
 	store float 0x7FF8000000000000, ptr %y, align 4
 	%0 = load float, ptr %y, align 4		; <float> [#uses=1]
 	%1 = fpext float %0 to double		; <double> [#uses=1]
@@ -34,7 +34,7 @@ entry:
 	%y = alloca float		; <ptr> [#uses=2]
 	%x = alloca float		; <ptr> [#uses=2]
 	%"alloca point" = bitcast i32 0 to i32		; <i32> [#uses=0]
-	store float 0x7FF0000000000000, ptr %x, align 4
+	store float +inf, ptr %x, align 4
 	store float 0.000000e+00, ptr %y, align 4
 	%0 = load float, ptr %y, align 4		; <float> [#uses=1]
 	%1 = fpext float %0 to double		; <double> [#uses=1]
@@ -53,7 +53,7 @@ entry:
 	%y = alloca float		; <ptr> [#uses=2]
 	%x = alloca float		; <ptr> [#uses=2]
 	%"alloca point" = bitcast i32 0 to i32		; <i32> [#uses=0]
-	store float 0x7FF0000000000000, ptr %x, align 4
+	store float +inf, ptr %x, align 4
 	store float 3.500000e+00, ptr %y, align 4
 	%0 = load float, ptr %y, align 4		; <float> [#uses=1]
 	%1 = fpext float %0 to double		; <double> [#uses=1]
@@ -72,8 +72,8 @@ entry:
 	%y = alloca float		; <ptr> [#uses=2]
 	%x = alloca float		; <ptr> [#uses=2]
 	%"alloca point" = bitcast i32 0 to i32		; <i32> [#uses=0]
-	store float 0x7FF0000000000000, ptr %x, align 4
-	store float 0x7FF0000000000000, ptr %y, align 4
+	store float +inf, ptr %x, align 4
+	store float +inf, ptr %y, align 4
 	%0 = load float, ptr %y, align 4		; <float> [#uses=1]
 	%1 = fpext float %0 to double		; <double> [#uses=1]
 	%2 = load float, ptr %x, align 4		; <float> [#uses=1]
@@ -92,7 +92,7 @@ entry:
 	%x = alloca float		; <ptr> [#uses=2]
 	%"alloca point" = bitcast i32 0 to i32		; <i32> [#uses=0]
 	store float 0x7FF8000000000000, ptr %x, align 4
-	store float 0x7FF0000000000000, ptr %y, align 4
+	store float +inf, ptr %y, align 4
 	%0 = load float, ptr %y, align 4		; <float> [#uses=1]
 	%1 = fpext float %0 to double		; <double> [#uses=1]
 	%2 = load float, ptr %x, align 4		; <float> [#uses=1]
@@ -187,7 +187,7 @@ entry:
 	%x = alloca float		; <ptr> [#uses=2]
 	%"alloca point" = bitcast i32 0 to i32		; <i32> [#uses=0]
 	store float 0.000000e+00, ptr %x, align 4
-	store float 0x7FF0000000000000, ptr %y, align 4
+	store float +inf, ptr %y, align 4
 	%0 = load float, ptr %y, align 4		; <float> [#uses=1]
 	%1 = fpext float %0 to double		; <double> [#uses=1]
 	%2 = load float, ptr %x, align 4		; <float> [#uses=1]
@@ -263,7 +263,7 @@ entry:
 	%x = alloca float		; <ptr> [#uses=2]
 	%"alloca point" = bitcast i32 0 to i32		; <i32> [#uses=0]
 	store float 3.500000e+00, ptr %x, align 4
-	store float 0x7FF0000000000000, ptr %y, align 4
+	store float +inf, ptr %y, align 4
 	%0 = load float, ptr %y, align 4		; <float> [#uses=1]
 	%1 = fpext float %0 to double		; <double> [#uses=1]
 	%2 = load float, ptr %x, align 4		; <float> [#uses=1]

--- a/llvm/test/Transforms/InstCombine/AMDGPU/amdgcn-intrinsics.ll
+++ b/llvm/test/Transforms/InstCombine/AMDGPU/amdgcn-intrinsics.ll
@@ -112,7 +112,7 @@ define float @test_constant_fold_rcp_f32_inf() nounwind {
 ; CHECK-LABEL: @test_constant_fold_rcp_f32_inf(
 ; CHECK-NEXT:    ret float 0.000000e+00
 ;
-  %val = call float @llvm.amdgcn.rcp.f32(float 0x7FF0000000000000)
+  %val = call float @llvm.amdgcn.rcp.f32(float +inf)
   ret float %val
 }
 
@@ -433,7 +433,7 @@ define float @test_constant_fold_frexp_mant_f32_inf() nounwind {
 ; CHECK-LABEL: @test_constant_fold_frexp_mant_f32_inf(
 ; CHECK-NEXT:    ret float +inf
 ;
-  %val = call float @llvm.amdgcn.frexp.mant.f32(float 0x7FF0000000000000)
+  %val = call float @llvm.amdgcn.frexp.mant.f32(float +inf)
   ret float %val
 }
 
@@ -449,7 +449,7 @@ define float @test_constant_fold_frexp_mant_f32_ninf() nounwind {
 ; CHECK-LABEL: @test_constant_fold_frexp_mant_f32_ninf(
 ; CHECK-NEXT:    ret float -inf
 ;
-  %val = call float @llvm.amdgcn.frexp.mant.f32(float 0xFFF0000000000000)
+  %val = call float @llvm.amdgcn.frexp.mant.f32(float -inf)
   ret float %val
 }
 
@@ -625,7 +625,7 @@ define i32 @test_constant_fold_frexp_exp_f32_inf() nounwind {
 ; CHECK-LABEL: @test_constant_fold_frexp_exp_f32_inf(
 ; CHECK-NEXT:    ret i32 0
 ;
-  %val = call i32 @llvm.amdgcn.frexp.exp.f32(float 0x7FF0000000000000)
+  %val = call i32 @llvm.amdgcn.frexp.exp.f32(float +inf)
   ret i32 %val
 }
 
@@ -641,7 +641,7 @@ define i32 @test_constant_fold_frexp_exp_f32_ninf() nounwind {
 ; CHECK-LABEL: @test_constant_fold_frexp_exp_f32_ninf(
 ; CHECK-NEXT:    ret i32 0
 ;
-  %val = call i32 @llvm.amdgcn.frexp.exp.f32(float 0xFFF0000000000000)
+  %val = call i32 @llvm.amdgcn.frexp.exp.f32(float -inf)
   ret i32 %val
 }
 
@@ -5465,7 +5465,7 @@ define float @test_constant_fold_log_f32_pinf() {
 ; CHECK-LABEL: @test_constant_fold_log_f32_pinf(
 ; CHECK-NEXT:    ret float +inf
 ;
-  %val = call float @llvm.amdgcn.log.f32(float 0x7FF0000000000000)
+  %val = call float @llvm.amdgcn.log.f32(float +inf)
   ret float %val
 }
 
@@ -5473,7 +5473,7 @@ define float @test_constant_fold_log_f32_ninf() {
 ; CHECK-LABEL: @test_constant_fold_log_f32_ninf(
 ; CHECK-NEXT:    ret float +qnan
 ;
-  %val = call float @llvm.amdgcn.log.f32(float 0xFFF0000000000000)
+  %val = call float @llvm.amdgcn.log.f32(float -inf)
   ret float %val
 }
 
@@ -5575,7 +5575,7 @@ define float @test_constant_fold_log_f32_pinf_strictfp() strictfp {
 ; CHECK-LABEL: @test_constant_fold_log_f32_pinf_strictfp(
 ; CHECK-NEXT:    ret float +inf
 ;
-  %val = call float @llvm.amdgcn.log.f32(float 0x7FF0000000000000) strictfp
+  %val = call float @llvm.amdgcn.log.f32(float +inf) strictfp
   ret float %val
 }
 
@@ -5584,7 +5584,7 @@ define float @test_constant_fold_log_f32_ninf_strictfp() strictfp {
 ; CHECK-NEXT:    [[VAL:%.*]] = call float @llvm.amdgcn.log.f32(float -inf) #[[ATTR10]]
 ; CHECK-NEXT:    ret float [[VAL]]
 ;
-  %val = call float @llvm.amdgcn.log.f32(float 0xFFF0000000000000) strictfp
+  %val = call float @llvm.amdgcn.log.f32(float -inf) strictfp
   ret float %val
 }
 
@@ -5718,7 +5718,7 @@ define float @test_constant_fold_exp2_f32_pinf() {
 ; CHECK-LABEL: @test_constant_fold_exp2_f32_pinf(
 ; CHECK-NEXT:    ret float +inf
 ;
-  %val = call float @llvm.amdgcn.exp2.f32(float 0x7FF0000000000000)
+  %val = call float @llvm.amdgcn.exp2.f32(float +inf)
   ret float %val
 }
 
@@ -5726,7 +5726,7 @@ define float @test_constant_fold_exp2_f32_ninf() {
 ; CHECK-LABEL: @test_constant_fold_exp2_f32_ninf(
 ; CHECK-NEXT:    ret float 0.000000e+00
 ;
-  %val = call float @llvm.amdgcn.exp2.f32(float 0xFFF0000000000000)
+  %val = call float @llvm.amdgcn.exp2.f32(float -inf)
   ret float %val
 }
 
@@ -5857,7 +5857,7 @@ define float @test_constant_fold_exp2_f32_pinf_strictfp() strictfp {
 ; CHECK-LABEL: @test_constant_fold_exp2_f32_pinf_strictfp(
 ; CHECK-NEXT:    ret float +inf
 ;
-  %val = call float @llvm.amdgcn.exp2.f32(float 0x7FF0000000000000) strictfp
+  %val = call float @llvm.amdgcn.exp2.f32(float +inf) strictfp
   ret float %val
 }
 
@@ -5865,7 +5865,7 @@ define float @test_constant_fold_exp2_f32_ninf_strictfp() strictfp {
 ; CHECK-LABEL: @test_constant_fold_exp2_f32_ninf_strictfp(
 ; CHECK-NEXT:    ret float 0.000000e+00
 ;
-  %val = call float @llvm.amdgcn.exp2.f32(float 0xFFF0000000000000) strictfp
+  %val = call float @llvm.amdgcn.exp2.f32(float -inf) strictfp
   ret float %val
 }
 

--- a/llvm/test/Transforms/InstCombine/AMDGPU/fmed3.ll
+++ b/llvm/test/Transforms/InstCombine/AMDGPU/fmed3.ll
@@ -567,7 +567,7 @@ define float @fmed3_inf_x_y_f32(float %x, float %y) #1 {
 ; IEEE0-NEXT:    [[MED3:%.*]] = call float @llvm.maximumnum.f32(float [[X]], float [[Y]])
 ; IEEE0-NEXT:    ret float [[MED3]]
 ;
-  %med3 = call float @llvm.amdgcn.fmed3.f32(float 0x7FF0000000000000, float %x, float %y)
+  %med3 = call float @llvm.amdgcn.fmed3.f32(float +inf, float %x, float %y)
   ret float %med3
 }
 
@@ -582,7 +582,7 @@ define float @fmed3_x_inf_y_f32(float %x, float %y) #1 {
 ; IEEE0-NEXT:    [[MED3:%.*]] = call float @llvm.maximumnum.f32(float [[X]], float [[Y]])
 ; IEEE0-NEXT:    ret float [[MED3]]
 ;
-  %med3 = call float @llvm.amdgcn.fmed3.f32(float %x, float 0x7FF0000000000000, float %y)
+  %med3 = call float @llvm.amdgcn.fmed3.f32(float %x, float +inf, float %y)
   ret float %med3
 }
 
@@ -597,7 +597,7 @@ define float @fmed3_x_y_inf_f32(float %x, float %y) #1 {
 ; IEEE0-NEXT:    [[MED3:%.*]] = call float @llvm.maximumnum.f32(float [[X]], float [[Y]])
 ; IEEE0-NEXT:    ret float [[MED3]]
 ;
-  %med3 = call float @llvm.amdgcn.fmed3.f32(float %x, float %y, float 0x7FF0000000000000)
+  %med3 = call float @llvm.amdgcn.fmed3.f32(float %x, float %y, float +inf)
   ret float %med3
 }
 
@@ -612,7 +612,7 @@ define float @fmed3_ninf_x_y_f32(float %x, float %y) #1 {
 ; IEEE0-NEXT:    [[MED3:%.*]] = call float @llvm.minimumnum.f32(float [[X]], float [[Y]])
 ; IEEE0-NEXT:    ret float [[MED3]]
 ;
-  %med3 = call float @llvm.amdgcn.fmed3.f32(float 0xFFF0000000000000, float %x, float %y)
+  %med3 = call float @llvm.amdgcn.fmed3.f32(float -inf, float %x, float %y)
   ret float %med3
 }
 
@@ -627,7 +627,7 @@ define float @fmed3_x_ninf_y_f32(float %x, float %y) #1 {
 ; IEEE0-NEXT:    [[MED3:%.*]] = call float @llvm.minimumnum.f32(float [[X]], float [[Y]])
 ; IEEE0-NEXT:    ret float [[MED3]]
 ;
-  %med3 = call float @llvm.amdgcn.fmed3.f32(float %x, float 0xFFF0000000000000, float %y)
+  %med3 = call float @llvm.amdgcn.fmed3.f32(float %x, float -inf, float %y)
   ret float %med3
 }
 
@@ -642,7 +642,7 @@ define float @fmed3_x_y_ninf_f32(float %x, float %y) #1 {
 ; IEEE0-NEXT:    [[MED3:%.*]] = call float @llvm.minimumnum.f32(float [[X]], float [[Y]])
 ; IEEE0-NEXT:    ret float [[MED3]]
 ;
-  %med3 = call float @llvm.amdgcn.fmed3.f32(float %x, float %y, float 0xFFF0000000000000)
+  %med3 = call float @llvm.amdgcn.fmed3.f32(float %x, float %y, float -inf)
   ret float %med3
 }
 

--- a/llvm/test/Transforms/InstCombine/X86/x86-scalar-max-min.ll
+++ b/llvm/test/Transforms/InstCombine/X86/x86-scalar-max-min.ll
@@ -17,7 +17,7 @@ define <4 x float> @test_min_ss_inf(<4 x float> %a) {
 ; CHECK-NEXT:    [[RES:%.*]] = call <4 x float> @llvm.x86.sse.min.ss(<4 x float> [[A]], <4 x float> <float +inf, float poison, float poison, float poison>)
 ; CHECK-NEXT:    ret <4 x float> [[RES]]
 ;
-  %res = call <4 x float> @llvm.x86.sse.min.ss(<4 x float> %a, <4 x float> <float 0x7FF0000000000000, float 0.0, float 0.0, float 0.0>)
+  %res = call <4 x float> @llvm.x86.sse.min.ss(<4 x float> %a, <4 x float> <float +inf, float 0.0, float 0.0, float 0.0>)
   ret <4 x float> %res
 }
 

--- a/llvm/test/Transforms/InstCombine/binop-select.ll
+++ b/llvm/test/Transforms/InstCombine/binop-select.ll
@@ -338,7 +338,7 @@ define float @fadd_sel_op0(i1 %b, float %x) {
 ; CHECK-NEXT:    [[R:%.*]] = select i1 [[B:%.*]], float -inf, float +inf
 ; CHECK-NEXT:    ret float [[R]]
 ;
-  %s = select i1 %b, float 0xFFF0000000000000, float 0x7FF0000000000000
+  %s = select i1 %b, float -inf, float +inf
   %r = fadd nnan float %s, %x
   ret float %r
 }
@@ -350,7 +350,7 @@ define float @fadd_sel_op0_use(i1 %b, float %x) {
 ; CHECK-NEXT:    [[R:%.*]] = fadd nnan float [[S]], [[X:%.*]]
 ; CHECK-NEXT:    ret float [[R]]
 ;
-  %s = select i1 %b, float 0xFFF0000000000000, float 0x7FF0000000000000
+  %s = select i1 %b, float -inf, float +inf
   call void @use_f32(float %s)
   %r = fadd nnan float %s, %x
   ret float %r

--- a/llvm/test/Transforms/InstCombine/cast-int-fcmp-eq-0.ll
+++ b/llvm/test/Transforms/InstCombine/cast-int-fcmp-eq-0.ll
@@ -564,6 +564,6 @@ define <2 x i1> @i32_vec_cast_cmp_oeq_vec_int_inf_sitofp(<2 x i32> %i) {
 ; CHECK-NEXT:    ret <2 x i1> zeroinitializer
 ;
   %f = sitofp <2 x i32> %i to <2 x float>
-  %cmp = fcmp oeq <2 x float> %f, <float 0x7FF0000000000000, float 0x7FF0000000000000>
+  %cmp = fcmp oeq <2 x float> %f, <float +inf, float +inf>
   ret <2 x i1> %cmp
 }

--- a/llvm/test/Transforms/InstCombine/constant-fold-nextafter.ll
+++ b/llvm/test/Transforms/InstCombine/constant-fold-nextafter.ll
@@ -5,11 +5,11 @@
 @flt_pos_min_subnormal = constant float 0x36A0000000000000, align 4
 @flt_pos_min_normal = constant float 0x3810000000000000, align 4
 @flt_pos_max = constant float 0x47EFFFFFE0000000, align 4
-@flt_pos_infinity = constant float 0x7FF0000000000000, align 4
+@flt_pos_infinity = constant float +inf, align 4
 @flt_neg_min_subnormal = constant float 0xB6A0000000000000, align 4
 @flt_neg_min_normal = constant float 0xB810000000000000, align 4
 @flt_neg_max = constant float 0xC7EFFFFFE0000000, align 4
-@flt_neg_infinity = constant float 0xFFF0000000000000, align 4
+@flt_neg_infinity = constant float -inf, align 4
 @dbl_nan = constant double 0x7FF8000000000000, align 8
 @dbl_snan = constant double 0x7FF0000000000001, align 8
 @dbl_pos_min_subnormal = constant double 4.940660e-324, align 8

--- a/llvm/test/Transforms/InstCombine/constant-fold-nexttoward-fp128.ll
+++ b/llvm/test/Transforms/InstCombine/constant-fold-nexttoward-fp128.ll
@@ -5,11 +5,11 @@
 @flt_pos_min_subnormal = constant float 0x36A0000000000000, align 4
 @flt_pos_min_normal = constant float 0x3810000000000000, align 4
 @flt_pos_max = constant float 0x47EFFFFFE0000000, align 4
-@flt_pos_infinity = constant float 0x7FF0000000000000, align 4
+@flt_pos_infinity = constant float +inf, align 4
 @flt_neg_min_subnormal = constant float 0xB6A0000000000000, align 4
 @flt_neg_min_normal = constant float 0xB810000000000000, align 4
 @flt_neg_max = constant float 0xC7EFFFFFE0000000, align 4
-@flt_neg_infinity = constant float 0xFFF0000000000000, align 4
+@flt_neg_infinity = constant float -inf, align 4
 @dbl_nan = constant double 0x7FF8000000000000, align 8
 @dbl_pos_min_subnormal = constant double 4.940660e-324, align 8
 @dbl_pos_min_normal = constant double 0x10000000000000, align 8

--- a/llvm/test/Transforms/InstCombine/constant-fold-nexttoward-ppc-fp128.ll
+++ b/llvm/test/Transforms/InstCombine/constant-fold-nexttoward-ppc-fp128.ll
@@ -5,11 +5,11 @@
 @flt_pos_min_subnormal = constant float 0x36A0000000000000, align 4
 @flt_pos_min_normal = constant float 0x3810000000000000, align 4
 @flt_pos_max = constant float 0x47EFFFFFE0000000, align 4
-@flt_pos_infinity = constant float 0x7FF0000000000000, align 4
+@flt_pos_infinity = constant float +inf, align 4
 @flt_neg_min_subnormal = constant float 0xB6A0000000000000, align 4
 @flt_neg_min_normal = constant float 0xB810000000000000, align 4
 @flt_neg_max = constant float 0xC7EFFFFFE0000000, align 4
-@flt_neg_infinity = constant float 0xFFF0000000000000, align 4
+@flt_neg_infinity = constant float -inf, align 4
 @dbl_nan = constant double 0x7FF8000000000000, align 8
 @dbl_pos_min_subnormal = constant double 4.940660e-324, align 8
 @dbl_pos_min_normal = constant double 0x10000000000000, align 8

--- a/llvm/test/Transforms/InstCombine/constant-fold-nexttoward-x86-fp80.ll
+++ b/llvm/test/Transforms/InstCombine/constant-fold-nexttoward-x86-fp80.ll
@@ -5,11 +5,11 @@
 @flt_pos_min_subnormal = constant float 0x36A0000000000000, align 4
 @flt_pos_min_normal = constant float 0x3810000000000000, align 4
 @flt_pos_max = constant float 0x47EFFFFFE0000000, align 4
-@flt_pos_infinity = constant float 0x7FF0000000000000, align 4
+@flt_pos_infinity = constant float +inf, align 4
 @flt_neg_min_subnormal = constant float 0xB6A0000000000000, align 4
 @flt_neg_min_normal = constant float 0xB810000000000000, align 4
 @flt_neg_max = constant float 0xC7EFFFFFE0000000, align 4
-@flt_neg_infinity = constant float 0xFFF0000000000000, align 4
+@flt_neg_infinity = constant float -inf, align 4
 @dbl_nan = constant double 0x7FF8000000000000, align 8
 @dbl_pos_min_subnormal = constant double 4.940660e-324, align 8
 @dbl_pos_min_normal = constant double 0x10000000000000, align 8

--- a/llvm/test/Transforms/InstCombine/erf.ll
+++ b/llvm/test/Transforms/InstCombine/erf.ll
@@ -60,7 +60,7 @@ define float @erff_inf() {
 ; CHECK-NEXT:    [[R:%.*]] = call float @erff(float +inf)
 ; CHECK-NEXT:    ret float [[R]]
 ;
-  %r = call float @erff(float 0x7FF0000000000000)
+  %r = call float @erff(float +inf)
   ret float %r
 }
 
@@ -78,7 +78,7 @@ define float @erff_inf_memory_none() {
 ; CHECK-NEXT:    [[R:%.*]] = call float @erff(float +inf) #[[ATTR2:[0-9]+]]
 ; CHECK-NEXT:    ret float [[R]]
 ;
-  %r = call float @erff(float 0x7FF0000000000000) readnone
+  %r = call float @erff(float +inf) readnone
   ret float %r
 }
 
@@ -96,7 +96,7 @@ define float @erff_neg_inf() {
 ; CHECK-NEXT:    [[R:%.*]] = call float @erff(float -inf)
 ; CHECK-NEXT:    ret float [[R]]
 ;
-  %r = call float @erff(float 0xFFF0000000000000)
+  %r = call float @erff(float -inf)
   ret float %r
 }
 
@@ -114,7 +114,7 @@ define float @erff_neg_inf_memory_none() {
 ; CHECK-NEXT:    [[R:%.*]] = call float @erff(float -inf) #[[ATTR2]]
 ; CHECK-NEXT:    ret float [[R]]
 ;
-  %r = call float @erff(float 0xFFF0000000000000) readnone
+  %r = call float @erff(float -inf) readnone
   ret float %r
 }
 

--- a/llvm/test/Transforms/InstCombine/frexp.ll
+++ b/llvm/test/Transforms/InstCombine/frexp.ll
@@ -184,7 +184,7 @@ define { float, i32 } @frexp_inf() {
 ; CHECK-LABEL: define { float, i32 } @frexp_inf() {
 ; CHECK-NEXT:    ret { float, i32 } { float +inf, i32 0 }
 ;
-  %ret = call { float, i32 } @llvm.frexp.f32.i32(float 0x7FF0000000000000)
+  %ret = call { float, i32 } @llvm.frexp.f32.i32(float +inf)
   ret { float, i32 } %ret
 }
 
@@ -192,7 +192,7 @@ define { float, i32 } @frexp_neginf() {
 ; CHECK-LABEL: define { float, i32 } @frexp_neginf() {
 ; CHECK-NEXT:    ret { float, i32 } { float -inf, i32 0 }
 ;
-  %ret = call { float, i32 } @llvm.frexp.f32.i32(float 0xFFF0000000000000)
+  %ret = call { float, i32 } @llvm.frexp.f32.i32(float -inf)
   ret { float, i32 } %ret
 }
 
@@ -272,7 +272,7 @@ define { <2 x float>, <2 x i32> } @frexp_splat_inf() {
 ; CHECK-LABEL: define { <2 x float>, <2 x i32> } @frexp_splat_inf() {
 ; CHECK-NEXT:    ret { <2 x float>, <2 x i32> } { <2 x float> splat (float +inf), <2 x i32> zeroinitializer }
 ;
-  %ret = call { <2 x float>, <2 x i32> } @llvm.frexp.v2f32.v2i32(<2 x float> <float 0x7FF0000000000000, float 0x7FF0000000000000>)
+  %ret = call { <2 x float>, <2 x i32> } @llvm.frexp.v2f32.v2i32(<2 x float> <float +inf, float +inf>)
   ret { <2 x float>, <2 x i32> } %ret
 }
 
@@ -280,7 +280,7 @@ define { <2 x float>, <2 x i32> } @frexp_splat_neginf() {
 ; CHECK-LABEL: define { <2 x float>, <2 x i32> } @frexp_splat_neginf() {
 ; CHECK-NEXT:    ret { <2 x float>, <2 x i32> } { <2 x float> splat (float -inf), <2 x i32> zeroinitializer }
 ;
-  %ret = call { <2 x float>, <2 x i32> } @llvm.frexp.v2f32.v2i32(<2 x float> <float 0xFFF0000000000000, float 0xFFF0000000000000>)
+  %ret = call { <2 x float>, <2 x i32> } @llvm.frexp.v2f32.v2i32(<2 x float> <float -inf, float -inf>)
   ret { <2 x float>, <2 x i32> } %ret
 }
 
@@ -289,7 +289,7 @@ define { <2 x float>, <2 x i32> } @frexp_splat_undef_inf() {
 ; CHECK-NEXT:    [[RET:%.*]] = call { <2 x float>, <2 x i32> } @llvm.frexp.v2f32.v2i32(<2 x float> <float undef, float +inf>)
 ; CHECK-NEXT:    ret { <2 x float>, <2 x i32> } [[RET]]
 ;
-  %ret = call { <2 x float>, <2 x i32> } @llvm.frexp.v2f32.v2i32(<2 x float> <float undef, float 0x7FF0000000000000>)
+  %ret = call { <2 x float>, <2 x i32> } @llvm.frexp.v2f32.v2i32(<2 x float> <float undef, float +inf>)
   ret { <2 x float>, <2 x i32> } %ret
 }
 

--- a/llvm/test/Transforms/InstCombine/ilogb.ll
+++ b/llvm/test/Transforms/InstCombine/ilogb.ll
@@ -78,7 +78,7 @@ define i32 @ilogbf_inf() {
 ; CHECK-NEXT:    [[R:%.*]] = call i32 @ilogbf(float +inf)
 ; CHECK-NEXT:    ret i32 [[R]]
 ;
-  %r = call i32 @ilogbf(float 0x7FF0000000000000)
+  %r = call i32 @ilogbf(float +inf)
   ret i32 %r
 }
 
@@ -150,7 +150,7 @@ define i32 @ilogbf_inf_readnone() {
 ; CHECK-NEXT:    [[R:%.*]] = call i32 @ilogbf(float +inf) #[[ATTR0]]
 ; CHECK-NEXT:    ret i32 [[R]]
 ;
-  %r = call i32 @ilogbf(float 0x7FF0000000000000) readnone
+  %r = call i32 @ilogbf(float +inf) readnone
   ret i32 %r
 }
 

--- a/llvm/test/Transforms/InstCombine/intrinsic-select.ll
+++ b/llvm/test/Transforms/InstCombine/intrinsic-select.ll
@@ -352,7 +352,7 @@ define float @test_fabs_select_multiuse(i1 %cond, float %x) {
 ; CHECK-NEXT:    [[FABS:%.*]] = call float @llvm.fabs.f32(float [[SELECT]])
 ; CHECK-NEXT:    ret float [[FABS]]
 ;
-  %select = select i1 %cond, float %x, float 0x7FF0000000000000
+  %select = select i1 %cond, float %x, float +inf
   call void @usef32(float %select)
   %fabs = call float @llvm.fabs.f32(float %select)
   ret float %fabs

--- a/llvm/test/Transforms/InstCombine/log1p.ll
+++ b/llvm/test/Transforms/InstCombine/log1p.ll
@@ -150,7 +150,7 @@ define float @log1pf_inf() {
 ; CHECK-NEXT:    [[R:%.*]] = call float @log1pf(float +inf)
 ; CHECK-NEXT:    ret float [[R]]
 ;
-  %r = call float @log1pf(float 0x7FF0000000000000)
+  %r = call float @log1pf(float +inf)
   ret float %r
 }
 
@@ -168,7 +168,7 @@ define float @log1pf_inf_memory_none() {
 ; CHECK-NEXT:    [[R:%.*]] = call float @log1pf(float +inf) #[[ATTR0]]
 ; CHECK-NEXT:    ret float [[R]]
 ;
-  %r = call float @log1pf(float 0x7FF0000000000000) readnone
+  %r = call float @log1pf(float +inf) readnone
   ret float %r
 }
 
@@ -186,7 +186,7 @@ define float @log1pf_neg_inf() {
 ; CHECK-NEXT:    [[R:%.*]] = call float @log1pf(float -inf)
 ; CHECK-NEXT:    ret float [[R]]
 ;
-  %r = call float @log1pf(float 0xFFF0000000000000)
+  %r = call float @log1pf(float -inf)
   ret float %r
 }
 
@@ -204,7 +204,7 @@ define float @log1pf_neg_inf_memory_none() {
 ; CHECK-NEXT:    [[R:%.*]] = call float @log1pf(float -inf) #[[ATTR0]]
 ; CHECK-NEXT:    ret float [[R]]
 ;
-  %r = call float @log1pf(float 0xFFF0000000000000) readnone
+  %r = call float @log1pf(float -inf) readnone
   ret float %r
 }
 

--- a/llvm/test/Transforms/InstCombine/logb.ll
+++ b/llvm/test/Transforms/InstCombine/logb.ll
@@ -60,7 +60,7 @@ define float @logbf_inf() {
 ; CHECK-NEXT:    [[R:%.*]] = call float @logbf(float +inf)
 ; CHECK-NEXT:    ret float [[R]]
 ;
-  %r = call float @logbf(float 0x7FF0000000000000)
+  %r = call float @logbf(float +inf)
   ret float %r
 }
 

--- a/llvm/test/Transforms/InstCombine/pow-1.ll
+++ b/llvm/test/Transforms/InstCombine/pow-1.ll
@@ -923,7 +923,7 @@ define float @test_simplify9(float %x) {
 ; CHECK-SAME: float [[X:%.*]]) {
 ; CHECK-NEXT:    ret float +inf
 ;
-  %retval = call float @llvm.pow.f32(float 0xFFF0000000000000, float 0.5)
+  %retval = call float @llvm.pow.f32(float -inf, float 0.5)
   ret float %retval
 }
 

--- a/llvm/test/Transforms/InstCombine/pow-exp.ll
+++ b/llvm/test/Transforms/InstCombine/pow-exp.ll
@@ -434,7 +434,7 @@ define float @powf_inf_base(float %e) {
 ; CHECK-NEXT:    [[CALL:%.*]] = tail call nnan ninf afn float @powf(float +inf, float [[E:%.*]])
 ; CHECK-NEXT:    ret float [[CALL]]
 ;
-  %call = tail call afn nnan ninf float @powf(float 0x7FF0000000000000, float %e)
+  %call = tail call afn nnan ninf float @powf(float +inf, float %e)
   ret float %call
 }
 

--- a/llvm/test/Transforms/InstCombine/remquo.ll
+++ b/llvm/test/Transforms/InstCombine/remquo.ll
@@ -59,7 +59,7 @@ define float @remquo_f32_inf_x(ptr %quo) {
 ; CHECK-NEXT:    ret float [[CALL]]
 ;
 entry:
-  %call = call float @remquof(float 0x7FF0000000000000, float 1.000000e+00, ptr %quo)
+  %call = call float @remquof(float +inf, float 1.000000e+00, ptr %quo)
   ret float %call
 }
 

--- a/llvm/test/Transforms/InstCombine/shufflevec-constant-inseltpoison.ll
+++ b/llvm/test/Transforms/InstCombine/shufflevec-constant-inseltpoison.ll
@@ -8,7 +8,7 @@ define <4 x float> @__inff4() nounwind readnone {
 ; CHECK-LABEL: @__inff4(
 ; CHECK-NEXT:    ret <4 x float> <float 0.000000e+00, float 0.000000e+00, float +inf, float +inf>
 ;
-  %tmp14 = extractelement <1 x double> bitcast (<2 x float> <float 0x7FF0000000000000, float 0x7FF0000000000000> to <1 x double>), i32 0
+  %tmp14 = extractelement <1 x double> bitcast (<2 x float> <float +inf, float +inf> to <1 x double>), i32 0
   %tmp4 = bitcast double %tmp14 to i64
   %tmp3 = bitcast i64 %tmp4 to <2 x float>
   %tmp8 = shufflevector <2 x float> %tmp3, <2 x float> poison, <4 x i32> <i32 0, i32 1, i32 undef, i32 undef>

--- a/llvm/test/Transforms/InstCombine/shufflevec-constant.ll
+++ b/llvm/test/Transforms/InstCombine/shufflevec-constant.ll
@@ -8,7 +8,7 @@ define <4 x float> @__inff4() nounwind readnone {
 ; CHECK-LABEL: @__inff4(
 ; CHECK-NEXT:    ret <4 x float> <float 0.000000e+00, float 0.000000e+00, float +inf, float +inf>
 ;
-  %tmp14 = extractelement <1 x double> bitcast (<2 x float> <float 0x7FF0000000000000, float 0x7FF0000000000000> to <1 x double>), i32 0
+  %tmp14 = extractelement <1 x double> bitcast (<2 x float> <float +inf, float +inf> to <1 x double>), i32 0
   %tmp4 = bitcast double %tmp14 to i64
   %tmp3 = bitcast i64 %tmp4 to <2 x float>
   %tmp8 = shufflevector <2 x float> %tmp3, <2 x float> undef, <4 x i32> <i32 0, i32 1, i32 undef, i32 undef>

--- a/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-aggregates.ll
+++ b/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-aggregates.ll
@@ -55,7 +55,7 @@ define nofpclass(pinf) { float } @ret_nofpclass_struct_ty_pinf__ninf() {
 ; CHECK-NEXT:    ret { float } { float -inf }
 ;
 entry:
-  ret { float } { float 0xFFF0000000000000 }
+  ret { float } { float -inf }
 }
 
 define nofpclass(pinf) { float, float } @ret_nofpclass_multiple_elems_struct_ty_pinf__ninf() {
@@ -64,7 +64,7 @@ define nofpclass(pinf) { float, float } @ret_nofpclass_multiple_elems_struct_ty_
 ; CHECK-NEXT:    ret { float, float } { float -inf, float -inf }
 ;
 entry:
-  ret { float, float } { float 0xFFF0000000000000, float 0xFFF0000000000000 }
+  ret { float, float } { float -inf, float -inf }
 }
 
 define nofpclass(pinf) { <2 x float> } @ret_nofpclass_vector_elems_struct_ty_pinf__ninf() {
@@ -73,7 +73,7 @@ define nofpclass(pinf) { <2 x float> } @ret_nofpclass_vector_elems_struct_ty_pin
 ; CHECK-NEXT:    ret { <2 x float> } { <2 x float> splat (float -inf) }
 ;
 entry:
-  ret { <2 x float>} { <2 x float> <float 0xFFF0000000000000, float 0xFFF0000000000000> }
+  ret { <2 x float>} { <2 x float> <float -inf, float -inf> }
 }
 
 ; UTC_ARGS: --disable
@@ -84,7 +84,7 @@ define nofpclass(pinf) [ 1 x [ 1 x float ]] @ret_nofpclass_nested_array_ty_pinf_
 ; CHECK-NEXT:    ret {{.*}}float -inf
 ;
 entry:
-  ret [ 1 x [ 1 x float ]] [[ 1 x float ] [float 0xFFF0000000000000]]
+  ret [ 1 x [ 1 x float ]] [[ 1 x float ] [float -inf]]
 }
 ; UTC_ARGS: --enable
 
@@ -103,7 +103,7 @@ define nofpclass(ninf) { float, float } @ret_nofpclass_multiple_elems_struct_ty_
 ; CHECK-NEXT:    ret { float, float } { float +inf, float +inf }
 ;
 entry:
-  ret { float, float } { float 0x7FF0000000000000, float 0x7FF0000000000000 }
+  ret { float, float } { float +inf, float +inf }
 }
 
 define nofpclass(inf) { float, float } @ret_nofpclass_multiple_elems_struct_ty_inf__npinf() {
@@ -112,7 +112,7 @@ define nofpclass(inf) { float, float } @ret_nofpclass_multiple_elems_struct_ty_i
 ; CHECK-NEXT:    ret { float, float } poison
 ;
 entry:
-  ret { float, float } { float 0x7FF0000000000000, float 0x7FF0000000000000 }
+  ret { float, float } { float +inf, float +inf }
 }
 
 define nofpclass(nzero) [ 1 x float ] @ret_nofpclass_multiple_elems_struct_ty_nzero_nzero() {

--- a/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-canonicalize.ll
+++ b/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-canonicalize.ll
@@ -20,7 +20,7 @@ define nofpclass(inf) float @ret_nofpclass_inf__canonicalize_select_pinf_rhs(i1 
 ; CHECK-NEXT:    [[TMP1:%.*]] = call ninf float @llvm.canonicalize.f32(float [[X]])
 ; CHECK-NEXT:    ret float [[TMP1]]
 ;
-  %select = select i1 %cond, float %x, float 0x7FF0000000000000
+  %select = select i1 %cond, float %x, float +inf
   %canon = call float @llvm.canonicalize.f32(float %select)
   ret float %canon
 }

--- a/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-fmul.ll
+++ b/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-fmul.ll
@@ -19,8 +19,8 @@ define nofpclass(pinf) float @ret_nofpclass_pinf__fmul_unknown_or_pinf(i1 %cond,
 ; CHECK-NEXT:    [[TMP1:%.*]] = fmul float [[X]], [[Y]]
 ; CHECK-NEXT:    ret float [[TMP1]]
 ;
-  %x.or.pinf = select i1 %cond, float %x, float 0x7FF0000000000000
-  %y.or.pinf = select i1 %cond, float %y, float 0x7FF0000000000000
+  %x.or.pinf = select i1 %cond, float %x, float +inf
+  %y.or.pinf = select i1 %cond, float %y, float +inf
   %mul = fmul float %x.or.pinf, %y.or.pinf
   ret float %mul
 }
@@ -33,8 +33,8 @@ define nofpclass(ninf) float @ret_nofpclass_pinf__fmul_unknown_or_ninf(i1 %cond,
 ; CHECK-NEXT:    [[MUL:%.*]] = select i1 [[COND]], float [[TMP1]], float +inf
 ; CHECK-NEXT:    ret float [[MUL]]
 ;
-  %x.or.ninf = select i1 %cond, float %x, float 0xFFF0000000000000
-  %y.or.ninf = select i1 %cond, float %y, float 0xFFF0000000000000
+  %x.or.ninf = select i1 %cond, float %x, float -inf
+  %y.or.ninf = select i1 %cond, float %y, float -inf
   %mul = fmul float %x.or.ninf, %y.or.ninf
   ret float %mul
 }
@@ -45,8 +45,8 @@ define nofpclass(inf) float @ret_nofpclass_inf__fmul_unknown_or_pinf(i1 %cond, f
 ; CHECK-NEXT:    [[TMP1:%.*]] = fmul float [[X]], [[Y]]
 ; CHECK-NEXT:    ret float [[TMP1]]
 ;
-  %x.or.pinf = select i1 %cond, float %x, float 0x7FF0000000000000
-  %y.or.pinf = select i1 %cond, float %y, float 0x7FF0000000000000
+  %x.or.pinf = select i1 %cond, float %x, float +inf
+  %y.or.pinf = select i1 %cond, float %y, float +inf
   %mul = fmul float %x.or.pinf, %y.or.pinf
   ret float %mul
 }
@@ -269,7 +269,7 @@ define nofpclass(pinf) float @ret_nofpclass_pinf__fmul_square_unknown_or_pinf(i1
 ; CHECK-NEXT:    [[MUL:%.*]] = fmul float [[X_OR_PINF]], [[X_OR_PINF]]
 ; CHECK-NEXT:    ret float [[MUL]]
 ;
-  %x.or.pinf = select i1 %cond, float %x, float 0x7FF0000000000000
+  %x.or.pinf = select i1 %cond, float %x, float +inf
   %mul = fmul float %x.or.pinf, %x.or.pinf
   ret float %mul
 }
@@ -282,7 +282,7 @@ define nofpclass(pinf) float @ret_nofpclass_pinf__fmul_square_unknown_or_pinf__o
 ; CHECK-NEXT:    [[MUL:%.*]] = fmul float [[X_OR_PINF]], [[X_OR_PINF]]
 ; CHECK-NEXT:    ret float [[MUL]]
 ;
-  %x.or.pinf = select i1 %cond, float %x, float 0x7FF0000000000000
+  %x.or.pinf = select i1 %cond, float %x, float +inf
   call void @use(float %x.or.pinf)
   %mul = fmul float %x.or.pinf, %x.or.pinf
   ret float %mul
@@ -296,7 +296,7 @@ define nofpclass(pinf) float @ret_nofpclass_pinf__fmul_square_unknown_or_pinf__o
 ; CHECK-NEXT:    call void @use(float [[X_OR_PINF]])
 ; CHECK-NEXT:    ret float [[MUL]]
 ;
-  %x.or.pinf = select i1 %cond, float %x, float 0x7FF0000000000000
+  %x.or.pinf = select i1 %cond, float %x, float +inf
   %mul = fmul float %x.or.pinf, %x.or.pinf
   call void @use(float %x.or.pinf)
   ret float %mul
@@ -401,7 +401,7 @@ define nofpclass(inf) float @ret_only_inf_results__lhs_known_non_inf(i1 %cond, f
 ; CHECK-NEXT:    [[MUL:%.*]] = fmul float [[X_OR_PINF]], [[Y]]
 ; CHECK-NEXT:    ret float [[MUL]]
 ;
-  %x.or.pinf = select i1 %cond, float %x, float 0x7FF0000000000000
+  %x.or.pinf = select i1 %cond, float %x, float +inf
   %mul = fmul float %x.or.pinf, %y
   ret float %mul
 }
@@ -413,7 +413,7 @@ define nofpclass(inf) float @ret_no_inf_results__rhs_known_non_inf(i1 %cond, flo
 ; CHECK-NEXT:    [[MUL:%.*]] = fmul float [[X]], [[Y_OR_PINF]]
 ; CHECK-NEXT:    ret float [[MUL]]
 ;
-  %y.or.pinf = select i1 %cond, float %y, float 0x7FF0000000000000
+  %y.or.pinf = select i1 %cond, float %y, float +inf
   %mul = fmul float %x, %y.or.pinf
   ret float %mul
 }
@@ -426,7 +426,7 @@ define nofpclass(ninf nan) float @ret_no_ninf_or_nan_results__lhs_known_non_inf(
 ; CHECK-NEXT:    [[MUL:%.*]] = fmul nnan float [[X_OR_PINF]], [[Y]]
 ; CHECK-NEXT:    ret float [[MUL]]
 ;
-  %x.or.pinf = select i1 %cond, float %x, float 0x7FF0000000000000
+  %x.or.pinf = select i1 %cond, float %x, float +inf
   %mul = fmul float %x.or.pinf, %y
   ret float %mul
 }
@@ -439,7 +439,7 @@ define nofpclass(pinf nan) float @ret_no_pinf_or_nan_results__lhs_known_non_inf(
 ; CHECK-NEXT:    [[MUL:%.*]] = fmul nnan float [[X_OR_PINF]], [[Y]]
 ; CHECK-NEXT:    ret float [[MUL]]
 ;
-  %x.or.pinf = select i1 %cond, float %x, float 0x7FF0000000000000
+  %x.or.pinf = select i1 %cond, float %x, float +inf
   %mul = fmul float %x.or.pinf, %y
   ret float %mul
 }
@@ -451,7 +451,7 @@ define nofpclass(inf nan) float @ret_no_inf_or_nan_results__lhs_known_non_inf(i1
 ; CHECK-NEXT:    [[MUL:%.*]] = fmul nnan ninf float [[X]], [[Y]]
 ; CHECK-NEXT:    ret float [[MUL]]
 ;
-  %x.or.pinf = select i1 %cond, float %x, float 0x7FF0000000000000
+  %x.or.pinf = select i1 %cond, float %x, float +inf
   %mul = fmul float %x.or.pinf, %y
   ret float %mul
 }
@@ -463,7 +463,7 @@ define nofpclass(inf nan) float @ret_no_inf_or_nan_results__rhs_known_non_inf(i1
 ; CHECK-NEXT:    [[MUL:%.*]] = fmul nnan ninf float [[X]], [[Y]]
 ; CHECK-NEXT:    ret float [[MUL]]
 ;
-  %y.or.pinf = select i1 %cond, float %y, float 0x7FF0000000000000
+  %y.or.pinf = select i1 %cond, float %y, float +inf
   %mul = fmul float %x, %y.or.pinf
   ret float %mul
 }

--- a/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-log.ll
+++ b/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-log.ll
@@ -103,7 +103,7 @@ define nofpclass(pinf) float @ret_nofpclass_pinf_log_select_inf_or_unknown(i1 %c
 ; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.log.f32(float [[UNKNOWN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
-  %select = select i1 %cond, float 0x7ff0000000000000, float %unknown
+  %select = select i1 %cond, float +inf, float %unknown
   %result = call float @llvm.log.f32(float %select)
   ret float %result
 }
@@ -115,7 +115,7 @@ define nofpclass(pinf) float @ret_nofpclass_pinf_log2_select_inf_or_unknown(i1 %
 ; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.log2.f32(float [[UNKNOWN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
-  %select = select i1 %cond, float 0x7ff0000000000000, float %unknown
+  %select = select i1 %cond, float +inf, float %unknown
   %result = call float @llvm.log2.f32(float %select)
   ret float %result
 }
@@ -127,7 +127,7 @@ define nofpclass(pinf) float @ret_nofpclass_pinf_log10_select_inf_or_unknown(i1 
 ; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.log10.f32(float [[UNKNOWN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
-  %select = select i1 %cond, float 0x7ff0000000000000, float %unknown
+  %select = select i1 %cond, float +inf, float %unknown
   %result = call float @llvm.log10.f32(float %select)
   ret float %result
 }

--- a/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-sqrt.ll
+++ b/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-sqrt.ll
@@ -216,7 +216,7 @@ define nofpclass(pinf) float @no_pinf_result_implies_no_pinf_source(i1 %cond, fl
 ; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.sqrt.f32(float [[UNKNOWN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
-  %select = select i1 %cond, float %unknown, float 0x7ff0000000000000
+  %select = select i1 %cond, float %unknown, float +inf
   %result = call float @llvm.sqrt.f32(float %select)
   ret float %result
 }

--- a/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass.ll
+++ b/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass.ll
@@ -20,7 +20,7 @@ define float @ninf_user_select_inf(i1 %cond, float %x, float %y) {
 ; CHECK-NEXT:    [[NINF_USER:%.*]] = fmul ninf float [[Y]], [[SELECT]]
 ; CHECK-NEXT:    ret float [[NINF_USER]]
 ;
-  %select = select i1 %cond, float %x, float 0x7FF0000000000000
+  %select = select i1 %cond, float %x, float +inf
   %ninf.user = fmul ninf float %y, %select
   ret float %ninf.user
 }
@@ -85,28 +85,28 @@ define nofpclass(inf) float @ret_nofpclass_inf__pinf() {
 ; CHECK-LABEL: define nofpclass(inf) float @ret_nofpclass_inf__pinf() {
 ; CHECK-NEXT:    ret float poison
 ;
-  ret float 0x7FF0000000000000
+  ret float +inf
 }
 
 define nofpclass(pinf) float @ret_nofpclass_pinf__pinf() {
 ; CHECK-LABEL: define nofpclass(pinf) float @ret_nofpclass_pinf__pinf() {
 ; CHECK-NEXT:    ret float poison
 ;
-  ret float 0x7FF0000000000000
+  ret float +inf
 }
 
 define nofpclass(pinf) float @ret_nofpclass_pinf__ninf() {
 ; CHECK-LABEL: define nofpclass(pinf) float @ret_nofpclass_pinf__ninf() {
 ; CHECK-NEXT:    ret float -inf
 ;
-  ret float 0xFFF0000000000000
+  ret float -inf
 }
 
 define nofpclass(inf) float @ret_nofpclass_inf__ninf() {
 ; CHECK-LABEL: define nofpclass(inf) float @ret_nofpclass_inf__ninf() {
 ; CHECK-NEXT:    ret float poison
 ;
-  ret float 0xFFF0000000000000
+  ret float -inf
 }
 
 
@@ -147,7 +147,7 @@ define nofpclass(inf) float @ret_nofpclass_inf__select_pinf_lhs(i1 %cond, float 
 ; CHECK-SAME: (i1 [[COND:%.*]], float [[X:%.*]]) {
 ; CHECK-NEXT:    ret float [[X]]
 ;
-  %select = select i1 %cond, float 0x7FF0000000000000, float %x
+  %select = select i1 %cond, float +inf, float %x
   ret float %select
 }
 
@@ -157,7 +157,7 @@ define nofpclass(inf) float @ret_nofpclass_inf__select_pinf_rhs(i1 %cond, float 
 ; CHECK-SAME: (i1 [[COND:%.*]], float [[X:%.*]]) {
 ; CHECK-NEXT:    ret float [[X]]
 ;
-  %select = select i1 %cond, float %x, float 0x7FF0000000000000
+  %select = select i1 %cond, float %x, float +inf
   ret float %select
 }
 
@@ -167,7 +167,7 @@ define nofpclass(inf) float @ret_nofpclass_inf__select_pinf_or_ninf(i1 %cond, fl
 ; CHECK-SAME: (i1 [[COND:%.*]], float [[X:%.*]]) {
 ; CHECK-NEXT:    ret float poison
 ;
-  %select = select i1 %cond, float 0x7FF0000000000000, float 0xFFF0000000000000
+  %select = select i1 %cond, float +inf, float -inf
   ret float %select
 }
 
@@ -177,7 +177,7 @@ define nofpclass(inf) float @ret_nofpclass_inf__select_ninf_or_pinf(i1 %cond, fl
 ; CHECK-SAME: (i1 [[COND:%.*]], float [[X:%.*]]) {
 ; CHECK-NEXT:    ret float poison
 ;
-  %select = select i1 %cond, float 0xFFF0000000000000, float 0x7FF0000000000000
+  %select = select i1 %cond, float -inf, float +inf
   ret float %select
 }
 
@@ -187,7 +187,7 @@ define nofpclass(ninf) float @ret_nofpclass_ninf__select_ninf_or_pinf(i1 %cond, 
 ; CHECK-SAME: (i1 [[COND:%.*]], float [[X:%.*]]) {
 ; CHECK-NEXT:    ret float +inf
 ;
-  %select = select i1 %cond, float 0xFFF0000000000000, float 0x7FF0000000000000
+  %select = select i1 %cond, float -inf, float +inf
   ret float %select
 }
 
@@ -197,7 +197,7 @@ define nofpclass(pinf) float @ret_nofpclass_pinf__select_ninf_or_pinf(i1 %cond, 
 ; CHECK-SAME: (i1 [[COND:%.*]], float [[X:%.*]]) {
 ; CHECK-NEXT:    ret float -inf
 ;
-  %select = select i1 %cond, float 0xFFF0000000000000, float 0x7FF0000000000000
+  %select = select i1 %cond, float -inf, float +inf
   ret float %select
 }
 
@@ -237,7 +237,7 @@ define nofpclass(inf) <2 x float> @ret_nofpclass_inf__select_pinf_lhs_vector(<2 
 ; CHECK-SAME: (<2 x i1> [[COND:%.*]], <2 x float> [[X:%.*]]) {
 ; CHECK-NEXT:    ret <2 x float> [[X]]
 ;
-  %select = select <2 x i1> %cond, <2 x float> <float 0x7FF0000000000000, float 0x7FF0000000000000>, <2 x float> %x
+  %select = select <2 x i1> %cond, <2 x float> <float +inf, float +inf>, <2 x float> %x
   ret <2 x float> %select
 }
 
@@ -247,7 +247,7 @@ define nofpclass(inf) <2 x float> @ret_nofpclass_inf__select_pinf_lhs_vector_und
 ; CHECK-SAME: (<2 x i1> [[COND:%.*]], <2 x float> [[X:%.*]]) {
 ; CHECK-NEXT:    ret <2 x float> [[X]]
 ;
-  %select = select <2 x i1> %cond, <2 x float> <float 0x7FF0000000000000, float poison>, <2 x float> %x
+  %select = select <2 x i1> %cond, <2 x float> <float +inf, float poison>, <2 x float> %x
   ret <2 x float> %select
 }
 
@@ -257,7 +257,7 @@ define nofpclass(inf) <2 x float> @ret_nofpclass_inf__select_mixed_inf_lhs_vecto
 ; CHECK-SAME: (<2 x i1> [[COND:%.*]], <2 x float> [[X:%.*]]) {
 ; CHECK-NEXT:    ret <2 x float> [[X]]
 ;
-  %select = select <2 x i1> %cond, <2 x float> <float 0x7FF0000000000000, float 0xFFF0000000000000>, <2 x float> %x
+  %select = select <2 x i1> %cond, <2 x float> <float +inf, float -inf>, <2 x float> %x
   ret <2 x float> %select
 }
 
@@ -269,7 +269,7 @@ define nofpclass(inf) float @ret_nofpclass_inf__select_multi_use_pinf_lhs(i1 %co
 ; CHECK-NEXT:    store float [[SELECT]], ptr [[PTR]], align 4
 ; CHECK-NEXT:    ret float [[X]]
 ;
-  %select = select i1 %cond, float 0x7FF0000000000000, float %x
+  %select = select i1 %cond, float +inf, float %x
   store float %select, ptr %ptr
   ret float %select
 }
@@ -303,7 +303,7 @@ define nofpclass(nan) float @ret_nofpclass_nan__select_pinf_lhs(i1 %cond, float 
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[COND]], float +inf, float [[X]]
 ; CHECK-NEXT:    ret float [[SELECT]]
 ;
-  %select = select i1 %cond, float 0x7FF0000000000000, float %x
+  %select = select i1 %cond, float +inf, float %x
   ret float %select
 }
 
@@ -314,7 +314,7 @@ define nofpclass(nan) float @ret_nofpclass_nan__select_pinf_rhs(i1 %cond, float 
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[COND]], float [[X]], float +inf
 ; CHECK-NEXT:    ret float [[SELECT]]
 ;
-  %select = select i1 %cond, float %x, float 0x7FF0000000000000
+  %select = select i1 %cond, float %x, float +inf
   ret float %select
 }
 
@@ -324,7 +324,7 @@ define nofpclass(inf nan) float @ret_nofpclass_inf_nan__select_chain_inf_nan_0(i
 ; CHECK-NEXT:    ret float [[X]]
 ;
   %select0 = select i1 %cond, float 0x7FF8000000000000, float %x
-  %select1 = select i1 %cond, float 0x7FF0000000000000, float %select0
+  %select1 = select i1 %cond, float +inf, float %select0
   ret float %select1
 }
 
@@ -334,7 +334,7 @@ define nofpclass(inf nan) float @ret_nofpclass_inf_nan__select_chain_inf_nan_1(i
 ; CHECK-NEXT:    ret float poison
 ;
   %select0 = select i1 %cond, float %x, float 0x7FF8000000000000
-  %select1 = select i1 %cond, float 0x7FF0000000000000, float %select0
+  %select1 = select i1 %cond, float +inf, float %select0
   ret float %select1
 }
 
@@ -345,7 +345,7 @@ define nofpclass(nan) float @ret_nofpclass_nan__select_chain_inf_nan(i1 %cond, f
 ; CHECK-NEXT:    ret float [[SELECT1]]
 ;
   %select0 = select i1 %cond, float 0x7FF8000000000000, float %x
-  %select1 = select i1 %cond, float 0x7FF0000000000000, float %select0
+  %select1 = select i1 %cond, float +inf, float %select0
   ret float %select1
 }
 
@@ -355,7 +355,7 @@ define nofpclass(inf) float @ret_nofpclass_inf__select_chain_inf_nan_0(i1 %cond,
 ; CHECK-NEXT:    ret float [[X]]
 ;
   %select0 = select i1 %cond, float 0x7FF8000000000000, float %x
-  %select1 = select i1 %cond, float 0x7FF0000000000000, float %select0
+  %select1 = select i1 %cond, float +inf, float %select0
   ret float %select1
 }
 
@@ -365,7 +365,7 @@ define nofpclass(inf) float @ret_nofpclass_inf__select_chain_inf_nan_1(i1 %cond,
 ; CHECK-NEXT:    ret float +qnan
 ;
   %select0 = select i1 %cond, float 0x7FF8000000000000, float %x
-  %select1 = select i1 %cond, float %select0, float 0x7FF0000000000000
+  %select1 = select i1 %cond, float %select0, float +inf
   ret float %select1
 }
 
@@ -376,7 +376,7 @@ define nofpclass(inf) float @ret_nofpclass_inf__fabs_select_ninf_rhs(i1 %cond, f
 ; CHECK-NEXT:    [[TMP1:%.*]] = call float @llvm.fabs.f32(float [[X]])
 ; CHECK-NEXT:    ret float [[TMP1]]
 ;
-  %select = select i1 %cond, float %x, float 0xFFF0000000000000
+  %select = select i1 %cond, float %x, float -inf
   %fabs = call float @llvm.fabs.f32(float %select)
   ret float %fabs
 }
@@ -388,7 +388,7 @@ define nofpclass(inf) float @ret_nofpclass_inf__fabs_select_pinf_rhs(i1 %cond, f
 ; CHECK-NEXT:    [[TMP1:%.*]] = call float @llvm.fabs.f32(float [[X]])
 ; CHECK-NEXT:    ret float [[TMP1]]
 ;
-  %select = select i1 %cond, float %x, float 0x7FF0000000000000
+  %select = select i1 %cond, float %x, float +inf
   %fabs = call float @llvm.fabs.f32(float %select)
   ret float %fabs
 }
@@ -400,7 +400,7 @@ define nofpclass(ninf nnorm nsub nzero) float @ret_nofpclass_no_negatives__fabs_
 ; CHECK-NEXT:    [[FABS:%.*]] = select i1 [[COND]], float [[TMP1]], float +inf
 ; CHECK-NEXT:    ret float [[FABS]]
 ;
-  %select = select i1 %cond, float %x, float 0x7FF0000000000000
+  %select = select i1 %cond, float %x, float +inf
   %fabs = call float @llvm.fabs.f32(float %select)
   ret float %fabs
 }
@@ -412,7 +412,7 @@ define nofpclass(pinf pnorm psub pzero) float @ret_nofpclass_no_positives__fabs_
 ; CHECK-NEXT:    [[TMP1:%.*]] = call float @llvm.fabs.f32(float [[X]])
 ; CHECK-NEXT:    ret float [[TMP1]]
 ;
-  %select = select i1 %cond, float %x, float 0x7FF0000000000000
+  %select = select i1 %cond, float %x, float +inf
   %fabs = call float @llvm.fabs.f32(float %select)
   ret float %fabs
 }
@@ -424,7 +424,7 @@ define nofpclass(nan ninf nnorm nsub nzero) float @ret_nofpclass_no_negatives_na
 ; CHECK-NEXT:    [[FABS:%.*]] = select i1 [[COND]], float [[TMP1]], float +inf
 ; CHECK-NEXT:    ret float [[FABS]]
 ;
-  %select = select i1 %cond, float %x, float 0x7FF0000000000000
+  %select = select i1 %cond, float %x, float +inf
   %fabs = call float @llvm.fabs.f32(float %select)
   ret float %fabs
 }
@@ -435,7 +435,7 @@ define nofpclass(nan pinf pnorm psub pzero) float @ret_nofpclass_no_positives_na
 ; CHECK-SAME: (i1 [[COND:%.*]], float [[X:%.*]]) {
 ; CHECK-NEXT:    ret float poison
 ;
-  %select = select i1 %cond, float %x, float 0x7FF0000000000000
+  %select = select i1 %cond, float %x, float +inf
   %fabs = call float @llvm.fabs.f32(float %select)
   ret float %fabs
 }
@@ -447,7 +447,7 @@ define nofpclass(inf) float @ret_nofpclass_inf__fneg_select_ninf_rhs(i1 %cond, f
 ; CHECK-NEXT:    [[X_NEG:%.*]] = fneg float [[X]]
 ; CHECK-NEXT:    ret float [[X_NEG]]
 ;
-  %select = select i1 %cond, float %x, float 0xFFF0000000000000
+  %select = select i1 %cond, float %x, float -inf
   %fneg = fneg float %select
   ret float %fneg
 }
@@ -459,7 +459,7 @@ define nofpclass(inf nnorm nsub nzero) float @ret_nofpclass_nonegatives_noinf___
 ; CHECK-NEXT:    [[X_NEG:%.*]] = fneg float [[X]]
 ; CHECK-NEXT:    ret float [[X_NEG]]
 ;
-  %select = select i1 %cond, float %x, float 0x7FF0000000000000
+  %select = select i1 %cond, float %x, float +inf
   %fneg = fneg float %select
   ret float %fneg
 }
@@ -471,7 +471,7 @@ define nofpclass(inf nnorm nsub nzero) float @ret_nofpclass_nonegatives_noinf___
 ; CHECK-NEXT:    [[X_NEG:%.*]] = fneg float [[X]]
 ; CHECK-NEXT:    ret float [[X_NEG]]
 ;
-  %select = select i1 %cond, float 0xFFF0000000000000, float %x
+  %select = select i1 %cond, float -inf, float %x
   %fneg = fneg float %select
   ret float %fneg
 }
@@ -483,7 +483,7 @@ define nofpclass(pzero psub pnorm pinf) float @ret_nofpclass_nopositives___fneg_
 ; CHECK-NEXT:    [[FNEG:%.*]] = select i1 [[COND]], float [[X_NEG]], float -inf
 ; CHECK-NEXT:    ret float [[FNEG]]
 ;
-  %select = select i1 %cond, float %x, float 0x7FF0000000000000
+  %select = select i1 %cond, float %x, float +inf
   %fneg = fneg float %select
   ret float %fneg
 }
@@ -496,7 +496,7 @@ define nofpclass(inf) float @ret_nofpclass_inf__fneg_fabs_select_pinf_rhs(i1 %co
 ; CHECK-NEXT:    [[DOTNEG:%.*]] = fneg float [[TMP1]]
 ; CHECK-NEXT:    ret float [[DOTNEG]]
 ;
-  %select = select i1 %cond, float %x, float 0x7FF0000000000000
+  %select = select i1 %cond, float %x, float +inf
   %fabs = call float @llvm.fabs.f32(float %select)
   %fneg = fneg float %fabs
   ret float %fneg
@@ -510,7 +510,7 @@ define nofpclass(ninf nnorm nsub nzero) float @ret_nofpclass_nonegatives__fneg_f
 ; CHECK-NEXT:    [[DOTNEG:%.*]] = fneg float [[TMP1]]
 ; CHECK-NEXT:    ret float [[DOTNEG]]
 ;
-  %select = select i1 %cond, float %x, float 0x7FF0000000000000
+  %select = select i1 %cond, float %x, float +inf
   %fabs = call float @llvm.fabs.f32(float %select)
   %fneg = fneg float %fabs
   ret float %fneg
@@ -523,7 +523,7 @@ define nofpclass(nan ninf nnorm nsub nzero) float @ret_nofpclass_nonegatives_non
 ; CHECK-SAME: (i1 [[COND:%.*]], float [[X:%.*]]) {
 ; CHECK-NEXT:    ret float poison
 ;
-  %select = select i1 %cond, float %x, float 0x7FF0000000000000
+  %select = select i1 %cond, float %x, float +inf
   %fabs = call float @llvm.fabs.f32(float %select)
   %fneg = fneg float %fabs
   ret float %fneg
@@ -1124,7 +1124,7 @@ define nofpclass(inf) float @ret_nofpclass_inf__copysign_unknown_select_pinf_rhs
 ; CHECK-NEXT:    [[COPYSIGN:%.*]] = call float @llvm.copysign.f32(float [[X]], float [[UNKNOWN_SIGN]])
 ; CHECK-NEXT:    ret float [[COPYSIGN]]
 ;
-  %select = select i1 %cond, float %x, float 0x7FF0000000000000
+  %select = select i1 %cond, float %x, float +inf
   %copysign = call float @llvm.copysign.f32(float %select, float %unknown.sign)
   ret float %copysign
 }
@@ -1135,7 +1135,7 @@ define nofpclass(inf) float @ret_nofpclass_inf__copysign_positive_select_pinf_rh
 ; CHECK-NEXT:    [[TMP1:%.*]] = call float @llvm.fabs.f32(float [[X]])
 ; CHECK-NEXT:    ret float [[TMP1]]
 ;
-  %select = select i1 %cond, float %x, float 0x7FF0000000000000
+  %select = select i1 %cond, float %x, float +inf
   %copysign = call float @llvm.copysign.f32(float %select, float 1.0)
   ret float %copysign
 }
@@ -1147,7 +1147,7 @@ define nofpclass(inf) float @ret_nofpclass_inf__copysign_negative_select_pinf_rh
 ; CHECK-NEXT:    [[DOTNEG:%.*]] = fneg float [[TMP1]]
 ; CHECK-NEXT:    ret float [[DOTNEG]]
 ;
-  %select = select i1 %cond, float %x, float 0x7FF0000000000000
+  %select = select i1 %cond, float %x, float +inf
   %copysign = call float @llvm.copysign.f32(float %select, float -1.0)
   ret float %copysign
 }
@@ -1238,7 +1238,7 @@ define nofpclass(pinf pnorm psub pzero) float @ret_nofpclass_nopositives__copysi
 ; CHECK-NEXT:    [[TMP1:%.*]] = call float @llvm.fabs.f32(float [[X]])
 ; CHECK-NEXT:    ret float [[TMP1]]
 ;
-  %select = select i1 %cond, float %x, float 0x7FF0000000000000
+  %select = select i1 %cond, float %x, float +inf
   %fabs.sign = call float @llvm.fabs.f32(float %sign)
   %copysign = call float @llvm.copysign.f32(float %select, float %fabs.sign)
   ret float %copysign
@@ -1251,7 +1251,7 @@ define nofpclass(inf nnorm nsub nzero) float @ret_nofpclass_no_negatives_noinf__
 ; CHECK-NEXT:    [[COPYSIGN:%.*]] = call float @llvm.copysign.f32(float [[X]], float [[UNKNOWN_SIGN]])
 ; CHECK-NEXT:    ret float [[COPYSIGN]]
 ;
-  %select = select i1 %cond, float %x, float 0x7FF0000000000000
+  %select = select i1 %cond, float %x, float +inf
   %copysign = call float @llvm.copysign.f32(float %select, float %unknown.sign)
   ret float %copysign
 }
@@ -1263,7 +1263,7 @@ define nofpclass(inf pnorm psub pzero) float @ret_nofpclass_no_positives_noinf__
 ; CHECK-NEXT:    [[COPYSIGN:%.*]] = call float @llvm.copysign.f32(float [[X]], float [[UNKNOWN_SIGN]])
 ; CHECK-NEXT:    ret float [[COPYSIGN]]
 ;
-  %select = select i1 %cond, float %x, float 0x7FF0000000000000
+  %select = select i1 %cond, float %x, float +inf
   %copysign = call float @llvm.copysign.f32(float %select, float %unknown.sign)
   ret float %copysign
 }
@@ -1276,7 +1276,7 @@ define nofpclass(ninf nnorm nsub nzero) float @ret_nofpclass_no_negatives__copys
 ; CHECK-NEXT:    [[COPYSIGN:%.*]] = call float @llvm.copysign.f32(float [[SELECT]], float [[UNKNOWN_SIGN]])
 ; CHECK-NEXT:    ret float [[COPYSIGN]]
 ;
-  %select = select i1 %cond, float %x, float 0x7FF0000000000000
+  %select = select i1 %cond, float %x, float +inf
   %copysign = call float @llvm.copysign.f32(float %select, float %unknown.sign)
   ret float %copysign
 }
@@ -1289,7 +1289,7 @@ define nofpclass(pinf pnorm psub pzero) float @ret_nofpclass_no_positives__copys
 ; CHECK-NEXT:    [[COPYSIGN:%.*]] = call float @llvm.copysign.f32(float [[SELECT]], float [[UNKNOWN_SIGN]])
 ; CHECK-NEXT:    ret float [[COPYSIGN]]
 ;
-  %select = select i1 %cond, float %x, float 0x7FF0000000000000
+  %select = select i1 %cond, float %x, float +inf
   %copysign = call float @llvm.copysign.f32(float %select, float %unknown.sign)
   ret float %copysign
 }
@@ -1302,7 +1302,7 @@ define nofpclass(nan ninf nnorm nsub nzero) float @ret_nofpclass_no_negatives_no
 ; CHECK-NEXT:    [[COPYSIGN:%.*]] = select i1 [[COND]], float [[TMP1]], float +inf
 ; CHECK-NEXT:    ret float [[COPYSIGN]]
 ;
-  %select = select i1 %cond, float %x, float 0x7FF0000000000000
+  %select = select i1 %cond, float %x, float +inf
   %copysign = call float @llvm.copysign.f32(float %select, float %unknown.sign)
   ret float %copysign
 }
@@ -1316,7 +1316,7 @@ define nofpclass(nan pinf pnorm psub pzero) float @ret_nofpclass_no_positives_no
 ; CHECK-NEXT:    [[COPYSIGN:%.*]] = select i1 [[COND]], float [[DOTNEG]], float -inf
 ; CHECK-NEXT:    ret float [[COPYSIGN]]
 ;
-  %select = select i1 %cond, float %x, float 0x7FF0000000000000
+  %select = select i1 %cond, float %x, float +inf
   %copysign = call float @llvm.copysign.f32(float %select, float %unknown.sign)
   ret float %copysign
 }
@@ -1516,7 +1516,7 @@ entry:
   %i2 = fmul float %i1, %y
   %i3 = tail call nofpclass(ninf nzero nsub nnorm) float @llvm.exp2.f32(float %i2)
   %i4 = fcmp olt float %y, 0.000000e+00
-  %i5 = select i1 %i4, float 0x7FF0000000000000, float 0.000000e+00
+  %i5 = select i1 %i4, float +inf, float 0.000000e+00
   %i6 = fcmp oeq float %x, 0.000000e+00
   %i7 = select i1 %i6, float %i5, float %i3
   %i8 = fcmp oeq float %y, 0.000000e+00
@@ -1549,7 +1549,7 @@ bb:
   %i5 = fmul float %i4, %i3
   %i6 = tail call noundef nofpclass(ninf nzero nsub nnorm) float @llvm.exp2.f32(float noundef %i5)
   %i7 = fcmp olt float %i4, 0.000000e+00
-  %i8 = select i1 %i7, float 0x7FF0000000000000, float 0.000000e+00
+  %i8 = select i1 %i7, float +inf, float 0.000000e+00
   %i9 = fcmp ueq float %i4, 0.000000e+00
   %i10 = fcmp oeq float %i2, 0.000000e+00
   %i11 = select i1 %i9, float 0x7FF8000000000000, float %i8
@@ -1605,7 +1605,7 @@ bb:
   %i17 = fcmp oeq float %arg, 0.000000e+00
   %i18 = fcmp olt float %arg1, 0.000000e+00
   %i19 = xor i1 %i17, %i18
-  %i20 = select i1 %i19, float 0.000000e+00, float 0x7FF0000000000000
+  %i20 = select i1 %i19, float 0.000000e+00, float +inf
   %i21 = select i1 %i11, float %arg, float 0.000000e+00
   %i22 = tail call noundef nofpclass(nan sub norm) float @llvm.copysign.f32(float noundef %i20, float noundef %i21)
   %i23 = select i1 %i17, float %i22, float %i16
@@ -1855,7 +1855,7 @@ define nofpclass(inf) float @ret_nofpclass_inf__arithmetic_fence_select_pinf_rhs
 ; CHECK-NEXT:    [[FENCE:%.*]] = call float @llvm.arithmetic.fence.f32(float [[X]])
 ; CHECK-NEXT:    ret float [[FENCE]]
 ;
-  %select = select i1 %cond, float %x, float 0x7FF0000000000000
+  %select = select i1 %cond, float %x, float +inf
   %fence = call float @llvm.arithmetic.fence.f32(float %select)
   ret float %fence
 }
@@ -1867,7 +1867,7 @@ define nofpclass(snan) float @arithmetic_fence__noinf_callsite_param_attr_select
 ; CHECK-NEXT:    [[FENCE:%.*]] = call float @llvm.arithmetic.fence.f32(float nofpclass(inf) [[SELECT]])
 ; CHECK-NEXT:    ret float [[FENCE]]
 ;
-  %select = select i1 %cond, float %x, float 0x7FF0000000000000
+  %select = select i1 %cond, float %x, float +inf
   %fence = call float @llvm.arithmetic.fence.f32(float nofpclass(inf) %select)
   ret float %fence
 }
@@ -1879,7 +1879,7 @@ define nofpclass(pinf) float @ret_nofpclass_pinf__minnum_pinf(i1 %cond, float %x
 ; CHECK-NEXT:    [[MIN:%.*]] = call nsz float @llvm.minnum.f32(float [[X]], float +inf)
 ; CHECK-NEXT:    ret float [[MIN]]
 ;
-  %min = call float @llvm.minnum.f32(float %x, float 0x7FF0000000000000)
+  %min = call float @llvm.minnum.f32(float %x, float +inf)
   ret float %min
 }
 
@@ -1889,7 +1889,7 @@ define nofpclass(pinf) float @ret_nofpclass_pinf__minnum_ninf(i1 %cond, float %x
 ; CHECK-SAME: (i1 [[COND:%.*]], float [[X:%.*]]) {
 ; CHECK-NEXT:    ret float -inf
 ;
-  %min = call float @llvm.minnum.f32(float %x, float 0xFFF0000000000000)
+  %min = call float @llvm.minnum.f32(float %x, float -inf)
   ret float %min
 }
 
@@ -1900,7 +1900,7 @@ define nofpclass(ninf) float @ret_nofpclass_ninf__maxnum_ninf(i1 %cond, float %x
 ; CHECK-NEXT:    [[MAX:%.*]] = call nsz float @llvm.maxnum.f32(float [[X]], float -inf)
 ; CHECK-NEXT:    ret float [[MAX]]
 ;
-  %max = call float @llvm.maxnum.f32(float %x, float 0xFFF0000000000000)
+  %max = call float @llvm.maxnum.f32(float %x, float -inf)
   ret float %max
 }
 
@@ -1910,7 +1910,7 @@ define nofpclass(ninf) float @ret_nofpclass_ninf__maxnum_pinf(i1 %cond, float %x
 ; CHECK-SAME: (i1 [[COND:%.*]], float [[X:%.*]]) {
 ; CHECK-NEXT:    ret float +inf
 ;
-  %max = call float @llvm.maxnum.f32(float %x, float 0x7FF0000000000000)
+  %max = call float @llvm.maxnum.f32(float %x, float +inf)
   ret float %max
 }
 
@@ -1937,14 +1937,14 @@ define nofpclass(ninf) <2 x float> @single_class_constant_partially_poison_pinf(
 ; CHECK-LABEL: define nofpclass(ninf) <2 x float> @single_class_constant_partially_poison_pinf() {
 ; CHECK-NEXT:    ret <2 x float> <float +inf, float poison>
 ;
-  ret <2 x float> <float 0x7FF0000000000000, float poison>
+  ret <2 x float> <float +inf, float poison>
 }
 
 define nofpclass(ninf) <2 x float> @single_class_constant_partially_undef_pinf() {
 ; CHECK-LABEL: define nofpclass(ninf) <2 x float> @single_class_constant_partially_undef_pinf() {
 ; CHECK-NEXT:    ret <2 x float> <float +inf, float undef>
 ;
-  ret <2 x float> <float 0x7FF0000000000000, float undef>
+  ret <2 x float> <float +inf, float undef>
 }
 
 define nofpclass(zero) <3 x float> @mixed_sign_zero_splat_to_poison() {

--- a/llvm/test/Transforms/InstSimplify/ConstProp/AMDGPU/cos.ll
+++ b/llvm/test/Transforms/InstSimplify/ConstProp/AMDGPU/cos.ll
@@ -122,9 +122,9 @@ define void @test_f32(ptr %p) {
   store volatile float %p1000, ptr %p
   %n1000 = call float @llvm.amdgcn.cos.f32(float -1000.0)
   store volatile float %n1000, ptr %p
-  %pinf = call float @llvm.amdgcn.cos.f32(float 0x7FF0000000000000) ; +inf
+  %pinf = call float @llvm.amdgcn.cos.f32(float +inf) ; +inf
   store volatile float %pinf, ptr %p
-  %ninf = call float @llvm.amdgcn.cos.f32(float 0xFFF0000000000000) ; -inf
+  %ninf = call float @llvm.amdgcn.cos.f32(float -inf) ; -inf
   store volatile float %ninf, ptr %p
   %nan = call float @llvm.amdgcn.cos.f32(float 0x7FF8000000000000) ; nan
   store volatile float %nan, ptr %p

--- a/llvm/test/Transforms/InstSimplify/ConstProp/AMDGPU/fma_legacy.ll
+++ b/llvm/test/Transforms/InstSimplify/ConstProp/AMDGPU/fma_legacy.ll
@@ -32,9 +32,9 @@ define void @test(ptr %p) {
   store volatile float %f, ptr %p
   %g = call float @llvm.amdgcn.fma.legacy(float -0.0, float -0.0, float -0.0)
   store volatile float %g, ptr %p
-  %h = call float @llvm.amdgcn.fma.legacy(float +0.0, float 0x7ff0000000000000, float +4.0) ; +inf
+  %h = call float @llvm.amdgcn.fma.legacy(float +0.0, float +inf, float +4.0) ; +inf
   store volatile float %h, ptr %p
-  %i = call float @llvm.amdgcn.fma.legacy(float 0xfff0000000000000, float +0.0, float +4.0) ; -inf
+  %i = call float @llvm.amdgcn.fma.legacy(float -inf, float +0.0, float +4.0) ; -inf
   store volatile float %i, ptr %p
   %j = call float @llvm.amdgcn.fma.legacy(float 0x7ff0001000000000, float -0.0, float +4.0) ; +nan
   store volatile float %j, ptr %p

--- a/llvm/test/Transforms/InstSimplify/ConstProp/AMDGPU/fmul_legacy.ll
+++ b/llvm/test/Transforms/InstSimplify/ConstProp/AMDGPU/fmul_legacy.ll
@@ -32,9 +32,9 @@ define void @test(ptr %p) {
   store volatile float %f, ptr %p
   %g = call float @llvm.amdgcn.fmul.legacy(float -0.0, float -0.0)
   store volatile float %g, ptr %p
-  %h = call float @llvm.amdgcn.fmul.legacy(float +0.0, float 0x7ff0000000000000) ; +inf
+  %h = call float @llvm.amdgcn.fmul.legacy(float +0.0, float +inf) ; +inf
   store volatile float %h, ptr %p
-  %i = call float @llvm.amdgcn.fmul.legacy(float 0xfff0000000000000, float +0.0) ; -inf
+  %i = call float @llvm.amdgcn.fmul.legacy(float -inf, float +0.0) ; -inf
   store volatile float %i, ptr %p
   %j = call float @llvm.amdgcn.fmul.legacy(float 0x7ff0001000000000, float -0.0) ; +nan
   store volatile float %j, ptr %p

--- a/llvm/test/Transforms/InstSimplify/ConstProp/AMDGPU/fract.ll
+++ b/llvm/test/Transforms/InstSimplify/ConstProp/AMDGPU/fract.ll
@@ -76,9 +76,9 @@ define void @test_f32(ptr %p) {
   store volatile float %ptiny, ptr %p
   %ntiny = call float @llvm.amdgcn.fract.f32(float 0xB810000000000000) ; -min normal
   store volatile float %ntiny, ptr %p
-  %pinf = call float @llvm.amdgcn.fract.f32(float 0x7FF0000000000000) ; +inf
+  %pinf = call float @llvm.amdgcn.fract.f32(float +inf) ; +inf
   store volatile float %pinf, ptr %p
-  %ninf = call float @llvm.amdgcn.fract.f32(float 0xFFF0000000000000) ; -inf
+  %ninf = call float @llvm.amdgcn.fract.f32(float -inf) ; -inf
   store volatile float %ninf, ptr %p
   %nan = call float @llvm.amdgcn.fract.f32(float 0x7FF8000000000000) ; nan
   store volatile float %nan, ptr %p

--- a/llvm/test/Transforms/InstSimplify/ConstProp/AMDGPU/sin.ll
+++ b/llvm/test/Transforms/InstSimplify/ConstProp/AMDGPU/sin.ll
@@ -122,9 +122,9 @@ define void @test_f32(ptr %p) {
   store volatile float %p1000, ptr %p
   %n1000 = call float @llvm.amdgcn.sin.f32(float -1000.0)
   store volatile float %n1000, ptr %p
-  %pinf = call float @llvm.amdgcn.sin.f32(float 0x7FF0000000000000) ; +inf
+  %pinf = call float @llvm.amdgcn.sin.f32(float +inf) ; +inf
   store volatile float %pinf, ptr %p
-  %ninf = call float @llvm.amdgcn.sin.f32(float 0xFFF0000000000000) ; -inf
+  %ninf = call float @llvm.amdgcn.sin.f32(float -inf) ; -inf
   store volatile float %ninf, ptr %p
   %nan = call float @llvm.amdgcn.sin.f32(float 0x7FF8000000000000) ; nan
   store volatile float %nan, ptr %p

--- a/llvm/test/Transforms/InstSimplify/ConstProp/WebAssembly/trunc.ll
+++ b/llvm/test/Transforms/InstSimplify/ConstProp/WebAssembly/trunc.ll
@@ -79,9 +79,9 @@ define void @test_i32_trunc_f32_s(ptr %p) {
   store volatile i32 %t14, ptr %p
   %t15 = call i32 @llvm.wasm.trunc.signed.i32.f32(float -2147483904.0)
   store volatile i32 %t15, ptr %p
-  %t16 = call i32 @llvm.wasm.trunc.signed.i32.f32(float 0x7ff0000000000000); inf
+  %t16 = call i32 @llvm.wasm.trunc.signed.i32.f32(float +inf); inf
   store volatile i32 %t16, ptr %p
-  %t17 = call i32 @llvm.wasm.trunc.signed.i32.f32(float 0xfff0000000000000); -inf
+  %t17 = call i32 @llvm.wasm.trunc.signed.i32.f32(float -inf); -inf
   store volatile i32 %t17, ptr %p
   %t18 = call i32 @llvm.wasm.trunc.signed.i32.f32(float 0x7ff8000000000000); nan
   store volatile i32 %t18, ptr %p
@@ -157,9 +157,9 @@ define void @test_i32_trunc_f32_u(ptr %p) {
   store volatile i32 %t13, ptr %p
   %t14 = call i32 @llvm.wasm.trunc.unsigned.i32.f32(float -1.0)
   store volatile i32 %t14, ptr %p
-  %t15 = call i32 @llvm.wasm.trunc.unsigned.i32.f32(float 0x7ff0000000000000); inf
+  %t15 = call i32 @llvm.wasm.trunc.unsigned.i32.f32(float +inf); inf
   store volatile i32 %t15, ptr %p
-  %t16 = call i32 @llvm.wasm.trunc.unsigned.i32.f32(float 0xfff0000000000000); -inf
+  %t16 = call i32 @llvm.wasm.trunc.unsigned.i32.f32(float -inf); -inf
   store volatile i32 %t16, ptr %p
   %t17 = call i32 @llvm.wasm.trunc.unsigned.i32.f32(float 0x7ff8000000000000); nan
   store volatile i32 %t17, ptr %p
@@ -427,9 +427,9 @@ define void @test_i64_trunc_f32_s(ptr %p) {
   store volatile i64 %t16, ptr %p
   %t17 = call i64 @llvm.wasm.trunc.signed.i64.f32(float -9223373136366403584.0)
   store volatile i64 %t17, ptr %p
-  %t18 = call i64 @llvm.wasm.trunc.signed.i64.f32(float 0x7ff0000000000000); inf
+  %t18 = call i64 @llvm.wasm.trunc.signed.i64.f32(float +inf); inf
   store volatile i64 %t18, ptr %p
-  %t19 = call i64 @llvm.wasm.trunc.signed.i64.f32(float 0xfff0000000000000); -inf
+  %t19 = call i64 @llvm.wasm.trunc.signed.i64.f32(float -inf); -inf
   store volatile i64 %t19, ptr %p
   %t20 = call i64 @llvm.wasm.trunc.signed.i64.f32(float 0x7ff8000000000000); nan
   store volatile i64 %t20, ptr %p
@@ -499,9 +499,9 @@ define void @test_i64_trunc_f32_u(ptr %p) {
   store volatile i64 %t11, ptr %p
   %t12 = call i64 @llvm.wasm.trunc.unsigned.i64.f32(float -1.0)
   store volatile i64 %t12, ptr %p
-  %t13 = call i64 @llvm.wasm.trunc.unsigned.i64.f32(float 0x7ff0000000000000); inf
+  %t13 = call i64 @llvm.wasm.trunc.unsigned.i64.f32(float +inf); inf
   store volatile i64 %t13, ptr %p
-  %t14 = call i64 @llvm.wasm.trunc.unsigned.i64.f32(float 0xfff0000000000000); -inf
+  %t14 = call i64 @llvm.wasm.trunc.unsigned.i64.f32(float -inf); -inf
   store volatile i64 %t14, ptr %p
   %t15 = call i64 @llvm.wasm.trunc.unsigned.i64.f32(float 0x7ff8000000000000); nan
   store volatile i64 %t15, ptr %p

--- a/llvm/test/Transforms/InstSimplify/canonicalize.ll
+++ b/llvm/test/Transforms/InstSimplify/canonicalize.ll
@@ -245,7 +245,7 @@ define float @canonicalize_inf() {
 ; CHECK-LABEL: @canonicalize_inf(
 ; CHECK-NEXT:    ret float +inf
 ;
-  %ret = call float @llvm.canonicalize.f32(float 0x7FF0000000000000)
+  %ret = call float @llvm.canonicalize.f32(float +inf)
   ret float %ret
 }
 
@@ -253,7 +253,7 @@ define float @canonicalize_neg_inf() {
 ; CHECK-LABEL: @canonicalize_neg_inf(
 ; CHECK-NEXT:    ret float -inf
 ;
-  %ret = call float @llvm.canonicalize.f32(float 0xFFF0000000000000)
+  %ret = call float @llvm.canonicalize.f32(float -inf)
   ret float %ret
 }
 

--- a/llvm/test/Transforms/InstSimplify/exp10.ll
+++ b/llvm/test/Transforms/InstSimplify/exp10.ll
@@ -182,7 +182,7 @@ define float @exp10_inf() {
 ; CHECK-NEXT:    [[RET:%.*]] = call float @llvm.exp10.f32(float +inf)
 ; CHECK-NEXT:    ret float [[RET]]
 ;
-  %ret = call float @llvm.exp10.f32(float 0x7FF0000000000000)
+  %ret = call float @llvm.exp10.f32(float +inf)
   ret float %ret
 }
 
@@ -191,7 +191,7 @@ define float @exp10_neginf() {
 ; CHECK-NEXT:    [[RET:%.*]] = call float @llvm.exp10.f32(float -inf)
 ; CHECK-NEXT:    ret float [[RET]]
 ;
-  %ret = call float @llvm.exp10.f32(float 0xFFF0000000000000)
+  %ret = call float @llvm.exp10.f32(float -inf)
   ret float %ret
 }
 
@@ -278,7 +278,7 @@ define <2 x float> @exp10_splat_inf() {
 ; CHECK-NEXT:    [[RET:%.*]] = call <2 x float> @llvm.exp10.v2f32(<2 x float> splat (float +inf))
 ; CHECK-NEXT:    ret <2 x float> [[RET]]
 ;
-  %ret = call <2 x float> @llvm.exp10.v2f32(<2 x float> <float 0x7FF0000000000000, float 0x7FF0000000000000>)
+  %ret = call <2 x float> @llvm.exp10.v2f32(<2 x float> <float +inf, float +inf>)
   ret <2 x float> %ret
 }
 
@@ -287,7 +287,7 @@ define <2 x float> @exp10_splat_neginf() {
 ; CHECK-NEXT:    [[RET:%.*]] = call <2 x float> @llvm.exp10.v2f32(<2 x float> splat (float -inf))
 ; CHECK-NEXT:    ret <2 x float> [[RET]]
 ;
-  %ret = call <2 x float> @llvm.exp10.v2f32(<2 x float> <float 0xFFF0000000000000, float 0xFFF0000000000000>)
+  %ret = call <2 x float> @llvm.exp10.v2f32(<2 x float> <float -inf, float -inf>)
   ret <2 x float> %ret
 }
 
@@ -296,6 +296,6 @@ define <2 x float> @exp10_splat_undef_inf() {
 ; CHECK-NEXT:    [[RET:%.*]] = call <2 x float> @llvm.exp10.v2f32(<2 x float> <float undef, float +inf>)
 ; CHECK-NEXT:    ret <2 x float> [[RET]]
 ;
-  %ret = call <2 x float> @llvm.exp10.v2f32(<2 x float> <float undef, float 0x7FF0000000000000>)
+  %ret = call <2 x float> @llvm.exp10.v2f32(<2 x float> <float undef, float +inf>)
   ret <2 x float> %ret
 }

--- a/llvm/test/Transforms/InstSimplify/floating-point-arithmetic.ll
+++ b/llvm/test/Transforms/InstSimplify/floating-point-arithmetic.ll
@@ -1295,7 +1295,7 @@ define <2 x float> @fabs_fmul_nan_vector(<2 x float> %x) {
 ; CHECK-NEXT:    ret <2 x float> [[ABS2]]
 ;
   %abs = call nnan <2 x float> @llvm.fabs.v2f32(<2 x float> %x)
-  %mul = fmul <2 x float> %abs, splat (float 0x7FF0000000000000)
+  %mul = fmul <2 x float> %abs, splat (float +inf)
   %abs2 = call <2 x float> @llvm.fabs.v2f32(<2 x float> %mul)
   ret <2 x float> %abs2
 }

--- a/llvm/test/Transforms/InstSimplify/floating-point-compare.ll
+++ b/llvm/test/Transforms/InstSimplify/floating-point-compare.ll
@@ -1749,7 +1749,7 @@ define <2 x i1> @is_infinite_neg(<2 x float> %x) {
 ; CHECK-NEXT:    ret <2 x i1> zeroinitializer
 ;
   %x42 = fadd ninf <2 x float> %x, <float 42.0, float 42.0>
-  %r = fcmp oeq <2 x float> %x42, <float 0xFFF0000000000000, float 0xFFF0000000000000>
+  %r = fcmp oeq <2 x float> %x42, <float -inf, float -inf>
   ret <2 x i1> %r
 }
 
@@ -1794,7 +1794,7 @@ define <2 x i1> @is_infinite_neg_or_nan(<2 x float> %x) {
 ; CHECK-NEXT:    ret <2 x i1> zeroinitializer
 ;
   %x42 = fadd nnan ninf <2 x float> %x, <float 42.0, float 42.0>
-  %r = fcmp ueq <2 x float> %x42, <float 0xFFF0000000000000, float 0xFFF0000000000000>
+  %r = fcmp ueq <2 x float> %x42, <float -inf, float -inf>
   ret <2 x i1> %r
 }
 
@@ -1813,7 +1813,7 @@ define <2 x i1> @is_finite_or_nan_commute(<2 x i8> %x) {
 ; CHECK-NEXT:    ret <2 x i1> splat (i1 true)
 ;
   %cast = uitofp <2 x i8> %x to <2 x float>
-  %r = fcmp une <2 x float> <float 0x7FF0000000000000, float 0x7FF0000000000000>, %cast
+  %r = fcmp une <2 x float> <float +inf, float +inf>, %cast
   ret <2 x i1> %r
 }
 
@@ -1860,7 +1860,7 @@ define <2 x i1> @is_finite_commute(<2 x i8> %x) {
 ; CHECK-NEXT:    ret <2 x i1> splat (i1 true)
 ;
   %cast = uitofp <2 x i8> %x to <2 x float>
-  %r = fcmp one <2 x float> <float 0x7FF0000000000000, float 0x7FF0000000000000>, %cast
+  %r = fcmp one <2 x float> <float +inf, float +inf>, %cast
   ret <2 x i1> %r
 }
 
@@ -1918,7 +1918,7 @@ define i1 @ogt_zero_fabs_select_negone_or_pinf(i1 %cond) {
 ; CHECK-NEXT:    ret i1 true
 ;
 entry:
-  %select = select i1 %cond, float -1.0, float 0x7FF0000000000000
+  %select = select i1 %cond, float -1.0, float +inf
   %fabs = call float @llvm.fabs.f32(float %select)
   %one = fcmp ogt float %fabs, 0.0
   ret i1 %one
@@ -1930,7 +1930,7 @@ define i1 @ogt_zero_fabs_select_one_or_ninf(i1 %cond) {
 ; CHECK-NEXT:    ret i1 true
 ;
 entry:
-  %select = select i1 %cond, float 1.0, float 0xFFF0000000000000
+  %select = select i1 %cond, float 1.0, float -inf
   %fabs = call float @llvm.fabs.f32(float %select)
   %one = fcmp ogt float %fabs, 0.0
   ret i1 %one

--- a/llvm/test/Transforms/InstSimplify/fminmax-folds.ll
+++ b/llvm/test/Transforms/InstSimplify/fminmax-folds.ll
@@ -264,19 +264,19 @@ define void @minmax_pos_inf_f32(float %x, ptr %minnum_res, ptr %maxnum_res, ptr 
 ; CHECK-NEXT:    store float +inf, ptr [[MAXIMUMNUM_RES:%.*]], align 4
 ; CHECK-NEXT:    ret void
 ;
-  %minnum = call float @llvm.minnum.f32(float %x, float 0x7FF0000000000000)
+  %minnum = call float @llvm.minnum.f32(float %x, float +inf)
   store float %minnum, ptr %minnum_res
-  %maxnum = call float @llvm.maxnum.f32(float %x, float 0x7FF0000000000000)
+  %maxnum = call float @llvm.maxnum.f32(float %x, float +inf)
   store float %maxnum, ptr %maxnum_res
 
-  %minimum = call float @llvm.minimum.f32(float %x, float 0x7FF0000000000000)
+  %minimum = call float @llvm.minimum.f32(float %x, float +inf)
   store float %minimum, ptr %minimum_res
-  %maximum = call float @llvm.maximum.f32(float %x, float 0x7FF0000000000000)
+  %maximum = call float @llvm.maximum.f32(float %x, float +inf)
   store float %maximum, ptr %maximum_res
 
-  %minimumnum = call float @llvm.minimumnum.f32(float %x, float 0x7FF0000000000000)
+  %minimumnum = call float @llvm.minimumnum.f32(float %x, float +inf)
   store float %minimumnum, ptr %minimumnum_res
-  %maximumnum = call float @llvm.maximumnum.f32(float %x, float 0x7FF0000000000000)
+  %maximumnum = call float @llvm.maximumnum.f32(float %x, float +inf)
   store float %maximumnum, ptr %maximumnum_res
   ret void
 }
@@ -292,19 +292,19 @@ define void @minmax_pos_inf_nnan_v2f32(<2 x float> %x, ptr %minnum_res, ptr %max
 ; CHECK-NEXT:    store <2 x float> splat (float +inf), ptr [[MAXIMUMNUM_RES:%.*]], align 8
 ; CHECK-NEXT:    ret void
 ;
-  %minnum = call nnan <2 x float> @llvm.minnum.v2f32(<2 x float> splat (float 0x7FF0000000000000), <2 x float> %x)
+  %minnum = call nnan <2 x float> @llvm.minnum.v2f32(<2 x float> splat (float +inf), <2 x float> %x)
   store <2 x float> %minnum, ptr %minnum_res
-  %maxnum = call nnan <2 x float> @llvm.maxnum.v2f32(<2 x float> splat (float 0x7FF0000000000000), <2 x float> %x)
+  %maxnum = call nnan <2 x float> @llvm.maxnum.v2f32(<2 x float> splat (float +inf), <2 x float> %x)
   store <2 x float> %maxnum, ptr %maxnum_res
 
-  %minimum = call nnan <2 x float> @llvm.minimum.v2f32(<2 x float> splat (float 0x7FF0000000000000), <2 x float> %x)
+  %minimum = call nnan <2 x float> @llvm.minimum.v2f32(<2 x float> splat (float +inf), <2 x float> %x)
   store <2 x float> %minimum, ptr %minimum_res
-  %maximum = call nnan <2 x float> @llvm.maximum.v2f32(<2 x float> splat (float 0x7FF0000000000000), <2 x float> %x)
+  %maximum = call nnan <2 x float> @llvm.maximum.v2f32(<2 x float> splat (float +inf), <2 x float> %x)
   store <2 x float> %maximum, ptr %maximum_res
 
-  %minimumnum = call nnan <2 x float> @llvm.minimumnum.v2f32(<2 x float> splat (float 0x7FF0000000000000), <2 x float> %x)
+  %minimumnum = call nnan <2 x float> @llvm.minimumnum.v2f32(<2 x float> splat (float +inf), <2 x float> %x)
   store <2 x float> %minimumnum, ptr %minimumnum_res
-  %maximumnum = call nnan <2 x float> @llvm.maximumnum.v2f32(<2 x float> splat (float 0x7FF0000000000000), <2 x float> %x)
+  %maximumnum = call nnan <2 x float> @llvm.maximumnum.v2f32(<2 x float> splat (float +inf), <2 x float> %x)
   store <2 x float> %maximumnum, ptr %maximumnum_res
   ret void
 }
@@ -333,19 +333,19 @@ define void @minmax_neg_inf_f32(float %x, ptr %minnum_res, ptr %maxnum_res, ptr 
 ; CHECK-NEXT:    store float [[MAXIMUMNUM]], ptr [[MAXIMUMNUM_RES:%.*]], align 4
 ; CHECK-NEXT:    ret void
 ;
-  %minnum = call float @llvm.minnum.f32(float %x, float 0xFFF0000000000000)
+  %minnum = call float @llvm.minnum.f32(float %x, float -inf)
   store float %minnum, ptr %minnum_res
-  %maxnum = call float @llvm.maxnum.f32(float %x, float 0xFFF0000000000000)
+  %maxnum = call float @llvm.maxnum.f32(float %x, float -inf)
   store float %maxnum, ptr %maxnum_res
 
-  %minimum = call float @llvm.minimum.f32(float %x, float 0xFFF0000000000000)
+  %minimum = call float @llvm.minimum.f32(float %x, float -inf)
   store float %minimum, ptr %minimum_res
-  %maximum = call float @llvm.maximum.f32(float %x, float 0xFFF0000000000000)
+  %maximum = call float @llvm.maximum.f32(float %x, float -inf)
   store float %maximum, ptr %maximum_res
 
-  %minimumnum = call float @llvm.minimumnum.f32(float %x, float 0xFFF0000000000000)
+  %minimumnum = call float @llvm.minimumnum.f32(float %x, float -inf)
   store float %minimumnum, ptr %minimumnum_res
-  %maximumnum = call float @llvm.maximumnum.f32(float %x, float 0xFFF0000000000000)
+  %maximumnum = call float @llvm.maximumnum.f32(float %x, float -inf)
   store float %maximumnum, ptr %maximumnum_res
   ret void
 }
@@ -641,19 +641,19 @@ define void @minmax_mixed_pos_inf_poison_snan_v3f32(<3 x float> %x, ptr %minnum_
 ; CHECK-NEXT:    store <3 x float> [[MAXIMUMNUM]], ptr [[MAXIMUMNUM_RES:%.*]], align 16
 ; CHECK-NEXT:    ret void
 ;
-  %minnum = call nnan <3 x float> @llvm.minnum.v3f32(<3 x float> <float poison, float 0x7FF0000000000000, float 0x7FF4000000000000>, <3 x float> %x)
+  %minnum = call nnan <3 x float> @llvm.minnum.v3f32(<3 x float> <float poison, float +inf, float 0x7FF4000000000000>, <3 x float> %x)
   store <3 x float> %minnum, ptr %minnum_res
-  %maxnum = call nnan <3 x float> @llvm.maxnum.v3f32(<3 x float> <float poison, float 0x7FF0000000000000, float 0x7FF4000000000000>, <3 x float> %x)
+  %maxnum = call nnan <3 x float> @llvm.maxnum.v3f32(<3 x float> <float poison, float +inf, float 0x7FF4000000000000>, <3 x float> %x)
   store <3 x float> %maxnum, ptr %maxnum_res
 
-  %minimum = call nnan <3 x float> @llvm.minimum.v3f32(<3 x float> <float poison, float 0x7FF0000000000000, float 0x7FF4000000000000>, <3 x float> %x)
+  %minimum = call nnan <3 x float> @llvm.minimum.v3f32(<3 x float> <float poison, float +inf, float 0x7FF4000000000000>, <3 x float> %x)
   store <3 x float> %minimum, ptr %minimum_res
-  %maximum = call nnan <3 x float> @llvm.maximum.v3f32(<3 x float> <float poison, float 0x7FF0000000000000, float 0x7FF4000000000000>, <3 x float> %x)
+  %maximum = call nnan <3 x float> @llvm.maximum.v3f32(<3 x float> <float poison, float +inf, float 0x7FF4000000000000>, <3 x float> %x)
   store <3 x float> %maximum, ptr %maximum_res
 
-  %minimumnum = call nnan <3 x float> @llvm.minimumnum.v3f32(<3 x float> <float poison, float 0x7FF0000000000000, float 0x7FF4000000000000>, <3 x float> %x)
+  %minimumnum = call nnan <3 x float> @llvm.minimumnum.v3f32(<3 x float> <float poison, float +inf, float 0x7FF4000000000000>, <3 x float> %x)
   store <3 x float> %minimumnum, ptr %minimumnum_res
-  %maximumnum = call nnan <3 x float> @llvm.maximumnum.v3f32(<3 x float> <float poison, float 0x7FF0000000000000, float 0x7FF4000000000000>, <3 x float> %x)
+  %maximumnum = call nnan <3 x float> @llvm.maximumnum.v3f32(<3 x float> <float poison, float +inf, float 0x7FF4000000000000>, <3 x float> %x)
   store <3 x float> %maximumnum, ptr %maximumnum_res
   ret void
 }

--- a/llvm/test/Transforms/InstSimplify/fp-undef-poison.ll
+++ b/llvm/test/Transforms/InstSimplify/fp-undef-poison.ll
@@ -340,6 +340,6 @@ define float @sqrt_ninf_inf() {
 ; CHECK-NEXT:    [[SQRT:%.*]] = call ninf float @llvm.sqrt.f32(float -inf)
 ; CHECK-NEXT:    ret float [[SQRT]]
 ;
-  %sqrt = call ninf float @llvm.sqrt(float 0xfff0000000000000)
+  %sqrt = call ninf float @llvm.sqrt(float -inf)
   ret float %sqrt
 }

--- a/llvm/test/Transforms/InstSimplify/fptoi-sat.ll
+++ b/llvm/test/Transforms/InstSimplify/fptoi-sat.ll
@@ -425,7 +425,7 @@ define i32 @fptosi_f32_to_i32_inf() {
 ; CHECK-LABEL: @fptosi_f32_to_i32_inf(
 ; CHECK-NEXT:    ret i32 2147483647
 ;
-  %r = call i32 @llvm.fptosi.sat.i32.f32(float 0x7ff0000000000000)
+  %r = call i32 @llvm.fptosi.sat.i32.f32(float +inf)
   ret i32 %r
 }
 
@@ -433,7 +433,7 @@ define i32 @fptosi_f32_to_i32_neg_inf() {
 ; CHECK-LABEL: @fptosi_f32_to_i32_neg_inf(
 ; CHECK-NEXT:    ret i32 -2147483648
 ;
-  %r = call i32 @llvm.fptosi.sat.i32.f32(float 0xfff0000000000000)
+  %r = call i32 @llvm.fptosi.sat.i32.f32(float -inf)
   ret i32 %r
 }
 
@@ -559,7 +559,7 @@ define i32 @fptoui_f32_to_i32_inf() {
 ; CHECK-LABEL: @fptoui_f32_to_i32_inf(
 ; CHECK-NEXT:    ret i32 -1
 ;
-  %r = call i32 @llvm.fptoui.sat.i32.f32(float 0x7ff0000000000000)
+  %r = call i32 @llvm.fptoui.sat.i32.f32(float +inf)
   ret i32 %r
 }
 
@@ -567,7 +567,7 @@ define i32 @fptoui_f32_to_i32_neg_inf() {
 ; CHECK-LABEL: @fptoui_f32_to_i32_neg_inf(
 ; CHECK-NEXT:    ret i32 0
 ;
-  %r = call i32 @llvm.fptoui.sat.i32.f32(float 0xfff0000000000000)
+  %r = call i32 @llvm.fptoui.sat.i32.f32(float -inf)
   ret i32 %r
 }
 

--- a/llvm/test/Transforms/InstSimplify/known-never-infinity.ll
+++ b/llvm/test/Transforms/InstSimplify/known-never-infinity.ll
@@ -1032,7 +1032,7 @@ define i1 @not_inf_fabs_select_pzero_or_ninf(i1 %cond) {
 ; CHECK-NEXT:    ret i1 [[ONE]]
 ;
 entry:
-  %select = select i1 %cond, float 0.000000e+00, float 0xFFF0000000000000
+  %select = select i1 %cond, float 0.000000e+00, float -inf
   %fabs = call float @llvm.fabs.f32(float %select)
   %one = fcmp one float %fabs, 0x7FF0000000000000
   ret i1 %one
@@ -1048,7 +1048,7 @@ define i1 @not_inf_fabs_select_nzero_or_pinf(i1 %cond) {
 ; CHECK-NEXT:    ret i1 [[ONE]]
 ;
 entry:
-  %select = select i1 %cond, float -0.000000e+00, float 0x7FF0000000000000
+  %select = select i1 %cond, float -0.000000e+00, float +inf
   %fabs = call float @llvm.fabs.f32(float %select)
   %one = fcmp one float %fabs, 0x7FF0000000000000
   ret i1 %one
@@ -1061,7 +1061,7 @@ define i1 @not_ninf_fabs_select_nzero_or_pinf(i1 %cond) {
 ; CHECK-NEXT:    ret i1 true
 ;
 entry:
-  %select = select i1 %cond, float -0.000000e+00, float 0x7FF0000000000000
+  %select = select i1 %cond, float -0.000000e+00, float +inf
   %fabs = call float @llvm.fabs.f32(float %select)
   %one = fcmp one float %fabs, 0xFFF0000000000000
   ret i1 %one
@@ -1078,7 +1078,7 @@ define i1 @not_ninf_fneg_fabs_select_nzero_or_pinf(i1 %cond) {
 ; CHECK-NEXT:    ret i1 [[ONE]]
 ;
 entry:
-  %select = select i1 %cond, float -0.000000e+00, float 0x7FF0000000000000
+  %select = select i1 %cond, float -0.000000e+00, float +inf
   %fabs = call float @llvm.fabs.f32(float %select)
   %fneg.fabs = fneg float %fabs
   %one = fcmp one float %fneg.fabs, 0xFFF0000000000000

--- a/llvm/test/Transforms/InstSimplify/known-never-nan.ll
+++ b/llvm/test/Transforms/InstSimplify/known-never-nan.ll
@@ -593,7 +593,7 @@ define i1 @issue63316_commute(i64 %arg) {
 ; CHECK-NEXT:    ret i1 [[FCMP]]
 ;
   %sitofp = sitofp i64 %arg to float
-  %fmul = fmul float 0x7FF0000000000000, %sitofp
+  %fmul = fmul float +inf, %sitofp
   %fcmp = fcmp uno float %fmul, 0.000000e+00
   ret i1 %fcmp
 }

--- a/llvm/test/Transforms/InstSimplify/ldexp.ll
+++ b/llvm/test/Transforms/InstSimplify/ldexp.ll
@@ -100,16 +100,16 @@ define void @ldexp_f32_val_infinity(i32 %y) {
 ; CHECK-NEXT:    store volatile float -inf, ptr addrspace(1) undef, align 4
 ; CHECK-NEXT:    ret void
 ;
-  %inf = call float @llvm.ldexp.f32.i32(float 0x7ff0000000000000, i32 %y)
+  %inf = call float @llvm.ldexp.f32.i32(float +inf, i32 %y)
   store volatile float %inf, ptr addrspace(1) undef
 
-  %neg.inf = call float @llvm.ldexp.f32.i32(float 0xfff0000000000000, i32 %y)
+  %neg.inf = call float @llvm.ldexp.f32.i32(float -inf, i32 %y)
   store volatile float %neg.inf, ptr addrspace(1) undef
 
-  %inf.zero = call float @llvm.ldexp.f32.i32(float 0x7ff0000000000000, i32 0)
+  %inf.zero = call float @llvm.ldexp.f32.i32(float +inf, i32 0)
   store volatile float %inf.zero, ptr addrspace(1) undef
 
-  %neg.inf.zero = call float @llvm.ldexp.f32.i32(float 0xfff0000000000000, i32 0)
+  %neg.inf.zero = call float @llvm.ldexp.f32.i32(float -inf, i32 0)
   store volatile float %neg.inf.zero, ptr addrspace(1) undef
 
   ret void

--- a/llvm/test/Transforms/InstSimplify/pr122582.ll
+++ b/llvm/test/Transforms/InstSimplify/pr122582.ll
@@ -78,7 +78,7 @@ define i32 @ilogbf_inf() {
 ; CHECK-NEXT:    [[R:%.*]] = call i32 @ilogbf(float +inf)
 ; CHECK-NEXT:    ret i32 [[R]]
 ;
-  %r = call i32 @ilogbf(float 0x7FF0000000000000)
+  %r = call i32 @ilogbf(float +inf)
   ret i32 %r
 }
 
@@ -150,7 +150,7 @@ define i32 @ilogbf_inf_readnone() {
 ; CHECK-NEXT:    [[R:%.*]] = call i32 @ilogbf(float +inf) #[[ATTR1]]
 ; CHECK-NEXT:    ret i32 [[R]]
 ;
-  %r = call i32 @ilogbf(float 0x7FF0000000000000) readnone
+  %r = call i32 @ilogbf(float +inf) readnone
   ret i32 %r
 }
 

--- a/llvm/test/Transforms/InstSimplify/sincos.ll
+++ b/llvm/test/Transforms/InstSimplify/sincos.ll
@@ -122,7 +122,7 @@ define { float, float } @sincos_inf() {
 ; CHECK-NEXT:    [[RET:%.*]] = call { float, float } @llvm.sincos.f32(float +inf)
 ; CHECK-NEXT:    ret { float, float } [[RET]]
 ;
-  %ret = call { float, float } @llvm.sincos.f32(float 0x7FF0000000000000)
+  %ret = call { float, float } @llvm.sincos.f32(float +inf)
   ret { float, float } %ret
 }
 
@@ -131,7 +131,7 @@ define { float, float } @sincos_neginf() {
 ; CHECK-NEXT:    [[RET:%.*]] = call { float, float } @llvm.sincos.f32(float -inf)
 ; CHECK-NEXT:    ret { float, float } [[RET]]
 ;
-  %ret = call { float, float } @llvm.sincos.f32(float 0xFFF0000000000000)
+  %ret = call { float, float } @llvm.sincos.f32(float -inf)
   ret { float, float } %ret
 }
 

--- a/llvm/test/Transforms/LoopUnroll/runtime-unroll-reductions-min-max.ll
+++ b/llvm/test/Transforms/LoopUnroll/runtime-unroll-reductions-min-max.ll
@@ -618,7 +618,7 @@ entry:
 
 loop:
   %iv = phi i64 [ 0, %entry ], [ %iv.next, %loop ]
-  %rdx = phi <4 x float> [ splat (float 0xFFF0000000000000), %entry ], [ %rdx.next, %loop ]
+  %rdx = phi <4 x float> [ splat (float -inf), %entry ], [ %rdx.next, %loop ]
   %gep.a = getelementptr inbounds nuw <4 x float>, ptr %a, i64 %iv
   %0 = load <4 x float>, ptr %gep.a, align 16
   %rdx.next = call <4 x float> @llvm.maxnum.v4f32(<4 x float> %rdx, <4 x float> %0)
@@ -685,7 +685,7 @@ entry:
 
 loop:
   %iv = phi i64 [ 0, %entry ], [ %iv.next, %loop ]
-  %rdx = phi <4 x float> [ <float 0x7FF0000000000000, float 0x7FF0000000000000, float 0x7FF0000000000000, float 0x7FF0000000000000>, %entry ], [ %rdx.next, %loop ]
+  %rdx = phi <4 x float> [ <float +inf, float +inf, float +inf, float +inf>, %entry ], [ %rdx.next, %loop ]
   %gep.a = getelementptr inbounds nuw <4 x float>, ptr %a, i64 %iv
   %1 = load <4 x float>, ptr %gep.a, align 16
   %rdx.next = call <4 x float> @llvm.minnum.v4f32(<4 x float> %rdx, <4 x float> %1)

--- a/llvm/test/Transforms/SLPVectorizer/catchswitch.ll
+++ b/llvm/test/Transforms/SLPVectorizer/catchswitch.ll
@@ -65,8 +65,8 @@ labelD:
   unreachable
 
 labelE:
-  %1 = extractelement <4 x float> <float 0x7FF0000000000000, float 0x7FF0000000000000, float 0x7FF0000000000000, float 0xFFF0000000000000>, i64 1
-  %f = extractelement <4 x float> <float 0x7FF0000000000000, float 0x7FF0000000000000, float 0x7FF0000000000000, float 0xFFF0000000000000>, i64 2
+  %1 = extractelement <4 x float> <float +inf, float +inf, float +inf, float -inf>, i64 1
+  %f = extractelement <4 x float> <float +inf, float +inf, float +inf, float -inf>, i64 2
   invoke void @funcA()
   to label %labelG unwind label %catch.dispatch
 
@@ -75,8 +75,8 @@ labelF:
   cleanupret from %2 unwind to caller
 
 labelG:
-  %g = extractelement <4 x float> <float 0x7FF0000000000000, float 0x7FF0000000000000, float 0x7FF0000000000000, float 0xFFF0000000000000>, i64 0
-  %h = extractelement <4 x float> <float 0x7FF0000000000000, float 0x7FF0000000000000, float 0x7FF0000000000000, float 0xFFF0000000000000>, i64 3
+  %g = extractelement <4 x float> <float +inf, float +inf, float +inf, float -inf>, i64 0
+  %h = extractelement <4 x float> <float +inf, float +inf, float +inf, float -inf>, i64 3
   invoke void @funcA()
   to label %labelH unwind label %catch.dispatch
 

--- a/llvm/unittests/Analysis/ValueTrackingTest.cpp
+++ b/llvm/unittests/Analysis/ValueTrackingTest.cpp
@@ -1543,29 +1543,26 @@ TEST_F(ComputeKnownFPClassTest, SelectPosOrNeg0) {
 }
 
 TEST_F(ComputeKnownFPClassTest, SelectPosInf) {
-  parseAssembly(
-      "define float @test(i1 %cond) {\n"
-      "  %A = select i1 %cond, float 0x7FF0000000000000, float 0x7FF0000000000000"
-      "  ret float %A\n"
-      "}\n");
+  parseAssembly("define float @test(i1 %cond) {\n"
+                "  %A = select i1 %cond, float +inf, float +inf"
+                "  ret float %A\n"
+                "}\n");
   expectKnownFPClass(fcPosInf, false);
 }
 
 TEST_F(ComputeKnownFPClassTest, SelectNegInf) {
-  parseAssembly(
-      "define float @test(i1 %cond) {\n"
-      "  %A = select i1 %cond, float 0xFFF0000000000000, float 0xFFF0000000000000"
-      "  ret float %A\n"
-      "}\n");
+  parseAssembly("define float @test(i1 %cond) {\n"
+                "  %A = select i1 %cond, float -inf, float -inf"
+                "  ret float %A\n"
+                "}\n");
   expectKnownFPClass(fcNegInf, true);
 }
 
 TEST_F(ComputeKnownFPClassTest, SelectPosOrNegInf) {
-  parseAssembly(
-      "define float @test(i1 %cond) {\n"
-      "  %A = select i1 %cond, float 0x7FF0000000000000, float 0xFFF0000000000000"
-      "  ret float %A\n"
-      "}\n");
+  parseAssembly("define float @test(i1 %cond) {\n"
+                "  %A = select i1 %cond, float +inf, float -inf"
+                "  ret float %A\n"
+                "}\n");
   expectKnownFPClass(fcInf, std::nullopt);
 }
 

--- a/llvm/unittests/CodeGen/GlobalISel/KnownFPClassTest.cpp
+++ b/llvm/unittests/CodeGen/GlobalISel/KnownFPClassTest.cpp
@@ -276,8 +276,8 @@ TEST_F(AArch64GISelMITest, TestFPClassSelectPosInf) {
   StringRef MIRString = R"(
     %ptr:_(p0) = G_IMPLICIT_DEF
     %cond:_(s1) = G_LOAD %ptr(p0) :: (load (s1))
-    %lhs:_(s32) = G_FCONSTANT float 0x7FF0000000000000
-    %rhs:_(s32) = G_FCONSTANT float 0x7FF0000000000000
+    %lhs:_(s32) = G_FCONSTANT float f0x7F800000
+    %rhs:_(s32) = G_FCONSTANT float f0x7F800000
     %sel:_(s32) = G_SELECT %cond, %lhs, %rhs
     %copy_sel:_(s32) = COPY %sel
 )";
@@ -302,8 +302,8 @@ TEST_F(AArch64GISelMITest, TestFPClassSelectNegInf) {
   StringRef MIRString = R"(
     %ptr:_(p0) = G_IMPLICIT_DEF
     %cond:_(s1) = G_LOAD %ptr(p0) :: (load (s1))
-    %lhs:_(s32) = G_FCONSTANT float 0xFFF0000000000000
-    %rhs:_(s32) = G_FCONSTANT float 0xFFF0000000000000
+    %lhs:_(s32) = G_FCONSTANT float f0xFF800000
+    %rhs:_(s32) = G_FCONSTANT float f0xFF800000
     %sel:_(s32) = G_SELECT %cond, %lhs, %rhs
     %copy_sel:_(s32) = COPY %sel
 )";
@@ -328,8 +328,8 @@ TEST_F(AArch64GISelMITest, TestFPClassSelectPosOrNegInf) {
   StringRef MIRString = R"(
     %ptr:_(p0) = G_IMPLICIT_DEF
     %cond:_(s1) = G_LOAD %ptr(p0) :: (load (s1))
-    %lhs:_(s32) = G_FCONSTANT float 0x7FF0000000000000
-    %rhs:_(s32) = G_FCONSTANT float 0xFFF0000000000000
+    %lhs:_(s32) = G_FCONSTANT float f0x7F800000
+    %rhs:_(s32) = G_FCONSTANT float f0xFF800000
     %sel:_(s32) = G_SELECT %cond, %lhs, %rhs
     %copy_sel:_(s32) = COPY %sel
 )";


### PR DESCRIPTION
Replaces the legacy float `0x*` encodings with the canonical `float +inf` and `float -inf` syntax for positive/negative infinity literals.

This reduces the chances that the old syntax is introduced in new code, whether by copying existing tests or by an LLM reproducing the preexisting style.

The following folders were ignored:
```
llvm/test/Assembler
```

```sh
rg -l -0 '\bfloat 0x7FF0000000000000\b' llvm \
  | xargs -0 perl -pi -e 's/\bfloat 0x7FF0000000000000\b/float +inf/g'

rg -l -0 '\bfloat 0x7ff0000000000000\b' llvm \
  | xargs -0 perl -pi -e 's/\bfloat 0x7ff0000000000000\b/float +inf/g'

rg -l -0 '\bfloat 0xFFF0000000000000\b' llvm \
  | xargs -0 perl -pi -e 's/\bfloat 0xFFF0000000000000\b/float -inf/g'

rg -l -0 '\bfloat 0xfff0000000000000\b' llvm \
  | xargs -0 perl -pi -e 's/\bfloat 0xfff0000000000000\b/float -inf/g'
```



Future work:
- Canonicalize `float 0x*` for finite values. This also makes it obvious to tell if a value is `subnormal` at a glance.
- Canonicalize `float 0x*` encodings for NaN.
- Perform similar canonicalization for `bfloat` and `half` literals.