### PR TITLE
[flang-rt] Guard CUDA descriptor fast path by element size

### DIFF
--- a/flang-rt/lib/cuda/memory.cpp
+++ b/flang-rt/lib/cuda/memory.cpp
@@ -262,7 +262,8 @@ void RTDECL(CUFDataTransferDescDesc)(Descriptor *dstDesc, Descriptor *srcDesc,
     dstDesc->Allocate(/*asyncObject=*/nullptr);
   }
   if ((srcDesc->rank() > 0) && (dstDesc->Elements() <= srcDesc->Elements()) &&
-      srcDesc->IsContiguous() && dstDesc->IsContiguous()) {
+      srcDesc->IsContiguous() && dstDesc->IsContiguous() &&
+      dstDesc->ElementBytes() == srcDesc->ElementBytes()) {
     // Special case when rhs is bigger than lhs and both are contiguous arrays.
     // In this case we do a simple ptr to ptr transfer with the size of lhs.
     // This is be allowed in the reference compiler and it avoids error


### PR DESCRIPTION
the contiguous-array fast path in CUFDataTransferDescDesc performs a raw pointer-to-pointer copy without checking that the source and destination descriptors have the same element size. When the element sizes differ (e.g. assigning REAL(4) to REAL(8)), this can read past the end of the source allocation and bypasses Fortran type conversion.

add an ElementBytes() equality check so the fast path is only taken when the copy is truly a like-for-like raw byte transfer, falling back to the general Assign() path otherwise.