### PR TITLE
[mlir][OpenMP] Test host_eval of num_teams and thread_limit

### DIFF
--- a/mlir/test/Target/LLVMIR/omptarget-host-eval.mlir
+++ b/mlir/test/Target/LLVMIR/omptarget-host-eval.mlir
@@ -1,0 +1,46 @@
+// RUN: mlir-translate -mlir-to-llvmir %s | FileCheck %s
+
+module attributes {omp.is_target_device = false, omp.target_triples = ["amdgcn-amd-amdhsa"]} {
+  llvm.func @omp_target_region_() {
+    %out_teams = llvm.mlir.constant(1000 : i32) : i32
+    %out_threads = llvm.mlir.constant(2000 : i32) : i32
+    %out_lb = llvm.mlir.constant(0 : i32) : i32
+    %out_ub = llvm.mlir.constant(3000 : i32) : i32
+    %out_step = llvm.mlir.constant(1 : i32) : i32
+
+    omp.target kernel_type(spmd)
+      host_eval(%out_teams -> %teams, %out_threads -> %threads,
+                %out_lb -> %lb, %out_ub -> %ub, %out_step -> %step :
+                i32, i32, i32, i32, i32) {
+      omp.teams num_teams(to %teams : i32) thread_limit(%threads : i32) {
+        omp.parallel {
+          omp.distribute {
+            omp.wsloop {
+              omp.loop_nest (%iv) : i32 = (%lb) to (%ub) step (%step) {
+                omp.yield
+              }
+            } {omp.composite}
+          } {omp.composite}
+          omp.terminator
+        } {omp.composite}
+        omp.terminator
+      } {omp.combined}
+      omp.terminator
+    } {omp.combined}
+    llvm.return
+  }
+}
+
+// CHECK-LABEL: define void @omp_target_region_
+// CHECK: %[[ARGS:.*]] = alloca %struct.__tgt_kernel_arguments
+
+// CHECK: %[[TRIPCOUNT_ADDR:.*]] = getelementptr inbounds nuw %struct.__tgt_kernel_arguments, ptr %[[ARGS]], i32 0, i32 8
+// CHECK: store i64 3000, ptr %[[TRIPCOUNT_ADDR]]
+
+// CHECK: %[[TEAMS_ADDR:.*]] = getelementptr inbounds nuw %struct.__tgt_kernel_arguments, ptr %[[ARGS]], i32 0, i32 10
+// CHECK: store [3 x i32] [i32 1000, i32 0, i32 0], ptr %[[TEAMS_ADDR]]
+
+// CHECK: %[[THREADS_ADDR:.*]] = getelementptr inbounds nuw %struct.__tgt_kernel_arguments, ptr %[[ARGS]], i32 0, i32 11
+// CHECK: store [3 x i32] [i32 2000, i32 0, i32 0], ptr %[[THREADS_ADDR]]
+
+// CHECK: call i32 @__tgt_target_kernel(ptr @{{.*}}, i64 {{.*}}, i32 1000, i32 2000, ptr @{{.*}}, ptr %[[ARGS]])


### PR DESCRIPTION
The existing openmp-target-spmd.mlir and openmp-target-generic-spmd.mlir
tests host-evaluate only the loop bounds and step, and check just the
tripcount field of __tgt_kernel_arguments. Nothing covers host_eval of
num_teams and thread_limit reaching the NumTeams and ThreadLimit fields
of that structure, nor the corresponding __tgt_target_kernel arguments.
Add a test for that path.