### PR TITLE
[InstCombine] Fold `uitofp nneg` comparisons above the signed maximum

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -8434,12 +8434,16 @@ Instruction *InstCombinerImpl::foldFCmpIntToFPConst(FCmpInst &I,
       return replaceInstUsesWith(I, ConstantInt::getFalse(I.getType()));
     }
   } else {
-    // If the RHS value is > UnsignedMax, fold the comparison. This handles
-    // +INF and large values.
-    APFloat UMax(RHS->getSemantics());
-    UMax.convertFromAPInt(APInt::getMaxValue(IntWidth), false,
-                          APFloat::rmNearestTiesToEven);
-    if (UMax < *RHS) { // umax < 13123.0
+    // If the RHS value is above the defined upper bound, fold the comparison.
+    // This handles +INF and large values.
+    // For uitofp nneg, negative signed inputs are poison, so the defined upper
+    // bound is signed max rather than unsigned max.
+    bool IsNonNegUIToFP = cast<PossiblyNonNegInst>(LHSI)->hasNonNeg();
+    APInt MaxInt = IsNonNegUIToFP ? APInt::getSignedMaxValue(IntWidth)
+                                  : APInt::getMaxValue(IntWidth);
+    APFloat Max(RHS->getSemantics());
+    Max.convertFromAPInt(MaxInt, false, APFloat::rmNearestTiesToEven);
+    if (Max < *RHS) { // max < 13123.0
       if (Pred == ICmpInst::ICMP_NE || Pred == ICmpInst::ICMP_ULT ||
           Pred == ICmpInst::ICMP_ULE)
         return replaceInstUsesWith(I, ConstantInt::getTrue(I.getType()));

--- a/llvm/test/Transforms/InstCombine/2009-05-23-FCmpToICmp.ll
+++ b/llvm/test/Transforms/InstCombine/2009-05-23-FCmpToICmp.ll
@@ -11,3 +11,61 @@ define i1 @f0(ptr %a) nounwind {
   %d = fcmp ogt double %c, 0x41EFFFFFFFE00000
   ret i1 %d
 }
+
+define i1 @uitofp_nneg_i8_cmp_olt_above_smax(i8 %x) {
+; CHECK-LABEL: @uitofp_nneg_i8_cmp_olt_above_smax(
+; CHECK-NEXT:    ret i1 true
+;
+  %f = uitofp nneg i8 %x to float
+  %cmp = fcmp olt float %f, 1.280000e+02
+  ret i1 %cmp
+}
+
+define i1 @uitofp_nneg_i8_cmp_oge_above_smax(i8 %x) {
+; CHECK-LABEL: @uitofp_nneg_i8_cmp_oge_above_smax(
+; CHECK-NEXT:    ret i1 false
+;
+  %f = uitofp nneg i8 %x to float
+  %cmp = fcmp oge float %f, 1.280000e+02
+  ret i1 %cmp
+}
+
+define i1 @uitofp_nneg_i8_cmp_oeq_above_smax(i8 %x) {
+; CHECK-LABEL: @uitofp_nneg_i8_cmp_oeq_above_smax(
+; CHECK-NEXT:    ret i1 false
+;
+  %f = uitofp nneg i8 %x to float
+  %cmp = fcmp oeq float %f, 1.280000e+02
+  ret i1 %cmp
+}
+
+define i1 @uitofp_nneg_i8_cmp_one_above_smax(i8 %x) {
+; CHECK-LABEL: @uitofp_nneg_i8_cmp_one_above_smax(
+; CHECK-NEXT:    ret i1 true
+;
+  %f = uitofp nneg i8 %x to float
+  %cmp = fcmp one float %f, 1.280000e+02
+  ret i1 %cmp
+}
+
+; INT_MAX rounds to 2^31 in float, so this comparison is not always true.
+define i1 @uitofp_nneg_i32_cmp_olt_smax_plus_one_not_true(i32 %x) {
+; CHECK-LABEL: @uitofp_nneg_i32_cmp_olt_smax_plus_one_not_true(
+; CHECK-NEXT:    [[F:%.*]] = uitofp nneg i32 [[X:%.*]] to float
+; CHECK-NEXT:    [[CMP:%.*]] = fcmp olt float [[F]], f0x4F000000
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %f = uitofp nneg i32 %x to float
+  %cmp = fcmp olt float %f, 0x41E0000000000000
+  ret i1 %cmp
+}
+
+define i1 @uitofp_i8_no_nneg_cmp_olt_128_not_true(i8 %x) {
+; CHECK-LABEL: @uitofp_i8_no_nneg_cmp_olt_128_not_true(
+; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i8 [[X:%.*]], -1
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %f = uitofp i8 %x to float
+  %cmp = fcmp olt float %f, 1.280000e+02
+  ret i1 %cmp
+}


### PR DESCRIPTION
Teach `foldFCmpIntToFPConst()` to use the signed maximum as the upper bound for `uitofp nneg` when applying the existing out-of-range comparison fold. This folds comparisons against constants above the defined range, including:

* `uitofp nneg i8 %x < 128.0` to `true`
* `uitofp nneg i8 %x >= 128.0` to `false`
* equality with `128.0` to `false`
* inequality with `128.0` to `true`

extracted from #208234