### PR TITLE
[lldb][Windows] Fix unused function GetModulePath warning with certain Python options

### DIFF
--- a/lldb/source/Host/windows/PythonRuntimeLoaderWindows.cpp
+++ b/lldb/source/Host/windows/PythonRuntimeLoaderWindows.cpp
@@ -28,6 +28,8 @@ namespace lldb_private {
 
 namespace {
 
+#ifdef LLDB_PYTHON_DLL_RELATIVE_PATH
+#ifdef LLDB_PYTHON_RUNTIME_LIBRARY_FILENAME
 /// Absolute path of \p module, or the running executable when null.
 std::string GetModulePath(HMODULE module) {
   std::vector<WCHAR> buffer(MAX_PATH);
@@ -46,8 +48,8 @@ std::string GetModulePath(HMODULE module) {
   }
   return "";
 }
+#endif // ifdef LLDB_PYTHON_RUNTIME_LIBRARY_FILENAME
 
-#ifdef LLDB_PYTHON_DLL_RELATIVE_PATH
 std::string ExeRelativeCandidate() {
 #ifdef LLDB_PYTHON_RUNTIME_LIBRARY_FILENAME
   std::string exe = GetModulePath(nullptr);
@@ -61,9 +63,9 @@ std::string ExeRelativeCandidate() {
   return std::string(path);
 #else
   return "";
-#endif
+#endif // ifdef LLDB_PYTHON_RUNTIME_LIBRARY_FILENAME
 }
-#endif
+#endif // ifdef LLDB_PYTHON_DLL_RELATIVE_PATH
 
 } // namespace
 


### PR DESCRIPTION
If LLDB_PYTHON_DLL_RELATIVE_PATH is OFF, or it is ON and LLDB_PYTHON_RUNTIME_LIBRARY_FILENAME is OFF, then GetModulePath is unused.
```
<...>/lldb/source/Host/windows/PythonRuntimeLoaderWindows.cpp(32,13): warning: unused function 'GetModulePath' [-Wunused-function]
   32 | std::string GetModulePath(HMODULE module) {
      |             ^~~~~~~~~~~~~
```

Rearrange the macros to define GetModulePath only if both options are enabled.