### PR TITLE
[flang] Fix crash with legacy DATA initializer for an invalid declaration

### DIFF
--- a/flang/lib/Semantics/check-data.cpp
+++ b/flang/lib/Semantics/check-data.cpp
@@ -265,7 +265,7 @@ void DataChecker::Leave(const parser::EntityDecl &decl) {
     const auto *list{
         std::get_if<std::list<common::Indirection<parser::DataStmtValue>>>(
             &init->u)};
-    if (name && list) {
+    if (name && list && !exprAnalyzer_.context().HasError(*name)) {
       AccumulateDataInitializations(inits_, exprAnalyzer_, *name, *list);
     }
   }

--- a/flang/test/Semantics/data27.f90
+++ b/flang/test/Semantics/data27.f90
@@ -1,0 +1,7 @@
+! RUN: %python %S/test_errors.py %s %flang_fc1
+program main
+  type foo
+  end type foo
+  !ERROR: 'foo' is already declared in this scoping unit
+  integer foo(1) /2/
+end program main


### PR DESCRIPTION
For legacy DATA /initialization/, declarations weren't checked for errors before construction, resulting in an assert crash. This PR fixes this by adding a check.

Fixes #220846