### PR TITLE
[MLIR][XeGPU] Optimize create_mask sg-to-lane lowering

### DIFF
--- a/mlir/lib/Dialect/XeGPU/Transforms/XeGPUSgToLaneDistribute.cpp
+++ b/mlir/lib/Dialect/XeGPU/Transforms/XeGPUSgToLaneDistribute.cpp
@@ -864,28 +864,8 @@ struct SgToLaneVectorBitcast : public OpConversionPattern<vector::BitCastOp> {
 };
 
 /// Distributes a subgroup-level vector.create_mask or vector.constant_mask op
-/// to lane-level. Uses `computeDistributedCoords()` to obtain the
-/// coordinates each lane owns, then compares each coordinate against the
-/// original mask bounds using `arith.cmpi slt`. The per-element boolean
-/// results are assembled into the distributed mask vector.
-///
-/// For multi-dimensional masks, the element is in-bounds when ALL dimensions
-/// satisfy `coord[i] < bound[i]`.
-///
-/// Example (1D):
-///   layout = #xegpu.layout<lane_layout = [16], lane_data = [1]>
-///   %mask = vector.create_mask %m0 : vector<16xi1>
-/// For lane k, computeDistributedCoords gives coord = [k], so:
-///   %in_bounds = arith.cmpi slt, %coord, %m0  →  i1
-///   %mask = vector.broadcast %in_bounds : i1 to vector<1xi1>
-///
-/// Example (2D):
-///   layout = #xegpu.layout<lane_layout = [8, 2], lane_data = [1, 1]>
-///   %mask = vector.create_mask %m0, %m1 : vector<8x4xi1>
-/// Each WI owns a 1x2 slice. computeDistributedCoords returns 2 coords:
-///   [[r0, c0], [r0, c1]]
-/// For each coord: in_bounds = (r < m0) && (c < m1)
-///   %mask = vector.from_elements %bit0, %bit1 : vector<1x2xi1>
+/// to lane-level. An element is in-bounds when every dim satisfies
+/// `coord[d] < bound[d]`.
 template <typename OpType,
           typename = std::enable_if_t<llvm::is_one_of<
               OpType, vector::CreateMaskOp, vector::ConstantMaskOp>::value>>
