### PR TITLE
[mlir][gpu] Move XeVM pipeline options into passes (NFC)

### DIFF
--- a/mlir/lib/Dialect/GPU/Pipelines/GPUToXeVMPipeline.cpp
+++ b/mlir/lib/Dialect/GPU/Pipelines/GPUToXeVMPipeline.cpp
@@ -34,6 +34,8 @@
 #include "mlir/Target/LLVM/XeVM/Target.h"
 #include "mlir/Transforms/Passes.h"
 
+#include <utility>
+
 using namespace mlir;
 
 namespace {
@@ -51,7 +53,7 @@ void buildPreGPUCommonPassPipeline(
     xevmTargetOptions.chip = options.zebinChip;
     xevmTargetOptions.optLevel = options.optLevel;
     xevmTargetOptions.cmdOptions = options.cmdOptions;
-    pm.addPass(createGpuXeVMAttachTarget(xevmTargetOptions));
+    pm.addPass(createGpuXeVMAttachTarget(std::move(xevmTargetOptions)));
   }
   pm.addPass(createLowerAffinePass());
   pm.addNestedPass<func::FuncOp>(createGpuAsyncRegionPass());
@@ -72,7 +74,7 @@ void buildGPUPassPipeline(OpPassManager &pm,
     xegpu::XeGPUPropagateLayoutOptions sgLayoutOptions;
     sgLayoutOptions.layoutKind = "subgroup";
     pm.addNestedPass<gpu::GPUModuleOp>(
-        xegpu::createXeGPUPropagateLayout(sgLayoutOptions));
+        xegpu::createXeGPUPropagateLayout(std::move(sgLayoutOptions)));
     pm.addNestedPass<gpu::GPUModuleOp>(xegpu::createXeGPUWgToSgDistribute());
     pm.addNestedPass<gpu::GPUModuleOp>(createCSEPass());
     pm.addNestedPass<gpu::GPUModuleOp>(createLowerAffinePass());
@@ -80,7 +82,7 @@ void buildGPUPassPipeline(OpPassManager &pm,
     xegpu::XeGPUPropagateLayoutOptions instDataOptions;
     instDataOptions.layoutKind = "inst";
     pm.addNestedPass<gpu::GPUModuleOp>(
-        xegpu::createXeGPUPropagateLayout(instDataOptions));
+        xegpu::createXeGPUPropagateLayout(std::move(instDataOptions)));
     pm.addNestedPass<gpu::GPUModuleOp>(xegpu::createXeGPUBlocking());
     pm.addNestedPass<gpu::GPUModuleOp>(createCSEPass());
   }
@@ -91,7 +93,7 @@ void buildGPUPassPipeline(OpPassManager &pm,
     pm.addNestedPass<gpu::GPUModuleOp>(xegpu::createXeGPUPeepHoleOptimizer());
     pm.addNestedPass<gpu::GPUModuleOp>(createCSEPass());
     pm.addNestedPass<gpu::GPUModuleOp>(
-        xegpu::createXeGPUPropagateLayout(laneLayoutOptions));
+        xegpu::createXeGPUPropagateLayout(std::move(laneLayoutOptions)));
     pm.addNestedPass<gpu::GPUModuleOp>(xegpu::createXeGPUSgToLaneDistribute());
     pm.addNestedPass<gpu::GPUModuleOp>(createCanonicalizerPass());
     pm.addNestedPass<gpu::GPUModuleOp>(createCSEPass());
@@ -112,18 +114,18 @@ void buildGPUPassPipeline(OpPassManager &pm,
     arith::ArithExpandOpsPassOptions arithExpandOptions;
     arithExpandOptions.includeF8E8M0 = true;
     pm.addNestedPass<gpu::GPUModuleOp>(
-        arith::createArithExpandOpsPass(arithExpandOptions));
+        arith::createArithExpandOpsPass(std::move(arithExpandOptions)));
   }
   pm.addNestedPass<gpu::GPUModuleOp>(createConvertMathToXeVM());
   ConvertXeGPUToXeVMPassOptions xegpuToXeVMOptions;
   xegpuToXeVMOptions.use64bitIndex = options.use64bitIndex;
   pm.addNestedPass<gpu::GPUModuleOp>(
-      createConvertXeGPUToXeVMPass(xegpuToXeVMOptions));
+      createConvertXeGPUToXeVMPass(std::move(xegpuToXeVMOptions)));
   {
     ConvertGpuOpsToLLVMSPVOpsOptions gpuToLLVMSPVOptions;
     gpuToLLVMSPVOptions.use64bitIndex = options.use64bitIndex;
     pm.addNestedPass<gpu::GPUModuleOp>(
-        createConvertGpuOpsToLLVMSPVOps(gpuToLLVMSPVOptions));
+        createConvertGpuOpsToLLVMSPVOps(std::move(gpuToLLVMSPVOptions)));
   }
   // Legalize math/arith ops on floating-point types that the XeVM target
   // cannot handle natively (e.g. bf16) by wrapping them with extf/truncf
@@ -134,7 +136,7 @@ void buildGPUPassPipeline(OpPassManager &pm,
                                            options.mathExtendExtraTypes.end());
     mathExtendOptions.targetTypeStr = options.supportedTargetTypes;
     pm.addNestedPass<gpu::GPUModuleOp>(
-        math::createMathExtendToSupportedTypes(mathExtendOptions));
+        math::createMathExtendToSupportedTypes(std::move(mathExtendOptions)));
   }
   {
     arith::ArithEmulateUnsupportedFloatsOptions arithEmulateOptions;
@@ -143,7 +145,8 @@ void buildGPUPassPipeline(OpPassManager &pm,
         options.unsupportedSourceTypes.end());
     arithEmulateOptions.targetTypeStr = options.supportedTargetTypes;
     pm.addNestedPass<gpu::GPUModuleOp>(
-        arith::createArithEmulateUnsupportedFloats(arithEmulateOptions));
+        arith::createArithEmulateUnsupportedFloats(
+            std::move(arithEmulateOptions)));
   }
   pm.addNestedPass<gpu::GPUModuleOp>(createCSEPass());
   pm.addNestedPass<gpu::GPUModuleOp>(createReconcileUnrealizedCastsPass());
@@ -162,7 +165,7 @@ void buildPostGPUCommonPassPipeline(
     GpuToLLVMConversionPassOptions gpuToLLVMOptions;
     gpuToLLVMOptions.hostBarePtrCallConv = options.hostBarePtrCallConv;
     gpuToLLVMOptions.kernelBarePtrCallConv = options.kernelBarePtrCallConv;
-    pm.addPass(createGpuToLLVMConversionPass(gpuToLLVMOptions));
+    pm.addPass(createGpuToLLVMConversionPass(std::move(gpuToLLVMOptions)));
   }
   pm.addPass(createLowerAffinePass());
   pm.addPass(createConvertVectorToLLVMPass());
@@ -177,7 +180,7 @@ void buildPostGPUCommonPassPipeline(
     GpuModuleToBinaryPassOptions gpuToModuleBinOptions;
     gpuToModuleBinOptions.compilationTarget = options.binaryFormat;
     gpuToModuleBinOptions.cmdOptions = options.cmdOptions;
-    pm.addPass(createGpuModuleToBinaryPass(gpuToModuleBinOptions));
+    pm.addPass(createGpuModuleToBinaryPass(std::move(gpuToModuleBinOptions)));
   }
 }
 } // namespace


### PR DESCRIPTION
Move locally assembled pass options into pass constructors at their last use. Keep the lane-layout options intact until the second propagation pass, then move them as well.

Found by Coverity.

Assisted-by: Codex