### PR TITLE
[ADT] Use isComparableWith in SmallPtrSet

### DIFF
--- a/llvm/include/llvm/ADT/SmallPtrSet.h
+++ b/llvm/include/llvm/ADT/SmallPtrSet.h
@@ -336,10 +336,11 @@ public:
   }
 
   bool operator==(const SmallPtrSetIterator &RHS) const {
+    assert(isComparableWith(RHS) && "incomparable iterators!");
     return Bucket == RHS.Bucket;
   }
   bool operator!=(const SmallPtrSetIterator &RHS) const {
-    return Bucket != RHS.Bucket;
+    return !(*this == RHS);
   }
 };
 

--- a/llvm/unittests/ADT/SmallPtrSetTest.cpp
+++ b/llvm/unittests/ADT/SmallPtrSetTest.cpp
@@ -511,4 +511,24 @@ TEST(SmallPtrSetTest, MoveAssignInvalidatesIterators) {
   Other = std::move(Set);
   EXPECT_DEATH((void)*It, "invalid iterator access");
 }
+
+TEST(SmallPtrSetTest, IteratorComparability) {
+  SmallPtrSet<int *, 4>::iterator I1, I2;
+  EXPECT_EQ(I1, I2);
+
+  int Vals[2];
+  SmallPtrSet<int *, 4> Set1, Set2;
+  Set1.insert(&Vals[0]);
+  Set2.insert(&Vals[1]);
+  EXPECT_DEATH((void)(Set1.begin() == Set2.begin()), "incomparable iterators");
+}
+
+TEST(SmallPtrSetTest, InsertInvalidatesIteratorComparison) {
+  int Vals[2];
+  SmallPtrSet<int *, 4> Set;
+  Set.insert(&Vals[0]);
+  auto It = Set.begin();
+  Set.insert(&Vals[1]);
+  EXPECT_DEATH((void)(It == Set.end()), "incomparable iterators");
+}
 #endif


### PR DESCRIPTION
This patch updates operator== in SmallPtrSet to use
DebugEpochBase::HandleBase::isComparableWith, bringing it in line with
DenseMap, FoldingSet, and StringMap.

Assisted-by: Antigravity
