### PR TITLE
[ADT] Remove the TempID parameter from FoldingSetTrait::Equals. NFC

### DIFF
--- a/llvm/include/llvm/ADT/FoldingSet.h
+++ b/llvm/include/llvm/ADT/FoldingSet.h
@@ -235,12 +235,11 @@ template <typename T> struct DefaultFoldingSetTrait {
   static void Profile(const T &X, FoldingSetNodeID &ID) { X.Profile(ID); }
   static void Profile(T &X, FoldingSetNodeID &ID) { X.Profile(ID); }
 
-  // Equals - Test if the profile for X would match ID, using TempID
-  // to compute a temporary ID if necessary. The default implementation
-  // just calls Profile and does a regular comparison. Implementations
-  // can override this to provide more efficient implementations.
-  static inline bool Equals(T &X, const FoldingSetNodeID &ID,
-                            FoldingSetNodeID &TempID) {
+  // Test if the profile for X would match ID. Implementations can override this
+  // to compare against X's fields, which avoids building a profile for every
+  // candidate.
+  static bool Equals(T &X, const FoldingSetNodeID &ID) {
+    FoldingSetNodeID TempID;
     FoldingSetTrait<T>::Profile(X, TempID);
     return TempID == ID;
   }
@@ -269,8 +268,8 @@ template <typename T, typename Ctx> struct DefaultContextualFoldingSetTrait {
     X.Profile(ID, Context);
   }
 
-  static inline bool Equals(T &X, const FoldingSetNodeID &ID,
-                            FoldingSetNodeID &TempID, Ctx Context) {
+  static bool Equals(T &X, const FoldingSetNodeID &ID, Ctx Context) {
+    FoldingSetNodeID TempID;
     ContextualFoldingSetTrait<T, Ctx>::Profile(X, TempID, Context);
     return TempID == ID;
   }
@@ -418,14 +417,10 @@ class FoldingSetImpl : public FoldingSetBase, public Trait::ContextStorage {
   }
 
   bool nodeEquals(FoldingSetNode *N, const FoldingSetNodeID &ID) const {
-    // Trait::Equals profiles into TempID without clearing it first, so each
-    // candidate needs its own.
-    FoldingSetNodeID TempID;
     if constexpr (std::is_empty_v<typename Trait::ContextStorage>)
-      return Trait::Equals(*static_cast<T *>(N), ID, TempID);
+      return Trait::Equals(*static_cast<T *>(N), ID);
     else
-      return Trait::Equals(*static_cast<T *>(N), ID, TempID,
-                           this->getContext());
+      return Trait::Equals(*static_cast<T *>(N), ID, this->getContext());
   }
 
 public:

--- a/llvm/include/llvm/Analysis/ScalarEvolution.h
+++ b/llvm/include/llvm/Analysis/ScalarEvolution.h
@@ -347,8 +347,7 @@ public:
 template <> struct FoldingSetTrait<SCEV> : DefaultFoldingSetTrait<SCEV> {
   static void Profile(const SCEV &X, FoldingSetNodeID &ID) { ID = X.FastID; }
 
-  static bool Equals(const SCEV &X, const FoldingSetNodeID &ID,
-                     FoldingSetNodeID &TempID) {
+  static bool Equals(const SCEV &X, const FoldingSetNodeID &ID) {
     return ID == X.FastID;
   }
 };
@@ -426,8 +425,7 @@ struct FoldingSetTrait<SCEVPredicate> : DefaultFoldingSetTrait<SCEVPredicate> {
     ID = X.FastID;
   }
 
-  static bool Equals(const SCEVPredicate &X, const FoldingSetNodeID &ID,
-                     FoldingSetNodeID &TempID) {
+  static bool Equals(const SCEVPredicate &X, const FoldingSetNodeID &ID) {
     return ID == X.FastID;
   }
 };

--- a/llvm/unittests/ADT/FoldingSet.cpp
+++ b/llvm/unittests/ADT/FoldingSet.cpp
@@ -552,6 +552,63 @@ TEST(FoldingSetTest, TokenSurvivesGrowth) {
   EXPECT_EQ(201u, Set.size());
 }
 
+// FoldingSetTrait::Equals compares against the looked-up ID instead
+// of rebuilding the node's profile.
+struct EqNode : FoldingSetNode {
+  unsigned X;
+  explicit EqNode(unsigned X) : X(X) {}
+
+  void Profile(FoldingSetNodeID &ID) const { ID.AddInteger(X); }
+  void Profile(FoldingSetNodeID &ID, TestContext Ctx) const {
+    ID.AddInteger(X ^ Ctx.Value);
+  }
+};
+
+unsigned EqCalls = 0;
+} // namespace
+
+namespace llvm {
+template <> struct FoldingSetTrait<EqNode> : DefaultFoldingSetTrait<EqNode> {
+  static bool Equals(EqNode &N, const FoldingSetNodeID &ID) {
+    ++EqCalls;
+    FoldingSetNodeIDRef Ref = ID.getRef();
+    return Ref.size() == 1 && Ref[0] == N.X;
+  }
+};
+
+template <>
+struct ContextualFoldingSetTrait<EqNode, TestContext>
+    : DefaultContextualFoldingSetTrait<EqNode, TestContext> {
+  static bool Equals(EqNode &N, const FoldingSetNodeID &ID, TestContext Ctx) {
+    ++EqCalls;
+    FoldingSetNodeIDRef Ref = ID.getRef();
+    return Ref.size() == 1 && Ref[0] == (N.X ^ Ctx.Value);
+  }
+};
+} // namespace llvm
+
+namespace {
+
+TEST(FoldingSetTest, TraitEqualsOverride) {
+  FoldingSet<EqNode> Set;
+  EqNode N(1), NCopy(1);
+  Set.getOrInsert(&N);
+
+  EqCalls = 0;
+  EXPECT_EQ(&N, Set.getOrInsert(&NCopy));
+  EXPECT_EQ(1u, EqCalls);
+}
+
+TEST(FoldingSetTest, ContextualTraitEqualsOverride) {
+  ContextualFoldingSet<EqNode, TestContext> Set(TestContext{0xABCD});
+  EqNode N(1), NCopy(1);
+  Set.getOrInsert(&N);
+
+  EqCalls = 0;
+  EXPECT_EQ(&N, Set.getOrInsert(&NCopy));
+  EXPECT_EQ(1u, EqCalls);
+}
+
 // FoldingSetNode is a non-first base, so lookup()'s two-step cast must adjust.
 struct KeyedPair : NonEmptyBase, FoldingSetNode {
   unsigned A, B;


### PR DESCRIPTION
Let the default implementation declare its own local, so an override
that compares against the node's fields need not accept an unused
FoldingSetNodeID.

Aided by Opus 5
