### PR TITLE
[CIR] Add cir.coro.intrinsic.promise Op

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -4989,18 +4989,22 @@ def CIR_CoroSizeOp : CIR_CoroIntrinsicOp<"size", (ins),
 //===----------------------------------------------------------------------===//
 
 def CIR_CoroPromiseOp : CIR_CoroIntrinsicOp<"promise",
-    (ins CIR_VoidPtrType:$coroframe, CIR_AnyIntType:$align, CIR_BoolType:$from),
+    (ins CIR_VoidPtrType:$coroframe, CIR_AnyIntType:$align,
+    CIR_BoolType:$isFromPromise),
     (outs CIR_VoidPtrType:$result)> {
   let summary = "Represents llvm.coro.promise";
   let description = [{
-    Given a coroutine handle (if `from` is false) or a pointer to a coroutine
-    promise (if `from` is true), obtains a pointer to the coroutine promise or
-    the coroutine handle, respectively. `align` is the alignment requirement
-    of the promise, and `from` indicates the direction of the transformation:
-    `true` recovers the coroutine handle from a promise pointer, `false`
-    recovers the promise pointer from a coroutine handle. Using this op on a
-    coroutine without a coroutine promise is undefined behavior.
+    Given a coroutine handle (if `isFromPromise` is false) or a pointer to a
+    coroutine promise (if `isFromPromise` is true), obtains a pointer to the
+    coroutine promise or the coroutine handle, respectively. `align` is the
+    alignment requirement of the promise, and `isFromPromise` indicates the
+    direction of the transformation: `true` recovers the coroutine handle
+    from a promise pointer, `false` recovers the promise pointer from a
+    coroutine handle. Using this op on a coroutine without a coroutine
+    promise is undefined behavior.
   }];
+
+  let llvmOp = "CoroPromiseOp";
 }
 
 //===----------------------------------------------------------------------===//

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -4993,6 +4993,13 @@ def CIR_CoroPromiseOp : CIR_CoroIntrinsicOp<"promise",
     (outs CIR_VoidPtrType:$result)> {
   let summary = "Represents llvm.coro.promise";
   let description = [{
+    Given a coroutine handle (if `from` is false) or a pointer to a coroutine
+    promise (if `from` is true), obtains a pointer to the coroutine promise or
+    the coroutine handle, respectively. `align` is the alignment requirement
+    of the promise, and `from` indicates the direction of the transformation:
+    `true` recovers the coroutine handle from a promise pointer, `false`
+    recovers the promise pointer from a coroutine handle. Using this op on a
+    coroutine without a coroutine promise is undefined behavior.
   }];
 }
 

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -4985,6 +4985,18 @@ def CIR_CoroSizeOp : CIR_CoroIntrinsicOp<"size", (ins),
 }
 
 //===----------------------------------------------------------------------===//
