### PR TITLE
[Remarks] Emit SROA and mem2reg missed remarks

### DIFF
--- a/llvm/include/llvm/Analysis/PtrUseVisitor.h
+++ b/llvm/include/llvm/Analysis/PtrUseVisitor.h
@@ -55,6 +55,7 @@ public:
     /// Reset the pointer info, clearing all state.
     void reset() {
       AbortedInfo = nullptr;
+      FailureReason = nullptr;
       EscapedInfo = nullptr;
     }
 
@@ -81,11 +82,17 @@ public:
     /// nocapture call.
     Instruction *getEscapedReadOnlyInst() const { return EscapedReadOnly; }
 
+    /// Why \c getAbortingInst() stopped the visit, or null if the visitor did
+    /// not supply a reason.
+    const char *getFailureReason() const { return FailureReason; }
+
     /// Mark the visit as aborted. Intended for use in a void return.
     /// \param I The instruction which caused the visit to abort, if available.
-    void setAborted(Instruction *I) {
+    /// \param Reason Explanation of the failure.
+    void setAborted(Instruction *I, const char *Reason = nullptr) {
       assert(I && "Expected a valid pointer in setAborted");
       AbortedInfo = I;
+      FailureReason = Reason;
     }
 
     /// Mark the pointer as escaped. Intended for use in a void return.
@@ -112,6 +119,7 @@ public:
 
   private:
     Instruction *AbortedInfo = nullptr;
+    const char *FailureReason = nullptr;
     Instruction *EscapedInfo = nullptr;
     Instruction *EscapedReadOnly = nullptr;
   };

--- a/llvm/include/llvm/Transforms/Utils/PromoteMemToReg.h
+++ b/llvm/include/llvm/Transforms/Utils/PromoteMemToReg.h
@@ -15,6 +15,7 @@
 #define LLVM_TRANSFORMS_UTILS_PROMOTEMEMTOREG_H
 
 #include "llvm/Support/Compiler.h"
+#include <cassert>
 
 namespace llvm {
 
@@ -23,13 +24,41 @@ class AllocaInst;
 class DominatorTree;
 class AssumptionCache;
 
-/// Return true if this alloca is legal for promotion.
+/// Either "this alloca is promotable" or the reason it is not, modelled on
+/// InlineResult. Converts to bool for convenience.
+class AllocaPromotionResult {
+  const char *Reason = nullptr;
+
+  AllocaPromotionResult(const char *Reason) : Reason(Reason) {}
+
+public:
+  AllocaPromotionResult() = default;
+
+  static AllocaPromotionResult success() { return {}; }
+
+  /// \p Reason is a sentence naming the blocking use, e.g. "Has a volatile
+  /// load.", and must outlive the result, so in practice a string literal.
+  static AllocaPromotionResult failure(const char *Reason) {
+    assert(Reason && "A failure must carry a reason.");
+    return AllocaPromotionResult(Reason);
+  }
+
+  bool isSuccess() const { return Reason == nullptr; }
+  explicit operator bool() const { return isSuccess(); }
+
+  const char *getFailureReason() const {
+    assert(!isSuccess() && "Not a failure.");
+    return Reason;
+  }
+};
+
+/// Return whether this alloca is legal for promotion, and if not, why.
 ///
-/// This is true if there are only loads, stores, and lifetime markers
+/// Promotion is legal if there are only loads, stores, and lifetime markers
 /// (transitively) using this alloca. This also enforces that there is only
 /// ever one layer of bitcasts or GEPs between the alloca and the lifetime
 /// markers.
-LLVM_ABI bool isAllocaPromotable(const AllocaInst *AI);
+LLVM_ABI AllocaPromotionResult isAllocaPromotable(const AllocaInst *AI);
 
 /// Promote the specified list of alloca instructions into scalar
 /// registers, inserting PHI nodes as appropriate.

--- a/llvm/lib/Transforms/Scalar/SROA.cpp
+++ b/llvm/lib/Transforms/Scalar/SROA.cpp
@@ -1312,8 +1312,7 @@ private:
       if (LoadInst *LI = dyn_cast<LoadInst>(I)) {
         TypeSize LoadSize = DL.getTypeStoreSize(LI->getType());
         if (LoadSize.isScalable()) {
-          PI.setAborted(LI,
-                        "Loaded with a scalable size and no known vscale.");
+          PI.setAborted(LI, "Loaded with a scalable size and no known vscale.");
           return nullptr;
         }
         Size = std::max(Size, LoadSize.getFixedValue());
@@ -1325,8 +1324,7 @@ private:
           return SI;
         TypeSize StoreSize = DL.getTypeStoreSize(Op->getType());
         if (StoreSize.isScalable()) {
-          PI.setAborted(SI,
-                        "Stored with a scalable size and no known vscale.");
+          PI.setAborted(SI, "Stored with a scalable size and no known vscale.");
           return nullptr;
         }
         Size = std::max(Size, StoreSize.getFixedValue());
@@ -1383,8 +1381,8 @@ private:
     }
 
     if (!IsOffsetKnown)
-      return PI.setAborted(
-          &I, "Reaches a phi or select with an unknown offset.");
+      return PI.setAborted(&I,
+                           "Reaches a phi or select with an unknown offset.");
 
     // See if we already have computed info on this node.
     uint64_t &Size = PHIOrSelectSizes[&I];

--- a/llvm/lib/Transforms/Scalar/SROA.cpp
+++ b/llvm/lib/Transforms/Scalar/SROA.cpp
@@ -609,9 +609,11 @@ public:
     return PtrI.isEscaped() ? PtrI.getEscapingInst() : PtrI.getAbortingInst();
   }
 
