### PR TITLE
[mlir][cf] Fix non-termination in simplifyBrToBlockWithSinglePred

### DIFF
--- a/mlir/lib/Dialect/ControlFlow/IR/ControlFlowOps.cpp
+++ b/mlir/lib/Dialect/ControlFlow/IR/ControlFlowOps.cpp
@@ -156,6 +156,25 @@ static LogicalResult collapseBranch(Block *&successor,
   return success();
 }
 
+/// Returns true if any of `values` is, or transitively derives from, a block
+/// argument of `block`.
+static bool derivesFromBlockArgOf(ValueRange values, Block *block) {
+  SmallVector<Value> worklist(values);
+  DenseSet<Value> visited(values.begin(), values.end());
+  while (!worklist.empty()) {
+    Value value = worklist.pop_back_val();
+    if (auto blockArg = dyn_cast<BlockArgument>(value)) {
+      if (blockArg.getOwner() == block)
+        return true;
+      continue;
+    }
+    for (Value operand : value.getDefiningOp()->getOperands())
+      if (visited.insert(operand).second)
+        worklist.push_back(operand);
+  }
+  return false;
+}
+
 /// Simplify a branch to a block that has a single predecessor. This effectively
 /// merges the two blocks.
 static LogicalResult
@@ -166,13 +185,11 @@ simplifyBrToBlockWithSinglePred(BranchOp op, PatternRewriter &rewriter) {
   if (succ == opParent || !llvm::hasSingleElement(succ->getPredecessors()))
     return failure();
 
-  // If any branch operand is itself a block argument of the successor, merging
-  // would call replaceAllUsesWith(arg, arg) — a no-op — leaving dangling uses
-  // of that argument after the successor block is erased.
-  for (Value operand : op.getOperands())
-    if (auto ba = dyn_cast<BlockArgument>(operand))
-      if (ba.getOwner() == succ)
-        return failure();
+  // Merging substitutes the branch operands for the successor's block
+  // arguments, so an operand derived from one of them would be defined in
+  // terms of itself. This happens when the two blocks form a loop.
+  if (derivesFromBlockArgOf(op.getOperands(), succ))
+    return failure();
 
   // Merge the successor into the current block and erase the branch.
   SmallVector<Value> brOperands(op.getOperands());

--- a/mlir/test/Dialect/ControlFlow/canonicalize.mlir
+++ b/mlir/test/Dialect/ControlFlow/canonicalize.mlir
@@ -687,6 +687,33 @@ func.func @no_merge_self_arg_loop(%step: i1) -> i1 {
   return %result : i1
 }
 
+// -----
+
+// Verify that a block is not merged into its sole predecessor when a branch
+// operand only derives from a block argument of the destination: substituting
+// %next for %iv would define %next in terms of itself. Folding the constant
+// compare is what leaves ^latch as ^header's only predecessor.
+
+// CHECK-LABEL: @no_merge_derived_arg_loop
+//  CHECK-NEXT:   return
+func.func @no_merge_derived_arg_loop() {
+  %c0 = arith.constant 0 : i32
+  %c1 = arith.constant 1 : i32
+  %c2 = arith.constant 2 : i32
+  %enter = arith.cmpi sgt, %c2, %c0 : i32
+  cf.cond_br %enter, ^exit, ^header(%c2 : i32)
+^header(%iv: i32):
+  %done = arith.cmpi eq, %iv, %c2 : i32
+  cf.cond_br %done, ^exit, ^latch
+^latch:
+  %next = arith.addi %iv, %c1 : i32
+  cf.br ^header(%next : i32)
+^exit:
+  return
+}
+
+// -----
+
 // Verify that block arguments are replaced with a uniform incoming value
 // when all predecessors pass the same SSA value
 


### PR DESCRIPTION
When `simplifyBrToBlockWithSinglePred` merges a block into its sole predecessor, each block argument of the destination is replaced by the corresponding value passed by the branch. If one of those values derives from a block argument of the destination, the substitution leaves that value defined in terms of itself, and the canonicalizer never reaches a fixed point.

This happens when the two blocks form a loop:

```mlir
// test.mlir
func.func @loop() {
  %c0 = arith.constant 0 : i32
  %c1 = arith.constant 1 : i32
  %c2 = arith.constant 2 : i32
  %enter = arith.cmpi sgt, %c2, %c0 : i32
  cf.cond_br %enter, ^exit, ^header(%c2 : i32)
^header(%iv: i32):
  %done = arith.cmpi eq, %iv, %c2 : i32
  cf.cond_br %done, ^exit, ^latch
^latch:
  %next = arith.addi %iv, %c1 : i32
  cf.br ^header(%next : i32)
^exit:
  return
}
```

`mlir-opt test.mlir -canonicalize` never terminates, spinning in `GreedyPatternRewriteDriver::processWorklist` folding `arith.addi`. Folding the constant `%enter` compare removes the loop's only entry edge, leaving `^latch` as `^header`'s sole predecessor. Merging then replaces `%iv` with `%next`, and since `%next = arith.addi %iv, %c1` derives from `%iv`, the result is `%next = arith.addi %next, %c1`.

This PR guards against this by returning early when any branch operand is, or transitively derives from, a block argument owned by the destination block. This subsumes the guard added in #183797, which covers the case where the operand is such an argument directly.

No simplification is lost in reachable code: such an operand can only exist if the destination dominates its only predecessor, so the loop has no entry from outside and region simplification still deletes it and the repro above canonicalizes to just `return`.

If the compile time of the backward walk is a concern, it can be capped, conservatively reporting a derived operand once the budget is exhausted; refusing to merge is always safe. Alternatively, the guard could rather bail whenever the two blocks are in a cycle. The detection would be a CFG walk rather than a value walk, and it would subsume the guard from #183797 as well, and would be similar to #160783.
