### PR TITLE
[GlobalISel] Fix unreachable hit on x86_fp80 constants in getFltSemanticForLLT

### DIFF
--- a/llvm/lib/CodeGen/GlobalISel/Utils.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/Utils.cpp
@@ -455,7 +455,7 @@ std::optional<FPValueAndVReg> llvm::getFConstantVRegValWithLookThrough(
   if (!Reg)
     return std::nullopt;
 
-  APFloat FloatVal(getFltSemanticForLLT(LLT::scalar(Reg->Value.getBitWidth())),
+  APFloat FloatVal(getFltSemanticForLLT(MRI.getType(Reg->VReg).getScalarType()),
                    Reg->Value);
   return FPValueAndVReg{FloatVal, Reg->VReg};
 }

--- a/llvm/lib/CodeGen/LowLevelTypeUtils.cpp
+++ b/llvm/lib/CodeGen/LowLevelTypeUtils.cpp
@@ -130,6 +130,8 @@ const llvm::fltSemantics &llvm::getFltSemanticForLLT(LLT Ty) {
       return APFloat::IEEEsingle();
     case 64:
       return APFloat::IEEEdouble();
+    case 80:
+      return APFloat::x87DoubleExtended();
     case 128:
       return APFloat::IEEEquad();
     }

--- a/llvm/test/CodeGen/X86/GlobalISel/fconstant.ll
+++ b/llvm/test/CodeGen/X86/GlobalISel/fconstant.ll
@@ -33,3 +33,29 @@ entry:
   ret void
 }
 
+
+define x86_fp80 @test_x86_fp80(x86_fp80 %x) {
+; CHECK64_SMALL-LABEL: test_x86_fp80:
+; CHECK64_SMALL:       # %bb.0:
+; CHECK64_SMALL-NEXT:    fldt {{[0-9]+}}(%rsp)
+; CHECK64_SMALL-NEXT:    fldt {{\.?LCPI[0-9]+_[0-9]+}}(%rip)
+; CHECK64_SMALL-NEXT:    faddp %st, %st(1)
+; CHECK64_SMALL-NEXT:    retq
+;
+; CHECK64_LARGE-LABEL: test_x86_fp80:
+; CHECK64_LARGE:       # %bb.0:
+; CHECK64_LARGE-NEXT:    fldt {{[0-9]+}}(%rsp)
+; CHECK64_LARGE-NEXT:    movabsq ${{\.?LCPI[0-9]+_[0-9]+}}, %rax
+; CHECK64_LARGE-NEXT:    fldt (%rax)
+; CHECK64_LARGE-NEXT:    faddp %st, %st(1)
+; CHECK64_LARGE-NEXT:    retq
+;
+; CHECK32-LABEL: test_x86_fp80:
+; CHECK32:       # %bb.0:
+; CHECK32-NEXT:    fldt {{[0-9]+}}(%esp)
+; CHECK32-NEXT:    fldt {{\.?LCPI[0-9]+_[0-9]+}}
+; CHECK32-NEXT:    faddp %st, %st(1)
+; CHECK32-NEXT:    retl
+  %r = fadd x86_fp80 %x, 0xK4000C000000000000000
+  ret x86_fp80 %r
+}


### PR DESCRIPTION
This fixes a crash where GlobalISel triggers an unreachable when encountering an 80-bit ANY_SCALAR (x86_fp80) in getFltSemanticForLLT.

When ExtendedLLT is disabled, x86_fp80 is represented as an 80-bit ANY_SCALAR. This patch adds the missing 'case 80:' to getFltSemanticForLLT so that it correctly returns APFloat::x87DoubleExtended().

Additionally, getFConstantVRegValWithLookThrough is updated to query the exact LLT from the virtual register (which contains the precise FpSemantics if ExtendedLLT is enabled) rather than blindly inferring semantics solely from the constant's bitwidth.

Fixes: https://github.com/llvm/llvm-project/issues/220807