### PR TITLE
[libc] implement getloadavg

### DIFF
--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -208,6 +208,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.stdlib.atoll
     libc.src.stdlib.bsearch
     libc.src.stdlib.div
+    libc.src.stdlib.getloadavg
     libc.src.stdlib.labs
     libc.src.stdlib.ldiv
     libc.src.stdlib.llabs

--- a/libc/config/linux/arm/entrypoints.txt
+++ b/libc/config/linux/arm/entrypoints.txt
@@ -172,6 +172,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.stdlib.atoll
     libc.src.stdlib.bsearch
     libc.src.stdlib.div
+    libc.src.stdlib.getloadavg
     libc.src.stdlib.labs
     libc.src.stdlib.ldiv
     libc.src.stdlib.llabs

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -231,6 +231,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.stdlib.atoll
     libc.src.stdlib.bsearch
     libc.src.stdlib.div
+    libc.src.stdlib.getloadavg
     libc.src.stdlib.l64a
     libc.src.stdlib.labs
     libc.src.stdlib.ldiv

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -231,6 +231,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.stdlib.atoll
     libc.src.stdlib.bsearch
     libc.src.stdlib.div
+    libc.src.stdlib.getloadavg
     libc.src.stdlib.l64a
     libc.src.stdlib.labs
     libc.src.stdlib.ldiv

--- a/libc/include/stdlib.yaml
+++ b/libc/include/stdlib.yaml
@@ -121,7 +121,7 @@ functions:
       - bsd
     return_type: int
     arguments:
-      - type: double *
+      - type: double[]
       - type: int
   - name: labs
     standards:

--- a/libc/include/stdlib.yaml
+++ b/libc/include/stdlib.yaml
@@ -116,6 +116,13 @@ functions:
     return_type: char *
     arguments:
       - type: const char *
+  - name: getloadavg
+    standards:
+      - bsd
+    return_type: int
+    arguments:
+      - type: double *
+      - type: int
   - name: labs
     standards:
       - stdc

--- a/libc/src/stdlib/CMakeLists.txt
+++ b/libc/src/stdlib/CMakeLists.txt
@@ -853,3 +853,11 @@ add_entrypoint_object(
   DEPENDS
     .${LIBC_TARGET_OS}.system
 )
+
+add_entrypoint_object(
+  getloadavg
+  ALIAS
+  DEPENDS
+    .${LIBC_TARGET_OS}.getloadavg
+)
+

--- a/libc/src/stdlib/CMakeLists.txt
+++ b/libc/src/stdlib/CMakeLists.txt
@@ -607,6 +607,13 @@ add_entrypoint_object(
     .${LIBC_TARGET_OS}.realpath
 )
 
+add_entrypoint_object(
+  getloadavg
+  ALIAS
+  DEPENDS
+    .${LIBC_TARGET_OS}.getloadavg
+)
+
 if(NOT LLVM_LIBC_FULL_BUILD)
   return()
 endif()
@@ -852,12 +859,5 @@ add_entrypoint_object(
   ALIAS
   DEPENDS
     .${LIBC_TARGET_OS}.system
-)
-
-add_entrypoint_object(
-  getloadavg
-  ALIAS
-  DEPENDS
-    .${LIBC_TARGET_OS}.getloadavg
 )
 

--- a/libc/src/stdlib/getloadavg.h
+++ b/libc/src/stdlib/getloadavg.h
@@ -18,7 +18,7 @@
 
 namespace LIBC_NAMESPACE_DECL {
 
-int getloadavg(double *loadavg, int nelem);
+int getloadavg(double loadavg[], int nelem);
 
 } // namespace LIBC_NAMESPACE_DECL
 

--- a/libc/src/stdlib/getloadavg.h
+++ b/libc/src/stdlib/getloadavg.h
@@ -1,0 +1,25 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implementation header for getloadavg.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STDLIB_GETLOADAVG_H
+#define LLVM_LIBC_SRC_STDLIB_GETLOADAVG_H
+
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+int getloadavg(double *loadavg, int nelem);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STDLIB_GETLOADAVG_H

--- a/libc/src/stdlib/linux/CMakeLists.txt
+++ b/libc/src/stdlib/linux/CMakeLists.txt
@@ -104,3 +104,18 @@ add_entrypoint_object(
     libc.src.signal.linux.signal_utils
     libc.src.unistd.environ
 )
+
+add_entrypoint_object(
+  getloadavg
+  SRCS
+    getloadavg.cpp
+  HDRS
+    ../getloadavg.h
+  DEPENDS
+    libc.hdr.types.struct_sysinfo
+    libc.src.__support.OSUtil.linux.syscall_wrappers.sysinfo
+    libc.src.__support.common
+    libc.src.__support.libc_errno
+    libc.src.__support.macros.config
+)
+

