### PR TITLE
Add REQUIRES: asserts to test cost-partial-red.ll added in #214760 because it uses -debug-only.

### DIFF
--- a/llvm/test/Transforms/LoopVectorize/PowerPC/cost-partial-red.ll
+++ b/llvm/test/Transforms/LoopVectorize/PowerPC/cost-partial-red.ll
@@ -1,3 +1,4 @@
+; REQUIRES: asserts
 ; RUN: opt -vectorizer-maximize-bandwidth -mcpu=pwr8 -S -passes=loop-vectorize -disable-output -debug-only=loop-vectorize < %s 2>&1 | FileCheck --check-prefix=P8COST %s
 ; NOTE: P9 uses 2x 64-bit vector units, P8 and P10 use 1x 128-bit vector unit
 ; RUN: opt -vectorizer-maximize-bandwidth -mcpu=pwr9 -S -passes=loop-vectorize -disable-output -debug-only=loop-vectorize < %s 2>&1 | FileCheck --check-prefix=P9COST %s


### PR DESCRIPTION
The test cost-partial-red.ll was added in #214760 and uses `-debug-only` as a flag in the RUN lines which causes it to fail in non-assert builds since that is only available when the compiler has assertions enabled.

This will fix the bot failure here:
https://lab.llvm.org/buildbot/#/builders/202/builds/2652
```
opt: Unknown command line argument '-debug-only=loop-vectorize'. Try: '/home/buildbot/buildbot-root/gcc-no-asserts/build/bin/opt --help'
```