### PR TITLE
(NFC)[Clang][Driver] Add ToolChain::GetFilePathIfExists and use it

### DIFF
--- a/clang/include/clang/Driver/ToolChain.h
+++ b/clang/include/clang/Driver/ToolChain.h
@@ -435,6 +435,7 @@ public:
   // Helper methods
 
   std::string GetFilePath(const char *Name) const;
+  std::optional<std::string> GetFilePathIfExists(const char *Name) const;
   std::string GetProgramPath(const char *Name) const;
 
   /// Returns the linker path, respecting the -fuse-ld= argument to determine

--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -1285,6 +1285,14 @@ std::string ToolChain::GetFilePath(const char *Name) const {
   return D.GetFilePath(Name, *this);
 }
 
+std::optional<std::string>
+ToolChain::GetFilePathIfExists(const char *Name) const {
+  std::string Path = D.GetFilePath(Name, *this);
+  if (Path == Name)
+    return std::nullopt;
+  return Path;
+}
+
 std::string ToolChain::GetProgramPath(const char *Name) const {
   return D.GetProgramPath(Name, *this);
 }

--- a/clang/lib/Driver/ToolChains/Cygwin.cpp
+++ b/clang/lib/Driver/ToolChains/Cygwin.cpp
@@ -377,9 +377,8 @@ void cygwin::Linker::ConstructJob(Compilation &C, const JobAction &JA,
 
     if (!Args.hasArg(options::OPT_nostartfiles)) {
       if (!Args.hasArg(options::OPT_mdll, options::OPT_shared)) {
-        std::string O = ToolChain.GetFilePath("default-manifest.o");
-        if (O != "default-manifest.o")
-          CmdArgs.push_back(Args.MakeArgString(std::move(O)));
+        if (auto O = ToolChain.GetFilePathIfExists("default-manifest.o"))
+          CmdArgs.push_back(Args.MakeArgString(std::move(*O)));
       }
       CmdArgs.push_back(Args.MakeArgString(ToolChain.GetFilePath("crtend.o")));
     }

--- a/clang/lib/Driver/ToolChains/Gnu.cpp
+++ b/clang/lib/Driver/ToolChains/Gnu.cpp
@@ -548,8 +548,7 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
                                      options::OPT_fstack_protector_all,
                                      options::OPT_fstack_protector_strong))
           WantsSSP = !A->getOption().matches(options::OPT_fno_stack_protector);
-        if (WantsSSP &&
-            ToolChain.GetFilePath("libssp_nonshared.a") != "libssp_nonshared.a")
+        if (WantsSSP && ToolChain.GetFilePathIfExists("libssp_nonshared.a"))
           CmdArgs.push_back("-lssp_nonshared");
       }
 

--- a/clang/lib/Driver/ToolChains/WebAssembly.cpp
+++ b/clang/lib/Driver/ToolChains/WebAssembly.cpp
@@ -166,7 +166,7 @@ void wasm::Linker::ConstructJob(Compilation &C, const JobAction &JA,
     // crt1-command.o. And once LLVM no longer needs to support WASI libc
     // versions before that, it can switch to using crt1-command.o.
     Crt1 = "crt1.o";
-    if (ToolChain.GetFilePath("crt1-command.o") != "crt1-command.o")
+    if (ToolChain.GetFilePathIfExists("crt1-command.o"))
       Crt1 = "crt1-command.o";
   } else {
     Crt1 = "crt1-reactor.o";


### PR DESCRIPTION
Replaces patterns like `if (TC.GetFilePath("file") != "file")` to avoid repeating `"file"`.