### PR TITLE
[AArch64] Avoid scalar DUP for promoted narrow extracts

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -15879,6 +15879,21 @@ static unsigned getDUPLANEOp(EVT EltType) {
   llvm_unreachable("Invalid vector element type?");
 }
 
+static bool isPromotedExtractForWiderVectorElement(SDValue Value, EVT VecVT) {
+  if (Value.getOpcode() != ISD::EXTRACT_VECTOR_ELT)
+    return false;
+
+  // A promoted extract only defines the source vector element's bits. Scalar
+  // vector construction with wider elements would make promoted high bits
+  // observable.
+  EVT ValueVT = Value.getValueType();
+  EVT ExtractVT = Value.getOperand(0).getValueType().getVectorElementType();
+  EVT EltVT = VecVT.getVectorElementType();
+  return ValueVT.isInteger() && ExtractVT.isInteger() && EltVT.isInteger() &&
+         ExtractVT.bitsLT(ValueVT) && ExtractVT.bitsLT(EltVT) &&
+         EltVT.bitsLE(ValueVT);
+}
+
 static SDValue constructDup(SDValue V, int Lane, SDLoc DL, EVT VT,
                             unsigned Opcode, SelectionDAG &DAG) {
   // Try to eliminate a bitcasted extract subvector before a DUPLANE.
@@ -17349,24 +17364,27 @@ SDValue AArch64TargetLowering::LowerBUILD_VECTOR(SDValue Op,
     if (!isConstant) {
       if (Value.getOpcode() != ISD::EXTRACT_VECTOR_ELT ||
           Value.getValueType() != VT) {
-        LLVM_DEBUG(
-            dbgs() << "LowerBUILD_VECTOR: use DUP for non-constant splats\n");
-        return DAG.getNode(AArch64ISD::DUP, DL, VT, Value);
+        if (!isPromotedExtractForWiderVectorElement(Value, VT)) {
+          LLVM_DEBUG(dbgs()
+                     << "LowerBUILD_VECTOR: use DUP for non-constant splats\n");
+          return DAG.getNode(AArch64ISD::DUP, DL, VT, Value);
+        }
+      } else {
+        // This is actually a DUPLANExx operation, which keeps everything
+        // vectory.
+
+        SDValue Lane = Value.getOperand(1);
+        Value = Value.getOperand(0);
+        if (Value.getValueSizeInBits() == 64) {
+          LLVM_DEBUG(dbgs()
+                     << "LowerBUILD_VECTOR: DUPLANE works on 128-bit vectors, "
+                        "widening it\n");
+          Value = WidenVector(Value, DAG);
+        }
+
+        unsigned Opcode = getDUPLANEOp(VT.getVectorElementType());
+        return DAG.getNode(Opcode, DL, VT, Value, Lane);
       }
-
-      // This is actually a DUPLANExx operation, which keeps everything vectory.
-
-      SDValue Lane = Value.getOperand(1);
-      Value = Value.getOperand(0);
-      if (Value.getValueSizeInBits() == 64) {
-        LLVM_DEBUG(
-            dbgs() << "LowerBUILD_VECTOR: DUPLANE works on 128-bit vectors, "
-                      "widening it\n");
-        Value = WidenVector(Value, DAG);
-      }
-
-      unsigned Opcode = getDUPLANEOp(VT.getVectorElementType());
-      return DAG.getNode(Opcode, DL, VT, Value, Lane);
     }
 
     if (VT.getVectorElementType().isFloatingPoint()) {

--- a/llvm/test/CodeGen/AArch64/arm64-be-bool-splat-dup.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-be-bool-splat-dup.ll
@@ -1,0 +1,22 @@
+; RUN: llc -O2 -mtriple=aarch64_be-linux-gnu -verify-machineinstrs < %s | FileCheck %s --check-prefix=BE
+
+; Regression test for https://github.com/llvm/llvm-project/issues/221122.
+; Do not form a scalar-fed halfword DUP from a promoted byte extract and then
+; consume the result through byte operations.
+
+define i1 @check(<16 x i32> %fr, <4 x i32> %fr1) {
+; BE-LABEL: check:
+; BE:       dup v[[DUP:[0-9]+]].8b, v{{[0-9]+}}.b[0]
+; BE:       and {{.*}}v[[DUP]].8b
+; BE:       uminv b0,
+entry:
+  %cmp16 = icmp eq <16 x i32> %fr, <i32 3208, i32 1334, i32 28764, i32 35679, i32 2789, i32 13028, i32 4754, i32 168364, i32 91254, i32 12399, i32 22848, i32 8174, i32 307964, i32 146829, i32 22009, i32 32668>
+  %cmp4 = icmp eq <4 x i32> %fr1, <i32 11594, i32 447564, i32 202404, i32 31619>
+  %splat = shufflevector <16 x i1> %cmp16, <16 x i1> poison, <4 x i32> zeroinitializer
+  %both = and <4 x i1> %splat, %cmp4
+  %pad = shufflevector <4 x i1> %both, <4 x i1> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 4, i32 4, i32 4, i32 4, i32 4, i32 4, i32 4, i32 4, i32 4, i32 4, i32 4>
+  %merge = shufflevector <16 x i1> %pad, <16 x i1> %cmp16, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %bits = bitcast <16 x i1> %merge to i16
+  %ok = icmp eq i16 %bits, -1
+  ret i1 %ok
+}

--- a/llvm/test/CodeGen/AArch64/intrinsic-vector-match-sve2.ll
+++ b/llvm/test/CodeGen/AArch64/intrinsic-vector-match-sve2.ll
@@ -457,51 +457,43 @@ define <3 x i1> @match_v3i8_v3i1(<3 x i8> %op1, <8 x i8> %op2, <3 x i1> %mask) #
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    fmov s1, w0
 ; CHECK-NEXT:    // kill: def $d0 killed $d0 def $q0
-; CHECK-NEXT:    umov w8, v0.b[1]
-; CHECK-NEXT:    umov w9, v0.b[0]
-; CHECK-NEXT:    umov w10, v0.b[2]
-; CHECK-NEXT:    umov w11, v0.b[3]
-; CHECK-NEXT:    umov w12, v0.b[4]
-; CHECK-NEXT:    umov w13, v0.b[5]
+; CHECK-NEXT:    dup v2.8b, v0.b[1]
+; CHECK-NEXT:    dup v3.8b, v0.b[0]
+; CHECK-NEXT:    dup v4.8b, v0.b[2]
+; CHECK-NEXT:    dup v5.8b, v0.b[3]
+; CHECK-NEXT:    dup v6.8b, v0.b[4]
+; CHECK-NEXT:    dup v7.8b, v0.b[5]
+; CHECK-NEXT:    dup v16.8b, v0.b[6]
+; CHECK-NEXT:    dup v0.8b, v0.b[7]
 ; CHECK-NEXT:    mov v1.h[1], w1
-; CHECK-NEXT:    dup v2.4h, w8
-; CHECK-NEXT:    umov w8, v0.b[6]
-; CHECK-NEXT:    dup v3.4h, w9
-; CHECK-NEXT:    dup v4.4h, w10
-; CHECK-NEXT:    dup v5.4h, w11
-; CHECK-NEXT:    dup v6.4h, w12
-; CHECK-NEXT:    dup v7.4h, w13
-; CHECK-NEXT:    mov v1.h[2], w2
-; CHECK-NEXT:    dup v16.4h, w8
 ; CHECK-NEXT:    bic v2.4h, #255, lsl #8
 ; CHECK-NEXT:    bic v3.4h, #255, lsl #8
 ; CHECK-NEXT:    bic v4.4h, #255, lsl #8
 ; CHECK-NEXT:    bic v5.4h, #255, lsl #8
 ; CHECK-NEXT:    bic v6.4h, #255, lsl #8
 ; CHECK-NEXT:    bic v7.4h, #255, lsl #8
-; CHECK-NEXT:    umov w8, v0.b[7]
-; CHECK-NEXT:    bic v1.4h, #255, lsl #8
 ; CHECK-NEXT:    bic v16.4h, #255, lsl #8
-; CHECK-NEXT:    cmeq v0.4h, v1.4h, v2.4h
-; CHECK-NEXT:    cmeq v2.4h, v1.4h, v3.4h
-; CHECK-NEXT:    cmeq v3.4h, v1.4h, v4.4h
-; CHECK-NEXT:    cmeq v4.4h, v1.4h, v5.4h
-; CHECK-NEXT:    cmeq v5.4h, v1.4h, v6.4h
-; CHECK-NEXT:    cmeq v6.4h, v1.4h, v7.4h
-; CHECK-NEXT:    orr v0.8b, v2.8b, v0.8b
-; CHECK-NEXT:    orr v2.8b, v3.8b, v4.8b
-; CHECK-NEXT:    orr v4.8b, v5.8b, v6.8b
+; CHECK-NEXT:    bic v0.4h, #255, lsl #8
+; CHECK-NEXT:    mov v1.h[2], w2
+; CHECK-NEXT:    bic v1.4h, #255, lsl #8
+; CHECK-NEXT:    cmeq v2.4h, v1.4h, v2.4h
+; CHECK-NEXT:    cmeq v3.4h, v1.4h, v3.4h
+; CHECK-NEXT:    cmeq v4.4h, v1.4h, v4.4h
+; CHECK-NEXT:    cmeq v5.4h, v1.4h, v5.4h
+; CHECK-NEXT:    cmeq v6.4h, v1.4h, v6.4h
+; CHECK-NEXT:    cmeq v7.4h, v1.4h, v7.4h
+; CHECK-NEXT:    cmeq v0.4h, v1.4h, v0.4h
+; CHECK-NEXT:    orr v2.8b, v3.8b, v2.8b
+; CHECK-NEXT:    orr v3.8b, v4.8b, v5.8b
+; CHECK-NEXT:    orr v4.8b, v6.8b, v7.8b
 ; CHECK-NEXT:    cmeq v5.4h, v1.4h, v16.4h
-; CHECK-NEXT:    dup v3.4h, w8
-; CHECK-NEXT:    orr v0.8b, v0.8b, v2.8b
-; CHECK-NEXT:    orr v2.8b, v4.8b, v5.8b
+; CHECK-NEXT:    orr v2.8b, v2.8b, v3.8b
+; CHECK-NEXT:    orr v3.8b, v4.8b, v5.8b
 ; CHECK-NEXT:    fmov s4, w3
-; CHECK-NEXT:    bic v3.4h, #255, lsl #8
 ; CHECK-NEXT:    mov v4.h[1], w4
-; CHECK-NEXT:    orr v0.8b, v0.8b, v2.8b
-; CHECK-NEXT:    cmeq v1.4h, v1.4h, v3.4h
+; CHECK-NEXT:    orr v2.8b, v2.8b, v3.8b
+; CHECK-NEXT:    orr v0.8b, v2.8b, v0.8b
 ; CHECK-NEXT:    mov v4.h[2], w5
-; CHECK-NEXT:    orr v0.8b, v0.8b, v1.8b
 ; CHECK-NEXT:    shl v0.4h, v0.4h, #8
 ; CHECK-NEXT:    shl v1.4h, v4.4h, #15
 ; CHECK-NEXT:    sshr v0.4h, v0.4h, #8


### PR DESCRIPTION
Fixes #221122.

## Summary

AArch64 may encounter a promoted `EXTRACT_VECTOR_ELT` whose scalar result is
wider than the original vector element.

The promoted high bits are not semantically significant. However,
`LowerBUILD_VECTOR()` could lower a splat of that value to a scalar-fed
`AArch64ISD::DUP` whose destination element is wider than the original
extracted element.

For example:

    v16i8 element
        |
        | EXTRACT_VECTOR_ELT promoted to i32
        v
       i32
        |
        | scalar-fed DUP
        v
      v4i16

In that transformation, bits 8..15 of the promoted scalar become observable
even though the original extract only defined the byte-sized value.

This is the underlying issue in #221122.

## Fix

Detect promoted `EXTRACT_VECTOR_ELT` values for which the destination vector
element would be wider than the original extracted element.

In that case, do not lower the non-constant splat through a scalar-fed
`AArch64ISD::DUP`.

Instead, allow the existing vector lowering path to preserve the original
element granularity.

For the reported big-endian case, the problematic lowering included:

    umov    w9, v4.b[0]
    dup     v4.4h, w9
    and     v1.8b, v4.8b, v1.8b

The halfword DUP makes promoted bits above the original byte observable.

With this change, lowering keeps the broadcast at byte granularity, using a
vector-lane byte DUP before the byte operation.

This does not choose either sign-extension or zero-extension for the promoted
bits; it avoids making those bits semantically relevant in the first place.

## Tests

Added `arm64-be-bool-splat-dup.ll` as regression coverage for #221122.

Updated `intrinsic-vector-match-sve2.ll` for the resulting vector-lane lowering.

Validation:

- `ninja -C ../llvm-arm-riscv-build llc`
- regression test with `-verify-machineinstrs`: PASS
- focused AArch64 tests: 4/4 PASS
- full `llvm/test/CodeGen/AArch64`:
  - 4204 PASS
  - 4 expected failures
  - 0 unexpected failures
- `git diff --check`: PASS

## AI Assistance

AI-assisted tools were used during the investigation to help explore relevant
code paths, analyze hypotheses, and iterate on the implementation and tests.

I personally reviewed and modified all resulting changes, verified the final
implementation against the identified root cause, inspected the generated code,
and ran the validation and regression tests listed above.

The submitted patch has been manually reviewed and validated by me.
