### PR TITLE
[MLIR][IRDL] Move generated dialect strings into storage (NFC)

### DIFF
--- a/mlir/lib/Target/IRDLToCpp/IRDLToCpp.cpp
+++ b/mlir/lib/Target/IRDLToCpp/IRDLToCpp.cpp
@@ -723,12 +723,12 @@ irdl::translateIRDLDialectToCpp(llvm::ArrayRef<irdl::DialectOp> dialects,
 
     DialectStrings dialectStrings;
     dialectStrings.dialectName = dialectName;
-    dialectStrings.dialectBaseTypeName = dialectBaseTypeName;
-    dialectStrings.dialectCppName = cppName;
-    dialectStrings.dialectCppShortName = cppShortName;
-    dialectStrings.namespaceOpen = namespaceOpen;
-    dialectStrings.namespaceClose = namespaceClose;
-    dialectStrings.namespacePath = namespacePath;
+    dialectStrings.dialectBaseTypeName = std::move(dialectBaseTypeName);
+    dialectStrings.dialectCppName = std::move(cppName);
+    dialectStrings.dialectCppShortName = std::move(cppShortName);
+    dialectStrings.namespaceOpen = std::move(namespaceOpen);
+    dialectStrings.namespaceClose = std::move(namespaceClose);
+    dialectStrings.namespacePath = std::move(namespacePath);
 
     dialectStringTable[dialect] = std::move(dialectStrings);
   }


### PR DESCRIPTION
Move locally assembled C++ names and namespace fragments into the dialect string table. Their temporary strings are not used after the table entry is built, so copying their allocations is unnecessary.

Found by Coverity.

Assisted-by: Codex