### PR TITLE
[SelectionDAG] Preserve element width when scalarizing widened extracts

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -25580,17 +25580,28 @@ static SDValue scalarizeExtractedBinOp(SDNode *ExtElt, SelectionDAG &DAG,
   SDValue Index = ExtElt->getOperand(1);
   auto *IndexC = dyn_cast<ConstantSDNode>(Index);
   unsigned Opc = Vec.getOpcode();
-  if (!IndexC || !Vec.hasOneUse() || (!TLI.isBinOp(Opc) && Opc != ISD::SETCC) ||
+  bool IsBinOp = TLI.isBinOp(Opc);
+  if (!IndexC || !Vec.hasOneUse() || (!IsBinOp && Opc != ISD::SETCC) ||
       Vec->getNumValues() != 1)
+    return SDValue();
+
+  EVT ResVT = ExtElt->getValueType(0);
+  EVT EltVT = Vec.getValueType().getVectorElementType();
+
+  if (Opc == ISD::SETCC && (ResVT != EltVT || LegalTypes))
+    return SDValue();
+
+  // If EXTRACT_VECTOR_ELT was promoted, rebuilding the binop in the promoted
+  // type can change operations whose semantics depend on type width. Keep the
+  // scalar binop in the vector element type when it is valid to introduce that
+  // type here.
+  bool UseEltVT = IsBinOp && ResVT != EltVT;
+  if (UseEltVT && (!ResVT.isInteger() || !EltVT.isInteger() ||
+                   (LegalTypes && !TLI.isTypeLegal(EltVT))))
     return SDValue();
 
   // Targets may want to avoid this to prevent an expensive register transfer.
   if (!TLI.shouldScalarizeBinop(Vec))
-    return SDValue();
-
-  EVT ResVT = ExtElt->getValueType(0);
-  if (Opc == ISD::SETCC &&
-      (ResVT != Vec.getValueType().getVectorElementType() || LegalTypes))
     return SDValue();
 
   // Extracting an element of a vector constant is constant-folded, so this
@@ -25629,9 +25640,14 @@ static SDValue scalarizeExtractedBinOp(SDNode *ExtElt, SelectionDAG &DAG,
     }
     return NewVal;
   }
-  Op0 = DAG.getNode(ISD::EXTRACT_VECTOR_ELT, DL, ResVT, Op0, Index);
-  Op1 = DAG.getNode(ISD::EXTRACT_VECTOR_ELT, DL, ResVT, Op1, Index);
-  return DAG.getNode(Opc, DL, ResVT, Op0, Op1);
+
+  EVT ScalarVT = UseEltVT ? EltVT : ResVT;
+  Op0 = DAG.getNode(ISD::EXTRACT_VECTOR_ELT, DL, ScalarVT, Op0, Index);
+  Op1 = DAG.getNode(ISD::EXTRACT_VECTOR_ELT, DL, ScalarVT, Op1, Index);
+  SDValue BinOp = DAG.getNode(Opc, DL, ScalarVT, Op0, Op1);
+  if (ScalarVT == ResVT)
+    return BinOp;
+  return DAG.getAnyExtOrTrunc(BinOp, DL, ResVT);
 }
 
 // Given a ISD::EXTRACT_VECTOR_ELT, which is a glorified bit sequence extract,

--- a/llvm/test/CodeGen/RISCV/rvv/extract-binop-widened.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/extract-binop-widened.ll
@@ -1,0 +1,26 @@
+; RUN: llc -mtriple=riscv64 -mattr=+v < %s | FileCheck %s
+
+define i64 @rotl_extract_widened() {
+; CHECK-LABEL: rotl_extract_widened:
+; CHECK:       lui a0, 15
+; CHECK-NEXT:  addi a0, a0, -106
+; CHECK-NEXT:  ret
+entry:
+  %vec.zero = insertelement <2 x i16> zeroinitializer, i16 0, i32 0
+  %vec.const = xor <2 x i16> %vec.zero, <i16 -7273, i16 -10240>
+  %vec.shifted = call <2 x i16> @llvm.fshl.v2i16(
+      <2 x i16> %vec.const, <2 x i16> %vec.const,
+      <2 x i16> <i16 0, i16 12>)
+
+  %a = extractelement <2 x i16> %vec.shifted, i32 0
+  %az = zext i16 %a to i64
+  %ax = xor i64 %az, 1
+
+  %b = extractelement <2 x i16> %vec.shifted, i32 1
+  %bz = zext i16 %b to i64
+
+  %r = or i64 %ax, %bz
+  ret i64 %r
+}
+
+declare <2 x i16> @llvm.fshl.v2i16(<2 x i16>, <2 x i16>, <2 x i16>)


### PR DESCRIPTION
`scalarizeExtractedBinOp()` may move a vector binop after an
`EXTRACT_VECTOR_ELT`.

After type legalization, an integer `EXTRACT_VECTOR_ELT` may have a result type
wider than the vector element type, with the extra high bits left unspecified.
Rebuilding the scalar binop directly in that promoted result type can therefore
change the semantics of width-sensitive operations. In #221100, a `v2i16`
rotate was effectively rebuilt as an `i64` rotate on RISC-V, causing a
miscompilation.

Preserve the original vector element width when scalarizing widened integer
extracts. The scalar binop is formed at the vector element type and the result
is then any-extended back to the extract result type. If that element type
cannot legally be introduced after type legalization, leave the vector binop in
place.

This keeps the semantic validity check ahead of the target
`shouldScalarizeBinop()` hook and avoids any opcode-specific whitelist.

The RISC-V regression no longer requires `optnone`; it naturally reaches the
post-type-legalization widened-extract SelectionDAG path.

Fixes #221100

Tests:
- `llvm-lit llvm/test/CodeGen/RISCV/rvv/extract-binop-widened.ll`
- `llvm-lit llvm/test/CodeGen/RISCV/rvv/` — 1254/1254 passed
- focused X86 scalarization/rotate tests — passed
- `git diff --check`

AI-assisted development tools were used during this contribution; I personally
modified, reviewed, and validated the final patch.