### PR TITLE
[flang-rt][NFC] Initialize OpenFile::nextId_

### DIFF
--- a/flang-rt/include/flang-rt/runtime/file.h
+++ b/flang-rt/include/flang-rt/runtime/file.h
@@ -102,7 +102,7 @@ private:
   bool isTerminal_{false};
   bool isWindowsTextFile_{false}; // expands LF to CR+LF on write
 
-  int nextId_;
+  int nextId_{0};
   OwningPtr<Pending> pending_;
 };
 


### PR DESCRIPTION
`OpenFile::nextId_` had no initializer and is assigned only in `Predefine()`, which runs for the three preconnected units. A unit created by `OPEN` therefore leaves it indeterminate. Added missing initializer.

Assisted-by: AI