### PR TITLE
[RISCV] Add isel pattern for vdot4aus.vx

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZvdot4a8i.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZvdot4a8i.td
@@ -95,6 +95,22 @@ defm : VPatBinaryVL_VV_VX<riscv_vdot4a_vl, "PseudoVDOT4A", AllE32Vectors, ExtraP
 defm : VPatBinaryVL_VV_VX<riscv_vdot4au_vl, "PseudoVDOT4AU", AllE32Vectors, ExtraPreds=[HasStdExtZvdot4a8i]>;
 defm : VPatBinaryVL_VV_VX<riscv_vdot4asu_vl, "PseudoVDOT4ASU", AllE32Vectors, ExtraPreds=[HasStdExtZvdot4a8i]>;
 
+// vdot4aus.vx is the operand-swapped counterpart of vdot4asu.vx: it takes an
+// unsigned vector and a signed scalar. Use it when the signed operand of
+// riscv_vdot4asu_vl is a scalar splat. There is no .vv form because the
+// register operands can just be swapped.
+foreach vti = AllE32Vectors in {
+  let Predicates = !listconcat([HasStdExtZvdot4a8i],
+                               GetVTypePredicates<vti>.Predicates) in
+  def : Pat<(riscv_vdot4asu_vl (vti.Vector (SplatPat (XLenVT GPR:$rs1))),
+                               (vti.Vector vti.RegClass:$rs2),
+                               vti.RegClass:$passthru, (vti.Mask VMV0:$vm),
+                               VLOpFrag),
+            (!cast<Instruction>("PseudoVDOT4AUS_VX_"#vti.LMul.MX#"_MASK")
+                 vti.RegClass:$passthru, vti.RegClass:$rs2, GPR:$rs1,
+                 (vti.Mask VMV0:$vm), GPR:$vl, vti.Log2SEW, TAIL_AGNOSTIC)>;
+}
+
 // These VPat definitions are for vdot4a because they have a different operand
 // order with other ternary instructions (i.e. vop.vx vd, vs2, rs1)
 multiclass VPatTernaryV_VX_AAAX<string intrinsic, string instruction,

--- a/llvm/test/CodeGen/RISCV/rvv/zvdot4a8i-sdnode.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/zvdot4a8i-sdnode.ll
@@ -936,6 +936,75 @@ entry:
   ret <vscale x 1 x i32> %res
 }
 
