### PR TITLE
[BOLT] Select matching profile from multi-document YAML

### DIFF
--- a/bolt/lib/Profile/YAMLProfileReader.cpp
+++ b/bolt/lib/Profile/YAMLProfileReader.cpp
@@ -374,8 +374,24 @@ Error YAMLProfileReader::preprocessProfile(BinaryContext &BC) {
   yaml::Input YamlInput(MB.get()->getBuffer());
   YamlInput.setAllowUnknownKeys(true);
 
-  // Consume YAML file.
+  const StringRef BinaryName = sys::path::filename(BC.getFilename());
+  auto matchesBinary = [&](const yaml::bolt::BinaryProfile &Profile) {
+    return sys::path::filename(Profile.Header.FileName) == BinaryName;
+  };
   YamlInput >> YamlBP;
+  // For multi-document YAML files, we need to find the document that matches
+  // the binary.
+  if (!matchesBinary(YamlBP)) {
+    while (!YamlInput.error() && YamlInput.nextDocument()) {
+      yaml::bolt::BinaryProfile Profile;
+      YamlInput >> Profile;
+      if (!YamlInput.error() && matchesBinary(Profile)) {
+        YamlBP = std::move(Profile);
+        break;
+      }
+    }
+  }
+
   if (YamlInput.error()) {
     errs() << "BOLT-ERROR: syntax error parsing profile in " << Filename
            << " : " << YamlInput.error().message() << '\n';
@@ -415,7 +431,8 @@ Error YAMLProfileReader::preprocessProfile(BinaryContext &BC) {
 }
 
 bool YAMLProfileReader::profileMatches(
-    const yaml::bolt::BinaryFunctionProfile &Profile, const BinaryFunction &BF) {
+    const yaml::bolt::BinaryFunctionProfile &Profile,
+    const BinaryFunction &BF) {
   if (opts::IgnoreHash)
     return Profile.NumBasicBlocks == BF.size();
   return Profile.Hash == static_cast<uint64_t>(BF.getHash());

--- a/bolt/lib/Profile/YAMLProfileReader.cpp
+++ b/bolt/lib/Profile/YAMLProfileReader.cpp
@@ -378,14 +378,18 @@ Error YAMLProfileReader::preprocessProfile(BinaryContext &BC) {
   auto matchesBinary = [&](const yaml::bolt::BinaryProfile &Profile) {
     return sys::path::filename(Profile.Header.FileName) == BinaryName;
   };
+  // Read the first profile as a default profile even if none matches the
+  // binary.
   YamlInput >> YamlBP;
   // For multi-document YAML files, we need to find the document that matches
   // the binary.
-  if (!matchesBinary(YamlBP)) {
-    while (!YamlInput.error() && YamlInput.nextDocument()) {
+  if (!YamlInput.error() && !matchesBinary(YamlBP)) {
+    while (YamlInput.nextDocument()) {
       yaml::bolt::BinaryProfile Profile;
       YamlInput >> Profile;
-      if (!YamlInput.error() && matchesBinary(Profile)) {
+      if (YamlInput.error())
+        break;
+      if (matchesBinary(Profile)) {
         YamlBP = std::move(Profile);
         break;
       }
@@ -431,7 +435,8 @@ Error YAMLProfileReader::preprocessProfile(BinaryContext &BC) {
 }
 
 bool YAMLProfileReader::profileMatches(
-    const yaml::bolt::BinaryFunctionProfile &Profile, const BinaryFunction &BF) {
+    const yaml::bolt::BinaryFunctionProfile &Profile,
+    const BinaryFunction &BF) {
   if (opts::IgnoreHash)
     return Profile.NumBasicBlocks == BF.size();
   return Profile.Hash == static_cast<uint64_t>(BF.getHash());

--- a/bolt/lib/Profile/YAMLProfileReader.cpp
+++ b/bolt/lib/Profile/YAMLProfileReader.cpp
@@ -431,8 +431,7 @@ Error YAMLProfileReader::preprocessProfile(BinaryContext &BC) {
 }
 
 bool YAMLProfileReader::profileMatches(
-    const yaml::bolt::BinaryFunctionProfile &Profile,
-    const BinaryFunction &BF) {
+    const yaml::bolt::BinaryFunctionProfile &Profile, const BinaryFunction &BF) {
   if (opts::IgnoreHash)
     return Profile.NumBasicBlocks == BF.size();
   return Profile.Hash == static_cast<uint64_t>(BF.getHash());

--- a/bolt/test/X86/yaml-multi-binary-selection.test
+++ b/bolt/test/X86/yaml-multi-binary-selection.test
@@ -1,0 +1,74 @@
+## Test selecting the matching YAML profile from a multi-document input and
+## falling back to the first profile if none matches.
+
+# REQUIRES: system-linux
+# RUN: split-file %s %t
+# RUN: llvm-mc -filetype=obj -triple x86_64-unknown-unknown %t/main.s -o %t.o
+# RUN: %clang %cflags %t.o -o %t.exe -Wl,-q -nostdlib
+# RUN: cp %t.exe %t.so
+# RUN: llvm-bolt %t.so -o %t.so.bolt --data %t/profile.yaml \
+# RUN:   --profile-ignore-hash --print-cfg --print-only=main -v=1 \
+# RUN:   2>&1 | FileCheck %s --check-prefix=MATCH
+# RUN: cp %t.exe %t.nomatch
+# RUN: llvm-bolt %t.nomatch -o %t.nomatch.bolt --data %t/profile.yaml \
+# RUN:   --profile-ignore-hash --print-cfg --print-only=main -v=1 \
+# RUN:   2>&1 | FileCheck %s --check-prefix=FALLBACK
+
+# MATCH: BOLT-INFO: matched 1 functions with identical names
+# MATCH: Binary Function "main" after building cfg {
+# MATCH:   Exec Count  : 111
+# FALLBACK: BOLT-INFO: matched 1 functions with identical names
+# FALLBACK: Binary Function "main" after building cfg {
+# FALLBACK:   Exec Count  : 222
+
+#--- main.s
+  .globl main
+  .type main, %function
+main:
+  .cfi_startproc
+  cmpl $0x0, %eax
+  retq
+  .cfi_endproc
+.size main, .-main
+
+#--- profile.yaml
+---
+header:
+  profile-version: 1
+  binary-name:     'yaml-multi-binary-selection.test.tmp.exe'
+  binary-build-id: '<unknown>'
+  profile-flags:   [ lbr ]
+  profile-origin:  branch profile reader
+  profile-events:  ''
+  dfs-order:       false
+functions:
+  - name:          'main'
+    fid:           1
+    hash:          0x1
+    exec:          222
+    nblocks:       1
+    blocks:
+      - bid:       0
+        insns:     2
+        hash:      0x1
+...
+---
+header:
+  profile-version: 1
+  binary-name:     'yaml-multi-binary-selection.test.tmp.so'
+  binary-build-id: '<unknown>'
+  profile-flags:   [ lbr ]
+  profile-origin:  branch profile reader
+  profile-events:  ''
+  dfs-order:       false
+functions:
+  - name:          'main'
+    fid:           1
+    hash:          0x2
+    exec:          111
+    nblocks:       1
+    blocks:
+      - bid:       0
+        insns:     2
+        hash:      0x2
+...


### PR DESCRIPTION
This change adds support for selecting a binary profile from a multi-document YAML file.

The primary use case is optimizing multiple shared libraries (`.so` files) together with main binary in a single pipeline using a shared YAML profile. This avoids maintaining and distributing a separate profile file for each binary, reducing profile-management overhead in the optimization pipeline.

Single-document YAML profiles continue to work as before, so this change does not affect existing workflows.

such as (**The YAML documents are separated by `....`**)
```
---
header:
  profile-version: 1
  binary-name:     './main_binary'
  binary-build-id: xxxxxx
  profile-flags:   [ lbr ]
  profile-origin:  perf data aggregator
  profile-events:  ''
  dfs-order:       false
  hash-func:       xxh3
functions:  xxxxx
...
---
header:
  profile-version: 1
  binary-name:     './libstdc++.so.6'
  binary-build-id: xxxxxx
  profile-flags:   [ lbr ]
  profile-origin:  perf data aggregator
  profile-events:  ''
  dfs-order:       false
  hash-func:       xxh3
functions:  xxxxx
...
---
header:
  profile-version: 1
  binary-name:     './lib/libc.so.6'
  binary-build-id: xxxxxxxx
  profile-flags:   [ lbr ]
  profile-origin:  perf data aggregator
  profile-events:  ''
  dfs-order:       false
  hash-func:       xxh3
functions:  xxxxx
...
and so on.
```