### PR TITLE
[lldb][Windows] Silence unused variable warning on Windows on Arm

### DIFF
--- a/lldb/source/Plugins/Process/Windows/Common/NativeProcessWindows.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/NativeProcessWindows.cpp
@@ -504,9 +504,9 @@ void NativeProcessWindows::OnDebuggerConnected(lldb::addr_t image_base) {
 
 ExceptionResult
 NativeProcessWindows::HandleSingleStepException(const ExceptionRecord &record) {
-  Log *log = GetLog(WindowsLog::Exception);
   uint32_t wp_id = LLDB_INVALID_INDEX32;
 #ifndef __aarch64__
+  Log *log = GetLog(WindowsLog::Exception);
   if (NativeThreadWindows *thread = GetThreadByID(record.GetThreadID())) {
     NativeRegisterContextWindows &reg_ctx = thread->GetRegisterContext();
     Status error =


### PR DESCRIPTION
<...>/llvm-project/lldb/source/Plugins/Process/Windows/Common/NativeProcessWindows.cpp(507,8): warning: unused variable 'log' [-Wunused-variable]
  507 |   Log *log = GetLog(WindowsLog::Exception);
      |        ^~~

Move that line into the `#ifndef __aarch64__` block to fix this.