### PR TITLE
[MLIR] Move inferred remainder bounds into results (NFC)

### DIFF
--- a/mlir/lib/Interfaces/Utils/InferIntRangeCommon.cpp
+++ b/mlir/lib/Interfaces/Utils/InferIntRangeCommon.cpp
@@ -24,6 +24,7 @@
 
 #include <iterator>
 #include <optional>
+#include <utility>
 
 using namespace mlir;
 
@@ -445,8 +446,8 @@ mlir::intrange::inferRemS(ArrayRef<ConstantIntRanges> argRanges) {
         APInt minRem = lhsMin.srem(maxDivisor);
         APInt maxRem = lhsMax.srem(maxDivisor);
         if (minRem.sle(maxRem)) {
-          smin = minRem;
-          smax = maxRem;
+          smin = std::move(minRem);
+          smax = std::move(maxRem);
         }
       }
     }
@@ -476,8 +477,8 @@ mlir::intrange::inferRemU(ArrayRef<ConstantIntRanges> argRanges) {
         APInt minRem = lhsMin.urem(rhsMax);
         APInt maxRem = lhsMax.urem(rhsMax);
         if (minRem.ule(maxRem)) {
-          umin = minRem;
-          umax = maxRem;
+          umin = std::move(minRem);
+          umax = std::move(maxRem);
         }
       }
     }


### PR DESCRIPTION
Move locally computed signed and unsigned remainder bounds into their final range accumulators when the special-case bounds are selected.

Found by Coverity.

Assisted-by: Codex