--- a/libc/src/stdlib/linux/getloadavg.cpp
+++ b/libc/src/stdlib/linux/getloadavg.cpp
@@ -21,7 +21,7 @@
 
 namespace LIBC_NAMESPACE_DECL {
 
-LLVM_LIBC_FUNCTION(int, getloadavg, (double *loadavg, int nelem)) {
+LLVM_LIBC_FUNCTION(int, getloadavg, (double loadavg[], int nelem)) {
   if (nelem <= 0)
     return 0;
 

--- a/libc/src/stdlib/linux/getloadavg.cpp
+++ b/libc/src/stdlib/linux/getloadavg.cpp
@@ -1,0 +1,47 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Linux implementation of getloadavg.
+///
+//===----------------------------------------------------------------------===//
+
+#include "src/stdlib/getloadavg.h"
+
+#include "hdr/types/struct_sysinfo.h"
+#include "src/__support/OSUtil/linux/syscall_wrappers/sysinfo.h"
+#include "src/__support/common.h"
+#include "src/__support/libc_errno.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(int, getloadavg, (double *loadavg, int nelem)) {
+  if (nelem <= 0)
+    return 0;
+
+  struct sysinfo info;
+  auto result = linux_syscalls::sysinfo(&info);
+  if (!result) {
+    libc_errno = result.error();
+    return -1;
+  }
+
+  if (nelem > 3)
+    nelem = 3;
+
+  // The Linux kernel represents 1, 5, and 15 minute load averages in info.loads
+  // scaled by (1 << SI_LOAD_SHIFT), where SI_LOAD_SHIFT is 16 (i.e. 65536.0).
+  constexpr double KERNEL_LOAD_SCALE = 65536.0;
+  for (int i = 0; i < nelem; ++i)
+    loadavg[i] = static_cast<double>(info.loads[i]) / KERNEL_LOAD_SCALE;
+
+  return nelem;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/test/src/stdlib/CMakeLists.txt
+++ b/libc/test/src/stdlib/CMakeLists.txt
@@ -611,5 +611,6 @@ add_libc_test(
   DEPENDS
     libc.src.stdlib.getloadavg
     libc.test.UnitTest.ErrnoCheckingTest
+    libc.test.UnitTest.ErrnoSetterMatcher
 )
 

--- a/libc/test/src/stdlib/CMakeLists.txt
+++ b/libc/test/src/stdlib/CMakeLists.txt
@@ -601,3 +601,15 @@ if((LIBC_TARGET_OS_IS_BAREMETAL OR LIBC_TARGET_OS_IS_GPU) AND
       libc.src.stdlib.free
   )
 endif()
+
+add_libc_test(
+  getloadavg_test
+  SUITE
+    libc-stdlib-tests
+  SRCS
+    getloadavg_test.cpp
+  DEPENDS
+    libc.src.stdlib.getloadavg
+    libc.test.UnitTest.ErrnoCheckingTest
+)
+

--- a/libc/test/src/stdlib/getloadavg_test.cpp
+++ b/libc/test/src/stdlib/getloadavg_test.cpp
@@ -13,40 +13,36 @@
 
 #include "src/stdlib/getloadavg.h"
 #include "test/UnitTest/ErrnoCheckingTest.h"
+#include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
 
+using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
 using LlvmLibcGetloadavgTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
 TEST_F(LlvmLibcGetloadavgTest, ZeroElements) {
   double samples[3] = {-1.0, -1.0, -1.0};
-  int ret = LIBC_NAMESPACE::getloadavg(samples, 0);
-  ASSERT_ERRNO_SUCCESS();
-  EXPECT_EQ(ret, 0);
+  EXPECT_THAT(LIBC_NAMESPACE::getloadavg(samples, 0), Succeeds(0));
   EXPECT_TRUE(samples[0] == -1.0);
   EXPECT_TRUE(samples[1] == -1.0);
   EXPECT_TRUE(samples[2] == -1.0);
 }
 
 TEST_F(LlvmLibcGetloadavgTest, NullptrZeroElements) {
-  int ret = LIBC_NAMESPACE::getloadavg(nullptr, 0);
-  ASSERT_ERRNO_SUCCESS();
-  EXPECT_EQ(ret, 0);
+  EXPECT_THAT(LIBC_NAMESPACE::getloadavg(nullptr, 0), Succeeds(0));
 }
 
 TEST_F(LlvmLibcGetloadavgTest, NegativeElements) {
   double samples[3] = {-1.0, -1.0, -1.0};
-  int ret = LIBC_NAMESPACE::getloadavg(samples, -1);
-  ASSERT_ERRNO_SUCCESS();
-  EXPECT_EQ(ret, 0);
+  EXPECT_THAT(LIBC_NAMESPACE::getloadavg(samples, -1), Succeeds(0));
   EXPECT_TRUE(samples[0] == -1.0);
+  EXPECT_TRUE(samples[1] == -1.0);
+  EXPECT_TRUE(samples[2] == -1.0);
 }
 
 TEST_F(LlvmLibcGetloadavgTest, ValidSamples) {
   for (int n = 1; n <= 3; ++n) {
     double samples[3] = {-1.0, -1.0, -1.0};
-    int ret = LIBC_NAMESPACE::getloadavg(samples, n);
-    ASSERT_ERRNO_SUCCESS();
-    EXPECT_EQ(ret, n);
+    EXPECT_THAT(LIBC_NAMESPACE::getloadavg(samples, n), Succeeds(n));
 
     for (int i = 0; i < n; ++i) {
       EXPECT_TRUE(samples[i] >= 0.0);
@@ -59,9 +55,7 @@ TEST_F(LlvmLibcGetloadavgTest, ValidSamples) {
 
 TEST_F(LlvmLibcGetloadavgTest, ClampedToThree) {
   double samples[5] = {-1.0, -1.0, -1.0, -1.0, -1.0};
-  int ret = LIBC_NAMESPACE::getloadavg(samples, 5);
-  ASSERT_ERRNO_SUCCESS();
-  EXPECT_EQ(ret, 3);
+  EXPECT_THAT(LIBC_NAMESPACE::getloadavg(samples, 5), Succeeds(3));
 
   EXPECT_TRUE(samples[0] >= 0.0);
   EXPECT_TRUE(samples[1] >= 0.0);

--- a/libc/test/src/stdlib/getloadavg_test.cpp
+++ b/libc/test/src/stdlib/getloadavg_test.cpp
@@ -1,0 +1,71 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Unittests for getloadavg.
+///
+//===----------------------------------------------------------------------===//
+
+#include "src/stdlib/getloadavg.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
+#include "test/UnitTest/Test.h"
+
+using LlvmLibcGetloadavgTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
+
+TEST_F(LlvmLibcGetloadavgTest, ZeroElements) {
+  double samples[3] = {-1.0, -1.0, -1.0};
+  int ret = LIBC_NAMESPACE::getloadavg(samples, 0);
+  ASSERT_ERRNO_SUCCESS();
+  EXPECT_EQ(ret, 0);
+  EXPECT_TRUE(samples[0] == -1.0);
+  EXPECT_TRUE(samples[1] == -1.0);
+  EXPECT_TRUE(samples[2] == -1.0);
+}
+
+TEST_F(LlvmLibcGetloadavgTest, NullptrZeroElements) {
+  int ret = LIBC_NAMESPACE::getloadavg(nullptr, 0);
+  ASSERT_ERRNO_SUCCESS();
+  EXPECT_EQ(ret, 0);
+}
+
+TEST_F(LlvmLibcGetloadavgTest, NegativeElements) {
+  double samples[3] = {-1.0, -1.0, -1.0};
+  int ret = LIBC_NAMESPACE::getloadavg(samples, -1);
+  ASSERT_ERRNO_SUCCESS();
+  EXPECT_EQ(ret, 0);
+  EXPECT_TRUE(samples[0] == -1.0);
+}
+
+TEST_F(LlvmLibcGetloadavgTest, ValidSamples) {
+  for (int n = 1; n <= 3; ++n) {
+    double samples[3] = {-1.0, -1.0, -1.0};
+    int ret = LIBC_NAMESPACE::getloadavg(samples, n);
+    ASSERT_ERRNO_SUCCESS();
+    EXPECT_EQ(ret, n);
+
+    for (int i = 0; i < n; ++i) {
+      EXPECT_TRUE(samples[i] >= 0.0);
+    }
+    for (int i = n; i < 3; ++i) {
+      EXPECT_TRUE(samples[i] == -1.0);
+    }
+  }
+}
+
+TEST_F(LlvmLibcGetloadavgTest, ClampedToThree) {
+  double samples[5] = {-1.0, -1.0, -1.0, -1.0, -1.0};
+  int ret = LIBC_NAMESPACE::getloadavg(samples, 5);
+  ASSERT_ERRNO_SUCCESS();
+  EXPECT_EQ(ret, 3);
+
+  EXPECT_TRUE(samples[0] >= 0.0);
+  EXPECT_TRUE(samples[1] >= 0.0);
+  EXPECT_TRUE(samples[2] >= 0.0);
+  EXPECT_TRUE(samples[3] == -1.0);
+  EXPECT_TRUE(samples[4] == -1.0);
+}


### PR DESCRIPTION
Implement the `getloadavg` function which was originally added in BSD
but also adopted by linux.

Assisted-by: Automated tooling, human reviewed
