### PR TITLE
[LLVM][NFC] Use +inf/-inf syntax for all floating point infinity literals

### DIFF
--- a/llvm/test/CodeGen/AArch64/fp-const-fold.ll
+++ b/llvm/test/CodeGen/AArch64/fp-const-fold.ll
@@ -33,7 +33,7 @@ define double @constant_fold_fmul_nan(ptr %p) {
 ; CHECK-NEXT:    mov x8, #9221120237041090560
 ; CHECK-NEXT:    fmov d0, x8
 ; CHECK-NEXT:    ret
-  %r = fmul double 0x7ff0000000000000, 0.0
+  %r = fmul double +inf, 0.0
   ret double %r
 }
 
@@ -45,7 +45,7 @@ define double @constant_fold_fadd_nan(ptr %p) {
 ; CHECK-NEXT:    mov x8, #9221120237041090560
 ; CHECK-NEXT:    fmov d0, x8
 ; CHECK-NEXT:    ret
-  %r = fadd double 0x7ff0000000000000, 0xfff0000000000000
+  %r = fadd double +inf, -inf
   ret double %r
 }
 
@@ -57,7 +57,7 @@ define double @constant_fold_fsub_nan(ptr %p) {
 ; CHECK-NEXT:    mov x8, #9221120237041090560
 ; CHECK-NEXT:    fmov d0, x8
 ; CHECK-NEXT:    ret
-  %r = fsub double 0x7ff0000000000000, 0x7ff0000000000000
+  %r = fsub double +inf, +inf
   ret double %r
 }
 
@@ -69,7 +69,7 @@ define double @constant_fold_fma_nan(ptr %p) {
 ; CHECK-NEXT:    mov x8, #9221120237041090560
 ; CHECK-NEXT:    fmov d0, x8
 ; CHECK-NEXT:    ret
-  %r =  call double @llvm.fma.f64(double 0x7ff0000000000000, double 0.0, double 42.0)
+  %r =  call double @llvm.fma.f64(double +inf, double 0.0, double 42.0)
   ret double %r
 }
 
@@ -121,7 +121,7 @@ define double @fdiv_ninf_inf_op0(double %x) {
 ; CHECK-LABEL: fdiv_ninf_inf_op0:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    ret
-  %r = fdiv ninf double 0x7ff0000000000000, %x
+  %r = fdiv ninf double +inf, %x
   ret double %r
 }
 
@@ -129,7 +129,7 @@ define double @fadd_ninf_inf_op1(double %x) {
 ; CHECK-LABEL: fadd_ninf_inf_op1:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    ret
-  %r = fadd ninf double %x, 0xfff0000000000000
+  %r = fadd ninf double %x, -inf
   ret double %r
 }
 
@@ -143,7 +143,7 @@ define double @fsub_nnan_inf_op0(double %x) {
 ; CHECK-NEXT:    fmov d1, x8
 ; CHECK-NEXT:    fsub d0, d1, d0
 ; CHECK-NEXT:    ret
-  %r = fsub nnan double 0x7ff0000000000000, %x
+  %r = fsub nnan double +inf, %x
   ret double %r
 }
 
@@ -157,7 +157,7 @@ define double @fmul_nnan_inf_op1(double %x) {
 ; CHECK-NEXT:    fmov d1, x8
 ; CHECK-NEXT:    fmul d0, d0, d1
 ; CHECK-NEXT:    ret
-  %r = fmul nnan double %x, 0xfff0000000000000
+  %r = fmul nnan double %x, -inf
   ret double %r
 }
 

--- a/llvm/test/CodeGen/AArch64/isinf.ll
+++ b/llvm/test/CodeGen/AArch64/isinf.ll
@@ -47,7 +47,7 @@ define i32 @replace_isinf_call_f32(float %x) {
 ; CHECK-GI-NEXT:    cset w0, eq
 ; CHECK-GI-NEXT:    ret
   %abs = tail call float @llvm.fabs.f32(float %x)
-  %cmpinf = fcmp oeq float %abs, 0x7FF0000000000000
+  %cmpinf = fcmp oeq float %abs, +inf
   %ret = zext i1 %cmpinf to i32
   ret i32 %ret
 }
@@ -71,7 +71,7 @@ define i32 @replace_isinf_call_f64(double %x) {
 ; CHECK-GI-NEXT:    cset w0, eq
 ; CHECK-GI-NEXT:    ret
   %abs = tail call double @llvm.fabs.f64(double %x)
-  %cmpinf = fcmp oeq double %abs, 0x7FF0000000000000
+  %cmpinf = fcmp oeq double %abs, +inf
   %ret = zext i1 %cmpinf to i32
   ret i32 %ret
 }

--- a/llvm/test/CodeGen/AArch64/known-never-nan.ll
+++ b/llvm/test/CodeGen/AArch64/known-never-nan.ll
@@ -52,7 +52,7 @@ define float @not_fmaxnm_maybe_nan(i32 %i1, i32 %i2) #0 {
 ; CHECK-GI-NEXT:    fmax s0, s0, s1
 ; CHECK-GI-NEXT:    ret
   %f1 = uitofp i32 %i1 to float
-  %fmul = fmul float %f1, 0xfff0000000000000 ; -INFINITY as 64-bit hex
+  %fmul = fmul float %f1, -inf ; -INFINITY as 64-bit hex
   %f2 = uitofp i32 %i2 to float
   %fadd2 = fadd float %f2, 17.0
   %cmp = fcmp uge float %fmul, %fadd2

