### PR TITLE
[mlir][presburger] Move generating-function storage (NFC)

### DIFF
--- a/mlir/include/mlir/Analysis/Presburger/GeneratingFunction.h
+++ b/mlir/include/mlir/Analysis/Presburger/GeneratingFunction.h
@@ -17,6 +17,8 @@
 #include "mlir/Analysis/Presburger/Fraction.h"
 #include "mlir/Analysis/Presburger/Matrix.h"
 
+#include <utility>
+
 namespace mlir {
 namespace presburger {
 namespace detail {
@@ -53,7 +55,8 @@ public:
   GeneratingFunction(unsigned numParam, SmallVector<int> signs,
                      std::vector<ParamPoint> nums,
                      std::vector<std::vector<Point>> dens)
-      : numParam(numParam), signs(signs), numerators(nums), denominators(dens) {
+      : numParam(numParam), signs(std::move(signs)),
+        numerators(std::move(nums)), denominators(std::move(dens)) {
 #ifndef NDEBUG
     for (const ParamPoint &term : numerators)
       assert(term.getNumRows() == numParam + 1 &&
@@ -64,11 +67,21 @@ public:
 
   unsigned getNumParams() const { return numParam; }
 
-  SmallVector<int> getSigns() const { return signs; }
+  const SmallVector<int> &getSigns() const & { return signs; }
+  SmallVector<int> getSigns() && { return std::move(signs); }
+  SmallVector<int> getSigns() const && { return signs; }
 
-  std::vector<ParamPoint> getNumerators() const { return numerators; }
+  const std::vector<ParamPoint> &getNumerators() const & { return numerators; }
+  std::vector<ParamPoint> getNumerators() && { return std::move(numerators); }
+  std::vector<ParamPoint> getNumerators() const && { return numerators; }
 
-  std::vector<std::vector<Point>> getDenominators() const {
+  const std::vector<std::vector<Point>> &getDenominators() const & {
+    return denominators;
+  }
+  std::vector<std::vector<Point>> getDenominators() && {
+    return std::move(denominators);
+  }
+  std::vector<std::vector<Point>> getDenominators() const && {
     return denominators;
   }
 
@@ -84,8 +97,9 @@ public:
 
     std::vector<std::vector<Point>> sumDenominators = denominators;
     llvm::append_range(sumDenominators, gf.denominators);
-    return GeneratingFunction(numParam, sumSigns, sumNumerators,
-                              sumDenominators);
+    return GeneratingFunction(numParam, std::move(sumSigns),
+                              std::move(sumNumerators),
+                              std::move(sumDenominators));
   }
 
   llvm::raw_ostream &print(llvm::raw_ostream &os) const {

--- a/mlir/unittests/Analysis/Presburger/GeneratingFunctionTest.cpp
+++ b/mlir/unittests/Analysis/Presburger/GeneratingFunctionTest.cpp
@@ -10,6 +10,8 @@
 #include "./Utils.h"
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <type_traits>
+#include <utility>
 
 using namespace mlir;
 using namespace presburger;
@@ -36,4 +38,35 @@ TEST(GeneratingFunctionTest, sum) {
                                {{2, 8}, {6, 3}},
                                {{3, 7}, {5, 1}},
                                {{5, 2}, {6, 2}}}));
+}
+
+TEST(GeneratingFunctionTest, gettersPreserveOwnership) {
+  static_assert(std::is_same_v<
+                decltype(std::declval<const GeneratingFunction &>().getSigns()),
+                const SmallVector<int> &>);
+  static_assert(
+      std::is_same_v<decltype(std::declval<GeneratingFunction &&>().getSigns()),
+                     SmallVector<int>>);
+  static_assert(
+      std::is_same_v<
+          decltype(std::declval<const GeneratingFunction &&>().getSigns()),
+          SmallVector<int>>);
+  static_assert(
+      std::is_same_v<
+          decltype(std::declval<const GeneratingFunction &&>().getNumerators()),
+          std::vector<ParamPoint>>);
+  static_assert(
+      std::is_same_v<decltype(std::declval<const GeneratingFunction &&>()
+                                  .getDenominators()),
+                     std::vector<std::vector<Point>>>);
+
+  GeneratingFunction gf(0, {1}, {makeFracMatrix(1, 1, {{2}})}, {{{3}}});
+  SmallVector<int> signs = std::move(gf).getSigns();
+  std::vector<ParamPoint> numerators = std::move(gf).getNumerators();
+  std::vector<std::vector<Point>> denominators =
+      std::move(gf).getDenominators();
+
+  EXPECT_THAT(signs, ::testing::ElementsAre(1));
+  EXPECT_EQ(numerators.size(), 1u);
+  EXPECT_EQ(denominators.size(), 1u);
 }


### PR DESCRIPTION
Move by-value constructor parameters into the generating function and move the locally accumulated term storage when returning a sum. Borrow storage from lvalue getters, transfer it from mutable rvalue getters, and preserve value semantics for const rvalues.

Found by Coverity.

Assisted-by: Codex