### PR TITLE
[C++26] [Contracts] Initial parser support

### DIFF
--- a/clang/include/clang/Basic/BuiltinTraits.td
+++ b/clang/include/clang/Basic/BuiltinTraits.td
@@ -41,10 +41,11 @@ def KEYHLSL : TokenKey<0x8000000>;
 def KEYFIXEDPOINT : TokenKey<0x10000000>;
 def KEYDEFERTS : TokenKey<0x20000000>;
 def KEYNOHLSL : TokenKey<0x40000000>;
-def KEYCONTRACTS : TokenKey<0x80000000>;
+def KEYCXX26 : TokenKey<0x80000000>;
 
-def KEYMAX : TokenKey<KEYCONTRACTS.Value>;
-def KEYALLCXX : TokenKey<!or(KEYCXX.Value, KEYCXX11.Value, KEYCXX20.Value)>;
+def KEYMAX : TokenKey<KEYCXX26.Value>;
+def KEYALLCXX : TokenKey<!or(KEYCXX.Value, KEYCXX11.Value, KEYCXX20.Value,
+                             KEYCXX26.Value)>;
 def KEYALL : TokenKey<!and(!or(KEYMAX.Value, !sub(KEYMAX.Value, 1)),
                            !xor(KEYNOMS18.Value, -1),
                            !xor(KEYNOOPENCL.Value, -1),

--- a/clang/include/clang/Basic/BuiltinTraits.td
+++ b/clang/include/clang/Basic/BuiltinTraits.td
@@ -41,8 +41,9 @@ def KEYHLSL : TokenKey<0x8000000>;
 def KEYFIXEDPOINT : TokenKey<0x10000000>;
 def KEYDEFERTS : TokenKey<0x20000000>;
 def KEYNOHLSL : TokenKey<0x40000000>;
+def KEYCONTRACTS : TokenKey<0x80000000>;
 
-def KEYMAX : TokenKey<KEYNOHLSL.Value>;
+def KEYMAX : TokenKey<KEYCONTRACTS.Value>;
 def KEYALLCXX : TokenKey<!or(KEYCXX.Value, KEYCXX11.Value, KEYCXX20.Value)>;
 def KEYALL : TokenKey<!and(!or(KEYMAX.Value, !sub(KEYMAX.Value, 1)),
                            !xor(KEYNOMS18.Value, -1),

--- a/clang/include/clang/Basic/DiagnosticLexKinds.td
+++ b/clang/include/clang/Basic/DiagnosticLexKinds.td
@@ -85,6 +85,8 @@ def warn_cxx11_keyword : Warning<"'%0' is a keyword in C++11">,
   InGroup<CXX11Compat>, DefaultIgnore;
 def warn_cxx20_keyword : Warning<"'%0' is a keyword in C++20">,
   InGroup<CXX20Compat>, DefaultIgnore;
+def warn_cxx26_keyword : Warning<"'%0' is a keyword in C++26">,
+  InGroup<CXX26Compat>, DefaultIgnore;
 def warn_c99_keyword : Warning<"'%0' is a keyword in C99">,
   InGroup<C99Compat>, DefaultIgnore;
 def warn_c23_keyword : Warning<"'%0' is a keyword in C23">,

--- a/clang/include/clang/Basic/DiagnosticParseKinds.td
+++ b/clang/include/clang/Basic/DiagnosticParseKinds.td
@@ -12,6 +12,10 @@
 
 let Component = "Parse" in {
 let CategoryName = "Parse Issue" in {
+def err_contracts_require_cxx26 : Error<"contracts are a C++26 feature">;
+def err_contracts_disabled : Error<
+  "contracts support is disabled; pass '-fcontracts' to enable it">;
+
 // C23 compatibility with C17 and earlier.
 defm c_label_at_end_of_compound_statement : C23Compat<
   "label at end of compound statement is", /*ext_warn*/true>;

--- a/clang/include/clang/Basic/DiagnosticParseKinds.td
+++ b/clang/include/clang/Basic/DiagnosticParseKinds.td
@@ -428,6 +428,10 @@ def warn_cxx98_compat_trailing_return_type : Warning<
   InGroup<CXX98Compat>, DefaultIgnore;
 def err_requires_clause_must_appear_after_trailing_return : Error<
   "trailing return type must appear before trailing requires clause">;
+def err_requires_clause_must_precede_contract_specifiers : Error<
+  "trailing requires clause must appear before contract specifiers">;
+def err_contract_specifier_not_function : Error<
+  "contract specifiers can only be applied to function declarations">;
 def err_requires_clause_on_declarator_not_declaring_a_function : Error<
   "trailing requires clause can only be used when declaring a function">;
 def err_requires_clause_inside_parens : Error<

--- a/clang/include/clang/Basic/DiagnosticParseKinds.td
+++ b/clang/include/clang/Basic/DiagnosticParseKinds.td
@@ -337,6 +337,8 @@ def err_ms_attributes_not_enabled : Error<
 def err_expected_method_body : Error<"expected method body">;
 def err_declspec_after_virtspec : Error<
   "'%0' qualifier may not appear after the virtual specifier '%1'">;
+def err_virt_specifier_after_contract : Error<
+  "virtual specifier '%0' must appear before contract specifiers">;
 def err_invalid_token_after_toplevel_declarator : Error<
   "expected ';' after top level declarator">;
 def err_invalid_token_after_declarator_suggest_equal : Error<

--- a/clang/include/clang/Basic/LangOptions.def
+++ b/clang/include/clang/Basic/LangOptions.def
@@ -444,6 +444,8 @@ LANGOPT(PaddingOnUnsignedFixedPoint, 1, 0, NotCompatible,
 
 LANGOPT(OverflowBehaviorTypes, 1, 0, NotCompatible, "overflow behavior types")
 
+LANGOPT(Contracts, 1, 0, Benign, "C++ contracts support")
+
 ENUM_LANGOPT(RegisterStaticDestructors, RegisterStaticDestructorsKind, 2,
              RegisterStaticDestructorsKind::All, NotCompatible,
              "Register C++ static destructors")

--- a/clang/include/clang/Basic/TokenKinds.def
+++ b/clang/include/clang/Basic/TokenKinds.def
@@ -28,14 +28,14 @@
 #ifndef CXX20_KEYWORD
 #define CXX20_KEYWORD(X,Y) KEYWORD(X,KEYCXX20|(Y))
 #endif
+#ifndef CXX26_KEYWORD
+#define CXX26_KEYWORD(X,Y) KEYWORD(X,KEYCXX26|(Y))
+#endif
 #ifndef C99_KEYWORD
 #define C99_KEYWORD(X,Y) KEYWORD(X,KEYC99|(Y))
 #endif
 #ifndef C23_KEYWORD
 #define C23_KEYWORD(X,Y) KEYWORD(X,KEYC23|(Y))
-#endif
-#ifndef CONTRACTS_KEYWORD
-#define CONTRACTS_KEYWORD(X) KEYWORD(X,KEYCONTRACTS)
 #endif
 #ifndef COROUTINES_KEYWORD
 #define COROUTINES_KEYWORD(X) CXX20_KEYWORD(X,KEYCOROUTINES)
@@ -281,6 +281,7 @@ PUNCTUATOR(greatergreatergreater, ">>>")
 //   KEYNOCXX - This is a keyword in every non-C++ dialect.
 //   KEYCXX11 - This is a C++ keyword introduced to C++ in C++11
 //   KEYCXX20 - This is a C++ keyword introduced to C++ in C++20
+//   KEYCXX26 - This is a C++ keyword introduced to C++ in C++26
 //   KEYMODULES - This is a keyword if the C++ extensions for modules
 //                are enabled.
 //   KEYGNU   - This is a keyword if GNU extensions are enabled
@@ -424,8 +425,8 @@ CXX11_KEYWORD(nullptr               , KEYC23)
 CXX11_KEYWORD(static_assert         , KEYMSCOMPAT|KEYC23)
 CXX11_KEYWORD(thread_local          , KEYC23)
 
-// C++26 Contracts keyword.
-CONTRACTS_KEYWORD(contract_assert)
+// C++26 keyword.
+CXX26_KEYWORD(contract_assert         , 0)
 
 // C++20 / coroutines keywords
 COROUTINES_KEYWORD(co_await)
@@ -937,7 +938,7 @@ ANNOTATION(embed)
 #undef TYPE_TRAIT_1
 #undef TYPE_TRAIT
 #undef MODULES_KEYWORD
-#undef CONTRACTS_KEYWORD
+#undef CXX26_KEYWORD
 #undef CXX20_KEYWORD
 #undef CXX11_KEYWORD
 #undef KEYWORD

--- a/clang/include/clang/Basic/TokenKinds.def
+++ b/clang/include/clang/Basic/TokenKinds.def
@@ -34,6 +34,9 @@
 #ifndef C23_KEYWORD
 #define C23_KEYWORD(X,Y) KEYWORD(X,KEYC23|(Y))
 #endif
+#ifndef CONTRACTS_KEYWORD
+#define CONTRACTS_KEYWORD(X) KEYWORD(X,KEYCONTRACTS)
+#endif
 #ifndef COROUTINES_KEYWORD
 #define COROUTINES_KEYWORD(X) CXX20_KEYWORD(X,KEYCOROUTINES)
 #endif
@@ -420,6 +423,9 @@ CXX11_KEYWORD(noexcept              , 0)
 CXX11_KEYWORD(nullptr               , KEYC23)
 CXX11_KEYWORD(static_assert         , KEYMSCOMPAT|KEYC23)
 CXX11_KEYWORD(thread_local          , KEYC23)
+
+// C++26 Contracts keyword.
+CONTRACTS_KEYWORD(contract_assert)
 
 // C++20 / coroutines keywords
 COROUTINES_KEYWORD(co_await)
@@ -931,6 +937,7 @@ ANNOTATION(embed)
 #undef TYPE_TRAIT_1
 #undef TYPE_TRAIT
 #undef MODULES_KEYWORD
+#undef CONTRACTS_KEYWORD
 #undef CXX20_KEYWORD
 #undef CXX11_KEYWORD
 #undef KEYWORD

--- a/clang/include/clang/Basic/TokenKinds.def
+++ b/clang/include/clang/Basic/TokenKinds.def
@@ -425,9 +425,6 @@ CXX11_KEYWORD(nullptr               , KEYC23)
 CXX11_KEYWORD(static_assert         , KEYMSCOMPAT|KEYC23)
 CXX11_KEYWORD(thread_local          , KEYC23)
 
-// C++26 keyword.
-CXX26_KEYWORD(contract_assert         , 0)
-
 // C++20 / coroutines keywords
 COROUTINES_KEYWORD(co_await)
 COROUTINES_KEYWORD(co_return)
@@ -442,6 +439,9 @@ CXX20_KEYWORD(consteval             , 0)
 CXX20_KEYWORD(constinit             , 0)
 CXX20_KEYWORD(concept               , 0)
 CXX20_KEYWORD(requires              , 0)
+
+// C++26 keyword.
+CXX26_KEYWORD(contract_assert       , 0)
 
 // Not a CXX20_KEYWORD because it is disabled by -fno-char8_t.
 KEYWORD(char8_t                     , CHAR8SUPPORT)

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -1835,9 +1835,9 @@ defm coroutines : BoolFOption<"coroutines",
 
 defm contracts : BoolFOption<"contracts",
   LangOpts<"Contracts">, DefaultFalse,
-  PosFlag<SetTrue, [], [ClangOption, CC1Option],
+  PosFlag<SetTrue, [], [CC1Option],
           "Enable support for C++ Contracts">,
-  NegFlag<SetFalse, [], [ClangOption, CC1Option],
+  NegFlag<SetFalse, [], [CC1Option],
           "Disable support for C++ Contracts">>,
   ShouldParseIf<cplusplus.KeyPath>;
 

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -1833,6 +1833,14 @@ defm coroutines : BoolFOption<"coroutines",
           "Enable support for the C++ Coroutines">,
   NegFlag<SetFalse>>;
 
+defm contracts : BoolFOption<"contracts",
+  LangOpts<"Contracts">, DefaultFalse,
+  PosFlag<SetTrue, [], [ClangOption, CC1Option],
+          "Enable support for C++ Contracts">,
+  NegFlag<SetFalse, [], [ClangOption, CC1Option],
+          "Disable support for C++ Contracts">>,
+  ShouldParseIf<cplusplus.KeyPath>;
+
 defm coro_aligned_allocation : BoolFOption<"coro-aligned-allocation",
   LangOpts<"CoroAlignedAllocation">, DefaultFalse,
   PosFlag<SetTrue, [], [ClangOption, CC1Option],

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -2763,6 +2763,17 @@ private:
       const Declarator &D, const DeclSpec &DS,
       std::optional<Sema::CXXThisScopeRAII> &ThisScope);
 
+  enum class ContractSpecifierKind { Pre, Post };
+  std::optional<ContractSpecifierKind> getContractSpecifierKind();
+  void ParseContractSpecifiers(Declarator &D);
+  /// Parse the function tails. e.g., requires clause and contracts.
+  ///
+  /// \param ParametersAlreadyInScope whether the paramers are arealdy in an
+  /// active function prototype scope. This can be true for lambda as lambda
+  /// would always build its function prototype scope.
+  void ParseFunctionDeclaratorTail(Declarator &D,
+                                   bool ParametersAlreadyInScope = false);
+
   /// ParseRefQualifier - Parses a member function ref-qualifier. Returns
   /// true if a ref-qualifier is found.
   bool ParseRefQualifier(bool &RefQualifierIsLValueRef,
@@ -7597,6 +7608,11 @@ public:
   /// Note: this lets the caller parse the end ';'.
   ///
   StmtResult ParseBreakStatement();
+
+  /// Parse a C++26 contract-assertion statement.
+  /// TODO: Currently the AST result of contracts is not support, its predicate
+  /// will be parsed and the corresponding AST result will be discarded.
+  StmtResult ParseContractAssertStatement();
 
   /// ParseReturnStatement
   /// \verbatim

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -2766,13 +2766,13 @@ private:
   enum class ContractSpecifierKind { Pre, Post };
   std::optional<ContractSpecifierKind> getContractSpecifierKind();
   void ParseContractSpecifiers(Declarator &D);
-  /// Parse the function tails. e.g., requires clause and contracts.
+  /// Parse the trailing requires-clause and function contract specifiers.
   ///
-  /// \param ParametersAlreadyInScope whether the paramers are arealdy in an
-  /// active function prototype scope. This can be true for lambda as lambda
-  /// would always build its function prototype scope.
-  void ParseFunctionDeclaratorTail(Declarator &D,
-                                   bool ParametersAlreadyInScope = false);
+  /// \param ParametersAlreadyInScope whether the parameters are already in an
+  /// active function prototype scope. This can be true for lambdas, which
+  /// always build their function prototype scope.
+  void ParseFunctionContractSpecifiersAndConstraints(
+      Declarator &D, bool ParametersAlreadyInScope = false);
 
   /// ParseRefQualifier - Parses a member function ref-qualifier. Returns
   /// true if a ref-qualifier is found.
@@ -2898,6 +2898,10 @@ private:
   mutable IdentifierInfo *Ident_GNU_final;
   mutable IdentifierInfo *Ident_override;
 
+  /// C++26 contextual keywords.
+  mutable IdentifierInfo *Ident_pre;
+  mutable IdentifierInfo *Ident_post;
+
   /// Representation of a class that has been parsed, including
   /// any member function declarations or definitions that need to be
   /// parsed after the corresponding top-level class is complete.
@@ -3003,7 +3007,6 @@ private:
                                      bool MayBeFollowedByDirectInit);
 
   /// Parse a requires-clause as part of a function declaration.
-  void ParseTrailingRequiresClauseWithScope(Declarator &D);
   void ParseTrailingRequiresClause(Declarator &D);
 
   void ParseMicrosoftIfExistsClassDeclaration(DeclSpec::TST TagType,

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -1288,7 +1288,7 @@ private:
   /// LateParsedMethodDeclaration - A method declaration inside a class that
   /// contains at least one entity whose parsing needs to be delayed
   /// until the class itself is completely-defined, such as a default
-  /// argument (C++ [class.mem]p2).
+  /// argument or contract predicate (C++ [class.mem]).
   struct LateParsedMethodDeclaration : public LateParsedDeclaration {
     explicit LateParsedMethodDeclaration(Parser *P, Decl *M)
         : Self(P), Method(M), ExceptionSpecTokens(nullptr) {}
@@ -1300,16 +1300,18 @@ private:
     /// Method - The method declaration.
     Decl *Method;
 
-    /// DefaultArgs - Contains the parameters of the function and
-    /// their default arguments. At least one of the parameters will
-    /// have a default argument, but all of the parameters of the
-    /// method will be stored so that they can be reintroduced into
-    /// scope at the appropriate times.
+    /// DefaultArgs - Contains the parameters of the function and their default
+    /// arguments. All parameters are stored so that they can be reintroduced
+    /// into scope for any delayed part of the method declaration.
     SmallVector<LateParsedDefaultArgument, 8> DefaultArgs;
 
     /// The set of tokens that make up an exception-specification that
     /// has not yet been parsed.
     CachedTokens *ExceptionSpecTokens;
+
+    /// Contract predicates that must be parsed after the enclosing class is
+    /// complete.
+    SmallVector<Declarator::LateParsedContractSpecifier, 2> ContractSpecifiers;
   };
 
   /// LateParsedMemberInitializer - An initializer for a non-static class data

--- a/clang/include/clang/Sema/DeclSpec.h
+++ b/clang/include/clang/Sema/DeclSpec.h
@@ -2052,6 +2052,19 @@ private:
 
   Expr *PackIndexingExpr;
 
+public:
+  /// A function contract specifier whose predicate must be parsed after its
+  /// enclosing class is complete.
+  struct LateParsedContractSpecifier {
+    bool IsPost;
+    IdentifierInfo *ResultName = nullptr;
+    SourceLocation ResultNameLoc;
+    std::unique_ptr<CachedTokens> PredicateTokens;
+  };
+
+private:
+  SmallVector<LateParsedContractSpecifier, 2> LateParsedContractSpecifiers;
+
   friend struct DeclaratorChunk;
 
 public:
@@ -2690,6 +2703,17 @@ public:
   /// declarator.
   bool hasTrailingRequiresClause() const {
     return TrailingRequiresClause != nullptr;
+  }
+
+  void addLateParsedContractSpecifier(LateParsedContractSpecifier &&Info) {
+    LateParsedContractSpecifiers.push_back(std::move(Info));
+  }
+  MutableArrayRef<LateParsedContractSpecifier>
+  getLateParsedContractSpecifiers() {
+    return LateParsedContractSpecifiers;
+  }
+  bool hasLateParsedContractSpecifiers() const {
+    return !LateParsedContractSpecifiers.empty();
   }
 
   /// Sets the template parameter lists that preceded the declarator.

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -6500,7 +6500,8 @@ public:
 
   void SetFunctionBodyKind(Decl *D, SourceLocation Loc, FnBodyKind BodyKind,
                            StringLiteral *DeletedMessage = nullptr);
-  void ActOnStartTrailingRequiresClause(Scope *S, Declarator &D);
+  void ActOnStartTrailingRequiresClauseOrContractSpecifier(Scope *S,
+                                                           Declarator &D);
   /// Create a result variable for postconditions and make it visible in the
   /// predicate's scope.
   VarDecl *ActOnPostConditionResultName(Scope *S, IdentifierInfo *ResultName,

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -6501,6 +6501,10 @@ public:
   void SetFunctionBodyKind(Decl *D, SourceLocation Loc, FnBodyKind BodyKind,
                            StringLiteral *DeletedMessage = nullptr);
   void ActOnStartTrailingRequiresClause(Scope *S, Declarator &D);
+  /// Create a result variable for postconditions and make it visible in the
+  /// predicate's scope.
+  VarDecl *ActOnPostConditionResultName(Scope *S, IdentifierInfo *ResultName,
+                                        SourceLocation ResultNameLoc);
   ExprResult ActOnFinishTrailingRequiresClause(ExprResult ConstraintExpr);
   ExprResult ActOnRequiresClause(ExprResult ConstraintExpr);
 

--- a/clang/lib/Basic/IdentifierTable.cpp
+++ b/clang/lib/Basic/IdentifierTable.cpp
@@ -108,6 +108,10 @@ static KeywordStatus getKeywordStatusHelper(const LangOptions &LangOpts,
     if (LangOpts.CPlusPlus20)
       return KS_Enabled;
     return LangOpts.CPlusPlus ? KS_Future : KS_Unknown;
+  case KEYCXX26:
+    if (LangOpts.CPlusPlus26)
+      return KS_Enabled;
+    return LangOpts.CPlusPlus ? KS_Future : KS_Unknown;
   case KEYGNU:
     return LangOpts.GNUKeywords ? KS_Extension : KS_Unknown;
   case KEYMS:
@@ -137,8 +141,6 @@ static KeywordStatus getKeywordStatusHelper(const LangOptions &LangOpts,
     return LangOpts.ObjC ? KS_Enabled : KS_Unknown;
   case KEYZVECTOR:
     return LangOpts.ZVector ? KS_Enabled : KS_Unknown;
-  case KEYCONTRACTS:
-    return LangOpts.CPlusPlus && LangOpts.Contracts ? KS_Enabled : KS_Unknown;
   case KEYCOROUTINES:
     return LangOpts.Coroutines ? KS_Enabled : KS_Unknown;
   case KEYMODULES:
@@ -201,7 +203,7 @@ KeywordStatus clang::getKeywordStatus(const LangOptions &LangOpts,
 }
 
 static bool IsKeywordInCpp(unsigned Flags) {
-  return (Flags & (KEYCXX | KEYCXX11 | KEYCXX20 | KEYCONTRACTS | BOOLSUPPORT |
+  return (Flags & (KEYCXX | KEYCXX11 | KEYCXX20 | KEYCXX26 | BOOLSUPPORT |
                    WCHARSUPPORT | CHAR8SUPPORT)) != 0;
 }
 
@@ -849,6 +851,9 @@ IdentifierTable::getFutureCompatDiagKind(const IdentifierInfo &II,
     if (((Flags & KEYCXX20) == KEYCXX20) ||
         ((Flags & CHAR8SUPPORT) == CHAR8SUPPORT))
       return diag::warn_cxx20_keyword;
+
+    if ((Flags & KEYCXX26) == KEYCXX26)
+      return diag::warn_cxx26_keyword;
   } else {
     if ((Flags & KEYC99) == KEYC99)
       return diag::warn_c99_keyword;

--- a/clang/lib/Basic/IdentifierTable.cpp
+++ b/clang/lib/Basic/IdentifierTable.cpp
@@ -137,6 +137,8 @@ static KeywordStatus getKeywordStatusHelper(const LangOptions &LangOpts,
     return LangOpts.ObjC ? KS_Enabled : KS_Unknown;
   case KEYZVECTOR:
     return LangOpts.ZVector ? KS_Enabled : KS_Unknown;
+  case KEYCONTRACTS:
+    return LangOpts.CPlusPlus && LangOpts.Contracts ? KS_Enabled : KS_Unknown;
   case KEYCOROUTINES:
     return LangOpts.Coroutines ? KS_Enabled : KS_Unknown;
   case KEYMODULES:
@@ -199,8 +201,8 @@ KeywordStatus clang::getKeywordStatus(const LangOptions &LangOpts,
 }
 
 static bool IsKeywordInCpp(unsigned Flags) {
-  return (Flags & (KEYCXX | KEYCXX11 | KEYCXX20 | BOOLSUPPORT | WCHARSUPPORT |
-                   CHAR8SUPPORT)) != 0;
+  return (Flags & (KEYCXX | KEYCXX11 | KEYCXX20 | KEYCONTRACTS | BOOLSUPPORT |
+                   WCHARSUPPORT | CHAR8SUPPORT)) != 0;
 }
 
 static void MarkIdentifierAsKeywordInCpp(IdentifierTable &Table,

--- a/clang/lib/Parse/ParseCXXInlineMethods.cpp
+++ b/clang/lib/Parse/ParseCXXInlineMethods.cpp
@@ -559,6 +559,64 @@ void Parser::ParseLexedMethodDeclaration(LateParsedMethodDeclaration &LM) {
     LM.ExceptionSpecTokens = nullptr;
   }
 
+  // A contract specifier within a member-specification is a complete-class
+  // context. Parse cached predicates now that all members of the enclosing
+  // class are known.
+  for (auto &Contract : LM.ContractSpecifiers) {
+    std::unique_ptr<CachedTokens> Toks = std::move(Contract.PredicateTokens);
+    if (!Toks || Toks->empty())
+      continue;
+
+    ParenBraceBracketBalancer BalancerRAIIObj(*this);
+
+    Token LastContractToken = Toks->back();
+    Token ContractEnd;
+    ContractEnd.startToken();
+    ContractEnd.setKind(tok::eof);
+    ContractEnd.setLocation(LastContractToken.getEndLoc());
+    ContractEnd.setEofData(LM.Method);
+    Toks->push_back(ContractEnd);
+
+    Toks->push_back(Tok); // So that the current token doesn't get lost.
+    PP.EnterTokenStream(*Toks, true, /*IsReinject=*/true);
+    ConsumeAnyToken(/*ConsumeCodeCompletionTok=*/true);
+
+    FunctionDecl *FunctionToPush;
+    if (auto *FunTmpl = dyn_cast<FunctionTemplateDecl>(LM.Method))
+      FunctionToPush = FunTmpl->getTemplatedDecl();
+    else
+      FunctionToPush = cast<FunctionDecl>(LM.Method);
+    auto *Method = dyn_cast<CXXMethodDecl>(FunctionToPush);
+
+    ParseScope FnScope(this, Scope::FnScope);
+    Sema::ContextRAII FnContext(Actions, FunctionToPush,
+                                /*NewThisContext=*/false);
+    Sema::CXXThisScopeRAII ThisScope(
+        Actions, Method ? Method->getParent() : nullptr,
+        Method ? Method->getMethodQualifiers() : Qualifiers{},
+        Method && Method->isImplicitObjectMemberFunction() &&
+            getLangOpts().CPlusPlus11);
+
+    std::optional<ParseScope> ResultNameScope;
+    if (Contract.IsPost && Contract.ResultName) {
+      ResultNameScope.emplace(this, Scope::DeclScope);
+      Actions.ActOnPostConditionResultName(getCurScope(), Contract.ResultName,
+                                           Contract.ResultNameLoc);
+    }
+
+    ExprResult Predicate = ParseConditionalExpression();
+    ResultNameScope.reset();
+
+    if (Predicate.isUsable() &&
+        (Tok.isNot(tok::eof) || Tok.getEofData() != LM.Method))
+      Diag(Tok, diag::err_expected) << tok::r_paren;
+
+    while (Tok.isNot(tok::eof))
+      ConsumeAnyToken();
+    if (Tok.is(tok::eof) && Tok.getEofData() == LM.Method)
+      ConsumeAnyToken();
+  }
+
   InFunctionTemplateScope.Scopes.Exit();
 
   // Finish the delayed C++ method declaration.

--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -2186,13 +2186,13 @@ Parser::DeclGroupPtrTy Parser::ParseDeclGroup(ParsingDeclSpec &DS,
     while (MaybeParseHLSLAnnotations(D))
       ;
 
-  if (Tok.is(tok::kw_requires)) {
+  if (Tok.is(tok::kw_requires) || getContractSpecifierKind()) {
     TemplateParameterDepthRAII CurTemplateDepthTracker(TemplateParameterDepth);
     // With abbreviated function templates - we need to explicitly add depth to
     // account for the implicit template parameter list induced by the template.
     if (!TemplateInfo.TemplateParams && D.getInventedTemplateParameterList())
       ++CurTemplateDepthTracker;
-    ParseTrailingRequiresClauseWithScope(D);
+    ParseFunctionDeclaratorTail(D);
   }
 
   // Save late-parsed attributes for now; they need to be parsed in the
@@ -2441,8 +2441,8 @@ Parser::DeclGroupPtrTy Parser::ParseDeclGroup(ParsingDeclSpec &DS,
       //    init-declarator:
       //	      declarator initializer[opt]
       //        declarator requires-clause
-      if (Tok.is(tok::kw_requires))
-        ParseTrailingRequiresClauseWithScope(D);
+      if (Tok.is(tok::kw_requires) || getContractSpecifierKind())
+        ParseFunctionDeclaratorTail(D);
       Decl *ThisDecl = ParseDeclarationAfterDeclarator(D, TemplateInfo);
       D.complete(ThisDecl);
       if (ThisDecl)

--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -2192,7 +2192,7 @@ Parser::DeclGroupPtrTy Parser::ParseDeclGroup(ParsingDeclSpec &DS,
     // account for the implicit template parameter list induced by the template.
     if (!TemplateInfo.TemplateParams && D.getInventedTemplateParameterList())
       ++CurTemplateDepthTracker;
-    ParseFunctionDeclaratorTail(D);
+    ParseFunctionContractSpecifiersAndConstraints(D);
   }
 
   // Save late-parsed attributes for now; they need to be parsed in the
@@ -2442,7 +2442,7 @@ Parser::DeclGroupPtrTy Parser::ParseDeclGroup(ParsingDeclSpec &DS,
       //	      declarator initializer[opt]
       //        declarator requires-clause
       if (Tok.is(tok::kw_requires) || getContractSpecifierKind())
-        ParseFunctionDeclaratorTail(D);
+        ParseFunctionContractSpecifiersAndConstraints(D);
       Decl *ThisDecl = ParseDeclarationAfterDeclarator(D, TemplateInfo);
       D.complete(ThisDecl);
       if (ThisDecl)

--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -7641,6 +7641,13 @@ void Parser::ParseParameterDeclarationClause(
                                   : DeclaratorContext::Prototype);
     ParseDeclarator(ParmDeclarator);
 
+    // A parameter declarator can spell a function type, but it is adjusted to
+    // a pointer-to-function type. Parse contract specifiers here to diagnose
+    // them and recover instead of treating them as an unexpected parameter
+    // list token.
+    if (getContractSpecifierKind())
+      ParseContractSpecifiers(ParmDeclarator);
+
     if (ThisLoc.isValid())
       ParmDeclarator.SetRangeBegin(ThisLoc);
 

--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -2563,8 +2563,9 @@ bool Parser::ParseCXXMemberDeclaratorBeforeInitializer(
     Declarator &DeclaratorInfo, VirtSpecifiers &VS, ExprResult &BitfieldSize,
     LateParsedAttrList &LateParsedAttrs) {
   // member-declarator:
-  //   declarator virt-specifier-seq[opt] pure-specifier[opt]
-  //   declarator requires-clause
+  //   declarator virt-specifier-seq[opt]
+  //     function-contract-specifier-seq[opt] pure-specifier[opt]
+  //   declarator requires-clause function-contract-specifier-seq[opt]
   //   declarator brace-or-equal-initializer[opt]
   //   identifier attribute-specifier-seq[opt] ':' constant-expression
   //       brace-or-equal-initializer[opt]
@@ -2591,21 +2592,30 @@ bool Parser::ParseCXXMemberDeclaratorBeforeInitializer(
     BitfieldSize = ParseConstantExpression();
     if (BitfieldSize.isInvalid())
       SkipUntil(tok::comma, StopAtSemi | StopBeforeMatch);
-  } else if (Tok.is(tok::kw_requires)) {
-    TemplateParameterDepthRAII CurTemplateDepthTracker(TemplateParameterDepth);
-    // With abbreviated function templates - we need to explicitly add depth to
-    // account for the implicit template parameter list induced by the template.
-    if (DeclaratorInfo.getTemplateParameterLists().empty() &&
-        DeclaratorInfo.getInventedTemplateParameterList())
-      ++CurTemplateDepthTracker;
-    ParseTrailingRequiresClauseWithScope(DeclaratorInfo);
   } else {
-    ParseOptionalCXX11VirtSpecifierSeq(
-        VS, getCurrentClass().IsInterface,
-        DeclaratorInfo.getDeclSpec().getFriendSpecLoc());
-    if (!VS.isUnset())
-      MaybeParseAndDiagnoseDeclSpecAfterCXX11VirtSpecifierSeq(DeclaratorInfo,
-                                                              VS);
+    // Requires clause can't follow 'override' but contracts can follow
+    // 'override'. Even if we don't support virtual functions with contractcs,
+    // we should diagnose at the sema stage instead of the parser stage.
+    if (Tok.isNot(tok::kw_requires)) {
+      ParseOptionalCXX11VirtSpecifierSeq(
+          VS, getCurrentClass().IsInterface,
+          DeclaratorInfo.getDeclSpec().getFriendSpecLoc());
+      if (!VS.isUnset())
+        MaybeParseAndDiagnoseDeclSpecAfterCXX11VirtSpecifierSeq(DeclaratorInfo,
+                                                                VS);
+    }
+
+    if (Tok.is(tok::kw_requires) || getContractSpecifierKind()) {
+      TemplateParameterDepthRAII CurTemplateDepthTracker(
+          TemplateParameterDepth);
+      // With abbreviated function templates - we need to explicitly add depth
+      // to account for the implicit template parameter list induced by the
+      // template.
+      if (DeclaratorInfo.getTemplateParameterLists().empty() &&
+          DeclaratorInfo.getInventedTemplateParameterList())
+        ++CurTemplateDepthTracker;
+      ParseFunctionDeclaratorTail(DeclaratorInfo);
+    }
   }
 
   // If a simple-asm-expr is present, parse it.
@@ -4242,6 +4252,134 @@ void Parser::ParseTrailingRequiresClause(Declarator &D) {
       SkipUntil({tok::equal, tok::l_brace, tok::arrow, tok::kw_try, tok::comma},
                 StopAtSemi | StopBeforeMatch);
   }
+}
+
+std::optional<Parser::ContractSpecifierKind>
+Parser::getContractSpecifierKind() {
+  if (!getLangOpts().Contracts || Tok.isNot(tok::identifier))
+    return std::nullopt;
+
+  IdentifierInfo *II = Tok.getIdentifierInfo();
+  if (II->isStr("pre"))
+    return ContractSpecifierKind::Pre;
+  if (II->isStr("post"))
+    return ContractSpecifierKind::Post;
+  return std::nullopt;
+}
+
+void Parser::ParseContractSpecifiers(Declarator &D) {
+  assert(getLangOpts().Contracts && "contracts are not enabled");
+
+  const bool IsFunction = D.isDeclarationOfFunction() &&
+                          (D.isFunctionDeclarationContext() ||
+                           D.getContext() == DeclaratorContext::LambdaExpr);
+  if (!IsFunction)
+    Diag(Tok, diag::err_contract_specifier_not_function);
+
+  while (std::optional<ContractSpecifierKind> Kind =
+             getContractSpecifierKind()) {
+    const bool IsPost = *Kind == ContractSpecifierKind::Post;
+    ConsumeToken();
+
+    ParsedAttributes Attrs(AttrFactory);
+    MaybeParseCXX11Attributes(Attrs);
+
+    BalancedDelimiterTracker T(*this, tok::l_paren);
+    if (T.expectAndConsume(diag::err_expected_lparen_after,
+                           IsPost ? "post" : "pre"))
+      return;
+
+    // !IsFunction is diagnosed before, avoid confusing diagnostics.
+    if (!IsFunction) {
+      T.skipToEnd();
+      continue;
+    }
+
+    // FIXME: We should accept attribute for the result binding, e.g.,
+    // post(r [[attr]] : expr).
+    std::optional<ParseScope> ResultNameScope;
+    if (IsPost && Tok.is(tok::identifier) && NextToken().is(tok::colon)) {
+      IdentifierInfo *ResultName = Tok.getIdentifierInfo();
+      SourceLocation ResultNameLoc = ConsumeToken();
+      ConsumeToken();
+
+      ResultNameScope.emplace(this, Scope::DeclScope);
+      Actions.ActOnPostConditionResultName(getCurScope(), ResultName,
+                                           ResultNameLoc);
+    }
+
+    EnterExpressionEvaluationContext Evaluated(
+        Actions, Sema::ExpressionEvaluationContext::PotentiallyEvaluated);
+    ExprResult Predicate = ParseConditionalExpression();
+    ResultNameScope.reset();
+    if (Predicate.isInvalid())
+      T.skipToEnd();
+    else
+      T.consumeClose();
+  }
+}
+
+// Parse the function tail where the require clause must appear first
+// and the contracts later.
+void Parser::ParseFunctionDeclaratorTail(Declarator &D,
+                                         bool ParametersAlreadyInScope) {
+  assert((Tok.is(tok::kw_requires) || getContractSpecifierKind()) &&
+         "expected a function declarator tail");
+
+  // TODO: We can consider merging ParseTrailingRequiresClauseWithScope into
+  // this function.
+  if (!ParametersAlreadyInScope && Tok.is(tok::kw_requires)) {
+    ParseTrailingRequiresClauseWithScope(D);
+    if (!getContractSpecifierKind())
+      return;
+  }
+
+  auto ParseTail = [&] {
+    bool ParametersInScope = ParametersAlreadyInScope;
+    if (Tok.is(tok::kw_requires)) {
+      ParseTrailingRequiresClause(D);
+      ParametersInScope = true;
+    }
+
+    while (getContractSpecifierKind()) {
+      if (!ParametersInScope) {
+        // FIXME: ActOnStartTrailingRequiresClause is not actually deal with
+        // require clause. It is actually adds the parameters to the scope
+        // chains. It needs a better name.
+        Actions.ActOnStartTrailingRequiresClause(getCurScope(), D);
+        ParametersInScope = true;
+      }
+
+      const DeclSpec *MethodDS = &D.getDeclSpec();
+      if (D.isFunctionDeclarator() && D.getFunctionTypeInfo().MethodQualifiers)
+        MethodDS = D.getFunctionTypeInfo().MethodQualifiers;
+      std::optional<Sema::CXXThisScopeRAII> ThisScope;
+      InitCXXThisScopeForDeclaratorIfRelevant(D, *MethodDS, ThisScope);
+      ParseContractSpecifiers(D);
+
+      // If we meet requires after contracts, emit a nice diagnostics and
+      // recovering compilation.
+      if (Tok.is(tok::kw_requires)) {
+        Diag(Tok, diag::err_requires_clause_must_precede_contract_specifiers);
+        ParseTrailingRequiresClause(D);
+      }
+    }
+  };
+
+  if (ParametersAlreadyInScope) {
+    ParseTail();
+    return;
+  }
+
+  CXXScopeSpec &SS = D.getCXXScopeSpec();
+  DeclaratorScopeObj DeclScopeObj(*this, SS);
+  if (SS.isValid() && Actions.ShouldEnterDeclaratorScope(getCurScope(), SS))
+    DeclScopeObj.EnterDeclaratorScope();
+
+  ParseScope ParamScope(this, Scope::DeclScope |
+                                  Scope::FunctionDeclarationScope |
+                                  Scope::FunctionPrototypeScope);
+  ParseTail();
 }
 
 Sema::ParsingClassState Parser::PushParsingClass(Decl *ClassDecl,

--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -2614,7 +2614,7 @@ bool Parser::ParseCXXMemberDeclaratorBeforeInitializer(
       if (DeclaratorInfo.getTemplateParameterLists().empty() &&
           DeclaratorInfo.getInventedTemplateParameterList())
         ++CurTemplateDepthTracker;
-      ParseFunctionDeclaratorTail(DeclaratorInfo);
+      ParseFunctionContractSpecifiersAndConstraints(DeclaratorInfo);
     }
   }
 
@@ -4172,49 +4172,17 @@ TypeResult Parser::ParseTrailingReturnType(SourceRange &Range,
                                    : DeclaratorContext::TrailingReturn);
 }
 
-void Parser::ParseTrailingRequiresClauseWithScope(Declarator &D) {
-  assert(Tok.is(tok::kw_requires) && "expected requires");
-
-  // C++23 [basic.scope.namespace]p1:
-  //   For each non-friend redeclaration or specialization whose target scope
-  //   is or is contained by the scope, the portion after the declarator-id,
-  //   class-head-name, or enum-head-name is also included in the scope.
-  // C++23 [basic.scope.class]p1:
-  //   For each non-friend redeclaration or specialization whose target scope
-  //   is or is contained by the scope, the portion after the declarator-id,
-  //   class-head-name, or enum-head-name is also included in the scope.
-  //
-  // FIXME: We should really be calling ParseTrailingRequiresClause in
-  // ParseDirectDeclarator, when we are already in the declarator scope.
-  // This would also correctly suppress access checks for specializations
-  // and explicit instantiations, which we currently do not do.
-  CXXScopeSpec &SS = D.getCXXScopeSpec();
-  DeclaratorScopeObj DeclScopeObj(*this, SS);
-  if (SS.isValid() && Actions.ShouldEnterDeclaratorScope(getCurScope(), SS))
-    DeclScopeObj.EnterDeclaratorScope();
-
-  ParseScope ParamScope(this, Scope::DeclScope |
-                                  Scope::FunctionDeclarationScope |
-                                  Scope::FunctionPrototypeScope);
-
-  ParseTrailingRequiresClause(D);
-}
-
 void Parser::ParseTrailingRequiresClause(Declarator &D) {
+  // The caller need to set up the scope for the parameters and init 'this'
+  // scope fro declarator if relevant.
+
   assert(Tok.is(tok::kw_requires) && "expected requires");
   assert(
       getCurScope()->isFunctionPrototypeScope() &&
       "trailing requires-clause must be parsed in a function prototype scope");
 
   SourceLocation RequiresKWLoc = ConsumeToken();
-
-  ExprResult TrailingRequiresClause;
-  Actions.ActOnStartTrailingRequiresClause(getCurScope(), D);
-
-  std::optional<Sema::CXXThisScopeRAII> ThisScope;
-  InitCXXThisScopeForDeclaratorIfRelevant(D, D.getDeclSpec(), ThisScope);
-
-  TrailingRequiresClause =
+  ExprResult TrailingRequiresClause =
       ParseConstraintLogicalOrExpression(/*IsTrailingRequiresClause=*/true);
 
   TrailingRequiresClause =
@@ -4256,19 +4224,29 @@ void Parser::ParseTrailingRequiresClause(Declarator &D) {
 
 std::optional<Parser::ContractSpecifierKind>
 Parser::getContractSpecifierKind() {
-  if (!getLangOpts().Contracts || Tok.isNot(tok::identifier))
+  if (!getLangOpts().CPlusPlus || Tok.isNot(tok::identifier))
     return std::nullopt;
 
-  IdentifierInfo *II = Tok.getIdentifierInfo();
-  if (II->isStr("pre"))
+  if (!Ident_pre) {
+    Ident_pre = &PP.getIdentifierTable().get("pre");
+    Ident_post = &PP.getIdentifierTable().get("post");
+  }
+
+  const IdentifierInfo *II = Tok.getIdentifierInfo();
+  if (II == Ident_pre)
     return ContractSpecifierKind::Pre;
-  if (II->isStr("post"))
+  if (II == Ident_post)
     return ContractSpecifierKind::Post;
   return std::nullopt;
 }
 
 void Parser::ParseContractSpecifiers(Declarator &D) {
-  assert(getLangOpts().Contracts && "contracts are not enabled");
+  assert(getContractSpecifierKind() && "expected a contract specifier");
+
+  if (!getLangOpts().CPlusPlus26)
+    Diag(Tok, diag::err_contracts_require_cxx26);
+  else if (!getLangOpts().Contracts)
+    Diag(Tok, diag::err_contracts_disabled);
 
   const bool IsFunction = D.isDeclarationOfFunction() &&
                           (D.isFunctionDeclarationContext() ||
@@ -4319,42 +4297,27 @@ void Parser::ParseContractSpecifiers(Declarator &D) {
   }
 }
 
-// Parse the function tail where the require clause must appear first
-// and the contracts later.
-void Parser::ParseFunctionDeclaratorTail(Declarator &D,
-                                         bool ParametersAlreadyInScope) {
+void Parser::ParseFunctionContractSpecifiersAndConstraints(
+    Declarator &D, bool ParametersAlreadyInScope) {
   assert((Tok.is(tok::kw_requires) || getContractSpecifierKind()) &&
-         "expected a function declarator tail");
+         "expected a trailing requires-clause or contract specifier");
 
-  // TODO: We can consider merging ParseTrailingRequiresClauseWithScope into
-  // this function.
-  if (!ParametersAlreadyInScope && Tok.is(tok::kw_requires)) {
-    ParseTrailingRequiresClauseWithScope(D);
-    if (!getContractSpecifierKind())
-      return;
-  }
+  auto ParseSpecifiersAndConstraints = [&] {
+    if (!ParametersAlreadyInScope)
+      Actions.ActOnStartTrailingRequiresClauseOrContractSpecifier(getCurScope(),
+                                                                  D);
 
-  auto ParseTail = [&] {
-    bool ParametersInScope = ParametersAlreadyInScope;
+    const DeclSpec *MethodDS = &D.getDeclSpec();
+    if (D.isFunctionDeclarator() && D.getFunctionTypeInfo().MethodQualifiers)
+      MethodDS = D.getFunctionTypeInfo().MethodQualifiers;
+    std::optional<Sema::CXXThisScopeRAII> ThisScope;
+    InitCXXThisScopeForDeclaratorIfRelevant(D, *MethodDS, ThisScope);
+
     if (Tok.is(tok::kw_requires)) {
       ParseTrailingRequiresClause(D);
-      ParametersInScope = true;
     }
 
     while (getContractSpecifierKind()) {
-      if (!ParametersInScope) {
-        // FIXME: ActOnStartTrailingRequiresClause is not actually deal with
-        // require clause. It is actually adds the parameters to the scope
-        // chains. It needs a better name.
-        Actions.ActOnStartTrailingRequiresClause(getCurScope(), D);
-        ParametersInScope = true;
-      }
-
-      const DeclSpec *MethodDS = &D.getDeclSpec();
-      if (D.isFunctionDeclarator() && D.getFunctionTypeInfo().MethodQualifiers)
-        MethodDS = D.getFunctionTypeInfo().MethodQualifiers;
-      std::optional<Sema::CXXThisScopeRAII> ThisScope;
-      InitCXXThisScopeForDeclaratorIfRelevant(D, *MethodDS, ThisScope);
       ParseContractSpecifiers(D);
 
       // If we meet requires after contracts, emit a nice diagnostics and
@@ -4367,10 +4330,23 @@ void Parser::ParseFunctionDeclaratorTail(Declarator &D,
   };
 
   if (ParametersAlreadyInScope) {
-    ParseTail();
+    ParseSpecifiersAndConstraints();
     return;
   }
 
+  // C++23 [basic.scope.namespace]p1:
+  //   For each non-friend redeclaration or specialization whose target scope
+  //   is or is contained by the scope, the portion after the declarator-id,
+  //   class-head-name, or enum-head-name is also included in the scope.
+  // C++23 [basic.scope.class]p1:
+  //   For each non-friend redeclaration or specialization whose target scope
+  //   is or is contained by the scope, the portion after the declarator-id,
+  //   class-head-name, or enum-head-name is also included in the scope.
+  //
+  // FIXME: We should really parse these in ParseDirectDeclarator, when we are
+  // already in the declarator scope. This would also correctly suppress access
+  // checks for specializations and explicit instantiations, which we currently
+  // do not do.
   CXXScopeSpec &SS = D.getCXXScopeSpec();
   DeclaratorScopeObj DeclScopeObj(*this, SS);
   if (SS.isValid() && Actions.ShouldEnterDeclaratorScope(getCurScope(), SS))
@@ -4379,7 +4355,7 @@ void Parser::ParseFunctionDeclaratorTail(Declarator &D,
   ParseScope ParamScope(this, Scope::DeclScope |
                                   Scope::FunctionDeclarationScope |
                                   Scope::FunctionPrototypeScope);
-  ParseTail();
+  ParseSpecifiersAndConstraints();
 }
 
 Sema::ParsingClassState Parser::PushParsingClass(Decl *ClassDecl,

--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -2424,7 +2424,8 @@ void Parser::HandleMemberFunctionDeclDelays(Declarator &DeclaratorInfo,
   DeclaratorChunk::FunctionTypeInfo &FTI = DeclaratorInfo.getFunctionTypeInfo();
   // If there was a late-parsed exception-specification, we'll need a
   // late parse
-  bool NeedLateParse = FTI.getExceptionSpecType() == EST_Unparsed;
+  bool NeedLateParse = FTI.getExceptionSpecType() == EST_Unparsed ||
+                       DeclaratorInfo.hasLateParsedContractSpecifiers();
 
   if (!NeedLateParse) {
     // Look ahead to see if there are any default args
@@ -2445,7 +2446,8 @@ void Parser::HandleMemberFunctionDeclDelays(Declarator &DeclaratorInfo,
 
     // Push tokens for each parameter. Those that do not have defaults will be
     // NULL. We need to track all the parameters so that we can push them into
-    // scope for later parameters and perhaps for the exception specification.
+    // scope for later parameters, the exception specification, and contract
+    // predicates.
     LateMethod->DefaultArgs.reserve(FTI.NumParams);
     for (unsigned ParamIdx = 0; ParamIdx < FTI.NumParams; ++ParamIdx)
       LateMethod->DefaultArgs.push_back(LateParsedDefaultArgument(
@@ -2457,6 +2459,9 @@ void Parser::HandleMemberFunctionDeclDelays(Declarator &DeclaratorInfo,
       LateMethod->ExceptionSpecTokens = FTI.ExceptionSpecTokens;
       FTI.ExceptionSpecTokens = nullptr;
     }
+
+    for (auto &Contract : DeclaratorInfo.getLateParsedContractSpecifiers())
+      LateMethod->ContractSpecifiers.push_back(std::move(Contract));
   }
 }
 
@@ -2636,6 +2641,12 @@ bool Parser::ParseCXXMemberDeclaratorBeforeInitializer(
   // For compatibility with code written to older Clang, also accept a
   // virt-specifier *after* the GNU attributes.
   if (BitfieldSize.isUnset() && VS.isUnset()) {
+    if (DeclaratorInfo.hasLateParsedContractSpecifiers()) {
+      VirtSpecifiers::Specifier Specifier = isCXX11VirtSpecifier();
+      if (Specifier != VirtSpecifiers::VS_None)
+        Diag(Tok, diag::err_virt_specifier_after_contract)
+            << VirtSpecifiers::getSpecifierName(Specifier);
+    }
     ParseOptionalCXX11VirtSpecifierSeq(
         VS, getCurrentClass().IsInterface,
         DeclaratorInfo.getDeclSpec().getFriendSpecLoc());
@@ -4272,12 +4283,33 @@ void Parser::ParseContractSpecifiers(Declarator &D) {
 
     // FIXME: We should accept attribute for the result binding, e.g.,
     // post(r [[attr]] : expr).
+    IdentifierInfo *ResultName = nullptr;
+    SourceLocation ResultNameLoc;
     std::optional<ParseScope> ResultNameScope;
     if (IsPost && Tok.is(tok::identifier) && NextToken().is(tok::colon)) {
-      IdentifierInfo *ResultName = Tok.getIdentifierInfo();
-      SourceLocation ResultNameLoc = ConsumeToken();
+      ResultName = Tok.getIdentifierInfo();
+      ResultNameLoc = ConsumeToken();
       ConsumeToken();
+    }
 
+    // A function contract specifier in a member-specification is a
+    // complete-class context. Cache its predicate so that name lookup and
+    // semantic analysis happen after the enclosing class is complete.
+    if (D.getContext() == DeclaratorContext::Member) {
+      auto PredicateTokens = std::make_unique<CachedTokens>();
+      ConsumeAndStoreUntil(tok::r_paren, *PredicateTokens,
+                           /*StopAtSemi=*/false,
+                           /*ConsumeFinalToken=*/false);
+      if (PredicateTokens->empty())
+        Diag(Tok, diag::err_expected_expression);
+      T.consumeClose();
+
+      D.addLateParsedContractSpecifier(
+          {IsPost, ResultName, ResultNameLoc, std::move(PredicateTokens)});
+      continue;
+    }
+
+    if (ResultName) {
       ResultNameScope.emplace(this, Scope::DeclScope);
       Actions.ActOnPostConditionResultName(getCurScope(), ResultName,
                                            ResultNameLoc);

--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -2593,9 +2593,6 @@ bool Parser::ParseCXXMemberDeclaratorBeforeInitializer(
     if (BitfieldSize.isInvalid())
       SkipUntil(tok::comma, StopAtSemi | StopBeforeMatch);
   } else {
-    // Requires clause can't follow 'override' but contracts can follow
-    // 'override'. Even if we don't support virtual functions with contractcs,
-    // we should diagnose at the sema stage instead of the parser stage.
     if (Tok.isNot(tok::kw_requires)) {
       ParseOptionalCXX11VirtSpecifierSeq(
           VS, getCurrentClass().IsInterface,

--- a/clang/lib/Parse/ParseExprCXX.cpp
+++ b/clang/lib/Parse/ParseExprCXX.cpp
@@ -1449,7 +1449,8 @@ ExprResult Parser::ParseLambdaExpressionAfterIntroducer(
 
     if ((HasParentheses && Tok.is(tok::kw_requires)) ||
         getContractSpecifierKind())
-      ParseFunctionDeclaratorTail(D, /*ParametersAlreadyInScope=*/true);
+      ParseFunctionContractSpecifiersAndConstraints(
+          D, /*ParametersAlreadyInScope=*/true);
   }
 
   // Emit a warning if we see a CUDA host/device/global attribute

--- a/clang/lib/Parse/ParseExprCXX.cpp
+++ b/clang/lib/Parse/ParseExprCXX.cpp
@@ -1349,6 +1349,7 @@ ExprResult Parser::ParseLambdaExpressionAfterIntroducer(
                   tok::kw___private, tok::kw___global, tok::kw___local,
                   tok::kw___constant, tok::kw___generic, tok::kw_groupshared,
                   tok::kw_requires, tok::kw_noexcept) ||
+      getContractSpecifierKind().has_value() ||
       Tok.isRegularKeywordAttribute() ||
       (Tok.is(tok::l_square) && NextToken().is(tok::l_square));
 
@@ -1446,8 +1447,9 @@ ExprResult Parser::ParseLambdaExpressionAfterIntroducer(
                       TrailingReturnType, TrailingReturnTypeLoc, &DS),
                   std::move(Attributes), DeclEndLoc);
 
-    if (HasParentheses && Tok.is(tok::kw_requires))
-      ParseTrailingRequiresClause(D);
+    if ((HasParentheses && Tok.is(tok::kw_requires)) ||
+        getContractSpecifierKind())
+      ParseFunctionDeclaratorTail(D, /*ParametersAlreadyInScope=*/true);
   }
 
   // Emit a warning if we see a CUDA host/device/global attribute

--- a/clang/lib/Parse/ParseStmt.cpp
+++ b/clang/lib/Parse/ParseStmt.cpp
@@ -158,6 +158,11 @@ Retry:
         getCurScope(), SemaCodeCompletion::PCC_Statement);
     return StmtError();
 
+  case tok::kw_contract_assert:
+    Res = ParseContractAssertStatement();
+    SemiError = "contract_assert";
+    break;
+
   case tok::identifier:
   ParseIdentifier: {
     Token Next = NextToken();
@@ -2460,6 +2465,33 @@ StmtResult Parser::ParseContinueStatement() {
 
 StmtResult Parser::ParseBreakStatement() {
   return ParseBreakOrContinueStatement(/*IsContinue=*/false);
+}
+
+StmtResult Parser::ParseContractAssertStatement() {
+  assert(Tok.is(tok::kw_contract_assert) && "expected contract_assert");
+  SourceLocation ContractAssertLoc = ConsumeToken();
+
+  ParsedAttributes Attrs(AttrFactory);
+  MaybeParseCXX11Attributes(Attrs);
+
+  BalancedDelimiterTracker T(*this, tok::l_paren);
+  if (T.expectAndConsume(diag::err_expected_lparen_after, "contract_assert")) {
+    SkipUntil(tok::semi, StopBeforeMatch);
+    return Actions.ActOnNullStmt(ContractAssertLoc,
+                                 /*HasLeadingEmptyMacro=*/false);
+  }
+
+  EnterExpressionEvaluationContext Evaluated(
+      Actions, Sema::ExpressionEvaluationContext::PotentiallyEvaluated);
+  ExprResult Predicate = ParseConditionalExpression();
+  if (Predicate.isInvalid())
+    T.skipToEnd();
+  else
+    T.consumeClose();
+
+  // TODO: Now we don't build AST node for contracts.
+  return Actions.ActOnNullStmt(ContractAssertLoc,
+                               /*HasLeadingEmptyMacro=*/false);
 }
 
 StmtResult Parser::ParseReturnStatement() {

--- a/clang/lib/Parse/ParseStmt.cpp
+++ b/clang/lib/Parse/ParseStmt.cpp
@@ -2469,6 +2469,8 @@ StmtResult Parser::ParseBreakStatement() {
 
 StmtResult Parser::ParseContractAssertStatement() {
   assert(Tok.is(tok::kw_contract_assert) && "expected contract_assert");
+  if (!getLangOpts().Contracts)
+    Diag(Tok, diag::err_contracts_disabled);
   SourceLocation ContractAssertLoc = ConsumeToken();
 
   ParsedAttributes Attrs(AttrFactory);

--- a/clang/lib/Parse/ParseStmt.cpp
+++ b/clang/lib/Parse/ParseStmt.cpp
@@ -2469,7 +2469,9 @@ StmtResult Parser::ParseBreakStatement() {
 
 StmtResult Parser::ParseContractAssertStatement() {
   assert(Tok.is(tok::kw_contract_assert) && "expected contract_assert");
-  if (!getLangOpts().Contracts)
+  if (!getLangOpts().CPlusPlus26)
+    Diag(Tok, diag::err_contracts_require_cxx26);
+  else if (!getLangOpts().Contracts)
     Diag(Tok, diag::err_contracts_disabled);
   SourceLocation ContractAssertLoc = ConsumeToken();
 

--- a/clang/lib/Parse/Parser.cpp
+++ b/clang/lib/Parse/Parser.cpp
@@ -521,6 +521,8 @@ void Parser::Initialize() {
   Ident_sealed = nullptr;
   Ident_abstract = nullptr;
   Ident_override = nullptr;
+  Ident_pre = nullptr;
+  Ident_post = nullptr;
   Ident_GNU_final = nullptr;
 
   Ident_super = &PP.getIdentifierTable().get("super");

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -4206,7 +4206,8 @@ void Sema::ActOnStartCXXInClassMemberInitializer() {
   PushFunctionScope();
 }
 
-void Sema::ActOnStartTrailingRequiresClause(Scope *S, Declarator &D) {
+void Sema::ActOnStartTrailingRequiresClauseOrContractSpecifier(Scope *S,
+                                                               Declarator &D) {
   if (!D.isFunctionDeclarator())
     return;
   auto &FTI = D.getFunctionTypeInfo();

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -4220,6 +4220,21 @@ void Sema::ActOnStartTrailingRequiresClause(Scope *S, Declarator &D) {
   }
 }
 
+VarDecl *Sema::ActOnPostConditionResultName(Scope *S,
+                                            IdentifierInfo *ResultName,
+                                            SourceLocation ResultNameLoc) {
+  // FIXME: We use a dependent type here to allow parsing the result name
+  // binding in post contracts. We should use the real result type when the
+  // support gets better Keeping this declaration out of the DeclContext makes
+  // it a predicate-local lookup aid rather than a program declaration.
+  VarDecl *ResultVar = VarDecl::Create(
+      Context, Context.getTranslationUnitDecl(), ResultNameLoc, ResultNameLoc,
+      ResultName, Context.DependentTy, /*TInfo=*/nullptr, SC_None);
+  ResultVar->setImplicit();
+  PushOnScopeChains(ResultVar, S, /*AddToContext=*/false);
+  return ResultVar;
+}
+
 ExprResult Sema::ActOnFinishTrailingRequiresClause(ExprResult ConstraintExpr) {
   return ActOnRequiresClause(ConstraintExpr);
 }

--- a/clang/test/CXX/class.derived/class.virtual/p6.cpp
+++ b/clang/test/CXX/class.derived/class.virtual/p6.cpp
@@ -11,7 +11,9 @@ class A {
 template<typename T>
 class B : A<T> {
   virtual void f1() requires (sizeof(T) == 0) override {}
-  // expected-error@-1{{virtual function cannot have a requires clause}}
+  virtual void f2() override requires (sizeof(T) == 0) {}
+  // expected-error@-2{{virtual function cannot have a requires clause}}
+  // expected-error@-2{{virtual function cannot have a requires clause}}
 };
 
 template<typename T> struct C : T {void f() requires true; };

--- a/clang/test/Lexer/keywords_test.cpp
+++ b/clang/test/Lexer/keywords_test.cpp
@@ -1,6 +1,7 @@
 // RUN: %clang_cc1 -std=c++03 -fsyntax-only %s
 // RUN: %clang_cc1 -std=c++11 -DCXX11 -fsyntax-only %s
 // RUN: %clang_cc1 -std=c++20 -DCXX11 -DCXX20 -fsyntax-only %s
+// RUN: %clang_cc1 -std=c++26 -DCXX11 -DCXX20 -DCXX26 -fsyntax-only %s
 // RUN: %clang_cc1 -std=c++03 -fdeclspec -DDECLSPEC -fsyntax-only %s
 // RUN: %clang_cc1 -std=c++03 -fms-extensions -DDECLSPEC -fsyntax-only %s
 // RUN: %clang_cc1 -std=c++03 -fborland-extensions -DDECLSPEC -fsyntax-only %s
@@ -15,7 +16,7 @@
 // RUN: %clang -std=c++03 -target i686-windows-msvc -DMS -fno-declspec -fsyntax-only %s
 // RUN: %clang -std=c++03 -target x86_64-scei-ps4 -fno-declspec -fsyntax-only %s
 
-// RUN: %clang_cc1 -std=c++98 -DFutureKeyword -fsyntax-only -Wc++11-compat -Wc++20-compat -verify=cxx98 %s
+// RUN: %clang_cc1 -std=c++98 -DFutureKeyword -fsyntax-only -Wc++11-compat -Wc++20-compat -Wc++2c-compat -verify=cxx98 %s
 
 #define IS_KEYWORD(NAME) _Static_assert(!__is_identifier(NAME), #NAME)
 #define NOT_KEYWORD(NAME) _Static_assert(__is_identifier(NAME), #NAME)
@@ -25,6 +26,12 @@
 #define CXX20_KEYWORD(NAME)  IS_KEYWORD(NAME)
 #else
 #define CXX20_KEYWORD(NAME)  NOT_KEYWORD(NAME)
+#endif
+
+#if defined(CXX26)
+#define CXX26_KEYWORD(NAME)  IS_KEYWORD(NAME)
+#else
+#define CXX26_KEYWORD(NAME)  NOT_KEYWORD(NAME)
 #endif
 
 #ifdef DECLSPEC
@@ -71,6 +78,9 @@ CXX20_KEYWORD(co_await);
 CXX20_KEYWORD(co_return);
 CXX20_KEYWORD(co_yield);
 
+// C++26 keywords
+CXX26_KEYWORD(contract_assert);
+
 // __declspec extension
 DECLSPEC_KEYWORD(__declspec);
 
@@ -100,5 +110,6 @@ int constinit; // cxx98-warning {{'constinit' is a keyword in C++20}}
 int consteval; // cxx98-warning {{'consteval' is a keyword in C++20}}
 int requires; // cxx98-warning {{'requires' is a keyword in C++20}}
 int concept; // cxx98-warning {{'concept' is a keyword in C++20}}
+int contract_assert; // cxx98-warning {{'contract_assert' is a keyword in C++26}}
 
 #endif

--- a/clang/test/Parser/cxx26-contracts-declarators.cpp
+++ b/clang/test/Parser/cxx26-contracts-declarators.cpp
@@ -1,0 +1,77 @@
+// RUN: %clang_cc1 -std=c++2c -fcontracts -fsyntax-only -verify %s
+
+// This file exercises the declaration paths which can lead to a function
+// contract specifier. Contract predicates are parsed but not retained yet.
+
+template <typename>
+concept Always = true;
+
+int declaration(int value) pre(value > 0) post(result: value >= 0);
+
+int definition(int value) pre(value > 0) post(result: value >= 0) {
+  return value;
+}
+
+auto trailing_return(int value) -> int pre(value > 0) post(value >= 0) {
+  return value;
+}
+
+decltype(auto) reference_return(int &value) pre(value > 0) post(value > 0) {
+  return (value);
+}
+
+int with_defaults(int value = 1) noexcept pre(value > 0) {
+  return value;
+}
+
+template <typename T>
+auto constrained(T value) -> T requires Always<T> pre(value > T{}) {
+  return value;
+}
+
+int first(int value) pre(value > 0),
+    second(int value) post(result: value > 0);
+
+struct Widget {
+  int value;
+
+  Widget(int input) pre(input > 0);
+  ~Widget() pre(true);
+
+  static int static_member(int input) noexcept pre(input > 0) {
+    return input;
+  }
+
+  friend int inspect(const Widget &, int input) pre(input > 0);
+
+  explicit operator bool() const pre(this->value >= 0);
+  int operator()(int input) const & noexcept pre(input > 0) post(input >= 0);
+
+  virtual int pure(int input) const pre(input > 0) = 0;
+
+  template <typename T>
+  T member_template(T input) requires Always<T> pre(input > T{}) {
+    return input;
+  }
+};
+
+Widget::Widget(int input) pre(input > 0) : value(input) {}
+Widget::~Widget() pre(true) {}
+
+namespace API {
+struct Service {
+  int limit;
+  int call(int input) const;
+};
+} // namespace API
+
+int API::Service::call(int input) const
+    pre(this->limit >= 0 && input > 0) post(input > 0) {
+  return input;
+}
+
+int object pre(true); // expected-error {{contract specifiers can only be applied to function declarations}}
+int (*function_pointer)(int) pre(true); // expected-error {{contract specifiers can only be applied to function declarations}}
+extern int (&function_reference)(int) pre(true); // expected-error {{contract specifiers can only be applied to function declarations}}
+
+typedef int FunctionTypedef(int) pre(true); // expected-error {{contract specifiers can only be applied to function declarations}}

--- a/clang/test/Parser/cxx26-contracts-declarators.cpp
+++ b/clang/test/Parser/cxx26-contracts-declarators.cpp
@@ -55,6 +55,42 @@ struct Widget {
   }
 };
 
+struct CompleteClassContext {
+  bool check() pre(sizeof(CompleteClassContext) > 0);
+  bool check_later_member() pre(sizeof(LaterMember) > 0);
+  bool check_later_data() const pre(this->value > 0);
+  int result() post(value: value >= 0);
+
+  struct LaterMember {};
+  int value;
+};
+
+struct ExplicitObjectMemberFunctions {
+  int value;
+
+  bool valid(this ExplicitObjectMemberFunctions &self)
+      pre(self.value > 0);
+  // expected-error@+2 {{invalid use of 'this' in a function with an explicit object parameter}}
+  bool invalid(this ExplicitObjectMemberFunctions &self)
+      pre(this->value > 0);
+};
+
+struct OuterCompleteClassContext {
+  struct Inner {
+    bool check() pre(sizeof(OuterCompleteClassContext) > 0 &&
+                     sizeof(Inner) > 0);
+  };
+};
+
+struct Base {
+  virtual void overridden();
+};
+
+struct Derived : Base {
+  // expected-error@+1 {{virtual specifier 'override' must appear before contract specifiers}}
+  void overridden() pre(true) override;
+};
+
 Widget::Widget(int input) pre(input > 0) : value(input) {}
 Widget::~Widget() pre(true) {}
 

--- a/clang/test/Parser/cxx26-contracts-declarators.cpp
+++ b/clang/test/Parser/cxx26-contracts-declarators.cpp
@@ -75,3 +75,8 @@ int (*function_pointer)(int) pre(true); // expected-error {{contract specifiers 
 extern int (&function_reference)(int) pre(true); // expected-error {{contract specifiers can only be applied to function declarations}}
 
 typedef int FunctionTypedef(int) pre(true); // expected-error {{contract specifiers can only be applied to function declarations}}
+
+void foo(int bar() pre(true)) {} // expected-error {{contract specifiers can only be applied to function declarations}}
+
+using ftype = void();
+ftype foo pre(true);

--- a/clang/test/Parser/cxx26-contracts-keyword.cpp
+++ b/clang/test/Parser/cxx26-contracts-keyword.cpp
@@ -1,15 +1,21 @@
-// RUN: %clang_cc1 -std=c++2c -fcontracts -DENABLED=1 -fsyntax-only -verify=enabled %s
-// RUN: %clang_cc1 -std=c++2c -fno-contracts -DENABLED=0 -fsyntax-only -verify=disabled %s
-
-// disabled-no-diagnostics
+// RUN: %clang_cc1 -std=c++2c -fcontracts -DCXX26 -fsyntax-only -verify=enabled,expected %s
+// RUN: %clang_cc1 -std=c++2c -fno-contracts -DCXX26 -fsyntax-only -verify=disabled,expected %s
+// RUN: %clang_cc1 -std=c++23 -fcontracts -fsyntax-only -verify=precxx26,expected %s
 
 #ifdef __cplusplus
+#ifdef CXX26
 void test() {
-#if ENABLED
-  int contract_assert; // enabled-error {{expected unqualified-id}}
-#else
-  int contract_assert;
-  ++contract_assert;
-#endif
+  int contract_assert; // expected-error {{expected unqualified-id}}
 }
+
+void assertion() {
+  contract_assert(true); // disabled-error {{contracts support is disabled; pass '-fcontracts' to enable it}}
+}
+
+int specifier(int value) pre(value > 0);
+// disabled-error@-1 {{contracts support is disabled; pass '-fcontracts' to enable it}}
+#else
+int old_standard(int value) pre(value > 0);
+// precxx26-error@-1 {{contracts are a C++26 feature}}
+#endif
 #endif

--- a/clang/test/Parser/cxx26-contracts-keyword.cpp
+++ b/clang/test/Parser/cxx26-contracts-keyword.cpp
@@ -1,0 +1,15 @@
+// RUN: %clang_cc1 -std=c++2c -fcontracts -DENABLED=1 -fsyntax-only -verify=enabled %s
+// RUN: %clang_cc1 -std=c++2c -fno-contracts -DENABLED=0 -fsyntax-only -verify=disabled %s
+
+// disabled-no-diagnostics
+
+#ifdef __cplusplus
+void test() {
+#if ENABLED
+  int contract_assert; // enabled-error {{expected unqualified-id}}
+#else
+  int contract_assert;
+  ++contract_assert;
+#endif
+}
+#endif

--- a/clang/test/Parser/cxx26-contracts-lambda.cpp
+++ b/clang/test/Parser/cxx26-contracts-lambda.cpp
@@ -1,0 +1,57 @@
+// RUN: %clang_cc1 -std=c++2c -fcontracts -fsyntax-only -verify %s
+
+template <typename>
+concept LambdaConstraint = true;
+
+void lambda_contracts() {
+  auto no_parentheses = [] pre(true) { return 0; };
+  auto explicit_return = [](int value) -> int
+      pre(value > 0) post(result: result >= value) { return value; };
+  auto qualified = [](int value) mutable noexcept -> int
+      pre(value > 0) post(value >= 0) { return value; };
+  auto constexpr_lambda = [](int value) constexpr pre(value > 0) {
+    return value;
+  };
+  auto static_lambda = [](int value) static noexcept pre(value > 0) {
+    return value;
+  };
+  auto with_default = [](int value = 1) pre(value > 0) { return value; };
+
+  auto generic = []<typename T>(T value) pre(value > T{}) { return value; };
+  auto constrained = []<typename T>(T value)
+      requires LambdaConstraint<T>
+      pre(value > T{}) post(value >= T{}) { return value; };
+  auto doubly_constrained = []<typename T>
+      requires LambdaConstraint<T>
+      (T value) -> T requires LambdaConstraint<T>
+      pre(value > T{}) post(value >= T{}) { return value; };
+  auto non_type_parameter = []<int N>() pre(N > 0) { return N; };
+  auto parameter_pack = []<typename... T>(T... values)
+      pre(sizeof...(values) > 0) { return sizeof...(values); };
+
+  auto nested = [](int outer) pre(outer > 0) {
+    return [outer](int inner) pre(inner > outer) { return inner; };
+  };
+
+  (void)no_parentheses;
+  (void)explicit_return;
+  (void)qualified;
+  (void)constexpr_lambda;
+  (void)static_lambda;
+  (void)with_default;
+  (void)generic;
+  (void)constrained;
+  (void)doubly_constrained;
+  (void)non_type_parameter;
+  (void)parameter_pack;
+  (void)nested;
+}
+
+void lambda_order_recovery() {
+  auto wrong_order = []<typename T>(T value)
+      pre(value > T{}) requires LambdaConstraint<T> {
+    // expected-error@-1 {{trailing requires clause must appear before contract specifiers}}
+    return value;
+  };
+  (void)wrong_order;
+}

--- a/clang/test/Parser/cxx26-contracts-language.c
+++ b/clang/test/Parser/cxx26-contracts-language.c
@@ -1,0 +1,16 @@
+// RUN: %clang_cc1 -std=c17 -fcontracts -fsyntax-only -verify %s
+
+// Contracts are a C++ feature. Enabling the parser option in C mode must not
+// turn its spellings into keywords or contextual keywords.
+
+// expected-no-diagnostics
+
+int contract_assert;
+int pre;
+int post;
+
+void use_contract_spellings(void) {
+  ++contract_assert;
+  ++pre;
+  ++post;
+}

--- a/clang/test/Parser/cxx26-contracts-parser.cpp
+++ b/clang/test/Parser/cxx26-contracts-parser.cpp
@@ -1,0 +1,59 @@
+// RUN: %clang_cc1 -std=c++2c -fcontracts -fsyntax-only -verify %s
+
+// This test intentionally exercises parser-only support. Contract predicates
+// are parsed as ordinary expressions, but are not retained in the AST yet.
+
+int pre = 42;
+int post(int value) { return value; }
+
+int divide(int a, int b) pre(b != 0);
+int square(int x) post(result: result >= x);
+int clamp(int x) pre(x >= 0) pre(x <= 100)
+    post(result: x >= 0) post(other_result: x <= 100);
+
+struct OuterResult {};
+OuterResult shadowed_result;
+int result_shadowing(int x)
+    post(shadowed_result: shadowed_result >= x);
+
+template <typename T>
+concept C = true;
+
+template <typename T>
+int constrained(T value) requires C<T> pre(value > T{});
+
+struct S {
+  int member(int value) pre(value > 0) post(result: result > value);
+  virtual int virtual_member(int value) const final pre(value > 0);
+};
+
+int S::member(int value) pre(value > 0) post(result: result > value) {
+  contract_assert(value > 0);
+  contract_assert [[maybe_unused]] (value < 100);
+  return value;
+}
+
+void lambdas() {
+  auto a = [](int value) pre(value > 0) { return value; };
+  auto b = [] pre(true) { return 0; };
+  (void)a;
+  (void)b;
+}
+
+int attributed(int value)
+    pre [[maybe_unused]] (value > 0)
+    post [[maybe_unused]] (result: value > 0);
+
+int not_a_function pre(true); // expected-error {{contract specifiers can only be applied to function declarations}}
+
+template <typename T>
+int wrong_order(T value) pre(value > T{}) requires C<T>;
+// expected-error@-1 {{trailing requires clause must appear before contract specifiers}}
+
+void missing_assert_lparen() {
+  contract_assert true; // expected-error {{expected '(' after 'contract_assert'}}
+}
+
+int missing_pre_lparen() pre true;
+// expected-error@-1 {{expected '(' after 'pre'}}
+// expected-error@-2 {{expected function body after function declarator}}

--- a/clang/test/Parser/cxx26-contracts-parser.cpp
+++ b/clang/test/Parser/cxx26-contracts-parser.cpp
@@ -24,6 +24,7 @@ int constrained(T value) requires C<T> pre(value > T{});
 
 struct S {
   int member(int value) pre(value > 0) post(result: result > value);
+  int member2(int value) post(result: result > value) pre(value > 0);
   virtual int virtual_member(int value) const final pre(value > 0);
 };
 
@@ -31,6 +32,12 @@ int S::member(int value) pre(value > 0) post(result: result > value) {
   contract_assert(value > 0);
   contract_assert [[maybe_unused]] (value < 100);
   return value;
+}
+
+int test_contextual_keyword() {
+  int pre = 32;
+  int post = 34;
+  return pre + post;
 }
 
 void lambdas() {
@@ -57,3 +64,13 @@ void missing_assert_lparen() {
 int missing_pre_lparen() pre true;
 // expected-error@-1 {{expected '(' after 'pre'}}
 // expected-error@-2 {{expected function body after function declarator}}
+
+class base {
+public:
+  virtual int member(int v) pre(v > 0) post(r: r > 0);
+};
+
+class inherited : public base {
+public:
+  int member(int v) override pre(v > 0) post(r: r > 0);
+};

--- a/clang/test/Parser/cxx26-contracts-parser.cpp
+++ b/clang/test/Parser/cxx26-contracts-parser.cpp
@@ -22,6 +22,9 @@ concept C = true;
 template <typename T>
 int constrained(T value) requires C<T> pre(value > T{});
 
+template <typename T>
+int constrained_invalid(T value) pre(value > T{}) requires C<T>; // expected-error {{trailing requires clause must appear before contract specifiers}}
+
 struct S {
   int member(int value) pre(value > 0) post(result: result > value);
   int member2(int value) post(result: result > value) pre(value > 0);

--- a/clang/test/Parser/cxx26-contracts-recovery.cpp
+++ b/clang/test/Parser/cxx26-contracts-recovery.cpp
@@ -1,0 +1,52 @@
+// RUN: %clang_cc1 -std=c++2c -fcontracts -fsyntax-only -verify %s
+
+template <typename>
+concept Recoverable = true;
+
+int empty_pre(int value) pre(); // expected-error {{expected expression}}
+int after_empty_pre(int value) pre(value > 0);
+
+int empty_post(int value) post(result:); // expected-error {{expected expression}}
+int after_empty_post(int value) post(value > 0);
+
+int missing_pre_close(int value) pre(value > 0; // expected-error {{expected ')'}} expected-note {{to match this '('}}
+int after_missing_pre_close(int value) pre(value > 0);
+
+void assertion_recovery(int value) {
+  contract_assert(); // expected-error {{expected expression}}
+  int after_empty = value;
+
+  contract_assert value > 0; // expected-error {{expected '(' after 'contract_assert'}}
+  int after_missing_open = after_empty;
+
+  contract_assert((value > 0) && ((value + 1) > 1));
+
+  contract_assert(value > 0; // expected-error {{expected ')'}} expected-note {{to match this '('}}
+  int after_missing_close = value;
+  (void)after_missing_close;
+  (void)after_missing_open;
+}
+
+template <typename T>
+int wrong_order_declaration(T value) pre(value > T{}) requires Recoverable<T>;
+// expected-error@-1 {{trailing requires clause must appear before contract specifiers}}
+
+template <typename T>
+int wrong_order_definition(T value) pre(value > T{}) requires Recoverable<T> {
+  // expected-error@-1 {{trailing requires clause must appear before contract specifiers}}
+  return value;
+}
+
+struct RecoveryMember {
+  template <typename T>
+  int wrong_order(T value) pre(value > T{}) requires Recoverable<T>;
+  // expected-error@-1 {{trailing requires clause must appear before contract specifiers}}
+
+  int after_error(int value) pre(value > 0);
+};
+
+int missing_pre_lparen(int value) pre value > 0;
+// expected-error@-1 {{expected '(' after 'pre'}}
+// expected-error@-2 {{expected function body after function declarator}}
+
+int after_missing_pre_lparen(int value) post(value > 0);


### PR DESCRIPTION
(See https://github.com/llvm/llvm-project/pull/205739 for the discussion of last run of contracts support)

---

#### Background

In our downstream (20.x based) I support the contracts and tested them with our internal workloads locally. Now I want to support contracts in the upstream. The rebased version can be found at https://github.com/ChuanqiXu9/llvm-project/tree/contracts_take2

But I do not feel good to send the big patch. From my experience, it is really hard to really review big patches. So I prefer to reimplement it and send the small patches one by one. In the process, we can do fine-grained review. This will be helpful for the implementation quality and the understanding of the patch for the community.

---

#### Roadmap

I plan to support in the following order:

- Parser Part (the current one). In this phase, the contracts can be parsed. The corresponding AST Node for the predicates expression in the contracts will be built but discarded (not stored).
- AST Part. In this phase, we will introduce AST Nodes for the contracts and the related components like serialization, test printer, AST node visitors and so on. It may be split into multiple patches.
- Sema Build Part. Including lookup contracts violation object and contracts violation handler. And from my experience, there will be some issues for result binding / delayed parsing / lambda capture / templates.   It may be split into multiple patches.
- Sema Diagnose Part. Contracts has a lot of checks, e.g., the constness checks, the use of this pointer in constructor and destructors, the check for virtual functions. We'll implement these checks in this phase. It may be split into multiple patches.
- CodeGen Part. In this part, we will generate codes for observe and enforce mode.
- libcxx Part. In this part, contribute the <contracts> header.

BTW, there is a some phase ordering issues that, in the end, the Sema Build Phase needs to depend on the standard library as it needs to lookup the corresponding library component and also AST design should leave space for the corresponding contracts violation object and contracts violation handler. 

And also, there are some problems for AST Part and Sema Build Part as we can't dump the AST Nodes if they are not built. So the AST part will introduce simple process to build the contracts AST Node too.

But I still do such a plan to split them because the patches should be more clear this way. I want to avoid big patches as much as possible.

There are some unimplemented/untouched part:

- Contracts in constexpr/consteval.
- Contracts for virtual functions.
- Contracts in windows.
- Otherstuff...

These are not touched in my implementation. We can implement these later.

---

This patch itself only implements the parser part  almost and a small (non complete) Sema part to handle the result variable in post contracts:

```
int f() post (r: r > 0);
```

we have to build the variable to make it to be accepted.

For flags, non driver flags is introduced yet. For people who want a try, they can use `-Xclang` before CodeGen part is done.

---

AI assisted