### PR TITLE
[MIR] Support +inf and -inf literals

### DIFF
--- a/llvm/lib/CodeGen/MIRParser/MILexer.cpp
+++ b/llvm/lib/CodeGen/MIRParser/MILexer.cpp
@@ -639,6 +639,18 @@ static Cursor maybeLexFloatHexBits(Cursor C, MIToken &Token) {
   return C;
 }
 
+static Cursor maybeLexInfinityLiteral(Cursor C, MIToken &Token) {
+  if ((C.peek() != '+' && C.peek() != '-') || C.peek(1) != 'i' ||
+      C.peek(2) != 'n' || C.peek(3) != 'f' ||
+      isIdentifierChar(C.peek(4)))
+    return std::nullopt;
+
+  auto Range = C;
+  C.advance(4);
+  Token.reset(MIToken::FloatingPointLiteral, Range.upto(C));
+  return C;
+}
+
 static Cursor maybeLexNumericalLiteral(Cursor C, MIToken &Token) {
   if (!isdigit(C.peek()) && (C.peek() != '-' || !isdigit(C.peek(1))))
     return std::nullopt;
@@ -778,6 +790,8 @@ StringRef llvm::lexMIToken(StringRef Source, MIToken &Token,
   if (Cursor R = maybeLexMachineBasicBlock(C, Token, ErrorCallback))
     return R.remaining();
   if (Cursor R = maybeLexFloatHexBits(C, Token))
+    return R.remaining();
+  if (Cursor R = maybeLexInfinityLiteral(C, Token))
     return R.remaining();
   if (Cursor R = maybeLexIdentifier(C, Token))
     return R.remaining();

--- a/llvm/test/CodeGen/MIR/Generic/fp-infinity.mir
+++ b/llvm/test/CodeGen/MIR/Generic/fp-infinity.mir
@@ -1,0 +1,11 @@
+# RUN: llc -run-pass none -o - %s | FileCheck %s
+
+---
+name: fp_infinity
+body: |
+  bb.0:
+    ; CHECK: %0:_(s32) = G_FCONSTANT float +inf
+    ; CHECK: %1:_(s32) = G_FCONSTANT float -inf
+    %0:_(s32) = G_FCONSTANT float +inf
+    %1:_(s32) = G_FCONSTANT float -inf
+...


### PR DESCRIPTION
Support parsing `+inf` and `-inf` as floating-point literals in MIR.

The MIR lexer previously tokenized the leading sign separately, causing
`G_FCONSTANT float +inf` and `G_FCONSTANT float -inf` to fail with
"expected a floating point literal".

Recognize signed infinity spellings as `FloatingPointLiteral` tokens so
they can be handled by the existing floating-point constant parsing path.

Add a regression test covering both positive and negative infinity.

Fixes #221040


Assisted-by: ChatGPT (rubber ducking)
