### PR TITLE
[ObjectYAML][DXContainer] Give the VERS test part room for its content

### DIFF
--- a/llvm/unittests/ObjectYAML/DXContainerYAMLTest.cpp
+++ b/llvm/unittests/ObjectYAML/DXContainerYAMLTest.cpp
@@ -685,7 +685,10 @@ TEST(DXCFile, ParseVERSPart) {
 TEST(DXCFile, ComputeVERSPart) {
   SmallString<128> Storage;
 
-  // Check default values of compiler version part fields.
+  // Check default values of compiler version part fields. The defaults are
+  // build-dependent: CommitSha is LLVM_REVISION and CustomVersionString is
+  // PACKAGE_VERSION. A downstream LLVM_REVISION can be much longer than an
+  // upstream git hash, so the part needs headroom for them.
   ASSERT_TRUE(convert(Storage, R"(--- !dxcontainer
   Header:
     Hash:            [ 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
@@ -696,7 +699,7 @@ TEST(DXCFile, ComputeVERSPart) {
     PartCount:       1
   Parts:
     - Name:            VERS
-      Size:            100
+      Size:            256
       CompilerVersion:
     )"));
 


### PR DESCRIPTION
Size the test's `VERS` part to fit its build-dependent content.

The `DXCFile.ComputeVERSPart` checks the default compiler version fields, which are build-dependent: `CommitSha` is `LLVM_REVISION` and `CustomVersionString` is `PACKAGE_VERSION`. The part was hardcoded to 100 bytes, leaving 84 after the
16-byte header, which fits an upstream 40-character git hash but not a longer downstream revision.

When the content does not fit, the emitter writes past the declared part size without diagnosing it, and parsing then fails with "CommitSha is out of file bounds". The test wraps `DXContainer::create` in `cantFail`, so this aborts with assertions enabled and is undefined behaviour without them. 

Reproduced with `-DLLVM_FORCE_VC_REVISION` set to an 89-character string.