### PR TITLE
[MLIR][linalg] Move transform options at their last use (NFC)

### DIFF
--- a/mlir/lib/Dialect/Linalg/TransformOps/LinalgTransformOps.cpp
+++ b/mlir/lib/Dialect/Linalg/TransformOps/LinalgTransformOps.cpp
@@ -755,14 +755,14 @@ transform::FuseOp::apply(transform::TransformRewriter &rewriter,
     return status;
 
   scf::SCFTilingOptions tilingOptions;
-  tilingOptions.interchangeVector = tileInterchange;
+  tilingOptions.interchangeVector = std::move(tileInterchange);
   bool useForall = getUseForall();
   tilingOptions.setLoopType(useForall
                                 ? scf::SCFTilingOptions::LoopType::ForallOp
                                 : scf::SCFTilingOptions::LoopType::ForOp);
-  tilingOptions = tilingOptions.setTileSizes(mixedTileSizes);
+  tilingOptions.setTileSizes(mixedTileSizes);
   scf::SCFTileAndFuseOptions tileAndFuseOptions;
-  tileAndFuseOptions.tilingOptions = tilingOptions;
+  tileAndFuseOptions.tilingOptions = std::move(tilingOptions);
   // Optional caller-asserted pack/unpack inner-tile alignment (see
   // InnerTileAlignment).
   tileAndFuseOptions.tilingOptions.setInnerTileAlignments(
@@ -2295,9 +2295,9 @@ transform::PadOp::apply(transform::TransformRewriter &rewriter,
       padToMultipleOf =
           SmallVector<int64_t>(options.paddingDimensions.size(), 1);
 
-    options.padToMultipleOf = padToMultipleOf;
-    options.paddingValues = paddingValues;
-    options.nofoldFlags = nofoldFlags;
+    options.padToMultipleOf = std::move(padToMultipleOf);
+    options.paddingValues = std::move(paddingValues);
+    options.nofoldFlags = std::move(nofoldFlags);
     if (getCopyBackOp() ==
         bufferization::MaterializeInDestinationOp::getOperationName()) {
       options.copyBackOp = LinalgPaddingOptions::CopyBackOp::
@@ -2528,14 +2528,15 @@ transform::PadTilingInterfaceOp::apply(transform::TransformRewriter &rewriter,
 
     // Set options.
     PadTilingInterfaceOptions options;
-    options.setPaddingValues(paddingValues)
-        .setPaddingSizes(getMixedPaddingSizes())
+    options.paddingValues = std::move(paddingValues);
+    options.setPaddingSizes(getMixedPaddingSizes())
         .setPadToMultipleOf(getPadToMultipleOf());
 
     OpBuilder::InsertionGuard g(rewriter);
     rewriter.setInsertionPointAfter(targetOp);
     auto maybePadOps = rewriteAsPaddedOp(
-        rewriter, cast<TilingInterface>(targetOp.getOperation()), options);
+        rewriter, cast<TilingInterface>(targetOp.getOperation()),
+        std::move(options));
     if (failed(maybePadOps)) {
       auto diag = emitSilenceableError() << "failed to pad op";
       diag.attachNote(target->getLoc()) << "target op";


### PR DESCRIPTION
Move locally assembled tiling and padding options into their owning destinations at their last use. Remove a self-copy assignment around setTileSizes while preserving its mutation.

Found by Coverity.

Assisted-by: Codex