### PR TITLE
[libc][netdb] Implement gai_strerror POSIX function.

### DIFF
--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -1402,6 +1402,7 @@ if(LLVM_LIBC_ENABLE_EXPERIMENTAL_ENTRYPOINTS)
 
       # netdb.h entrypoints
       libc.src.netdb.freeaddrinfo
+      libc.src.netdb.gai_strerror
       libc.src.netdb.getaddrinfo
 
       # regex.h entrypoints

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -1633,6 +1633,7 @@ if(LLVM_LIBC_ENABLE_EXPERIMENTAL_ENTRYPOINTS)
 
       # netdb.h entrypoints
       libc.src.netdb.freeaddrinfo
+      libc.src.netdb.gai_strerror
       libc.src.netdb.getaddrinfo
 
       # regex.h entrypoints

--- a/libc/include/netdb.yaml
+++ b/libc/include/netdb.yaml
@@ -33,6 +33,12 @@ functions:
     return_type: void
     arguments:
       - type: struct addrinfo *
+  - name: gai_strerror
+    standards:
+      - posix
+    return_type: const char *
+    arguments:
+      - type: int
   - name: getaddrinfo
     standards:
       - posix

--- a/libc/src/netdb/CMakeLists.txt
+++ b/libc/src/netdb/CMakeLists.txt
@@ -11,6 +11,18 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
+  gai_strerror
+  SRCS
+    gai_strerror.cpp
+  HDRS
+    gai_strerror.h
+  DEPENDS
+    libc.hdr.netdb_macros
+    libc.src.__support.common
+    libc.src.__support.macros.config
+)
+
+add_entrypoint_object(
   getaddrinfo
   SRCS
     getaddrinfo.cpp

--- a/libc/src/netdb/gai_strerror.cpp
+++ b/libc/src/netdb/gai_strerror.cpp
@@ -1,0 +1,48 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implementation of gai_strerror.
+///
+//===----------------------------------------------------------------------===//
+
+#include "src/netdb/gai_strerror.h"
+#include "hdr/netdb_macros.h"
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(const char *, gai_strerror, (int errcode)) {
+  switch (errcode) {
+  case EAI_AGAIN:
+    return "Name could not be resolved at this time";
+  case EAI_BADFLAGS:
+    return "Flags had an invalid value";
+  case EAI_FAIL:
+    return "Non-recoverable error occurred";
+  case EAI_FAMILY:
+    return "Address family not recognized";
+  case EAI_MEMORY:
+    return "Memory allocation failure";
+  case EAI_NONAME:
+    return "Name does not resolve for the supplied parameters";
+  case EAI_OVERFLOW:
+    return "Argument buffer overflowed";
+  case EAI_SERVICE:
+    return "Service not recognized for specified socket type";
+  case EAI_SOCKTYPE:
+    return "Intended socket type not recognized";
+  case EAI_SYSTEM:
+    return "System error";
+  default:
+    return "Unknown error";
+  }
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/netdb/gai_strerror.h
+++ b/libc/src/netdb/gai_strerror.h
@@ -1,0 +1,25 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implementation header for gai_strerror.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_NETDB_GAI_STRERROR_H
+#define LLVM_LIBC_SRC_NETDB_GAI_STRERROR_H
+
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+const char *gai_strerror(int errcode);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_NETDB_GAI_STRERROR_H

--- a/libc/test/src/netdb/CMakeLists.txt
+++ b/libc/test/src/netdb/CMakeLists.txt
@@ -1,6 +1,17 @@
 add_custom_target(libc-netdb-tests)
 
 add_libc_test(
+  gai_strerror_test
+  SUITE
+    libc-netdb-tests
+  SRCS
+    gai_strerror_test.cpp
+  DEPENDS
+    libc.hdr.netdb_macros
+    libc.src.netdb.gai_strerror
+)
+
+add_libc_test(
   netdb_test
   SUITE
     libc-netdb-tests

--- a/libc/test/src/netdb/gai_strerror_test.cpp
+++ b/libc/test/src/netdb/gai_strerror_test.cpp
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Unittests for gai_strerror.
+///
+//===----------------------------------------------------------------------===//
+
+#include "hdr/netdb_macros.h"
+#include "src/netdb/gai_strerror.h"
+#include "test/UnitTest/Test.h"
+
+TEST(LlvmLibcGaiStrerrorTest, AllKnownErrors) {
+  EXPECT_STREQ(LIBC_NAMESPACE::gai_strerror(EAI_AGAIN),
+               "Name could not be resolved at this time");
+  EXPECT_STREQ(LIBC_NAMESPACE::gai_strerror(EAI_BADFLAGS),
+               "Flags had an invalid value");
+  EXPECT_STREQ(LIBC_NAMESPACE::gai_strerror(EAI_FAIL),
+               "Non-recoverable error occurred");
+  EXPECT_STREQ(LIBC_NAMESPACE::gai_strerror(EAI_FAMILY),
+               "Address family not recognized");
+  EXPECT_STREQ(LIBC_NAMESPACE::gai_strerror(EAI_MEMORY),
+               "Memory allocation failure");
+  EXPECT_STREQ(LIBC_NAMESPACE::gai_strerror(EAI_NONAME),
+               "Name does not resolve for the supplied parameters");
+  EXPECT_STREQ(LIBC_NAMESPACE::gai_strerror(EAI_OVERFLOW),
+               "Argument buffer overflowed");
+  EXPECT_STREQ(LIBC_NAMESPACE::gai_strerror(EAI_SERVICE),
+               "Service not recognized for specified socket type");
+  EXPECT_STREQ(LIBC_NAMESPACE::gai_strerror(EAI_SOCKTYPE),
+               "Intended socket type not recognized");
+  EXPECT_STREQ(LIBC_NAMESPACE::gai_strerror(EAI_SYSTEM), "System error");
+}
+
+TEST(LlvmLibcGaiStrerrorTest, UnknownErrors) {
+  EXPECT_STREQ(LIBC_NAMESPACE::gai_strerror(100), "Unknown error");
+  EXPECT_STREQ(LIBC_NAMESPACE::gai_strerror(-1000), "Unknown error");
+}


### PR DESCRIPTION
`gai_strerror` is defined in POSIX and used to provide human-readable strings for `EAI_*` error codes returned by
`getaddrinfo` and `getnameinfo`.

Provide our implementation via simple switch. Provide string values based on the POSIX documentation for `EAI_`
values in https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/netdb.h.html, but shorten them for brevity.