### PR TITLE
[libFuzzer] Don't count leak-verification re-executions towards `-runs`

### DIFF
--- a/compiler-rt/lib/fuzzer/FuzzerLoop.cpp
+++ b/compiler-rt/lib/fuzzer/FuzzerLoop.cpp
@@ -683,9 +683,6 @@ void Fuzzer::TryDetectingAMemoryLeak(const uint8_t *Data, size_t Size,
     return; // mallocs==frees, a leak is unlikely.
   if (!Options.DetectLeaks)
     return;
-  if (!DuringInitialCorpusExecution &&
-      TotalNumberOfRuns >= Options.MaxNumberOfRuns)
-    return;
   if (!&(EF->__lsan_enable) || !&(EF->__lsan_disable) ||
       !(EF->__lsan_do_recoverable_leak_check))
     return; // No lsan.
@@ -694,6 +691,10 @@ void Fuzzer::TryDetectingAMemoryLeak(const uint8_t *Data, size_t Size,
   EF->__lsan_disable();
   ExecuteCallback(Data, Size);
   EF->__lsan_enable();
+  // The above is a verification run, and not a fuzzing run, without the
+  // correction the number of runs would exceed -runs.
+  // See https://github.com/llvm/llvm-project/issues/66331
+  TotalNumberOfRuns--;
   if (!HasMoreMallocsThanFrees)
     return; // a leak is unlikely.
   if (NumberOfLeakDetectionAttempts++ > 1000) {

--- a/compiler-rt/test/fuzzer/fuzzer-finalstats.test
+++ b/compiler-rt/test/fuzzer/fuzzer-finalstats.test
@@ -1,23 +1,18 @@
-// See https://github.com/llvm/llvm-project/issues/97712.
-UNSUPPORTED: target={{.*}}
-
 RUN: %cpp_compiler %S/SimpleTest.cpp -o %t-SimpleTest
 
-// Note: `-detect_leaks=0` is required to prevent flakiness in this test.
-// There's some logic in LeakSanitizer and its integration into libFuzzer that
-// will disable LSan and re-run the input. This only happens when more malloc()s
-// are detected than free()s. Under high system load, this appears to be
-// possible as the "more mallocs than frees" is dependent on walltime. In these
-// instances, the number of runs ends up being `n + 1`, which is undesirable.
-
-RUN: %run %t-SimpleTest -seed=1 -runs=77 -print_final_stats=1 -detect_leaks=0 2>&1 | FileCheck %s --check-prefix=FINAL_STATS
+RUN: %run %t-SimpleTest -seed=1 -runs=77 -print_final_stats=1 2>&1 | FileCheck %s --check-prefix=FINAL_STATS
 FINAL_STATS: stat::number_of_executed_units: 77
 FINAL_STATS: stat::average_exec_per_sec:     0
 FINAL_STATS: stat::new_units_added:
 FINAL_STATS: stat::slowest_unit_time_sec:    0
 FINAL_STATS: stat::peak_rss_mb:
 
-RUN: %run %t-SimpleTest %S/dict1.txt -runs=33 -print_final_stats=1 -detect_leaks=0 2>&1 | FileCheck %s --check-prefix=FINAL_STATS1
+RUN: %run %t-SimpleTest %S/dict1.txt -runs=33 -print_final_stats=1 2>&1 | FileCheck %s --check-prefix=FINAL_STATS1
 FINAL_STATS1: stat::number_of_executed_units: 33
 FINAL_STATS1: stat::peak_rss_mb:
 
+// This target triggers a leak-detection verification re-run on every input
+// but those re-runs must not be counted towards the executed units.
+RUN: %cpp_compiler %S/AccumulateAllocationsTest.cpp -o %t-AccumulateAllocationsTest
+RUN: %run %t-AccumulateAllocationsTest %S/dict1.txt -runs=42 -print_final_stats=1 2>&1 | FileCheck %s --check-prefix=FINAL_STATS2
+FINAL_STATS2: stat::number_of_executed_units: 42

--- a/llvm/docs/LibFuzzer.md
+++ b/llvm/docs/LibFuzzer.md
@@ -661,9 +661,11 @@ is expensive.
 By default (`-detect_leaks=1`) libFuzzer will count the number of
 `malloc` and `free` calls when executing every mutation.
 If the numbers don't match (which by itself doesn't mean there is a leak)
-libFuzzer will invoke the more expensive [LeakSanitizer]
+libFuzzer will re-execute the input to verify the mismatch and then invoke
+the more expensive [LeakSanitizer]
 pass and if the actual leak is found, it will be reported with the reproducer
-and the process will exit.
+and the process will exit. The verification re-executions are not fuzzing
+runs and do not count towards `-runs`.
 
 If your target has massive leaks and the leak detection is disabled
 you will eventually run out of RAM (see the `-rss_limit_mb` flag).


### PR DESCRIPTION
Fixes #66331. Stop countring the verification run in TryDetectingAMemoryLeak() as part of TotalNumberOfRuns, as the number of executed units could exceed -runs=N.