### PR TITLE
[clang][OpenMP] Add explicit default libomp value to test.

### DIFF
--- a/clang/unittests/AST/AttrTest.cpp
+++ b/clang/unittests/AST/AttrTest.cpp
@@ -315,7 +315,7 @@ TEST(Attr, OMPInvariantPredicateBoundOnIntraTileLoop) {
             body(i);
         }
       )cpp",
-      {"-fopenmp"});
+      {"-fopenmp=libomp"});
   ASSERT_TRUE(AST);
 
   auto GetHint = [&AST](const char *FuncName) {


### PR DESCRIPTION
The test OMPInvariantPredicateBoundOnIntraTileLoop, in AttrTest.cpp uses '-fopenmp' without supplying an explcit value. In some places the default value is 'libomp', which works just fine for this test. But in envorinments where 'libomp' is not the default value (e.g. places that use 'libgomp' by default) the test fails. This fixes that issue by explicitly telling the test to use 'libomp'.