### PR TITLE
[flang-rt] Initialize I/O unit storage read by short-circuit predicates

### DIFF
--- a/flang-rt/include/flang-rt/runtime/connection.h
+++ b/flang-rt/include/flang-rt/runtime/connection.h
@@ -25,6 +25,14 @@ enum class Access { Sequential, Direct, Stream };
 // These characteristics of a connection are immutable after being
 // established in an OPEN statement.
 struct ConnectionAttributes {
+  // See common::ResetWithDefinedPayload(): the optionals below are read through
+  // short-circuit predicates that compilers may if-convert, so their payload
+  // storage is written once here to keep memory checkers quiet.
+  RT_API_ATTRS ConnectionAttributes() {
+    common::ResetWithDefinedPayload(isUnformatted);
+    common::ResetWithDefinedPayload(openRecl);
+  }
+
   Access access{Access::Sequential}; // ACCESS='SEQUENTIAL', 'DIRECT', 'STREAM'
   common::optional<bool> isUnformatted; // FORM='UNFORMATTED' if true
   bool isUTF8{false}; // ENCODING='UTF-8'
@@ -45,6 +53,12 @@ struct ConnectionAttributes {
 };
 
 struct ConnectionState : public ConnectionAttributes {
+  RT_API_ATTRS ConnectionState() {
+    common::ResetWithDefinedPayload(recordLength);
+    common::ResetWithDefinedPayload(leftTabLimit);
+    common::ResetWithDefinedPayload(endfileRecordNumber);
+  }
+
   RT_API_ATTRS bool IsAtEOF() const {
     // true when read has hit EOF or endfile record
     return endfileRecordNumber && currentRecordNumber >= *endfileRecordNumber;

--- a/flang-rt/include/flang-rt/runtime/file.h
+++ b/flang-rt/include/flang-rt/runtime/file.h
@@ -27,6 +27,14 @@ class OpenFile {
 public:
   using FileOffset = std::int64_t;
 
+  // See common::ResetWithDefinedPayload(): openPosition_ and knownSize_ are
+  // read through short-circuit predicates that compilers may if-convert, so
+  // their payload storage is written once here to keep memory checkers quiet.
+  OpenFile() {
+    common::ResetWithDefinedPayload(openPosition_);
+    common::ResetWithDefinedPayload(knownSize_);
+  }
+
   int fd() const { return fd_; }
   const char *path() const { return path_.get(); }
   std::size_t pathLength() const { return pathLength_; }
@@ -90,7 +98,7 @@ private:
 
   int fd_{-1};
   OwningPtr<char> path_;
-  std::size_t pathLength_;
+  std::size_t pathLength_{0};
   bool mayRead_{false};
   bool mayWrite_{false};
   bool mayPosition_{false};
@@ -102,7 +110,7 @@ private:
   bool isTerminal_{false};
   bool isWindowsTextFile_{false}; // expands LF to CR+LF on write
 
-  int nextId_;
+  int nextId_{0};
   OwningPtr<Pending> pending_;
 };
 

--- a/flang-rt/include/flang-rt/runtime/file.h
+++ b/flang-rt/include/flang-rt/runtime/file.h
@@ -110,7 +110,7 @@ private:
   bool isTerminal_{false};
   bool isWindowsTextFile_{false}; // expands LF to CR+LF on write
 
-  int nextId_{0};
+  int nextId_;
   OwningPtr<Pending> pending_;
 };
 

--- a/flang/include/flang/Common/optional.h
+++ b/flang/include/flang/Common/optional.h
@@ -237,6 +237,31 @@ using std::nullopt_t;
 using std::optional;
 #endif // !STD_OPTIONAL_UNSUPPORTED
 
+// Leaves an optional disengaged, but with its payload storage written rather
+// than left indeterminate.
+//
+// Predicates of the form `opt && x < *opt` test the engaged flag before
+// reading the payload, so they never use an indeterminate value.  Compilers
+// do, however, routinely if-convert the short-circuit `&&` into a branchless
+// compare and select, which speculates the payload load.  On targets where
+// that happens the select's condition is computed from indeterminate storage,
+// and memory checkers then report a conditional branch that depends on
+// uninitialized memory.  This matters for runtime objects that are
+// placement-new'd into malloc'd storage, where a checker can see that the
+// payload bytes were never written.
+//
+// Writing the payload once at construction makes those bytes defined without
+// changing any observable behavior: the optional is still disengaged, and the
+// speculated read is still meaningless.  The assignment below is therefore NOT
+// dead code -- it exists solely for its effect on the payload storage, and
+// reset() on a trivially destructible payload merely clears the engaged flag.
+template <typename A>
+FORTRAN_OPTIONAL_INLINE_WITH_ATTRS void ResetWithDefinedPayload(
+    optional<A> &opt) {
+  opt = A{};
+  opt.reset();
+}
+
 } // namespace Fortran::common
 
 #endif // FORTRAN_COMMON_OPTIONAL_H


### PR DESCRIPTION
ConnectionState and OpenFile hold common::optional members read through
predicates of the form `opt && x < *opt`, which never use an indeterminate
value in the abstract machine. Compilers do, however, routinely if-convert
the short-circuit && into a branchless compare and select, which speculates
the payload load; because these objects are placement-new'd into malloc'd
storage by UnitMap::Create(), a memory checker then reports a conditional
branch that depends on uninitialized memory. On AArch64 this fires for every
Fortran program that writes a record, giving two reports in
ExternalFileUnit::AdvanceRecord() from IsAfterEndfile() and IsAtEOF(), while
x86-64 is unaffected and libgfortran is clean on the same program and host.
The reports are false positives -- the engaged flag is 0, so both arms of the
select are 0 -- but they are unavoidable noise for anyone running Valgrind on
Fortran code.

Add common::ResetWithDefinedPayload(), which leaves an optional disengaged
while writing its payload storage, and call it at construction for the
optionals in ConnectionAttributes, ConnectionState and OpenFile. Also
initialize OpenFile::pathLength_, which is read through the same
if-convertible shape by the unit-lookup-by-path scans in external-unit.cpp
and unit-map.cpp. No observable behavior changes.

No test is added: the difference is in shadow-memory definedness, which
neither a LIT test nor a flang-rt unit test can observe, and there is no MSan
or Valgrind CI for flang-rt. Verified by compiling the patched headers into a
standalone probe on AArch64, where the unpatched headers give two reports and
the patched headers give none with identical program output, and by
check-flang-rt.

Co-authored-by: Razvan Lupusoru <razvan.lupusoru@gmail.com>

Fixes #220633 

Assisted-by: AI