### PR TITLE
[clang-format] Keep empty lines before namespace `}` in range formatting

### DIFF
--- a/clang/lib/Format/UnwrappedLineFormatter.cpp
+++ b/clang/lib/Format/UnwrappedLineFormatter.cpp
@@ -8,7 +8,6 @@
 
 #include "UnwrappedLineFormatter.h"
 #include "FormatToken.h"
-#include "NamespaceEndCommentsFixer.h"
 #include "WhitespaceManager.h"
 #include "llvm/Support/Debug.h"
 #include <queue>
@@ -1572,7 +1571,7 @@ unsigned UnwrappedLineFormatter::format(
     if (ShouldFormat && TheLine.Type != LT_Invalid) {
       if (!DryRun) {
         bool LastLine = TheLine.First->is(tok::eof);
-        formatFirstToken(TheLine, PreviousLine, PrevPrevLine, Lines, Indent,
+        formatFirstToken(TheLine, PreviousLine, PrevPrevLine, Indent,
                          LastLine ? LastStartColumn : NextStartColumn + Indent);
       }
 
@@ -1620,7 +1619,7 @@ unsigned UnwrappedLineFormatter::format(
                               TheLine.LeadingEmptyLinesAffected);
         // Format the first token.
         if (ReformatLeadingWhitespace) {
-          formatFirstToken(TheLine, PreviousLine, PrevPrevLine, Lines,
+          formatFirstToken(TheLine, PreviousLine, PrevPrevLine,
                            TheLine.First->OriginalColumn,
                            TheLine.First->OriginalColumn);
         } else {
@@ -1645,7 +1644,6 @@ unsigned UnwrappedLineFormatter::format(
 static auto computeNewlines(const AnnotatedLine &Line,
                             const AnnotatedLine *PreviousLine,
                             const AnnotatedLine *PrevPrevLine,
-                            const SmallVectorImpl<AnnotatedLine *> &Lines,
                             const FormatStyle &Style) {
   const auto &RootToken = *Line.First;
   if (isClangFormatOn(RootToken.TokenText))
@@ -1657,7 +1655,7 @@ static auto computeNewlines(const AnnotatedLine &Line,
       (!RootToken.Next ||
        (RootToken.Next->is(tok::semi) && !RootToken.Next->Next)) &&
       // Do not remove empty lines before namespace closing "}".
-      !getNamespaceToken(&Line, Lines)) {
+      (Line.InPPDirective || !Line.startsWith(TT_NamespaceRBrace))) {
     Newlines = std::min(Newlines, 1u);
   }
   // Remove empty lines at the start of nested blocks (lambdas/arrow functions)
@@ -1753,11 +1751,11 @@ static auto computeNewlines(const AnnotatedLine &Line,
   return Newlines;
 }
 
-void UnwrappedLineFormatter::formatFirstToken(
-    const AnnotatedLine &Line, const AnnotatedLine *PreviousLine,
-    const AnnotatedLine *PrevPrevLine,
-    const SmallVectorImpl<AnnotatedLine *> &Lines, unsigned Indent,
-    unsigned NewlineIndent) {
+void UnwrappedLineFormatter::formatFirstToken(const AnnotatedLine &Line,
+                                              const AnnotatedLine *PreviousLine,
+                                              const AnnotatedLine *PrevPrevLine,
+                                              unsigned Indent,
+                                              unsigned NewlineIndent) {
   FormatToken &RootToken = *Line.First;
   if (RootToken.is(tok::eof)) {
     unsigned Newlines = std::min(
@@ -1771,7 +1769,7 @@ void UnwrappedLineFormatter::formatFirstToken(
 
   if (RootToken.Newlines < 0) {
     RootToken.Newlines =
-        computeNewlines(Line, PreviousLine, PrevPrevLine, Lines, Style);
+        computeNewlines(Line, PreviousLine, PrevPrevLine, Style);
     assert(RootToken.Newlines >= 0);
   }
 

--- a/clang/lib/Format/UnwrappedLineFormatter.h
+++ b/clang/lib/Format/UnwrappedLineFormatter.h
@@ -45,9 +45,8 @@ private:
   /// of the \c UnwrappedLine if there was no structural parsing error.
   void formatFirstToken(const AnnotatedLine &Line,
                         const AnnotatedLine *PreviousLine,
-                        const AnnotatedLine *PrevPrevLine,
-                        const SmallVectorImpl<AnnotatedLine *> &Lines,
-                        unsigned Indent, unsigned NewlineIndent);
+                        const AnnotatedLine *PrevPrevLine, unsigned Indent,
+                        unsigned NewlineIndent);
 
   /// Returns the column limit for a line, taking into account whether we
   /// need an escaped newline due to a continued preprocessor directive.

--- a/clang/unittests/Format/FormatTestSelective.cpp
+++ b/clang/unittests/Format/FormatTestSelective.cpp
@@ -406,6 +406,18 @@ TEST_F(FormatTestSelective, WrongIndent) {
                    1, 0));
 }
 
+TEST_F(FormatTestSelective, KeepsEmptyLineBeforeNamespaceClosingBrace) {
+  // The closing brace is not in the range, but its leading empty line is
+  // reformatted because the previous line (or the empty line itself) is.
+  std::string Code = "namespace N {\n"
+                     "\n"
+                     "int i;\n"
+                     "\n"
+                     "}";
+  EXPECT_EQ(Code, format(Code, 15, 0)); // Format `int i;`.
+  EXPECT_EQ(Code, format(Code, 22, 0)); // Format the empty line before `}`.
+}
+
 TEST_F(FormatTestSelective, AlwaysFormatsEntireMacroDefinitions) {
   Style.AlignEscapedNewlines = FormatStyle::ENAS_Left;
   EXPECT_EQ("int  i;\n"


### PR DESCRIPTION
BEEP BOOP! I am Copilot using Bugale's account:

*Per the [LLVM AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html): this PR was drafted with an AI assistant (GitHub Copilot, Claude Fable 5.1) operated by @bugale, who reviewed every line, validated the change locally, and is accountable for it and for addressing review feedback.*

Fixes #220868.

`computeNewlines()` keeps the empty lines before the closing brace of a namespace. It found that brace with `getNamespaceToken()`, which returns null when the line is not affected by the formatting range. When only the body of the namespace is in the range (typical for `git-clang-format`), the `}` line is not affected, but its leading whitespace is still formatted. The empty line was then removed, unlike in whole-file formatting.

Use `TT_NamespaceRBrace` instead, like the `WrapNamespaceBodyWithEmptyLines` code below it. The `InPPDirective` exclusion of `getNamespaceToken()` is kept so that whole-file output does not change. The `Lines` parameters that are now unused are removed.

Tested: all 1281 FormatTests pass; the new test fails without the fix.