-  /// Failure reason, if any.
+  /// Failure reason, generic text about pointer escape if we don't have one.
   const char *getFailureReason() const {
-    return PtrI.isEscaped() ? nullptr : PtrI.getFailureReason();
+    if (PtrI.isEscaped())
+      return "Pointer escapes.";
+    return PtrI.getFailureReason();
   }
 
   /// Support for iterating over the slices.

--- a/llvm/lib/Transforms/Scalar/SROA.cpp
+++ b/llvm/lib/Transforms/Scalar/SROA.cpp
@@ -42,6 +42,7 @@
 #include "llvm/Analysis/DomTreeUpdater.h"
 #include "llvm/Analysis/GlobalsModRef.h"
 #include "llvm/Analysis/Loads.h"
+#include "llvm/Analysis/OptimizationRemarkEmitter.h"
 #include "llvm/Analysis/PtrUseVisitor.h"
 #include "llvm/Analysis/ValueTracking.h"
 #include "llvm/Analysis/VectorUtils.h"
@@ -176,6 +177,7 @@ class SROA {
   LLVMContext *const C;
   DomTreeUpdater *const DTU;
   AssumptionCache *const AC;
+  OptimizationRemarkEmitter *const ORE;
   const bool PreserveCFG;
   const bool AggregateToVector;
 
@@ -238,8 +240,8 @@ class SROA {
 
 public:
   SROA(LLVMContext *C, DomTreeUpdater *DTU, AssumptionCache *AC,
-       SROAOptions Options)
-      : C(C), DTU(DTU), AC(AC),
+       SROAOptions Options, OptimizationRemarkEmitter *ORE = nullptr)
+      : C(C), DTU(DTU), AC(AC), ORE(ORE),
         PreserveCFG(Options.CFG == SROAOptions::PreserveCFG),
         AggregateToVector(Options.AggregateToVector) {}
 
@@ -598,8 +600,19 @@ public:
   ///
   /// If this is true, the slices are never fully built and should be
   /// ignored.
-  bool isEscaped() const { return PointerEscapingInstr; }
-  bool isEscapedReadOnly() const { return PointerEscapingInstrReadOnly; }
+  bool isEscaped() const { return PtrI.isEscaped() || PtrI.isAborted(); }
+
+  bool isEscapedReadOnly() const { return PtrI.isEscapedReadOnly(); }
+
+  /// The instruction that stopped us from building slices (null if none)
+  Instruction *getPointerEscapingInst() const {
+    return PtrI.isEscaped() ? PtrI.getEscapingInst() : PtrI.getAbortingInst();
+  }
+
+  /// Failure reason, if any.
+  const char *getFailureReason() const {
+    return PtrI.isEscaped() ? nullptr : PtrI.getFailureReason();
+  }
 
   /// Support for iterating over the slices.
   /// @{
@@ -675,14 +688,13 @@ private:
   AllocaInst &AI;
 #endif
 
-  /// The instruction responsible for this alloca not having a known set
-  /// of slices.
+  /// The outcome of walking the uses of the alloca.
   ///
-  /// When an instruction (potentially) escapes the pointer to the alloca, we
-  /// store a pointer to that here and abort trying to form slices of the
-  /// alloca. This will be null if the alloca slices are analyzed successfully.
-  Instruction *PointerEscapingInstr;
-  Instruction *PointerEscapingInstrReadOnly;
+  /// When an instruction (potentially) escapes the pointer to the alloca, or
+  /// is a use the walk cannot model, this records it and we abort trying to
+  /// form slices of the alloca. It reports neither if the alloca slices are
+  /// analyzed successfully.
+  detail::PtrUseVisitorBase::PtrInfo PtrI;
 
   /// The slices of the alloca.
   ///
@@ -1120,7 +1132,8 @@ private:
     if (Size.isScalable()) {
       unsigned VScale = LI.getFunction()->getVScaleValue();
       if (!VScale)
-        return PI.setAborted(&LI);
+        return PI.setAborted(
+            &LI, "Is loaded with a scalable size and no known vscale.");
 
       Size = TypeSize::getFixed(Size.getKnownMinValue() * VScale);
     }
@@ -1134,13 +1147,14 @@ private:
     if (ValOp == *U)
       return PI.setEscapedAndAborted(&SI);
     if (!IsOffsetKnown)
-      return PI.setAborted(&SI);
+      return PI.setAborted(&SI, "Is stored at an offset that is not known.");
 
     TypeSize StoreSize = DL.getTypeStoreSize(ValOp->getType());
     if (StoreSize.isScalable()) {
       unsigned VScale = SI.getFunction()->getVScaleValue();
       if (!VScale)
-        return PI.setAborted(&SI);
+        return PI.setAborted(
+            &SI, "Is stored with a scalable size and no known vscale.");
 
       StoreSize = TypeSize::getFixed(StoreSize.getKnownMinValue() * VScale);
     }
@@ -1177,7 +1191,7 @@ private:
       return markAsDead(II);
 
     if (!IsOffsetKnown)
-      return PI.setAborted(&II);
+      return PI.setAborted(&II, "Has a memset at an offset that is not known.");
 
     insertUse(II, Offset,
               Length ? Length->getLimitedValue()
@@ -1197,7 +1211,8 @@ private:
       return;
 
     if (!IsOffsetKnown)
-      return PI.setAborted(&II);
+      return PI.setAborted(
+          &II, "Has a memory transfer at an offset that is not known.");
 
     // This side of the transfer is completely out-of-bounds, and so we can
     // nuke the entire transfer. However, we also need to nuke the other side
@@ -1264,7 +1279,8 @@ private:
     }
 
     if (!IsOffsetKnown)
-      return PI.setAborted(&II);
+      return PI.setAborted(
+          &II, "Used by an intrinsic at an offset that is not known.");
 
     if (II.isLifetimeStartOrEnd()) {
       insertUse(II, Offset, AllocSize, true);
@@ -1294,7 +1310,8 @@ private:
       if (LoadInst *LI = dyn_cast<LoadInst>(I)) {
         TypeSize LoadSize = DL.getTypeStoreSize(LI->getType());
         if (LoadSize.isScalable()) {
-          PI.setAborted(LI);
+          PI.setAborted(LI,
+                        "Loaded with a scalable size and no known vscale.");
           return nullptr;
         }
         Size = std::max(Size, LoadSize.getFixedValue());
@@ -1306,7 +1323,8 @@ private:
           return SI;
         TypeSize StoreSize = DL.getTypeStoreSize(Op->getType());
         if (StoreSize.isScalable()) {
-          PI.setAborted(SI);
+          PI.setAborted(SI,
+                        "Stored with a scalable size and no known vscale.");
           return nullptr;
         }
         Size = std::max(Size, StoreSize.getFixedValue());
@@ -1338,7 +1356,8 @@ private:
     // instructions in this BB, which may be required during rewriting. Bail out
     // on these cases.
     if (isa<PHINode>(I) && !I.getParent()->hasInsertionPt())
-      return PI.setAborted(&I);
+      return PI.setAborted(
+          &I, "Address reaches a phi with no valid insertion point.");
 
     // TODO: We could use simplifyInstruction here to fold PHINodes and
     // SelectInsts. However, doing so requires to change the current
@@ -1362,14 +1381,16 @@ private:
     }
 
     if (!IsOffsetKnown)
-      return PI.setAborted(&I);
+      return PI.setAborted(
+          &I, "Reaches a phi or select with an unknown offset.");
 
     // See if we already have computed info on this node.
     uint64_t &Size = PHIOrSelectSizes[&I];
     if (!Size) {
       // This is a new PHI/Select, check for an unsafe use of it.
       if (Instruction *UnsafeI = hasUnsafePHIOrSelectUse(&I, Size))
-        return PI.setAborted(UnsafeI);
+        return PI.setAborted(
+            UnsafeI, "Reaches a phi or select with an unsupported use.");
     }
 
     // For PHI and select operands outside the alloca, we can't nuke the entire
@@ -1391,7 +1412,9 @@ private:
   void visitSelectInst(SelectInst &SI) { visitPHINodeOrSelectInst(SI); }
 
   /// Disable SROA entirely if there are unhandled users of the alloca.
-  void visitInstruction(Instruction &I) { PI.setAborted(&I); }
+  void visitInstruction(Instruction &I) {
+    PI.setAborted(&I, "Has a use that could not be analyzed.");
+  }
 
   void visitCallBase(CallBase &CB) {
     // If the call operand is read-only and only does a read-only or address
@@ -1412,18 +1435,13 @@ AllocaSlices::AllocaSlices(const DataLayout &DL, AllocaInst &AI)
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
       AI(AI),
 #endif
-      PointerEscapingInstr(nullptr), PointerEscapingInstrReadOnly(nullptr) {
+      PtrI() {
   SliceBuilder PB(DL, AI, *this);
-  SliceBuilder::PtrInfo PtrI = PB.visitPtr(AI);
-  if (PtrI.isEscaped() || PtrI.isAborted()) {
-    // FIXME: We should sink the escape vs. abort info into the caller nicely,
-    // possibly by just storing the PtrInfo in the AllocaSlices.
-    PointerEscapingInstr = PtrI.getEscapingInst() ? PtrI.getEscapingInst()
-                                                  : PtrI.getAbortingInst();
-    assert(PointerEscapingInstr && "Did not track a bad instruction");
+  PtrI = PB.visitPtr(AI);
+  if (isEscaped()) {
+    assert(getPointerEscapingInst() && "Did not track a bad instruction");
     return;
   }
-  PointerEscapingInstrReadOnly = PtrI.getEscapedReadOnlyInst();
 
   llvm::erase_if(Slices, [](const Slice &S) { return S.isDead(); });
 
@@ -1454,15 +1472,17 @@ void AllocaSlices::printUse(raw_ostream &OS, const_iterator I,
 }
 
 void AllocaSlices::print(raw_ostream &OS) const {
-  if (PointerEscapingInstr) {
+  if (isEscaped()) {
     OS << "Can't analyze slices for alloca: " << AI << "\n"
        << "  A pointer to this alloca escaped by:\n"
-       << "  " << *PointerEscapingInstr << "\n";
+       << "  " << *getPointerEscapingInst() << "\n";
+    if (const char *Reason = getFailureReason())
+      OS << "  " << Reason << "\n";
     return;
   }
 
-  if (PointerEscapingInstrReadOnly)
-    OS << "Escapes into ReadOnly: " << *PointerEscapingInstrReadOnly << "\n";
+  if (Instruction *ReadOnly = PtrI.getEscapedReadOnlyInst())
+    OS << "Escapes into ReadOnly: " << *ReadOnly << "\n";
 
   OS << "Slices of alloca: " << AI << "\n";
   for (const_iterator I = begin(), E = end(); I != E; ++I)
@@ -6159,6 +6179,24 @@ bool SROA::propagateStoredValuesToLoads(AllocaInst &AI, AllocaSlices &AS) {
   return true;
 }
 
+/// Report an aggregate allocation that slice analysis could not take apart.
+/// Only aggregates are reported: an escaping scalar alloca is not a missed
+/// splitting opportunity. The remark is anchored at the blocking use rather
+/// than the alloca, because that use is what the user can act on.
+static void reportAllocaNotSplit(const AllocaInst &AI, const AllocaSlices &AS,
+                                 OptimizationRemarkEmitter *ORE) {
+  if (!ORE || !AI.getAllocatedType()->isAggregateType())
+    return;
+  Instruction *Blocker = AS.getPointerEscapingInst();
+  if (!Blocker)
+    return;
+  ORE->emit([&] {
+    return OptimizationRemarkMissed(DEBUG_TYPE, "AllocaNotSplit", Blocker)
+           << "aggregate allocation was not split. "
+           << ore::NV("Reason", AS.getFailureReason());
+  });
+}
+
 /// Analyze an alloca for SROA.
 ///
 /// This analyzes the alloca to ensure we can reason about it, builds
@@ -6194,8 +6232,10 @@ SROA::runOnAlloca(AllocaInst &AI) {
   // Build the slices using a recursive instruction-visiting builder.
   AllocaSlices AS(DL, AI);
   LLVM_DEBUG(AS.print(dbgs()));
-  if (AS.isEscaped())
+  if (AS.isEscaped()) {
+    reportAllocaNotSplit(AI, AS, ORE);
     return {Changed, CFGChanged};
+  }
 
   if (AS.isEscapedReadOnly()) {
     Changed |= propagateStoredValuesToLoads(AI, AS);
@@ -6370,8 +6410,10 @@ PreservedAnalyses SROAPass::run(Function &F, FunctionAnalysisManager &AM) {
   DominatorTree &DT = AM.getResult<DominatorTreeAnalysis>(F);
   AssumptionCache &AC = AM.getResult<AssumptionAnalysis>(F);
   DomTreeUpdater DTU(DT, DomTreeUpdater::UpdateStrategy::Lazy);
+  OptimizationRemarkEmitter &ORE =
+      AM.getResult<OptimizationRemarkEmitterAnalysis>(F);
   auto [Changed, CFGChanged] =
-      SROA(&F.getContext(), &DTU, &AC, Options).runSROA(F);
+      SROA(&F.getContext(), &DTU, &AC, Options, &ORE).runSROA(F);
   if (!Changed)
     return PreservedAnalyses::all();
   PreservedAnalyses PA;

--- a/llvm/lib/Transforms/Utils/Mem2Reg.cpp
+++ b/llvm/lib/Transforms/Utils/Mem2Reg.cpp
@@ -14,7 +14,9 @@
 #include "llvm/Transforms/Utils/Mem2Reg.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/Analysis/AssumptionCache.h"
+#include "llvm/Analysis/OptimizationRemarkEmitter.h"
 #include "llvm/IR/BasicBlock.h"
+#include "llvm/IR/DiagnosticInfo.h"
 #include "llvm/IR/Dominators.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/Instructions.h"
@@ -24,6 +26,7 @@
 #include "llvm/Support/Casting.h"
 #include "llvm/Transforms/Utils.h"
 #include "llvm/Transforms/Utils/PromoteMemToReg.h"
+#include <cassert>
 #include <vector>
 
 using namespace llvm;
@@ -32,8 +35,26 @@ using namespace llvm;
 
 STATISTIC(NumPromoted, "Number of alloca's promoted");
 
+static void reportAllocaNotPromoted(const AllocaInst *AI,
+                                    OptimizationRemarkEmitter &ORE) {
+  // SROA handles the reporting for aggregates
+  if (AI->getAllocatedType()->isAggregateType())
+    return;
+
+  ORE.emit([&] {
+    AllocaPromotionResult Promotable = isAllocaPromotable(AI);
+    assert(!Promotable && "Reporting an alloca that could have been promoted");
+    return OptimizationRemarkMissed(DEBUG_TYPE, "AllocaNotPromotable", AI)
+           << "Alloca was not promoted. "
+           << ore::NV("Reason", Promotable.getFailureReason());
+  });
+}
+
+/// \p ORE is optional; when non-null, allocas that cannot be promoted are
+/// reported as missed optimizations.
 static bool promoteMemoryToRegister(Function &F, DominatorTree &DT,
-                                    AssumptionCache &AC) {
+                                    AssumptionCache &AC,
+                                    OptimizationRemarkEmitter *ORE) {
   std::vector<AllocaInst *> Allocas;
   BasicBlock &BB = F.getEntryBlock(); // Get the entry node for the function
   bool Changed = false;
@@ -55,13 +76,23 @@ static bool promoteMemoryToRegister(Function &F, DominatorTree &DT,
     NumPromoted += Allocas.size();
     Changed = true;
   }
+
+  // Report once promotion has reached a fixed point: the allocas still standing
+  // in the entry block are exactly the ones that could not be promoted, and
+  // reporting inside the loop would emit a remark per round instead of one.
+  if (ORE)
+    for (const Instruction &I : BB)
+      if (const auto *AI = dyn_cast<AllocaInst>(&I))
+        reportAllocaNotPromoted(AI, *ORE);
+
   return Changed;
 }
 
 PreservedAnalyses PromotePass::run(Function &F, FunctionAnalysisManager &AM) {
   auto &DT = AM.getResult<DominatorTreeAnalysis>(F);
   auto &AC = AM.getResult<AssumptionAnalysis>(F);
-  if (!promoteMemoryToRegister(F, DT, AC))
+  auto &ORE = AM.getResult<OptimizationRemarkEmitterAnalysis>(F);
+  if (!promoteMemoryToRegister(F, DT, AC, &ORE))
     return PreservedAnalyses::all();
 
   PreservedAnalyses PA;
@@ -88,7 +119,7 @@ struct PromoteLegacyPass : public FunctionPass {
     DominatorTree &DT = getAnalysis<DominatorTreeWrapperPass>().getDomTree();
     AssumptionCache &AC =
         getAnalysis<AssumptionCacheTracker>().getAssumptionCache(F);
-    return promoteMemoryToRegister(F, DT, AC);
+    return promoteMemoryToRegister(F, DT, AC, /*ORE=*/nullptr);
   }
 
   void getAnalysisUsage(AnalysisUsage &AU) const override {

--- a/llvm/lib/Transforms/Utils/PromoteMemoryToRegister.cpp
+++ b/llvm/lib/Transforms/Utils/PromoteMemoryToRegister.cpp
@@ -63,7 +63,9 @@ STATISTIC(NumSingleStore,   "Number of alloca's promoted with a single store");
 STATISTIC(NumDeadAlloca,    "Number of dead alloca's removed");
 STATISTIC(NumPHIInsert,     "Number of PHI nodes inserted");
 
-bool llvm::isAllocaPromotable(const AllocaInst *AI) {
+AllocaPromotionResult llvm::isAllocaPromotable(const AllocaInst *AI) {
+  using Result = AllocaPromotionResult;
+
   // Only allow direct and non-volatile loads and stores...
   // All loads and stores must use the same type (determined by the first one
   // seen). We don't require the type to match the alloca's declared type.
@@ -73,44 +75,50 @@ bool llvm::isAllocaPromotable(const AllocaInst *AI) {
       // Note that atomic loads can be transformed; atomic semantics do
       // not have any meaning for a local alloca.
       if (LI->isVolatile())
-        return false;
+        return Result::failure("Has a volatile load.");
       if (!ExpectedType)
         ExpectedType = LI->getType();
       else if (LI->getType() != ExpectedType)
-        return false;
+        return Result::failure("Has loads and stores of different types.");
     } else if (const StoreInst *SI = dyn_cast<StoreInst>(U)) {
       if (SI->getValueOperand() == AI)
-        return false; // Don't allow a store OF the AI, only INTO the AI.
+        // Don't allow a store OF the AI, only INTO the AI.
+        return Result::failure("Address is stored to memory.");
       // Note that atomic stores can be transformed; atomic semantics do
       // not have any meaning for a local alloca.
       if (SI->isVolatile())
-        return false;
+        return Result::failure("Has a volatile store.");
       Type *StoreType = SI->getValueOperand()->getType();
       if (!ExpectedType)
         ExpectedType = StoreType;
       else if (StoreType != ExpectedType)
-        return false;
+        return Result::failure("Has loads and stores of different types.");
     } else if (const IntrinsicInst *II = dyn_cast<IntrinsicInst>(U)) {
       if (!II->isLifetimeStartOrEnd() && !II->isDroppable() &&
           II->getIntrinsicID() != Intrinsic::fake_use)
-        return false;
+        return Result::failure("Address is passed to an intrinsic.");
     } else if (const BitCastInst *BCI = dyn_cast<BitCastInst>(U)) {
       if (!onlyUsedByLifetimeMarkersOrDroppableInsts(BCI))
-        return false;
+        return Result::failure("Address is used through a bitcast.");
     } else if (const GetElementPtrInst *GEPI = dyn_cast<GetElementPtrInst>(U)) {
       if (!GEPI->hasAllZeroIndices())
-        return false;
+        return Result::failure("Is accessed at a non-zero offset.");
       if (!onlyUsedByLifetimeMarkersOrDroppableInsts(GEPI))
-        return false;
+        return Result::failure("Address is used through a zero-index GEP with "
+                               "non-lifetime uses.");
     } else if (const AddrSpaceCastInst *ASCI = dyn_cast<AddrSpaceCastInst>(U)) {
       if (!onlyUsedByLifetimeMarkers(ASCI))
-        return false;
+        return Result::failure("Address is used through an addrspacecast.");
+    } else if (isa<CallBase>(U)) {
+      // Rejected by the catch-all below too, split out only so that the most
+      // common blocker gets a more specific reason.
+      return Result::failure("Address is passed to a call.");
     } else {
-      return false;
+      return Result::failure("Has a use that is not a load or store.");
     }
   }
 
-  return true;
+  return Result::success();
 }
 
 namespace {

--- a/llvm/test/Other/new-pm-defaults.ll
+++ b/llvm/test/Other/new-pm-defaults.ll
@@ -95,6 +95,7 @@
 ; CHECK-O-NEXT: Running analysis: AssumptionAnalysis
 ; CHECK-O-NEXT: Running pass: SROAPass
 ; CHECK-O-NEXT: Running analysis: DominatorTreeAnalysis
+; CHECK-O-NEXT: Running analysis: OptimizationRemarkEmitterAnalysis
 ; CHECK-O-NEXT: Running pass: EarlyCSEPass
 ; CHECK-O-NEXT: Running analysis: TargetLibraryAnalysis
 ; CHECK-O3-NEXT: Running pass: CallSiteSplittingPass
@@ -106,7 +107,6 @@
 ; CHECK-O-NEXT: Running pass: PromotePass
 ; CHECK-O-NEXT: Running pass: InstCombinePass
 ; CHECK-O-NEXT: Running analysis: LastRunTrackingAnalysis
-; CHECK-O-NEXT: Running analysis: OptimizationRemarkEmitterAnalysis
 ; CHECK-O-NEXT: Running analysis: AAManager
 ; CHECK-O-NEXT: Running analysis: BasicAA
 ; CHECK-O-NEXT: Running analysis: ScopedNoAliasAA

--- a/llvm/test/Other/new-pm-thinlto-prelink-defaults.ll
+++ b/llvm/test/Other/new-pm-thinlto-prelink-defaults.ll
@@ -65,6 +65,7 @@
 ; CHECK-O-NEXT: Running analysis: AssumptionAnalysis
 ; CHECK-O-NEXT: Running pass: SROAPass
 ; CHECK-O-NEXT: Running analysis: DominatorTreeAnalysis
+; CHECK-O-NEXT: Running analysis: OptimizationRemarkEmitterAnalysis
 ; CHECK-O-NEXT: Running pass: EarlyCSEPass
 ; CHECK-O-NEXT: Running analysis: TargetLibraryAnalysis
 ; CHECK-O3-NEXT: Running pass: CallSiteSplittingPass
@@ -75,7 +76,6 @@
 ; CHECK-O-NEXT: Running pass: PromotePass
 ; CHECK-O-NEXT: Running pass: InstCombinePass
 ; CHECK-O-NEXT: Running analysis: LastRunTrackingAnalysis
-; CHECK-O-NEXT: Running analysis: OptimizationRemarkEmitterAnalysis
 ; CHECK-O-NEXT: Running analysis: AAManager
 ; CHECK-O-NEXT: Running analysis: BasicAA
 ; CHECK-O-NEXT: Running analysis: ScopedNoAliasAA

--- a/llvm/test/Other/new-pm-thinlto-prelink-pgo-defaults.ll
+++ b/llvm/test/Other/new-pm-thinlto-prelink-pgo-defaults.ll
@@ -33,6 +33,7 @@
 ; CHECK-O-NEXT: Running analysis: AssumptionAnalysis
 ; CHECK-O-NEXT: Running pass: SROAPass
 ; CHECK-O-NEXT: Running analysis: DominatorTreeAnalysis
+; CHECK-O-NEXT: Running analysis: OptimizationRemarkEmitterAnalysis
 ; CHECK-O-NEXT: Running pass: EarlyCSEPass
 ; CHECK-O-NEXT: Running analysis: TargetLibraryAnalysis
 ; CHECK-O3-NEXT: Running pass: CallSiteSplittingPass
@@ -43,7 +44,6 @@
 ; CHECK-O-NEXT: Running pass: PromotePass
 ; CHECK-O-NEXT: Running pass: InstCombinePass
 ; CHECK-O-NEXT: Running analysis: LastRunTrackingAnalysis
-; CHECK-O-NEXT: Running analysis: OptimizationRemarkEmitterAnalysis
 ; CHECK-O-NEXT: Running analysis: AAManager
 ; CHECK-O-NEXT: Running analysis: BasicAA
 ; CHECK-O-NEXT: Running analysis: ScopedNoAliasAA

--- a/llvm/test/Other/new-pm-thinlto-prelink-samplepgo-defaults.ll
+++ b/llvm/test/Other/new-pm-thinlto-prelink-samplepgo-defaults.ll
@@ -32,6 +32,7 @@
 ; CHECK-O-NEXT: Running analysis: AssumptionAnalysis
 ; CHECK-O-NEXT: Running pass: SROAPass
 ; CHECK-O-NEXT: Running analysis: DominatorTreeAnalysis
+; CHECK-O-NEXT: Running analysis: OptimizationRemarkEmitterAnalysis on foo
 ; CHECK-O-NEXT: Running pass: EarlyCSEPass
 ; CHECK-O-NEXT: Running analysis: TargetLibraryAnalysis
 ; CHECK-O3-NEXT: Running pass: CallSiteSplittingPass
@@ -46,7 +47,6 @@
 ; CHECK-O-NEXT: Running pass: PromotePass
 ; CHECK-O-NEXT: Running pass: InstCombinePass
 ; CHECK-O-NEXT: Running analysis: LastRunTrackingAnalysis
-; CHECK-O-NEXT: Running analysis: OptimizationRemarkEmitterAnalysis on foo
 ; CHECK-O-NEXT: Running analysis: AAManager on foo
 ; CHECK-O-NEXT: Running analysis: BasicAA
 ; CHECK-O-NEXT: Running analysis: ScopedNoAliasAA

--- a/llvm/test/Transforms/Mem2Reg/missed-remarks.ll
+++ b/llvm/test/Transforms/Mem2Reg/missed-remarks.ll
@@ -1,0 +1,74 @@
+; RUN: opt -passes=mem2reg -pass-remarks-output=%t.yaml -disable-output < %s
+; RUN: FileCheck %s -implicit-check-not=aggregate_deferred < %t.yaml
+
+; mem2reg reports scalar allocas it cannot promote, naming the use that blocked
+; promotion. Aggregates are not reported: promoting them is SROA's job, and
+; SROA reports the ones it cannot split.
+
+%struct.Pair = type { i32, i32 }
+
+declare void @escape(ptr)
+
+; CHECK:      Name:{{ +}}AllocaNotPromotable
+; CHECK:      Function:{{ +}}escapes_to_call
+; CHECK:      Address is passed to a call.
+
+define i32 @escapes_to_call() {
+entry:
+  %escaping = alloca i32
+  %promotable = alloca i32
+  store i32 42, ptr %promotable
+  call void @escape(ptr %escaping)
+  %v = load i32, ptr %promotable
+  ret i32 %v
+}
+
+; CHECK:      Name:{{ +}}AllocaNotPromotable
+; CHECK:      Function:{{ +}}volatile_load
+; CHECK:      Has a volatile load.
+
+define i32 @volatile_load() {
+entry:
+  %x = alloca i32
+  store i32 42, ptr %x
+  %v = load volatile i32, ptr %x
+  ret i32 %v
+}
+
+; CHECK:      Name:{{ +}}AllocaNotPromotable
+; CHECK:      Function:{{ +}}address_stored
+; CHECK:      Address is stored to memory.
+
+define void @address_stored(ptr %sink) {
+entry:
+  %x = alloca i32
+  store i32 42, ptr %x
+  store ptr %x, ptr %sink
+  ret void
+}
+
+; CHECK:      Name:{{ +}}AllocaNotPromotable
+; CHECK:      Function:{{ +}}mixed_types
+; CHECK:      Has loads and stores of different types.
+
+define float @mixed_types() {
+entry:
+  %x = alloca i32
+  store i32 42, ptr %x
+  %v = load float, ptr %x
+  ret float %v
+}
+
+; An aggregate mem2reg cannot see through: handed off to SROA, not reported.
+define i32 @aggregate_deferred(i32 %n) {
+entry:
+  %p = alloca %struct.Pair
+  %a = getelementptr inbounds %struct.Pair, ptr %p, i32 0, i32 0
+  %b = getelementptr inbounds %struct.Pair, ptr %p, i32 0, i32 1
+  store i32 %n, ptr %a
+  store i32 %n, ptr %b
+  %la = load i32, ptr %a
+  %lb = load i32, ptr %b
+  %sum = add i32 %la, %lb
+  ret i32 %sum
+}

--- a/llvm/test/Transforms/SROA/missed-remarks.ll
+++ b/llvm/test/Transforms/SROA/missed-remarks.ll
@@ -1,0 +1,54 @@
+; RUN: opt -passes=sroa -pass-remarks-output=%t.yaml -disable-output < %s
+; RUN: FileCheck %s -implicit-check-not=scalar_escapes < %t.yaml
+
+; SROA reports an aggregate allocation whose slices it could not build. An
+; escaping use speaks for itself, so it is named by the instruction the remark
+; is anchored at; a use slice analysis cannot model also carries a reason. An
+; escaping scalar alloca is not reported: there is nothing to split, so it is
+; not a missed splitting opportunity.
+
+%struct.S = type { i32, i32 }
+
+declare void @escape(ptr)
+
+; CHECK:      Name:{{ +}}AllocaNotSplit
+; CHECK:      Function:{{ +}}aggregate_escapes
+; CHECK:      A pointer to it escapes here.
+
+define void @aggregate_escapes() {
+entry:
+  %s = alloca %struct.S
+  call void @escape(ptr %s)
+  ret void
+}
+
+; CHECK:      Name:{{ +}}AllocaNotSplit
+; CHECK:      Function:{{ +}}aggregate_unknown_offset
+; CHECK:      Is stored at an offset that is not known.
+
+define void @aggregate_unknown_offset(i64 %n) {
+entry:
+  %s = alloca %struct.S
+  %p = getelementptr i8, ptr %s, i64 %n
+  store i32 7, ptr %p
+  ret void
+}
+
+; CHECK:      Name:{{ +}}AllocaNotSplit
+; CHECK:      Function:{{ +}}aggregate_unanalyzable_use
+; CHECK:      Has a use that could not be analyzed.
+
+define void @aggregate_unanalyzable_use() {
+entry:
+  %s = alloca %struct.S
+  %v = va_arg ptr %s, i32
+  ret void
+}
+
+; A scalar alloca has nothing to split, so an escape is not reported.
+define void @scalar_escapes() {
+entry:
+  %x = alloca i32
+  call void @escape(ptr %x)
+  ret void
+}

--- a/llvm/test/Transforms/SROA/missed-remarks.ll
+++ b/llvm/test/Transforms/SROA/missed-remarks.ll
@@ -13,7 +13,7 @@ declare void @escape(ptr)
 
 ; CHECK:      Name:{{ +}}AllocaNotSplit
 ; CHECK:      Function:{{ +}}aggregate_escapes
-; CHECK:      A pointer to it escapes here.
+; CHECK:      Pointer escapes.
 
 define void @aggregate_escapes() {
 entry:


### PR DESCRIPTION
Emit remarks with a reason when SROA can not split an alloca because of an escaping pointer, or mem2reg can not promote one.
Also resolves a FIXME.