### PR TITLE
[RISCV] Andes: model fast unaligned accesses for the 45-series

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVProcessors.td
+++ b/llvm/lib/Target/RISCV/RISCVProcessors.td
@@ -1017,7 +1017,8 @@ def ANDES_N45 : RISCVProcessorModel<"andes-n45",
                                      FeatureStdExtF,
                                      FeatureStdExtD,
                                      FeatureStdExtC,
-                                     FeatureVendorXAndesPerf],
+                                     FeatureVendorXAndesPerf,
+                                     FeatureUnalignedScalarMem],
                                     Andes45TuneFeatures>;
 
 def ANDES_NX45 : RISCVProcessorModel<"andes-nx45",
@@ -1031,7 +1032,8 @@ def ANDES_NX45 : RISCVProcessorModel<"andes-nx45",
                                       FeatureStdExtF,
                                       FeatureStdExtD,
                                       FeatureStdExtC,
-                                      FeatureVendorXAndesPerf],
+                                      FeatureVendorXAndesPerf,
+                                      FeatureUnalignedScalarMem],
                                      Andes45TuneFeatures>;
 
 def ANDES_A45 : RISCVProcessorModel<"andes-a45",
@@ -1045,7 +1047,8 @@ def ANDES_A45 : RISCVProcessorModel<"andes-a45",
                                      FeatureStdExtF,
                                      FeatureStdExtD,
                                      FeatureStdExtC,
-                                     FeatureVendorXAndesPerf],
+                                     FeatureVendorXAndesPerf,
+                                     FeatureUnalignedScalarMem],
                                     Andes45TuneFeatures>;
 
 def ANDES_AX45 : RISCVProcessorModel<"andes-ax45",
@@ -1059,7 +1062,8 @@ def ANDES_AX45 : RISCVProcessorModel<"andes-ax45",
                                       FeatureStdExtF,
                                       FeatureStdExtD,
                                       FeatureStdExtC,
-                                      FeatureVendorXAndesPerf],
+                                      FeatureVendorXAndesPerf,
+                                      FeatureUnalignedScalarMem],
                                      Andes45TuneFeatures>;
 
 def ANDES_AX45MPV : RISCVProcessorModel<"andes-ax45mpv",
@@ -1074,7 +1078,8 @@ def ANDES_AX45MPV : RISCVProcessorModel<"andes-ax45mpv",
                                          FeatureStdExtD,
                                          FeatureStdExtC,
                                          FeatureStdExtV,
-                                         FeatureVendorXAndesPerf],
+                                         FeatureVendorXAndesPerf,
+                                         FeatureUnalignedScalarMem],
                                         Andes45TuneFeatures>;
 
 def ESPERANTO_SOC1 : RISCVProcessorModel<"et-soc1",

--- a/llvm/test/CodeGen/RISCV/memcpy.ll
+++ b/llvm/test/CodeGen/RISCV/memcpy.ll
@@ -5,7 +5,11 @@
 ; RUN:   | FileCheck %s --check-prefixes=RV64-BOTH,RV64
 ; RUN: llc < %s -mtriple=riscv32 -mattr=+unaligned-scalar-mem \
 ; RUN:   | FileCheck %s --check-prefixes=RV32-BOTH,RV32-FAST
+; RUN: llc < %s -mtriple=riscv32 -mcpu=andes-a45 -mtune=rocket \
+; RUN:   | FileCheck %s --check-prefixes=RV32-BOTH,RV32-FAST
 ; RUN: llc < %s -mtriple=riscv64 -mattr=+unaligned-scalar-mem \
+; RUN:   | FileCheck %s --check-prefixes=RV64-BOTH,RV64-FAST
+; RUN: llc < %s -mtriple=riscv64 -mcpu=andes-ax45 -mtune=rocket \
 ; RUN:   | FileCheck %s --check-prefixes=RV64-BOTH,RV64-FAST
 
 ; ----------------------------------------------------------------------


### PR DESCRIPTION
The 45-series cores support unaligned scalar accesses. Add
FeatureUnalignedScalarMem to each 45-series processor (andes-n45,
andes-nx45, andes-a45, andes-ax45 and andes-ax45mpv), so that it is
selected by -mcpu rather than -mtune. Other processors declare it this
way too. The feature is somewhat architectural: -mtune is only supposed
to affect performance, but reaching it through tune features lets -mtune
introduce unaligned accesses that crash on a CPU which does not support
them.

Cover this in memcpy.ll using -mcpu=andes-a45/-mcpu=andes-ax45. The new
RUN lines pass -mtune=rocket so that the 45-series scheduling model does
not reorder the output, letting them reuse the existing check lines.