--- a/llvm/test/CodeGen/AArch64/sve-vector-splat.ll
+++ b/llvm/test/CodeGen/AArch64/sve-vector-splat.ll
@@ -586,7 +586,7 @@ define <vscale x 2 x half> @splat_pinf_nxv2f16() {
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    dupm z0.h, #0x7c00
 ; CHECK-NEXT:    ret
-  ret <vscale x 2 x half> splat (half 0x7FF0000000000000)
+  ret <vscale x 2 x half> splat (half +inf)
 }
 
 define <vscale x 4 x half> @splat_pinf_nxv4f16() {
@@ -594,7 +594,7 @@ define <vscale x 4 x half> @splat_pinf_nxv4f16() {
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    dupm z0.h, #0x7c00
 ; CHECK-NEXT:    ret
-  ret <vscale x 4 x half> splat (half 0x7FF0000000000000)
+  ret <vscale x 4 x half> splat (half +inf)
 }
 
 define <vscale x 8 x half> @splat_pinf_nxv8f16() {
@@ -602,7 +602,7 @@ define <vscale x 8 x half> @splat_pinf_nxv8f16() {
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    dupm z0.h, #0x7c00
 ; CHECK-NEXT:    ret
-  ret <vscale x 8 x half> splat (half 0x7FF0000000000000)
+  ret <vscale x 8 x half> splat (half +inf)
 }
 
 define <vscale x 2 x float> @splat_pinf_nxv2f32() {
@@ -626,7 +626,7 @@ define <vscale x 2 x double> @splat_pinf_nxv2f64() {
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    mov z0.d, #0x7ff0000000000000
 ; CHECK-NEXT:    ret
-  ret <vscale x 2 x double> splat (double 0x7FF0000000000000)
+  ret <vscale x 2 x double> splat (double +inf)
 }
 
 define <vscale x 2 x bfloat> @splat_pinf_nxv2bf16() {
@@ -634,7 +634,7 @@ define <vscale x 2 x bfloat> @splat_pinf_nxv2bf16() {
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    mov z0.h, #32640 // =0x7f80
 ; CHECK-NEXT:    ret
-  ret <vscale x 2 x bfloat> splat (bfloat 0x7FF0000000000000)
+  ret <vscale x 2 x bfloat> splat (bfloat +inf)
 }
 
 define <vscale x 4 x bfloat> @splat_pinf_nxv4bf16() {
@@ -642,7 +642,7 @@ define <vscale x 4 x bfloat> @splat_pinf_nxv4bf16() {
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    mov z0.h, #32640 // =0x7f80
 ; CHECK-NEXT:    ret
-  ret <vscale x 4 x bfloat> splat (bfloat 0x7FF0000000000000)
+  ret <vscale x 4 x bfloat> splat (bfloat +inf)
 }
 
 define <vscale x 8 x bfloat> @splat_pinf_nxv8bf16() {
@@ -650,7 +650,7 @@ define <vscale x 8 x bfloat> @splat_pinf_nxv8bf16() {
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    mov z0.h, #32640 // =0x7f80
 ; CHECK-NEXT:    ret
-  ret <vscale x 8 x bfloat> splat (bfloat 0x7FF0000000000000)
+  ret <vscale x 8 x bfloat> splat (bfloat +inf)
 }
 
 define <vscale x 2 x half> @splat_ninf_nxv2f16() {
@@ -658,7 +658,7 @@ define <vscale x 2 x half> @splat_ninf_nxv2f16() {
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    dupm z0.h, #0xfc00
 ; CHECK-NEXT:    ret
-  ret <vscale x 2 x half> splat (half 0xFFF0000000000000)
+  ret <vscale x 2 x half> splat (half -inf)
 }
 
 define <vscale x 4 x half> @splat_ninf_nxv4f16() {
@@ -666,7 +666,7 @@ define <vscale x 4 x half> @splat_ninf_nxv4f16() {
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    dupm z0.h, #0xfc00
 ; CHECK-NEXT:    ret
-  ret <vscale x 4 x half> splat (half 0xFFF0000000000000)
+  ret <vscale x 4 x half> splat (half -inf)
 }
 
 define <vscale x 8 x half> @splat_ninf_nxv8f16() {
@@ -674,7 +674,7 @@ define <vscale x 8 x half> @splat_ninf_nxv8f16() {
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    dupm z0.h, #0xfc00
 ; CHECK-NEXT:    ret
-  ret <vscale x 8 x half> splat (half 0xFFF0000000000000)
+  ret <vscale x 8 x half> splat (half -inf)
 }
 
 define <vscale x 2 x float> @splat_ninf_nxv2f32() {
@@ -698,7 +698,7 @@ define <vscale x 2 x double> @splat_ninf_nxv2f64() {
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    mov z0.d, #0xfff0000000000000
 ; CHECK-NEXT:    ret
-  ret <vscale x 2 x double> splat (double 0xFFF0000000000000)
+  ret <vscale x 2 x double> splat (double -inf)
 }
 
 define <vscale x 2 x bfloat> @splat_ninf_nxv2bf16() {
@@ -706,7 +706,7 @@ define <vscale x 2 x bfloat> @splat_ninf_nxv2bf16() {
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    dupm z0.h, #0xff80
 ; CHECK-NEXT:    ret
-  ret <vscale x 2 x bfloat> splat (bfloat 0xFFF0000000000000)
+  ret <vscale x 2 x bfloat> splat (bfloat -inf)
 }
 
 define <vscale x 4 x bfloat> @splat_ninf_nxv4bf16() {
@@ -714,7 +714,7 @@ define <vscale x 4 x bfloat> @splat_ninf_nxv4bf16() {
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    dupm z0.h, #0xff80
 ; CHECK-NEXT:    ret
-  ret <vscale x 4 x bfloat> splat (bfloat 0xFFF0000000000000)
+  ret <vscale x 4 x bfloat> splat (bfloat -inf)
 }
 
 define <vscale x 8 x bfloat> @splat_ninf_nxv8bf16() {
@@ -722,7 +722,7 @@ define <vscale x 8 x bfloat> @splat_ninf_nxv8bf16() {
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    dupm z0.h, #0xff80
 ; CHECK-NEXT:    ret
-  ret <vscale x 8 x bfloat> splat (bfloat 0xFFF0000000000000)
+  ret <vscale x 8 x bfloat> splat (bfloat -inf)
 }
 
 define <vscale x 2 x half> @splat_nan_nxv2f16() {

--- a/llvm/test/CodeGen/AMDGPU/amdgpu-simplify-libcall-pow.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdgpu-simplify-libcall-pow.ll
@@ -5987,7 +5987,7 @@ define float @test_pow_f32__y_known_integral_nearbyint_assume(float %x, float %y
 ;
   %y = call float @llvm.nearbyint.f32(float %y.arg)
   %y.fabs = call float @llvm.fabs.f32(float %y)
-  %y.is.finite = fcmp one float %y.fabs, 0x7FF0000000000000
+  %y.is.finite = fcmp one float %y.fabs, +inf
   call void @llvm.assume(i1 %y.is.finite)
   %pow = tail call float @_Z3powff(float %x, float %y)
   ret float %pow
@@ -6014,7 +6014,7 @@ define float @test_pow_f32__y_known_integral_nearbyint_assume_arg_input(float %x
 ; NOPRELINK-NEXT:    ret float [[POW]]
 ;
   %y.arg.fabs = call float @llvm.fabs.f32(float %y.arg)
-  %is.finite = fcmp one float %y.arg.fabs, 0x7FF0000000000000
+  %is.finite = fcmp one float %y.arg.fabs, +inf
   call void @llvm.assume(i1 %is.finite)
   %y = call float @llvm.nearbyint.f32(float %y.arg)
   %pow = tail call float @_Z3powff(float %x, float %y)

--- a/llvm/test/CodeGen/AMDGPU/debug-value2.ll
+++ b/llvm/test/CodeGen/AMDGPU/debug-value2.ll
@@ -150,7 +150,7 @@ bb86:                                             ; preds = %bb
   br label %bb141
 
 bb96:                                             ; preds = %bb
-  %tmp97 = fcmp oeq float %tmp84, 0x7FF0000000000000
+  %tmp97 = fcmp oeq float %tmp84, +inf
   br i1 %tmp97, label %bb98, label %bb141
 
 bb98:                                             ; preds = %bb96
@@ -163,7 +163,7 @@ bb98:                                             ; preds = %bb96
   %tmp105 = tail call float @llvm.fmuladd.f32(float %tmp102, float %tmp102, float %tmp104)
   %tmp106 = tail call float @llvm.fmuladd.f32(float %tmp101, float %tmp101, float %tmp105)
   %tmp107 = tail call float @llvm.fmuladd.f32(float %tmp100, float %tmp100, float %tmp106)
-  %tmp108 = fcmp oeq float %tmp107, 0x7FF0000000000000
+  %tmp108 = fcmp oeq float %tmp107, +inf
   br i1 %tmp108, label %bb109, label %bb141
 
 bb109:                                            ; preds = %bb98

--- a/llvm/test/CodeGen/AMDGPU/dpp64_combine.ll
+++ b/llvm/test/CodeGen/AMDGPU/dpp64_combine.ll
@@ -119,7 +119,7 @@ bb1:
 ; DPP32: v_min{{(_num)?}}_f64{{(_e32)?}} v[0:1], v[0:1], v[{{[0-9:]+}}]{{$}}
 define nofpclass(nan) double @dpp64_fmin(double nofpclass(nan) %x) {
 entry:
-  %dpp = tail call double @llvm.amdgcn.update.dpp.f64(double 0x7FF0000000000000, double %x, i32 337, i32 15, i32 15, i1 false)
+  %dpp = tail call double @llvm.amdgcn.update.dpp.f64(double +inf, double %x, i32 337, i32 15, i32 15, i1 false)
   %min = tail call nnan double @llvm.minnum.f64(double %x, double %dpp)
   ret double %min
 }
@@ -130,7 +130,7 @@ entry:
 ; DPP32: v_max{{(_num)?}}_f64{{(_e32)?}} v[0:1], v[0:1], v[{{[0-9:]+}}]{{$}}
 define nofpclass(nan) double @dpp64_fmax(double nofpclass(nan) %x) #0 {
 entry:
-  %dpp = tail call double @llvm.amdgcn.update.dpp.f64(double 0xFFF0000000000000, double %x, i32 337, i32 15, i32 15, i1 false)
+  %dpp = tail call double @llvm.amdgcn.update.dpp.f64(double -inf, double %x, i32 337, i32 15, i32 15, i1 false)
   %max = tail call nnan double @llvm.maxnum.f64(double %x, double %dpp)
   ret double %max
 }

--- a/llvm/test/CodeGen/AMDGPU/fp-classify.ll
+++ b/llvm/test/CodeGen/AMDGPU/fp-classify.ll
@@ -52,7 +52,7 @@ define amdgpu_kernel void @test_isinf_pattern(ptr addrspace(1) nocapture %out, f
 ; GFX11-NEXT:    global_store_b32 v0, v1, s[0:1]
 ; GFX11-NEXT:    s_endpgm
   %fabs = tail call float @llvm.fabs.f32(float %x) #1
-  %cmp = fcmp oeq float %fabs, 0x7FF0000000000000
+  %cmp = fcmp oeq float %fabs, +inf
   %ext = zext i1 %cmp to i32
   store i32 %ext, ptr addrspace(1) %out, align 4
   ret void
@@ -103,7 +103,7 @@ define amdgpu_kernel void @test_not_isinf_pattern_0(ptr addrspace(1) nocapture %
 ; GFX11-NEXT:    global_store_b32 v0, v1, s[0:1]
 ; GFX11-NEXT:    s_endpgm
   %fabs = tail call float @llvm.fabs.f32(float %x) #1
-  %cmp = fcmp ueq float %fabs, 0x7FF0000000000000
+  %cmp = fcmp ueq float %fabs, +inf
   %ext = zext i1 %cmp to i32
   store i32 %ext, ptr addrspace(1) %out, align 4
   ret void
@@ -138,7 +138,7 @@ define amdgpu_kernel void @test_not_isinf_pattern_1(ptr addrspace(1) nocapture %
 ; GFX11-NEXT:    global_store_b32 v0, v0, s[0:1]
 ; GFX11-NEXT:    s_endpgm
   %fabs = tail call float @llvm.fabs.f32(float %x) #1
-  %cmp = fcmp oeq float %fabs, 0xFFF0000000000000
+  %cmp = fcmp oeq float %fabs, -inf
   %ext = zext i1 %cmp to i32
   store i32 %ext, ptr addrspace(1) %out, align 4
   ret void
@@ -190,7 +190,7 @@ define amdgpu_kernel void @test_isfinite_pattern_0(ptr addrspace(1) nocapture %o
 ; GFX11-NEXT:    s_endpgm
   %ord = fcmp ord float %x, 0.000000e+00
   %x.fabs = tail call float @llvm.fabs.f32(float %x) #1
-  %ninf = fcmp une float %x.fabs, 0x7FF0000000000000
+  %ninf = fcmp une float %x.fabs, +inf
   %and = and i1 %ord, %ninf
   %ext = zext i1 %and to i32
   store i32 %ext, ptr addrspace(1) %out, align 4
@@ -242,7 +242,7 @@ define amdgpu_kernel void @test_isfinite_pattern_1(ptr addrspace(1) nocapture %o
 ; GFX11-NEXT:    global_store_b32 v0, v1, s[0:1]
 ; GFX11-NEXT:    s_endpgm
   %x.fabs = tail call float @llvm.fabs.f32(float %x) #3
-  %cmpinf = fcmp one float %x.fabs, 0x7FF0000000000000
+  %cmpinf = fcmp one float %x.fabs, +inf
   %ext = zext i1 %cmpinf to i32
   store i32 %ext, ptr addrspace(1) %out, align 4
   ret void
@@ -293,7 +293,7 @@ define amdgpu_kernel void @test_isfinite_not_pattern_0(ptr addrspace(1) nocaptur
 ; GFX11-NEXT:    s_endpgm
   %ord = fcmp ord float %x, 0.000000e+00
   %x.fabs = tail call float @llvm.fabs.f32(float %x) #1
-  %ninf = fcmp une float %x.fabs, 0xFFF0000000000000
+  %ninf = fcmp une float %x.fabs, -inf
   %and = and i1 %ord, %ninf
   %ext = zext i1 %and to i32
   store i32 %ext, ptr addrspace(1) %out, align 4
@@ -352,7 +352,7 @@ define amdgpu_kernel void @test_isfinite_not_pattern_1(ptr addrspace(1) nocaptur
 ; GFX11-NEXT:    global_store_b32 v0, v1, s[0:1]
 ; GFX11-NEXT:    s_endpgm
   %ord = fcmp ord float %x, 0.000000e+00
-  %ninf = fcmp une float %x, 0x7FF0000000000000
+  %ninf = fcmp une float %x, +inf
   %and = and i1 %ord, %ninf
   %ext = zext i1 %and to i32
   store i32 %ext, ptr addrspace(1) %out, align 4
@@ -410,7 +410,7 @@ define amdgpu_kernel void @test_isfinite_not_pattern_2(ptr addrspace(1) nocaptur
 ; GFX11-NEXT:    s_endpgm
   %ord = fcmp ord float %x, 0.000000e+00
   %x.fabs = tail call float @llvm.fabs.f32(float %y) #1
-  %ninf = fcmp une float %x.fabs, 0x7FF0000000000000
+  %ninf = fcmp une float %x.fabs, +inf
   %and = and i1 %ord, %ninf
   %ext = zext i1 %and to i32
   store i32 %ext, ptr addrspace(1) %out, align 4
@@ -470,7 +470,7 @@ define amdgpu_kernel void @test_isfinite_not_pattern_3(ptr addrspace(1) nocaptur
 ; GFX11-NEXT:    s_endpgm
   %ord = fcmp uno float %x, 0.000000e+00
   %x.fabs = tail call float @llvm.fabs.f32(float %x) #1
-  %ninf = fcmp une float %x.fabs, 0x7FF0000000000000
+  %ninf = fcmp une float %x.fabs, +inf
   %and = and i1 %ord, %ninf
   %ext = zext i1 %and to i32
   store i32 %ext, ptr addrspace(1) %out, align 4
@@ -523,7 +523,7 @@ define amdgpu_kernel void @test_isfinite_pattern_4(ptr addrspace(1) nocapture %o
 ; GFX11-NEXT:    s_endpgm
   %ord = fcmp ord float %x, 0.000000e+00
   %x.fabs = tail call float @llvm.fabs.f32(float %x) #1
-  %ninf = fcmp one float %x.fabs, 0x7FF0000000000000
+  %ninf = fcmp one float %x.fabs, +inf
   %and = and i1 %ord, %ninf
   %ext = zext i1 %and to i32
   store i32 %ext, ptr addrspace(1) %out, align 4
@@ -576,7 +576,7 @@ define amdgpu_kernel void @test_isfinite_pattern_4_commute_and(ptr addrspace(1) 
 ; GFX11-NEXT:    s_endpgm
   %ord = fcmp ord float %x, 0.000000e+00
   %x.fabs = tail call float @llvm.fabs.f32(float %x) #1
-  %ninf = fcmp one float %x.fabs, 0x7FF0000000000000
+  %ninf = fcmp one float %x.fabs, +inf
   %and = and i1 %ninf, %ord
   %ext = zext i1 %and to i32
   store i32 %ext, ptr addrspace(1) %out, align 4
@@ -640,7 +640,7 @@ define amdgpu_kernel void @test_not_isfinite_pattern_4_wrong_ord_test(ptr addrsp
 ; GFX11-NEXT:    s_endpgm
   %ord = fcmp ord float %x, %y
   %x.fabs = tail call float @llvm.fabs.f32(float %x) #1
-  %ninf = fcmp one float %x.fabs, 0x7FF0000000000000
+  %ninf = fcmp one float %x.fabs, +inf
   %and = and i1 %ord, %ninf
   %ext = zext i1 %and to i32
   store i32 %ext, ptr addrspace(1) %out, align 4

--- a/llvm/test/CodeGen/AMDGPU/fract-match.ll
+++ b/llvm/test/CodeGen/AMDGPU/fract-match.ll
@@ -124,7 +124,7 @@ entry:
   %uno = fcmp uno float %x, 0.000000e+00
   %cond = select i1 %uno, float %x, float %min
   %fabs = tail call float @llvm.fabs.f32(float %x)
-  %cmpinf = fcmp oeq float %fabs, 0x7FF0000000000000
+  %cmpinf = fcmp oeq float %fabs, +inf
   %cond6 = select i1 %cmpinf, float 0.000000e+00, float %cond
   store float %floor, ptr addrspace(1) %ip, align 4
   ret float %cond6
@@ -516,7 +516,7 @@ entry:
   %uno = fcmp ord float %x, 0.000000e+00
   %cond = select i1 %uno, float %min, float %x
   %fabs = tail call float @llvm.fabs.f32(float %x)
-  %cmpinf = fcmp oeq float %fabs, 0x7FF0000000000000
+  %cmpinf = fcmp oeq float %fabs, +inf
   %cond6 = select i1 %cmpinf, float 0.000000e+00, float %cond
   store float %floor, ptr addrspace(1) %ip, align 4
   ret float %cond6
@@ -695,7 +695,7 @@ entry:
   %sub = fsub float %x, %floor
   %min = tail call float @llvm.minnum.f32(float %sub, float 0x3FEFFFFFE0000000)
   %fabs = tail call float @llvm.fabs.f32(float %x)
-  %cmpinf = fcmp oeq float %fabs, 0x7FF0000000000000
+  %cmpinf = fcmp oeq float %fabs, +inf
   %cond6 = select i1 %cmpinf, float 0.000000e+00, float %min
   store float %floor, ptr addrspace(1) %ip, align 4
   ret float %cond6
@@ -2627,7 +2627,7 @@ entry:
   %uno = fcmp uno double %x, 0.000000e+00
   %cond = select i1 %uno, double %x, double %min
   %fabs = tail call double @llvm.fabs.f64(double %x)
-  %cmpinf = fcmp oeq double %fabs, 0x7FF0000000000000
+  %cmpinf = fcmp oeq double %fabs, +inf
   %cond6 = select i1 %cmpinf, double 0.000000e+00, double %cond
   store double %floor, ptr addrspace(1) %ip, align 4
   ret double %cond6
@@ -3193,7 +3193,7 @@ entry:
   %uno = fcmp uno <2 x double> %x, zeroinitializer
   %cond = select <2 x i1> %uno, <2 x double> %x, <2 x double> %min
   %fabs = tail call <2 x double> @llvm.fabs.v2f64(<2 x double> %x)
-  %cmpinf = fcmp oeq <2 x double> %fabs, <double 0x7FF0000000000000, double 0x7FF0000000000000>
+  %cmpinf = fcmp oeq <2 x double> %fabs, <double +inf, double +inf>
   %cond6 = select <2 x i1> %cmpinf, <2 x double> zeroinitializer, <2 x double> %cond
   store <2 x double> %floor, ptr addrspace(1) %ip, align 4
   ret <2 x double> %cond6
@@ -3304,7 +3304,7 @@ entry:
   %uno = fcmp uno float %x, 0.000000e+00
   %cond = select i1 %uno, float %x, float %min
   %fabs = tail call float @llvm.fabs.f32(float %x)
-  %cmpinf = fcmp oeq float %fabs, 0x7FF0000000000000
+  %cmpinf = fcmp oeq float %fabs, +inf
   %cond6 = select i1 %cmpinf, float 0.000000e+00, float %cond
   store float %floor, ptr addrspace(1) %ip, align 4
   ret float %cond6
@@ -3415,7 +3415,7 @@ entry:
   %uno = fcmp ord float %x, 0.000000e+00
   %cond = select i1 %uno, float %min, float %x
   %fabs = tail call float @llvm.fabs.f32(float %x)
-  %cmpinf = fcmp oeq float %fabs, 0x7FF0000000000000
+  %cmpinf = fcmp oeq float %fabs, +inf
   %cond6 = select i1 %cmpinf, float 0.000000e+00, float %cond
   store float %floor, ptr addrspace(1) %ip, align 4
   ret float %cond6
@@ -3523,7 +3523,7 @@ entry:
   %uno = fcmp uno float %x, 0.000000e+00
   %cond = select i1 %uno, float %x, float %min
   %fabs = tail call float @llvm.fabs.f32(float %x)
-  %cmpinf = fcmp oeq float %fabs, 0x7FF0000000000000
+  %cmpinf = fcmp oeq float %fabs, +inf
   %cond6 = select i1 %cmpinf, float 0.000000e+00, float %cond
   store float %floor, ptr addrspace(1) %ip, align 4
   ret float %cond6
@@ -3631,7 +3631,7 @@ entry:
   %uno = fcmp ord float %x, 0.000000e+00
   %cond = select i1 %uno, float %min, float %x
   %fabs = tail call float @llvm.fabs.f32(float %x)
-  %cmpinf = fcmp oeq float %fabs, 0x7FF0000000000000
+  %cmpinf = fcmp oeq float %fabs, +inf
   %cond6 = select i1 %cmpinf, float 0.000000e+00, float %cond
   store float %floor, ptr addrspace(1) %ip, align 4
   ret float %cond6
@@ -4063,7 +4063,7 @@ entry:
   %sub = fsub double %x, %floor
   %min = tail call double @llvm.minnum.f64(double %sub, double 0x3FEFFFFFFFFFFFFF)
   %x.abs = tail call double @llvm.fabs.f64(double %x)
-  %is.inf = fcmp oeq double %x.abs, 0x7FF0000000000000
+  %is.inf = fcmp oeq double %x.abs, +inf
   %result = select i1 %is.inf, double 0.0, double %min
   ret double %result
 }
@@ -4146,7 +4146,7 @@ entry:
   %sub = fsub float %x, %floor
   %min = call float @llvm.minnum.f32(float %sub, float 0x3FEFFFFFE0000000)
   %x.fabs = call float @llvm.fabs.f32(float %x)
-  %not.inf = fcmp une float %x.fabs, 0x7FF0000000000000
+  %not.inf = fcmp une float %x.fabs, +inf
   %cond = select i1 %not.inf, float %min, float 0.0
   %not.nan = fcmp ord float %x, 0.0
   %cond8 = select i1 %not.nan, float %cond, float %x
@@ -4249,7 +4249,7 @@ define float @safe_math_fract_f32_swapped_edge_case_multi_use_inner_select(float
   %sub = fsub float %x, %floor
   %min = call float @llvm.minnum.f32(float %sub, float 0x3FEFFFFFE0000000)
   %x.fabs = call float @llvm.fabs.f32(float %x)
-  %not.inf = fcmp une float %x.fabs, 0x7FF0000000000000
+  %not.inf = fcmp une float %x.fabs, +inf
   %cond = select i1 %not.inf, float %min, float 0.0
   store float %cond, ptr addrspace(1) %ptr
   %not.nan = fcmp ord float %x, 0.0
@@ -4358,7 +4358,7 @@ define float @safe_math_fract_f32_swapped_edge_case_multi_use_inner_select_fcmp(
   %sub = fsub float %x, %floor
   %min = call float @llvm.minnum.f32(float %sub, float 0x3FEFFFFFE0000000)
   %x.fabs = call float @llvm.fabs.f32(float %x)
-  %not.inf = fcmp une float %x.fabs, 0x7FF0000000000000
+  %not.inf = fcmp une float %x.fabs, +inf
   store i1 %not.inf, ptr addrspace(1) %ptr
   %cond = select i1 %not.inf, float %min, float 0.0
   %not.nan = fcmp ord float %x, 0.0
@@ -4468,7 +4468,7 @@ define float @safe_math_fract_f32_swapped_edge_case_multi_use_fabs(float %x, ptr
   %min = call float @llvm.minnum.f32(float %sub, float 0x3FEFFFFFE0000000)
   %x.fabs = call float @llvm.fabs.f32(float %x)
   store float %x.fabs, ptr addrspace(1) %ptr
-  %not.inf = fcmp une float %x.fabs, 0x7FF0000000000000
+  %not.inf = fcmp une float %x.fabs, +inf
   %cond = select i1 %not.inf, float %min, float 0.0
   %not.nan = fcmp ord float %x, 0.0
   %cond8 = select i1 %not.nan, float %cond, float %x
@@ -4562,7 +4562,7 @@ entry:
   %sub = fsub float %x, %floor
   %min = call float @llvm.minnum.f32(float %sub, float 0x3FEFFFFFE0000000)
   %wrong.fabs = call float @llvm.fabs.f32(float %wrong)
-  %not.inf = fcmp une float %wrong.fabs, 0x7FF0000000000000
+  %not.inf = fcmp une float %wrong.fabs, +inf
   %cond = select i1 %not.inf, float %min, float 0.0
   %not.nan = fcmp ord float %x, 0.0
   %cond8 = select i1 %not.nan, float %cond, float %x
@@ -4656,7 +4656,7 @@ entry:
   %sub = fsub float %x, %floor
   %min = call float @llvm.minnum.f32(float %sub, float 0x3FEFFFFFE0000000)
   %x.fabs = call float @llvm.fabs.f32(float %x)
-  %is.inf = fcmp oeq float %x.fabs, 0x7FF0000000000000
+  %is.inf = fcmp oeq float %x.fabs, +inf
   %cond = select i1 %is.inf, float 0.0, float %min
   %not.nan = fcmp ord float %x, 0.0
   %cond8 = select i1 %not.nan, float %cond, float %x
@@ -4750,7 +4750,7 @@ entry:
   %sub = fsub float %x, %floor
   %min = call float @llvm.minnum.f32(float %sub, float 0x3FEFFFFFE0000000)
   %x.fabs = call float @llvm.fabs.f32(float %x)
-  %not.inf = fcmp une float %x.fabs, 0x7FF0000000000000
+  %not.inf = fcmp une float %x.fabs, +inf
   %cond = select i1 %not.inf, float %min, float 0.0
   %is.nan = fcmp uno float %x, 0.0
   %cond8 = select i1 %is.nan, float %x, float %cond
@@ -4810,7 +4810,7 @@ entry:
   %sub = fsub float %x, %floor
   %min = call float @llvm.minnum.f32(float %sub, float 0x3FEFFFFFE0000000)
   %x.fabs = call float @llvm.fabs.f32(float %x)
-  %not.inf = fcmp une float %x.fabs, 0xFFF0000000000000
+  %not.inf = fcmp une float %x.fabs, -inf
   %cond = select i1 %not.inf, float %min, float 0.0
   %not.nan = fcmp ord float %x, 0.0
   %cond8 = select i1 %not.nan, float %cond, float %x
@@ -4891,7 +4891,7 @@ entry:
   %sub = fsub float %x, %floor
   %min = tail call float @llvm.minnum.f32(float %sub, float 0x3FEFFFFFE0000000)
   %x.fabs = call float @llvm.fabs.f32(float %x)
-  %not.inf = fcmp une float %x.fabs, 0x7FF0000000000000
+  %not.inf = fcmp une float %x.fabs, +inf
   %clamp.inf.to.zero = select i1 %not.inf, float %min, float 0.0
   ret float %clamp.inf.to.zero
 }
@@ -4969,7 +4969,7 @@ entry:
   %sub = fsub float %x, %floor
   %min = tail call float @llvm.minnum.f32(float %sub, float 0x3FEFFFFFE0000000)
   %x.fabs = call float @llvm.fabs.f32(float %x)
-  %not.inf = fcmp une float %x.fabs, 0x7FF0000000000000
+  %not.inf = fcmp une float %x.fabs, +inf
   %clamp.inf.to.zero = select i1 %not.inf, float %min, float 0.0
   ret float %clamp.inf.to.zero
 }
@@ -5068,7 +5068,7 @@ entry:
   %sub = fsub float bitcast (i32 ptrtoint (ptr @gv to i32) to float), %floor
   %min = call float @llvm.minnum.f32(float %sub, float 0x3FEFFFFFE0000000)
   %x.fabs = call float @llvm.fabs.f32(float bitcast (i32 ptrtoint (ptr @gv to i32) to float))
-  %not.inf = fcmp une float %x.fabs, 0x7FF0000000000000
+  %not.inf = fcmp une float %x.fabs, +inf
   %cond = select i1 %not.inf, float %min, float 0.000000e+00
   %not.nan = fcmp ord float bitcast (i32 ptrtoint (ptr @gv to i32) to float), 0.000000e+00
   %cond8 = select i1 %not.nan, float %cond, float bitcast (i32 ptrtoint (ptr @gv to i32) to float)
@@ -5259,7 +5259,7 @@ define float @safe_math_fract_f32_swapped_edge_case_split_block(float %x, i1 %co
   br i1 %cond, label %edge_cases, label %ret
 
 edge_cases:
-  %not.inf = fcmp une float %x.fabs, 0x7FF0000000000000
+  %not.inf = fcmp une float %x.fabs, +inf
   %clamp.inf = select i1 %not.inf, float %min, float 0.0
   %not.nan = fcmp ord float %x, 0.0
   %cond8 = select i1 %not.nan, float %clamp.inf, float %x
@@ -5444,7 +5444,7 @@ entry:
   %sub = fsub float %x, %floor
   %min = call float @llvm.minnum.f32(float %sub, float 0x3FEFFFFFE0000000)
   %x.fabs = call float @llvm.fabs.f32(float %x)
-  %not.not.inf = fcmp ule float %x.fabs, 0x7FF0000000000000
+  %not.not.inf = fcmp ule float %x.fabs, +inf
   %cond = select i1 %not.not.inf, float %min, float 0.0
   %not.nan = fcmp ord float %x, 0.0
   %cond8 = select i1 %not.nan, float %cond, float %x
@@ -5556,7 +5556,7 @@ entry:
   %cmp = fcmp oge float %sub1, 0x3FEFFFFFE0000000
   %cond = select i1 %cmp, float 0x3FEFFFFFE0000000, float %sub1
   %fabs.x = call float @llvm.fabs.f32(float %x)
-  %not.inf = fcmp une float %fabs.x, 0x7FF0000000000000
+  %not.inf = fcmp une float %fabs.x, +inf
   %cond6 = select i1 %not.inf, float %cond, float 0.000000e+00
   ret float %cond6
 }
@@ -5664,7 +5664,7 @@ entry:
   %cmp = fcmp ogt float %sub1, 0x3FEFFFFFE0000000
   %cond = select i1 %cmp, float 0x3FEFFFFFE0000000, float %sub1
   %fabs.x = call float @llvm.fabs.f32(float %x)
-  %not.inf = fcmp une float %fabs.x, 0x7FF0000000000000
+  %not.inf = fcmp une float %fabs.x, +inf
   %cond6 = select i1 %not.inf, float %cond, float 0.000000e+00
   ret float %cond6
 }
@@ -5766,7 +5766,7 @@ entry:
   %cmp = fcmp olt float %sub1, 0x3FEFFFFFE0000000
   %cond = select i1 %cmp, float %sub1, float 0x3FEFFFFFE0000000
   %fabs.x = call float @llvm.fabs.f32(float %x)
-  %not.inf = fcmp une float %fabs.x, 0x7FF0000000000000
+  %not.inf = fcmp une float %fabs.x, +inf
   %cond6 = select i1 %not.inf, float %cond, float 0.000000e+00
   ret float %cond6
 }
@@ -5867,7 +5867,7 @@ entry:
   %cmp = fcmp olt float %sub1, 0x3FEFFFFFE0000000
   %cond = select i1 %cmp, float %sub1, float 0x3FEFFFFFE0000000
   %fabs.x = call float @llvm.fabs.f32(float %x)
-  %not.inf = fcmp une float %fabs.x, 0x7FF0000000000000
+  %not.inf = fcmp une float %fabs.x, +inf
   %cond6 = select i1 %not.inf, float %cond, float 0.000000e+00
   ret float %cond6
 }
@@ -5977,7 +5977,7 @@ entry:
   %sub1 = fsub float %x, %call
   %min = call float @llvm.minimum.f32(float %sub1, float 0x3FEFFFFFE0000000)
   %fabs.x = call float @llvm.fabs.f32(float %x)
-  %not.inf = fcmp une float %fabs.x, 0x7FF0000000000000
+  %not.inf = fcmp une float %fabs.x, +inf
   %cond6 = select i1 %not.inf, float %min, float 0.0
   ret float %cond6
 }

--- a/llvm/test/CodeGen/AMDGPU/known-never-nan.ll
+++ b/llvm/test/CodeGen/AMDGPU/known-never-nan.ll
@@ -36,7 +36,7 @@ define float @fma_not_fmaxnm_maybe_nan(i32 %i1, i32 %i2, i32 %i3) #0 {
   %f2 = uitofp i32 %i2 to float
   %f3 = uitofp i32 %i2 to float
   %fma = tail call float @llvm.fma.f32(float %f2, float %f1, float -inf)
-  %cmp = fcmp ugt float %fma, 0xfff0000000000000
+  %cmp = fcmp ugt float %fma, -inf
   %val = select i1 %cmp, float %fma, float -inf
   ret float %val
 }

--- a/llvm/test/CodeGen/AMDGPU/schedule-if-2.ll
+++ b/llvm/test/CodeGen/AMDGPU/schedule-if-2.ll
@@ -18,7 +18,7 @@ main_body:
 
 IF:                                               ; preds = %main_body
   %11 = call float @llvm.fabs.f32(float %2)
-  %12 = fcmp ueq float %11, 0x7FF0000000000000
+  %12 = fcmp ueq float %11, +inf
   %13 = select i1 %12, float 1.000000e+00, float 0.000000e+00
   %14 = fsub float -0.000000e+00, %13
   %15 = fptosi float %14 to i32

--- a/llvm/test/CodeGen/AMDGPU/select-cmp-shared-constant-fp.ll
+++ b/llvm/test/CodeGen/AMDGPU/select-cmp-shared-constant-fp.ll
@@ -334,7 +334,7 @@ define float @fcmp_select_no_fold_posinf_oeq_f32(float %arg, float %other) {
 ; GFX1010-NEXT:    v_cndmask_b32_e32 v0, 0x7f800000, v1, vcc_lo
 ; GFX1010-NEXT:    s_setpc_b64 s[30:31]
 entry:
-  %cmp = fcmp oeq float %arg, 0x7FF0000000000000
+  %cmp = fcmp oeq float %arg, +inf
   %sel = select i1 %cmp, float +inf, float %other
   ret float %sel
 }
@@ -796,8 +796,8 @@ define double @fcmp_select_no_fold_posinf_f64(double %arg, double %other) {
 ; GFX1010-NEXT:    v_cndmask_b32_e32 v1, 0x7ff00000, v3, vcc_lo
 ; GFX1010-NEXT:    s_setpc_b64 s[30:31]
 entry:
-  %cmp = fcmp oeq double %arg, 0x7FF0000000000000
-  %sel = select i1 %cmp, double 0x7FF0000000000000, double %other
+  %cmp = fcmp oeq double %arg, +inf
+  %sel = select i1 %cmp, double +inf, double %other
   ret double %sel
 }
 
@@ -823,8 +823,8 @@ define double @fcmp_select_no_fold_neginf_f64(double %arg, double %other) {
 ; GFX1010-NEXT:    v_cndmask_b32_e32 v1, 0xfff00000, v3, vcc_lo
 ; GFX1010-NEXT:    s_setpc_b64 s[30:31]
 entry:
-  %cmp = fcmp oeq double %arg, 0xFFF0000000000000
-  %sel = select i1 %cmp, double 0xFFF0000000000000, double %other
+  %cmp = fcmp oeq double %arg, -inf
+  %sel = select i1 %cmp, double -inf, double %other
   ret double %sel
 }
 
@@ -850,8 +850,8 @@ define double @fcmp_select_no_fold_posinf_f64_comm(double %arg, double %other) {
 ; GFX1010-NEXT:    v_cndmask_b32_e32 v1, 0x7ff00000, v3, vcc_lo
 ; GFX1010-NEXT:    s_setpc_b64 s[30:31]
 entry:
-  %cmp = fcmp oeq double 0x7FF0000000000000, %arg
-  %sel = select i1 %cmp, double 0x7FF0000000000000, double %other
+  %cmp = fcmp oeq double +inf, %arg
+  %sel = select i1 %cmp, double +inf, double %other
   ret double %sel
 }
 
@@ -877,8 +877,8 @@ define double @fcmp_select_no_fold_neginf_f64_comm(double %arg, double %other) {
 ; GFX1010-NEXT:    v_cndmask_b32_e32 v1, 0xfff00000, v3, vcc_lo
 ; GFX1010-NEXT:    s_setpc_b64 s[30:31]
 entry:
-  %cmp = fcmp oeq double 0xFFF0000000000000, %arg
-  %sel = select i1 %cmp, double 0xFFF0000000000000, double %other
+  %cmp = fcmp oeq double -inf, %arg
+  %sel = select i1 %cmp, double -inf, double %other
   ret double %sel
 }
 

--- a/llvm/test/CodeGen/AMDGPU/wave32.ll
+++ b/llvm/test/CodeGen/AMDGPU/wave32.ll
@@ -163,7 +163,7 @@ define amdgpu_kernel void @test_vopc_class(ptr addrspace(1) %out, float %x) #0 {
 ; GFX1064-NEXT:    global_store_dword v0, v1, s[0:1]
 ; GFX1064-NEXT:    s_endpgm
   %fabs = tail call float @llvm.fabs.f32(float %x)
-  %cmp = fcmp oeq float %fabs, 0x7FF0000000000000
+  %cmp = fcmp oeq float %fabs, +inf
   %ext = zext i1 %cmp to i32
   store i32 %ext, ptr addrspace(1) %out, align 4
   ret void
@@ -195,7 +195,7 @@ define amdgpu_kernel void @test_vcmp_vcnd_f16(ptr addrspace(1) %out, half %x) #0
 ; GFX1064-NEXT:    v_cndmask_b32_e32 v0, 0x3c00, v0, vcc
 ; GFX1064-NEXT:    global_store_short v1, v0, s[0:1]
 ; GFX1064-NEXT:    s_endpgm
-  %cmp = fcmp oeq half %x, 0x7FF0000000000000
+  %cmp = fcmp oeq half %x, +inf
   %sel = select i1 %cmp, half 1.0, half %x
   store half %sel, ptr addrspace(1) %out, align 2
   ret void

--- a/llvm/test/CodeGen/NVPTX/reg-copy.ll
+++ b/llvm/test/CodeGen/NVPTX/reg-copy.ll
@@ -26,19 +26,19 @@ entry:
   %add.i = fadd float %mul6.i, %mul5.i
   %5 = bitcast float %add.i to i32
   %6 = tail call float @llvm.nvvm.fabs.f(float %sub.i) #2
-  %7 = fcmp ugt float %6, 0x7FF0000000000000
+  %7 = fcmp ugt float %6, +inf
   br i1 %7, label %land.lhs.true.i, label %_ZN12cuda_builtinmlIfEENS_7complexIT_EERKS3_S5_.exit
 
 land.lhs.true.i:                                  ; preds = %entry
   %8 = tail call float @llvm.nvvm.fabs.f(float %add.i) #2
-  %9 = fcmp ugt float %8, 0x7FF0000000000000
+  %9 = fcmp ugt float %8, +inf
   br i1 %9, label %if.then.i, label %_ZN12cuda_builtinmlIfEENS_7complexIT_EERKS3_S5_.exit
 
 if.then.i:                                        ; preds = %land.lhs.true.i
   %10 = tail call float @llvm.nvvm.fabs.f(float %0) #2
-  %11 = fcmp oeq float %10, 0x7FF0000000000000
+  %11 = fcmp oeq float %10, +inf
   %.pre.i = tail call float @llvm.nvvm.fabs.f(float %1) #2
-  %12 = fcmp oeq float %.pre.i, 0x7FF0000000000000
+  %12 = fcmp oeq float %.pre.i, +inf
   %or.cond.i = or i1 %11, %12
   br i1 %or.cond.i, label %if.then.14.i, label %if.end.31.i
 
@@ -54,7 +54,7 @@ if.then.14.i:                                     ; preds = %if.then.i
   %21 = or i32 %20, %19
   %22 = bitcast i32 %21 to float
   %23 = tail call float @llvm.nvvm.fabs.f(float %2) #2
-  %24 = fcmp ugt float %23, 0x7FF0000000000000
+  %24 = fcmp ugt float %23, +inf
   br i1 %24, label %if.then.24.i, label %if.end.i
 
 if.then.24.i:                                     ; preds = %if.then.14.i
@@ -66,7 +66,7 @@ if.then.24.i:                                     ; preds = %if.then.14.i
 if.end.i:                                         ; preds = %if.then.24.i, %if.then.14.i
   %__c.0.i = phi float [ %27, %if.then.24.i ], [ %2, %if.then.14.i ]
   %28 = tail call float @llvm.nvvm.fabs.f(float %3) #2
-  %29 = fcmp ugt float %28, 0x7FF0000000000000
+  %29 = fcmp ugt float %28, +inf
   br i1 %29, label %if.then.28.i, label %if.end.31.i
 
 if.then.28.i:                                     ; preds = %if.end.i
@@ -82,9 +82,9 @@ if.end.31.i:                                      ; preds = %if.then.28.i, %if.e
   %__a.0.i = phi float [ %17, %if.then.28.i ], [ %17, %if.end.i ], [ %0, %if.then.i ]
   %__recalc.0.off0.i = phi i1 [ true, %if.then.28.i ], [ true, %if.end.i ], [ false, %if.then.i ]
   %33 = tail call float @llvm.nvvm.fabs.f(float %__c.1.i) #2
-  %34 = fcmp oeq float %33, 0x7FF0000000000000
+  %34 = fcmp oeq float %33, +inf
   %.pre6.i = tail call float @llvm.nvvm.fabs.f(float %__d.1.i) #2
-  %35 = fcmp oeq float %.pre6.i, 0x7FF0000000000000
+  %35 = fcmp oeq float %.pre6.i, +inf
   %or.cond8.i = or i1 %34, %35
   br i1 %or.cond8.i, label %if.then.37.i, label %if.end.56.i
 
@@ -100,7 +100,7 @@ if.then.37.i:                                     ; preds = %if.end.31.i
   %44 = or i32 %43, %42
   %45 = bitcast i32 %44 to float
   %46 = tail call float @llvm.nvvm.fabs.f(float %__a.0.i) #2
-  %47 = fcmp ugt float %46, 0x7FF0000000000000
+  %47 = fcmp ugt float %46, +inf
   br i1 %47, label %if.then.48.i, label %if.end.50.i
 
 if.then.48.i:                                     ; preds = %if.then.37.i
@@ -112,7 +112,7 @@ if.then.48.i:                                     ; preds = %if.then.37.i
 if.end.50.i:                                      ; preds = %if.then.48.i, %if.then.37.i
   %__a.1.i = phi float [ %50, %if.then.48.i ], [ %__a.0.i, %if.then.37.i ]
   %51 = tail call float @llvm.nvvm.fabs.f(float %__b.0.i) #2
-  %52 = fcmp ugt float %51, 0x7FF0000000000000
+  %52 = fcmp ugt float %51, +inf
   br i1 %52, label %if.then.53.i, label %if.then.93.i
 
 if.then.53.i:                                     ; preds = %if.end.50.i
@@ -126,27 +126,27 @@ if.end.56.i:                                      ; preds = %if.end.31.i
 
 land.lhs.true.58.i:                               ; preds = %if.end.56.i
   %56 = tail call float @llvm.nvvm.fabs.f(float %mul.i) #2
-  %57 = fcmp oeq float %56, 0x7FF0000000000000
+  %57 = fcmp oeq float %56, +inf
   br i1 %57, label %if.then.70.i, label %lor.lhs.false.61.i
 
 lor.lhs.false.61.i:                               ; preds = %land.lhs.true.58.i
   %58 = tail call float @llvm.nvvm.fabs.f(float %mul4.i) #2
-  %59 = fcmp oeq float %58, 0x7FF0000000000000
+  %59 = fcmp oeq float %58, +inf
   br i1 %59, label %if.then.70.i, label %lor.lhs.false.64.i
 
 lor.lhs.false.64.i:                               ; preds = %lor.lhs.false.61.i
   %60 = tail call float @llvm.nvvm.fabs.f(float %mul5.i) #2
-  %61 = fcmp oeq float %60, 0x7FF0000000000000
+  %61 = fcmp oeq float %60, +inf
   br i1 %61, label %if.then.70.i, label %lor.lhs.false.67.i
 
 lor.lhs.false.67.i:                               ; preds = %lor.lhs.false.64.i
   %62 = tail call float @llvm.nvvm.fabs.f(float %mul6.i) #2
-  %63 = fcmp oeq float %62, 0x7FF0000000000000
+  %63 = fcmp oeq float %62, +inf
   br i1 %63, label %if.then.70.i, label %_ZN12cuda_builtinmlIfEENS_7complexIT_EERKS3_S5_.exit
 
 if.then.70.i:                                     ; preds = %lor.lhs.false.67.i, %lor.lhs.false.64.i, %lor.lhs.false.61.i, %land.lhs.true.58.i
   %64 = tail call float @llvm.nvvm.fabs.f(float %__a.0.i) #2
-  %65 = fcmp ugt float %64, 0x7FF0000000000000
+  %65 = fcmp ugt float %64, +inf
   br i1 %65, label %if.then.73.i, label %if.end.75.i
 
 if.then.73.i:                                     ; preds = %if.then.70.i
@@ -158,7 +158,7 @@ if.then.73.i:                                     ; preds = %if.then.70.i
 if.end.75.i:                                      ; preds = %if.then.73.i, %if.then.70.i
   %__a.3.i = phi float [ %68, %if.then.73.i ], [ %__a.0.i, %if.then.70.i ]
   %69 = tail call float @llvm.nvvm.fabs.f(float %__b.0.i) #2
-  %70 = fcmp ugt float %69, 0x7FF0000000000000
+  %70 = fcmp ugt float %69, +inf
   br i1 %70, label %if.then.78.i, label %if.end.80.i
 
 if.then.78.i:                                     ; preds = %if.end.75.i
@@ -169,7 +169,7 @@ if.then.78.i:                                     ; preds = %if.end.75.i
 
 if.end.80.i:                                      ; preds = %if.then.78.i, %if.end.75.i
   %__b.3.i = phi float [ %73, %if.then.78.i ], [ %__b.0.i, %if.end.75.i ]
-  %74 = fcmp ugt float %33, 0x7FF0000000000000
+  %74 = fcmp ugt float %33, +inf
   br i1 %74, label %if.then.83.i, label %if.end.85.i
 
 if.then.83.i:                                     ; preds = %if.end.80.i
@@ -180,7 +180,7 @@ if.then.83.i:                                     ; preds = %if.end.80.i
 
 if.end.85.i:                                      ; preds = %if.then.83.i, %if.end.80.i
   %__c.3.i = phi float [ %77, %if.then.83.i ], [ %__c.1.i, %if.end.80.i ]
-  %78 = fcmp ugt float %.pre6.i, 0x7FF0000000000000
+  %78 = fcmp ugt float %.pre6.i, +inf
   br i1 %78, label %if.then.88.i, label %if.then.93.i
 
 if.then.88.i:                                     ; preds = %if.end.85.i
@@ -197,12 +197,12 @@ if.then.93.i:                                     ; preds = %if.then.88.i, %if.e
   %mul95.i = fmul float %__c.4.ph.i, %__a.4.ph.i
   %mul96.i = fmul float %__d.4.ph.i, %__b.4.ph.i
   %sub97.i = fsub float %mul95.i, %mul96.i
-  %mul98.i = fmul float %sub97.i, 0x7FF0000000000000
+  %mul98.i = fmul float %sub97.i, +inf
   %82 = bitcast float %mul98.i to i32
   %mul100.i = fmul float %__d.4.ph.i, %__a.4.ph.i
   %mul101.i = fmul float %__c.4.ph.i, %__b.4.ph.i
   %add102.i = fadd float %mul101.i, %mul100.i
-  %mul103.i = fmul float %add102.i, 0x7FF0000000000000
+  %mul103.i = fmul float %add102.i, +inf
   %83 = bitcast float %mul103.i to i32
   br label %_ZN12cuda_builtinmlIfEENS_7complexIT_EERKS3_S5_.exit
 

--- a/llvm/test/CodeGen/PowerPC/fp-classify.ll
+++ b/llvm/test/CodeGen/PowerPC/fp-classify.ll
@@ -25,7 +25,7 @@ define zeroext i1 @abs_isinff(float %x) {
 ; P9-NEXT:    blr
 entry:
   %0 = tail call float @llvm.fabs.f32(float %x)
-  %cmpinf = fcmp oeq float %0, 0x7FF0000000000000
+  %cmpinf = fcmp oeq float %0, +inf
   ret i1 %cmpinf
 }
 
@@ -50,7 +50,7 @@ define zeroext i1 @abs_isinf(double %x) {
 ; P9-NEXT:    blr
 entry:
   %0 = tail call double @llvm.fabs.f64(double %x)
-  %cmpinf = fcmp oeq double %0, 0x7FF0000000000000
+  %cmpinf = fcmp oeq double %0, +inf
   ret i1 %cmpinf
 }
 
@@ -103,7 +103,7 @@ define zeroext i1 @abs_isinfornanf(float %x) {
 ; P9-NEXT:    blr
 entry:
   %0 = tail call float @llvm.fabs.f32(float %x)
-  %cmpinf = fcmp ueq float %0, 0x7FF0000000000000
+  %cmpinf = fcmp ueq float %0, +inf
   ret i1 %cmpinf
 }
 
@@ -127,7 +127,7 @@ define zeroext i1 @abs_isinfornan(double %x) {
 ; P9-NEXT:    blr
 entry:
   %0 = tail call double @llvm.fabs.f64(double %x)
-  %cmpinf = fcmp ueq double %0, 0x7FF0000000000000
+  %cmpinf = fcmp ueq double %0, +inf
   ret i1 %cmpinf
 }
 
@@ -202,7 +202,7 @@ define <2 x i1> @abs_isinfv2f64(<2 x double> %x) {
 ; P9-NEXT:    blr
 entry:
   %0 = tail call <2 x double> @llvm.fabs.v2f64(<2 x double> %x)
-  %cmpinf = fcmp oeq <2 x double> %0, <double 0x7FF0000000000000, double 0x7FF0000000000000>
+  %cmpinf = fcmp oeq <2 x double> %0, <double +inf, double +inf>
   ret <2 x i1> %cmpinf
 }
 

--- a/llvm/test/CodeGen/PowerPC/p10-splatImm.ll
+++ b/llvm/test/CodeGen/PowerPC/p10-splatImm.ll
@@ -222,7 +222,7 @@ define dso_local <2 x double> @testDoubleToDoubleInfinity() local_unnamed_addr {
 ; CHECK-NEXT:    blr
 
 entry:
-  ret <2 x double> <double 0x7FF0000000000000, double 0x7FF0000000000000>
+  ret <2 x double> <double +inf, double +inf>
 }
 
 define dso_local <2 x double> @testFloatToDoubleNaN() local_unnamed_addr {
@@ -242,7 +242,7 @@ define dso_local <2 x double> @testFloatToDoubleInfinity() local_unnamed_addr {
 ; CHECK-NEXT:    blr
 
 entry:
-  ret <2 x double> <double 0x7FF0000000000000, double 0x7FF0000000000000>
+  ret <2 x double> <double +inf, double +inf>
 }
 
 define dso_local float @testFloatScalar() local_unnamed_addr {

--- a/llvm/test/CodeGen/RISCV/double-zfa.ll
+++ b/llvm/test/CodeGen/RISCV/double-zfa.ll
@@ -49,7 +49,7 @@ define double @loadfpimm6() {
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    fli.d fa0, inf
 ; CHECK-NEXT:    ret
-  ret double 0x7FF0000000000000
+  ret double +inf
 }
 
 define double @loadfpimm7() {

--- a/llvm/test/CodeGen/SPIRV/literals.ll
+++ b/llvm/test/CodeGen/SPIRV/literals.ll
@@ -38,9 +38,9 @@ entry:
   %snan = alloca float, align 4
   store float 0x7FF4000000000000, ptr %snan, align 4
   %dinf = alloca double, align 8
-  store double 0x7FF0000000000000, ptr %dinf, align 8
+  store double +inf, ptr %dinf, align 8
   %dninf = alloca double, align 8
-  store double 0xFFF0000000000000, ptr %dninf, align 8
+  store double -inf, ptr %dninf, align 8
   %dnan = alloca double, align 8
   store double 0x7FF8000000000000, ptr %dnan, align 8
   %dsnan = alloca double, align 8

--- a/llvm/test/CodeGen/SystemZ/tdc-03.ll
+++ b/llvm/test/CodeGen/SystemZ/tdc-03.ll
@@ -49,7 +49,7 @@ define i32 @f3(float %x) {
 ; CHECK-NOT: tceb
 ; CHECK: ceb %f0, 0(%r{{[0-9]+}})
 ; CHECK-NOT: tceb
-  %res = fcmp ult float %x, 0x7ff0000000000000
+  %res = fcmp ult float %x, +inf
   %xres = zext i1 %res to i32
   ret i32 %xres
 }
@@ -60,7 +60,7 @@ define i32 @f4_half(half %x) {
 ; CHECK: brasl %r14, __extendhfsf2@PLT
 ; CHECK: tceb %f0, 4047
   %y = call half @llvm.fabs.f16(half %x)
-  %res = fcmp ult half %y, 0x7ff0000000000000
+  %res = fcmp ult half %y, +inf
   %xres = zext i1 %res to i32
   ret i32 %xres
 }
@@ -70,7 +70,7 @@ define i32 @f4(float %x) {
 ; CHECK-LABEL: f4:
 ; CHECK: tceb %f0, 4047
   %y = call float @llvm.fabs.f32(float %x)
-  %res = fcmp ult float %y, 0x7ff0000000000000
+  %res = fcmp ult float %y, +inf
   %xres = zext i1 %res to i32
   ret i32 %xres
 }
@@ -147,7 +147,7 @@ define i32 @f11(double %x) {
 ; CHECK-LABEL: f11
 ; CHECK: tcdb %f0, 4032
   %y = call double @llvm.fabs.f64(double %x)
-  %res = fcmp one double %y, 0x7ff0000000000000
+  %res = fcmp one double %y, +inf
   %xres = zext i1 %res to i32
   ret i32 %xres
 }
@@ -157,7 +157,7 @@ define i32 @f12(double %x) {
 ; CHECK-LABEL: f12
 ; CHECK: tcdb %f0, 48
   %y = call double @llvm.fabs.f64(double %x)
-  %res = fcmp oeq double %y, 0x7ff0000000000000
+  %res = fcmp oeq double %y, +inf
   %xres = zext i1 %res to i32
   ret i32 %xres
 }

--- a/llvm/test/CodeGen/SystemZ/tdc-05.ll
+++ b/llvm/test/CodeGen/SystemZ/tdc-05.ll
@@ -69,7 +69,7 @@ define i32 @f2(float %x) {
 ; CHECK-NEXT:    br %r14
   %cast = bitcast float %x to i32
   %sign = icmp sgt i32 %cast, -1
-  %fcmp = fcmp ult float %x, 0x7ff0000000000000
+  %fcmp = fcmp ult float %x, +inf
   %res = and i1 %sign, %fcmp
   %xres = zext i1 %res to i32
   ret i32 %xres
@@ -103,7 +103,7 @@ define i32 @f4(float %x) {
 ; CHECK-NEXT:    br %r14
   %y = call float @llvm.fabs.f32(float %x)
   %ord = fcmp ord float %x, 0.0
-  %a = fcmp ult float %y, 0x7ff0000000000000
+  %a = fcmp ult float %y, +inf
   %b = fcmp uge float %y, 0x3810000000000000
   %c = and i1 %a, %b
   %res = and i1 %ord, %c
@@ -139,7 +139,7 @@ define i32 @f6(double %x) {
 ; CHECK-NEXT:    br %r14
   %y = call double @llvm.fabs.f64(double %x)
   %ord = fcmp ord double %x, 0.0
-  %a = fcmp ult double %y, 0x7ff0000000000000
+  %a = fcmp ult double %y, +inf
   %b = fcmp uge double %y, 0x0010000000000000
   %c = and i1 %ord, %a
   %res = and i1 %b, %c
@@ -157,7 +157,7 @@ define i32 @f7(double %x) {
 ; CHECK-NEXT:    # kill: def $r2l killed $r2l killed $r2d
 ; CHECK-NEXT:    br %r14
   %y = call double @llvm.fabs.f64(double %x)
-  %a = fcmp oeq double %y, 0x7ff0000000000000
+  %a = fcmp oeq double %y, +inf
   %b = fcmp uno double %x, 0.0
   %res = or i1 %a, %b
   %xres = zext i1 %res to i32

--- a/llvm/test/CodeGen/SystemZ/tdc-06.ll
+++ b/llvm/test/CodeGen/SystemZ/tdc-06.ll
@@ -26,7 +26,7 @@ nonzeroord:
 ; CHECK-DAG: tcdb %f0, 48
 ; CHECK: jl [[RET]]
   %abs = tail call double @llvm.fabs.f64(double %x)
-  %testinf = fcmp oeq double %abs, 0x7FF0000000000000
+  %testinf = fcmp oeq double %abs, +inf
   br i1 %testinf, label %ret, label %finite, !prof !1
 
 finite:

--- a/llvm/test/CodeGen/WebAssembly/immediates.ll
+++ b/llvm/test/CodeGen/WebAssembly/immediates.ll
@@ -201,7 +201,7 @@ define double @negnan_f64() {
 ; CHECK-NEXT: f64.const $push[[NUM:[0-9]+]]=, infinity{{$}}
 ; CHECK-NEXT: return $pop[[NUM]]{{$}}
 define double @inf_f64() {
-  ret double 0x7FF0000000000000
+  ret double +inf
 }
 
 ; CHECK-LABEL: neginf_f64:
@@ -209,7 +209,7 @@ define double @inf_f64() {
 ; CHECK-NEXT: f64.const $push[[NUM:[0-9]+]]=, -infinity{{$}}
 ; CHECK-NEXT: return $pop[[NUM]]{{$}}
 define double @neginf_f64() {
-  ret double 0xFFF0000000000000
+  ret double -inf
 }
 
 ;; Custom NaN playloads are currently not always preserved because of the use of

--- a/llvm/test/CodeGen/X86/2010-05-25-DotDebugLoc.ll
+++ b/llvm/test/CodeGen/X86/2010-05-25-DotDebugLoc.ll
@@ -116,12 +116,12 @@ bb16:                                             ; preds = %bb15
   %48 = fmul float %42, %c, !dbg !35              ; <float> [#uses=1]
   %49 = fmul float %47, %d, !dbg !35              ; <float> [#uses=1]
   %50 = fadd float %48, %49, !dbg !35             ; <float> [#uses=1]
-  %51 = fmul float %50, 0x7FF0000000000000, !dbg !35 ; <float> [#uses=1]
+  %51 = fmul float %50, +inf, !dbg !35 ; <float> [#uses=1]
   tail call void @llvm.dbg.value(metadata float %51, i64 0, metadata !17, metadata !DIExpression()), !dbg !35
   %52 = fmul float %47, %c, !dbg !36              ; <float> [#uses=1]
   %53 = fmul float %42, %d, !dbg !36              ; <float> [#uses=1]
   %54 = fsub float %52, %53, !dbg !36             ; <float> [#uses=1]
-  %55 = fmul float %54, 0x7FF0000000000000, !dbg !36 ; <float> [#uses=1]
+  %55 = fmul float %54, +inf, !dbg !36 ; <float> [#uses=1]
   tail call void @llvm.dbg.value(metadata float %55, i64 0, metadata !18, metadata !DIExpression()), !dbg !36
   br label %bb46, !dbg !36
 

--- a/llvm/test/CodeGen/X86/avx512-intrinsics-fast-isel.ll
+++ b/llvm/test/CodeGen/X86/avx512-intrinsics-fast-isel.ll
@@ -7738,7 +7738,7 @@ define double @test_mm512_mask_reduce_max_pd(i8 zeroext %__M, <8 x double> %__W)
 ; X64-NEXT:    retq
 entry:
   %0 = bitcast i8 %__M to <8 x i1>
-  %1 = select <8 x i1> %0, <8 x double> %__W, <8 x double> <double 0xFFF0000000000000, double 0xFFF0000000000000, double 0xFFF0000000000000, double 0xFFF0000000000000, double 0xFFF0000000000000, double 0xFFF0000000000000, double 0xFFF0000000000000, double 0xFFF0000000000000>
+  %1 = select <8 x i1> %0, <8 x double> %__W, <8 x double> <double -inf, double -inf, double -inf, double -inf, double -inf, double -inf, double -inf, double -inf>
   %vecext.i = call nnan double @llvm.vector.reduce.fmax.v8f64(<8 x double> %1)
   ret double %vecext.i
 }
@@ -7860,7 +7860,7 @@ define double @test_mm512_mask_reduce_min_pd(i8 zeroext %__M, <8 x double> %__W)
 ; X64-NEXT:    retq
 entry:
   %0 = bitcast i8 %__M to <8 x i1>
-  %1 = select <8 x i1> %0, <8 x double> %__W, <8 x double> <double 0x7FF0000000000000, double 0x7FF0000000000000, double 0x7FF0000000000000, double 0x7FF0000000000000, double 0x7FF0000000000000, double 0x7FF0000000000000, double 0x7FF0000000000000, double 0x7FF0000000000000>
+  %1 = select <8 x i1> %0, <8 x double> %__W, <8 x double> <double +inf, double +inf, double +inf, double +inf, double +inf, double +inf, double +inf, double +inf>
   %vecext.i = call nnan double @llvm.vector.reduce.fmin.v8f64(<8 x double> %1)
   ret double %vecext.i
 }

--- a/llvm/test/CodeGen/X86/coff-fp-section-name.ll
+++ b/llvm/test/CodeGen/X86/coff-fp-section-name.ll
@@ -37,7 +37,7 @@ entry:
   store double 1.000000e+00, ptr %l, align 8
   store double 8.000000e+00, ptr %m, align 8
   store double 0x7FF8000000000000, ptr %n, align 8
-  store double 0x7FF0000000000000, ptr %o, align 8
+  store double +inf, ptr %o, align 8
 
   ret i32 0
 }

--- a/llvm/test/CodeGen/X86/compare-inf.ll
+++ b/llvm/test/CodeGen/X86/compare-inf.ll
@@ -9,7 +9,7 @@ declare void @f() nounwind
 ; CHECK: ucomiss
 ; CHECK: jb
 define void @oeq_inff(float %x) nounwind {
-  %t0 = fcmp oeq float %x, 0x7FF0000000000000
+  %t0 = fcmp oeq float %x, +inf
   br i1 %t0, label %true, label %false
 
 true:
@@ -24,7 +24,7 @@ false:
 ; CHECK: ucomisd
 ; CHECK: jb
 define void @oeq_inf(double %x) nounwind {
-  %t0 = fcmp oeq double %x, 0x7FF0000000000000
+  %t0 = fcmp oeq double %x, +inf
   br i1 %t0, label %true, label %false
 
 true:
@@ -39,7 +39,7 @@ false:
 ; CHECK: ucomiss
 ; CHECK: jae
 define void @une_inff(float %x) nounwind {
-  %t0 = fcmp une float %x, 0x7FF0000000000000
+  %t0 = fcmp une float %x, +inf
   br i1 %t0, label %true, label %false
 
 true:
@@ -54,7 +54,7 @@ false:
 ; CHECK: ucomisd
 ; CHECK: jae
 define void @une_inf(double %x) nounwind {
-  %t0 = fcmp une double %x, 0x7FF0000000000000
+  %t0 = fcmp une double %x, +inf
   br i1 %t0, label %true, label %false
 
 true:
@@ -69,7 +69,7 @@ false:
 ; CHECK: ucomiss
 ; CHECK: jb
 define void @oeq_neg_inff(float %x) nounwind {
-  %t0 = fcmp oeq float %x, 0xFFF0000000000000
+  %t0 = fcmp oeq float %x, -inf
   br i1 %t0, label %true, label %false
 
 true:
@@ -84,7 +84,7 @@ false:
 ; CHECK: ucomisd
 ; CHECK: jb
 define void @oeq_neg_inf(double %x) nounwind {
-  %t0 = fcmp oeq double %x, 0xFFF0000000000000
+  %t0 = fcmp oeq double %x, -inf
   br i1 %t0, label %true, label %false
 
 true:
@@ -99,7 +99,7 @@ false:
 ; CHECK: ucomiss
 ; CHECK: jae
 define void @une_neg_inff(float %x) nounwind {
-  %t0 = fcmp une float %x, 0xFFF0000000000000
+  %t0 = fcmp une float %x, -inf
   br i1 %t0, label %true, label %false
 
 true:
@@ -114,7 +114,7 @@ false:
 ; CHECK: ucomisd
 ; CHECK: jae
 define void @une_neg_inf(double %x) nounwind {
-  %t0 = fcmp une double %x, 0xFFF0000000000000
+  %t0 = fcmp une double %x, -inf
   br i1 %t0, label %true, label %false
 
 true:

--- a/llvm/test/CodeGen/X86/constpool.ll
+++ b/llvm/test/CodeGen/X86/constpool.ll
@@ -8,7 +8,7 @@ target datalayout = "e-p:32:32:32-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:32:64-f3
 
 define i32 @main() nounwind {
 entry:
-	%0 = fcmp oeq float undef, 0x7FF0000000000000		; <i1> [#uses=1]
+	%0 = fcmp oeq float undef, +inf		; <i1> [#uses=1]
 	%1 = zext i1 %0 to i32		; <i32> [#uses=1]
 	store i32 %1, ptr undef, align 4
 	ret i32 undef

--- a/llvm/test/CodeGen/X86/fp-undef.ll
+++ b/llvm/test/CodeGen/X86/fp-undef.ll
@@ -400,7 +400,7 @@ define double @fadd_undef_op0_constant_inf(double %x) {
 ; ANY:       # %bb.0:
 ; ANY-NEXT:    movsd {{.*#+}} xmm0 = [NaN,0.0E+0]
 ; ANY-NEXT:    retq
-  %r = fadd double undef, 0x7FF0000000000000
+  %r = fadd double undef, +inf
   ret double %r
 }
 
@@ -408,7 +408,7 @@ define double @fadd_undef_op1_fast_constant_inf(double %x) {
 ; ANY-LABEL: fadd_undef_op1_fast_constant_inf:
 ; ANY:       # %bb.0:
 ; ANY-NEXT:    retq
-  %r = fadd fast double 0xFFF0000000000000, undef
+  %r = fadd fast double -inf, undef
   ret double %r
 }
 
@@ -417,7 +417,7 @@ define double @fsub_undef_op0_constant_inf(double %x) {
 ; ANY:       # %bb.0:
 ; ANY-NEXT:    movsd {{.*#+}} xmm0 = [NaN,0.0E+0]
 ; ANY-NEXT:    retq
-  %r = fsub double undef, 0xFFF0000000000000
+  %r = fsub double undef, -inf
   ret double %r
 }
 
@@ -425,7 +425,7 @@ define double @fsub_undef_op1_ninf_constant_inf(double %x) {
 ; ANY-LABEL: fsub_undef_op1_ninf_constant_inf:
 ; ANY:       # %bb.0:
 ; ANY-NEXT:    retq
-  %r = fsub ninf double 0x7FF0000000000000, undef
+  %r = fsub ninf double +inf, undef
   ret double %r
 }
 
@@ -434,7 +434,7 @@ define double @fmul_undef_op0_constant_inf(double %x) {
 ; ANY:       # %bb.0:
 ; ANY-NEXT:    movsd {{.*#+}} xmm0 = [NaN,0.0E+0]
 ; ANY-NEXT:    retq
-  %r = fmul double undef, 0x7FF0000000000000
+  %r = fmul double undef, +inf
   ret double %r
 }
 
@@ -442,7 +442,7 @@ define double @fmul_undef_op1_fast_constant_inf(double %x) {
 ; ANY-LABEL: fmul_undef_op1_fast_constant_inf:
 ; ANY:       # %bb.0:
 ; ANY-NEXT:    retq
-  %r = fmul fast double 0xFFF0000000000000, undef
+  %r = fmul fast double -inf, undef
   ret double %r
 }
 
@@ -451,7 +451,7 @@ define double @fdiv_undef_op0_constant_inf(double %x) {
 ; ANY:       # %bb.0:
 ; ANY-NEXT:    movsd {{.*#+}} xmm0 = [NaN,0.0E+0]
 ; ANY-NEXT:    retq
-  %r = fdiv double undef, 0xFFF0000000000000
+  %r = fdiv double undef, -inf
   ret double %r
 }
 
@@ -459,7 +459,7 @@ define double @fdiv_undef_op1_ninf_constant_inf(double %x) {
 ; ANY-LABEL: fdiv_undef_op1_ninf_constant_inf:
 ; ANY:       # %bb.0:
 ; ANY-NEXT:    retq
-  %r = fdiv ninf double 0x7FF0000000000000, undef
+  %r = fdiv ninf double +inf, undef
   ret double %r
 }
 
@@ -468,7 +468,7 @@ define double @frem_undef_op0_constant_inf(double %x) {
 ; ANY:       # %bb.0:
 ; ANY-NEXT:    movsd {{.*#+}} xmm0 = [NaN,0.0E+0]
 ; ANY-NEXT:    retq
-  %r = frem double undef, 0x7FF0000000000000
+  %r = frem double undef, +inf
   ret double %r
 }
 
@@ -476,7 +476,7 @@ define double @frem_undef_op1_fast_constant_inf(double %x) {
 ; ANY-LABEL: frem_undef_op1_fast_constant_inf:
 ; ANY:       # %bb.0:
 ; ANY-NEXT:    retq
-  %r = frem fast double 0xFFF0000000000000, undef
+  %r = frem fast double -inf, undef
   ret double %r
 }
 

--- a/llvm/test/CodeGen/X86/fp128-cast.ll
+++ b/llvm/test/CodeGen/X86/fp128-cast.ll
@@ -1692,7 +1692,7 @@ entry:
 
 if.then:                                          ; preds = %entry
   %conv = fptrunc fp128 %x to double
-  %call = tail call double @copysign(double 0x7FF0000000000000, double %conv) #2
+  %call = tail call double @copysign(double +inf, double %conv) #2
   %conv1 = fpext double %call to fp128
   br label %cleanup
 

--- a/llvm/test/Transforms/Attributor/nofpclass-fmul.ll
+++ b/llvm/test/Transforms/Attributor/nofpclass-fmul.ll
@@ -312,7 +312,7 @@ define float @ret_mul_f32_inf(float %arg0) {
 ; CHECK-NEXT:    [[CALL:%.*]] = fmul float [[ARG0]], +inf
 ; CHECK-NEXT:    ret float [[CALL]]
 ;
-  %call = fmul float %arg0, 0x7FF0000000000000
+  %call = fmul float %arg0, +inf
   ret float %call
 }
 

--- a/llvm/test/Transforms/Attributor/nofpclass-implied-by-fcmp.ll
+++ b/llvm/test/Transforms/Attributor/nofpclass-implied-by-fcmp.ll
@@ -2434,7 +2434,7 @@ define float @assume_ole_pinf(float noundef %arg) {
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[FCMP]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
 ;
-  %fcmp = fcmp ole float %arg, 0x7FF0000000000000
+  %fcmp = fcmp ole float %arg, +inf
   call void @llvm.assume(i1 %fcmp)
   ret float %arg
 }
@@ -2446,7 +2446,7 @@ define float @assume_ole_ninf(float noundef %arg) {
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[FCMP]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
 ;
-  %fcmp = fcmp ole float %arg, 0xFFF0000000000000
+  %fcmp = fcmp ole float %arg, -inf
   call void @llvm.assume(i1 %fcmp)
   ret float %arg
 }
@@ -2458,7 +2458,7 @@ define float @assume_ugt_pinf(float noundef %arg) {
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[FCMP]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
 ;
-  %fcmp = fcmp ugt float %arg, 0x7FF0000000000000
+  %fcmp = fcmp ugt float %arg, +inf
   call void @llvm.assume(i1 %fcmp)
   ret float %arg
 }
@@ -2470,7 +2470,7 @@ define float @assume_ugt_ninf(float noundef %arg) {
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[FCMP]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
 ;
-  %fcmp = fcmp ugt float %arg, 0xFFF0000000000000
+  %fcmp = fcmp ugt float %arg, -inf
   call void @llvm.assume(i1 %fcmp)
   ret float %arg
 }
@@ -2484,7 +2484,7 @@ define float @assume_fabs_ole_pinf(float noundef %arg) {
 ; CHECK-NEXT:    ret float [[ARG]]
 ;
   %fabs = call float @llvm.fabs.f32(float %arg)
-  %fcmp = fcmp ole float %fabs, 0x7FF0000000000000
+  %fcmp = fcmp ole float %fabs, +inf
   call void @llvm.assume(i1 %fcmp)
   ret float %arg
 }
@@ -2496,7 +2496,7 @@ define float @assume_fabs_ole_ninf(float noundef %arg) {
 ; CHECK-NEXT:    ret float [[ARG]]
 ;
   %fabs = call float @llvm.fabs.f32(float %arg)
-  %fcmp = fcmp ole float %fabs, 0xFFF0000000000000
+  %fcmp = fcmp ole float %fabs, -inf
   call void @llvm.assume(i1 %fcmp)
   ret float %arg
 }
@@ -2510,7 +2510,7 @@ define float @assume_fabs_ugt_pinf(float noundef %arg) {
 ; CHECK-NEXT:    ret float [[ARG]]
 ;
   %fabs = call float @llvm.fabs.f32(float %arg)
-  %fcmp = fcmp ugt float %fabs, 0x7FF0000000000000
+  %fcmp = fcmp ugt float %fabs, +inf
   call void @llvm.assume(i1 %fcmp)
   ret float %arg
 }
@@ -2522,7 +2522,7 @@ define float @assume_fabs_ugt_ninf(float noundef %arg) {
 ; CHECK-NEXT:    ret float [[ARG]]
 ;
   %fabs = call float @llvm.fabs.f32(float %arg)
-  %fcmp = fcmp ugt float %fabs, 0xFFF0000000000000
+  %fcmp = fcmp ugt float %fabs, -inf
   call void @llvm.assume(i1 %fcmp)
   ret float %arg
 }
@@ -2538,7 +2538,7 @@ define float @assume_fabs_false_pinf(float noundef %arg) {
 ; CHECK-NEXT:    ret float [[ARG]]
 ;
   %fabs = call float @llvm.fabs.f32(float %arg)
-  %fcmp = fcmp false float %fabs, 0x7FF0000000000000
+  %fcmp = fcmp false float %fabs, +inf
   call void @llvm.assume(i1 %fcmp)
   ret float %arg
 }
@@ -2550,7 +2550,7 @@ define float @assume_fabs_false_ninf(float noundef %arg) {
 ; CHECK-NEXT:    ret float [[ARG]]
 ;
   %fabs = call float @llvm.fabs.f32(float %arg)
-  %fcmp = fcmp false float %fabs, 0xFFF0000000000000
+  %fcmp = fcmp false float %fabs, -inf
   call void @llvm.assume(i1 %fcmp)
   ret float %arg
 }
@@ -2561,7 +2561,7 @@ define float @assume_false_pinf(float noundef %arg) {
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef false) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
 ;
-  %fcmp = fcmp false float %arg, 0x7FF0000000000000
+  %fcmp = fcmp false float %arg, +inf
   call void @llvm.assume(i1 %fcmp)
   ret float %arg
 }
@@ -2572,7 +2572,7 @@ define float @assume_false_ninf(float noundef %arg) {
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef false) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
 ;
-  %fcmp = fcmp false float %arg, 0xFFF0000000000000
+  %fcmp = fcmp false float %arg, -inf
   call void @llvm.assume(i1 %fcmp)
   ret float %arg
 }
@@ -2582,7 +2582,7 @@ define float @clamp_false_pinf_0.0(float noundef %arg) {
 ; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    ret float [[ARG]]
 ;
-  %fcmp = fcmp false float %arg, 0x7FF0000000000000
+  %fcmp = fcmp false float %arg, +inf
   %select = select i1 %fcmp, float 0.0, float %arg
   ret float %select
 }
@@ -2592,7 +2592,7 @@ define float @clamp_false_ninf_0.0(float noundef %arg) {
 ; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    ret float [[ARG]]
 ;
-  %fcmp = fcmp false float %arg, 0xFFF0000000000000
+  %fcmp = fcmp false float %arg, -inf
   %select = select i1 %fcmp, float 0.0, float %arg
   ret float %select
 }
@@ -2681,7 +2681,7 @@ define float @assume_fabs_true_pinf(float noundef %arg) {
 ; CHECK-NEXT:    ret float [[ARG]]
 ;
   %fabs = call float @llvm.fabs.f32(float %arg)
-  %fcmp = fcmp true float %fabs, 0x7FF0000000000000
+  %fcmp = fcmp true float %fabs, +inf
   call void @llvm.assume(i1 %fcmp)
   ret float %arg
 }
@@ -2693,7 +2693,7 @@ define float @assume_fabs_true_ninf(float noundef %arg) {
 ; CHECK-NEXT:    ret float [[ARG]]
 ;
   %fabs = call float @llvm.fabs.f32(float %arg)
-  %fcmp = fcmp true float %fabs, 0xFFF0000000000000
+  %fcmp = fcmp true float %fabs, -inf
   call void @llvm.assume(i1 %fcmp)
   ret float %arg
 }
@@ -2704,7 +2704,7 @@ define float @assume_true_pinf(float noundef %arg) {
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef true) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
 ;
-  %fcmp = fcmp true float %arg, 0x7FF0000000000000
+  %fcmp = fcmp true float %arg, +inf
   call void @llvm.assume(i1 %fcmp)
   ret float %arg
 }
@@ -2715,7 +2715,7 @@ define float @assume_true_ninf(float noundef %arg) {
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef true) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
 ;
-  %fcmp = fcmp true float %arg, 0xFFF0000000000000
+  %fcmp = fcmp true float %arg, -inf
   call void @llvm.assume(i1 %fcmp)
   ret float %arg
 }
@@ -2758,7 +2758,7 @@ define float @clamp_true_pinf_0.0(float noundef %arg) {
 ; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    ret float 0.000000e+00
 ;
-  %fcmp = fcmp true float %arg, 0x7FF0000000000000
+  %fcmp = fcmp true float %arg, +inf
   %select = select i1 %fcmp, float 0.0, float %arg
   ret float %select
 }
@@ -2768,7 +2768,7 @@ define float @clamp_true_ninf_0.0(float noundef %arg) {
 ; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    ret float 0.000000e+00
 ;
-  %fcmp = fcmp true float %arg, 0xFFF0000000000000
+  %fcmp = fcmp true float %arg, -inf
   %select = select i1 %fcmp, float 0.0, float %arg
   ret float %select
 }

--- a/llvm/test/Transforms/Attributor/nofpclass-nan-fmul.ll
+++ b/llvm/test/Transforms/Attributor/nofpclass-nan-fmul.ll
@@ -200,7 +200,7 @@ define float @ret_fmul_ieee_inf(float %arg) {
 ; CHECK-NEXT:    [[FMUL:%.*]] = fmul float [[ARG]], +inf
 ; CHECK-NEXT:    ret float [[FMUL]]
 ;
-  %fmul = fmul float %arg, 0x7FF0000000000000
+  %fmul = fmul float %arg, +inf
   ret float %fmul
 }
 

--- a/llvm/test/Transforms/Attributor/nofpclass-select.ll
+++ b/llvm/test/Transforms/Attributor/nofpclass-select.ll
@@ -109,7 +109,7 @@ define float @clamp_nonfinite_to_normal_olt(float %arg) {
 ; CHECK-NEXT:    ret float [[SELECT]]
 ;
   %fabs = call float @llvm.fabs.f32(float %arg)
-  %is.finite = fcmp olt float %fabs, 0x7FF0000000000000
+  %is.finite = fcmp olt float %fabs, +inf
   %select = select i1 %is.finite, float %arg, float 1024.0
   ret float %select
 }
@@ -123,7 +123,7 @@ define float @clamp_eq_inf_to_pnormal(float %arg) {
 ; CHECK-NEXT:    ret float [[SELECT]]
 ;
   %fabs = call float @llvm.fabs.f32(float %arg)
-  %is.inf = fcmp oeq float %fabs, 0x7FF0000000000000
+  %is.inf = fcmp oeq float %fabs, +inf
   %select = select i1 %is.inf, float 1024.0, float %arg
   ret float %select
 }
@@ -135,7 +135,7 @@ define float @clamp_eq_pinf_to_pnormal(float %arg) {
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_INF]], float 1.024000e+03, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
 ;
-  %is.inf = fcmp oeq float %arg, 0x7FF0000000000000
+  %is.inf = fcmp oeq float %arg, +inf
   %select = select i1 %is.inf, float 1024.0, float %arg
   ret float %select
 }
@@ -147,7 +147,7 @@ define float @clamp_eq_ninf_to_negnormal(float %arg) {
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_INF]], float -1.024000e+03, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
 ;
-  %is.inf = fcmp oeq float %arg, 0xFFF0000000000000
+  %is.inf = fcmp oeq float %arg, -inf
   %select = select i1 %is.inf, float -1024.0, float %arg
   ret float %select
 }
@@ -161,7 +161,7 @@ define float @clamp_eq_inf_to_nan(float %arg) {
 ; CHECK-NEXT:    ret float [[SELECT]]
 ;
   %fabs = call float @llvm.fabs.f32(float %arg)
-  %is.inf = fcmp oeq float %fabs, 0x7FF0000000000000
+  %is.inf = fcmp oeq float %fabs, +inf
   %select = select i1 %is.inf, float 0x7FF8000000000000, float %arg
   ret float %select
 }
@@ -187,7 +187,7 @@ define float @isfinite_select_fabs_val_0(float %arg) {
 ; CHECK-NEXT:    ret float [[SELECT]]
 ;
   %fabs = call float @llvm.fabs.f32(float %arg)
-  %is.finite = fcmp olt float %fabs, 0x7FF0000000000000
+  %is.finite = fcmp olt float %fabs, +inf
   %select = select i1 %is.finite, float %fabs, float 1024.0
   ret float %select
 }
@@ -273,7 +273,7 @@ define float @clamp_inf_to_fabs(float %arg) {
 ; CHECK-NEXT:    ret float [[SELECT]]
 ;
   %fabs = call float @llvm.fabs.f32(float %arg)
-  %is.inf = fcmp oeq float %fabs, 0x7FF0000000000000
+  %is.inf = fcmp oeq float %fabs, +inf
   %select = select i1 %is.inf, float %fabs, float %arg
   ret float %select
 }
@@ -287,7 +287,7 @@ define float @not_clamp_inf_to_fabs(float %arg) {
 ; CHECK-NEXT:    ret float [[SELECT]]
 ;
   %fabs = call float @llvm.fabs.f32(float %arg)
-  %is.inf = fcmp oeq float %fabs, 0x7FF0000000000000
+  %is.inf = fcmp oeq float %fabs, +inf
   %select = select i1 %is.inf, float %arg, float %fabs
   ret float %select
 }

--- a/llvm/test/Transforms/CodeGenPrepare/AArch64/fpclass-test.ll
+++ b/llvm/test/Transforms/CodeGenPrepare/AArch64/fpclass-test.ll
@@ -8,7 +8,7 @@ define i1 @test_is_inf_or_nan(double %arg) {
 ; CHECK-NEXT:    ret i1 [[TMP1]]
 ;
   %abs = tail call double @llvm.fabs.f64(double %arg)
-  %ret = fcmp ueq double %abs, 0x7FF0000000000000
+  %ret = fcmp ueq double %abs, +inf
   ret i1 %ret
 }
 
@@ -19,7 +19,7 @@ define i1 @test_is_not_inf_or_nan(double %arg) {
 ; CHECK-NEXT:    ret i1 [[TMP1]]
 ;
   %abs = tail call double @llvm.fabs.f64(double %arg)
-  %ret = fcmp one double %abs, 0x7FF0000000000000
+  %ret = fcmp one double %abs, +inf
   ret i1 %ret
 }
 
@@ -30,7 +30,7 @@ define i1 @test_is_inf(double %arg) {
 ; CHECK-NEXT:    ret i1 [[TMP1]]
 ;
   %abs = tail call double @llvm.fabs.f64(double %arg)
-  %ret = fcmp oeq double %abs, 0x7FF0000000000000
+  %ret = fcmp oeq double %abs, +inf
   ret i1 %ret
 }
 
@@ -41,7 +41,7 @@ define i1 @test_is_not_inf(double %arg) {
 ; CHECK-NEXT:    ret i1 [[TMP1]]
 ;
   %abs = tail call double @llvm.fabs.f64(double %arg)
-  %ret = fcmp une double %abs, 0x7FF0000000000000
+  %ret = fcmp une double %abs, +inf
   ret i1 %ret
 }
 
@@ -52,7 +52,7 @@ define <vscale x 2 x i1> @test_vec_is_inf_or_nan(<vscale x 2 x double> %arg) {
 ; CHECK-NEXT:    ret <vscale x 2 x i1> [[TMP1]]
 ;
   %abs = tail call <vscale x 2 x double> @llvm.fabs.nxv2f64(<vscale x 2 x double> %arg)
-  %ret = fcmp ueq <vscale x 2 x double> %abs, splat (double 0x7FF0000000000000)
+  %ret = fcmp ueq <vscale x 2 x double> %abs, splat (double +inf)
   ret <vscale x 2 x i1> %ret
 }
 
@@ -63,7 +63,7 @@ define <vscale x 2 x i1> @test_vec_is_not_inf_or_nan(<vscale x 2 x double> %arg)
 ; CHECK-NEXT:    ret <vscale x 2 x i1> [[TMP1]]
 ;
   %abs = tail call <vscale x 2 x double> @llvm.fabs.nxv2f64(<vscale x 2 x double> %arg)
-  %ret = fcmp one <vscale x 2 x double> %abs, splat (double 0x7FF0000000000000)
+  %ret = fcmp one <vscale x 2 x double> %abs, splat (double +inf)
   ret <vscale x 2 x i1> %ret
 }
 
@@ -74,7 +74,7 @@ define <vscale x 2 x i1> @test_vec_is_inf(<vscale x 2 x double> %arg) {
 ; CHECK-NEXT:    ret <vscale x 2 x i1> [[TMP1]]
 ;
   %abs = tail call <vscale x 2 x double> @llvm.fabs.nxv2f64(<vscale x 2 x double> %arg)
-  %ret = fcmp oeq <vscale x 2 x double> %abs, splat (double 0x7FF0000000000000)
+  %ret = fcmp oeq <vscale x 2 x double> %abs, splat (double +inf)
   ret <vscale x 2 x i1> %ret
 }
 
@@ -85,7 +85,7 @@ define <vscale x 2 x i1> @test_vec_is_not_inf(<vscale x 2 x double> %arg) {
 ; CHECK-NEXT:    ret <vscale x 2 x i1> [[TMP1]]
 ;
   %abs = tail call <vscale x 2 x double> @llvm.fabs.nxv2f64(<vscale x 2 x double> %arg)
-  %ret = fcmp une <vscale x 2 x double> %abs, splat (double 0x7FF0000000000000)
+  %ret = fcmp une <vscale x 2 x double> %abs, splat (double +inf)
   ret <vscale x 2 x i1> %ret
 }
 

--- a/llvm/test/Transforms/CodeGenPrepare/RISCV/fpclass-test.ll
+++ b/llvm/test/Transforms/CodeGenPrepare/RISCV/fpclass-test.ll
@@ -8,7 +8,7 @@ define i1 @test_is_inf_or_nan(double %arg) {
 ; CHECK-NEXT:    ret i1 [[TMP1]]
 ;
   %abs = tail call double @llvm.fabs.f64(double %arg)
-  %ret = fcmp ueq double %abs, 0x7FF0000000000000
+  %ret = fcmp ueq double %abs, +inf
   ret i1 %ret
 }
 
@@ -19,7 +19,7 @@ define i1 @test_is_not_inf_or_nan(double %arg) {
 ; CHECK-NEXT:    ret i1 [[TMP1]]
 ;
   %abs = tail call double @llvm.fabs.f64(double %arg)
-  %ret = fcmp one double %abs, 0x7FF0000000000000
+  %ret = fcmp one double %abs, +inf
   ret i1 %ret
 }
 
@@ -30,7 +30,7 @@ define i1 @test_is_inf(double %arg) {
 ; CHECK-NEXT:    ret i1 [[TMP1]]
 ;
   %abs = tail call double @llvm.fabs.f64(double %arg)
-  %ret = fcmp oeq double %abs, 0x7FF0000000000000
+  %ret = fcmp oeq double %abs, +inf
   ret i1 %ret
 }
 
@@ -41,7 +41,7 @@ define i1 @test_is_not_inf(double %arg) {
 ; CHECK-NEXT:    ret i1 [[TMP1]]
 ;
   %abs = tail call double @llvm.fabs.f64(double %arg)
-  %ret = fcmp une double %abs, 0x7FF0000000000000
+  %ret = fcmp une double %abs, +inf
   ret i1 %ret
 }
 
@@ -52,7 +52,7 @@ define <vscale x 4 x i1> @test_vec_is_inf_or_nan(<vscale x 4 x double> %arg) {
 ; CHECK-NEXT:    ret <vscale x 4 x i1> [[TMP1]]
 ;
   %abs = tail call <vscale x 4 x double> @llvm.fabs.nxv4f64(<vscale x 4 x double> %arg)
-  %ret = fcmp ueq <vscale x 4 x double> %abs, splat (double 0x7FF0000000000000)
+  %ret = fcmp ueq <vscale x 4 x double> %abs, splat (double +inf)
   ret <vscale x 4 x i1> %ret
 }
 
@@ -63,7 +63,7 @@ define <vscale x 4 x i1> @test_vec_is_not_inf_or_nan(<vscale x 4 x double> %arg)
 ; CHECK-NEXT:    ret <vscale x 4 x i1> [[TMP1]]
 ;
   %abs = tail call <vscale x 4 x double> @llvm.fabs.nxv4f64(<vscale x 4 x double> %arg)
-  %ret = fcmp one <vscale x 4 x double> %abs, splat (double 0x7FF0000000000000)
+  %ret = fcmp one <vscale x 4 x double> %abs, splat (double +inf)
   ret <vscale x 4 x i1> %ret
 }
 
@@ -74,7 +74,7 @@ define <vscale x 4 x i1> @test_vec_is_inf(<vscale x 4 x double> %arg) {
 ; CHECK-NEXT:    ret <vscale x 4 x i1> [[TMP1]]
 ;
   %abs = tail call <vscale x 4 x double> @llvm.fabs.nxv4f64(<vscale x 4 x double> %arg)
-  %ret = fcmp oeq <vscale x 4 x double> %abs, splat (double 0x7FF0000000000000)
+  %ret = fcmp oeq <vscale x 4 x double> %abs, splat (double +inf)
   ret <vscale x 4 x i1> %ret
 }
 
@@ -85,7 +85,7 @@ define <vscale x 4 x i1> @test_vec_is_not_inf(<vscale x 4 x double> %arg) {
 ; CHECK-NEXT:    ret <vscale x 4 x i1> [[TMP1]]
 ;
   %abs = tail call <vscale x 4 x double> @llvm.fabs.nxv4f64(<vscale x 4 x double> %arg)
-  %ret = fcmp une <vscale x 4 x double> %abs, splat (double 0x7FF0000000000000)
+  %ret = fcmp une <vscale x 4 x double> %abs, splat (double +inf)
   ret <vscale x 4 x i1> %ret
 }
 

--- a/llvm/test/Transforms/CodeGenPrepare/X86/fpclass-test.ll
+++ b/llvm/test/Transforms/CodeGenPrepare/X86/fpclass-test.ll
@@ -8,7 +8,7 @@ define i1 @test_is_inf_or_nan(double %arg) {
 ; CHECK-NEXT:    ret i1 [[TMP1]]
 ;
   %abs = tail call double @llvm.fabs.f64(double %arg)
-  %ret = fcmp ueq double %abs, 0x7FF0000000000000
+  %ret = fcmp ueq double %abs, +inf
   ret i1 %ret
 }
 
@@ -19,7 +19,7 @@ define i1 @test_is_not_inf_or_nan(double %arg) {
 ; CHECK-NEXT:    ret i1 [[TMP1]]
 ;
   %abs = tail call double @llvm.fabs.f64(double %arg)
-  %ret = fcmp one double %abs, 0x7FF0000000000000
+  %ret = fcmp one double %abs, +inf
   ret i1 %ret
 }
 
@@ -30,7 +30,7 @@ define i1 @test_is_inf(double %arg) {
 ; CHECK-NEXT:    ret i1 [[TMP1]]
 ;
   %abs = tail call double @llvm.fabs.f64(double %arg)
-  %ret = fcmp oeq double %abs, 0x7FF0000000000000
+  %ret = fcmp oeq double %abs, +inf
   ret i1 %ret
 }
 
@@ -41,7 +41,7 @@ define i1 @test_is_not_inf(double %arg) {
 ; CHECK-NEXT:    ret i1 [[TMP1]]
 ;
   %abs = tail call double @llvm.fabs.f64(double %arg)
-  %ret = fcmp une double %abs, 0x7FF0000000000000
+  %ret = fcmp une double %abs, +inf
   ret i1 %ret
 }
 
@@ -52,7 +52,7 @@ define <4 x i1> @test_vec_is_inf_or_nan(<4 x double> %arg) {
 ; CHECK-NEXT:    ret <4 x i1> [[TMP1]]
 ;
   %abs = tail call <4 x double> @llvm.fabs.v4f64(<4 x double> %arg)
-  %ret = fcmp ueq <4 x double> %abs, splat (double 0x7FF0000000000000)
+  %ret = fcmp ueq <4 x double> %abs, splat (double +inf)
   ret <4 x i1> %ret
 }
 
@@ -63,7 +63,7 @@ define <4 x i1> @test_vec_is_not_inf_or_nan(<4 x double> %arg) {
 ; CHECK-NEXT:    ret <4 x i1> [[TMP1]]
 ;
   %abs = tail call <4 x double> @llvm.fabs.v4f64(<4 x double> %arg)
-  %ret = fcmp one <4 x double> %abs, splat (double 0x7FF0000000000000)
+  %ret = fcmp one <4 x double> %abs, splat (double +inf)
   ret <4 x i1> %ret
 }
 
@@ -74,7 +74,7 @@ define <4 x i1> @test_vec_is_inf(<4 x double> %arg) {
 ; CHECK-NEXT:    ret <4 x i1> [[TMP1]]
 ;
   %abs = tail call <4 x double> @llvm.fabs.v4f64(<4 x double> %arg)
-  %ret = fcmp oeq <4 x double> %abs, splat (double 0x7FF0000000000000)
+  %ret = fcmp oeq <4 x double> %abs, splat (double +inf)
   ret <4 x i1> %ret
 }
 
@@ -85,7 +85,7 @@ define <4 x i1> @test_vec_is_not_inf(<4 x double> %arg) {
 ; CHECK-NEXT:    ret <4 x i1> [[TMP1]]
 ;
   %abs = tail call <4 x double> @llvm.fabs.v4f64(<4 x double> %arg)
-  %ret = fcmp une <4 x double> %abs, splat (double 0x7FF0000000000000)
+  %ret = fcmp une <4 x double> %abs, splat (double +inf)
   ret <4 x i1> %ret
 }
 

--- a/llvm/test/Transforms/DCE/calls-errno.ll
+++ b/llvm/test/Transforms/DCE/calls-errno.ll
@@ -75,23 +75,23 @@ entry:
   %cos1 = call double @cos(double 0.000000e+00)
 
 ; cos(inf) is a domain error
-  %cos2 = call double @cos(double 0x7FF0000000000000)
+  %cos2 = call double @cos(double +inf)
 
 ; cos(0) nobuiltin may have side effects
   %cos3 = call double @cos(double 0.000000e+00) nobuiltin
 
 ; pow(0, 1) is 0
-  %pow1 = call double @pow(double 0x7FF0000000000000, double 1.000000e+00)
+  %pow1 = call double @pow(double +inf, double 1.000000e+00)
 
 ; pow(0, -1) is a pole error
 ; FIXME: It fails on mingw host. Suppress checking.
 ; %pow2 = call double @pow(double 0.000000e+00, double -1.000000e+00)
 
 ; fmod(inf, nan) is nan
-  %fmod1 = call double @fmod(double 0x7FF0000000000000, double 0x7FF0000000000001)
+  %fmod1 = call double @fmod(double +inf, double 0x7FF0000000000001)
 
 ; fmod(inf, 1) is a domain error
-  %fmod2 = call double @fmod(double 0x7FF0000000000000, double 1.000000e+00)
+  %fmod2 = call double @fmod(double +inf, double 1.000000e+00)
 
   ret void
 }

--- a/llvm/test/Transforms/ExpandIRInsts/AMDGPU/frem-inf.ll
+++ b/llvm/test/Transforms/ExpandIRInsts/AMDGPU/frem-inf.ll
@@ -27,13 +27,13 @@ define float @frem_x_maybe_inf(float %x, float %y)  {
 ; OPT0-LABEL: define float @frem_x_assumed_non_inf(float %x, float %y)
 ; OPT0: 2:
 ; OPT0: [[FABS:%.*]] = call float @llvm.fabs.f32(float %x)
-; OPT0: [[FCMP:%.*]] = fcmp ult float [[FABS]], 0x7FF0000000000000
+; OPT0: [[FCMP:%.*]] = fcmp ult float [[FABS]], +inf
 ; OPT0-NEXT: %ret = select i1 [[FCMP]], float %{{.*}}, float 0x7FF8000000000000
 ; OPT0-NEXT: ret float %ret
 ; OPT0-LABEL: }
 define float @frem_x_assumed_non_inf(float %x, float %y)  {
   %absx = call float @llvm.fabs.f32(float %x)
-  %noninf = fcmp ult float %absx, 0x7FF0000000000000
+  %noninf = fcmp ult float %absx, +inf
   call void @llvm.assume(i1 %noninf)
   %ret = frem float %x, %y
   ret float %ret

--- a/llvm/test/Transforms/GVNHoist/hoist-call.ll
+++ b/llvm/test/Transforms/GVNHoist/hoist-call.ll
@@ -23,12 +23,12 @@ if.then:                                          ; preds = %entry
 
 lor.lhs.false:                                    ; preds = %if.then
   %0 = call float @llvm.fabs.f32(float %__b) #2
-  %cmpinf7 = fcmp oeq float %0, 0x7FF0000000000000
+  %cmpinf7 = fcmp oeq float %0, +inf
   unreachable
 
 if.then8:                                         ; preds = %if.then
   %1 = call float @llvm.fabs.f32(float %__b) #2
-  %cmpinf10 = fcmp oeq float %1, 0x7FF0000000000000
+  %cmpinf10 = fcmp oeq float %1, +inf
   ret void
 }
 

--- a/llvm/test/Transforms/Inline/simplify-instruction-computeKnownFPClass-context.ll
+++ b/llvm/test/Transforms/Inline/simplify-instruction-computeKnownFPClass-context.ll
@@ -177,7 +177,7 @@ define i1 @simplify_fcmp_ord_ldexp_caller(double nofpclass(zero inf) %i0) {
 
 define internal i1 @simplify_fcmp_ord_ldexp_callee(double %a) {
   %ldexp = call double @llvm.ldexp.f64.i32(double %a, i32 42)
-  %cmp = fcmp one double %ldexp, 0x7FF0000000000000
+  %cmp = fcmp one double %ldexp, +inf
   ret i1 %cmp
 }
 
@@ -198,7 +198,7 @@ define i1 @simplify_fcmp_ord_frexp_caller(double nofpclass(zero inf) %i0) {
 define internal i1 @simplify_fcmp_ord_frexp_callee(double %a) {
   %frexp = call { double, i32 } @llvm.frexp.f64.i32(double %a)
   %frexp.0 = extractvalue { double, i32 } %frexp, 0
-  %cmp = fcmp one double %frexp.0, 0x7FF0000000000000
+  %cmp = fcmp one double %frexp.0, +inf
   ret i1 %cmp
 }
 

--- a/llvm/test/Transforms/InstCombine/2007-03-25-BadShiftMask.ll
+++ b/llvm/test/Transforms/InstCombine/2007-03-25-BadShiftMask.ll
@@ -22,7 +22,7 @@ define i32 @main() {
 ;
 entry:
   %u = alloca %struct..1anon, align 8
-  store double 0x7FF0000000000000, ptr %u
+  store double +inf, ptr %u
   %tmp5 = getelementptr %struct..0anon, ptr %u, i32 0, i32 1
   %tmp6 = load i32, ptr %tmp5
   %tmp7 = shl i32 %tmp6, 1

--- a/llvm/test/Transforms/InstCombine/AMDGPU/amdgcn-intrinsics.ll
+++ b/llvm/test/Transforms/InstCombine/AMDGPU/amdgcn-intrinsics.ll
@@ -441,7 +441,7 @@ define double @test_constant_fold_frexp_mant_f64_inf() nounwind {
 ; CHECK-LABEL: @test_constant_fold_frexp_mant_f64_inf(
 ; CHECK-NEXT:    ret double +inf
 ;
-  %val = call double @llvm.amdgcn.frexp.mant.f64(double 0x7FF0000000000000)
+  %val = call double @llvm.amdgcn.frexp.mant.f64(double +inf)
   ret double %val
 }
 
@@ -457,7 +457,7 @@ define double @test_constant_fold_frexp_mant_f64_ninf() nounwind {
 ; CHECK-LABEL: @test_constant_fold_frexp_mant_f64_ninf(
 ; CHECK-NEXT:    ret double -inf
 ;
-  %val = call double @llvm.amdgcn.frexp.mant.f64(double 0xFFF0000000000000)
+  %val = call double @llvm.amdgcn.frexp.mant.f64(double -inf)
   ret double %val
 }
 
@@ -633,7 +633,7 @@ define i32 @test_constant_fold_frexp_exp_f64_inf() nounwind {
 ; CHECK-LABEL: @test_constant_fold_frexp_exp_f64_inf(
 ; CHECK-NEXT:    ret i32 0
 ;
-  %val = call i32 @llvm.amdgcn.frexp.exp.f64(double 0x7FF0000000000000)
+  %val = call i32 @llvm.amdgcn.frexp.exp.f64(double +inf)
   ret i32 %val
 }
 
@@ -649,7 +649,7 @@ define i32 @test_constant_fold_frexp_exp_f64_ninf() nounwind {
 ; CHECK-LABEL: @test_constant_fold_frexp_exp_f64_ninf(
 ; CHECK-NEXT:    ret i32 0
 ;
-  %val = call i32 @llvm.amdgcn.frexp.exp.f64(double 0xFFF0000000000000)
+  %val = call i32 @llvm.amdgcn.frexp.exp.f64(double -inf)
   ret i32 %val
 }
 
@@ -870,7 +870,7 @@ define i1 @test_constant_class_ninf_test_ninf_f64() nounwind {
 ; CHECK-LABEL: @test_constant_class_ninf_test_ninf_f64(
 ; CHECK-NEXT:    ret i1 true
 ;
-  %val = call i1 @llvm.amdgcn.class.f64(double 0xFFF0000000000000, i32 4)
+  %val = call i1 @llvm.amdgcn.class.f64(double -inf, i32 4)
   ret i1 %val
 }
 
@@ -878,7 +878,7 @@ define i1 @test_constant_class_pinf_test_ninf_f64() nounwind {
 ; CHECK-LABEL: @test_constant_class_pinf_test_ninf_f64(
 ; CHECK-NEXT:    ret i1 false
 ;
-  %val = call i1 @llvm.amdgcn.class.f64(double 0x7FF0000000000000, i32 4)
+  %val = call i1 @llvm.amdgcn.class.f64(double +inf, i32 4)
   ret i1 %val
 }
 
@@ -998,7 +998,7 @@ define i1 @test_constant_class_pinf_test_pinf_f64() nounwind {
 ; CHECK-LABEL: @test_constant_class_pinf_test_pinf_f64(
 ; CHECK-NEXT:    ret i1 true
 ;
-  %val = call i1 @llvm.amdgcn.class.f64(double 0x7FF0000000000000, i32 512)
+  %val = call i1 @llvm.amdgcn.class.f64(double +inf, i32 512)
   ret i1 %val
 }
 
@@ -1006,7 +1006,7 @@ define i1 @test_constant_class_ninf_test_pinf_f64() nounwind {
 ; CHECK-LABEL: @test_constant_class_ninf_test_pinf_f64(
 ; CHECK-NEXT:    ret i1 false
 ;
-  %val = call i1 @llvm.amdgcn.class.f64(double 0xFFF0000000000000, i32 512)
+  %val = call i1 @llvm.amdgcn.class.f64(double -inf, i32 512)
   ret i1 %val
 }
 
@@ -5037,7 +5037,7 @@ define double @trig_preop_inf_0() {
 ; CHECK-LABEL: @trig_preop_inf_0(
 ; CHECK-NEXT:    ret double f0x0B43DD63F5F2F8BD
 ;
-  %val = call double @llvm.amdgcn.trig.preop.f64(double 0x7FF0000000000000, i32 0)
+  %val = call double @llvm.amdgcn.trig.preop.f64(double +inf, i32 0)
   ret double %val
 }
 
@@ -5045,7 +5045,7 @@ define double @trig_preop_ninf_0() {
 ; CHECK-LABEL: @trig_preop_ninf_0(
 ; CHECK-NEXT:    ret double f0x0B43DD63F5F2F8BD
 ;
-  %val = call double @llvm.amdgcn.trig.preop.f64(double 0xFFF0000000000000, i32 0)
+  %val = call double @llvm.amdgcn.trig.preop.f64(double -inf, i32 0)
   ret double %val
 }
 

--- a/llvm/test/Transforms/InstCombine/AMDGPU/fma_legacy.ll
+++ b/llvm/test/Transforms/InstCombine/AMDGPU/fma_legacy.ll
@@ -109,9 +109,9 @@ define float @test_finite_assumed_nsz(float %x, float %y, float %z) {
 ; CHECK-NEXT:    ret float [[CALL]]
 ;
   %fabs.x = call float @llvm.fabs.f32(float %x)
-  %is.finite.x = fcmp one float %fabs.x, 0x7FF0000000000000
+  %is.finite.x = fcmp one float %fabs.x, +inf
   %fabs.y = call float @llvm.fabs.f32(float %y)
-  %is.finite.y = fcmp one float %fabs.y, 0x7FF0000000000000
+  %is.finite.y = fcmp one float %fabs.y, +inf
   call void @llvm.assume(i1 %is.finite.x)
   call void @llvm.assume(i1 %is.finite.y)
   %call = call nsz float @llvm.amdgcn.fma.legacy(float %x, float %y, float %z)
@@ -131,9 +131,9 @@ define float @test_finite_assumed(float %x, float %y, float %z) {
 ; CHECK-NEXT:    ret float [[CALL]]
 ;
   %fabs.x = call float @llvm.fabs.f32(float %x)
-  %is.finite.x = fcmp one float %fabs.x, 0x7FF0000000000000
+  %is.finite.x = fcmp one float %fabs.x, +inf
   %fabs.y = call float @llvm.fabs.f32(float %y)
-  %is.finite.y = fcmp one float %fabs.y, 0x7FF0000000000000
+  %is.finite.y = fcmp one float %fabs.y, +inf
   call void @llvm.assume(i1 %is.finite.x)
   call void @llvm.assume(i1 %is.finite.y)
   %call = call float @llvm.amdgcn.fma.legacy(float %x, float %y, float %z)

--- a/llvm/test/Transforms/InstCombine/AMDGPU/fmul_legacy.ll
+++ b/llvm/test/Transforms/InstCombine/AMDGPU/fmul_legacy.ll
@@ -77,9 +77,9 @@ define float @test_finite_assumed_nsz(float %x, float %y) {
 ; CHECK-NEXT:    ret float [[CALL]]
 ;
   %fabs.x = call float @llvm.fabs.f32(float %x)
-  %is.finite.x = fcmp one float %fabs.x, 0x7FF0000000000000
+  %is.finite.x = fcmp one float %fabs.x, +inf
   %fabs.y = call float @llvm.fabs.f32(float %y)
-  %is.finite.y = fcmp one float %fabs.y, 0x7FF0000000000000
+  %is.finite.y = fcmp one float %fabs.y, +inf
   call void @llvm.assume(i1 %is.finite.x)
   call void @llvm.assume(i1 %is.finite.y)
   %call = call nsz float @llvm.amdgcn.fmul.legacy(float %x, float %y)
@@ -99,9 +99,9 @@ define float @test_finite_assumed(float %x, float %y) {
 ; CHECK-NEXT:    ret float [[CALL]]
 ;
   %fabs.x = call float @llvm.fabs.f32(float %x)
-  %is.finite.x = fcmp one float %fabs.x, 0x7FF0000000000000
+  %is.finite.x = fcmp one float %fabs.x, +inf
   %fabs.y = call float @llvm.fabs.f32(float %y)
-  %is.finite.y = fcmp one float %fabs.y, 0x7FF0000000000000
+  %is.finite.y = fcmp one float %fabs.y, +inf
   call void @llvm.assume(i1 %is.finite.x)
   call void @llvm.assume(i1 %is.finite.y)
   %call = call float @llvm.amdgcn.fmul.legacy(float %x, float %y)

--- a/llvm/test/Transforms/InstCombine/atomicrmw.ll
+++ b/llvm/test/Transforms/InstCombine/atomicrmw.ll
@@ -366,7 +366,7 @@ define double @sat_fmax_inf(ptr %addr) {
 ; CHECK-NEXT:    [[RES:%.*]] = atomicrmw xchg ptr [[ADDR:%.*]], double +inf monotonic, align 8
 ; CHECK-NEXT:    ret double [[RES]]
 ;
-  %res = atomicrmw fmax ptr %addr, double 0x7FF0000000000000 monotonic
+  %res = atomicrmw fmax ptr %addr, double +inf monotonic
   ret double %res
 }
 
@@ -384,7 +384,7 @@ define double @sat_fmin_inf(ptr %addr) {
 ; CHECK-NEXT:    [[RES:%.*]] = atomicrmw xchg ptr [[ADDR:%.*]], double -inf monotonic, align 8
 ; CHECK-NEXT:    ret double [[RES]]
 ;
-  %res = atomicrmw fmin ptr %addr, double 0xFFF0000000000000 monotonic
+  %res = atomicrmw fmin ptr %addr, double -inf monotonic
   ret double %res
 }
 
@@ -402,7 +402,7 @@ define double @sat_fmaximum_inf(ptr %addr) {
 ; CHECK-NEXT:    [[RES:%.*]] = atomicrmw fmaximum ptr [[ADDR:%.*]], double +inf monotonic, align 8
 ; CHECK-NEXT:    ret double [[RES]]
 ;
-  %res = atomicrmw fmaximum ptr %addr, double 0x7FF0000000000000 monotonic
+  %res = atomicrmw fmaximum ptr %addr, double +inf monotonic
   ret double %res
 }
 
@@ -420,7 +420,7 @@ define double @sat_fminimum_inf(ptr %addr) {
 ; CHECK-NEXT:    [[RES:%.*]] = atomicrmw fminimum ptr [[ADDR:%.*]], double -inf monotonic, align 8
 ; CHECK-NEXT:    ret double [[RES]]
 ;
-  %res = atomicrmw fminimum ptr %addr, double 0xFFF0000000000000 monotonic
+  %res = atomicrmw fminimum ptr %addr, double -inf monotonic
   ret double %res
 }
 
@@ -793,7 +793,7 @@ define double @sat_fmax_inf_preserve_md(ptr %addr) {
 ; CHECK-NEXT:    [[RES:%.*]] = atomicrmw xchg ptr [[ADDR:%.*]], double +inf syncscope("agent") monotonic, align 8, !mmra [[META0]], !amdgpu.no.fine.grained.host.memory [[META1]], !amdgpu.no.remote.memory.access [[META1]]
 ; CHECK-NEXT:    ret double [[RES]]
 ;
-  %res = atomicrmw fmax ptr %addr, double 0x7FF0000000000000 syncscope("agent") monotonic, !amdgpu.no.fine.grained.host.memory !0, !amdgpu.no.remote.memory.access !0, !mmra !1
+  %res = atomicrmw fmax ptr %addr, double +inf syncscope("agent") monotonic, !amdgpu.no.fine.grained.host.memory !0, !amdgpu.no.remote.memory.access !0, !mmra !1
   ret double %res
 }
 
@@ -811,7 +811,7 @@ define double @sat_fmin_inf_preserve_md(ptr %addr) {
 ; CHECK-NEXT:    [[RES:%.*]] = atomicrmw xchg ptr [[ADDR:%.*]], double -inf syncscope("agent") monotonic, align 8, !mmra [[META0]], !amdgpu.no.fine.grained.host.memory [[META1]], !amdgpu.no.remote.memory.access [[META1]]
 ; CHECK-NEXT:    ret double [[RES]]
 ;
-  %res = atomicrmw fmin ptr %addr, double 0xFFF0000000000000 syncscope("agent") monotonic, !amdgpu.no.fine.grained.host.memory !0, !amdgpu.no.remote.memory.access !0, !mmra !1
+  %res = atomicrmw fmin ptr %addr, double -inf syncscope("agent") monotonic, !amdgpu.no.fine.grained.host.memory !0, !amdgpu.no.remote.memory.access !0, !mmra !1
   ret double %res
 }
 
@@ -829,7 +829,7 @@ define double @sat_fmaximum_inf_preserve_md(ptr %addr) {
 ; CHECK-NEXT:    [[RES:%.*]] = atomicrmw fmaximum ptr [[ADDR:%.*]], double +inf syncscope("agent") monotonic, align 8, !mmra [[META0]], !amdgpu.no.fine.grained.host.memory [[META1]], !amdgpu.no.remote.memory.access [[META1]]
 ; CHECK-NEXT:    ret double [[RES]]
 ;
-  %res = atomicrmw fmaximum ptr %addr, double 0x7FF0000000000000 syncscope("agent") monotonic, !amdgpu.no.fine.grained.host.memory !0, !amdgpu.no.remote.memory.access !0, !mmra !1
+  %res = atomicrmw fmaximum ptr %addr, double +inf syncscope("agent") monotonic, !amdgpu.no.fine.grained.host.memory !0, !amdgpu.no.remote.memory.access !0, !mmra !1
   ret double %res
 }
 
@@ -847,7 +847,7 @@ define double @sat_fminimum_inf_preserve_md(ptr %addr) {
 ; CHECK-NEXT:    [[RES:%.*]] = atomicrmw fminimum ptr [[ADDR:%.*]], double -inf syncscope("agent") monotonic, align 8, !mmra [[META0]], !amdgpu.no.fine.grained.host.memory [[META1]], !amdgpu.no.remote.memory.access [[META1]]
 ; CHECK-NEXT:    ret double [[RES]]
 ;
-  %res = atomicrmw fminimum ptr %addr, double 0xFFF0000000000000 syncscope("agent") monotonic, !amdgpu.no.fine.grained.host.memory !0, !amdgpu.no.remote.memory.access !0, !mmra !1
+  %res = atomicrmw fminimum ptr %addr, double -inf syncscope("agent") monotonic, !amdgpu.no.fine.grained.host.memory !0, !amdgpu.no.remote.memory.access !0, !mmra !1
   ret double %res
 }
 

--- a/llvm/test/Transforms/InstCombine/bitcast-select-const-vector.ll
+++ b/llvm/test/Transforms/InstCombine/bitcast-select-const-vector.ll
@@ -9,7 +9,7 @@ define double @bitcast_v2i32_select_to_double_const_rhs(double %i, <2 x i32> %i4
 ; CHECK-NEXT:    [[ASTYPE13_I_I:%.*]] = select i1 [[I42]], double [[TMP1]], double +qnan
 ; CHECK-NEXT:    ret double [[ASTYPE13_I_I]]
 ;
-  %i42 = fcmp one double %i, 0x7FF0000000000000
+  %i42 = fcmp one double %i, +inf
   %s.0.i.i = select i1 %i42, <2 x i32> %i41, <2 x i32> <i32 0, i32 2146959360>
   %astype13.i.i = bitcast <2 x i32> %s.0.i.i to double
   ret double %astype13.i.i
@@ -23,7 +23,7 @@ define double @bitcast_v2i32_select_to_double_const_lhs(double %i, <2 x i32> %i4
 ; CHECK-NEXT:    [[ASTYPE13_I_I:%.*]] = select i1 [[I42]], double +qnan, double [[TMP1]]
 ; CHECK-NEXT:    ret double [[ASTYPE13_I_I]]
 ;
-  %i42 = fcmp one double %i, 0x7FF0000000000000
+  %i42 = fcmp one double %i, +inf
   %s.0.i.i = select i1 %i42, <2 x i32> <i32 0, i32 2146959360>, <2 x i32> %i41
   %astype13.i.i = bitcast <2 x i32> %s.0.i.i to double
   ret double %astype13.i.i
@@ -66,7 +66,7 @@ define double @bitcast_v2i32_vselect_to_double_const_rhs(<2 x double> %cmp.vec, 
 ; CHECK-NEXT:    [[ASTYPE13_I_I:%.*]] = bitcast <2 x i32> [[S_0_I_I]] to double
 ; CHECK-NEXT:    ret double [[ASTYPE13_I_I]]
 ;
-  %vcmp = fcmp one <2 x double> %cmp.vec, splat (double 0x7FF0000000000000)
+  %vcmp = fcmp one <2 x double> %cmp.vec, splat (double +inf)
   %select = select <2 x i1> %vcmp, <2 x i32> %val, <2 x i32> <i32 0, i32 2146959360>
   %cast = bitcast <2 x i32> %select to double
   ret double %cast
@@ -80,7 +80,7 @@ define <2 x float> @bitcast_v4i16_select_to_v2f32_const_lhs(double %arg, <4 x i1
 ; CHECK-NEXT:    [[ASTYPE13_I_I:%.*]] = select i1 [[CMP]], <2 x float> <float f0x5B950000, float f0x85BA270F>, <2 x float> [[TMP1]]
 ; CHECK-NEXT:    ret <2 x float> [[ASTYPE13_I_I]]
 ;
-  %cmp = fcmp one double %arg, 0x7FF0000000000000
+  %cmp = fcmp one double %arg, +inf
   %select = select i1 %cmp, <4 x i16> <i16 0, i16 23445, i16 9999, i16 34234>, <4 x i16> %vec.v4i16
   %astype13.i.i = bitcast <4 x i16> %select to <2 x float>
   ret <2 x float> %astype13.i.i
@@ -94,7 +94,7 @@ define <2 x float> @bitcast_v4i16_select_to_v2f32_const_rhs(double %arg, <4 x i1
 ; CHECK-NEXT:    [[ASTYPE13_I_I:%.*]] = select i1 [[CMP]], <2 x float> [[TMP1]], <2 x float> <float f0x5B950000, float f0x85BA270F>
 ; CHECK-NEXT:    ret <2 x float> [[ASTYPE13_I_I]]
 ;
-  %cmp = fcmp one double %arg, 0x7FF0000000000000
+  %cmp = fcmp one double %arg, +inf
   %select = select i1 %cmp, <4 x i16> %vec.v4i16, <4 x i16> <i16 0, i16 23445, i16 9999, i16 34234>
   %astype13.i.i = bitcast <4 x i16> %select to <2 x float>
   ret <2 x float> %astype13.i.i
@@ -108,7 +108,7 @@ define <2 x float> @bitcast_v2i32_select_to_v2f32_const_rhs(double %arg, <2 x i3
 ; CHECK-NEXT:    [[ASTYPE13_I_I:%.*]] = select i1 [[I42]], <2 x float> [[TMP1]], <2 x float> <float 0.000000e+00, float +nan(0x380000)>
 ; CHECK-NEXT:    ret <2 x float> [[ASTYPE13_I_I]]
 ;
-  %cmp = fcmp one double %arg, 0x7FF0000000000000
+  %cmp = fcmp one double %arg, +inf
   %s.0.i.i = select i1 %cmp, <2 x i32> %vec, <2 x i32> <i32 0, i32 2146959360>
   %astype13.i.i = bitcast <2 x i32> %s.0.i.i to <2 x float>
   ret <2 x float> %astype13.i.i
@@ -122,7 +122,7 @@ define <2 x float> @bitcast_v2i32_select_to_v2f32_const_lhs(double %arg, <2 x i3
 ; CHECK-NEXT:    [[ASTYPE13_I_I:%.*]] = select i1 [[CMP]], <2 x float> <float 0.000000e+00, float +nan(0x380000)>, <2 x float> [[TMP1]]
 ; CHECK-NEXT:    ret <2 x float> [[ASTYPE13_I_I]]
 ;
-  %cmp = fcmp one double %arg, 0x7FF0000000000000
+  %cmp = fcmp one double %arg, +inf
   %s.0.i.i = select i1 %cmp, <2 x i32> <i32 0, i32 2146959360>, <2 x i32> %vec
   %astype13.i.i = bitcast <2 x i32> %s.0.i.i to <2 x float>
   ret <2 x float> %astype13.i.i

--- a/llvm/test/Transforms/InstCombine/cast-int-fcmp-eq-0.ll
+++ b/llvm/test/Transforms/InstCombine/cast-int-fcmp-eq-0.ll
@@ -485,7 +485,7 @@ define i1 @i32_cast_cmp_oeq_int_inf_uitofp(i32 %i) {
 ; CHECK-NEXT:    ret i1 false
 ;
   %f = uitofp i32 %i to float
-  %cmp = fcmp oeq float %f, 0x7FF0000000000000
+  %cmp = fcmp oeq float %f, +inf
   ret i1 %cmp
 }
 
@@ -494,7 +494,7 @@ define i1 @i32_cast_cmp_oeq_int_inf_sitofp(i32 %i) {
 ; CHECK-NEXT:    ret i1 false
 ;
   %f = sitofp i32 %i to float
-  %cmp = fcmp oeq float %f, 0x7FF0000000000000
+  %cmp = fcmp oeq float %f, +inf
   ret i1 %cmp
 }
 
@@ -506,7 +506,7 @@ define i1 @i128_cast_cmp_oeq_int_inf_uitofp(i128 %i) {
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
   %f = uitofp i128 %i to float
-  %cmp = fcmp oeq float %f, 0x7FF0000000000000
+  %cmp = fcmp oeq float %f, +inf
   ret i1 %cmp
 }
 

--- a/llvm/test/Transforms/InstCombine/constant-fold-nextafter.ll
+++ b/llvm/test/Transforms/InstCombine/constant-fold-nextafter.ll
@@ -15,11 +15,11 @@
 @dbl_pos_min_subnormal = constant double 4.940660e-324, align 8
 @dbl_pos_min_normal = constant double 0x10000000000000, align 8
 @dbl_pos_max = constant double 0x7FEFFFFFFFFFFFFF, align 8
-@dbl_pos_infinity = constant double 0x7FF0000000000000, align 8
+@dbl_pos_infinity = constant double +inf, align 8
 @dbl_neg_min_subnormal = constant double -4.940660e-324, align 8
 @dbl_neg_min_normal = constant double 0x8010000000000000, align 8
 @dbl_neg_max = constant double 0xFFEFFFFFFFFFFFFF, align 8
-@dbl_neg_infinity = constant double 0xFFF0000000000000, align 8
+@dbl_neg_infinity = constant double -inf, align 8
 
 define double @nextafter_up_direction() {
 ; CHECK-LABEL: define double @nextafter_up_direction() {

--- a/llvm/test/Transforms/InstCombine/constant-fold-nexttoward-fp128.ll
+++ b/llvm/test/Transforms/InstCombine/constant-fold-nexttoward-fp128.ll
@@ -14,11 +14,11 @@
 @dbl_pos_min_subnormal = constant double 4.940660e-324, align 8
 @dbl_pos_min_normal = constant double 0x10000000000000, align 8
 @dbl_pos_max = constant double 0x7FEFFFFFFFFFFFFF, align 8
-@dbl_pos_infinity = constant double 0x7FF0000000000000, align 8
+@dbl_pos_infinity = constant double +inf, align 8
 @dbl_neg_min_subnormal = constant double -4.940660e-324, align 8
 @dbl_neg_min_normal = constant double 0x8010000000000000, align 8
 @dbl_neg_max = constant double 0xFFEFFFFFFFFFFFFF, align 8
-@dbl_neg_infinity = constant double 0xFFF0000000000000, align 8
+@dbl_neg_infinity = constant double -inf, align 8
 
 define double @nexttoward_up_direction() {
 ; CHECK-LABEL: define double @nexttoward_up_direction() {

--- a/llvm/test/Transforms/InstCombine/constant-fold-nexttoward-ppc-fp128.ll
+++ b/llvm/test/Transforms/InstCombine/constant-fold-nexttoward-ppc-fp128.ll
@@ -14,11 +14,11 @@
 @dbl_pos_min_subnormal = constant double 4.940660e-324, align 8
 @dbl_pos_min_normal = constant double 0x10000000000000, align 8
 @dbl_pos_max = constant double 0x7FEFFFFFFFFFFFFF, align 8
-@dbl_pos_infinity = constant double 0x7FF0000000000000, align 8
+@dbl_pos_infinity = constant double +inf, align 8
 @dbl_neg_min_subnormal = constant double -4.940660e-324, align 8
 @dbl_neg_min_normal = constant double 0x8010000000000000, align 8
 @dbl_neg_max = constant double 0xFFEFFFFFFFFFFFFF, align 8
-@dbl_neg_infinity = constant double 0xFFF0000000000000, align 8
+@dbl_neg_infinity = constant double -inf, align 8
 
 define double @nexttoward_up_direction() {
 ; CHECK-LABEL: define double @nexttoward_up_direction() {

--- a/llvm/test/Transforms/InstCombine/constant-fold-nexttoward-x86-fp80.ll
+++ b/llvm/test/Transforms/InstCombine/constant-fold-nexttoward-x86-fp80.ll
@@ -14,11 +14,11 @@
 @dbl_pos_min_subnormal = constant double 4.940660e-324, align 8
 @dbl_pos_min_normal = constant double 0x10000000000000, align 8
 @dbl_pos_max = constant double 0x7FEFFFFFFFFFFFFF, align 8
-@dbl_pos_infinity = constant double 0x7FF0000000000000, align 8
+@dbl_pos_infinity = constant double +inf, align 8
 @dbl_neg_min_subnormal = constant double -4.940660e-324, align 8
 @dbl_neg_min_normal = constant double 0x8010000000000000, align 8
 @dbl_neg_max = constant double 0xFFEFFFFFFFFFFFFF, align 8
-@dbl_neg_infinity = constant double 0xFFF0000000000000, align 8
+@dbl_neg_infinity = constant double -inf, align 8
 
 define double @nexttoward_up_direction() {
 ; CHECK-LABEL: define double @nexttoward_up_direction() {

--- a/llvm/test/Transforms/InstCombine/erf.ll
+++ b/llvm/test/Transforms/InstCombine/erf.ll
@@ -69,7 +69,7 @@ define double @erf_inf() {
 ; CHECK-NEXT:    [[R:%.*]] = call double @erf(double +inf)
 ; CHECK-NEXT:    ret double [[R]]
 ;
-  %r = call double @erf(double 0x7FF0000000000000)
+  %r = call double @erf(double +inf)
   ret double %r
 }
 
@@ -87,7 +87,7 @@ define double @erf_inf_memory_none() {
 ; CHECK-NEXT:    [[R:%.*]] = call double @erf(double +inf) #[[ATTR2]]
 ; CHECK-NEXT:    ret double [[R]]
 ;
-  %r = call double @erf(double 0x7FF0000000000000) readnone
+  %r = call double @erf(double +inf) readnone
   ret double %r
 }
 
@@ -105,7 +105,7 @@ define double @erf_neg_inf() {
 ; CHECK-NEXT:    [[R:%.*]] = call double @erf(double -inf)
 ; CHECK-NEXT:    ret double [[R]]
 ;
-  %r = call double @erf(double 0xFFF0000000000000)
+  %r = call double @erf(double -inf)
   ret double %r
 }
 
@@ -123,7 +123,7 @@ define double @erf_neg_inf_memory_none() {
 ; CHECK-NEXT:    [[R:%.*]] = call double @erf(double -inf) #[[ATTR2]]
 ; CHECK-NEXT:    ret double [[R]]
 ;
-  %r = call double @erf(double 0xFFF0000000000000) readnone
+  %r = call double @erf(double -inf) readnone
   ret double %r
 }
 

--- a/llvm/test/Transforms/InstCombine/fcmp-range-check-idiom.ll
+++ b/llvm/test/Transforms/InstCombine/fcmp-range-check-idiom.ll
@@ -140,8 +140,8 @@ define i1 @test_and_olt_infinity(float %x) {
 ; CHECK-NEXT:    [[COND:%.*]] = fcmp one float [[TMP1]], +inf
 ; CHECK-NEXT:    ret i1 [[COND]]
 ;
-  %cmp1 = fcmp olt float %x, 0x7FF0000000000000
-  %cmp2 = fcmp ogt float %x, 0xFFF0000000000000
+  %cmp1 = fcmp olt float %x, +inf
+  %cmp2 = fcmp ogt float %x, -inf
   %cond = and i1 %cmp1, %cmp2
   ret i1 %cond
 }

--- a/llvm/test/Transforms/InstCombine/fcmp-select.ll
+++ b/llvm/test/Transforms/InstCombine/fcmp-select.ll
@@ -292,7 +292,7 @@ define double @test_fcmp_ord_select_fabs_fcmp_one_select_var_const(double %x) {
   %cmp1 = fcmp ord double %x, 0.000000e+00
   %sel1 = select i1 %cmp1, double %x, double 0.000000e+00
   %abs = call double @llvm.fabs.f64(double %sel1)
-  %cmp2 = fcmp one double %abs, 0x7FF0000000000000
+  %cmp2 = fcmp one double %abs, +inf
   %sel2 = select i1 %cmp2, double %sel1, double 0.000000e+00
   ret double %sel2
 }
@@ -307,7 +307,7 @@ define double @test_fcmp_ord_commuted_select_fabs_fcmp_one_select_var_const(doub
   %cmp1 = fcmp ord double 0.000000e+00, %x
   %sel1 = select i1 %cmp1, double %x, double 0.000000e+00
   %abs = call double @llvm.fabs.f64(double %sel1)
-  %cmp2 = fcmp one double %abs, 0x7FF0000000000000
+  %cmp2 = fcmp one double %abs, +inf
   %sel2 = select i1 %cmp2, double %sel1, double 0.000000e+00
   ret double %sel2
 }
@@ -322,7 +322,7 @@ define double @test_fcmp_ord_select_fabs_fcmp_one_select_nonnan_const(double %x,
   %cmp1 = fcmp ord double %x, 1.000000e+00
   %sel1 = select i1 %cmp1, double %x, double %y
   %abs = call double @llvm.fabs.f64(double %sel1)
-  %cmp2 = fcmp one double %abs, 0x7FF0000000000000
+  %cmp2 = fcmp one double %abs, +inf
   %sel2 = select i1 %cmp2, double %sel1, double %y
   ret double %sel2
 }
@@ -337,7 +337,7 @@ define double @test_fcmp_ord_self_select_fabs_fcmp_one_select_var_var(double %x,
   %cmp1 = fcmp ord double %x, %x
   %sel1 = select i1 %cmp1, double %x, double %y
   %abs = call double @llvm.fabs.f64(double %sel1)
-  %cmp2 = fcmp one double %abs, 0x7FF0000000000000
+  %cmp2 = fcmp one double %abs, +inf
   %sel2 = select i1 %cmp2, double %sel1, double %y
   ret double %sel2
 }
@@ -353,7 +353,7 @@ define double @test_fcmp_ord_select_fabs_fcmp_one_select_uitofp_nonnan(double %x
   %cmp1 = fcmp ord double %x, %nonnan
   %sel1 = select i1 %cmp1, double %x, double %y
   %abs = call double @llvm.fabs.f64(double %sel1)
-  %cmp2 = fcmp one double %abs, 0x7FF0000000000000
+  %cmp2 = fcmp one double %abs, +inf
   %sel2 = select i1 %cmp2, double %sel1, double %y
   ret double %sel2
 }
@@ -369,7 +369,7 @@ define double @test_fcmp_ord_commuted_select_fabs_fcmp_one_select_sitofp_nonnan(
   %cmp1 = fcmp ord double %nonnan, %x
   %sel1 = select i1 %cmp1, double %x, double %y
   %abs = call double @llvm.fabs.f64(double %sel1)
-  %cmp2 = fcmp one double %abs, 0x7FF0000000000000
+  %cmp2 = fcmp one double %abs, +inf
   %sel2 = select i1 %cmp2, double %sel1, double %y
   ret double %sel2
 }
@@ -402,7 +402,7 @@ define double @test_fcmp_ord_select_fabs_fcmp_une_select_var_const(double %x) {
   %cmp1 = fcmp ord double %x, 0.000000e+00
   %sel1 = select i1 %cmp1, double %x, double 0.000000e+00
   %abs = call double @llvm.fabs.f64(double %sel1)
-  %cmp2 = fcmp une double %abs, 0x7FF0000000000000
+  %cmp2 = fcmp une double %abs, +inf
   %sel2 = select i1 %cmp2, double %sel1, double 0.000000e+00
   ret double %sel2
 }
@@ -417,7 +417,7 @@ define double @test_fcmp_ord_select_fabs_fcmp_nnan_one_select_var_var(double %x,
   %cmp1 = fcmp ord double %x, 0.000000e+00
   %sel1 = select i1 %cmp1, double %x, double %y
   %abs = call double @llvm.fabs.f64(double %sel1)
-  %cmp2 = fcmp nnan one double %abs, 0x7FF0000000000000
+  %cmp2 = fcmp nnan one double %abs, +inf
   %sel2 = select i1 %cmp2, double %sel1, double %y
   ret double %sel2
 }
@@ -447,7 +447,7 @@ define <2 x double> @test_fcmp_ord_select_fabs_fcmp_one_select_v2f64(<2 x double
   %cmp1 = fcmp ord <2 x double> %x, zeroinitializer
   %sel1 = select <2 x i1> %cmp1, <2 x double> %x, <2 x double> %y
   %abs = call <2 x double> @llvm.fabs.v2f64(<2 x double> %sel1)
-  %cmp2 = fcmp one <2 x double> %abs, <double 0x7FF0000000000000, double 0x7FF0000000000000>
+  %cmp2 = fcmp one <2 x double> %abs, <double +inf, double +inf>
   %sel2 = select <2 x i1> %cmp2, <2 x double> %sel1, <2 x double> %y
   ret <2 x double> %sel2
 }
@@ -463,7 +463,7 @@ define <2 x double> @test_fcmp_ord_select_fabs_fcmp_one_select_uitofp_v2f64(<2 x
   %cmp1 = fcmp ord <2 x double> %x, %nonnan
   %sel1 = select <2 x i1> %cmp1, <2 x double> %x, <2 x double> %y
   %abs = call <2 x double> @llvm.fabs.v2f64(<2 x double> %sel1)
-  %cmp2 = fcmp one <2 x double> %abs, <double 0x7FF0000000000000, double 0x7FF0000000000000>
+  %cmp2 = fcmp one <2 x double> %abs, <double +inf, double +inf>
   %sel2 = select <2 x i1> %cmp2, <2 x double> %sel1, <2 x double> %y
   ret <2 x double> %sel2
 }
@@ -478,7 +478,7 @@ define <2 x double> @test_fcmp_ord_select_fabs_fcmp_nnan_one_select_v2f64(<2 x d
   %cmp1 = fcmp ord <2 x double> %x, zeroinitializer
   %sel1 = select <2 x i1> %cmp1, <2 x double> %x, <2 x double> %y
   %abs = call <2 x double> @llvm.fabs.v2f64(<2 x double> %sel1)
-  %cmp2 = fcmp nnan one <2 x double> %abs, <double 0x7FF0000000000000, double 0x7FF0000000000000>
+  %cmp2 = fcmp nnan one <2 x double> %abs, <double +inf, double +inf>
   %sel2 = select <2 x i1> %cmp2, <2 x double> %sel1, <2 x double> %y
   ret <2 x double> %sel2
 }

--- a/llvm/test/Transforms/InstCombine/fdim.ll
+++ b/llvm/test/Transforms/InstCombine/fdim.ll
@@ -71,7 +71,7 @@ define double @fdim_inf_ninf() {
 ; CHECK-LABEL: define double @fdim_inf_ninf() {
 ; CHECK-NEXT:    ret double +inf
 ;
-  %dim = call double @fdim(double 0x7FF0000000000000, double 0x8000000000000000 )
+  %dim = call double @fdim(double +inf, double 0x8000000000000000 )
   ret double %dim
 }
 
@@ -79,7 +79,7 @@ define double @fdim_inf() {
 ; CHECK-LABEL: define double @fdim_inf() {
 ; CHECK-NEXT:    ret double 0.000000e+00
 ;
-  %dim = call double @fdim(double 0x7FF0000000000000, double 0x7FF0000000000000)
+  %dim = call double @fdim(double +inf, double +inf)
   ret double %dim
 }
 
@@ -87,7 +87,7 @@ define double @fdim_ninf() {
 ; CHECK-LABEL: define double @fdim_ninf() {
 ; CHECK-NEXT:    ret double 0.000000e+00
 ;
-  %dim = call double @fdim(double 0xFFF0000000000000, double 0xFFF0000000000000)
+  %dim = call double @fdim(double -inf, double -inf)
   ret double %dim
 }
 

--- a/llvm/test/Transforms/InstCombine/fmod.ll
+++ b/llvm/test/Transforms/InstCombine/fmod.ll
@@ -16,7 +16,7 @@ define float @test_inf_const(float %f) {
 ;
 entry:
   %abs = tail call float @llvm.fabs.f32(float %f)
-  %isinf = fcmp oeq float %abs, 0x7FF0000000000000
+  %isinf = fcmp oeq float %abs, +inf
   br i1 %isinf, label %return, label %if.end
 
 if.end:

--- a/llvm/test/Transforms/InstCombine/fneg.ll
+++ b/llvm/test/Transforms/InstCombine/fneg.ll
@@ -94,7 +94,7 @@ define <4 x double> @fmul_fsub_vec(<4 x double> %x) {
 ; CHECK-NEXT:    [[R:%.*]] = fmul <4 x double> [[X:%.*]], <double -4.200000e+01, double -qnan, double -inf, double poison>
 ; CHECK-NEXT:    ret <4 x double> [[R]]
 ;
-  %m = fmul <4 x double> %x, <double 42.0, double 0x7FF8000000000000, double 0x7FF0000000000000, double poison>
+  %m = fmul <4 x double> %x, <double 42.0, double 0x7FF8000000000000, double +inf, double poison>
   %r = fsub <4 x double> <double -0.0, double -0.0, double -0.0, double -0.0>, %m
   ret <4 x double> %r
 }
@@ -104,7 +104,7 @@ define <4 x double> @fmul_fneg_vec(<4 x double> %x) {
 ; CHECK-NEXT:    [[R:%.*]] = fmul <4 x double> [[X:%.*]], <double -4.200000e+01, double -qnan, double -inf, double poison>
 ; CHECK-NEXT:    ret <4 x double> [[R]]
 ;
-  %m = fmul <4 x double> %x, <double 42.0, double 0x7FF8000000000000, double 0x7FF0000000000000, double poison>
+  %m = fmul <4 x double> %x, <double 42.0, double 0x7FF8000000000000, double +inf, double poison>
   %r = fneg <4 x double> %m
   ret <4 x double> %r
 }
@@ -173,7 +173,7 @@ define float @fdiv_op1_constant_fneg_ninf(float %x) {
 ; CHECK-NEXT:    [[R:%.*]] = fdiv float [[X:%.*]], -inf
 ; CHECK-NEXT:    ret float [[R]]
 ;
-  %d = fdiv float %x, 0x7FF0000000000000
+  %d = fdiv float %x, +inf
   %r = fneg ninf float %d
   ret float %r
 }
@@ -245,7 +245,7 @@ define <4 x double> @fdiv_op1_constant_fsub_vec(<4 x double> %x) {
 ; CHECK-NEXT:    [[R:%.*]] = fdiv <4 x double> [[X:%.*]], <double 4.200000e+01, double +nan(0xABCD000), double +inf, double poison>
 ; CHECK-NEXT:    ret <4 x double> [[R]]
 ;
-  %d = fdiv <4 x double> %x, <double -42.0, double 0xFFF800000ABCD000, double 0xFFF0000000000000, double poison>
+  %d = fdiv <4 x double> %x, <double -42.0, double 0xFFF800000ABCD000, double -inf, double poison>
   %r = fsub <4 x double> <double -0.0, double -0.0, double -0.0, double -0.0>, %d
   ret <4 x double> %r
 }
@@ -255,7 +255,7 @@ define <4 x double> @fdiv_op1_constant_fneg_vec(<4 x double> %x) {
 ; CHECK-NEXT:    [[R:%.*]] = fdiv <4 x double> [[X:%.*]], <double 4.200000e+01, double +nan(0xABCD000), double +inf, double poison>
 ; CHECK-NEXT:    ret <4 x double> [[R]]
 ;
-  %d = fdiv <4 x double> %x, <double -42.0, double 0xFFF800000ABCD000, double 0xFFF0000000000000, double poison>
+  %d = fdiv <4 x double> %x, <double -42.0, double 0xFFF800000ABCD000, double -inf, double poison>
   %r = fneg <4 x double> %d
   ret <4 x double> %r
 }
@@ -419,7 +419,7 @@ define <4 x double> @fdiv_op0_constant_fsub_vec(<4 x double> %x) {
 ; CHECK-NEXT:    [[R:%.*]] = fdiv <4 x double> <double 4.200000e+01, double -qnan, double +inf, double poison>, [[X:%.*]]
 ; CHECK-NEXT:    ret <4 x double> [[R]]
 ;
-  %d = fdiv <4 x double> <double -42.0, double 0x7FF8000000000000, double 0xFFF0000000000000, double poison>, %x
+  %d = fdiv <4 x double> <double -42.0, double 0x7FF8000000000000, double -inf, double poison>, %x
   %r = fsub <4 x double> <double -0.0, double -0.0, double -0.0, double -0.0>, %d
   ret <4 x double> %r
 }
@@ -429,7 +429,7 @@ define <4 x double> @fdiv_op0_constant_fneg_vec(<4 x double> %x) {
 ; CHECK-NEXT:    [[R:%.*]] = fdiv <4 x double> <double 4.200000e+01, double -qnan, double +inf, double poison>, [[X:%.*]]
 ; CHECK-NEXT:    ret <4 x double> [[R]]
 ;
-  %d = fdiv <4 x double> <double -42.0, double 0x7FF8000000000000, double 0xFFF0000000000000, double poison>, %x
+  %d = fdiv <4 x double> <double -42.0, double 0x7FF8000000000000, double -inf, double poison>, %x
   %r = fneg <4 x double> %d
   ret <4 x double> %r
 }

--- a/llvm/test/Transforms/InstCombine/fold-calls.ll
+++ b/llvm/test/Transforms/InstCombine/fold-calls.ll
@@ -4,7 +4,7 @@
 ; CHECK-LABEL: @foo(
 ; CHECK:   %t = call double @sin(double +inf)
 define double @foo() {
-  %t = call double @sin(double 0x7FF0000000000000)
+  %t = call double @sin(double +inf)
   ret double %t
 }
 

--- a/llvm/test/Transforms/InstCombine/fold-fcmp-trunc.ll
+++ b/llvm/test/Transforms/InstCombine/fold-fcmp-trunc.ll
@@ -75,7 +75,7 @@ define i1 @fcmp_trunc_ord_inf(double %0) {
 ; CHECK-NEXT:    ret i1 [[RESULT]]
 ;
   %trunc = fptrunc double %0 to float
-  %result = fcmp ord float %trunc, 0x7FF0000000000000
+  %result = fcmp ord float %trunc, +inf
   ret i1 %result
 }
 
@@ -365,7 +365,7 @@ define i1 @fcmp_trunc_literal_positive_inf(double %0) {
 ; CHECK-NEXT:    ret i1 [[RESULT]]
 ;
   %trunc = fptrunc double %0 to float
-  %result = fcmp oge float %trunc, 0x7FF0000000000000
+  %result = fcmp oge float %trunc, +inf
   ret i1 %result
 }
 
@@ -377,7 +377,7 @@ define i1 @fcmp_trunc_literal_negative_inf(double %0) {
 ; CHECK-NEXT:    ret i1 [[RESULT]]
 ;
   %trunc = fptrunc double %0 to float
-  %result = fcmp ult float %trunc, 0xFFF0000000000000
+  %result = fcmp ult float %trunc, -inf
   ret i1 %result
 }
 
@@ -400,7 +400,7 @@ define i1 @fcmp_trunc_inf_uge(double %0) {
 ; CHECK-NEXT:    ret i1 [[RESULT]]
 ;
   %trunc = fptrunc double %0 to float
-  %result = fcmp uge float %trunc, 0x7FF0000000000000
+  %result = fcmp uge float %trunc, +inf
   ret i1 %result
 }
 
@@ -411,7 +411,7 @@ define i1 @fcmp_trunc_ninf_olt(double %0) {
 ; CHECK-NEXT:    ret i1 false
 ;
   %trunc = fptrunc double %0 to float
-  %result = fcmp olt float %trunc, 0xFFF0000000000000
+  %result = fcmp olt float %trunc, -inf
   ret i1 %result
 }
 

--- a/llvm/test/Transforms/InstCombine/fold-select-fmul-if-zero.ll
+++ b/llvm/test/Transforms/InstCombine/fold-select-fmul-if-zero.ll
@@ -376,7 +376,7 @@ define float @fmul_by_neginf_if_0_oeq_zero_f32(float %x) {
 ; CHECK-NEXT:    ret float [[SCALED_IF_DENORMAL]]
 ;
   %x.is.zero = fcmp oeq float %x, 0.0
-  %scaled.x = fmul float %x, 0xFFF0000000000000
+  %scaled.x = fmul float %x, -inf
   %scaled.if.denormal = select i1 %x.is.zero, float %scaled.x, float %x
   ret float %scaled.if.denormal
 }
@@ -389,7 +389,7 @@ define float @fmul_by_posinf_if_0_oeq_zero_f32(float %x) {
 ; CHECK-NEXT:    ret float [[SCALED_IF_DENORMAL]]
 ;
   %x.is.zero = fcmp oeq float %x, 0.0
-  %scaled.x = fmul float %x, 0x7FF0000000000000
+  %scaled.x = fmul float %x, +inf
   %scaled.if.denormal = select i1 %x.is.zero, float %scaled.x, float %x
   ret float %scaled.if.denormal
 }
@@ -658,7 +658,7 @@ define float @fmul_by_var_if_0_oeq_zero_f32_assume_finite_fmul_nsz(float %x, flo
 ; CHECK-NEXT:    ret float [[X:%.*]]
 ;
   %fabs.y = call float @llvm.fabs.f32(float %y)
-  %is.finite = fcmp olt float %fabs.y, 0x7FF0000000000000
+  %is.finite = fcmp olt float %fabs.y, +inf
   call void @llvm.assume(i1 %is.finite)
   %x.is.zero = fcmp oeq float %x, 0.0
   %scaled.x = fmul float %x, %y
@@ -675,7 +675,7 @@ define float @fmul_by_var_if_not_one_0_zero_f32_assume_finite_fmul_nsz(float %x,
 ; CHECK-NEXT:    ret float [[X:%.*]]
 ;
   %fabs.y = call float @llvm.fabs.f32(float %y)
-  %is.finite = fcmp olt float %fabs.y, 0x7FF0000000000000
+  %is.finite = fcmp olt float %fabs.y, +inf
   call void @llvm.assume(i1 %is.finite)
   %x.is.not.zero = fcmp one float %x, 0.0
   %scaled.x = fmul float %x, %y

--- a/llvm/test/Transforms/InstCombine/fpclass-from-dom-cond.ll
+++ b/llvm/test/Transforms/InstCombine/fpclass-from-dom-cond.ll
@@ -88,7 +88,7 @@ entry:
   br i1 %cmp, label %if.then, label %if.else
 if.then:
   %abs = call float @llvm.fabs.f32(float %x)
-  %ret = fcmp oeq float %abs, 0x7FF0000000000000
+  %ret = fcmp oeq float %abs, +inf
   ret i1 %ret
 if.else:
   ret i1 false
@@ -216,7 +216,7 @@ define i1 @test8(float %x) {
 ; CHECK-NEXT:    ret i1 [[RET2]]
 ;
   %abs = call float @llvm.fabs.f32(float %x)
-  %cond = fcmp oeq float %abs, 0x7FF0000000000000
+  %cond = fcmp oeq float %abs, +inf
   br i1 %cond, label %if.then, label %if.else
 if.then:
   %ret1 = call i1 @llvm.is.fpclass.f32(float %x, i32 575)
@@ -239,7 +239,7 @@ define i1 @test9(float %x) {
   %cond = fcmp olt float %x, -1.0
   br i1 %cond, label %if.then, label %if.else
 if.then:
-  %ret1 = fcmp oeq float %x, 0x7FF0000000000000
+  %ret1 = fcmp oeq float %x, +inf
   ret i1 %ret1
 if.else:
   ret i1 false
@@ -259,7 +259,7 @@ define i1 @test10(float %x) {
   %neg = fneg float %x
   br i1 %cond, label %if.then, label %if.else
 if.then:
-  %ret1 = fcmp oeq float %neg, 0xFFF0000000000000
+  %ret1 = fcmp oeq float %neg, -inf
   ret i1 %ret1
 if.else:
   ret i1 false
@@ -281,7 +281,7 @@ define i1 @test11_and(float %x, i1 %cond2) {
   %and = and i1 %cond, %cond2
   br i1 %and, label %if.then, label %if.else
 if.then:
-  %ret1 = fcmp oeq float %neg, 0xFFF0000000000000
+  %ret1 = fcmp oeq float %neg, -inf
   ret i1 %ret1
 if.else:
   ret i1 false
@@ -537,7 +537,7 @@ define i1 @test_inv_and(float %x, i1 %cond2) {
   %and = and i1 %not, %cond2
   br i1 %and, label %if.then, label %if.else
 if.then:
-  %ret1 = fcmp oeq float %neg, 0xFFF0000000000000
+  %ret1 = fcmp oeq float %neg, -inf
   ret i1 %ret1
 if.else:
   ret i1 false

--- a/llvm/test/Transforms/InstCombine/frem-inf.ll
+++ b/llvm/test/Transforms/InstCombine/frem-inf.ll
@@ -22,6 +22,6 @@ define i1 @test_frem_fcmp_inf(double %a, double %b) {
 ;
 entry:
   %rem = frem double %a, %b
-  %is.inf = fcmp oeq double %rem, 0x7FF0000000000000
+  %is.inf = fcmp oeq double %rem, +inf
   ret i1 %is.inf
 }

--- a/llvm/test/Transforms/InstCombine/ilogb.ll
+++ b/llvm/test/Transforms/InstCombine/ilogb.ll
@@ -87,7 +87,7 @@ define i32 @ilogb_inf() {
 ; CHECK-NEXT:    [[R:%.*]] = call i32 @ilogb(double +inf)
 ; CHECK-NEXT:    ret i32 [[R]]
 ;
-  %r = call i32 @ilogb(double 0x7FF0000000000000)
+  %r = call i32 @ilogb(double +inf)
   ret i32 %r
 }
 
@@ -159,7 +159,7 @@ define i32 @ilogb_inf_readnone() {
 ; CHECK-NEXT:    [[R:%.*]] = call i32 @ilogb(double +inf) #[[ATTR0]]
 ; CHECK-NEXT:    ret i32 [[R]]
 ;
-  %r = call i32 @ilogb(double 0x7FF0000000000000) readnone
+  %r = call i32 @ilogb(double +inf) readnone
   ret i32 %r
 }
 

--- a/llvm/test/Transforms/InstCombine/intrinsic-select.ll
+++ b/llvm/test/Transforms/InstCombine/intrinsic-select.ll
@@ -315,7 +315,7 @@ define double @test_fabs_select2(double %a) {
 ; CHECK-NEXT:    ret double [[ABS2]]
 ;
   %abs1 = call double @llvm.fabs.f64(double %a)
-  %cmp = fcmp oeq double %abs1, 0x7FF0000000000000
+  %cmp = fcmp oeq double %abs1, +inf
   %sel = select i1 %cmp, double -0.000000e+00, double %abs1
   %abs2 = call double @llvm.fabs.f64(double %sel)
   ret double %abs2

--- a/llvm/test/Transforms/InstCombine/is_fpclass.ll
+++ b/llvm/test/Transforms/InstCombine/is_fpclass.ll
@@ -650,7 +650,7 @@ define i1 @test_constant_class_ninf_test_ninf_f64() {
 ; CHECK-LABEL: @test_constant_class_ninf_test_ninf_f64(
 ; CHECK-NEXT:    ret i1 true
 ;
-  %val = call i1 @llvm.is.fpclass.f64(double 0xFFF0000000000000, i32 4)
+  %val = call i1 @llvm.is.fpclass.f64(double -inf, i32 4)
   ret i1 %val
 }
 
@@ -658,7 +658,7 @@ define i1 @test_constant_class_pinf_test_ninf_f64() {
 ; CHECK-LABEL: @test_constant_class_pinf_test_ninf_f64(
 ; CHECK-NEXT:    ret i1 false
 ;
-  %val = call i1 @llvm.is.fpclass.f64(double 0x7FF0000000000000, i32 4)
+  %val = call i1 @llvm.is.fpclass.f64(double +inf, i32 4)
   ret i1 %val
 }
 
@@ -778,7 +778,7 @@ define i1 @test_constant_class_pinf_test_pinf_f64() {
 ; CHECK-LABEL: @test_constant_class_pinf_test_pinf_f64(
 ; CHECK-NEXT:    ret i1 true
 ;
-  %val = call i1 @llvm.is.fpclass.f64(double 0x7FF0000000000000, i32 512)
+  %val = call i1 @llvm.is.fpclass.f64(double +inf, i32 512)
   ret i1 %val
 }
 
@@ -786,7 +786,7 @@ define i1 @test_constant_class_ninf_test_pinf_f64() {
 ; CHECK-LABEL: @test_constant_class_ninf_test_pinf_f64(
 ; CHECK-NEXT:    ret i1 false
 ;
-  %val = call i1 @llvm.is.fpclass.f64(double 0xFFF0000000000000, i32 512)
+  %val = call i1 @llvm.is.fpclass.f64(double -inf, i32 512)
   ret i1 %val
 }
 
@@ -2744,7 +2744,7 @@ define i1 @test_class_is_nan_assume_not_eq_pinf(float %x) {
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[ORD]])
 ; CHECK-NEXT:    ret i1 false
 ;
-  %ord = fcmp oeq float %x, 0x7FF0000000000000
+  %ord = fcmp oeq float %x, +inf
   call void @llvm.assume(i1 %ord)
   %class = call i1 @llvm.is.fpclass.f32(float %x, i32 3)
   ret i1 %class

--- a/llvm/test/Transforms/InstCombine/known-bits.ll
+++ b/llvm/test/Transforms/InstCombine/known-bits.ll
@@ -1607,7 +1607,7 @@ define i32 @test_ninf_only(double %x) {
 ; CHECK:       if.else:
 ; CHECK-NEXT:    ret i32 0
 ;
-  %cmp = fcmp oeq double %x, 0xFFF0000000000000
+  %cmp = fcmp oeq double %x, -inf
   br i1 %cmp, label %if.then, label %if.else
 
 if.then:
@@ -1711,7 +1711,7 @@ define i1 @test_simplify_icmp2(double %x) {
 ; CHECK-NEXT:    ret i1 false
 ;
   %abs = tail call double @llvm.fabs.f64(double %x)
-  %cond = fcmp oeq double %abs, 0x7FF0000000000000
+  %cond = fcmp oeq double %abs, +inf
   br i1 %cond, label %if.then, label %if.else
 
 if.then:

--- a/llvm/test/Transforms/InstCombine/log1p.ll
+++ b/llvm/test/Transforms/InstCombine/log1p.ll
@@ -159,7 +159,7 @@ define double @log1p_inf() {
 ; CHECK-NEXT:    [[R:%.*]] = call double @log1p(double +inf)
 ; CHECK-NEXT:    ret double [[R]]
 ;
-  %r = call double @log1p(double 0x7FF0000000000000)
+  %r = call double @log1p(double +inf)
   ret double %r
 }
 
@@ -177,7 +177,7 @@ define double @log1p_inf_memory_none() {
 ; CHECK-NEXT:    [[R:%.*]] = call double @log1p(double +inf) #[[ATTR0]]
 ; CHECK-NEXT:    ret double [[R]]
 ;
-  %r = call double @log1p(double 0x7FF0000000000000) readnone
+  %r = call double @log1p(double +inf) readnone
   ret double %r
 }
 
@@ -195,7 +195,7 @@ define double @log1p_neg_inf() {
 ; CHECK-NEXT:    [[R:%.*]] = call double @log1p(double -inf)
 ; CHECK-NEXT:    ret double [[R]]
 ;
-  %r = call double @log1p(double 0xFFF0000000000000)
+  %r = call double @log1p(double -inf)
   ret double %r
 }
 
@@ -213,7 +213,7 @@ define double @log1p_neg_inf_memory_none() {
 ; CHECK-NEXT:    [[R:%.*]] = call double @log1p(double -inf) #[[ATTR0]]
 ; CHECK-NEXT:    ret double [[R]]
 ;
-  %r = call double @log1p(double 0xFFF0000000000000) readnone
+  %r = call double @log1p(double -inf) readnone
   ret double %r
 }
 

--- a/llvm/test/Transforms/InstCombine/logb.ll
+++ b/llvm/test/Transforms/InstCombine/logb.ll
@@ -69,7 +69,7 @@ define double @logb_inf() {
 ; CHECK-NEXT:    [[R:%.*]] = call double @logb(double +inf)
 ; CHECK-NEXT:    ret double [[R]]
 ;
-  %r = call double @logb(double 0x7FF0000000000000)
+  %r = call double @logb(double +inf)
   ret double %r
 }
 

--- a/llvm/test/Transforms/InstCombine/phi.ll
+++ b/llvm/test/Transforms/InstCombine/phi.ll
@@ -809,7 +809,7 @@ true:
 false:
   br label %ret
 ret:
-  %p = phi double [ %x, %true ], [ 0x7FF0000000000000, %false ]; RHS = +infty
+  %p = phi double [ %x, %true ], [ +inf, %false ]; RHS = +infty
   %cmp = fcmp ule double %x, %p
   ret i1 %cmp
 }

--- a/llvm/test/Transforms/InstCombine/pow-1.ll
+++ b/llvm/test/Transforms/InstCombine/pow-1.ll
@@ -748,7 +748,7 @@ define float @powf_libcall_half_assume_ninf_noerrno(float %x) {
 ; NOLIB-NEXT:    ret float [[RETVAL]]
 ;
   %fabs = call float @llvm.fabs.f32(float %x)
-  %not.inf = fcmp one float %fabs, 0x7FF0000000000000
+  %not.inf = fcmp one float %fabs, +inf
   call void @llvm.assume(i1 %not.inf)
   %retval = call float @powf(float %x, float 0.5) #0
   ret float %retval
@@ -887,7 +887,7 @@ define double @pow_libcall_half_fromdomcondition(double %x) {
 ; NOLIB-NEXT:    ret double [[RETVAL]]
 ;
   %a = call double @llvm.fabs.f64(double %x)
-  %c = fcmp oeq double %a, 0x7FF0000000000000
+  %c = fcmp oeq double %a, +inf
   br i1 %c, label %then, label %else
 
 then:
@@ -932,7 +932,7 @@ define double @test_simplify10(double %x) {
 ; CHECK-SAME: double [[X:%.*]]) {
 ; CHECK-NEXT:    ret double +inf
 ;
-  %retval = call double @llvm.pow.f64(double 0xFFF0000000000000, double 0.5)
+  %retval = call double @llvm.pow.f64(double -inf, double 0.5)
   ret double %retval
 }
 

--- a/llvm/test/Transforms/InstCombine/pow-exp.ll
+++ b/llvm/test/Transforms/InstCombine/pow-exp.ll
@@ -349,7 +349,7 @@ define double @pow_inf_base(double %e) {
 ; CHECK-NEXT:    [[CALL:%.*]] = tail call nnan ninf afn double @pow(double +inf, double [[E:%.*]])
 ; CHECK-NEXT:    ret double [[CALL]]
 ;
-  %call = tail call afn nnan ninf double @pow(double 0x7FF0000000000000, double %e)
+  %call = tail call afn nnan ninf double @pow(double +inf, double %e)
   ret double %call
 }
 

--- a/llvm/test/Transforms/InstCombine/select-fcmp-fmul-zero-absorbing-value.ll
+++ b/llvm/test/Transforms/InstCombine/select-fcmp-fmul-zero-absorbing-value.ll
@@ -340,7 +340,7 @@ define float @degenerate_fmul_posinf(float %x) {
 ; CHECK-NEXT:    ret float [[SELECT]]
 ;
   %fabs.x = call float @llvm.fabs.f32(float %x)
-  %mul.fabs.x = fmul float %fabs.x, 0x7FF0000000000000
+  %mul.fabs.x = fmul float %fabs.x, +inf
   %x.is.zero = fcmp oeq float %x, 0.0
   %select = select i1 %x.is.zero, float %mul.fabs.x, float %fabs.x
   ret float %select
@@ -356,7 +356,7 @@ define float @degenerate_fmul_neginf(float %x) {
 ; CHECK-NEXT:    ret float [[SELECT]]
 ;
   %fabs.x = call float @llvm.fabs.f32(float %x)
-  %mul.fabs.x = fmul float %fabs.x, 0xFFF0000000000000
+  %mul.fabs.x = fmul float %fabs.x, -inf
   %x.is.zero = fcmp oeq float %x, 0.0
   %select = select i1 %x.is.zero, float %mul.fabs.x, float %fabs.x
   ret float %select

--- a/llvm/test/Transforms/InstCombine/select.ll
+++ b/llvm/test/Transforms/InstCombine/select.ll
@@ -724,7 +724,7 @@ define i1 @test39(i1 %cond, double %x) {
 ; CHECK-SAME: i1 [[COND:%.*]], double [[X:%.*]]) {
 ; CHECK-NEXT:    ret i1 true
 ;
-  %s = select i1 %cond, double %x, double 0x7FF0000000000000   ; RHS = +infty
+  %s = select i1 %cond, double %x, double +inf   ; RHS = +infty
   %cmp = fcmp ule double %x, %s
   ret i1 %cmp
 }

--- a/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-fdiv.ll
+++ b/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-fdiv.ll
@@ -22,8 +22,8 @@ define nofpclass(pinf) half @ret_nofpclass_pinf__fdiv_unknown_or_pinf(i1 %cond, 
 ; CHECK-NEXT:    [[TMP1:%.*]] = fdiv half [[X_OR_PINF]], [[Y_OR_PINF]]
 ; CHECK-NEXT:    ret half [[TMP1]]
 ;
-  %x.or.pinf = select i1 %cond, half %x, half 0x7FF0000000000000
-  %y.or.pinf = select i1 %cond, half %y, half 0x7FF0000000000000
+  %x.or.pinf = select i1 %cond, half %x, half +inf
+  %y.or.pinf = select i1 %cond, half %y, half +inf
   %div = fdiv half %x.or.pinf, %y.or.pinf
   ret half %div
 }
@@ -36,8 +36,8 @@ define nofpclass(ninf) half @ret_nofpclass_pinf__fdiv_unknown_or_ninf(i1 %cond, 
 ; CHECK-NEXT:    [[DIV:%.*]] = fdiv half [[X_OR_NINF]], [[Y_OR_NINF]]
 ; CHECK-NEXT:    ret half [[DIV]]
 ;
-  %x.or.ninf = select i1 %cond, half %x, half 0xFFF0000000000000
-  %y.or.ninf = select i1 %cond, half %y, half 0xFFF0000000000000
+  %x.or.ninf = select i1 %cond, half %x, half -inf
+  %y.or.ninf = select i1 %cond, half %y, half -inf
   %div = fdiv half %x.or.ninf, %y.or.ninf
   ret half %div
 }
@@ -50,8 +50,8 @@ define nofpclass(inf) half @ret_nofpclass_inf__fdiv_unknown_or_pinf(i1 %cond, ha
 ; CHECK-NEXT:    [[TMP1:%.*]] = fdiv half [[X_OR_PINF]], [[Y_OR_PINF]]
 ; CHECK-NEXT:    ret half [[TMP1]]
 ;
-  %x.or.pinf = select i1 %cond, half %x, half 0x7FF0000000000000
-  %y.or.pinf = select i1 %cond, half %y, half 0x7FF0000000000000
+  %x.or.pinf = select i1 %cond, half %x, half +inf
+  %y.or.pinf = select i1 %cond, half %y, half +inf
   %div = fdiv half %x.or.pinf, %y.or.pinf
   ret half %div
 }
@@ -441,7 +441,7 @@ define nofpclass(pinf) half @ret_nofpclass_pinf__fdiv_self_unknown_or_pinf(i1 %c
 ; CHECK-NEXT:    [[DIV:%.*]] = fdiv half [[X_OR_PINF]], [[X_OR_PINF]]
 ; CHECK-NEXT:    ret half [[DIV]]
 ;
-  %x.or.pinf = select i1 %cond, half %x, half 0x7FF0000000000000
+  %x.or.pinf = select i1 %cond, half %x, half +inf
   %div = fdiv half %x.or.pinf, %x.or.pinf
   ret half %div
 }
@@ -454,7 +454,7 @@ define nofpclass(pinf) half @ret_nofpclass_pinf__fdiv_self_unknown_or_pinf__othe
 ; CHECK-NEXT:    [[DIV:%.*]] = fdiv half [[X_OR_PINF]], [[X_OR_PINF]]
 ; CHECK-NEXT:    ret half [[DIV]]
 ;
-  %x.or.pinf = select i1 %cond, half %x, half 0x7FF0000000000000
+  %x.or.pinf = select i1 %cond, half %x, half +inf
   call void @use(half %x.or.pinf)
   %div = fdiv half %x.or.pinf, %x.or.pinf
   ret half %div
@@ -468,7 +468,7 @@ define nofpclass(pinf) half @ret_nofpclass_pinf__fdiv_self_unknown_or_pinf__othe
 ; CHECK-NEXT:    call void @use(half [[X_OR_PINF]])
 ; CHECK-NEXT:    ret half [[DIV]]
 ;
-  %x.or.pinf = select i1 %cond, half %x, half 0x7FF0000000000000
+  %x.or.pinf = select i1 %cond, half %x, half +inf
   %div = fdiv half %x.or.pinf, %x.or.pinf
   call void @use(half %x.or.pinf)
   ret half %div
@@ -573,7 +573,7 @@ define nofpclass(inf) half @ret_only_inf_results__lhs_known_non_inf(i1 %cond, ha
 ; CHECK-NEXT:    [[DIV:%.*]] = fdiv half [[X_OR_PINF]], [[Y]]
 ; CHECK-NEXT:    ret half [[DIV]]
 ;
-  %x.or.pinf = select i1 %cond, half %x, half 0x7FF0000000000000
+  %x.or.pinf = select i1 %cond, half %x, half +inf
   %div = fdiv half %x.or.pinf, %y
   ret half %div
 }
@@ -585,7 +585,7 @@ define nofpclass(inf) half @ret_no_inf_results__rhs_known_non_inf(i1 %cond, half
 ; CHECK-NEXT:    [[DIV:%.*]] = fdiv half [[X]], [[Y_OR_PINF]]
 ; CHECK-NEXT:    ret half [[DIV]]
 ;
-  %y.or.pinf = select i1 %cond, half %y, half 0x7FF0000000000000
+  %y.or.pinf = select i1 %cond, half %y, half +inf
   %div = fdiv half %x, %y.or.pinf
   ret half %div
 }
@@ -598,7 +598,7 @@ define nofpclass(ninf nan) half @ret_no_ninf_or_nan_results__lhs_known_non_inf(i
 ; CHECK-NEXT:    [[DIV:%.*]] = fdiv nnan half [[X_OR_PINF]], [[Y]]
 ; CHECK-NEXT:    ret half [[DIV]]
 ;
-  %x.or.pinf = select i1 %cond, half %x, half 0x7FF0000000000000
+  %x.or.pinf = select i1 %cond, half %x, half +inf
   %div = fdiv half %x.or.pinf, %y
   ret half %div
 }
@@ -611,7 +611,7 @@ define nofpclass(pinf nan) half @ret_no_pinf_or_nan_results__lhs_known_non_inf(i
 ; CHECK-NEXT:    [[DIV:%.*]] = fdiv nnan half [[X_OR_PINF]], [[Y]]
 ; CHECK-NEXT:    ret half [[DIV]]
 ;
-  %x.or.pinf = select i1 %cond, half %x, half 0x7FF0000000000000
+  %x.or.pinf = select i1 %cond, half %x, half +inf
   %div = fdiv half %x.or.pinf, %y
   ret half %div
 }
@@ -623,7 +623,7 @@ define nofpclass(inf nan) half @ret_no_inf_or_nan_results__lhs_known_non_inf(i1 
 ; CHECK-NEXT:    [[DIV:%.*]] = fdiv nnan ninf half [[X]], [[Y]]
 ; CHECK-NEXT:    ret half [[DIV]]
 ;
-  %x.or.pinf = select i1 %cond, half %x, half 0x7FF0000000000000
+  %x.or.pinf = select i1 %cond, half %x, half +inf
   %div = fdiv half %x.or.pinf, %y
   ret half %div
 }
@@ -636,7 +636,7 @@ define nofpclass(inf nan) half @ret_no_inf_or_nan_results__rhs_known_non_inf(i1 
 ; CHECK-NEXT:    [[DIV:%.*]] = fdiv nnan half [[X]], [[Y_OR_PINF]]
 ; CHECK-NEXT:    ret half [[DIV]]
 ;
-  %y.or.pinf = select i1 %cond, half %y, half 0x7FF0000000000000
+  %y.or.pinf = select i1 %cond, half %y, half +inf
   %div = fdiv half %x, %y.or.pinf
   ret half %div
 }

--- a/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass.ll
+++ b/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass.ll
@@ -1487,7 +1487,7 @@ define nofpclass(inf) float @ret_nofpclass_noinfs__assumed_isinf__select_pinf_lh
 ; CHECK-NEXT:    ret float [[Y]]
 ;
   %fabs.x = call float @llvm.fabs.f32(float %x)
-  %x.is.inf = fcmp oeq float %fabs.x, 0x7FF0000000000000
+  %x.is.inf = fcmp oeq float %fabs.x, +inf
   call void @llvm.assume(i1 %x.is.inf)
   %select = select i1 %cond, float %x, float %y
   ret float %select
@@ -1705,7 +1705,7 @@ define nofpclass(inf) float @ret_nofpclass_inf__select_assumed_call_result_only_
 ;
   %must.be.inf = call float @extern()
   %fabs = call float @llvm.fabs.f32(float %must.be.inf)
-  %is.inf = fcmp oeq float %fabs, 0x7FF0000000000000
+  %is.inf = fcmp oeq float %fabs, +inf
   call void @llvm.assume(i1 %is.inf)
   %select = select i1 %cond, float %must.be.inf, float %y
   ret float %select
@@ -1728,7 +1728,7 @@ bb0:
   br label %ret
 
 ret:
-  %phi = phi float [ 0x7FF0000000000000, %entry ], [ %x, %bb0 ]
+  %phi = phi float [ +inf, %entry ], [ %x, %bb0 ]
   ret float %phi
 }
 
@@ -1756,7 +1756,7 @@ entry:
   br i1 %cond0, label %loop, label %ret
 
 loop:
-  %phi.loop = phi float [ 0x7FF0000000000000, %entry ], [ %loop.func, %loop ]
+  %phi.loop = phi float [ +inf, %entry ], [ %loop.func, %loop ]
   %loop.func = call nofpclass(nan) float @loop.func()
   %loop.cond = call i1 @loop.cond()
   br i1 %loop.cond, label %ret, label %loop
@@ -1782,7 +1782,7 @@ entry:
   br i1 %cond0, label %loop, label %ret
 
 loop:
-  %phi.loop = phi float [ 0x7FF0000000000000, %entry ], [ %phi.loop, %loop ]
+  %phi.loop = phi float [ +inf, %entry ], [ %phi.loop, %loop ]
   %loop.cond = call i1 @loop.cond()
   br i1 %loop.cond, label %ret, label %loop
 
@@ -1807,12 +1807,12 @@ entry:
   br i1 %cond0, label %loop, label %ret
 
 loop:
-  %phi.loop = phi float [ 0x7FF0000000000000, %entry ], [ %phi.loop, %loop ]
+  %phi.loop = phi float [ +inf, %entry ], [ %phi.loop, %loop ]
   %loop.cond = call i1 @loop.cond()
   br i1 %loop.cond, label %ret, label %loop
 
 ret:
-  %phi.ret = phi float [ 0x7FF0000000000000, %entry ], [ %phi.loop, %loop ]
+  %phi.ret = phi float [ +inf, %entry ], [ %phi.loop, %loop ]
   ret float %phi.ret
 }
 
@@ -1839,7 +1839,7 @@ entry:
   ]
 
 loop:
-  %phi.loop = phi float [ 0x7FF0000000000000, %entry ], [ 0x7FF0000000000000, %entry ], [ %unknown, %loop ]
+  %phi.loop = phi float [ +inf, %entry ], [ +inf, %entry ], [ %unknown, %loop ]
   %loop.cond = call i1 @loop.cond()
   br i1 %loop.cond, label %ret, label %loop
 

--- a/llvm/test/Transforms/InstSimplify/ConstProp/AMDGPU/cos.ll
+++ b/llvm/test/Transforms/InstSimplify/ConstProp/AMDGPU/cos.ll
@@ -185,9 +185,9 @@ define void @test_f64(ptr %p) {
   store volatile double %p1000, ptr %p
   %n1000 = call double @llvm.amdgcn.cos.f64(double -1000.0)
   store volatile double %n1000, ptr %p
-  %pinf = call double @llvm.amdgcn.cos.f64(double 0x7FF0000000000000) ; +inf
+  %pinf = call double @llvm.amdgcn.cos.f64(double +inf) ; +inf
   store volatile double %pinf, ptr %p
-  %ninf = call double @llvm.amdgcn.cos.f64(double 0xFFF0000000000000) ; -inf
+  %ninf = call double @llvm.amdgcn.cos.f64(double -inf) ; -inf
   store volatile double %ninf, ptr %p
   %nan = call double @llvm.amdgcn.cos.f64(double 0x7FF8000000000000) ; nan
   store volatile double %nan, ptr %p

--- a/llvm/test/Transforms/InstSimplify/ConstProp/AMDGPU/fract.ll
+++ b/llvm/test/Transforms/InstSimplify/ConstProp/AMDGPU/fract.ll
@@ -116,9 +116,9 @@ define void @test_f64(ptr %p) {
   store volatile double %ptiny, ptr %p
   %ntiny = call double @llvm.amdgcn.fract.f64(double -2.0e-308) ; -min normal
   store volatile double %ntiny, ptr %p
-  %pinf = call double @llvm.amdgcn.fract.f64(double 0x7FF0000000000000) ; +inf
+  %pinf = call double @llvm.amdgcn.fract.f64(double +inf) ; +inf
   store volatile double %pinf, ptr %p
-  %ninf = call double @llvm.amdgcn.fract.f64(double 0xFFF0000000000000) ; -inf
+  %ninf = call double @llvm.amdgcn.fract.f64(double -inf) ; -inf
   store volatile double %ninf, ptr %p
   %nan = call double @llvm.amdgcn.fract.f64(double 0x7FF8000000000000) ; nan
   store volatile double %nan, ptr %p

--- a/llvm/test/Transforms/InstSimplify/ConstProp/AMDGPU/sin.ll
+++ b/llvm/test/Transforms/InstSimplify/ConstProp/AMDGPU/sin.ll
@@ -185,9 +185,9 @@ define void @test_f64(ptr %p) {
   store volatile double %p1000, ptr %p
   %n1000 = call double @llvm.amdgcn.sin.f64(double -1000.0)
   store volatile double %n1000, ptr %p
-  %pinf = call double @llvm.amdgcn.sin.f64(double 0x7FF0000000000000) ; +inf
+  %pinf = call double @llvm.amdgcn.sin.f64(double +inf) ; +inf
   store volatile double %pinf, ptr %p
-  %ninf = call double @llvm.amdgcn.sin.f64(double 0xFFF0000000000000) ; -inf
+  %ninf = call double @llvm.amdgcn.sin.f64(double -inf) ; -inf
   store volatile double %ninf, ptr %p
   %nan = call double @llvm.amdgcn.sin.f64(double 0x7FF8000000000000) ; nan
   store volatile double %nan, ptr %p

--- a/llvm/test/Transforms/InstSimplify/ConstProp/WebAssembly/trunc.ll
+++ b/llvm/test/Transforms/InstSimplify/ConstProp/WebAssembly/trunc.ll
@@ -244,9 +244,9 @@ define void @test_i32_trunc_f64_s(ptr %p) {
   store volatile i32 %t16, ptr %p
   %t17 = call i32 @llvm.wasm.trunc.signed.i32.f64(double -2147483649.0)
   store volatile i32 %t17, ptr %p
-  %t18 = call i32 @llvm.wasm.trunc.signed.i32.f64(double 0x7ff0000000000000); inf
+  %t18 = call i32 @llvm.wasm.trunc.signed.i32.f64(double +inf); inf
   store volatile i32 %t18, ptr %p
-  %t19 = call i32 @llvm.wasm.trunc.signed.i32.f64(double 0xfff0000000000000); -inf
+  %t19 = call i32 @llvm.wasm.trunc.signed.i32.f64(double -inf); -inf
   store volatile i32 %t19, ptr %p
   %t20 = call i32 @llvm.wasm.trunc.signed.i32.f64(double 0x7ff8000000000000); nan
   store volatile i32 %t20, ptr %p
@@ -340,9 +340,9 @@ define void @test_i32_trunc_f64_u(ptr %p) {
   store volatile i32 %t18, ptr %p
   %t19 = call i32 @llvm.wasm.trunc.unsigned.i32.f64(double 9223372036854775808.0)
   store volatile i32 %t19, ptr %p
-  %t20 = call i32 @llvm.wasm.trunc.unsigned.i32.f64(double 0x7ff0000000000000); inf
+  %t20 = call i32 @llvm.wasm.trunc.unsigned.i32.f64(double +inf); inf
   store volatile i32 %t20, ptr %p
-  %t21 = call i32 @llvm.wasm.trunc.unsigned.i32.f64(double 0xfff0000000000000); -inf
+  %t21 = call i32 @llvm.wasm.trunc.unsigned.i32.f64(double -inf); -inf
   store volatile i32 %t21, ptr %p
   %t22 = call i32 @llvm.wasm.trunc.unsigned.i32.f64(double 0x7ff8000000000000); nan
   store volatile i32 %t22, ptr %p
@@ -586,9 +586,9 @@ define void @test_i64_trunc_f64_s(ptr %p) {
   store volatile i64 %t16, ptr %p
   %t17 = call i64 @llvm.wasm.trunc.signed.i64.f64(double -9223372036854777856.0)
   store volatile i64 %t17, ptr %p
-  %t18 = call i64 @llvm.wasm.trunc.signed.i64.f64(double 0x7ff0000000000000); inf
+  %t18 = call i64 @llvm.wasm.trunc.signed.i64.f64(double +inf); inf
   store volatile i64 %t18, ptr %p
-  %t19 = call i64 @llvm.wasm.trunc.signed.i64.f64(double 0xfff0000000000000); -inf
+  %t19 = call i64 @llvm.wasm.trunc.signed.i64.f64(double -inf); -inf
   store volatile i64 %t19, ptr %p
   %t20 = call i64 @llvm.wasm.trunc.signed.i64.f64(double 0x7ff8000000000000); nan
   store volatile i64 %t20, ptr %p
@@ -670,9 +670,9 @@ define void @test_i64_trunc_f64_u(ptr %p) {
   store volatile i64 %t15, ptr %p
   %t16 = call i64 @llvm.wasm.trunc.unsigned.i64.f64(double -1.0)
   store volatile i64 %t16, ptr %p
-  %t17 = call i64 @llvm.wasm.trunc.unsigned.i64.f64(double 0x7ff0000000000000); inf
+  %t17 = call i64 @llvm.wasm.trunc.unsigned.i64.f64(double +inf); inf
   store volatile i64 %t17, ptr %p
-  %t18 = call i64 @llvm.wasm.trunc.unsigned.i64.f64(double 0xfff0000000000000); -inf
+  %t18 = call i64 @llvm.wasm.trunc.unsigned.i64.f64(double -inf); -inf
   store volatile i64 %t18, ptr %p
   %t19 = call i64 @llvm.wasm.trunc.unsigned.i64.f64(double 0x7ff8000000000000); nan
   store volatile i64 %t19, ptr %p

--- a/llvm/test/Transforms/InstSimplify/ConstProp/atan-intrinsic.ll
+++ b/llvm/test/Transforms/InstSimplify/ConstProp/atan-intrinsic.ll
@@ -73,7 +73,7 @@ define double @test_atan_pos_inf() {
 ; CHECK-NEXT:    [[RES:%.*]] = call double @llvm.atan.f64(double +inf)
 ; CHECK-NEXT:    ret double [[RES]]
 ;
-  %res = call double @llvm.atan.f64(double 0x7ff0000000000000)
+  %res = call double @llvm.atan.f64(double +inf)
   ret double %res
 }
 
@@ -82,6 +82,6 @@ define double @test_atan_neg_inf() {
 ; CHECK-NEXT:    [[RES:%.*]] = call double @llvm.atan.f64(double -inf)
 ; CHECK-NEXT:    ret double [[RES]]
 ;
-  %res = call double @llvm.atan.f64(double 0xfff0000000000000)
+  %res = call double @llvm.atan.f64(double -inf)
   ret double %res
 }

--- a/llvm/test/Transforms/InstSimplify/ConstProp/fma.ll
+++ b/llvm/test/Transforms/InstSimplify/ConstProp/fma.ll
@@ -55,7 +55,7 @@ define double @test_Inf_addend()  {
 ; CHECK-LABEL: @test_Inf_addend(
 ; CHECK-NEXT:    ret double +inf
 ;
-  %1 = call double @llvm.fma.f64(double 7.0, double 8.0, double 0x7FF0000000000000)
+  %1 = call double @llvm.fma.f64(double 7.0, double 8.0, double +inf)
   ret double %1
 }
 
@@ -63,7 +63,7 @@ define double @test_Inf_addend_2()  {
 ; CHECK-LABEL: @test_Inf_addend_2(
 ; CHECK-NEXT:    ret double -inf
 ;
-  %1 = call double @llvm.fma.f64(double 7.0, double 8.0, double 0xFFF0000000000000)
+  %1 = call double @llvm.fma.f64(double 7.0, double 8.0, double -inf)
   ret double %1
 }
 
@@ -105,7 +105,7 @@ define double @test_Inf_1()  {
 ; CHECK-LABEL: @test_Inf_1(
 ; CHECK-NEXT:    ret double +inf
 ;
-  %1 = call double @llvm.fma.f64(double 0x7FF0000000000000, double 8.0, double 0.0)
+  %1 = call double @llvm.fma.f64(double +inf, double 8.0, double 0.0)
   ret double %1
 }
 
@@ -113,7 +113,7 @@ define double @test_Inf_2()  {
 ; CHECK-LABEL: @test_Inf_2(
 ; CHECK-NEXT:    ret double +inf
 ;
-  %1 = call double @llvm.fma.f64(double 7.0, double 0x7FF0000000000000, double 0.0)
+  %1 = call double @llvm.fma.f64(double 7.0, double +inf, double 0.0)
   ret double %1
 }
 
@@ -121,7 +121,7 @@ define double @test_Inf_3()  {
 ; CHECK-LABEL: @test_Inf_3(
 ; CHECK-NEXT:    ret double -inf
 ;
-  %1 = call double @llvm.fma.f64(double 0xFFF0000000000000, double 8.0, double 0.0)
+  %1 = call double @llvm.fma.f64(double -inf, double 8.0, double 0.0)
   ret double %1
 }
 
@@ -129,7 +129,7 @@ define double @test_Inf_4()  {
 ; CHECK-LABEL: @test_Inf_4(
 ; CHECK-NEXT:    ret double -inf
 ;
-  %1 = call double @llvm.fma.f64(double 7.0, double 0xFFF0000000000000, double 0.0)
+  %1 = call double @llvm.fma.f64(double 7.0, double -inf, double 0.0)
   ret double %1
 }
 
@@ -139,7 +139,7 @@ define double @inf_product_opposite_inf_addend_1()  {
 ; CHECK-LABEL: @inf_product_opposite_inf_addend_1(
 ; CHECK-NEXT:    ret double +qnan
 ;
-  %1 = call double @llvm.fma.f64(double 7.0, double 0xFFF0000000000000, double 0x7FF0000000000000)
+  %1 = call double @llvm.fma.f64(double 7.0, double -inf, double +inf)
   ret double %1
 }
 
@@ -149,7 +149,7 @@ define double @inf_product_opposite_inf_addend_2()  {
 ; CHECK-LABEL: @inf_product_opposite_inf_addend_2(
 ; CHECK-NEXT:    ret double +qnan
 ;
-  %1 = call double @llvm.fma.f64(double 7.0, double 0x7FF0000000000000, double 0xFFF0000000000000)
+  %1 = call double @llvm.fma.f64(double 7.0, double +inf, double -inf)
   ret double %1
 }
 
@@ -159,7 +159,7 @@ define double @inf_product_opposite_inf_addend_3()  {
 ; CHECK-LABEL: @inf_product_opposite_inf_addend_3(
 ; CHECK-NEXT:    ret double +qnan
 ;
-  %1 = call double @llvm.fma.f64(double 0xFFF0000000000000, double 42.0, double 0x7FF0000000000000)
+  %1 = call double @llvm.fma.f64(double -inf, double 42.0, double +inf)
   ret double %1
 }
 
@@ -169,7 +169,7 @@ define double @inf_product_opposite_inf_addend_4()  {
 ; CHECK-LABEL: @inf_product_opposite_inf_addend_4(
 ; CHECK-NEXT:    ret double +qnan
 ;
-  %1 = call double @llvm.fma.f64(double 0x7FF0000000000000, double 42.0, double 0xFFF0000000000000)
+  %1 = call double @llvm.fma.f64(double +inf, double 42.0, double -inf)
   ret double %1
 }
 
@@ -179,7 +179,7 @@ define double @inf_times_zero_1()  {
 ; CHECK-LABEL: @inf_times_zero_1(
 ; CHECK-NEXT:    ret double +qnan
 ;
-  %1 = call double @llvm.fma.f64(double 0.0, double 0xFFF0000000000000, double 42.0)
+  %1 = call double @llvm.fma.f64(double 0.0, double -inf, double 42.0)
   ret double %1
 }
 
@@ -189,7 +189,7 @@ define double @inf_times_zero_2()  {
 ; CHECK-LABEL: @inf_times_zero_2(
 ; CHECK-NEXT:    ret double +qnan
 ;
-  %1 = call double @llvm.fma.f64(double 0.0, double 0x7FF0000000000000, double 42.0)
+  %1 = call double @llvm.fma.f64(double 0.0, double +inf, double 42.0)
   ret double %1
 }
 
@@ -199,7 +199,7 @@ define double @inf_times_zero_3()  {
 ; CHECK-LABEL: @inf_times_zero_3(
 ; CHECK-NEXT:    ret double +qnan
 ;
-  %1 = call double @llvm.fma.f64(double 0xFFF0000000000000, double 0.0, double 42.0)
+  %1 = call double @llvm.fma.f64(double -inf, double 0.0, double 42.0)
   ret double %1
 }
 
@@ -209,7 +209,7 @@ define double @inf_times_zero_4()  {
 ; CHECK-LABEL: @inf_times_zero_4(
 ; CHECK-NEXT:    ret double +qnan
 ;
-  %1 = call double @llvm.fma.f64(double 0x7FF0000000000000, double 0.0, double 42.0)
+  %1 = call double @llvm.fma.f64(double +inf, double 0.0, double 42.0)
   ret double %1
 }
 
@@ -219,7 +219,7 @@ define double @inf_times_zero_5()  {
 ; CHECK-LABEL: @inf_times_zero_5(
 ; CHECK-NEXT:    ret double +qnan
 ;
-  %1 = call double @llvm.fma.f64(double -0.0, double 0xFFF0000000000000, double 42.0)
+  %1 = call double @llvm.fma.f64(double -0.0, double -inf, double 42.0)
   ret double %1
 }
 
@@ -229,7 +229,7 @@ define double @inf_times_zero_6()  {
 ; CHECK-LABEL: @inf_times_zero_6(
 ; CHECK-NEXT:    ret double +qnan
 ;
-  %1 = call double @llvm.fma.f64(double -0.0, double 0x7FF0000000000000, double 42.0)
+  %1 = call double @llvm.fma.f64(double -0.0, double +inf, double 42.0)
   ret double %1
 }
 
@@ -239,7 +239,7 @@ define double @inf_times_zero_7()  {
 ; CHECK-LABEL: @inf_times_zero_7(
 ; CHECK-NEXT:    ret double +qnan
 ;
-  %1 = call double @llvm.fma.f64(double 0xFFF0000000000000, double -0.0, double 42.0)
+  %1 = call double @llvm.fma.f64(double -inf, double -0.0, double 42.0)
   ret double %1
 }
 
@@ -249,6 +249,6 @@ define double @inf_times_zero_8()  {
 ; CHECK-LABEL: @inf_times_zero_8(
 ; CHECK-NEXT:    ret double +qnan
 ;
-  %1 = call double @llvm.fma.f64(double 0x7FF0000000000000, double -0.0, double 42.0)
+  %1 = call double @llvm.fma.f64(double +inf, double -0.0, double 42.0)
   ret double %1
 }

--- a/llvm/test/Transforms/InstSimplify/ConstProp/fp-undef.ll
+++ b/llvm/test/Transforms/InstSimplify/ConstProp/fp-undef.ll
@@ -384,7 +384,7 @@ define double @fadd_undef_op0_constant_inf(double %x) {
 ; CHECK-LABEL: @fadd_undef_op0_constant_inf(
 ; CHECK-NEXT:    ret double +qnan
 ;
-  %r = fadd double undef, 0x7FF0000000000000
+  %r = fadd double undef, +inf
   ret double %r
 }
 
@@ -392,7 +392,7 @@ define double @fadd_undef_op1_fast_constant_inf(double %x) {
 ; CHECK-LABEL: @fadd_undef_op1_fast_constant_inf(
 ; CHECK-NEXT:    ret double +qnan
 ;
-  %r = fadd fast double 0xFFF0000000000000, undef
+  %r = fadd fast double -inf, undef
   ret double %r
 }
 
@@ -400,7 +400,7 @@ define double @fsub_undef_op0_constant_inf(double %x) {
 ; CHECK-LABEL: @fsub_undef_op0_constant_inf(
 ; CHECK-NEXT:    ret double +qnan
 ;
-  %r = fsub double undef, 0xFFF0000000000000
+  %r = fsub double undef, -inf
   ret double %r
 }
 
@@ -408,7 +408,7 @@ define double @fsub_undef_op1_ninf_constant_inf(double %x) {
 ; CHECK-LABEL: @fsub_undef_op1_ninf_constant_inf(
 ; CHECK-NEXT:    ret double +qnan
 ;
-  %r = fsub ninf double 0x7FF0000000000000, undef
+  %r = fsub ninf double +inf, undef
   ret double %r
 }
 
@@ -416,7 +416,7 @@ define double @fmul_undef_op0_constant_inf(double %x) {
 ; CHECK-LABEL: @fmul_undef_op0_constant_inf(
 ; CHECK-NEXT:    ret double +qnan
 ;
-  %r = fmul double undef, 0x7FF0000000000000
+  %r = fmul double undef, +inf
   ret double %r
 }
 
@@ -424,7 +424,7 @@ define double @fmul_undef_op1_fast_constant_inf(double %x) {
 ; CHECK-LABEL: @fmul_undef_op1_fast_constant_inf(
 ; CHECK-NEXT:    ret double +qnan
 ;
-  %r = fmul fast double 0xFFF0000000000000, undef
+  %r = fmul fast double -inf, undef
   ret double %r
 }
 
@@ -432,7 +432,7 @@ define double @fdiv_undef_op0_constant_inf(double %x) {
 ; CHECK-LABEL: @fdiv_undef_op0_constant_inf(
 ; CHECK-NEXT:    ret double +qnan
 ;
-  %r = fdiv double undef, 0xFFF0000000000000
+  %r = fdiv double undef, -inf
   ret double %r
 }
 
@@ -440,7 +440,7 @@ define double @fdiv_undef_op1_ninf_constant_inf(double %x) {
 ; CHECK-LABEL: @fdiv_undef_op1_ninf_constant_inf(
 ; CHECK-NEXT:    ret double +qnan
 ;
-  %r = fdiv ninf double 0x7FF0000000000000, undef
+  %r = fdiv ninf double +inf, undef
   ret double %r
 }
 
@@ -448,7 +448,7 @@ define double @frem_undef_op0_constant_inf(double %x) {
 ; CHECK-LABEL: @frem_undef_op0_constant_inf(
 ; CHECK-NEXT:    ret double +qnan
 ;
-  %r = frem double undef, 0x7FF0000000000000
+  %r = frem double undef, +inf
   ret double %r
 }
 
@@ -456,7 +456,7 @@ define double @frem_undef_op1_fast_constant_inf(double %x) {
 ; CHECK-LABEL: @frem_undef_op1_fast_constant_inf(
 ; CHECK-NEXT:    ret double +qnan
 ;
-  %r = frem fast double 0xFFF0000000000000, undef
+  %r = frem fast double -inf, undef
   ret double %r
 }
 

--- a/llvm/test/Transforms/InstSimplify/ConstProp/sinh-cosh-intrinsics.ll
+++ b/llvm/test/Transforms/InstSimplify/ConstProp/sinh-cosh-intrinsics.ll
@@ -73,7 +73,7 @@ define double @test_sinh_pos_inf() {
 ; CHECK-NEXT:    [[RES:%.*]] = call double @llvm.sinh.f64(double +inf)
 ; CHECK-NEXT:    ret double [[RES]]
 ;
-  %res = call double @llvm.sinh.f64(double 0x7ff0000000000000)
+  %res = call double @llvm.sinh.f64(double +inf)
   ret double %res
 }
 
@@ -82,7 +82,7 @@ define double @test_sinh_neg_inf() {
 ; CHECK-NEXT:    [[RES:%.*]] = call double @llvm.sinh.f64(double -inf)
 ; CHECK-NEXT:    ret double [[RES]]
 ;
-  %res = call double @llvm.sinh.f64(double 0xfff0000000000000)
+  %res = call double @llvm.sinh.f64(double -inf)
   ret double %res
 }
 
@@ -158,7 +158,7 @@ define double @test_cosh_pos_inf() {
 ; CHECK-NEXT:    [[RES:%.*]] = call double @llvm.cosh.f64(double +inf)
 ; CHECK-NEXT:    ret double [[RES]]
 ;
-  %res = call double @llvm.cosh.f64(double 0x7ff0000000000000)
+  %res = call double @llvm.cosh.f64(double +inf)
   ret double %res
 }
 
@@ -167,6 +167,6 @@ define double @test_cosh_neg_inf() {
 ; CHECK-NEXT:    [[RES:%.*]] = call double @llvm.cosh.f64(double -inf)
 ; CHECK-NEXT:    ret double [[RES]]
 ;
-  %res = call double @llvm.cosh.f64(double 0xfff0000000000000)
+  %res = call double @llvm.cosh.f64(double -inf)
   ret double %res
 }

--- a/llvm/test/Transforms/InstSimplify/assume-fcmp-constant-implies-class.ll
+++ b/llvm/test/Transforms/InstSimplify/assume-fcmp-constant-implies-class.ll
@@ -2856,7 +2856,7 @@ define i1 @assume_olt_neg1__oeq_inf(float %arg) {
 ;
   %olt.neg1 = fcmp olt float %arg, -1.0
   call void @llvm.assume(i1 %olt.neg1)
-  %cmp = fcmp oeq float %arg, 0x7FF0000000000000
+  %cmp = fcmp oeq float %arg, +inf
   ret i1 %cmp
 }
 
@@ -2869,7 +2869,7 @@ define i1 @assume_olt_neg1__one_inf(float %arg) {
 ;
   %olt.neg1 = fcmp olt float %arg, -1.0
   call void @llvm.assume(i1 %olt.neg1)
-  %cmp = fcmp one float %arg, 0x7FF0000000000000
+  %cmp = fcmp one float %arg, +inf
   ret i1 %cmp
 }
 
@@ -2883,7 +2883,7 @@ define i1 @assume_olt_neg1__oeq_ninf(float %arg) {
 ;
   %olt.neg1 = fcmp olt float %arg, -1.0
   call void @llvm.assume(i1 %olt.neg1)
-  %cmp = fcmp oeq float %arg, 0xFFF0000000000000
+  %cmp = fcmp oeq float %arg, -inf
   ret i1 %cmp
 }
 
@@ -2897,7 +2897,7 @@ define i1 @assume_olt_neg1__one_ninf(float %arg) {
 ;
   %olt.neg1 = fcmp olt float %arg, -1.0
   call void @llvm.assume(i1 %olt.neg1)
-  %cmp = fcmp one float %arg, 0xFFF0000000000000
+  %cmp = fcmp one float %arg, -inf
   ret i1 %cmp
 }
 
@@ -2959,9 +2959,9 @@ define i1 @assume_ogt_neginf_one_neginf(float %arg) {
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[CMP_OGT_NEGINF]])
 ; CHECK-NEXT:    ret i1 true
 ;
-  %cmp.ogt.neginf = fcmp ogt float %arg, 0xFFF0000000000000
+  %cmp.ogt.neginf = fcmp ogt float %arg, -inf
   call void @llvm.assume(i1 %cmp.ogt.neginf)
-  %cmp = fcmp one float %arg, 0xFFF0000000000000
+  %cmp = fcmp one float %arg, -inf
   ret i1 %cmp
 }
 
@@ -2973,9 +2973,9 @@ define i1 @assume_ogt_neginf_oeq_posinf(float %arg) {
 ; CHECK-NEXT:    [[CMP:%.*]] = fcmp oeq float [[ARG]], +inf
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
-  %cmp.ogt.neginf = fcmp ogt float %arg, 0xFFF0000000000000
+  %cmp.ogt.neginf = fcmp ogt float %arg, -inf
   call void @llvm.assume(i1 %cmp.ogt.neginf)
-  %cmp = fcmp oeq float %arg, 0x7FF0000000000000
+  %cmp = fcmp oeq float %arg, +inf
   ret i1 %cmp
 }
 
@@ -2987,9 +2987,9 @@ define i1 @assume_ule_neginf_oeq_neginf(float %arg) {
 ; CHECK-NEXT:    [[CMP:%.*]] = fcmp oeq float [[ARG]], -inf
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
-  %cmp.ule.neginf = fcmp ule float %arg, 0xFFF0000000000000
+  %cmp.ule.neginf = fcmp ule float %arg, -inf
   call void @llvm.assume(i1 %cmp.ule.neginf)
-  %cmp = fcmp oeq float %arg, 0xFFF0000000000000
+  %cmp = fcmp oeq float %arg, -inf
   ret i1 %cmp
 }
 
@@ -3000,9 +3000,9 @@ define i1 @assume_ult_neginf_oeq_neginf(float %arg) {
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[CMP_ULT_NEGINF]])
 ; CHECK-NEXT:    ret i1 false
 ;
-  %cmp.ult.neginf = fcmp ult float %arg, 0xFFF0000000000000
+  %cmp.ult.neginf = fcmp ult float %arg, -inf
   call void @llvm.assume(i1 %cmp.ult.neginf)
-  %cmp = fcmp oeq float %arg, 0xFFF0000000000000
+  %cmp = fcmp oeq float %arg, -inf
   ret i1 %cmp
 }
 
@@ -3016,9 +3016,9 @@ define i1 @assume_fabs_ogt_neginf_one_neginf(float %arg) {
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
   %fabs.arg = call float @llvm.fabs.f32(float %arg)
-  %cmp.ogt.neginf = fcmp ogt float %fabs.arg, 0xFFF0000000000000
+  %cmp.ogt.neginf = fcmp ogt float %fabs.arg, -inf
   call void @llvm.assume(i1 %cmp.ogt.neginf)
-  %cmp = fcmp one float %arg, 0xFFF0000000000000
+  %cmp = fcmp one float %arg, -inf
   ret i1 %cmp
 }
 
@@ -3032,9 +3032,9 @@ define i1 @assume_fabs_ogt_neginf_one_posinf(float %arg) {
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
   %fabs.arg = call float @llvm.fabs.f32(float %arg)
-  %cmp.ogt.neginf = fcmp ogt float %fabs.arg, 0xFFF0000000000000
+  %cmp.ogt.neginf = fcmp ogt float %fabs.arg, -inf
   call void @llvm.assume(i1 %cmp.ogt.neginf)
-  %cmp = fcmp one float %arg, 0x7FF0000000000000
+  %cmp = fcmp one float %arg, +inf
   ret i1 %cmp
 }
 
@@ -3047,9 +3047,9 @@ define i1 @assume_fabs_ule_neginf_oeq_neginf(float %arg) {
 ; CHECK-NEXT:    ret i1 false
 ;
   %fabs.arg = call float @llvm.fabs.f32(float %arg)
-  %cmp.ogt.neginf = fcmp ule float %fabs.arg, 0xFFF0000000000000
+  %cmp.ogt.neginf = fcmp ule float %fabs.arg, -inf
   call void @llvm.assume(i1 %cmp.ogt.neginf)
-  %cmp = fcmp oeq float %arg, 0xFFF0000000000000
+  %cmp = fcmp oeq float %arg, -inf
   ret i1 %cmp
 }
 
@@ -3061,9 +3061,9 @@ define i1 @assume_oge_neginf_oeq_neginf(float %arg) {
 ; CHECK-NEXT:    [[CMP:%.*]] = fcmp oeq float [[ARG]], -inf
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
-  %cmp.oge.neginf = fcmp oge float %arg, 0xFFF0000000000000
+  %cmp.oge.neginf = fcmp oge float %arg, -inf
   call void @llvm.assume(i1 %cmp.oge.neginf)
-  %cmp = fcmp oeq float %arg, 0xFFF0000000000000
+  %cmp = fcmp oeq float %arg, -inf
   ret i1 %cmp
 }
 

--- a/llvm/test/Transforms/InstSimplify/call.ll
+++ b/llvm/test/Transforms/InstSimplify/call.ll
@@ -1244,7 +1244,7 @@ define double @fma_nan_multiplicand_inf_zero(double %x) {
 ; CHECK-NEXT:    [[R:%.*]] = call double @llvm.fma.f64(double +inf, double 0.000000e+00, double [[X:%.*]])
 ; CHECK-NEXT:    ret double [[R]]
 ;
-  %r = call double @llvm.fma.f64(double 0x7ff0000000000000, double 0.0, double %x)
+  %r = call double @llvm.fma.f64(double +inf, double 0.0, double %x)
   ret double %r
 }
 
@@ -1253,7 +1253,7 @@ define double @fma_nan_multiplicand_zero_inf(double %x) {
 ; CHECK-NEXT:    [[R:%.*]] = call double @llvm.fma.f64(double 0.000000e+00, double +inf, double [[X:%.*]])
 ; CHECK-NEXT:    ret double [[R]]
 ;
-  %r = call double @llvm.fma.f64(double 0.0, double 0x7ff0000000000000, double %x)
+  %r = call double @llvm.fma.f64(double 0.0, double +inf, double %x)
   ret double %r
 }
 
@@ -1264,7 +1264,7 @@ define double @fma_nan_addend_inf_neginf(double %x, i32 %y) {
 ; CHECK-NEXT:    ret double [[R]]
 ;
   %notnan = uitofp i32 %y to double
-  %r = call double @llvm.fma.f64(double 0x7ff0000000000000, double %notnan, double 0xfff0000000000000)
+  %r = call double @llvm.fma.f64(double +inf, double %notnan, double -inf)
   ret double %r
 }
 
@@ -1275,7 +1275,7 @@ define double @fma_nan_addend_neginf_inf(double %x, i1 %y) {
 ; CHECK-NEXT:    ret double [[R]]
 ;
   %notnan = select i1 %y, double 42.0, double -0.1
-  %r = call double @llvm.fma.f64(double %notnan, double 0xfff0000000000000, double 0x7ff0000000000000)
+  %r = call double @llvm.fma.f64(double %notnan, double -inf, double +inf)
   ret double %r
 }
 
@@ -1284,7 +1284,7 @@ define double @fmuladd_nan_multiplicand_neginf_zero(double %x) {
 ; CHECK-NEXT:    [[R:%.*]] = call double @llvm.fmuladd.f64(double -inf, double 0.000000e+00, double [[X:%.*]])
 ; CHECK-NEXT:    ret double [[R]]
 ;
-  %r = call double @llvm.fmuladd.f64(double 0xfff0000000000000, double 0.0, double %x)
+  %r = call double @llvm.fmuladd.f64(double -inf, double 0.0, double %x)
   ret double %r
 }
 
@@ -1293,7 +1293,7 @@ define double @fmuladd_nan_multiplicand_negzero_inf(double %x) {
 ; CHECK-NEXT:    [[R:%.*]] = call double @llvm.fmuladd.f64(double -0.000000e+00, double +inf, double [[X:%.*]])
 ; CHECK-NEXT:    ret double [[R]]
 ;
-  %r = call double @llvm.fmuladd.f64(double -0.0, double 0x7ff0000000000000, double %x)
+  %r = call double @llvm.fmuladd.f64(double -0.0, double +inf, double %x)
   ret double %r
 }
 
@@ -1304,7 +1304,7 @@ define double @fmuladd_nan_addend_inf_neginf(double %x, i32 %y) {
 ; CHECK-NEXT:    ret double [[R]]
 ;
   %notnan = sitofp i32 %y to double
-  %r = call double @llvm.fmuladd.f64(double 0x7ff0000000000000, double %notnan, double 0xfff0000000000000)
+  %r = call double @llvm.fmuladd.f64(double +inf, double %notnan, double -inf)
   ret double %r
 }
 
@@ -1315,7 +1315,7 @@ define double @fmuladd_nan_addend_neginf_inf(double %x, i1 %y) {
 ; CHECK-NEXT:    ret double [[R]]
 ;
   %notnan = select i1 %y, double 42.0, double -0.1
-  %r = call double @llvm.fmuladd.f64(double %notnan, double 0xfff0000000000000, double 0x7ff0000000000000)
+  %r = call double @llvm.fmuladd.f64(double %notnan, double -inf, double +inf)
   ret double %r
 }
 

--- a/llvm/test/Transforms/InstSimplify/canonicalize.ll
+++ b/llvm/test/Transforms/InstSimplify/canonicalize.ll
@@ -379,7 +379,7 @@ define double @canonicalize_inf_f64() {
 ; CHECK-LABEL: @canonicalize_inf_f64(
 ; CHECK-NEXT:    ret double +inf
 ;
-  %ret = call double @llvm.canonicalize.f64(double 0x7FF0000000000000)
+  %ret = call double @llvm.canonicalize.f64(double +inf)
   ret double %ret
 }
 
@@ -387,7 +387,7 @@ define double @canonicalize_ninf_f64() {
 ; CHECK-LABEL: @canonicalize_ninf_f64(
 ; CHECK-NEXT:    ret double -inf
 ;
-  %ret = call double @llvm.canonicalize.f64(double 0xFFF0000000000000)
+  %ret = call double @llvm.canonicalize.f64(double -inf)
   ret double %ret
 }
 

--- a/llvm/test/Transforms/InstSimplify/constfold-constrained.ll
+++ b/llvm/test/Transforms/InstSimplify/constfold-constrained.ll
@@ -195,7 +195,7 @@ define double @nonfinite_04() #0 {
 ; CHECK-NEXT:    ret double +inf
 ;
 entry:
-  %result = call double @llvm.experimental.constrained.trunc.f64(double 0x7ff0000000000000, metadata !"fpexcept.strict") #0
+  %result = call double @llvm.experimental.constrained.trunc.f64(double +inf, metadata !"fpexcept.strict") #0
   ret double %result
 }
 

--- a/llvm/test/Transforms/InstSimplify/floating-point-arithmetic.ll
+++ b/llvm/test/Transforms/InstSimplify/floating-point-arithmetic.ll
@@ -280,7 +280,7 @@ define { float, float } @test_fmul_0_assumed_finite(float %x) {
 ; CHECK-NEXT:    ret { float, float } { float 0.000000e+00, float -0.000000e+00 }
 ;
   %fabs.x = call float @llvm.fabs.f32(float %x)
-  %is.finite.x = fcmp one float %fabs.x, 0x7FF0000000000000
+  %is.finite.x = fcmp one float %fabs.x, +inf
   call void @llvm.assume(i1 %is.finite.x)
   %mul.0 = fmul float %fabs.x, 0.0
   %mul.neg0 = fmul float %fabs.x, -0.0
@@ -912,7 +912,7 @@ define double @fadd_nnan_inf_op0(double %x) {
 ; CHECK-LABEL: @fadd_nnan_inf_op0(
 ; CHECK-NEXT:    ret double +inf
 ;
-  %r = fadd nnan double 0x7ff0000000000000, %x
+  %r = fadd nnan double +inf, %x
   ret double %r
 }
 
@@ -920,7 +920,7 @@ define double @fadd_nnan_inf_op1(double %x) {
 ; CHECK-LABEL: @fadd_nnan_inf_op1(
 ; CHECK-NEXT:    ret double +inf
 ;
-  %r = fadd nnan double %x, 0x7ff0000000000000
+  %r = fadd nnan double %x, +inf
   ret double %r
 }
 
@@ -928,7 +928,7 @@ define <2 x double> @fadd_nnan_neginf_op1(<2 x double> %x) {
 ; CHECK-LABEL: @fadd_nnan_neginf_op1(
 ; CHECK-NEXT:    ret <2 x double> <double -inf, double poison>
 ;
-  %r = fadd nnan <2 x double> %x, <double 0xfff0000000000000, double poison>
+  %r = fadd nnan <2 x double> %x, <double -inf, double poison>
   ret <2 x double> %r
 }
 
@@ -936,7 +936,7 @@ define double @fadd_nnan_neginf_op0(double %x) {
 ; CHECK-LABEL: @fadd_nnan_neginf_op0(
 ; CHECK-NEXT:    ret double -inf
 ;
-  %r = fadd nnan double 0xfff0000000000000, %x
+  %r = fadd nnan double -inf, %x
   ret double %r
 }
 
@@ -947,7 +947,7 @@ define double @fadd_inf_op0(double %x) {
 ; CHECK-NEXT:    [[R:%.*]] = fadd double +inf, [[X:%.*]]
 ; CHECK-NEXT:    ret double [[R]]
 ;
-  %r = fadd double 0x7ff0000000000000, %x
+  %r = fadd double +inf, %x
   ret double %r
 }
 
@@ -955,7 +955,7 @@ define double @fsub_nnan_inf_op0(double %x) {
 ; CHECK-LABEL: @fsub_nnan_inf_op0(
 ; CHECK-NEXT:    ret double +inf
 ;
-  %r = fsub nnan double 0x7ff0000000000000, %x
+  %r = fsub nnan double +inf, %x
   ret double %r
 }
 
@@ -965,7 +965,7 @@ define double @fsub_nnan_inf_op1(double %x) {
 ; CHECK-LABEL: @fsub_nnan_inf_op1(
 ; CHECK-NEXT:    ret double -inf
 ;
-  %r = fsub nnan double %x, 0x7ff0000000000000
+  %r = fsub nnan double %x, +inf
   ret double %r
 }
 
@@ -973,7 +973,7 @@ define <2 x double> @fsub_nnan_inf_op1_vec(<2 x double> %x) {
 ; CHECK-LABEL: @fsub_nnan_inf_op1_vec(
 ; CHECK-NEXT:    ret <2 x double> <double +inf, double poison>
 ;
-  %r = fsub nnan <2 x double> %x, <double 0xfff0000000000000, double poison>
+  %r = fsub nnan <2 x double> %x, <double -inf, double poison>
   ret <2 x double> %r
 }
 
@@ -981,7 +981,7 @@ define <2 x double> @fsub_nnan_neginf_op0(<2 x double> %x) {
 ; CHECK-LABEL: @fsub_nnan_neginf_op0(
 ; CHECK-NEXT:    ret <2 x double> <double -inf, double poison>
 ;
-  %r = fsub nnan <2 x double> <double 0xfff0000000000000, double poison>, %x
+  %r = fsub nnan <2 x double> <double -inf, double poison>, %x
   ret <2 x double> %r
 }
 
@@ -991,7 +991,7 @@ define double @fsub_nnan_neginf_op1(double %x) {
 ; CHECK-LABEL: @fsub_nnan_neginf_op1(
 ; CHECK-NEXT:    ret double +inf
 ;
-  %r = fsub nnan double %x, 0xfff0000000000000
+  %r = fsub nnan double %x, -inf
   ret double %r
 }
 
@@ -1002,7 +1002,7 @@ define double @fsub_inf_op0(double %x) {
 ; CHECK-NEXT:    [[R:%.*]] = fsub double +inf, [[X:%.*]]
 ; CHECK-NEXT:    ret double [[R]]
 ;
-  %r = fsub double 0x7ff0000000000000, %x
+  %r = fsub double +inf, %x
   ret double %r
 }
 
@@ -1282,7 +1282,7 @@ define float @fabs_fmul_nan(float %x) {
 ; CHECK-NEXT:    ret float [[ABS2]]
 ;
   %abs = call nnan float @llvm.fabs.f32(float %x)
-  %mul = fmul float %abs, 0x7FF0000000000000
+  %mul = fmul float %abs, +inf
   %abs2 = call float @llvm.fabs.f32(float %mul)
   ret float %abs2
 }

--- a/llvm/test/Transforms/InstSimplify/floating-point-compare.ll
+++ b/llvm/test/Transforms/InstSimplify/floating-point-compare.ll
@@ -7,7 +7,7 @@ define i1 @inf0(double %arg) {
 ; CHECK-LABEL: @inf0(
 ; CHECK-NEXT:    ret i1 false
 ;
-  %tmp = fcmp ogt double %arg, 0x7FF0000000000000
+  %tmp = fcmp ogt double %arg, +inf
   ret i1 %tmp
 }
 
@@ -16,7 +16,7 @@ define i1 @inf0_fabs(double %arg) {
 ; CHECK-NEXT:    ret i1 false
 ;
   %fabs.arg = call double @llvm.fabs.f64(double %arg)
-  %tmp = fcmp ogt double %fabs.arg, 0x7FF0000000000000
+  %tmp = fcmp ogt double %fabs.arg, +inf
   ret i1 %tmp
 }
 
@@ -24,7 +24,7 @@ define i1 @inf1(double %arg) {
 ; CHECK-LABEL: @inf1(
 ; CHECK-NEXT:    ret i1 true
 ;
-  %tmp = fcmp ule double %arg, 0x7FF0000000000000
+  %tmp = fcmp ule double %arg, +inf
   ret i1 %tmp
 }
 
@@ -33,7 +33,7 @@ define i1 @inf1_fabs(double %arg) {
 ; CHECK-NEXT:    ret i1 true
 ;
   %fabs.arg = call double @llvm.fabs.f64(double %arg)
-  %tmp = fcmp ule double %fabs.arg, 0x7FF0000000000000
+  %tmp = fcmp ule double %fabs.arg, +inf
   ret i1 %tmp
 }
 
@@ -43,7 +43,7 @@ define i1 @ninf0(double %arg) {
 ; CHECK-LABEL: @ninf0(
 ; CHECK-NEXT:    ret i1 false
 ;
-  %tmp = fcmp olt double %arg, 0xFFF0000000000000
+  %tmp = fcmp olt double %arg, -inf
   ret i1 %tmp
 }
 
@@ -52,7 +52,7 @@ define i1 @ninf0_fabs(double %arg) {
 ; CHECK-NEXT:    ret i1 false
 ;
   %fabs.arg = call double @llvm.fabs.f64(double %arg)
-  %tmp = fcmp olt double %fabs.arg, 0xFFF0000000000000
+  %tmp = fcmp olt double %fabs.arg, -inf
   ret i1 %tmp
 }
 
@@ -60,7 +60,7 @@ define i1 @ninf1(double %arg) {
 ; CHECK-LABEL: @ninf1(
 ; CHECK-NEXT:    ret i1 true
 ;
-  %tmp = fcmp uge double %arg, 0xFFF0000000000000
+  %tmp = fcmp uge double %arg, -inf
   ret i1 %tmp
 }
 
@@ -69,7 +69,7 @@ define i1 @ninf1_fabs(double %arg) {
 ; CHECK-NEXT:    ret i1 true
 ;
   %fabs.arg = call double @llvm.fabs.f64(double %arg)
-  %tmp = fcmp uge double %fabs.arg, 0xFFF0000000000000
+  %tmp = fcmp uge double %fabs.arg, -inf
   ret i1 %tmp
 }
 
@@ -1663,7 +1663,7 @@ define i1 @pr58046(i64 %arg) {
   %fp = uitofp i64 %arg to double
   %mul = fmul double -0.000000e+00, %fp
   %div = fdiv double 1.000000e+00, %mul
-  %cmp = fcmp oeq double %div, 0xFFF0000000000000
+  %cmp = fcmp oeq double %div, -inf
   ret i1 %cmp
 }
 
@@ -1712,7 +1712,7 @@ define i1 @is_infinite(float %x) {
 ; CHECK-NEXT:    ret i1 false
 ;
   %xabs = call ninf float @llvm.fabs.f32(float %x)
-  %r = fcmp oeq float %xabs, 0x7FF0000000000000
+  %r = fcmp oeq float %xabs, +inf
   ret i1 %r
 }
 
@@ -1724,9 +1724,9 @@ define i1 @is_infinite_assumed_finite(float %x) {
 ; CHECK-NEXT:    ret i1 false
 ;
   %xabs = call float @llvm.fabs.f32(float %x)
-  %not.inf = fcmp one float %xabs, 0x7FF0000000000000
+  %not.inf = fcmp one float %xabs, +inf
   call void @llvm.assume(i1 %not.inf)
-  %r = fcmp oeq float %xabs, 0x7FF0000000000000
+  %r = fcmp oeq float %xabs, +inf
   ret i1 %r
 }
 
@@ -1738,9 +1738,9 @@ define i1 @une_inf_assumed_not_inf(float %x) {
 ; CHECK-NEXT:    ret i1 true
 ;
   %xabs = call float @llvm.fabs.f32(float %x)
-  %not.inf = fcmp one float %xabs, 0x7FF0000000000000
+  %not.inf = fcmp one float %xabs, +inf
   call void @llvm.assume(i1 %not.inf)
-  %r = fcmp une float %xabs, 0x7FF0000000000000
+  %r = fcmp une float %xabs, +inf
   ret i1 %r
 }
 
@@ -1762,7 +1762,7 @@ define i1 @is_infinite_or_nan(float %x) {
 ; CHECK-NEXT:    ret i1 [[R]]
 ;
   %x42 = fadd ninf float %x, 42.0
-  %r = fcmp ueq float %x42, 0xFFF0000000000000
+  %r = fcmp ueq float %x42, -inf
   ret i1 %r
 }
 
@@ -1771,7 +1771,7 @@ define i1 @is_infinite_or_nan2(float %x) {
 ; CHECK-NEXT:    ret i1 false
 ;
   %xabs = call nnan ninf float @llvm.fabs.f32(float %x)
-  %r = fcmp ueq float %xabs, 0x7FF0000000000000
+  %r = fcmp ueq float %xabs, +inf
   ret i1 %r
 }
 
@@ -1783,9 +1783,9 @@ define i1 @is_infinite_or_nan2_assume(float %x) {
 ; CHECK-NEXT:    ret i1 false
 ;
   %xabs = call float @llvm.fabs.f32(float %x)
-  %is.inf.or.nan = fcmp one float %xabs, 0x7FF0000000000000
+  %is.inf.or.nan = fcmp one float %xabs, +inf
   call void @llvm.assume(i1 %is.inf.or.nan)
-  %r = fcmp ueq float %xabs, 0x7FF0000000000000
+  %r = fcmp ueq float %xabs, +inf
   ret i1 %r
 }
 
@@ -1804,7 +1804,7 @@ define i1 @is_finite_or_nan(i1 %c, double %x) {
 ;
   %xx = fmul ninf double %x, %x
   %s = select i1 %c, double 42.0, double %xx
-  %r = fcmp une double %s, 0x7FF0000000000000
+  %r = fcmp une double %s, +inf
   ret i1 %r
 }
 
@@ -1826,7 +1826,7 @@ define i1 @is_finite_and_ordered(double %x) {
 ; CHECK-NEXT:    ret i1 [[R]]
 ;
   %xx = fmul ninf double %x, %x
-  %r = fcmp one double %xx, 0x7FF0000000000000
+  %r = fcmp one double %xx, +inf
   ret i1 %r
 }
 
@@ -1836,7 +1836,7 @@ define i1 @is_finite(i1 %c, double %x) {
 ;
   %xx = fmul nnan ninf double %x, %x
   %s = select i1 %c, double 42.0, double %xx
-  %r = fcmp one double %s, 0x7FF0000000000000
+  %r = fcmp one double %s, +inf
   ret i1 %r
 }
 
@@ -1848,10 +1848,10 @@ define i1 @is_finite_assume(i1 %c, double %x) {
 ; CHECK-NEXT:    ret i1 true
 ;
   %xabs = call double @llvm.fabs.f64(double %x)
-  %is.inf.or.nan = fcmp one double %xabs, 0x7FF0000000000000
+  %is.inf.or.nan = fcmp one double %xabs, +inf
   call void @llvm.assume(i1 %is.inf.or.nan)
   %s = select i1 %c, double 42.0, double %x
-  %r = fcmp one double %s, 0x7FF0000000000000
+  %r = fcmp one double %s, +inf
   ret i1 %r
 }
 

--- a/llvm/test/Transforms/InstSimplify/fminmax-folds.ll
+++ b/llvm/test/Transforms/InstSimplify/fminmax-folds.ll
@@ -361,19 +361,19 @@ define void @minmax_neg_inf_nnan_v2f64(<2 x double> %x, ptr %minnum_res, ptr %ma
 ; CHECK-NEXT:    store <2 x double> [[X]], ptr [[MAXIMUMNUM_RES:%.*]], align 16
 ; CHECK-NEXT:    ret void
 ;
-  %minnum = call nnan <2 x double> @llvm.minnum.v2f64(<2 x double> %x, <2 x double> splat (double 0xFFF0000000000000))
+  %minnum = call nnan <2 x double> @llvm.minnum.v2f64(<2 x double> %x, <2 x double> splat (double -inf))
   store <2 x double> %minnum, ptr %minnum_res
-  %maxnum = call nnan <2 x double> @llvm.maxnum.v2f64(<2 x double> %x, <2 x double> splat (double 0xFFF0000000000000))
+  %maxnum = call nnan <2 x double> @llvm.maxnum.v2f64(<2 x double> %x, <2 x double> splat (double -inf))
   store <2 x double> %maxnum, ptr %maxnum_res
 
-  %minimum = call nnan <2 x double> @llvm.minimum.v2f64(<2 x double> %x, <2 x double> splat (double 0xFFF0000000000000))
+  %minimum = call nnan <2 x double> @llvm.minimum.v2f64(<2 x double> %x, <2 x double> splat (double -inf))
   store <2 x double> %minimum, ptr %minimum_res
-  %maximum = call nnan <2 x double> @llvm.maximum.v2f64(<2 x double> %x, <2 x double> splat (double 0xFFF0000000000000))
+  %maximum = call nnan <2 x double> @llvm.maximum.v2f64(<2 x double> %x, <2 x double> splat (double -inf))
   store <2 x double> %maximum, ptr %maximum_res
 
-  %minimumnum = call nnan <2 x double> @llvm.minimumnum.v2f64(<2 x double> %x, <2 x double> splat (double 0xFFF0000000000000))
+  %minimumnum = call nnan <2 x double> @llvm.minimumnum.v2f64(<2 x double> %x, <2 x double> splat (double -inf))
   store <2 x double> %minimumnum, ptr %minimumnum_res
-  %maximumnum = call nnan <2 x double> @llvm.maximumnum.v2f64(<2 x double> %x, <2 x double> splat (double 0xFFF0000000000000))
+  %maximumnum = call nnan <2 x double> @llvm.maximumnum.v2f64(<2 x double> %x, <2 x double> splat (double -inf))
   store <2 x double> %maximumnum, ptr %maximumnum_res
   ret void
 }
@@ -601,19 +601,19 @@ define void @minmax_mixed_pos_inf_poison_v2f64_nnan(<2 x double> %x, ptr %minnum
 ; CHECK-NEXT:    store <2 x double> <double poison, double +inf>, ptr [[MAXIMUMNUM_RES:%.*]], align 16
 ; CHECK-NEXT:    ret void
 ;
-  %minnum = call nnan <2 x double> @llvm.minnum.v2f64(<2 x double> <double poison, double 0x7FF0000000000000>, <2 x double> %x)
+  %minnum = call nnan <2 x double> @llvm.minnum.v2f64(<2 x double> <double poison, double +inf>, <2 x double> %x)
   store <2 x double> %minnum, ptr %minnum_res
-  %maxnum = call nnan <2 x double> @llvm.maxnum.v2f64(<2 x double> <double poison, double 0x7FF0000000000000>, <2 x double> %x)
+  %maxnum = call nnan <2 x double> @llvm.maxnum.v2f64(<2 x double> <double poison, double +inf>, <2 x double> %x)
   store <2 x double> %maxnum, ptr %maxnum_res
 
-  %minimum = call nnan <2 x double> @llvm.minimum.v2f64(<2 x double> <double poison, double 0x7FF0000000000000>, <2 x double> %x)
+  %minimum = call nnan <2 x double> @llvm.minimum.v2f64(<2 x double> <double poison, double +inf>, <2 x double> %x)
   store <2 x double> %minimum, ptr %minimum_res
-  %maximum = call nnan <2 x double> @llvm.maximum.v2f64(<2 x double> <double poison, double 0x7FF0000000000000>, <2 x double> %x)
+  %maximum = call nnan <2 x double> @llvm.maximum.v2f64(<2 x double> <double poison, double +inf>, <2 x double> %x)
   store <2 x double> %maximum, ptr %maximum_res
 
-  %minimumnum = call nnan <2 x double> @llvm.minimumnum.v2f64(<2 x double> <double poison, double 0x7FF0000000000000>, <2 x double> %x)
+  %minimumnum = call nnan <2 x double> @llvm.minimumnum.v2f64(<2 x double> <double poison, double +inf>, <2 x double> %x)
   store <2 x double> %minimumnum, ptr %minimumnum_res
-  %maximumnum = call nnan <2 x double> @llvm.maximumnum.v2f64(<2 x double> <double poison, double 0x7FF0000000000000>, <2 x double> %x)
+  %maximumnum = call nnan <2 x double> @llvm.maximumnum.v2f64(<2 x double> <double poison, double +inf>, <2 x double> %x)
   store <2 x double> %maximumnum, ptr %maximumnum_res
   ret void
 }

--- a/llvm/test/Transforms/InstSimplify/fp-undef-poison.ll
+++ b/llvm/test/Transforms/InstSimplify/fp-undef-poison.ll
@@ -263,7 +263,7 @@ define double @fdiv_ninf_inf_op0(double %x) {
 ; CHECK-LABEL: @fdiv_ninf_inf_op0(
 ; CHECK-NEXT:    ret double poison
 ;
-  %r = fdiv ninf double 0x7ff0000000000000, %x
+  %r = fdiv ninf double +inf, %x
   ret double %r
 }
 
@@ -271,7 +271,7 @@ define double @fadd_ninf_inf_op1(double %x) {
 ; CHECK-LABEL: @fadd_ninf_inf_op1(
 ; CHECK-NEXT:    ret double poison
 ;
-  %r = fadd ninf double %x, 0xfff0000000000000
+  %r = fadd ninf double %x, -inf
   ret double %r
 }
 
@@ -279,7 +279,7 @@ define double @fsub_nnan_inf_op0(double %x) {
 ; CHECK-LABEL: @fsub_nnan_inf_op0(
 ; CHECK-NEXT:    ret double +inf
 ;
-  %r = fsub nnan double 0x7ff0000000000000, %x
+  %r = fsub nnan double +inf, %x
   ret double %r
 }
 
@@ -290,7 +290,7 @@ define double @fmul_nnan_inf_op1(double %x) {
 ; CHECK-NEXT:    [[R:%.*]] = fmul nnan double [[X:%.*]], -inf
 ; CHECK-NEXT:    ret double [[R]]
 ;
-  %r = fmul nnan double %x, 0xfff0000000000000
+  %r = fmul nnan double %x, -inf
   ret double %r
 }
 

--- a/llvm/test/Transforms/InstSimplify/fptoi-sat.ll
+++ b/llvm/test/Transforms/InstSimplify/fptoi-sat.ll
@@ -125,7 +125,7 @@ define i32 @fptosi_f64_to_i32_inf() {
 ; CHECK-LABEL: @fptosi_f64_to_i32_inf(
 ; CHECK-NEXT:    ret i32 2147483647
 ;
-  %r = call i32 @llvm.fptosi.sat.i32.f64(double 0x7ff0000000000000)
+  %r = call i32 @llvm.fptosi.sat.i32.f64(double +inf)
   ret i32 %r
 }
 
@@ -133,7 +133,7 @@ define i32 @fptosi_f64_to_i32_neg_inf() {
 ; CHECK-LABEL: @fptosi_f64_to_i32_neg_inf(
 ; CHECK-NEXT:    ret i32 -2147483648
 ;
-  %r = call i32 @llvm.fptosi.sat.i32.f64(double 0xfff0000000000000)
+  %r = call i32 @llvm.fptosi.sat.i32.f64(double -inf)
   ret i32 %r
 }
 
@@ -267,7 +267,7 @@ define i32 @fptoui_f64_to_i32_inf() {
 ; CHECK-LABEL: @fptoui_f64_to_i32_inf(
 ; CHECK-NEXT:    ret i32 -1
 ;
-  %r = call i32 @llvm.fptoui.sat.i32.f64(double 0x7ff0000000000000)
+  %r = call i32 @llvm.fptoui.sat.i32.f64(double +inf)
   ret i32 %r
 }
 
@@ -275,7 +275,7 @@ define i32 @fptoui_f64_to_i32_neg_inf() {
 ; CHECK-LABEL: @fptoui_f64_to_i32_neg_inf(
 ; CHECK-NEXT:    ret i32 0
 ;
-  %r = call i32 @llvm.fptoui.sat.i32.f64(double 0xfff0000000000000)
+  %r = call i32 @llvm.fptoui.sat.i32.f64(double -inf)
   ret i32 %r
 }
 

--- a/llvm/test/Transforms/InstSimplify/known-never-infinity.ll
+++ b/llvm/test/Transforms/InstSimplify/known-never-infinity.ll
@@ -108,7 +108,7 @@ define i1 @isKnownNeverInfinity_fpext(float %x) {
 ;
   %a = fadd ninf float %x, 1.0
   %e = fpext float %a to double
-  %r = fcmp une double %e, 0x7ff0000000000000
+  %r = fcmp une double %e, +inf
   ret i1 %r
 }
 
@@ -119,7 +119,7 @@ define i1 @isKnownNeverInfinity_fpext_sitofp(i16 %x) {
 ;
   %f = sitofp i16 %x to half
   %e = fpext half %f to double
-  %r = fcmp oeq double %e, 0xfff0000000000000
+  %r = fcmp oeq double %e, -inf
   ret i1 %r
 }
 
@@ -133,7 +133,7 @@ define i1 @isKnownNeverInfinity_fptrunc(double %x) {
 ;
   %a = fadd ninf double %x, 1.0
   %e = fptrunc double %a to float
-  %r = fcmp une float %e, 0x7FF0000000000000
+  %r = fcmp une float %e, +inf
   ret i1 %r
 }
 
@@ -145,7 +145,7 @@ define i1 @isNotKnownNeverInfinity_fptrunc(double %unknown) {
 ; CHECK-NEXT:    ret i1 [[R]]
 ;
   %e = fptrunc double %unknown to float
-  %r = fcmp une float %e, 0x7FF0000000000000
+  %r = fcmp une float %e, +inf
   ret i1 %r
 }
 
@@ -156,7 +156,7 @@ define i1 @isKnownNeverInfinity_canonicalize(double %x) {
 ;
   %a = fadd ninf double %x, 1.0
   %e = call double @llvm.canonicalize.f64(double %a)
-  %r = fcmp une double %e, 0x7ff0000000000000
+  %r = fcmp une double %e, +inf
   ret i1 %r
 }
 
@@ -168,7 +168,7 @@ define i1 @isNotKnownNeverInfinity_canonicalize(double %x) {
 ; CHECK-NEXT:    ret i1 [[R]]
 ;
   %e = call double @llvm.canonicalize.f64(double %x)
-  %r = fcmp une double %e, 0x7ff0000000000000
+  %r = fcmp une double %e, +inf
   ret i1 %r
 }
 
@@ -179,7 +179,7 @@ define i1 @isKnownNeverInfinity_fabs(double %x) {
 ;
   %a = fadd ninf double %x, 1.0
   %e = call double @llvm.fabs.f64(double %a)
-  %r = fcmp une double %e, 0x7ff0000000000000
+  %r = fcmp une double %e, +inf
   ret i1 %r
 }
 
@@ -191,7 +191,7 @@ define i1 @isNotKnownNeverInfinity_fabs(double %x) {
 ; CHECK-NEXT:    ret i1 [[R]]
 ;
   %e = call double @llvm.fabs.f64(double %x)
-  %r = fcmp une double %e, 0x7ff0000000000000
+  %r = fcmp une double %e, +inf
   ret i1 %r
 }
 
@@ -202,7 +202,7 @@ define i1 @isKnownNeverInfinity_fneg(double %x) {
 ;
   %a = fadd ninf double %x, 1.0
   %e = fneg double %a
-  %r = fcmp une double %e, 0x7ff0000000000000
+  %r = fcmp une double %e, +inf
   ret i1 %r
 }
 
@@ -214,7 +214,7 @@ define i1 @isNotKnownNeverInfinity_fneg(double %x) {
 ; CHECK-NEXT:    ret i1 [[R]]
 ;
   %e = fneg double %x
-  %r = fcmp une double %e, 0x7ff0000000000000
+  %r = fcmp une double %e, +inf
   ret i1 %r
 }
 
@@ -225,7 +225,7 @@ define i1 @isKnownNeverInfinity_copysign(double %x, double %sign) {
 ;
   %a = fadd ninf double %x, 1.0
   %e = call double @llvm.copysign.f64(double %a, double %sign)
-  %r = fcmp une double %e, 0x7ff0000000000000
+  %r = fcmp une double %e, +inf
   ret i1 %r
 }
 
@@ -237,7 +237,7 @@ define i1 @isNotKnownNeverInfinity_copysign(double %x, double %sign) {
 ; CHECK-NEXT:    ret i1 [[R]]
 ;
   %e = call double @llvm.copysign.f64(double %x, double %sign)
-  %r = fcmp une double %e, 0x7ff0000000000000
+  %r = fcmp une double %e, +inf
   ret i1 %r
 }
 
@@ -248,7 +248,7 @@ define i1 @isKnownNeverInfinity_arithmetic_fence(double %x) {
 ;
   %a = fadd ninf double %x, 1.0
   %e = call double @llvm.arithmetic.fence.f64(double %a)
-  %r = fcmp une double %e, 0x7ff0000000000000
+  %r = fcmp une double %e, +inf
   ret i1 %r
 }
 
@@ -260,7 +260,7 @@ define i1 @isNotKnownNeverInfinity_arithmetic_fence(double %x) {
 ; CHECK-NEXT:    ret i1 [[R]]
 ;
   %e = call double @llvm.arithmetic.fence.f64(double %x)
-  %r = fcmp une double %e, 0x7ff0000000000000
+  %r = fcmp une double %e, +inf
   ret i1 %r
 }
 
@@ -271,7 +271,7 @@ define i1 @isKnownNeverInfinity_floor(double %x) {
 ;
   %a = fadd ninf double %x, 1.0
   %e = call double @llvm.floor.f64(double %a)
-  %r = fcmp une double %e, 0x7ff0000000000000
+  %r = fcmp une double %e, +inf
   ret i1 %r
 }
 
@@ -283,7 +283,7 @@ define i1 @isNotKnownNeverInfinity_floor(double %x) {
 ; CHECK-NEXT:    ret i1 [[R]]
 ;
   %e = call double @llvm.floor.f64(double %x)
-  %r = fcmp une double %e, 0x7ff0000000000000
+  %r = fcmp une double %e, +inf
   ret i1 %r
 }
 
@@ -294,7 +294,7 @@ define i1 @isKnownNeverInfinity_ceil(double %x) {
 ;
   %a = fadd ninf double %x, 1.0
   %e = call double @llvm.ceil.f64(double %a)
-  %r = fcmp une double %e, 0x7ff0000000000000
+  %r = fcmp une double %e, +inf
   ret i1 %r
 }
 
@@ -306,7 +306,7 @@ define i1 @isNotKnownNeverInfinity_ceil(double %x) {
 ; CHECK-NEXT:    ret i1 [[R]]
 ;
   %e = call double @llvm.ceil.f64(double %x)
-  %r = fcmp une double %e, 0x7ff0000000000000
+  %r = fcmp une double %e, +inf
   ret i1 %r
 }
 
@@ -317,7 +317,7 @@ define i1 @isKnownNeverInfinity_trunc(double %x) {
 ;
   %a = fadd ninf double %x, 1.0
   %e = call double @llvm.trunc.f64(double %a)
-  %r = fcmp une double %e, 0x7ff0000000000000
+  %r = fcmp une double %e, +inf
   ret i1 %r
 }
 
@@ -329,7 +329,7 @@ define i1 @isNotKnownNeverInfinity_trunc(double %x) {
 ; CHECK-NEXT:    ret i1 [[R]]
 ;
   %e = call double @llvm.trunc.f64(double %x)
-  %r = fcmp une double %e, 0x7ff0000000000000
+  %r = fcmp une double %e, +inf
   ret i1 %r
 }
 
@@ -340,7 +340,7 @@ define i1 @isKnownNeverInfinity_rint(double %x) {
 ;
   %a = fadd ninf double %x, 1.0
   %e = call double @llvm.rint.f64(double %a)
-  %r = fcmp une double %e, 0x7ff0000000000000
+  %r = fcmp une double %e, +inf
   ret i1 %r
 }
 
@@ -352,7 +352,7 @@ define i1 @isNotKnownNeverInfinity_rint(double %x) {
 ; CHECK-NEXT:    ret i1 [[R]]
 ;
   %e = call double @llvm.rint.f64(double %x)
-  %r = fcmp une double %e, 0x7ff0000000000000
+  %r = fcmp une double %e, +inf
   ret i1 %r
 }
 
@@ -363,7 +363,7 @@ define i1 @isKnownNeverInfinity_nearbyint(double %x) {
 ;
   %a = fadd ninf double %x, 1.0
   %e = call double @llvm.nearbyint.f64(double %a)
-  %r = fcmp une double %e, 0x7ff0000000000000
+  %r = fcmp une double %e, +inf
   ret i1 %r
 }
 
@@ -375,7 +375,7 @@ define i1 @isNotKnownNeverInfinity_nearbyint(double %x) {
 ; CHECK-NEXT:    ret i1 [[R]]
 ;
   %e = call double @llvm.nearbyint.f64(double %x)
-  %r = fcmp une double %e, 0x7ff0000000000000
+  %r = fcmp une double %e, +inf
   ret i1 %r
 }
 
@@ -386,7 +386,7 @@ define i1 @isKnownNeverInfinity_round(double %x) {
 ;
   %a = fadd ninf double %x, 1.0
   %e = call double @llvm.round.f64(double %a)
-  %r = fcmp une double %e, 0x7ff0000000000000
+  %r = fcmp une double %e, +inf
   ret i1 %r
 }
 
@@ -398,7 +398,7 @@ define i1 @isNotKnownNeverInfinity_round(double %x) {
 ; CHECK-NEXT:    ret i1 [[R]]
 ;
   %e = call double @llvm.round.f64(double %x)
-  %r = fcmp une double %e, 0x7ff0000000000000
+  %r = fcmp une double %e, +inf
   ret i1 %r
 }
 
@@ -409,7 +409,7 @@ define i1 @isKnownNeverInfinity_roundeven(double %x) {
 ;
   %a = fadd ninf double %x, 1.0
   %e = call double @llvm.roundeven.f64(double %a)
-  %r = fcmp une double %e, 0x7ff0000000000000
+  %r = fcmp une double %e, +inf
   ret i1 %r
 }
 
@@ -421,7 +421,7 @@ define i1 @isNotKnownNeverInfinity_roundeven(double %x) {
 ; CHECK-NEXT:    ret i1 [[R]]
 ;
   %e = call double @llvm.roundeven.f64(double %x)
-  %r = fcmp une double %e, 0x7ff0000000000000
+  %r = fcmp une double %e, +inf
   ret i1 %r
 }
 
@@ -435,7 +435,7 @@ define i1 @isNotKnownNeverInfinity_fptrunc_round(double %x) {
 ;
   %a = fadd ninf double %x, 1.0
   %e = call float @llvm.fptrunc.round.f32.f64(double %a, metadata !"round.downward")
-  %r = fcmp une float %e, 0x7ff0000000000000
+  %r = fcmp une float %e, +inf
   ret i1 %r
 }
 
@@ -553,7 +553,7 @@ define i1 @isKnownNeverInfinity_minnum(double %x, double %y) {
   %ninf.x = fadd ninf double %x, 1.0
   %ninf.y = fadd ninf double %y, 1.0
   %op = call double @llvm.minnum.f64(double %ninf.x, double %ninf.y)
-  %cmp = fcmp une double %op, 0x7ff0000000000000
+  %cmp = fcmp une double %op, +inf
   ret i1 %cmp
 }
 
@@ -567,7 +567,7 @@ define i1 @isNotKnownNeverInfinity_minnum_lhs(double %x, double %y) {
 ;
   %ninf.y = fadd ninf double %y, 1.0
   %op = call double @llvm.minnum.f64(double %x, double %ninf.y)
-  %cmp = fcmp une double %op, 0x7ff0000000000000
+  %cmp = fcmp une double %op, +inf
   ret i1 %cmp
 }
 
@@ -581,7 +581,7 @@ define i1 @isNotKnownNeverInfinity_minnum_rhs(double %x, double %y) {
 ;
   %ninf.x = fadd ninf double %x, 1.0
   %op = call double @llvm.minnum.f64(double %ninf.x, double %y)
-  %cmp = fcmp une double %op, 0x7ff0000000000000
+  %cmp = fcmp une double %op, +inf
   ret i1 %cmp
 }
 
@@ -593,7 +593,7 @@ define i1 @isKnownNeverInfinity_maxnum(double %x, double %y) {
   %ninf.x = fadd ninf double %x, 1.0
   %ninf.y = fadd ninf double %y, 1.0
   %op = call double @llvm.maxnum.f64(double %ninf.x, double %ninf.y)
-  %cmp = fcmp une double %op, 0x7ff0000000000000
+  %cmp = fcmp une double %op, +inf
   ret i1 %cmp
 }
 
@@ -607,7 +607,7 @@ define i1 @isNotKnownNeverInfinity_maxnum_lhs(double %x, double %y) {
 ;
   %ninf.y = fadd ninf double %y, 1.0
   %op = call double @llvm.maxnum.f64(double %x, double %ninf.y)
-  %cmp = fcmp une double %op, 0x7ff0000000000000
+  %cmp = fcmp une double %op, +inf
   ret i1 %cmp
 }
 
@@ -621,7 +621,7 @@ define i1 @isNotKnownNeverInfinity_maxnum_rhs(double %x, double %y) {
 ;
   %ninf.x = fadd ninf double %x, 1.0
   %op = call double @llvm.maxnum.f64(double %ninf.x, double %y)
-  %cmp = fcmp une double %op, 0x7ff0000000000000
+  %cmp = fcmp une double %op, +inf
   ret i1 %cmp
 }
 
@@ -633,7 +633,7 @@ define i1 @isKnownNeverInfinity_minimum(double %x, double %y) {
   %ninf.x = fadd ninf double %x, 1.0
   %ninf.y = fadd ninf double %y, 1.0
   %op = call double @llvm.minimum.f64(double %ninf.x, double %ninf.y)
-  %cmp = fcmp une double %op, 0x7ff0000000000000
+  %cmp = fcmp une double %op, +inf
   ret i1 %cmp
 }
 
@@ -644,7 +644,7 @@ define i1 @isNotKnownNeverPInfinity_minimum_lhs(double %x, double %y) {
 ;
   %ninf.y = fadd ninf double %y, 1.0
   %op = call double @llvm.minimum.f64(double %x, double %ninf.y)
-  %cmp = fcmp une double %op, 0x7ff0000000000000
+  %cmp = fcmp une double %op, +inf
   ret i1 %cmp
 }
 
@@ -658,7 +658,7 @@ define i1 @isNotKnownNeverNInfinity_minimum_lhs(double %x, double %y) {
 ;
   %ninf.y = fadd ninf double %y, 1.0
   %op = call double @llvm.minimum.f64(double %x, double %ninf.y)
-  %cmp = fcmp une double %op, 0xfff0000000000000
+  %cmp = fcmp une double %op, -inf
   ret i1 %cmp
 }
 
@@ -669,7 +669,7 @@ define i1 @isNotKnownNeverPInfinity_minimum_rhs(double %x, double %y) {
 ;
   %ninf.x = fadd ninf double %x, 1.0
   %op = call double @llvm.minimum.f64(double %ninf.x, double %y)
-  %cmp = fcmp une double %op, 0x7ff0000000000000
+  %cmp = fcmp une double %op, +inf
   ret i1 %cmp
 }
 
@@ -683,7 +683,7 @@ define i1 @isNotKnownNeverNInfinity_minimum_rhs(double %x, double %y) {
 ;
   %ninf.x = fadd ninf double %x, 1.0
   %op = call double @llvm.minimum.f64(double %ninf.x, double %y)
-  %cmp = fcmp une double %op, 0xfff0000000000000
+  %cmp = fcmp une double %op, -inf
   ret i1 %cmp
 }
 
@@ -695,7 +695,7 @@ define i1 @isKnownNeverInfinity_maximum(double %x, double %y) {
   %ninf.x = fadd ninf double %x, 1.0
   %ninf.y = fadd ninf double %y, 1.0
   %op = call double @llvm.maximum.f64(double %ninf.x, double %ninf.y)
-  %cmp = fcmp une double %op, 0x7ff0000000000000
+  %cmp = fcmp une double %op, +inf
   ret i1 %cmp
 }
 
@@ -709,7 +709,7 @@ define i1 @isNotKnownNeverPInfinity_maximum_lhs(double %x, double %y) {
 ;
   %ninf.y = fadd ninf double %y, 1.0
   %op = call double @llvm.maximum.f64(double %x, double %ninf.y)
-  %cmp = fcmp une double %op, 0x7ff0000000000000
+  %cmp = fcmp une double %op, +inf
   ret i1 %cmp
 }
 
@@ -720,7 +720,7 @@ define i1 @isNotKnownNeverNInfinity_maximum_lhs(double %x, double %y) {
 ;
   %ninf.y = fadd ninf double %y, 1.0
   %op = call double @llvm.maximum.f64(double %x, double %ninf.y)
-  %cmp = fcmp une double %op, 0xfff0000000000000
+  %cmp = fcmp une double %op, -inf
   ret i1 %cmp
 }
 
@@ -734,7 +734,7 @@ define i1 @isNotKnownNeverPInfinity_maximum_rhs(double %x, double %y) {
 ;
   %ninf.x = fadd ninf double %x, 1.0
   %op = call double @llvm.maximum.f64(double %ninf.x, double %y)
-  %cmp = fcmp une double %op, 0x7ff0000000000000
+  %cmp = fcmp une double %op, +inf
   ret i1 %cmp
 }
 
@@ -745,7 +745,7 @@ define i1 @isNotKnownNeverNInfinity_maximum_rhs(double %x, double %y) {
 ;
   %ninf.x = fadd ninf double %x, 1.0
   %op = call double @llvm.maximum.f64(double %ninf.x, double %y)
-  %cmp = fcmp une double %op, 0xfff0000000000000
+  %cmp = fcmp une double %op, -inf
   ret i1 %cmp
 }
 
@@ -756,7 +756,7 @@ define i1 @isKnownNeverInfinity_sqrt(double %x) {
 ;
   %a = fadd ninf double %x, 1.0
   %e = call double @llvm.sqrt.f64(double %a)
-  %r = fcmp une double %e, 0x7ff0000000000000
+  %r = fcmp une double %e, +inf
   ret i1 %r
 }
 
@@ -768,7 +768,7 @@ define i1 @isNotKnownNeverInfinity_sqrt(double %x) {
 ; CHECK-NEXT:    ret i1 [[R]]
 ;
   %e = call double @llvm.sqrt.f64(double %x)
-  %r = fcmp une double %e, 0x7ff0000000000000
+  %r = fcmp une double %e, +inf
   ret i1 %r
 }
 
@@ -780,7 +780,7 @@ define i1 @isKnownNeverInfinity_log(double %x) {
   %x.clamp.zero = call double @llvm.maxnum.f64(double %x, double 0.0)
   %a = fadd ninf double %x.clamp.zero, 1.0
   %e = call double @llvm.log.f64(double %a)
-  %r = fcmp une double %e, 0x7ff0000000000000
+  %r = fcmp une double %e, +inf
   ret i1 %r
 }
 
@@ -792,7 +792,7 @@ define i1 @isNotKnownNeverInfinity_log_maybe_negative(double %x) {
 
   %x.not.inf = fadd ninf double %x, 1.0
   %e = call double @llvm.log.f64(double %x.not.inf)
-  %r = fcmp une double %e, 0x7ff0000000000000
+  %r = fcmp une double %e, +inf
   ret i1 %r
 }
 
@@ -806,7 +806,7 @@ define i1 @isNotKnownNeverInfinity_log_maybe_inf(double %x) {
 ;
   %x.clamp.zero = call double @llvm.maxnum.f64(double %x, double 0.0)
   %e = call double @llvm.log.f64(double %x.clamp.zero)
-  %r = fcmp une double %e, 0x7ff0000000000000
+  %r = fcmp une double %e, +inf
   ret i1 %r
 }
 
@@ -820,7 +820,7 @@ define i1 @isKnownNeverNegInfinity_log_maybe_0(double %x) {
 ;
   %a = call ninf double @llvm.sqrt.f64(double %x) ; could be 0.0
   %e = call double @llvm.log.f64(double %a) ; log(0.0) --> -inf
-  %r = fcmp une double %e, 0xfff0000000000000
+  %r = fcmp une double %e, -inf
   ret i1 %r
 }
 
@@ -832,7 +832,7 @@ define i1 @isKnownNeverInfinity_log10(double %x) {
   %x.clamp.zero = call double @llvm.maxnum.f64(double %x, double 0.0)
   %a = fadd ninf double %x.clamp.zero, 1.0
   %e = call double @llvm.log10.f64(double %a)
-  %r = fcmp une double %e, 0x7ff0000000000000
+  %r = fcmp une double %e, +inf
   ret i1 %r
 }
 
@@ -844,7 +844,7 @@ define i1 @isNotKnownNeverInfinity_log10_maybe_negative(double %x) {
 
   %x.not.inf = fadd ninf double %x, 1.0
   %e = call double @llvm.log10.f64(double %x.not.inf)
-  %r = fcmp une double %e, 0x7ff0000000000000
+  %r = fcmp une double %e, +inf
   ret i1 %r
 }
 
@@ -858,7 +858,7 @@ define i1 @isNotKnownNeverInfinity_log10_maybe_inf(double %x) {
 ;
   %x.clamp.zero = call double @llvm.maxnum.f64(double %x, double 0.0)
   %e = call double @llvm.log10.f64(double %x.clamp.zero)
-  %r = fcmp une double %e, 0x7ff0000000000000
+  %r = fcmp une double %e, +inf
   ret i1 %r
 }
 
@@ -872,7 +872,7 @@ define i1 @isKnownNeverNegInfinity_log10_maybe_0(double %x) {
 ;
   %a = call ninf double @llvm.sqrt.f64(double %x) ; could be 0.0
   %e = call double @llvm.log10.f64(double %a) ; log(0.0) --> -inf
-  %r = fcmp une double %e, 0xfff0000000000000
+  %r = fcmp une double %e, -inf
   ret i1 %r
 }
 
@@ -884,7 +884,7 @@ define i1 @isKnownNeverInfinity_log2(double %x) {
   %x.clamp.zero = call double @llvm.maxnum.f64(double %x, double 0.0)
   %a = fadd ninf double %x.clamp.zero, 1.0
   %e = call double @llvm.log2.f64(double %a)
-  %r = fcmp une double %e, 0x7ff0000000000000
+  %r = fcmp une double %e, +inf
   ret i1 %r
 }
 
@@ -896,7 +896,7 @@ define i1 @isNotKnownNeverInfinity_log2_maybe_negative(double %x) {
 
   %x.not.inf = fadd ninf double %x, 1.0
   %e = call double @llvm.log2.f64(double %x.not.inf)
-  %r = fcmp une double %e, 0x7ff0000000000000
+  %r = fcmp une double %e, +inf
   ret i1 %r
 }
 
@@ -910,7 +910,7 @@ define i1 @isNotKnownNeverInfinity_log2_maybe_inf(double %x) {
 ;
   %x.clamp.zero = call double @llvm.maxnum.f64(double %x, double 0.0)
   %e = call double @llvm.log2.f64(double %x.clamp.zero)
-  %r = fcmp une double %e, 0x7ff0000000000000
+  %r = fcmp une double %e, +inf
   ret i1 %r
 }
 
@@ -924,7 +924,7 @@ define i1 @isKnownNeverNegInfinity_log2_maybe_0(double %x) {
 ;
   %a = call ninf double @llvm.sqrt.f64(double %x) ; could be 0.0
   %e = call double @llvm.log2.f64(double %a) ; log(0.0) --> -inf
-  %r = fcmp une double %e, 0xfff0000000000000
+  %r = fcmp une double %e, -inf
   ret i1 %r
 }
 
@@ -940,7 +940,7 @@ define i1 @isNotKnownNeverInfinity_pow(double %x, double %y) {
   %ninf.x = fadd ninf double %x, 1.0
   %ninf.y = fadd ninf double %y, 1.0
   %op = call double @llvm.pow.f64(double %ninf.x, double %ninf.y)
-  %cmp = fcmp une double %op, 0x7ff0000000000000
+  %cmp = fcmp une double %op, +inf
   ret i1 %cmp
 }
 
@@ -954,7 +954,7 @@ define i1 @isNotKnownNeverInfinity_powi(double %x) {
 ;
   %ninf.x = fadd ninf double %x, 1.0
   %op = call double @llvm.powi.f64.i32(double %ninf.x, i32 2)
-  %cmp = fcmp une double %op, 0x7ff0000000000000
+  %cmp = fcmp une double %op, +inf
   ret i1 %cmp
 }
 
@@ -968,7 +968,7 @@ define i1 @isNotKnownNeverInfinity_exp(double %x) {
 ;
   %a = fadd ninf double %x, 1.0
   %e = call double @llvm.exp.f64(double %a)
-  %r = fcmp une double %e, 0x7ff0000000000000
+  %r = fcmp une double %e, +inf
   ret i1 %r
 }
 
@@ -982,7 +982,7 @@ define i1 @isNotKnownNeverInfinity_exp2(double %x) {
 ;
   %a = fadd ninf double %x, 1.0
   %e = call double @llvm.exp2.f64(double %a)
-  %r = fcmp une double %e, 0x7ff0000000000000
+  %r = fcmp une double %e, +inf
   ret i1 %r
 }
 
@@ -1000,7 +1000,7 @@ define i1 @isNotKnownNeverInfinity_fma(double %x, double %y, double %z) {
   %ninf.y = fadd ninf double %y, 1.0
   %ninf.z = fadd ninf double %z, 1.0
   %op = call double @llvm.fma.f64(double %ninf.x, double %ninf.y, double %ninf.z)
-  %cmp = fcmp une double %op, 0x7ff0000000000000
+  %cmp = fcmp une double %op, +inf
   ret i1 %cmp
 }
 
@@ -1018,7 +1018,7 @@ define i1 @isNotKnownNeverInfinity_fmuladd(double %x, double %y, double %z) {
   %ninf.y = fadd ninf double %y, 1.0
   %ninf.z = fadd ninf double %z, 1.0
   %op = call double @llvm.fmuladd.f64(double %ninf.x, double %ninf.y, double %ninf.z)
-  %cmp = fcmp une double %op, 0x7ff0000000000000
+  %cmp = fcmp une double %op, +inf
   ret i1 %cmp
 }
 
@@ -1034,7 +1034,7 @@ define i1 @not_inf_fabs_select_pzero_or_ninf(i1 %cond) {
 entry:
   %select = select i1 %cond, float 0.000000e+00, float -inf
   %fabs = call float @llvm.fabs.f32(float %select)
-  %one = fcmp one float %fabs, 0x7FF0000000000000
+  %one = fcmp one float %fabs, +inf
   ret i1 %one
 }
 
@@ -1050,7 +1050,7 @@ define i1 @not_inf_fabs_select_nzero_or_pinf(i1 %cond) {
 entry:
   %select = select i1 %cond, float -0.000000e+00, float +inf
   %fabs = call float @llvm.fabs.f32(float %select)
-  %one = fcmp one float %fabs, 0x7FF0000000000000
+  %one = fcmp one float %fabs, +inf
   ret i1 %one
 }
 
@@ -1063,7 +1063,7 @@ define i1 @not_ninf_fabs_select_nzero_or_pinf(i1 %cond) {
 entry:
   %select = select i1 %cond, float -0.000000e+00, float +inf
   %fabs = call float @llvm.fabs.f32(float %select)
-  %one = fcmp one float %fabs, 0xFFF0000000000000
+  %one = fcmp one float %fabs, -inf
   ret i1 %one
 }
 
@@ -1081,7 +1081,7 @@ entry:
   %select = select i1 %cond, float -0.000000e+00, float +inf
   %fabs = call float @llvm.fabs.f32(float %select)
   %fneg.fabs = fneg float %fabs
-  %one = fcmp one float %fneg.fabs, 0xFFF0000000000000
+  %one = fcmp one float %fneg.fabs, -inf
   ret i1 %one
 }
 
@@ -1092,7 +1092,7 @@ define float @fcmp_ogt_neginf_implies_class_assert(float %arg) {
 ; CHECK-SAME: (float [[ARG:%.*]]) {
 ; CHECK-NEXT:    ret float 0.000000e+00
 ;
-  %cmp.ogt.neginf = fcmp ogt float %arg, 0xFFF0000000000000
+  %cmp.ogt.neginf = fcmp ogt float %arg, -inf
   %select_1_0 = select i1 %cmp.ogt.neginf, float 1.0, float 0.0
   %mul_by_zero = fmul float %select_1_0, 0.0
   ret float %mul_by_zero
@@ -1103,7 +1103,7 @@ define float @fcmp_ule_neginf_implies_class_assert(float %arg) {
 ; CHECK-SAME: (float [[ARG:%.*]]) {
 ; CHECK-NEXT:    ret float 0.000000e+00
 ;
-  %cmp.ule.neginf = fcmp ule float %arg, 0xFFF0000000000000
+  %cmp.ule.neginf = fcmp ule float %arg, -inf
   %select_1_0 = select i1 %cmp.ule.neginf, float 1.0, float 0.0
   %mul_by_zero = fmul float %select_1_0, 0.0
   ret float %mul_by_zero
@@ -1114,7 +1114,7 @@ define float @fcmp_oge_neginf_implies_class_assert(float %arg) {
 ; CHECK-SAME: (float [[ARG:%.*]]) {
 ; CHECK-NEXT:    ret float 0.000000e+00
 ;
-  %cmp.oge.neginf = fcmp oge float %arg, 0xFFF0000000000000
+  %cmp.oge.neginf = fcmp oge float %arg, -inf
   %select_1_0 = select i1 %cmp.oge.neginf, float 1.0, float 0.0
   %mul_by_zero = fmul float %select_1_0, 0.0
   ret float %mul_by_zero
@@ -1125,7 +1125,7 @@ define float @fcmp_ult_neginf_implies_class_assert(float %arg) {
 ; CHECK-SAME: (float [[ARG:%.*]]) {
 ; CHECK-NEXT:    ret float 0.000000e+00
 ;
-  %cmp.ult.neginf = fcmp ult float %arg, 0xFFF0000000000000
+  %cmp.ult.neginf = fcmp ult float %arg, -inf
   %select_1_0 = select i1 %cmp.ult.neginf, float 1.0, float 0.0
   %mul_by_zero = fmul float %select_1_0, 0.0
   ret float %mul_by_zero
@@ -1138,7 +1138,7 @@ define i1 @isKnownNeverInfinity_vector_reduce_maximum(<4 x double> %x) {
 ;
   %ninf.x = fadd ninf <4 x double> %x, <double 1.0, double 1.0, double 1.0, double 1.0>
   %op = call double @llvm.vector.reduce.fmaximum.v4f64(<4 x double> %ninf.x)
-  %cmp = fcmp une double %op, 0x7ff0000000000000
+  %cmp = fcmp une double %op, +inf
   ret i1 %cmp
 }
 
@@ -1152,7 +1152,7 @@ define i1 @isKnownNeverInfinity_vector_reduce_maximum_fail(<4 x double> %x) {
 ;
   %ninf.x = fadd <4 x double> %x, <double 1.0, double 1.0, double 1.0, double 1.0>
   %op = call double @llvm.vector.reduce.fmaximum.v4f64(<4 x double> %ninf.x)
-  %cmp = fcmp une double %op, 0x7ff0000000000000
+  %cmp = fcmp une double %op, +inf
   ret i1 %cmp
 }
 
@@ -1163,7 +1163,7 @@ define i1 @isKnownNeverInfinity_vector_reduce_minimum(<4 x double> %x) {
 ;
   %ninf.x = fadd ninf <4 x double> %x, <double 1.0, double 1.0, double 1.0, double 1.0>
   %op = call double @llvm.vector.reduce.fminimum.v4f64(<4 x double> %ninf.x)
-  %cmp = fcmp une double %op, 0x7ff0000000000000
+  %cmp = fcmp une double %op, +inf
   ret i1 %cmp
 }
 
@@ -1177,7 +1177,7 @@ define i1 @isKnownNeverInfinity_vector_reduce_minimum_fail(<4 x double> %x) {
 ;
   %ninf.x = fadd <4 x double> %x, <double 1.0, double 1.0, double 1.0, double 1.0>
   %op = call double @llvm.vector.reduce.fminimum.v4f64(<4 x double> %ninf.x)
-  %cmp = fcmp une double %op, 0x7ff0000000000000
+  %cmp = fcmp une double %op, +inf
   ret i1 %cmp
 }
 
@@ -1188,7 +1188,7 @@ define i1 @isKnownNeverInfinity_vector_reduce_fmax(<4 x double> %x) {
 ;
   %ninf.x = fadd ninf <4 x double> %x, <double 1.0, double 1.0, double 1.0, double 1.0>
   %op = call double @llvm.vector.reduce.fmax.v4f64(<4 x double> %ninf.x)
-  %cmp = fcmp une double %op, 0x7ff0000000000000
+  %cmp = fcmp une double %op, +inf
   ret i1 %cmp
 }
 
@@ -1202,7 +1202,7 @@ define i1 @isKnownNeverInfinity_vector_reduce_fmax_fail(<4 x double> %x) {
 ;
   %ninf.x = fadd <4 x double> %x, <double 1.0, double 1.0, double 1.0, double 1.0>
   %op = call double @llvm.vector.reduce.fmax.v4f64(<4 x double> %ninf.x)
-  %cmp = fcmp une double %op, 0x7ff0000000000000
+  %cmp = fcmp une double %op, +inf
   ret i1 %cmp
 }
 
@@ -1213,7 +1213,7 @@ define i1 @isKnownNeverInfinity_vector_reduce_fmin(<4 x double> %x) {
 ;
   %ninf.x = fadd ninf <4 x double> %x, <double 1.0, double 1.0, double 1.0, double 1.0>
   %op = call double @llvm.vector.reduce.fmin.v4f64(<4 x double> %ninf.x)
-  %cmp = fcmp une double %op, 0x7ff0000000000000
+  %cmp = fcmp une double %op, +inf
   ret i1 %cmp
 }
 
@@ -1227,7 +1227,7 @@ define i1 @isKnownNeverInfinity_vector_reduce_fmin_fail(<4 x double> %x) {
 ;
   %ninf.x = fadd <4 x double> %x, <double 1.0, double 1.0, double 1.0, double 1.0>
   %op = call double @llvm.vector.reduce.fmin.v4f64(<4 x double> %ninf.x)
-  %cmp = fcmp une double %op, 0x7ff0000000000000
+  %cmp = fcmp une double %op, +inf
   ret i1 %cmp
 }
 

--- a/llvm/test/Transforms/InstSimplify/known-never-nan.ll
+++ b/llvm/test/Transforms/InstSimplify/known-never-nan.ll
@@ -580,7 +580,7 @@ define i1 @issue63316(i64 %arg) {
 ; CHECK-NEXT:    ret i1 [[FCMP]]
 ;
   %sitofp = sitofp i64 %arg to float
-  %fmul = fmul float %sitofp, 0x7FF0000000000000
+  %fmul = fmul float %sitofp, +inf
   %fcmp = fcmp uno float %fmul, 0.000000e+00
   ret i1 %fcmp
 }

--- a/llvm/test/Transforms/InstSimplify/logic-of-fcmps.ll
+++ b/llvm/test/Transforms/InstSimplify/logic-of-fcmps.ll
@@ -255,7 +255,7 @@ define <2 x i1> @uno8(<2 x double> %x, <2 x double> %y) {
 ; CHECK-NEXT:    ret <2 x i1> [[CMP1]]
 ;
   %cmp1 = fcmp uno <2 x double> %y, %x
-  %cmp2 = fcmp uno <2 x double> %x, <double 0x7ff0000000000000, double 42.0>
+  %cmp2 = fcmp uno <2 x double> %x, <double +inf, double 42.0>
   %r = or <2 x i1> %cmp1, %cmp2
   ret <2 x i1> %r
 }

--- a/llvm/test/Transforms/InstSimplify/pr122582.ll
+++ b/llvm/test/Transforms/InstSimplify/pr122582.ll
@@ -87,7 +87,7 @@ define i32 @ilogb_inf() {
 ; CHECK-NEXT:    [[R:%.*]] = call i32 @ilogb(double +inf)
 ; CHECK-NEXT:    ret i32 [[R]]
 ;
-  %r = call i32 @ilogb(double 0x7FF0000000000000)
+  %r = call i32 @ilogb(double +inf)
   ret i32 %r
 }
 
@@ -159,7 +159,7 @@ define i32 @ilogb_inf_readnone() {
 ; CHECK-NEXT:    [[R:%.*]] = call i32 @ilogb(double +inf) #[[ATTR1]]
 ; CHECK-NEXT:    ret i32 [[R]]
 ;
-  %r = call i32 @ilogb(double 0x7FF0000000000000) readnone
+  %r = call i32 @ilogb(double +inf) readnone
   ret i32 %r
 }
 

--- a/llvm/test/Transforms/LoopUnroll/runtime-unroll-reductions-min-max.ll
+++ b/llvm/test/Transforms/LoopUnroll/runtime-unroll-reductions-min-max.ll
@@ -194,7 +194,7 @@ entry:
 
 loop:
   %iv = phi i64 [ 0, %entry ], [ %iv.next, %loop ]
-  %min = phi float [ 0x7FF0000000000000, %entry ], [ %rdx.next, %loop ]
+  %min = phi float [ +inf, %entry ], [ %rdx.next, %loop ]
   %gep.a = getelementptr inbounds float, ptr %a, i64 %iv
   %1 = load float, ptr %gep.a, align 4
   %cmp = fcmp olt float %min, %1
@@ -263,7 +263,7 @@ entry:
 
 loop:
   %iv = phi i64 [ 0, %entry ], [ %iv.next, %loop ]
-  %max = phi float [ 0xFFF0000000000000, %entry ], [ %rdx.next, %loop ]
+  %max = phi float [ -inf, %entry ], [ %rdx.next, %loop ]
   %gep.a = getelementptr inbounds float, ptr %a, i64 %iv
   %1 = load float, ptr %gep.a, align 4
   %cmp = fcmp ogt float %max, %1
@@ -338,7 +338,7 @@ entry:
 
 loop:
   %iv = phi i64 [ 0, %entry ], [ %iv.next, %loop ]
-  %min = phi float [ 0x7FF0000000000000, %entry ], [ %rdx.next, %loop ]
+  %min = phi float [ +inf, %entry ], [ %rdx.next, %loop ]
   %gep.a = getelementptr inbounds float, ptr %a, i64 %iv
   %1 = load float, ptr %gep.a, align 4
   %cmp = fcmp nnan ninf nsz olt float %min, %1
@@ -410,7 +410,7 @@ entry:
 
 loop:
   %iv = phi i64 [ 0, %entry ], [ %iv.next, %loop ]
-  %max = phi float [ 0xFFF0000000000000, %entry ], [ %rdx.next, %loop ]
+  %max = phi float [ -inf, %entry ], [ %rdx.next, %loop ]
   %gep.a = getelementptr inbounds float, ptr %a, i64 %iv
   %1 = load float, ptr %gep.a, align 4
   %cmp = fcmp nnan ninf nsz ogt float %max, %1
@@ -483,7 +483,7 @@ entry:
 
 loop:
   %iv = phi i64 [ 0, %entry ], [ %iv.next, %loop ]
-  %min = phi float [ 0x7FF0000000000000, %entry ], [ %rdx.next, %loop ]
+  %min = phi float [ +inf, %entry ], [ %rdx.next, %loop ]
   %gep.a = getelementptr inbounds float, ptr %a, i64 %iv
   %1 = load float, ptr %gep.a, align 4
   %rdx.next = call nnan ninf nsz float @llvm.minnum.f32(float %min, float %1)
@@ -551,7 +551,7 @@ entry:
 
 loop:
   %iv = phi i64 [ 0, %entry ], [ %iv.next, %loop ]
-  %max = phi float [ 0xFFF0000000000000, %entry ], [ %rdx.next, %loop ]
+  %max = phi float [ -inf, %entry ], [ %rdx.next, %loop ]
   %gep.a = getelementptr inbounds float, ptr %a, i64 %iv
   %1 = load float, ptr %gep.a, align 4
   %rdx.next = call nnan ninf nsz float @llvm.maxnum.f32(float %max, float %1)

--- a/llvm/test/Transforms/LoopVectorize/select-cmp-multiuse.ll
+++ b/llvm/test/Transforms/LoopVectorize/select-cmp-multiuse.ll
@@ -1173,7 +1173,7 @@ for.body:
   %indvars.iv = phi i64 [ 0, %entry ], [ %indvars.iv.next, %for.body ]
   %all.0.off010 = phi i1 [ true, %entry ], [ %all.0.off0., %for.body ]
   %any.0.off09 = phi i1 [ false, %entry ], [ %.any.0.off0, %for.body ]
-  %max.015 = phi float [ 0xFFF0000000000000, %entry ], [ %.max.0, %for.body ]
+  %max.015 = phi float [ -inf, %entry ], [ %.max.0, %for.body ]
   %arrayidx = getelementptr inbounds float, ptr %a, i64 %indvars.iv
   %load1 = load float, ptr %arrayidx, align 4
   %cmp1 = fcmp ogt float %load1, %max.015

--- a/llvm/test/Transforms/Reassociate/pr42349.ll
+++ b/llvm/test/Transforms/Reassociate/pr42349.ll
@@ -10,7 +10,7 @@ define  float @wibble(float %tmp6) #0 {
 ;
 bb:
   %tmp7 = fsub float -0.000000e+00, %tmp6
-  %tmp9 = fmul fast float %tmp7, 0x7FF0000000000000
+  %tmp9 = fmul fast float %tmp7, +inf
   ret float %tmp9
 }
 

--- a/llvm/test/Transforms/SLPVectorizer/X86/copyable-addsub-reorder.ll
+++ b/llvm/test/Transforms/SLPVectorizer/X86/copyable-addsub-reorder.ll
@@ -76,18 +76,18 @@ define i32 @fadd_fsub_constant_lhs_mix(float %s) {
 entry:
   %a = fadd float %s, 1.000000e+00
   %fa = tail call float @llvm.fabs.f32(float %a)
-  %ca = fcmp ueq float %fa, 0x7FF0000000000000
+  %ca = fcmp ueq float %fa, +inf
   %mulb = fmul float %s, 1.125000e+00
   %b = fsub float 0.000000e+00, %mulb
   %fb = tail call float @llvm.fabs.f32(float %b)
-  %cb = fcmp ueq float %fb, 0x7FF0000000000000
+  %cb = fcmp ueq float %fb, +inf
   %d = fsub float 2.000000e+00, %s
   %fd = tail call float @llvm.fabs.f32(float %d)
-  %cd = fcmp ueq float %fd, 0x7FF0000000000000
+  %cd = fcmp ueq float %fd, +inf
   %mule = fmul float %s, 2.000000e+00
   %e = fadd float %mule, 0.000000e+00
   %fe = tail call float @llvm.fabs.f32(float %e)
-  %ce = fcmp ueq float %fe, 0x7FF0000000000000
+  %ce = fcmp ueq float %fe, +inf
   br i1 %ca, label %abort, label %split
 
 split:

--- a/llvm/test/Transforms/SimplifyCFG/fold-branch-to-common-dest.ll
+++ b/llvm/test/Transforms/SimplifyCFG/fold-branch-to-common-dest.ll
@@ -1179,7 +1179,7 @@ fpclassify_not_zero:
 
 fpclassify_not_nan:
   %x.abs = tail call float @llvm.fabs.f32(float %x)
-  %isinf = fcmp oeq float %x.abs, 0x7FF0000000000000
+  %isinf = fcmp oeq float %x.abs, +inf
   br i1 %isinf, label %fpclassify_end, label %fpclassify_not_inf
 
 fpclassify_not_inf:

--- a/llvm/unittests/Analysis/ValueTrackingTest.cpp
+++ b/llvm/unittests/Analysis/ValueTrackingTest.cpp
@@ -2208,12 +2208,12 @@ TEST_F(ComputeKnownFPClassTest, FCmpToClassTest_OrdNan) {
 
 TEST_F(ComputeKnownFPClassTest, FCmpToClassTest_NInf) {
   parseAssembly("define i1 @test(double %arg) {\n"
-                "  %A = fcmp olt double %arg, 0xFFF0000000000000"
-                "  %A2 = fcmp uge double %arg, 0xFFF0000000000000"
-                "  %A3 = fcmp ogt double %arg, 0xFFF0000000000000"
-                "  %A4 = fcmp ule double %arg, 0xFFF0000000000000"
-                "  %A5 = fcmp oge double %arg, 0xFFF0000000000000"
-                "  %A6 = fcmp ult double %arg, 0xFFF0000000000000"
+                "  %A = fcmp olt double %arg, -inf"
+                "  %A2 = fcmp uge double %arg, -inf"
+                "  %A3 = fcmp ogt double %arg, -inf"
+                "  %A4 = fcmp ule double %arg, -inf"
+                "  %A5 = fcmp oge double %arg, -inf"
+                "  %A6 = fcmp ult double %arg, -inf"
                 "  ret i1 %A\n"
                 "}\n");
 
@@ -2257,12 +2257,12 @@ TEST_F(ComputeKnownFPClassTest, FCmpToClassTest_FabsNInf) {
   parseAssembly("declare double @llvm.fabs.f64(double)\n"
                 "define i1 @test(double %arg) {\n"
                 "  %fabs.arg = call double @llvm.fabs.f64(double %arg)\n"
-                "  %A = fcmp olt double %fabs.arg, 0xFFF0000000000000"
-                "  %A2 = fcmp uge double %fabs.arg, 0xFFF0000000000000"
-                "  %A3 = fcmp ogt double %fabs.arg, 0xFFF0000000000000"
-                "  %A4 = fcmp ule double %fabs.arg, 0xFFF0000000000000"
-                "  %A5 = fcmp oge double %fabs.arg, 0xFFF0000000000000"
-                "  %A6 = fcmp ult double %fabs.arg, 0xFFF0000000000000"
+                "  %A = fcmp olt double %fabs.arg, -inf"
+                "  %A2 = fcmp uge double %fabs.arg, -inf"
+                "  %A3 = fcmp ogt double %fabs.arg, -inf"
+                "  %A4 = fcmp ule double %fabs.arg, -inf"
+                "  %A5 = fcmp oge double %fabs.arg, -inf"
+                "  %A6 = fcmp ult double %fabs.arg, -inf"
                 "  ret i1 %A\n"
                 "}\n");
 
@@ -2306,10 +2306,10 @@ TEST_F(ComputeKnownFPClassTest, FCmpToClassTest_FabsNInf) {
 
 TEST_F(ComputeKnownFPClassTest, FCmpToClassTest_PInf) {
   parseAssembly("define i1 @test(double %arg) {\n"
-                "  %A = fcmp ogt double %arg, 0x7FF0000000000000"
-                "  %A2 = fcmp ule double %arg, 0x7FF0000000000000"
-                "  %A3 = fcmp ole double %arg, 0x7FF0000000000000"
-                "  %A4 = fcmp ugt double %arg, 0x7FF0000000000000"
+                "  %A = fcmp ogt double %arg, +inf"
+                "  %A2 = fcmp ule double %arg, +inf"
+                "  %A3 = fcmp ole double %arg, +inf"
+                "  %A4 = fcmp ugt double %arg, +inf"
                 "  ret i1 %A\n"
                 "}\n");
 


### PR DESCRIPTION
Follow up to https://github.com/llvm/llvm-project/pull/221019

Replaces all remaining legacy `0x*` (double literal) encodings with the canonical `+inf` and `-inf` syntax for positive/negative infinity literals.
The following files and folders were ignored:
```
llvm/test/Assembler
llvm/test/MC/LoongArch/Macros/macros-li.s
llvm/test/CodeGen/X86/is_fpclass.ll
llvm/test/CodeGen/AMDGPU/branch-relaxation-debug-info.mir
llvm/test/CodeGen/ARM/misched-prevent-erase-history-of-subunits.mir
```

```sh
rg -l -0 ' 0x7FF0000000000000\b' llvm \
  | xargs -0 perl -pi -e 's/ 0x7FF0000000000000\b/ +inf/g'

rg -l -0 ' 0x7ff0000000000000\b' llvm \
  | xargs -0 perl -pi -e 's/ 0x7ff0000000000000\b/ +inf/g'

rg -l -0 ' 0xFFF0000000000000\b' llvm \
  | xargs -0 perl -pi -e 's/ 0xFFF0000000000000\b/ -inf/g'

rg -l -0 ' 0xfff0000000000000\b' llvm \
  | xargs -0 perl -pi -e 's/ 0xfff0000000000000\b/ -inf/g'
```

I believe this removes all relevant uses of the legacy infinity hexadecimal double literal
```
zerico@DESKTOP-K3KRQL8:~/programming/llvm-project$ rg "0x[7fF][fF][fF]0000000000000" llvm
llvm/unittests/ADT/APFloatTest.cpp
5485:      std::make_tuple(0x7ff8000000000000ull, 0, 0x7ff0000000000000ull, 0,
5491:      std::make_tuple(0x7ff0000000000000ull, 0, 0x7ff0000000000000ull, 0,
5494:      std::make_tuple(0x7ff0000000000000ull, 0, 0, 0, APFloat::fcNaN,
5497:      std::make_tuple(0x7ff0000000000000ull, 0, 0x3ff0000000000000ull, 0,
5568:                      0x7ff0000000000000ull, 0, APFloat::rmNearestTiesToEven),
6557:      std::make_tuple(0x7ff0000000000000ull, 0, 0x7ff0000000000000ull, 0,
6686:      std::make_tuple(0x7ff0000000000000ull, 0, 0x7ff0000000000000ull, 0, true),

llvm/test/Assembler/2002-04-07-InfConstant.ll
8:        %tmp = fmul float 0x7FF0000000000000, 1.000000e+01               ; <float> [#uses=1]

llvm/lib/Target/AMDGPU/GCNDPPCombine.cpp
496:    if (static_cast<uint64_t>(OldOpnd->getImm()) == /*+inf=*/0x7FF0000000000000)
501:    if (static_cast<uint64_t>(OldOpnd->getImm()) == /*-inf=*/0xFFF0000000000000)

llvm/test/MC/LoongArch/Macros/macros-li.s
69:li.d $a0, 0x7ff0000000000000

llvm/lib/Target/LoongArch/LoongArchMergeBaseOffset.cpp
416:      Mask ^= 0xFFF0000000000000ULL;

llvm/test/CodeGen/X86/is_fpclass.ll
1131:; X64-GENERIC-NEXT:    movabsq $9218868437227405312, %rax # imm = 0x7FF0000000000000
1141:; X64-NDD-NEXT:    movabsq $9218868437227405312, %rcx # imm = 0x7FF0000000000000
1189:; X64-GENERIC-NEXT:    movabsq $-4503599627370496, %rax # imm = 0xFFF0000000000000
1201:; X64-NDD-NEXT:    movabsq $-4503599627370496, %rcx # imm = 0xFFF0000000000000
1294:; X64-GENERIC-NEXT:    movabsq $9218868437227405312, %rax # imm = 0x7FF0000000000000
1308:; X64-NDD-NEXT:    movabsq $9218868437227405312, %rdx # imm = 0x7FF0000000000000
1368:; X64-GENERIC-NEXT:    movabsq $9218868437227405312, %rax # imm = 0x7FF0000000000000
1378:; X64-NDD-NEXT:    movabsq $9218868437227405312, %rcx # imm = 0x7FF0000000000000

llvm/test/CodeGen/AMDGPU/branch-relaxation-debug-info.mir
37:    %tmp6 = fcmp oeq float %tmp5, 0x7FF0000000000000

llvm/test/CodeGen/AArch64/masked-integer-compare.ll
28:  %sub = sub i64 %and, u0x7ff0000000000000

llvm/test/CodeGen/AArch64/is_fpclass.ll
204:; CHECK-GI-NEXT:    mov x8, #9218868437227405312 // =0x7ff0000000000000
233:; CHECK-GI-NEXT:    mov x8, #9218868437227405312 // =0x7ff0000000000000
264:; CHECK-GI-NEXT:    mov x8, #9218868437227405312 // =0x7ff0000000000000
293:; CHECK-GI-NEXT:    mov x8, #9218868437227405312 // =0x7ff0000000000000
546:; CHECK-SD-NEXT:    mov x8, #9218868437227405312 // =0x7ff0000000000000

llvm/test/CodeGen/AArch64/sve-vector-splat.ll
627:; CHECK-NEXT:    mov z0.d, #0x7ff0000000000000
699:; CHECK-NEXT:    mov z0.d, #0xfff0000000000000

llvm/test/CodeGen/AArch64/isinf.ll
68:; CHECK-GI-NEXT:    mov x8, #9218868437227405312 // =0x7ff0000000000000

llvm/test/CodeGen/ARM/misched-prevent-erase-history-of-subunits.mir
24:    value:           double 0x7FF0000000000000
zerico@DESKTOP-K3KRQL8:~/programming/llvm-project$ 
```