### PR TITLE
Wasm: Remove unnecessary cast and error

### DIFF
--- a/llvm/lib/Target/WebAssembly/WebAssemblyLowerEmscriptenEHSjLj.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyLowerEmscriptenEHSjLj.cpp
@@ -420,14 +420,16 @@ static bool canThrow(const Value *V) {
 // link time.
 static GlobalVariable *getGlobalVariable(Module &M, Type *Ty,
                                          const char *Name) {
-  GlobalVariable *GV = M.getOrInsertGlobal(Name, Ty);
-
   // Variables created by this function are thread local. If the target does not
   // support TLS, we depend on CoalesceFeaturesAndStripAtomics to downgrade it
   // to non-thread-local ones, in which case we don't allow this object to be
   // linked with other objects using shared memory.
-  GV->setThreadLocalMode(GlobalValue::GeneralDynamicTLSModel);
-  return GV;
+  return M.getOrInsertGlobal(Name, Ty, [&]() {
+    return new GlobalVariable(
+        M, Ty, /*isConstant=*/false, GlobalVariable::ExternalLinkage,
+        /*Initializer=*/nullptr, Name,
+        /*InsertBefore=*/nullptr, GlobalValue::GeneralDynamicTLSModel);
+  });
 }
 
 // Simple function name mangler.

--- a/llvm/lib/Target/WebAssembly/WebAssemblyLowerEmscriptenEHSjLj.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyLowerEmscriptenEHSjLj.cpp
@@ -420,9 +420,7 @@ static bool canThrow(const Value *V) {
 // link time.
 static GlobalVariable *getGlobalVariable(Module &M, Type *Ty,
                                          const char *Name) {
-  auto *GV = dyn_cast<GlobalVariable>(M.getOrInsertGlobal(Name, Ty));
-  if (!GV)
-    report_fatal_error(Twine("unable to create global: ") + Name);
+  GlobalVariable *GV = M.getOrInsertGlobal(Name, Ty);
 
   // Variables created by this function are thread local. If the target does not
   // support TLS, we depend on CoalesceFeaturesAndStripAtomics to downgrade it


### PR DESCRIPTION
This cannot fail and is already the correct type.

Also set the TLS mode on construction, instead of unconditionally modifying an existing global.