### PR TITLE
[MLIR] Move bitwise bounds into local arrays (NFC)

### DIFF
--- a/mlir/lib/Interfaces/Utils/InferIntRangeCommon.cpp
+++ b/mlir/lib/Interfaces/Utils/InferIntRangeCommon.cpp
@@ -22,8 +22,10 @@
 
 #include "llvm/Support/Debug.h"
 
+#include <array>
 #include <iterator>
 #include <optional>
+#include <utility>
 
 using namespace mlir;
 
@@ -550,8 +552,9 @@ mlir::intrange::inferAnd(ArrayRef<ConstantIntRanges> argRanges) {
   auto andi = [](const APInt &a, const APInt &b) -> std::optional<APInt> {
     return a & b;
   };
-  return minMaxBy(andi, {lhsZeros, lhsOnes}, {rhsZeros, rhsOnes},
-                  /*isSigned=*/false);
+  std::array<APInt, 2> lhsBounds = {std::move(lhsZeros), std::move(lhsOnes)};
+  std::array<APInt, 2> rhsBounds = {std::move(rhsZeros), std::move(rhsOnes)};
+  return minMaxBy(andi, lhsBounds, rhsBounds, /*isSigned=*/false);
 }
 
 ConstantIntRanges
@@ -561,8 +564,9 @@ mlir::intrange::inferOr(ArrayRef<ConstantIntRanges> argRanges) {
   auto ori = [](const APInt &a, const APInt &b) -> std::optional<APInt> {
     return a | b;
   };
-  return minMaxBy(ori, {lhsZeros, lhsOnes}, {rhsZeros, rhsOnes},
-                  /*isSigned=*/false);
+  std::array<APInt, 2> lhsBounds = {std::move(lhsZeros), std::move(lhsOnes)};
+  std::array<APInt, 2> rhsBounds = {std::move(rhsZeros), std::move(rhsOnes)};
+  return minMaxBy(ori, lhsBounds, rhsBounds, /*isSigned=*/false);
 }
 
 /// Get bitmask of all bits which can change while iterating in


### PR DESCRIPTION
Materialize bitwise-and and bitwise-or candidate bounds in fixed-size arrays by moving local APInt values. This avoids initializer-list copies before min/max inference.

Found by Coverity.

Assisted-by: Codex