### PR TITLE
[CodeGen] Do not constrain a virtual register to a non-allocatable class

### DIFF
--- a/llvm/lib/CodeGen/MachineRegisterInfo.cpp
+++ b/llvm/lib/CodeGen/MachineRegisterInfo.cpp
@@ -77,6 +77,13 @@ constrainRegClass(MachineRegisterInfo &MRI, Register Reg,
     return NewRC;
   if (NewRC->getNumRegs() < MinNumRegs)
     return nullptr;
+  // getCommonSubClass() can return a class with no allocatable registers (for
+  // targets whose register files overlap only in reserved registers). A vreg
+  // constrained to such a class cannot be allocated, and setRegClass() below
+  // requires an allocatable class, so report the constraint as infeasible. This
+  // mirrors the equivalent guard in the register coalescer.
+  if (!NewRC->isAllocatable())
+    return nullptr;
   MRI.setRegClass(Reg, NewRC);
   return NewRC;
 }


### PR DESCRIPTION
constrainRegClass() assigns the common subclass of the register's current class
and the constraining class without checking that it is allocatable. On targets
whose register files overlap only in reserved registers, getCommonSubClass() can
return a class with no allocatable registers; constraining a vreg to it trips the
setRegClass() assert and produces a register that cannot be allocated.

Return nullptr in that case so callers keep the COPY, mirroring the existing
guard in the register coalescer.