### PR TITLE
[AArch64][CMPBR] Fix splitting of CBB/CBH instructions into ext + cmp

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
@@ -869,6 +869,21 @@ unsigned AArch64InstrInfo::insertBranch(
   return 2;
 }
 
+#ifndef NDEBUG
+static bool isValidCBExtend(int64_t Opc, AArch64_AM::ShiftExtendType Ext) {
+  switch (Ext) {
+  default:
+    return false;
+  case AArch64_AM::UXTB:
+  case AArch64_AM::SXTB:
+    return Opc == AArch64::CBBAssertExt;
+  case AArch64_AM::UXTH:
+  case AArch64_AM::SXTH:
+    return Opc == AArch64::CBHAssertExt;
+  }
+}
+#endif
+
 AArch64CC::CondCode AArch64InstrInfo::insertCmpForCondBr(
     MachineBasicBlock &MBB, MachineBasicBlock::iterator MI, const DebugLoc &DL,
     ArrayRef<MachineOperand> Cond) const {
@@ -1001,49 +1016,39 @@ AArch64CC::CondCode AArch64InstrInfo::insertCmpForCondBr(
     // Cond is { -1, Opcode, CC, Op0, Op1, Ext0, Ext1 }
 
     // We need a new register for the now explicitly extended register
-    Register Reg = Cond[4].getReg();
+    Register Reg = Cond[3].getReg();
     if (Cond[5].getImm() != AArch64_AM::InvalidShiftExtend) {
       unsigned ExtOpc;
       unsigned ExtBits;
       AArch64_AM::ShiftExtendType ExtendType =
           AArch64_AM::getExtendType(Cond[5].getImm());
+      assert(isValidCBExtend(Cond[1].getImm(), ExtendType) &&
+             "Unexpected compare-and-branch instruction for extend type");
       switch (ExtendType) {
       default:
         llvm_unreachable("Unknown shift-extend for CB instruction");
       case AArch64_AM::SXTB:
-        assert(
-            Cond[1].getImm() == AArch64::CBBAssertExt &&
-            "Unexpected compare-and-branch instruction for SXTB shift-extend");
         ExtOpc = AArch64::SBFMWri;
         ExtBits = AArch64_AM::encodeLogicalImmediate(0xff, 32);
         break;
       case AArch64_AM::SXTH:
-        assert(
-            Cond[1].getImm() == AArch64::CBHAssertExt &&
-            "Unexpected compare-and-branch instruction for SXTH shift-extend");
         ExtOpc = AArch64::SBFMWri;
         ExtBits = AArch64_AM::encodeLogicalImmediate(0xffff, 32);
         break;
       case AArch64_AM::UXTB:
-        assert(
-            Cond[1].getImm() == AArch64::CBBAssertExt &&
-            "Unexpected compare-and-branch instruction for UXTB shift-extend");
         ExtOpc = AArch64::ANDWri;
         ExtBits = AArch64_AM::encodeLogicalImmediate(0xff, 32);
         break;
       case AArch64_AM::UXTH:
-        assert(
-            Cond[1].getImm() == AArch64::CBHAssertExt &&
-            "Unexpected compare-and-branch instruction for UXTH shift-extend");
         ExtOpc = AArch64::ANDWri;
         ExtBits = AArch64_AM::encodeLogicalImmediate(0xffff, 32);
         break;
       }
 
       // Build the explicit extension of the first operand
-      Reg = MRI.createVirtualRegister(&AArch64::GPR32spRegClass);
+      Reg = MRI.createVirtualRegister(&AArch64::GPR32commonRegClass);
       MachineInstrBuilder MBBI =
-          BuildMI(MBB, MI, DL, get(ExtOpc), Reg).addReg(Cond[4].getReg());
+          BuildMI(MBB, MI, DL, get(ExtOpc), Reg).addReg(Cond[3].getReg());
       if (ExtOpc != AArch64::ANDWri)
         MBBI.addImm(0);
       MBBI.addImm(ExtBits);
@@ -1051,21 +1056,20 @@ AArch64CC::CondCode AArch64InstrInfo::insertCmpForCondBr(
 
     // Now, subs with an extended second operand
     if (Cond[6].getImm() != AArch64_AM::InvalidShiftExtend) {
+      MRI.constrainRegClass(Reg, &AArch64::GPR32commonRegClass);
       AArch64_AM::ShiftExtendType ExtendType =
           AArch64_AM::getExtendType(Cond[6].getImm());
-      MRI.constrainRegClass(Reg, MRI.getRegClass(Cond[3].getReg()));
-      MRI.constrainRegClass(Cond[3].getReg(), &AArch64::GPR32spRegClass);
+      assert(isValidCBExtend(Cond[1].getImm(), ExtendType) &&
+             "Unexpected compare-and-branch instruction for extend type");
       BuildMI(MBB, MI, DL, get(AArch64::SUBSWrx), AArch64::WZR)
-          .addReg(Cond[3].getReg())
           .addReg(Reg)
+          .addReg(Cond[4].getReg())
           .addImm(AArch64_AM::getArithExtendImm(ExtendType, 0));
     } // If no extension is needed, just a regular subs
     else {
-      MRI.constrainRegClass(Reg, MRI.getRegClass(Cond[3].getReg()));
-      MRI.constrainRegClass(Cond[3].getReg(), &AArch64::GPR32spRegClass);
       BuildMI(MBB, MI, DL, get(AArch64::SUBSWrr), AArch64::WZR)
-          .addReg(Cond[3].getReg())
-          .addReg(Reg);
+          .addReg(Reg)
+          .addReg(Cond[4].getReg());
     }
 
     CC = static_cast<AArch64CC::CondCode>(Cond[2].getImm());

--- a/llvm/test/CodeGen/AArch64/cmpbr-early-ifcvt.mir
+++ b/llvm/test/CodeGen/AArch64/cmpbr-early-ifcvt.mir
@@ -244,7 +244,7 @@ body:             |
   ; CHECK: bb.0:
   ; CHECK-NEXT:   liveins: $w0, $w1
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   [[COPY:%[0-9]+]]:gpr32common = COPY $w0
+  ; CHECK-NEXT:   [[COPY:%[0-9]+]]:gpr32 = COPY $w0
   ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:gpr32 = COPY $w1
   ; CHECK-NEXT:   [[ADDWrr:%[0-9]+]]:gpr32 = ADDWrr [[COPY]], [[COPY1]]
   ; CHECK-NEXT:   [[MADDWrrr:%[0-9]+]]:gpr32 = MADDWrrr [[COPY]], [[COPY1]], $wzr
@@ -305,12 +305,12 @@ body:             |
   ; CHECK: bb.0:
   ; CHECK-NEXT:   liveins: $w0, $w1
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   [[COPY:%[0-9]+]]:gpr32common = COPY $w0
+  ; CHECK-NEXT:   [[COPY:%[0-9]+]]:gpr32 = COPY $w0
   ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:gpr32 = COPY $w1
   ; CHECK-NEXT:   [[ADDWrr:%[0-9]+]]:gpr32 = ADDWrr [[COPY]], [[COPY1]]
   ; CHECK-NEXT:   [[MADDWrrr:%[0-9]+]]:gpr32 = MADDWrrr [[COPY]], [[COPY1]], $wzr
-  ; CHECK-NEXT:   [[ANDWri:%[0-9]+]]:gpr32common = ANDWri [[COPY1]], 7
-  ; CHECK-NEXT:   $wzr = SUBSWrx [[COPY]], [[ANDWri]], 0, implicit-def $nzcv
+  ; CHECK-NEXT:   [[ANDWri:%[0-9]+]]:gpr32common = ANDWri [[COPY]], 7
+  ; CHECK-NEXT:   $wzr = SUBSWrx [[ANDWri]], [[COPY1]], 0, implicit-def $nzcv
   ; CHECK-NEXT:   [[CSELWr:%[0-9]+]]:gpr32 = CSELWr [[ADDWrr]], [[MADDWrrr]], 11, implicit $nzcv
   ; CHECK-NEXT:   [[ADDWrr1:%[0-9]+]]:gpr32 = ADDWrr killed [[CSELWr]], [[COPY]]
   ; CHECK-NEXT:   $w0 = COPY [[ADDWrr1]]
@@ -367,12 +367,12 @@ body:             |
   ; CHECK: bb.0:
   ; CHECK-NEXT:   liveins: $w0, $w1
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   [[COPY:%[0-9]+]]:gpr32common = COPY $w0
+  ; CHECK-NEXT:   [[COPY:%[0-9]+]]:gpr32 = COPY $w0
   ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:gpr32 = COPY $w1
   ; CHECK-NEXT:   [[ADDWrr:%[0-9]+]]:gpr32 = ADDWrr [[COPY]], [[COPY1]]
   ; CHECK-NEXT:   [[MADDWrrr:%[0-9]+]]:gpr32 = MADDWrrr [[COPY]], [[COPY1]], $wzr
-  ; CHECK-NEXT:   [[SBFMWri:%[0-9]+]]:gpr32common = SBFMWri [[COPY1]], 0, 7
-  ; CHECK-NEXT:   $wzr = SUBSWrx [[COPY]], [[SBFMWri]], 32, implicit-def $nzcv
+  ; CHECK-NEXT:   [[SBFMWri:%[0-9]+]]:gpr32common = SBFMWri [[COPY]], 0, 7
+  ; CHECK-NEXT:   $wzr = SUBSWrx [[SBFMWri]], [[COPY1]], 32, implicit-def $nzcv
   ; CHECK-NEXT:   [[CSELWr:%[0-9]+]]:gpr32 = CSELWr [[ADDWrr]], [[MADDWrrr]], 11, implicit $nzcv
   ; CHECK-NEXT:   [[ADDWrr1:%[0-9]+]]:gpr32 = ADDWrr killed [[CSELWr]], [[COPY]]
   ; CHECK-NEXT:   $w0 = COPY [[ADDWrr1]]
@@ -429,12 +429,12 @@ body:             |
   ; CHECK: bb.0:
   ; CHECK-NEXT:   liveins: $w0, $w1
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   [[COPY:%[0-9]+]]:gpr32common = COPY $w0
+  ; CHECK-NEXT:   [[COPY:%[0-9]+]]:gpr32 = COPY $w0
   ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:gpr32 = COPY $w1
   ; CHECK-NEXT:   [[ADDWrr:%[0-9]+]]:gpr32 = ADDWrr [[COPY]], [[COPY1]]
   ; CHECK-NEXT:   [[MADDWrrr:%[0-9]+]]:gpr32 = MADDWrrr [[COPY]], [[COPY1]], $wzr
-  ; CHECK-NEXT:   [[ANDWri:%[0-9]+]]:gpr32common = ANDWri [[COPY1]], 15
-  ; CHECK-NEXT:   $wzr = SUBSWrx [[COPY]], [[ANDWri]], 8, implicit-def $nzcv
+  ; CHECK-NEXT:   [[ANDWri:%[0-9]+]]:gpr32common = ANDWri [[COPY]], 15
+  ; CHECK-NEXT:   $wzr = SUBSWrx [[ANDWri]], [[COPY1]], 8, implicit-def $nzcv
   ; CHECK-NEXT:   [[CSELWr:%[0-9]+]]:gpr32 = CSELWr [[ADDWrr]], [[MADDWrrr]], 11, implicit $nzcv
   ; CHECK-NEXT:   [[ADDWrr1:%[0-9]+]]:gpr32 = ADDWrr killed [[CSELWr]], [[COPY]]
   ; CHECK-NEXT:   $w0 = COPY [[ADDWrr1]]
@@ -491,12 +491,12 @@ body:             |
   ; CHECK: bb.0:
   ; CHECK-NEXT:   liveins: $w0, $w1
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   [[COPY:%[0-9]+]]:gpr32common = COPY $w0
+  ; CHECK-NEXT:   [[COPY:%[0-9]+]]:gpr32 = COPY $w0
   ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:gpr32 = COPY $w1
   ; CHECK-NEXT:   [[ADDWrr:%[0-9]+]]:gpr32 = ADDWrr [[COPY]], [[COPY1]]
   ; CHECK-NEXT:   [[MADDWrrr:%[0-9]+]]:gpr32 = MADDWrrr [[COPY]], [[COPY1]], $wzr
-  ; CHECK-NEXT:   [[SBFMWri:%[0-9]+]]:gpr32common = SBFMWri [[COPY1]], 0, 15
-  ; CHECK-NEXT:   $wzr = SUBSWrx [[COPY]], [[SBFMWri]], 40, implicit-def $nzcv
+  ; CHECK-NEXT:   [[SBFMWri:%[0-9]+]]:gpr32common = SBFMWri [[COPY]], 0, 15
+  ; CHECK-NEXT:   $wzr = SUBSWrx [[SBFMWri]], [[COPY1]], 40, implicit-def $nzcv
   ; CHECK-NEXT:   [[CSELWr:%[0-9]+]]:gpr32 = CSELWr [[ADDWrr]], [[MADDWrrr]], 11, implicit $nzcv
   ; CHECK-NEXT:   [[ADDWrr1:%[0-9]+]]:gpr32 = ADDWrr killed [[CSELWr]], [[COPY]]
   ; CHECK-NEXT:   $w0 = COPY [[ADDWrr1]]
@@ -553,12 +553,12 @@ body:             |
   ; CHECK: bb.0:
   ; CHECK-NEXT:   liveins: $w0, $w1
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   [[COPY:%[0-9]+]]:gpr32common = COPY $w0
+  ; CHECK-NEXT:   [[COPY:%[0-9]+]]:gpr32 = COPY $w0
   ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:gpr32 = COPY $w1
   ; CHECK-NEXT:   [[ADDWrr:%[0-9]+]]:gpr32 = ADDWrr [[COPY]], [[COPY1]]
   ; CHECK-NEXT:   [[MADDWrrr:%[0-9]+]]:gpr32 = MADDWrrr [[COPY]], [[COPY1]], $wzr
-  ; CHECK-NEXT:   [[SBFMWri:%[0-9]+]]:gpr32common = SBFMWri [[COPY1]], 0, 15
-  ; CHECK-NEXT:   $wzr = SUBSWrr [[COPY]], [[SBFMWri]], implicit-def $nzcv
+  ; CHECK-NEXT:   [[SBFMWri:%[0-9]+]]:gpr32common = SBFMWri [[COPY]], 0, 15
+  ; CHECK-NEXT:   $wzr = SUBSWrr [[SBFMWri]], [[COPY1]], implicit-def $nzcv
   ; CHECK-NEXT:   [[CSELWr:%[0-9]+]]:gpr32 = CSELWr [[ADDWrr]], [[MADDWrrr]], 11, implicit $nzcv
   ; CHECK-NEXT:   [[ADDWrr1:%[0-9]+]]:gpr32 = ADDWrr killed [[CSELWr]], [[COPY]]
   ; CHECK-NEXT:   $w0 = COPY [[ADDWrr1]]


### PR DESCRIPTION
We falsely split CBB/CBH instructions by explicitly extending the
second register operand instead of the first one, leading to the
following, wrong codegen:

    cbh $wn, $wm, cc, trgt  =>  sxth $wt, $wm
                                cmp  $wn, $wt, cc, sxth

Correct is

    cbh $wn, $wm, cc, trgt  =>  sxth $wt, $wn
                                cmp  $wt, $wm, cc, sxth

since cmp with extended register extends it's second, not its first
operand.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>