### PR TITLE
[clang] remove unused NestedNameSpecifier 'Invalid' constructor

### DIFF
--- a/clang/include/clang/AST/NestedNameSpecifier.h
+++ b/clang/include/clang/AST/NestedNameSpecifier.h
@@ -28,8 +28,6 @@ auto NestedNameSpecifier::getKind() const -> Kind {
       return Kind::Null;
     case FlagKind::Global:
       return Kind::Global;
-    case FlagKind::Invalid:
-      llvm_unreachable("use of invalid NestedNameSpecifier");
     }
     llvm_unreachable("unhandled FlagKind");
   }

--- a/clang/include/clang/AST/NestedNameSpecifierBase.h
+++ b/clang/include/clang/AST/NestedNameSpecifierBase.h
@@ -49,7 +49,7 @@ struct alignas(8) NamespaceAndPrefixStorage;
 /// the global specifier ('::'). The last two specifiers can only appear at the
 /// start of a nested-namespace-specifier.
 class NestedNameSpecifier {
-  enum class FlagKind { Null, Global, Invalid };
+  enum class FlagKind { Null, Global };
   enum class StoredKind {
     Type,
     NamespaceOrSuper,
@@ -100,15 +100,11 @@ class NestedNameSpecifier {
                                              NestedNameSpecifier Prefix);
 
 public:
-  static constexpr NestedNameSpecifier getInvalid() {
-    return NestedNameSpecifier(FlagKind::Invalid);
-  }
-
   static constexpr NestedNameSpecifier getGlobal() {
     return NestedNameSpecifier(FlagKind::Global);
   }
 
-  NestedNameSpecifier() : NestedNameSpecifier(FlagKind::Invalid) {}
+  NestedNameSpecifier() = delete;
 
   /// The kind of specifier that completes this nested name
   /// specifier.

--- a/clang/lib/AST/ASTImporter.cpp
+++ b/clang/lib/AST/ASTImporter.cpp
@@ -1638,16 +1638,18 @@ ASTNodeImporter::VisitFunctionProtoType(const FunctionProtoType *T) {
 
 ExpectedType ASTNodeImporter::VisitUnresolvedUsingType(
     const UnresolvedUsingType *T) {
-  Error Err = Error::success();
-  auto ToQualifier = importChecked(Err, T->getQualifier());
-  auto *ToD = importChecked(Err, T->getDecl());
-  if (Err)
-    return std::move(Err);
+  auto ToQualifierOrErr = import(T->getQualifier());
+  if (!ToQualifierOrErr)
+    return ToQualifierOrErr.takeError();
+  auto ToDeclOrErr = import(T->getDecl());
+  if (!ToDeclOrErr)
+    return ToDeclOrErr.takeError();
 
   if (T->isCanonicalUnqualified())
-    return Importer.getToContext().getCanonicalUnresolvedUsingType(ToD);
-  return Importer.getToContext().getUnresolvedUsingType(T->getKeyword(),
-                                                        ToQualifier, ToD);
+    return Importer.getToContext().getCanonicalUnresolvedUsingType(
+        *ToDeclOrErr);
+  return Importer.getToContext().getUnresolvedUsingType(
+      T->getKeyword(), *ToQualifierOrErr, *ToDeclOrErr);
 }
 
 ExpectedType ASTNodeImporter::VisitParenType(const ParenType *T) {
@@ -1704,14 +1706,18 @@ ExpectedType ASTNodeImporter::VisitTypeOfType(const TypeOfType *T) {
 }
 
 ExpectedType ASTNodeImporter::VisitUsingType(const UsingType *T) {
-  Error Err = Error::success();
-  auto ToQualifier = importChecked(Err, T->getQualifier());
-  auto *ToD = importChecked(Err, T->getDecl());
-  QualType ToT = importChecked(Err, T->desugar());
-  if (Err)
-    return std::move(Err);
-  return Importer.getToContext().getUsingType(T->getKeyword(), ToQualifier, ToD,
-                                              ToT);
+  auto ToQualifierOrErr = import(T->getQualifier());
+  if (!ToQualifierOrErr)
+    return ToQualifierOrErr.takeError();
+  auto ToDeclOrErr = import(T->getDecl());
+  if (!ToDeclOrErr)
+    return ToDeclOrErr.takeError();
+
+  ExpectedType ToTypeOrErr = import(T->desugar());
+  if (!ToTypeOrErr)
+    return ToTypeOrErr.takeError();
+  return Importer.getToContext().getUsingType(
+      T->getKeyword(), *ToQualifierOrErr, *ToDeclOrErr, *ToTypeOrErr);
 }
 
 ExpectedType ASTNodeImporter::VisitDecltypeType(const DecltypeType *T) {


### PR DESCRIPTION
These invalid NNS were used as thombstone keys for DenseMap, but the DenseMap implementation changed and that's not needed anymore.