@@ -933,36 +913,90 @@ struct SgToLaneCreateMask : public OpConversionPattern<OpType> {
       return rewriter.notifyMatchFailure(
           op, "failed to compute distributed coordinates from layout");
 
-    SmallVector<SmallVector<Value>> coordsVec = maybeCoordsVec.value();
+    SmallVector<SmallVector<Value>> laneDataCoords = maybeCoordsVec.value();
+    SmallVector<int64_t> laneData = layout.getEffectiveLaneDataAsInt();
+    ArrayRef<int64_t> distShape = distType.getShape();
+    int64_t rank = distType.getRank();
     int64_t numElements = distType.getNumElements();
-    assert(static_cast<int64_t>(coordsVec.size()) == numElements &&
-           "number of coordinate sets must match number of distributed "
-           "elements");
 
-    // For each element, compare all coordinates against bounds.
-    Value trueVal =
-        arith::ConstantIntOp::create(rewriter, loc, /*value=*/1, /*width=*/1);
-    SmallVector<Value> maskBits;
-    for (auto &coords : coordsVec) {
-      Value inBounds = trueVal;
-      for (size_t i = 0; i < coords.size(); ++i) {
-        Value cmp = arith::CmpIOp::create(
-            rewriter, loc, arith::CmpIPredicate::slt, coords[i], origBounds[i]);
-        inBounds = arith::AndIOp::create(rewriter, loc, inBounds, cmp);
+    if (static_cast<int64_t>(laneData.size()) != rank ||
+        !computeShapeRatio(distShape, laneData))
+      return rewriter.notifyMatchFailure(
+          op, "lane_data does not tile the distributed vector");
+
+    SmallVector<int64_t> resultStrides = computeStrides(distShape);
+    assert(static_cast<int64_t>(laneDataCoords.size()) *
+                   computeProduct(laneData) ==
+               numElements &&
+           "number of coordinate sets must match number of lane_data blocks");
+
+    // Static offsets to be applied to a dynamic lane's dist units coordinates.
+    SmallVector<SmallVector<int64_t>> staticLaneDataOffsetsOrigShape =
+        layout.computeStaticDistributedCoords(/*linearId=*/0, origShape);
+    if (staticLaneDataOffsetsOrigShape.empty() ||
+        staticLaneDataOffsetsOrigShape.size() != laneDataCoords.size())
+      return rewriter.notifyMatchFailure(
+          op, "static and dynamic coordinates disagree on the distribution "
+              "unit count");
+
+    SmallVector<int64_t> unitTile(rank, 1);
+    int64_t linearLaneDataIdx = 0;
+    // Layout and shape information is static, compute static offset of lane's
+    // elements in the source dimensions.
+    SmallVector<SmallVector<int64_t>> staticElemOffsetInSrcDims(
+        rank, SmallVector<int64_t>(numElements));
+    // For each lane_data block in the overall lane's shape
+    for (SmallVector<int64_t> laneDataOffsetInResult :
+         StaticTileOffsetRange(distShape, laneData)) {
+      ArrayRef<int64_t> staticLaneDataOffsetInSource =
+          staticLaneDataOffsetsOrigShape[linearLaneDataIdx++];
+      // For each element in the lane_data block
+      for (SmallVector<int64_t> elementOffsetInLaneData :
+           StaticTileOffsetRange(laneData, unitTile)) {
+        // For each dim of indexing space
+        SmallVector<int64_t> elementOffsetInResult(rank);
+        for (int64_t d = 0; d < rank; d++)
+          elementOffsetInResult[d] =
+              laneDataOffsetInResult[d] + elementOffsetInLaneData[d];
+        int64_t elemLinearizedIdx =
+            linearize(elementOffsetInResult, resultStrides);
+        for (int64_t d = 0; d < rank; d++)
+          staticElemOffsetInSrcDims[d][elemLinearizedIdx] =
+              staticLaneDataOffsetInSource[d] + elementOffsetInLaneData[d];
       }
-      maskBits.push_back(inBounds);
     }
 
-    // Build the distributed mask vector.
-    Value result;
-    if (numElements == 1) {
-      result =
-          vector::BroadcastOp::create(rewriter, loc, distType, maskBits[0]);
-    } else {
-      result =
-          vector::FromElementsOp::create(rewriter, loc, distType, maskBits);
+    // Check, whether ALL elements of the distributed mask are within the valid
+    // extent of EACH source dimension.
+    // Expressed as dyn_offset[d] + static_offset[d] < dyn_mask_bound[d],
+    // or equivalently,
+    // static_offset[d] < dyn_mask_bound[d] - dyn_offset[d]
+    auto flatIndexType = VectorType::get(numElements, rewriter.getIndexType());
+    Value inBounds;
+    for (int64_t d = 0; d < rank; d++) {
+      Value materializedStaticOffset = arith::ConstantOp::create(
+          rewriter, loc,
+          rewriter.getIndexVectorAttr(staticElemOffsetInSrcDims[d]));
+      // Consider only the first unit, all others are compile-time multiple
+      // offsets of the first one and are already encoded in staticOffsets.
+      Value validDimExtent = arith::SubIOp::create(rewriter, loc, origBounds[d],
+                                                   laneDataCoords[0][d]);
+      // Dim extent applies to all elements.
+      Value validDimExtentPerElement = vector::BroadcastOp::create(
+          rewriter, loc, flatIndexType, validDimExtent);
+      Value elementMaskInDim = arith::CmpIOp::create(
+          rewriter, loc, arith::CmpIPredicate::slt, materializedStaticOffset,
+          validDimExtentPerElement);
+      // An element is valid iff it is within the valid extent of ALL
+      // dimensions.
+      inBounds = inBounds ? arith::AndIOp::create(rewriter, loc, inBounds,
+                                                  elementMaskInDim)
+                                .getResult()
+                          : elementMaskInDim;
     }
-    rewriter.replaceOp(op, result);
+    auto resMask =
+        rewriter.createOrFold<vector::ShapeCastOp>(loc, distType, inBounds);
+    rewriter.replaceOp(op, resMask);
     return success();
   }
 };

--- a/mlir/test/Dialect/XeGPU/sg-to-lane-distribute-unit.mlir
+++ b/mlir/test/Dialect/XeGPU/sg-to-lane-distribute-unit.mlir
@@ -601,11 +601,13 @@ gpu.func @vector_bitcast() {
 
 // CHECK-LABEL: gpu.func @create_mask_1d
 //  CHECK-SAME: (%[[M0:.*]]: index)
-//   CHECK-DAG:   %[[LANE:.*]] = gpu.lane_id
-//   CHECK-DAG:   %[[TRUE:.*]] = arith.constant true
-//       CHECK:   %[[CMP:.*]] = arith.cmpi slt, %{{.*}}, %[[M0]] : index
-//       CHECK:   %[[AND:.*]] = arith.andi %[[TRUE]], %[[CMP]] : i1
-//       CHECK:   %[[MASK:.*]] = vector.broadcast %[[AND]] : i1 to vector<1xi1>
+//       CHECK:   %[[LANE:.*]] = gpu.lane_id
+//       CHECK:   %[[K0:.*]] = arith.constant dense<0> : vector<1xindex>
+//       CHECK:   %[[LEN0:.*]] = arith.subi %[[M0]], %{{.*}} : index
+//       CHECK:   %[[EXT0:.*]] = vector.broadcast %[[LEN0]] : index to vector<1xindex>
+//       CHECK:   %[[MASK:.*]] = arith.cmpi slt, %[[K0]], %[[EXT0]] : vector<1xindex>
+//   CHECK-NOT:   vector.from_elements
+//   CHECK-NOT:   vector.shape_cast
 //       CHECK:   gpu.return
 gpu.func @create_mask_1d(%m0: index) {
   %mask = vector.create_mask %m0
@@ -618,12 +620,13 @@ gpu.func @create_mask_1d(%m0: index) {
 }
 
 // CHECK-LABEL: gpu.func @constant_mask_1d
-//   CHECK-DAG:   %[[C4:.*]] = arith.constant 4 : index
-//   CHECK-DAG:   %[[LANE:.*]] = gpu.lane_id
-//   CHECK-DAG:   %[[TRUE:.*]] = arith.constant true
-//       CHECK:   %[[CMP:.*]] = arith.cmpi slt, %{{.*}}, %[[C4]] : index
-//       CHECK:   %[[AND:.*]] = arith.andi %[[TRUE]], %[[CMP]] : i1
-//       CHECK:   %[[MASK:.*]] = vector.broadcast %[[AND]] : i1 to vector<1xi1>
+//       CHECK:   %[[C4:.*]] = arith.constant 4 : index
+//       CHECK:   %[[LANE:.*]] = gpu.lane_id
+//       CHECK:   %[[K0:.*]] = arith.constant dense<0> : vector<1xindex>
+//       CHECK:   %[[LEN0:.*]] = arith.subi %[[C4]], %{{.*}} : index
+//       CHECK:   %[[EXT0:.*]] = vector.broadcast %[[LEN0]] : index to vector<1xindex>
+//       CHECK:   %[[MASK:.*]] = arith.cmpi slt, %[[K0]], %[[EXT0]] : vector<1xindex>
+//   CHECK-NOT:   vector.from_elements
 //       CHECK:   gpu.return
 gpu.func @constant_mask_1d() {
   %mask = vector.constant_mask [4]
@@ -635,19 +638,55 @@ gpu.func @constant_mask_1d() {
   gpu.return
 }
 
+// CHECK-LABEL: gpu.func @create_mask_1d_multi_unit
+//  CHECK-SAME: (%[[M0:.*]]: index)
+//       CHECK:   %[[K0:.*]] = arith.constant dense<[0, 4, 8, 12]> : vector<4xindex>
+//       CHECK:   %[[LEN0:.*]] = arith.subi %[[M0]], %{{.*}} : index
+//       CHECK:   %[[EXT0:.*]] = vector.broadcast %[[LEN0]] : index to vector<4xindex>
+//       CHECK:   %[[MASK:.*]] = arith.cmpi slt, %[[K0]], %[[EXT0]] : vector<4xindex>
+//   CHECK-NOT:   vector.from_elements
+//       CHECK:   gpu.return
+gpu.func @create_mask_1d_multi_unit(%m0: index) {
+  %mask = vector.create_mask %m0
+    : vector<16xi1>
+  %mask_cl = xegpu.convert_layout %mask
+    <{
+      target_layout = #xegpu.layout<lane_layout = [4], lane_data = [1]>
+    }> : vector<16xi1>
+  gpu.return
+}
+
+// CHECK-LABEL: gpu.func @create_mask_1d_lane_data
+//  CHECK-SAME: (%[[M0:.*]]: index)
+//       CHECK:   %[[K0:.*]] = arith.constant dense<[0, 1, 2, 3, 8, 9, 10, 11]> : vector<8xindex>
+//       CHECK:   %[[LEN0:.*]] = arith.subi %[[M0]], %{{.*}} : index
+//       CHECK:   %[[EXT0:.*]] = vector.broadcast %[[LEN0]] : index to vector<8xindex>
+//       CHECK:   %[[MASK:.*]] = arith.cmpi slt, %[[K0]], %[[EXT0]] : vector<8xindex>
+//   CHECK-NOT:   vector.from_elements
+//       CHECK:   gpu.return
+gpu.func @create_mask_1d_lane_data(%m0: index) {
+  %mask = vector.create_mask %m0
+    : vector<16xi1>
+  %mask_cl = xegpu.convert_layout %mask
+    <{
+      target_layout = #xegpu.layout<lane_layout = [2], lane_data = [4]>
+    }> : vector<16xi1>
+  gpu.return
+}
+
 // CHECK-LABEL: gpu.func @create_mask_2d
 //  CHECK-SAME: (%[[M0:.*]]: index, %[[M1:.*]]: index)
-//   CHECK-DAG:   %[[LANE:.*]] = gpu.lane_id
-//   CHECK-DAG:   %[[TRUE:.*]] = arith.constant true
-//       CHECK:   %[[CMP_R0:.*]] = arith.cmpi slt, %{{.*}}, %[[M0]] : index
-//       CHECK:   %[[AND0:.*]] = arith.andi %[[TRUE]], %[[CMP_R0]] : i1
-//       CHECK:   %[[CMP_C0:.*]] = arith.cmpi slt, %{{.*}}, %[[M1]] : index
-//       CHECK:   %[[BIT0:.*]] = arith.andi %[[AND0]], %[[CMP_C0]] : i1
-//       CHECK:   %[[CMP_R1:.*]] = arith.cmpi slt, %{{.*}}, %[[M0]] : index
-//       CHECK:   %[[AND1:.*]] = arith.andi %[[TRUE]], %[[CMP_R1]] : i1
-//       CHECK:   %[[CMP_C1:.*]] = arith.cmpi slt, %{{.*}}, %[[M1]] : index
-//       CHECK:   %[[BIT1:.*]] = arith.andi %[[AND1]], %[[CMP_C1]] : i1
-//       CHECK:   %[[MASK:.*]] = vector.from_elements %[[BIT0]], %[[BIT1]] : vector<1x2xi1>
+//       CHECK:   %[[K0:.*]] = arith.constant dense<0> : vector<2xindex>
+//       CHECK:   %[[LEN0:.*]] = arith.subi %[[M0]], %{{.*}} : index
+//       CHECK:   %[[EXT0:.*]] = vector.broadcast %[[LEN0]] : index to vector<2xindex>
+//       CHECK:   %[[P0:.*]] = arith.cmpi slt, %[[K0]], %[[EXT0]] : vector<2xindex>
+//       CHECK:   %[[K1:.*]] = arith.constant dense<[0, 2]> : vector<2xindex>
+//       CHECK:   %[[LEN1:.*]] = arith.subi %[[M1]], %{{.*}} : index
+//       CHECK:   %[[EXT1:.*]] = vector.broadcast %[[LEN1]] : index to vector<2xindex>
+//       CHECK:   %[[P1:.*]] = arith.cmpi slt, %[[K1]], %[[EXT1]] : vector<2xindex>
+//       CHECK:   %[[AND:.*]] = arith.andi %[[P0]], %[[P1]] : vector<2xi1>
+//       CHECK:   %[[MASK:.*]] = vector.shape_cast %[[AND]] : vector<2xi1> to vector<1x2xi1>
+//   CHECK-NOT:   vector.from_elements
 //       CHECK:   gpu.return
 gpu.func @create_mask_2d(%m0: index, %m1: index) {
   %mask = vector.create_mask %m0, %m1
@@ -660,19 +699,19 @@ gpu.func @create_mask_2d(%m0: index, %m1: index) {
 }
 
 // CHECK-LABEL: gpu.func @constant_mask_2d
-//   CHECK-DAG:   %[[C2:.*]] = arith.constant 2 : index
-//   CHECK-DAG:   %[[C3:.*]] = arith.constant 3 : index
-//   CHECK-DAG:   %[[LANE:.*]] = gpu.lane_id
-//   CHECK-DAG:   %[[TRUE:.*]] = arith.constant true
-//       CHECK:   %[[CMP_R0:.*]] = arith.cmpi slt, %{{.*}}, %[[C2]] : index
-//       CHECK:   %[[AND0:.*]] = arith.andi %[[TRUE]], %[[CMP_R0]] : i1
-//       CHECK:   %[[CMP_C0:.*]] = arith.cmpi slt, %{{.*}}, %[[C3]] : index
-//       CHECK:   %[[BIT0:.*]] = arith.andi %[[AND0]], %[[CMP_C0]] : i1
-//       CHECK:   %[[CMP_R1:.*]] = arith.cmpi slt, %{{.*}}, %[[C2]] : index
-//       CHECK:   %[[AND1:.*]] = arith.andi %[[TRUE]], %[[CMP_R1]] : i1
-//       CHECK:   %[[CMP_C1:.*]] = arith.cmpi slt, %{{.*}}, %[[C3]] : index
-//       CHECK:   %[[BIT1:.*]] = arith.andi %[[AND1]], %[[CMP_C1]] : i1
-//       CHECK:   %[[MASK:.*]] = vector.from_elements %[[BIT0]], %[[BIT1]] : vector<1x2xi1>
+//       CHECK:   %[[C2:.*]] = arith.constant 2 : index
+//       CHECK:   %[[C3:.*]] = arith.constant 3 : index
+//       CHECK:   %[[K0:.*]] = arith.constant dense<0> : vector<2xindex>
+//       CHECK:   %[[LEN0:.*]] = arith.subi %[[C2]], %{{.*}} : index
+//       CHECK:   %[[EXT0:.*]] = vector.broadcast %[[LEN0]] : index to vector<2xindex>
+//       CHECK:   %[[P0:.*]] = arith.cmpi slt, %[[K0]], %[[EXT0]] : vector<2xindex>
+//       CHECK:   %[[K1:.*]] = arith.constant dense<[0, 2]> : vector<2xindex>
+//       CHECK:   %[[LEN1:.*]] = arith.subi %[[C3]], %{{.*}} : index
+//       CHECK:   %[[EXT1:.*]] = vector.broadcast %[[LEN1]] : index to vector<2xindex>
+//       CHECK:   %[[P1:.*]] = arith.cmpi slt, %[[K1]], %[[EXT1]] : vector<2xindex>
+//       CHECK:   %[[AND:.*]] = arith.andi %[[P0]], %[[P1]] : vector<2xi1>
+//       CHECK:   %[[MASK:.*]] = vector.shape_cast %[[AND]] : vector<2xi1> to vector<1x2xi1>
+//   CHECK-NOT:   vector.from_elements
 //       CHECK:   gpu.return
 gpu.func @constant_mask_2d() {
   %mask = vector.constant_mask [2, 3]
@@ -682,6 +721,59 @@ gpu.func @constant_mask_2d() {
           target_layout = #xegpu.layout<lane_layout = [8, 2], lane_data = [1, 1]>
         }> : vector<8x4xi1>
       gpu.return
+}
+
+// CHECK-LABEL: gpu.func @create_mask_2d_lane_data
+//  CHECK-SAME: (%[[M0:.*]]: index, %[[M1:.*]]: index)
+//       CHECK:   %[[K0:.*]] = arith.constant dense<[0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7]> : vector<16xindex>
+//       CHECK:   %[[LEN0:.*]] = arith.subi %[[M0]], %{{.*}} : index
+//       CHECK:   %[[EXT0:.*]] = vector.broadcast %[[LEN0]] : index to vector<16xindex>
+//       CHECK:   %[[P0:.*]] = arith.cmpi slt, %[[K0]], %[[EXT0]] : vector<16xindex>
+//       CHECK:   %[[K1:.*]] = arith.constant dense<[0, 16, 0, 16, 0, 16, 0, 16, 0, 16, 0, 16, 0, 16, 0, 16]> : vector<16xindex>
+//       CHECK:   %[[LEN1:.*]] = arith.subi %[[M1]], %{{.*}} : index
+//       CHECK:   %[[EXT1:.*]] = vector.broadcast %[[LEN1]] : index to vector<16xindex>
+//       CHECK:   %[[P1:.*]] = arith.cmpi slt, %[[K1]], %[[EXT1]] : vector<16xindex>
+//       CHECK:   %[[AND:.*]] = arith.andi %[[P0]], %[[P1]] : vector<16xi1>
+//       CHECK:   %[[MASK:.*]] = vector.shape_cast %[[AND]] : vector<16xi1> to vector<8x2xi1>
+//   CHECK-NOT:   vector.from_elements
+//       CHECK:   gpu.return
+gpu.func @create_mask_2d_lane_data(%m0: index, %m1: index) {
+  %mask = vector.create_mask %m0, %m1
+    : vector<8x32xi1>
+  %mask_cl = xegpu.convert_layout %mask
+    <{
+      target_layout = #xegpu.layout<lane_layout = [1, 16], lane_data = [2, 1]>
+    }> : vector<8x32xi1>
+  gpu.return
+}
+
+// CHECK-LABEL: gpu.func @create_mask_3d
+//  CHECK-SAME: (%[[M0:.*]]: index, %[[M1:.*]]: index, %[[M2:.*]]: index)
+//       CHECK:   %[[K0:.*]] = arith.constant dense<[0, 0, 0, 0, 1, 1, 1, 1]> : vector<8xindex>
+//       CHECK:   %[[LEN0:.*]] = arith.subi %[[M0]], %{{.*}} : index
+//       CHECK:   %[[EXT0:.*]] = vector.broadcast %[[LEN0]] : index to vector<8xindex>
+//       CHECK:   %[[P0:.*]] = arith.cmpi slt, %[[K0]], %[[EXT0]] : vector<8xindex>
+//       CHECK:   %[[K1:.*]] = arith.constant dense<[0, 2, 4, 6, 0, 2, 4, 6]> : vector<8xindex>
+//       CHECK:   %[[LEN1:.*]] = arith.subi %[[M1]], %{{.*}} : index
+//       CHECK:   %[[EXT1:.*]] = vector.broadcast %[[LEN1]] : index to vector<8xindex>
+//       CHECK:   %[[P1:.*]] = arith.cmpi slt, %[[K1]], %[[EXT1]] : vector<8xindex>
+//       CHECK:   %[[AND0:.*]] = arith.andi %[[P0]], %[[P1]] : vector<8xi1>
+//       CHECK:   %[[K2:.*]] = arith.constant dense<0> : vector<8xindex>
+//       CHECK:   %[[LEN2:.*]] = arith.subi %[[M2]], %{{.*}} : index
+//       CHECK:   %[[EXT2:.*]] = vector.broadcast %[[LEN2]] : index to vector<8xindex>
+//       CHECK:   %[[P2:.*]] = arith.cmpi slt, %[[K2]], %[[EXT2]] : vector<8xindex>
+//       CHECK:   %[[AND1:.*]] = arith.andi %[[AND0]], %[[P2]] : vector<8xi1>
+//       CHECK:   %[[MASK:.*]] = vector.shape_cast %[[AND1]] : vector<8xi1> to vector<2x4x1xi1>
+//   CHECK-NOT:   vector.from_elements
+//       CHECK:   gpu.return
+gpu.func @create_mask_3d(%m0: index, %m1: index, %m2: index) {
+  %mask = vector.create_mask %m0, %m1, %m2
+    : vector<2x8x8xi1>
+  %mask_cl = xegpu.convert_layout %mask
+    <{
+      target_layout = #xegpu.layout<lane_layout = [1, 2, 8], lane_data = [1, 1, 1]>
+    }> : vector<2x8x8xi1>
+  gpu.return
 }
 
 // CHECK-LABEL: gpu.func @vector_multi_reduction_3d_leading_unit_dim_lane_local


### PR DESCRIPTION
This PR:
1. Enables non-unit lane_data for sg-to-lane create_mask distribution
2. Optimizes create_mask lane distribtuion by shifting the indexing logic to compile-time static offsets calculation and vectorizing in-bound checking.
The new logic can be expressed as: 
> Is the element's static offset along dim `d` less than the distance from the lane's first distribution unit to `bound[d]`? If yes, the element is valid for dim d, and it is in the mask iff it is valid for every dim.
> For all `d`: `base[d] + staticOffset[d] < bound[d]` or `staticOffset[d] < bound[d] - base[d]`, where `base[d]` is the lane's first distribution unit coordinate along d. 

The main IR savings come from checking all final mask elements at once _per dim_ (vectorized), instead of once per element.
The comparison is signed to prevent underflows.