### PR TITLE
[CIR] Fix a problem with global view index calculation

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.cpp
@@ -186,9 +186,6 @@ uint64_t CIRGenBuilderTy::computeOffsetFromGlobalViewIndices(
   for (int64_t idx : indices) {
     if (auto recordTy = dyn_cast<cir::RecordType>(ty)) {
       offset += recordTy.getElementOffset(layout.layout, idx);
-      const llvm::Align tyAlign = llvm::Align(
-          recordTy.getPacked() ? 1 : layout.layout.getTypeABIAlignment(ty));
-      offset = llvm::alignTo(offset, tyAlign);
       assert(idx < (int64_t)recordTy.getMembers().size());
       ty = recordTy.getMembers()[idx];
     } else if (auto arrayTy = dyn_cast<cir::ArrayType>(ty)) {

--- a/clang/test/CIR/CodeGen/global-replace-record-array.c
+++ b/clang/test/CIR/CodeGen/global-replace-record-array.c
@@ -1,0 +1,32 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
+
+struct T {
+  int i;
+  char c[6];
+  double d;
+};
+
+extern struct T arr[];
+
+// Member 'c' is followed by padding, so the offset of arr[N].c is not a
+// multiple of the alignment of struct T. When the incomplete array type of
+// @arr is replaced with the complete type, the views below must still
+// designate the same byte offsets.
+char *p0 = &arr[0].c[2];
+char *p1 = &arr[1].c[0];
+double *p2 = &arr[1].d;
+
+struct T arr[2] = {{1, "ab", 2.0}, {3, "cd", 4.0}};
+
+// CIR-DAG: cir.global external @p0 = #cir.global_view<@arr, [0, 1, 2]> : !cir.ptr<!s8i>
+// CIR-DAG: cir.global external @p1 = #cir.global_view<@arr, [1, 1]> : !cir.ptr<!s8i>
+// CIR-DAG: cir.global external @p2 = #cir.global_view<@arr, [1, 2]> : !cir.ptr<!cir.double>
+
+// LLVM-DAG: @p0 = global ptr getelementptr {{.*}}(i8, ptr @arr, i64 6)
+// LLVM-DAG: @p1 = global ptr getelementptr {{.*}}(i8, ptr @arr, i64 28)
+// LLVM-DAG: @p2 = global ptr getelementptr {{.*}}(i8, ptr @arr, i64 40)


### PR DESCRIPTION
When a global that was declared with an incomplete array type is replaced by a global with the completed type, the byte offset of each global view on the old global is recomputed from its indices, and new indices are derived from that offset. The offset computation rounded its running total up to the ABI alignment of the record being indexed, which incorrectly assumes that every member starts at a multiple of its enclosing record's alignment. That does not hold for a member followed by padding, so the offset came out too large. The recomputed view then designated the wrong address or, when the inflated offset no longer landed on a subelement boundary, fell back to a global offset attribute holding the wrong offset.

Assisted-by: Cursor / claude-opus-5