### PR TITLE
[InstSimplify] Don't fold ptrtoint of ptradd of sub

### DIFF
--- a/llvm/lib/Analysis/InstructionSimplify.cpp
+++ b/llvm/lib/Analysis/InstructionSimplify.cpp
@@ -5679,9 +5679,13 @@ static Value *simplifyCastInst(unsigned CastOpc, Value *Op, Type *Ty,
     if (Op->getType() == Ty)
       return Op;
 
-  // ptrtoint (ptradd (Ptr, X - ptrtoint(Ptr))) -> X
+  // ptrtoaddr (ptradd (Ptr, X - ptrtoint/ptrtoaddr(Ptr))) -> X
+  // This is also valid for ptrtoint, but only if the (now unused) ptrtoint
+  // instruction is preserved for its provenance exposure side effect. As this
+  // is currently not the case, only fold ptrtoaddr, which does not expose
+  // provenance.
   Value *Ptr, *X;
-  if ((CastOpc == Instruction::PtrToInt || CastOpc == Instruction::PtrToAddr) &&
+  if (CastOpc == Instruction::PtrToAddr &&
       match(Op,
             m_PtrAdd(m_Value(Ptr),
                      m_Sub(m_Value(X), m_PtrToIntOrAddr(m_Deferred(Ptr))))) &&

--- a/llvm/test/Transforms/InstCombine/ptr-int-cast.ll
+++ b/llvm/test/Transforms/InstCombine/ptr-int-cast.ll
@@ -87,9 +87,14 @@ define <4 x ptr> @test7(<4 x i128> %arg) nounwind {
   ret <4 x ptr> %p1
 }
 
+; Folding this would lose %ptr provenance exposure.
 define i64 @ptrtoint_gep_sub(ptr %ptr, i64 %end.addr) {
 ; CHECK-LABEL: @ptrtoint_gep_sub(
-; CHECK-NEXT:    ret i64 [[END_ADDR:%.*]]
+; CHECK-NEXT:    [[PTR_ADDR:%.*]] = ptrtoint ptr [[PTR:%.*]] to i64
+; CHECK-NEXT:    [[SIZE:%.*]] = sub i64 [[END_ADDR1:%.*]], [[PTR_ADDR]]
+; CHECK-NEXT:    [[END:%.*]] = getelementptr i8, ptr [[PTR]], i64 [[SIZE]]
+; CHECK-NEXT:    [[END_ADDR:%.*]] = ptrtoint ptr [[END]] to i64
+; CHECK-NEXT:    ret i64 [[END_ADDR]]
 ;
   %ptr.addr = ptrtoint ptr %ptr to i64
   %size = sub i64 %end.addr, %ptr.addr

--- a/llvm/test/Transforms/InstSimplify/ptrtoint.ll
+++ b/llvm/test/Transforms/InstSimplify/ptrtoint.ll
@@ -3,10 +3,15 @@
 
 target datalayout = "p1:128:128:128"
 
+; Folding this would lose %ptr provenance exposure.
 define i64 @ptrtoint_gep_sub(ptr %ptr, i64 %end.addr) {
 ; CHECK-LABEL: define i64 @ptrtoint_gep_sub(
 ; CHECK-SAME: ptr [[PTR:%.*]], i64 [[END_ADDR:%.*]]) {
-; CHECK-NEXT:    ret i64 [[END_ADDR]]
+; CHECK-NEXT:    [[PTR_ADDR:%.*]] = ptrtoint ptr [[PTR]] to i64
+; CHECK-NEXT:    [[SIZE:%.*]] = sub i64 [[END_ADDR]], [[PTR_ADDR]]
+; CHECK-NEXT:    [[END:%.*]] = getelementptr i8, ptr [[PTR]], i64 [[SIZE]]
+; CHECK-NEXT:    [[END_ADDR2:%.*]] = ptrtoint ptr [[END]] to i64
+; CHECK-NEXT:    ret i64 [[END_ADDR2]]
 ;
   %ptr.addr = ptrtoint ptr %ptr to i64
   %size = sub i64 %end.addr, %ptr.addr
@@ -18,7 +23,11 @@ define i64 @ptrtoint_gep_sub(ptr %ptr, i64 %end.addr) {
 define <2 x i64> @ptrtoint_gep_sub_vector(<2 x ptr> %ptr, <2 x i64> %end.addr) {
 ; CHECK-LABEL: define <2 x i64> @ptrtoint_gep_sub_vector(
 ; CHECK-SAME: <2 x ptr> [[PTR:%.*]], <2 x i64> [[END_ADDR:%.*]]) {
-; CHECK-NEXT:    ret <2 x i64> [[END_ADDR]]
+; CHECK-NEXT:    [[PTR_ADDR:%.*]] = ptrtoint <2 x ptr> [[PTR]] to <2 x i64>
+; CHECK-NEXT:    [[SIZE:%.*]] = sub <2 x i64> [[END_ADDR]], [[PTR_ADDR]]
+; CHECK-NEXT:    [[END:%.*]] = getelementptr i8, <2 x ptr> [[PTR]], <2 x i64> [[SIZE]]
+; CHECK-NEXT:    [[END_ADDR2:%.*]] = ptrtoint <2 x ptr> [[END]] to <2 x i64>
+; CHECK-NEXT:    ret <2 x i64> [[END_ADDR2]]
 ;
   %ptr.addr = ptrtoint <2 x ptr> %ptr to <2 x i64>
   %size = sub <2 x i64> %end.addr, %ptr.addr


### PR DESCRIPTION
Don't fold `ptrtoint (ptradd (Ptr, X - ptrtoint(Ptr))) -> X`. While valid by itself, the fact that LLVM currently does not properly model the ptrtoint side effect means that we lose the provenance exposure of Ptr. This results in end-to-end miscompiles that led to the revert of #210729.

We can still perform the optimization for ptrtoaddr, which does not expose provenance.