+; The unsigned operand of vdot4asu is a scalar splat, so this should select
+; vdot4asu.vx directly.
+define <vscale x 4 x i32> @partial_reduce_vdot4asu_vx(<vscale x 4 x i32> %acc, <vscale x 16 x i8> %a, i32 %x) {
+; NODOT-LABEL: partial_reduce_vdot4asu_vx:
+; NODOT:       # %bb.0: # %entry
+; NODOT-NEXT:    vsetvli a1, zero, e32, m2, ta, ma
+; NODOT-NEXT:    vmv.v.x v16, a0
+; NODOT-NEXT:    vsetvli a0, zero, e16, m4, ta, ma
+; NODOT-NEXT:    vsext.vf2 v12, v10
+; NODOT-NEXT:    vzext.vf2 v24, v16
+; NODOT-NEXT:    vwmulsu.vv v16, v12, v24
+; NODOT-NEXT:    vsetvli a0, zero, e32, m2, ta, ma
+; NODOT-NEXT:    vadd.vv v10, v18, v20
+; NODOT-NEXT:    vadd.vv v8, v8, v16
+; NODOT-NEXT:    vadd.vv v8, v22, v8
+; NODOT-NEXT:    vadd.vv v8, v10, v8
+; NODOT-NEXT:    ret
+;
+; DOT-LABEL: partial_reduce_vdot4asu_vx:
+; DOT:       # %bb.0: # %entry
+; DOT-NEXT:    vsetvli a1, zero, e32, m2, ta, ma
+; DOT-NEXT:    vdot4asu.vx v8, v10, a0
+; DOT-NEXT:    ret
+entry:
+  %h = insertelement <vscale x 4 x i32> poison, i32 %x, i32 0
+  %s = shufflevector <vscale x 4 x i32> %h, <vscale x 4 x i32> poison, <vscale x 4 x i32> zeroinitializer
+  %b = bitcast <vscale x 4 x i32> %s to <vscale x 16 x i8>
+  %a.sext = sext <vscale x 16 x i8> %a to <vscale x 16 x i32>
+  %b.zext = zext <vscale x 16 x i8> %b to <vscale x 16 x i32>
+  %mul = mul <vscale x 16 x i32> %a.sext, %b.zext
+  %res = call <vscale x 4 x i32> @llvm.vector.partial.reduce.add(<vscale x 4 x i32> %acc, <vscale x 16 x i32> %mul)
+  ret <vscale x 4 x i32> %res
+}
+
+; The signed operand of vdot4asu is a scalar splat, so this should select
+; vdot4aus.vx (the operand-swapped counterpart) directly instead of
+; materializing a vmv.v.x splat and using vdot4asu.vv.
+define <vscale x 4 x i32> @partial_reduce_vdot4aus_vx(<vscale x 4 x i32> %acc, <vscale x 16 x i8> %b, i32 %x) {
+; NODOT-LABEL: partial_reduce_vdot4aus_vx:
+; NODOT:       # %bb.0: # %entry
+; NODOT-NEXT:    vsetvli a1, zero, e32, m2, ta, ma
+; NODOT-NEXT:    vmv.v.x v16, a0
+; NODOT-NEXT:    vsetvli a0, zero, e16, m4, ta, ma
+; NODOT-NEXT:    vsext.vf2 v12, v16
+; NODOT-NEXT:    vzext.vf2 v24, v10
+; NODOT-NEXT:    vwmulsu.vv v16, v12, v24
+; NODOT-NEXT:    vsetvli a0, zero, e32, m2, ta, ma
+; NODOT-NEXT:    vadd.vv v10, v18, v20
+; NODOT-NEXT:    vadd.vv v8, v8, v16
+; NODOT-NEXT:    vadd.vv v8, v22, v8
+; NODOT-NEXT:    vadd.vv v8, v10, v8
+; NODOT-NEXT:    ret
+;
+; DOT-LABEL: partial_reduce_vdot4aus_vx:
+; DOT:       # %bb.0: # %entry
+; DOT-NEXT:    vsetvli a1, zero, e32, m2, ta, ma
+; DOT-NEXT:    vmv.v.x v12, a0
+; DOT-NEXT:    vdot4asu.vv v8, v12, v10
+; DOT-NEXT:    ret
+entry:
+  %h = insertelement <vscale x 4 x i32> poison, i32 %x, i32 0
+  %s = shufflevector <vscale x 4 x i32> %h, <vscale x 4 x i32> poison, <vscale x 4 x i32> zeroinitializer
+  %a = bitcast <vscale x 4 x i32> %s to <vscale x 16 x i8>
+  %a.sext = sext <vscale x 16 x i8> %a to <vscale x 16 x i32>
+  %b.zext = zext <vscale x 16 x i8> %b to <vscale x 16 x i32>
+  %mul = mul <vscale x 16 x i32> %a.sext, %b.zext
+  %res = call <vscale x 4 x i32> @llvm.vector.partial.reduce.add(<vscale x 4 x i32> %acc, <vscale x 16 x i32> %mul)
+  ret <vscale x 4 x i32> %res
+}
 
 define <vscale x 4 x i32> @partial_of_sext(<vscale x 16 x i8> %a) {
 ; NODOT-LABEL: partial_of_sext:

--- a/llvm/test/CodeGen/RISCV/rvv/zvdot4a8i-sdnode.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/zvdot4a8i-sdnode.ll
@@ -992,8 +992,7 @@ define <vscale x 4 x i32> @partial_reduce_vdot4aus_vx(<vscale x 4 x i32> %acc, <
 ; DOT-LABEL: partial_reduce_vdot4aus_vx:
 ; DOT:       # %bb.0: # %entry
 ; DOT-NEXT:    vsetvli a1, zero, e32, m2, ta, ma
-; DOT-NEXT:    vmv.v.x v12, a0
-; DOT-NEXT:    vdot4asu.vv v8, v12, v10
+; DOT-NEXT:    vdot4aus.vx v8, v10, a0
 ; DOT-NEXT:    ret
 entry:
   %h = insertelement <vscale x 4 x i32> poison, i32 %x, i32 0


### PR DESCRIPTION
The splat of i32 and bitcast is probably not realistic. I'm just trying to cover the assymmetry in the patterns with this patch.

Assisted-by: Claude