+// Coroutine intrinsic PromiseOp
+//===----------------------------------------------------------------------===//
+
+def CIR_CoroPromiseOp : CIR_CoroIntrinsicOp<"promise",
+    (ins CIR_VoidPtrType:$coroframe, CIR_AnyIntType:$align, CIR_BoolType:$from),
+    (outs CIR_VoidPtrType:$result)> {
+  let summary = "Represents llvm.coro.promise";
+  let description = [{
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // CopyOp
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -1717,8 +1717,7 @@ RValue CIRGenFunction::emitBuiltinExpr(const GlobalDecl &gd, unsigned builtinID,
   case Builtin::BI__builtin_coro_end:
     return RValue::get(emitCoroEndBuiltinCall(e).getResult());
   case Builtin::BI__builtin_coro_promise:
-    cgm.errorNYI(e->getSourceRange(), "BI__builtin_coro_promise NYI");
-    return getUndefRValue(e->getType());
+    return RValue::get(emitCoroPromiseBuiltinCall(e).getResult());
   case Builtin::BI__builtin_coro_resume:
     cgm.errorNYI(e->getSourceRange(), "BI__builtin_coro_resume NYI");
     return getUndefRValue(e->getType());

--- a/clang/lib/CIR/CodeGen/CIRGenCoroutine.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCoroutine.cpp
@@ -311,8 +311,14 @@ cir::CoroSizeOp CIRGenFunction::emitCoroSizeBuiltinCall(const CallExpr *e) {
 
 cir::CoroPromiseOp
 CIRGenFunction::emitCoroPromiseBuiltinCall(const CallExpr *e) {
+  mlir::Location loc = getLoc(e->getBeginLoc());
 
-  return {};
+  llvm::SmallVector<mlir::Value, 3> args;
+  for (const Expr *arg : e->arguments())
+    args.push_back(emitScalarExpr(arg));
+
+  auto coroPromise = cir::CoroPromiseOp::create(cgm.getBuilder(), loc, args);
+  return coroPromise;
 }
 
 static mlir::LogicalResult

--- a/clang/lib/CIR/CodeGen/CIRGenCoroutine.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCoroutine.cpp
@@ -309,6 +309,12 @@ cir::CoroSizeOp CIRGenFunction::emitCoroSizeBuiltinCall(const CallExpr *e) {
   return cir::CoroSizeOp::create(cgm.getBuilder(), loc);
 }
 
+cir::CoroPromiseOp
+CIRGenFunction::emitCoroPromiseBuiltinCall(const CallExpr *e) {
+
+  return {};
+}
+
 static mlir::LogicalResult
 coroutineBodyExceptionHelper(CIRGenFunction &cgf, const CoroutineBodyStmt &s) {
 

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -1907,6 +1907,7 @@ public:
   cir::CoroIdOp emitCoroIDBuiltinCall(const CallExpr *e);
   cir::CoroAllocOp emitCoroAllocBuiltinCall(const CallExpr *e);
   cir::CoroBeginOp emitCoroBeginBuiltinCall(const CallExpr *e);
+  cir::CoroPromiseOp emitCoroPromiseBuiltinCall(const CallExpr *e);
 
   cir::CoroSizeOp emitCoroSizeBuiltinCall(const CallExpr *e);
   cir::CoroFreeOp emitCoroFreeBuiltin(const CallExpr *e);

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -5639,15 +5639,6 @@ mlir::LogicalResult CIRToLLVMCoroSizeOpLowering::matchAndRewrite(
   return mlir::success();
 }
 
-mlir::LogicalResult CIRToLLVMCoroPromiseOpLowering::matchAndRewrite(
-    cir::CoroPromiseOp op, OpAdaptor adaptor,
-    mlir::ConversionPatternRewriter &rewriter) const {
-  rewriter.replaceOpWithNewOp<mlir::LLVM::CoroPromiseOp>(
-      op, mlir::LLVM::LLVMPointerType::get(rewriter.getContext()),
-      adaptor.getCoroframe(), adaptor.getAlign(), adaptor.getFrom());
-  return mlir::success();
-}
-
 mlir::LogicalResult CIRToLLVMCpuIdOpLowering::matchAndRewrite(
     cir::CpuIdOp op, OpAdaptor adaptor,
     mlir::ConversionPatternRewriter &rewriter) const {

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -5639,6 +5639,12 @@ mlir::LogicalResult CIRToLLVMCoroSizeOpLowering::matchAndRewrite(
   return mlir::success();
 }
 
+mlir::LogicalResult CIRToLLVMCoroPromiseOpLowering::matchAndRewrite(
+    cir::CoroPromiseOp op, OpAdaptor adaptor,
+    mlir::ConversionPatternRewriter &rewriter) const {
+  return mlir::failure();
+}
+
 mlir::LogicalResult CIRToLLVMCpuIdOpLowering::matchAndRewrite(
     cir::CpuIdOp op, OpAdaptor adaptor,
     mlir::ConversionPatternRewriter &rewriter) const {

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -5642,7 +5642,10 @@ mlir::LogicalResult CIRToLLVMCoroSizeOpLowering::matchAndRewrite(
 mlir::LogicalResult CIRToLLVMCoroPromiseOpLowering::matchAndRewrite(
     cir::CoroPromiseOp op, OpAdaptor adaptor,
     mlir::ConversionPatternRewriter &rewriter) const {
-  return mlir::failure();
+  rewriter.replaceOpWithNewOp<mlir::LLVM::CoroPromiseOp>(
+      op, mlir::LLVM::LLVMPointerType::get(rewriter.getContext()),
+      adaptor.getCoroframe(), adaptor.getAlign(), adaptor.getFrom());
+  return mlir::success();
 }
 
 mlir::LogicalResult CIRToLLVMCpuIdOpLowering::matchAndRewrite(

--- a/clang/test/CIR/CodeGenCoroutines/coro-builtins.cpp
+++ b/clang/test/CIR/CodeGenCoroutines/coro-builtins.cpp
@@ -54,9 +54,9 @@ void f(int n) {
   //__builtin_coro_done(__builtin_coro_frame());
 
   __builtin_coro_promise(__builtin_coro_frame(), 48, 0);
-  // CIR: %[[ALIGN:.*]] = cir.const #cir.int<48> : !s32i loc(#loc18)
-  // CIR: %[[ZERO:.*]] = cir.const #cir.int<0> : !s32i loc(#loc19)
-  // CIR: %[[FALSE:.*]] = cir.cast int_to_bool %13 : !s32i -> !cir.bool loc(#loc19)
+  // CIR: %[[ALIGN:.*]] = cir.const #cir.int<48> : !s32i
+  // CIR: %[[ZERO:.*]] = cir.const #cir.int<0> : !s32i
+  // CIR: %[[FALSE:.*]] = cir.cast int_to_bool %[[ZERO]] : !s32i -> !cir.bool
   // CIR: cir.coro.intrinsic.promise(%[[FRAME]], %[[ALIGN]], %[[FALSE]])
   // LLVM: call ptr @llvm.coro.promise(ptr %[[FRAME]], i32 48, i1 false)
 

--- a/clang/test/CIR/CodeGenCoroutines/coro-builtins.cpp
+++ b/clang/test/CIR/CodeGenCoroutines/coro-builtins.cpp
@@ -53,8 +53,12 @@ void f(int n) {
   // TODO(CIR):
   //__builtin_coro_done(__builtin_coro_frame());
 
-  // TODO(CIR):
-  //__builtin_coro_promise(__builtin_coro_frame(), 48, 0);
+  __builtin_coro_promise(__builtin_coro_frame(), 48, 0);
+  // CIR: %[[ALIGN:.*]] = cir.const #cir.int<48> : !s32i loc(#loc18)
+  // CIR: %[[ZERO:.*]] = cir.const #cir.int<0> : !s32i loc(#loc19)
+  // CIR: %[[FALSE:.*]] = cir.cast int_to_bool %13 : !s32i -> !cir.bool loc(#loc19)
+  // CIR: cir.coro.intrinsic.promise(%[[FRAME]], %[[ALIGN]], %[[FALSE]])
+  // LLVM: call ptr @llvm.coro.promise(ptr %[[FRAME]], i32 48, i1 false)
 
   __builtin_coro_free(__builtin_coro_frame());
   // CIR: cir.coro.intrinsic.free(%[[COROID]], %[[FRAME]])


### PR DESCRIPTION
This PR adds `cir.coro.intrinsic.promise`, representing `llvm.coro.promise`, to the set of coroutine intrinsic ops. It also adds the corresponding lowering to `llvm.coro.promise`.