### PR TITLE
[HLSL] Use icmp-ne instead of truncation on boolean load

### DIFF
--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -653,6 +653,12 @@ static bool FixupInvocation(CompilerInvocation &Invocation,
       Warnings.insert(Warnings.begin(), "vector-conversion");
     if (!llvm::is_contained(Warnings, "matrix-conversion"))
       Warnings.insert(Warnings.begin(), "matrix-conversion");
+
+    // HLSL booleans in memory are i32; any non-zero value is true.
+    // Use icmp-ne rather than truncation to avoid InstCombine rewriting
+    // trunc i32 to i1 into an illegal wide <N x i1> bitcast (issue #140824).
+    if (!Args.hasArg(OPT_load_bool_from_mem))
+      CodeGenOpts.setLoadBoolFromMem(CodeGenOptions::BoolFromMem::NonZero);
   }
 
   // When these options are used, the compiler is allowed to apply

--- a/clang/test/CodeGenHLSL/strict-bool.hlsl
+++ b/clang/test/CodeGenHLSL/strict-bool.hlsl
@@ -1,6 +1,6 @@
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library -O1 -load-bool-from-mem=truncate -emit-llvm -o - %s | FileCheck %s -check-prefixes=CHECK-TRUNCATE
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library -O1 -load-bool-from-mem=nonzero -emit-llvm -o - %s | FileCheck %s -check-prefixes=CHECK-NONZERO
-// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library -O0 -emit-llvm -o - %s | FileCheck %s -check-prefixes=CHECK-NONZERO
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library -O1 -emit-llvm -o - %s | FileCheck %s -check-prefixes=CHECK-NONZERO
 
 typedef bool bool8_t __attribute__((ext_vector_type(8)));
 extern bool8_t vec;


### PR DESCRIPTION
Fixes #140824

Assisted-by: Claude Sonnet 4