### PR TITLE
[flang][cuda] Add compiler generated global to unified register global

### DIFF
--- a/flang/lib/Optimizer/Transforms/CUDA/CUFAddConstructor.cpp
+++ b/flang/lib/Optimizer/Transforms/CUDA/CUFAddConstructor.cpp
@@ -17,6 +17,7 @@
 #include "flang/Optimizer/Dialect/FIROps.h"
 #include "flang/Optimizer/Dialect/FIRType.h"
 #include "flang/Optimizer/Support/DataLayout.h"
+#include "flang/Optimizer/Support/InternalNames.h"
 #include "flang/Optimizer/Transforms/Passes.h"
 #include "flang/Runtime/CUDA/registration.h"
 #include "flang/Runtime/entry-names.h"
@@ -103,9 +104,11 @@ static bool definesGlobal(fir::GlobalOp globalOp) {
 /// CUFDeviceGlobal pass under -gpu=mem:unified.
 static bool isCudaUnifiedExternalGlobal(fir::GlobalOp hostGlobal,
                                         mlir::SymbolTable &gpuSymTable) {
+  bool isCompilerGenerated =
+      fir::NameUniquer::isCompilerGenerated(hostGlobal.getSymName());
   if (hostGlobal.getDataAttrAttr())
     return false;
-  if (hostGlobal.getConstant())
+  if (hostGlobal.getConstant() && !isCompilerGenerated)
     return false;
   return isDeviceExternReference(hostGlobal, gpuSymTable);
 }

--- a/flang/lib/Optimizer/Transforms/CUDA/CUFDeviceGlobal.cpp
+++ b/flang/lib/Optimizer/Transforms/CUDA/CUFDeviceGlobal.cpp
@@ -259,7 +259,9 @@ public:
       // cuf.register_variable_static so the CUDA
       // runtime maps the device extern to the host pointer at module-load
       // time, and HMM/ATS handles migration.
-      if (cudaUnified && !globalOp.getConstant() &&
+      bool isCompilerGenerated =
+          fir::NameUniquer::isCompilerGenerated(globalOp.getSymName());
+      if (cudaUnified && (!globalOp.getConstant() || isCompilerGenerated) &&
           !globalOp.getDataAttrAttr()) {
         clonedGlobal.getRegion().getBlocks().clear();
         clonedGlobal.removeInitValAttr();

--- a/flang/test/Fir/CUDA/cuda-device-global.f90
+++ b/flang/test/Fir/CUDA/cuda-device-global.f90
@@ -128,3 +128,22 @@ module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", gpu.conta
 
 // UNIFIED: gpu.module @cuda_device_mod
 // UNIFIED: fir.global @_QMmtestsEdev(dense<[1, 2, 3]> : tensor<3xi32>) {data_attr = #cuf.cuda<device>} : !fir.array<3xi32>
+
+// -----
+
+module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", gpu.container_module} {
+  fir.global linkonce @_QMmod1EXdtXstruct {acc.declare = #acc.declare<dataClause = acc_copyin>} constant : !fir.char<1,3> {
+    %0 = fir.string_lit "abc"(3) : !fir.char<1,3>
+    fir.has_value %0 : !fir.char<1,3>
+  }
+  gpu.module @cuda_device_mod {
+    func.func @_QMmod1Pg1() attributes {cuf.proc_attr = #cuf.cuda_proc<global>} {
+      %0 = fir.address_of(@_QMmod1EXdtXstruct) : !fir.ref<!fir.char<1,3>>
+      return
+    }
+  }
+}
+
+// UNIFIED: gpu.module @cuda_device_mod
+// UNIFIED: fir.global @_QMmod1EXdtXstruct
+// UNIFIED-NOT: fir.has_value


### PR DESCRIPTION
Treat compiler generated global the same way as other in unified mode. Host has the initializer body and the device side is just a declaration. 