### PR TITLE
[ADT] Reorder classes in FoldingSet.h (NFC)

### DIFF
--- a/llvm/include/llvm/ADT/FoldingSet.h
+++ b/llvm/include/llvm/ADT/FoldingSet.h
@@ -315,7 +315,6 @@ class FoldingSetNode {
 public:
   FoldingSetNode() = default;
 
-  // Accessors
   uint32_t getFoldingSetHash() const { return FoldingSetHash; }
   void setFoldingSetHash(uint32_t Hash) { FoldingSetHash = Hash; }
 };
@@ -348,11 +347,11 @@ public:
 
   T *operator->() const { return &operator*(); }
 
-  inline FoldingSetIterator &operator++() { // Preincrement
+  FoldingSetIterator &operator++() {
     advance();
     return *this;
   }
-  FoldingSetIterator operator++(int) { // Postincrement
+  FoldingSetIterator operator++(int) {
     FoldingSetIterator tmp = *this;
     ++*this;
     return tmp;

--- a/llvm/include/llvm/ADT/FoldingSet.h
+++ b/llvm/include/llvm/ADT/FoldingSet.h
@@ -306,12 +306,74 @@ public:
 };
 
 //===----------------------------------------------------------------------===//
+/// This class is used to maintain node state in a folding set.
+class FoldingSetNode {
+  // Hash of the node's profile, cached so that growth and removal never
+  // re-run Profile(). NotAHash while the node is in no folding set.
+  uint32_t FoldingSetHash = FoldingSetNodeIDRef::NotAHash;
+
+public:
+  FoldingSetNode() = default;
+
+  // Accessors
+  uint32_t getFoldingSetHash() const { return FoldingSetHash; }
+  void setFoldingSetHash(uint32_t Hash) { FoldingSetHash = Hash; }
+};
+
+//===----------------------------------------------------------------------===//
+/// Forward iterator for FoldingSet and ContextualFoldingSet.
+template <class T> class FoldingSetIterator : DebugEpochBase::HandleBase {
+  FoldingSetNode **Bucket = nullptr;
+  FoldingSetNode **End = nullptr;
+
+  void advance() {
+    assert(isHandleInSync() && "invalid iterator access!");
+    do
+      ++Bucket;
+    while (Bucket != End && *Bucket == nullptr);
+  }
+
+public:
+  FoldingSetIterator(FoldingSetNode **Bucket, FoldingSetNode **End,
+                     const DebugEpochBase *Epoch)
+      : DebugEpochBase::HandleBase(Epoch), Bucket(Bucket), End(End) {
+    while (this->Bucket != this->End && *this->Bucket == nullptr)
+      ++this->Bucket;
+  }
+
+  T &operator*() const {
+    assert(isHandleInSync() && "invalid iterator access!");
+    return *static_cast<T *>(*Bucket);
+  }
+
+  T *operator->() const { return &operator*(); }
+
+  inline FoldingSetIterator &operator++() { // Preincrement
+    advance();
+    return *this;
+  }
+  FoldingSetIterator operator++(int) { // Postincrement
+    FoldingSetIterator tmp = *this;
+    ++*this;
+    return tmp;
+  }
+
+  bool operator==(const FoldingSetIterator &RHS) const {
+    assert(isComparableWith(RHS) && "incomparable iterators!");
+    return Bucket == RHS.Bucket;
+  }
+  bool operator!=(const FoldingSetIterator &RHS) const {
+    return !(*this == RHS);
+  }
+};
+
+//===----------------------------------------------------------------------===//
 /// Non-templated base class for FoldingSet and ContextualFoldingSet, holding
 /// the memory management and probing that does not depend on the node type.
 class FoldingSetBase : public DebugEpochBase {
 protected:
   /// Array of node pointers; a null entry marks an empty slot.
-  void **Buckets = nullptr;
+  FoldingSetNode **Buckets = nullptr;
 
   /// Length of the Buckets array.  Always a power of 2.
   unsigned NumBuckets = 0;
@@ -325,22 +387,6 @@ protected:
   LLVM_ABI ~FoldingSetBase();
 
 public:
-  //===--------------------------------------------------------------------===//
-  /// This class is used to maintain node state in a folding set.
-  class Node {
-  private:
-    // Hash of the node's profile, cached so that growth and removal never
-    // re-run Profile(). NotAHash while the node is in no folding set.
-    uint32_t FoldingSetHash = FoldingSetNodeIDRef::NotAHash;
-
-  public:
-    Node() = default;
-
-    // Accessors
-    uint32_t getFoldingSetHash() const { return FoldingSetHash; }
-    void setFoldingSetHash(uint32_t Hash) { FoldingSetHash = Hash; }
-  };
-
   /// Remove all nodes from the folding set.
   LLVM_ABI void clear();
 
@@ -357,7 +403,7 @@ public:
 private:
   /// Put \p N in the first empty slot following its home, without checking
   /// capacity. Does not touch \p N, so a rehash need not dirty every node.
-  void placeNode(Node *N, uint32_t Hash);
+  void placeNode(FoldingSetNode *N, uint32_t Hash);
 
   /// Rehash into at least \p MinNumBuckets buckets, rounded up to a power of
   /// two and floored at the constructor's minimum.
@@ -369,17 +415,18 @@ protected:
 
   /// Remove a node from the folding set, returning true if one
   /// was removed or false if the node was not in the folding set.
-  LLVM_ABI bool erase(Node *N);
+  LLVM_ABI bool erase(FoldingSetNode *N);
 
   /// Walk the probe chain for \p Hash, offering each node whose cached hash
   /// matches to \p IsMatch. \p IsMatch is a template parameter so that it, and
   /// the profile it may build, inline into the loop.
   template <typename MatchFn>
-  Node *probe(uint32_t Hash, FoldingSetInsertToken &Token, MatchFn IsMatch) {
+  FoldingSetNode *probe(uint32_t Hash, FoldingSetInsertToken &Token,
+                        MatchFn IsMatch) {
     assert(Hash != FoldingSetNodeIDRef::NotAHash && "Hash must be normalized");
     unsigned Mask = NumBuckets - 1;
     for (unsigned I = Hash & Mask; Buckets[I]; I = (I + 1) & Mask) {
-      Node *N = static_cast<Node *>(Buckets[I]);
+      FoldingSetNode *N = Buckets[I];
       if (N->getFoldingSetHash() == Hash && IsMatch(N)) {
         Token = {};
         return N;
@@ -393,17 +440,13 @@ protected:
   /// Insert the specified node into the folding set, knowing that it is not
   /// already in the folding set.  \p Token must come from lookup for an ID that
   /// \p N profiles identically to.
-  LLVM_ABI void insert(Node *N, FoldingSetInsertToken Token);
+  LLVM_ABI void insert(FoldingSetNode *N, FoldingSetInsertToken Token);
 
   /// Wrap \p Hash, which must not be NotAHash, as the token insert takes.
   static FoldingSetInsertToken makeInsertToken(uint32_t Hash) {
     return FoldingSetInsertToken(Hash);
   }
 };
-
-// Convenience type to hide the implementation of the folding set.
-using FoldingSetNode = FoldingSetBase::Node;
-template <class T> class FoldingSetIterator;
 
 //===----------------------------------------------------------------------===//
 /// An implementation detail that lets us share code between FoldingSet and
@@ -592,52 +635,6 @@ public:
 };
 
 //===----------------------------------------------------------------------===//
-/// Forward iterator for FoldingSet and ContextualFoldingSet.
-template <class T> class FoldingSetIterator : DebugEpochBase::HandleBase {
-  void **Bucket = nullptr;
-  void **End = nullptr;
-
-  void advance() {
-    assert(isHandleInSync() && "invalid iterator access!");
-    do
-      ++Bucket;
-    while (Bucket != End && *Bucket == nullptr);
-  }
-
-public:
-  FoldingSetIterator(void **Bucket, void **End, const DebugEpochBase *Epoch)
-      : DebugEpochBase::HandleBase(Epoch), Bucket(Bucket), End(End) {
-    while (this->Bucket != this->End && *this->Bucket == nullptr)
-      ++this->Bucket;
-  }
-
-  T &operator*() const {
-    assert(isHandleInSync() && "invalid iterator access!");
-    return *static_cast<T *>(static_cast<FoldingSetNode *>(*Bucket));
-  }
-
-  T *operator->() const { return &operator*(); }
-
-  inline FoldingSetIterator &operator++() { // Preincrement
-    advance();
-    return *this;
-  }
-  FoldingSetIterator operator++(int) { // Postincrement
-    FoldingSetIterator tmp = *this;
-    ++*this;
-    return tmp;
-  }
-
-  bool operator==(const FoldingSetIterator &RHS) const {
-    assert(isComparableWith(RHS) && "incomparable iterators!");
-    return Bucket == RHS.Bucket;
-  }
-  bool operator!=(const FoldingSetIterator &RHS) const {
-    return !(*this == RHS);
-  }
-};
-
-//===----------------------------------------------------------------------===//
 /// This template class is used to "wrap" arbitrary types in an enclosing object
 /// so that they can be inserted into FoldingSets.
 template <typename T> class FoldingSetNodeWrapper : public FoldingSetNode {
@@ -720,7 +717,7 @@ public:
   /// Look up \p Key.  On a hit \p Token is cleared; on a miss it receives a
   /// token for insert().
   T *lookup(const KeyTy &Key, FoldingSetInsertToken &Token) {
-    return static_cast<T *>(probe(hashKey(Key), Token, [&](Node *N) {
+    return static_cast<T *>(probe(hashKey(Key), Token, [&](FoldingSetNode *N) {
       return Info::isEqual(Key, *static_cast<T *>(N));
     }));
   }

--- a/llvm/lib/Support/FoldingSet.cpp
+++ b/llvm/lib/Support/FoldingSet.cpp
@@ -115,7 +115,8 @@ FoldingSetBase::FoldingSetBase(unsigned Log2InitSize) {
   assert(5 < Log2InitSize && Log2InitSize < 32 &&
          "Initial hash table size out of range");
   NumBuckets = 1 << Log2InitSize;
-  Buckets = static_cast<void **>(safe_calloc(NumBuckets, sizeof(void *)));
+  Buckets = static_cast<FoldingSetNode **>(
+      safe_calloc(NumBuckets, sizeof(FoldingSetNode *)));
 }
 
 FoldingSetBase::FoldingSetBase(FoldingSetBase &&Arg)
@@ -144,11 +145,11 @@ void FoldingSetBase::clear() {
   incrementEpoch();
   // Stale hashes are unreachable, so only the occupancy needs resetting.
   if (NumBuckets)
-    memset(Buckets, 0, NumBuckets * sizeof(void *));
+    memset(Buckets, 0, NumBuckets * sizeof(FoldingSetNode *));
   NumNodes = 0;
 }
 
-void FoldingSetBase::placeNode(Node *N, uint32_t Hash) {
+void FoldingSetBase::placeNode(FoldingSetNode *N, uint32_t Hash) {
   unsigned Mask = NumBuckets - 1;
   unsigned I = Hash & Mask;
   while (Buckets[I]) {
@@ -166,9 +167,8 @@ void FoldingSetBase::grow(unsigned MinNumBuckets) {
 
   FoldingSetBase Tmp(llvm::Log2_32(NewBucketCount));
   for (unsigned I = 0; I != NumBuckets; ++I)
-    if (void *N = Buckets[I])
-      Tmp.placeNode(static_cast<Node *>(N),
-                    static_cast<Node *>(N)->getFoldingSetHash());
+    if (FoldingSetNode *N = Buckets[I])
+      Tmp.placeNode(N, N->getFoldingSetHash());
 
   *this = std::move(Tmp);
 }
@@ -180,7 +180,7 @@ void FoldingSetBase::reserve(unsigned N) {
   grow(N + (N + 2) / 3);
 }
 
-void FoldingSetBase::insert(Node *N, FoldingSetInsertToken Token) {
+void FoldingSetBase::insert(FoldingSetNode *N, FoldingSetInsertToken Token) {
   assert(N && "Cannot insert a null node");
   assert(Token && "Invalid token!");
   incrementEpoch();
@@ -191,7 +191,7 @@ void FoldingSetBase::insert(Node *N, FoldingSetInsertToken Token) {
   N->setFoldingSetHash(Hash);
 }
 
-bool FoldingSetBase::erase(Node *N) {
+bool FoldingSetBase::erase(FoldingSetNode *N) {
   uint32_t Hash = N->getFoldingSetHash();
   if (Hash == FoldingSetNodeIDRef::NotAHash)
     return false; // Never inserted.
@@ -209,7 +209,7 @@ bool FoldingSetBase::erase(Node *N) {
   // Knuth TAOCP 6.4 Algorithm R: walk forward sliding each following entry
   // whose probe path crosses the hole.
   for (unsigned J = (I + 1) & Mask; Buckets[J]; J = (J + 1) & Mask) {
-    unsigned Ideal = static_cast<Node *>(Buckets[J])->getFoldingSetHash();
+    unsigned Ideal = Buckets[J]->getFoldingSetHash();
     if (((I - Ideal) & Mask) < ((J - Ideal) & Mask)) {
       Buckets[I] = Buckets[J];
       I = J;


### PR DESCRIPTION
This patch reorders classes in FoldingSet.h in bottom-up order:

- FoldingSetNode
- FoldingSetIterator
- FoldingSetBase

This setup brings two benefits:

- Eliminates the forward declaration of FoldingSetIterator.

- Enables consistent use of "FoldingSetNode *" instead of "Node *"
  and "void *", eliminating several static_casts.

Assisted-by: Antigravity
