### PR TITLE
[include-cleaner] Prioritize reporting the category declaration in ObjCCategoryImplDecl

### DIFF
--- a/clang-tools-extra/include-cleaner/lib/WalkAST.cpp
+++ b/clang-tools-extra/include-cleaner/lib/WalkAST.cpp
@@ -585,21 +585,17 @@ public:
 
   bool VisitObjCCategoryDecl(ObjCCategoryDecl *D) {
     // A category declaration depends on its base interface.
-    if (auto *Interface = D->getClassInterface()) {
-      report(D->getLocation(), Interface);
-    }
+    report(D->getCategoryNameLoc(), D->getClassInterface());
     return true;
   }
 
   bool VisitObjCCategoryImplDecl(ObjCCategoryImplDecl *D) {
-    // Implementation requires the base interface.
-    if (auto *Interface = D->getClassInterface()) {
-      report(D->getLocation(), Interface);
-    }
-    // Implementation requires the category declaration.
-    if (auto *Category = D->getCategoryDecl()) {
-      report(D->getCategoryNameLoc(), Category);
-    }
+    auto *Category = D->getCategoryDecl();
+    SourceLocation Loc = D->getCategoryNameLoc();
+    if (Category && !Category->isImplicit())
+      report(Loc, Category);
+    else
+      report(Loc, D->getClassInterface());
     return true;
   }
 

--- a/clang-tools-extra/include-cleaner/unittests/WalkASTTest.cpp
+++ b/clang-tools-extra/include-cleaner/unittests/WalkASTTest.cpp
@@ -1056,21 +1056,19 @@ TEST(WalkAST, ObjCCategoryDeclDependsOnInterface) {
     @end
   )objc",
            R"objc(
-    @interface ^MyClass (Category)
+    @interface MyClass (^Category)
     @end
   )objc",
            {"-x", "objective-c"});
 }
 
-TEST(WalkAST, ObjCCategoryImplDependsOnInterface) {
+TEST(WalkAST, ObjCCategoryImplDependsOnInterfaceIfNoCategoryDecl) {
   testWalk(R"objc(
     @interface $explicit^MyClass
     @end
   )objc",
            R"objc(
-    @interface MyClass (Category)
-    @end
-    @implementation ^MyClass (Category)
+    @implementation MyClass (^Category)
     @end
   )objc",
            {"-x", "objective-c"});


### PR DESCRIPTION
Modify `VisitObjCCategoryImplDecl` to report the category declaration if it is explicit. Fall back to reporting the class interface only if the category is implicit or missing, rather than reporting both. Update the corresponding tests to expect the category location.