### PR TITLE
[MLIR] Move affine range operands into inference helpers (NFC)

### DIFF
--- a/mlir/lib/Interfaces/Utils/InferIntRangeCommon.cpp
+++ b/mlir/lib/Interfaces/Utils/InferIntRangeCommon.cpp
@@ -22,8 +22,10 @@
 
 #include "llvm/Support/Debug.h"
 
+#include <array>
 #include <iterator>
 #include <optional>
+#include <utility>
 
 using namespace mlir;
 
@@ -811,7 +813,9 @@ mlir::intrange::inferAffineExpr(AffineExpr expr,
         inferAffineExpr(binExpr.getLHS(), dimRanges, symbolRanges);
     ConstantIntRanges rhs =
         inferAffineExpr(binExpr.getRHS(), dimRanges, symbolRanges);
-    return inferAdd({lhs, rhs}, OverflowFlags::Nsw);
+    std::array<ConstantIntRanges, 2> operands = {std::move(lhs),
+                                                 std::move(rhs)};
+    return inferAdd(operands, OverflowFlags::Nsw);
   }
   case AffineExprKind::Mul: {
     auto binExpr = cast<AffineBinaryOpExpr>(expr);
@@ -819,7 +823,9 @@ mlir::intrange::inferAffineExpr(AffineExpr expr,
         inferAffineExpr(binExpr.getLHS(), dimRanges, symbolRanges);
     ConstantIntRanges rhs =
         inferAffineExpr(binExpr.getRHS(), dimRanges, symbolRanges);
-    return inferMul({lhs, rhs}, OverflowFlags::Nsw);
+    std::array<ConstantIntRanges, 2> operands = {std::move(lhs),
+                                                 std::move(rhs)};
+    return inferMul(operands, OverflowFlags::Nsw);
   }
   case AffineExprKind::Mod: {
     auto binExpr = cast<AffineBinaryOpExpr>(expr);
@@ -839,10 +845,8 @@ mlir::intrange::inferAffineExpr(AffineExpr expr,
     if (rhsMax.isZero())
       return ConstantIntRanges::maxRange(width);
 
-    APInt zero = APInt::getZero(width);
-
     // For Euclidean mod, result is in [0, max(rhs)-1].
-    APInt umin = zero;
+    APInt umin = APInt::getZero(width);
     APInt umax = rhsMax - 1;
 
     // Special case: if dividend is already in [0, min(rhs)), result equals
@@ -880,7 +884,9 @@ mlir::intrange::inferAffineExpr(AffineExpr expr,
     // Affine floordiv requires strictly positive divisor (> 0).
     // Clamp divisor lower bound to 1 for tighter range inference.
     ConstantIntRanges clampedRhs = clampToPositive(rhs);
-    return inferFloorDivS({lhs, clampedRhs});
+    std::array<ConstantIntRanges, 2> operands = {std::move(lhs),
+                                                 std::move(clampedRhs)};
+    return inferFloorDivS(operands);
   }
   case AffineExprKind::CeilDiv: {
     auto binExpr = cast<AffineBinaryOpExpr>(expr);
@@ -891,7 +897,9 @@ mlir::intrange::inferAffineExpr(AffineExpr expr,
     // Affine ceildiv requires strictly positive divisor (> 0).
     // Clamp divisor lower bound to 1 for tighter range inference.
     ConstantIntRanges clampedRhs = clampToPositive(rhs);
-    return inferCeilDivS({lhs, clampedRhs});
+    std::array<ConstantIntRanges, 2> operands = {std::move(lhs),
+                                                 std::move(clampedRhs)};
+    return inferCeilDivS(operands);
   }
   }
   llvm_unreachable("unknown affine expression kind");


### PR DESCRIPTION
Move recursively inferred ranges into fixed-size operand arrays before calling arithmetic inference helpers. Initialize the affine modulo lower bound directly instead of copying a local APInt.

Found by Coverity.

Assisted-by: Codex