### PR TITLE
[TOSA] Add pass to sanitize gather/scatter indices

### DIFF
--- a/mlir/include/mlir/Dialect/Tosa/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/Tosa/Transforms/Passes.td
@@ -203,10 +203,11 @@ def TosaGatherScatterHardeningPass
     : Pass<"tosa-gather-scatter-hardening", "func::FuncOp"> {
   let summary = "Clamp TOSA gather and scatter indices to valid bounds";
   let description = [{
-    Inserts a TOSA clamp on the indices used by each gather and scatter so that
-    all accesses are in bounds. When the same indices value is used by several
-    gather or scatter operations that require identical clamp bounds, one clamp
-    is shared by all of them. Other users continue to use the original indices.
+    Bounds the indices used by each gather and scatter with TOSA minimum and
+    maximum operations so that all accesses are in bounds. When the same
+    indices value is used by several gather or scatter operations that require
+    identical bounds, one bounding sequence is shared by all of them. Other
+    users continue to use the original indices.
 
     The indexed dimension must be statically known and non-empty.
   }];

--- a/mlir/include/mlir/Dialect/Tosa/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/Tosa/Transforms/Passes.td
@@ -199,6 +199,23 @@ def TosaDowngrade1p1To1p0Pass
   }];
 }
 
+def TosaGatherScatterHardeningPass
+    : Pass<"tosa-gather-scatter-hardening", "func::FuncOp"> {
+  let summary = "Clamp TOSA gather and scatter indices to valid bounds";
+  let description = [{
+    Inserts a TOSA clamp on the indices used by each gather and scatter so that
+    all accesses are in bounds. When the same indices value is used by several
+    gather or scatter operations that require identical clamp bounds, one clamp
+    is shared by all of them. Other users continue to use the original indices.
+
+    The indexed dimension must be statically known and non-empty.
+  }];
+
+  let dependentDialects = [
+    "tosa::TosaDialect"
+  ];
+}
+
 def TosaNarrowI64ToI32Pass : Pass<"tosa-narrow-i64-to-i32", "func::FuncOp"> {
   let summary = "Narrow I64 TOSA operations to I32";
   let description = [{

--- a/mlir/include/mlir/Dialect/Tosa/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/Tosa/Transforms/Passes.td
@@ -204,17 +204,17 @@ def TosaGatherScatterHardeningPass
   let summary = "Clamp TOSA gather and scatter indices to valid bounds";
   let description = [{
     Bounds the indices used by each gather and scatter with TOSA minimum and
-    maximum operations so that all accesses are in bounds. When the same
-    indices value is used by several gather or scatter operations that require
-    identical bounds, one bounding sequence is shared by all of them. Other
-    users continue to use the original indices.
+    maximum operations so that all accesses are in bounds. This improves
+    security in the context of untrusted TOSA graph by preventing memory access
+    outside values (gather) and values_out (scatter) tensor.
 
-    The indexed dimension must be statically known and non-empty.
+    Each operation is rewritten independently; a subsequent CSE pass is
+    required to share bounding ops between gather/scatter with the same input
+    and bounds. Other users continue to use the original indices.
+
+    Currently the pass only supports static index dimensions and fails
+    otherwise.
   }];
-
-  let dependentDialects = [
-    "tosa::TosaDialect"
-  ];
 }
 
 def TosaNarrowI64ToI32Pass : Pass<"tosa-narrow-i64-to-i32", "func::FuncOp"> {

--- a/mlir/lib/Dialect/Tosa/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/Tosa/Transforms/CMakeLists.txt
@@ -6,6 +6,7 @@ add_mlir_dialect_library(MLIRTosaTransforms
   TosaDecomposeTransposeConv.cpp
   TosaDecomposeDepthwise.cpp
   TosaFolders.cpp
+  TosaGatherScatterHardening.cpp
   TosaInferShapes.cpp
   TosaLayerwiseConstantFoldPass.cpp
   TosaMakeBroadcastable.cpp

--- a/mlir/lib/Dialect/Tosa/Transforms/TosaGatherScatterHardening.cpp
+++ b/mlir/lib/Dialect/Tosa/Transforms/TosaGatherScatterHardening.cpp
@@ -16,7 +16,9 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Tosa/IR/TosaOps.h"
 #include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Matchers.h"
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
@@ -75,8 +77,8 @@ static LogicalResult collectIndexUse(Operation *op, Value indices, Value values,
         "gather/scatter hardening");
   }
 
-  // Clamp bounds must be representable in the index element type. Group only
-  // users whose resulting clamp bounds are identical.
+  // Bounds must be representable in the index element type. Group only users
+  // whose resulting bounds are identical.
   int64_t maxRepresentable =
       llvm::APInt::getSignedMaxValue(elementType.getWidth()).getSExtValue();
   int64_t upperBound = std::min(indexedSize - 1, maxRepresentable);
@@ -123,33 +125,55 @@ collectIndexUseGroups(func::FuncOp funcOp,
 }
 
 /// Returns whether the indices already have sufficiently restrictive bounds.
-static bool isAlreadyHardened(Value indices, IntegerAttr maxAttr) {
-  auto clampOp = indices.getDefiningOp<tosa::ClampOp>();
-  if (!clampOp)
+static bool isAlreadyHardened(Value indices, int64_t requiredUpperBound) {
+  auto minimumOp = indices.getDefiningOp<tosa::MinimumOp>();
+  if (!minimumOp)
     return false;
 
-  auto existingMin = dyn_cast<IntegerAttr>(clampOp.getMinValAttr());
-  auto existingMax = dyn_cast<IntegerAttr>(clampOp.getMaxValAttr());
-  return existingMin && existingMax && !existingMin.getValue().isNegative() &&
-         existingMax.getValue().sle(maxAttr.getValue());
+  Value maximumResult = minimumOp.getInput1();
+  llvm::APInt upperBound;
+  if (!matchPattern(minimumOp.getInput2(), m_ConstantInt(&upperBound))) {
+    maximumResult = minimumOp.getInput2();
+    if (!matchPattern(minimumOp.getInput1(), m_ConstantInt(&upperBound)))
+      return false;
+  }
+
+  auto maximumOp = maximumResult.getDefiningOp<tosa::MaximumOp>();
+  if (!maximumOp)
+    return false;
+
+  llvm::APInt lowerBound;
+  if (!matchPattern(maximumOp.getInput2(), m_ConstantInt(&lowerBound)) &&
+      !matchPattern(maximumOp.getInput1(), m_ConstantInt(&lowerBound)))
+    return false;
+
+  unsigned bitWidth = upperBound.getBitWidth();
+  llvm::APInt requiredUpper(bitWidth,
+                            static_cast<uint64_t>(requiredUpperBound));
+  return lowerBound.getBitWidth() == bitWidth && !lowerBound.isNegative() &&
+         !upperBound.isNegative() && upperBound.sle(requiredUpper);
 }
 
-/// Creates a clamp for the group and rewires its gather/scatter users.
+/// Creates a rank-two splat constant suitable for index broadcasting.
+static Value createIndexBoundConstant(OpBuilder &builder, Location loc,
+                                      IntegerType elementType, int64_t value) {
+  auto type = RankedTensorType::get({1, 1}, elementType);
+  auto valueAttr =
+      IntegerAttr::get(elementType, llvm::APInt(elementType.getWidth(),
+                                                static_cast<uint64_t>(value)));
+  auto values = DenseElementsAttr::get(type, valueAttr);
+  return tosa::ConstOp::create(builder, loc, type, values).getResult();
+}
+
+/// Creates minimum/maximum bounds and rewires the group's index users.
 static void hardenIndexUseGroup(IndexUseGroup &group, OpBuilder &builder) {
   Value indices = group.indices;
   auto indicesType = cast<ShapedType>(indices.getType());
   auto elementType = cast<IntegerType>(indicesType.getElementType());
-  unsigned bitWidth = elementType.getWidth();
 
-  IntegerAttr minAttr =
-      IntegerAttr::get(elementType, llvm::APInt::getZero(bitWidth));
-  IntegerAttr maxAttr = IntegerAttr::get(
-      elementType,
-      llvm::APInt(bitWidth, static_cast<uint64_t>(group.upperBound)));
-
-  // Keep the pass idempotent and avoid nesting a second clamp around an
-  // existing clamp that is at least as restrictive as the required one.
-  if (isAlreadyHardened(indices, maxAttr))
+  // Keep the pass idempotent and avoid nesting a second min/max pair around
+  // indices that are already at least as restricted as required.
+  if (isAlreadyHardened(indices, group.upperBound))
     return;
 
   if (Operation *definingOp = indices.getDefiningOp())
@@ -157,9 +181,17 @@ static void hardenIndexUseGroup(IndexUseGroup &group, OpBuilder &builder) {
   else
     builder.setInsertionPointToStart(cast<BlockArgument>(indices).getOwner());
 
+  Location loc = group.users.front()->getLoc();
+  Value lowerBound = createIndexBoundConstant(builder, loc, elementType, 0);
+  Value upperBound =
+      createIndexBoundConstant(builder, loc, elementType, group.upperBound);
+  Value nonNegativeIndices =
+      tosa::MaximumOp::create(builder, loc, indices.getType(), indices,
+                              lowerBound)
+          .getResult();
   Value clampedIndices =
-      tosa::ClampOp::create(builder, group.users.front()->getLoc(),
-                            indices.getType(), indices, minAttr, maxAttr)
+      tosa::MinimumOp::create(builder, loc, indices.getType(),
+                              nonNegativeIndices, upperBound)
           .getResult();
 
   for (Operation *user : group.users)
@@ -174,7 +206,7 @@ struct TosaGatherScatterHardeningPass
   void runOnOperation() override {
     SmallVector<IndexUseGroup> groups;
     // Do not partially harden the function when one operation cannot be made
-    // safe using a statically bounded tosa.clamp.
+    // safe using statically bounded minimum and maximum operations.
     if (failed(collectIndexUseGroups(getOperation(), groups))) {
       signalPassFailure();
       return;

--- a/mlir/lib/Dialect/Tosa/Transforms/TosaGatherScatterHardening.cpp
+++ b/mlir/lib/Dialect/Tosa/Transforms/TosaGatherScatterHardening.cpp
@@ -1,0 +1,189 @@
+//===- TosaGatherScatterHardening.cpp -------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements a pass that clamps gather and scatter indices to the
+// statically known bounds of their indexed tensors.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/Tosa/Transforms/Passes.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Tosa/IR/TosaOps.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "llvm/ADT/APInt.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+#include <algorithm>
+#include <cstdint>
+
+namespace mlir {
+namespace tosa {
+#define GEN_PASS_DEF_TOSAGATHERSCATTERHARDENINGPASS
+#include "mlir/Dialect/Tosa/Transforms/Passes.h.inc"
+} // namespace tosa
+} // namespace mlir
+
+using namespace mlir;
+using namespace mlir::tosa;
+
+namespace {
+
+struct IndexUseGroup {
+  IndexUseGroup(Value indices, int64_t upperBound)
+      : indices(indices), upperBound(upperBound) {}
+
+  Value indices;
+  SmallVector<Operation *> users;
+  int64_t upperBound;
+};
+
+using GroupsForIndices = DenseMap<Value, SmallVector<unsigned>>;
+
+/// Validates one gather/scatter index use and adds it to a compatible group.
+static LogicalResult collectIndexUse(Operation *op, Value indices, Value values,
+                                     GroupsForIndices &groupsForIndices,
+                                     SmallVectorImpl<IndexUseGroup> &groups) {
+  auto valuesType = dyn_cast<RankedTensorType>(values.getType());
+  if (!valuesType || valuesType.getRank() <= 1 || valuesType.isDynamicDim(1)) {
+    return op->emitOpError(
+        "requires a statically known indexed dimension for gather/scatter "
+        "hardening");
+  }
+
+  int64_t indexedSize = valuesType.getDimSize(1);
+  if (indexedSize <= 0) {
+    return op->emitOpError(
+        "requires a non-empty indexed dimension for gather/scatter hardening");
+  }
+
+  auto indicesType = dyn_cast<ShapedType>(indices.getType());
+  auto elementType = indicesType
+                         ? dyn_cast<IntegerType>(indicesType.getElementType())
+                         : IntegerType();
+  if (!elementType || elementType.getWidth() > 64) {
+    return op->emitOpError(
+        "requires indices with an integer element type of at most 64 bits for "
+        "gather/scatter hardening");
+  }
+
+  // Clamp bounds must be representable in the index element type. Group only
+  // users whose resulting clamp bounds are identical.
+  int64_t maxRepresentable =
+      llvm::APInt::getSignedMaxValue(elementType.getWidth()).getSExtValue();
+  int64_t upperBound = std::min(indexedSize - 1, maxRepresentable);
+
+  unsigned groupIndex = groups.size();
+  SmallVector<unsigned> &candidateGroups = groupsForIndices[indices];
+  for (unsigned candidate : candidateGroups) {
+    if (groups[candidate].upperBound == upperBound) {
+      groupIndex = candidate;
+      break;
+    }
+  }
+  if (groupIndex == groups.size()) {
+    groups.emplace_back(indices, upperBound);
+    candidateGroups.push_back(groupIndex);
+  }
+
+  groups[groupIndex].users.push_back(op);
+  return success();
+}
+
+/// Collects and validates all gather/scatter index uses in the function.
+static LogicalResult
+collectIndexUseGroups(func::FuncOp funcOp,
+                      SmallVectorImpl<IndexUseGroup> &groups) {
+  GroupsForIndices groupsForIndices;
+  bool analysisFailed = false;
+
+  funcOp.walk([&](Operation *op) {
+    llvm::TypeSwitch<Operation *>(op)
+        .Case<tosa::GatherOp>([&](tosa::GatherOp gatherOp) {
+          analysisFailed |= failed(collectIndexUse(op, gatherOp.getIndices(),
+                                                   gatherOp.getValues(),
+                                                   groupsForIndices, groups));
+        })
+        .Case<tosa::ScatterOp>([&](tosa::ScatterOp scatterOp) {
+          analysisFailed |= failed(collectIndexUse(op, scatterOp.getIndices(),
+                                                   scatterOp.getValuesIn(),
+                                                   groupsForIndices, groups));
+        });
+  });
+
+  return analysisFailed ? failure() : success();
+}
+
+/// Returns whether the indices already have sufficiently restrictive bounds.
+static bool isAlreadyHardened(Value indices, IntegerAttr maxAttr) {
+  auto clampOp = indices.getDefiningOp<tosa::ClampOp>();
+  if (!clampOp)
+    return false;
+
+  auto existingMin = dyn_cast<IntegerAttr>(clampOp.getMinValAttr());
+  auto existingMax = dyn_cast<IntegerAttr>(clampOp.getMaxValAttr());
+  return existingMin && existingMax && !existingMin.getValue().isNegative() &&
+         existingMax.getValue().sle(maxAttr.getValue());
+}
+
+/// Creates a clamp for the group and rewires its gather/scatter users.
+static void hardenIndexUseGroup(IndexUseGroup &group, OpBuilder &builder) {
+  Value indices = group.indices;
+  auto indicesType = cast<ShapedType>(indices.getType());
+  auto elementType = cast<IntegerType>(indicesType.getElementType());
+  unsigned bitWidth = elementType.getWidth();
+
+  IntegerAttr minAttr =
+      IntegerAttr::get(elementType, llvm::APInt::getZero(bitWidth));
+  IntegerAttr maxAttr = IntegerAttr::get(
+      elementType,
+      llvm::APInt(bitWidth, static_cast<uint64_t>(group.upperBound)));
+
+  // Keep the pass idempotent and avoid nesting a second clamp around an
+  // existing clamp that is at least as restrictive as the required one.
+  if (isAlreadyHardened(indices, maxAttr))
+    return;
+
+  if (Operation *definingOp = indices.getDefiningOp())
+    builder.setInsertionPointAfter(definingOp);
+  else
+    builder.setInsertionPointToStart(cast<BlockArgument>(indices).getOwner());
+
+  Value clampedIndices =
+      tosa::ClampOp::create(builder, group.users.front()->getLoc(),
+                            indices.getType(), indices, minAttr, maxAttr)
+          .getResult();
+
+  for (Operation *user : group.users)
+    user->setOperand(/*indices=*/1, clampedIndices);
+}
+
+struct TosaGatherScatterHardeningPass
+    : public tosa::impl::TosaGatherScatterHardeningPassBase<
+          TosaGatherScatterHardeningPass> {
+  using Base::Base;
+
+  void runOnOperation() override {
+    SmallVector<IndexUseGroup> groups;
+    // Do not partially harden the function when one operation cannot be made
+    // safe using a statically bounded tosa.clamp.
+    if (failed(collectIndexUseGroups(getOperation(), groups))) {
+      signalPassFailure();
+      return;
+    }
+
+    OpBuilder builder(&getContext());
+    for (IndexUseGroup &group : groups)
+      hardenIndexUseGroup(group, builder);
+  }
+};
+
+} // namespace

--- a/mlir/lib/Dialect/Tosa/Transforms/TosaGatherScatterHardening.cpp
+++ b/mlir/lib/Dialect/Tosa/Transforms/TosaGatherScatterHardening.cpp
@@ -22,9 +22,11 @@
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "llvm/ADT/APInt.h"
+#include "llvm/ADT/STLExtras.h"
 
 #include <algorithm>
 #include <cstdint>
+#include <type_traits>
 
 namespace mlir {
 namespace tosa {
@@ -58,33 +60,58 @@ static FailureOr<int64_t> getIndexUpperBound(Operation *op) {
 }
 
 /// Returns whether the indices already have sufficiently restrictive bounds.
+template <typename OuterOp, typename InnerOp>
 static bool isAlreadyHardened(Value indices, int64_t requiredUpperBound) {
-  auto minimumOp = indices.getDefiningOp<tosa::MinimumOp>();
-  if (!minimumOp)
+  static_assert(
+      (std::is_same_v<OuterOp, tosa::MinimumOp> &&
+       std::is_same_v<InnerOp, tosa::MaximumOp>) ||
+          (std::is_same_v<OuterOp, tosa::MaximumOp> &&
+           std::is_same_v<InnerOp, tosa::MinimumOp>),
+      "expected a tosa::MinimumOp/tosa::MaximumOp pair in either order");
+
+  auto outerOp = indices.getDefiningOp<OuterOp>();
+  if (!outerOp)
     return false;
 
-  Value maximumResult = minimumOp.getInput1();
-  llvm::APInt upperBound;
-  if (!matchPattern(minimumOp.getInput2(), m_ConstantInt(&upperBound))) {
-    maximumResult = minimumOp.getInput2();
-    if (!matchPattern(minimumOp.getInput1(), m_ConstantInt(&upperBound)))
-      return false;
+  // Either operand can be the bound, including when both are constants. A
+  // constant match alone is not enough: try the other operand if it is unsafe.
+  for (unsigned boundOperand = 0; boundOperand < 2; ++boundOperand) {
+    llvm::APInt outerBound;
+    if (!matchPattern(outerOp->getOperand(boundOperand),
+                      m_ConstantInt(&outerBound)))
+      continue;
+
+    llvm::APInt requiredUpper(outerBound.getBitWidth(),
+                              static_cast<uint64_t>(requiredUpperBound));
+    // The outer bound must itself be in range, since it can override the inner
+    // bound, e.g. minimum(maximum(x, 0), -1) would produce -1. This guarantees
+    // the other operand is meeting the outer bound check (e.g. smaller or equal
+    // to the required upper bound if outer op is a minimum). The inner
+    // operation only needs to enforce the opposite bound.
+    if (outerBound.isNegative() || outerBound.sgt(requiredUpper))
+      continue;
+
+    auto matchesInnerBound = [&](Value value) {
+      llvm::APInt innerBound;
+      if (!matchPattern(value, m_ConstantInt(&innerBound)))
+        return false;
+      return isa<tosa::MinimumOp>(outerOp) ? !innerBound.isNegative()
+                                           : innerBound.sle(requiredUpper);
+    };
+
+    // Check whether other operand of the outer op is also a constant and is
+    // meeting the inner bound check. No inner op involved and the result is
+    // therefore completely within bound thanks to the earlier check.
+    Value innerResult = outerOp->getOperand(1 - boundOperand);
+    if (matchesInnerBound(innerResult))
+      return true;
+    // The other outer op operand is not a constant so check that the inner op
+    // enforces inner bound check.
+    if (auto innerOp = innerResult.getDefiningOp<InnerOp>())
+      if (llvm::any_of(innerOp->getOperands(), matchesInnerBound))
+        return true;
   }
-
-  auto maximumOp = maximumResult.getDefiningOp<tosa::MaximumOp>();
-  if (!maximumOp)
-    return false;
-
-  llvm::APInt lowerBound;
-  if (!matchPattern(maximumOp.getInput2(), m_ConstantInt(&lowerBound)) &&
-      !matchPattern(maximumOp.getInput1(), m_ConstantInt(&lowerBound)))
-    return false;
-
-  unsigned bitWidth = upperBound.getBitWidth();
-  llvm::APInt requiredUpper(bitWidth,
-                            static_cast<uint64_t>(requiredUpperBound));
-  return lowerBound.getBitWidth() == bitWidth && !lowerBound.isNegative() &&
-         !upperBound.isNegative() && upperBound.sle(requiredUpper);
+  return false;
 }
 
 /// Creates a rank-two splat constant suitable for index broadcasting.
@@ -114,7 +141,10 @@ struct HardenIndexUsePattern final : OpRewritePattern<OpTy> {
     }
 
     Value indices = op->getOperand(1);
-    if (isAlreadyHardened(indices, *upperBound))
+    if (isAlreadyHardened<tosa::MinimumOp, tosa::MaximumOp>(indices,
+                                                            *upperBound) ||
+        isAlreadyHardened<tosa::MaximumOp, tosa::MinimumOp>(indices,
+                                                            *upperBound))
       return rewriter.notifyMatchFailure(op, "indices are already hardened");
 
     auto indicesType = cast<ShapedType>(indices.getType());

--- a/mlir/lib/Dialect/Tosa/Transforms/TosaGatherScatterHardening.cpp
+++ b/mlir/lib/Dialect/Tosa/Transforms/TosaGatherScatterHardening.cpp
@@ -19,10 +19,9 @@
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Matchers.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "llvm/ADT/APInt.h"
-#include "llvm/ADT/DenseMap.h"
-#include "llvm/ADT/SmallVector.h"
-#include "llvm/ADT/TypeSwitch.h"
 
 #include <algorithm>
 #include <cstdint>
@@ -39,89 +38,23 @@ using namespace mlir::tosa;
 
 namespace {
 
-struct IndexUseGroup {
-  IndexUseGroup(Value indices, int64_t upperBound)
-      : indices(indices), upperBound(upperBound) {}
-
-  Value indices;
-  SmallVector<Operation *> users;
-  int64_t upperBound;
-};
-
-using GroupsForIndices = DenseMap<Value, SmallVector<unsigned>>;
-
-/// Validates one gather/scatter index use and adds it to a compatible group.
-static LogicalResult collectIndexUse(Operation *op, Value indices, Value values,
-                                     GroupsForIndices &groupsForIndices,
-                                     SmallVectorImpl<IndexUseGroup> &groups) {
+/// Returns the effective upper bound when the indexed dimension is static.
+static FailureOr<int64_t> getIndexUpperBound(Operation *op) {
+  Value values = op->getOperand(0);
   auto valuesType = dyn_cast<RankedTensorType>(values.getType());
-  if (!valuesType || valuesType.getRank() <= 1 || valuesType.isDynamicDim(1)) {
-    return op->emitOpError(
-        "requires a statically known indexed dimension for gather/scatter "
-        "hardening");
+  if (!valuesType || valuesType.isDynamicDim(1)) {
+    op->emitOpError("requires a statically known indexed dimension for "
+                    "gather/scatter hardening");
+    return failure();
   }
 
-  int64_t indexedSize = valuesType.getDimSize(1);
-  if (indexedSize <= 0) {
-    return op->emitOpError(
-        "requires a non-empty indexed dimension for gather/scatter hardening");
-  }
+  auto indicesType = cast<ShapedType>(op->getOperand(1).getType());
+  auto elementType = cast<IntegerType>(indicesType.getElementType());
 
-  auto indicesType = dyn_cast<ShapedType>(indices.getType());
-  auto elementType = indicesType
-                         ? dyn_cast<IntegerType>(indicesType.getElementType())
-                         : IntegerType();
-  if (!elementType || elementType.getWidth() > 64) {
-    return op->emitOpError(
-        "requires indices with an integer element type of at most 64 bits for "
-        "gather/scatter hardening");
-  }
-
-  // Bounds must be representable in the index element type. Group only users
-  // whose resulting bounds are identical.
+  // The upper bound must be representable in the index element type.
   int64_t maxRepresentable =
       llvm::APInt::getSignedMaxValue(elementType.getWidth()).getSExtValue();
-  int64_t upperBound = std::min(indexedSize - 1, maxRepresentable);
-
-  unsigned groupIndex = groups.size();
-  SmallVector<unsigned> &candidateGroups = groupsForIndices[indices];
-  for (unsigned candidate : candidateGroups) {
-    if (groups[candidate].upperBound == upperBound) {
-      groupIndex = candidate;
-      break;
-    }
-  }
-  if (groupIndex == groups.size()) {
-    groups.emplace_back(indices, upperBound);
-    candidateGroups.push_back(groupIndex);
-  }
-
-  groups[groupIndex].users.push_back(op);
-  return success();
-}
-
-/// Collects and validates all gather/scatter index uses in the function.
-static LogicalResult
-collectIndexUseGroups(func::FuncOp funcOp,
-                      SmallVectorImpl<IndexUseGroup> &groups) {
-  GroupsForIndices groupsForIndices;
-  bool analysisFailed = false;
-
-  funcOp.walk([&](Operation *op) {
-    llvm::TypeSwitch<Operation *>(op)
-        .Case<tosa::GatherOp>([&](tosa::GatherOp gatherOp) {
-          analysisFailed |= failed(collectIndexUse(op, gatherOp.getIndices(),
-                                                   gatherOp.getValues(),
-                                                   groupsForIndices, groups));
-        })
-        .Case<tosa::ScatterOp>([&](tosa::ScatterOp scatterOp) {
-          analysisFailed |= failed(collectIndexUse(op, scatterOp.getIndices(),
-                                                   scatterOp.getValuesIn(),
-                                                   groupsForIndices, groups));
-        });
-  });
-
-  return analysisFailed ? failure() : success();
+  return std::min(valuesType.getDimSize(1) - 1, maxRepresentable);
 }
 
 /// Returns whether the indices already have sufficiently restrictive bounds.
@@ -165,38 +98,48 @@ static Value createIndexBoundConstant(OpBuilder &builder, Location loc,
   return tosa::ConstOp::create(builder, loc, type, values).getResult();
 }
 
-/// Creates minimum/maximum bounds and rewires the group's index users.
-static void hardenIndexUseGroup(IndexUseGroup &group, OpBuilder &builder) {
-  Value indices = group.indices;
-  auto indicesType = cast<ShapedType>(indices.getType());
-  auto elementType = cast<IntegerType>(indicesType.getElementType());
+/// Independently hardens one gather or scatter operation's indices.
+template <typename OpTy>
+struct HardenIndexUsePattern final : OpRewritePattern<OpTy> {
+  HardenIndexUsePattern(MLIRContext *context, bool &hardeningFailed)
+      : OpRewritePattern<OpTy>(context), hardeningFailed(hardeningFailed) {}
 
-  // Keep the pass idempotent and avoid nesting a second min/max pair around
-  // indices that are already at least as restricted as required.
-  if (isAlreadyHardened(indices, group.upperBound))
-    return;
+  LogicalResult matchAndRewrite(OpTy op,
+                                PatternRewriter &rewriter) const override {
+    FailureOr<int64_t> upperBound = getIndexUpperBound(op.getOperation());
+    if (failed(upperBound)) {
+      hardeningFailed = true;
+      return rewriter.notifyMatchFailure(
+          op, "indexed dimension does not have a static upper bound");
+    }
 
-  if (Operation *definingOp = indices.getDefiningOp())
-    builder.setInsertionPointAfter(definingOp);
-  else
-    builder.setInsertionPointToStart(cast<BlockArgument>(indices).getOwner());
+    Value indices = op->getOperand(1);
+    if (isAlreadyHardened(indices, *upperBound))
+      return rewriter.notifyMatchFailure(op, "indices are already hardened");
 
-  Location loc = group.users.front()->getLoc();
-  Value lowerBound = createIndexBoundConstant(builder, loc, elementType, 0);
-  Value upperBound =
-      createIndexBoundConstant(builder, loc, elementType, group.upperBound);
-  Value nonNegativeIndices =
-      tosa::MaximumOp::create(builder, loc, indices.getType(), indices,
-                              lowerBound)
-          .getResult();
-  Value clampedIndices =
-      tosa::MinimumOp::create(builder, loc, indices.getType(),
-                              nonNegativeIndices, upperBound)
-          .getResult();
+    auto indicesType = cast<ShapedType>(indices.getType());
+    auto elementType = cast<IntegerType>(indicesType.getElementType());
+    Value lowerBound =
+        createIndexBoundConstant(rewriter, op.getLoc(), elementType, 0);
+    Value upperBoundValue = createIndexBoundConstant(rewriter, op.getLoc(),
+                                                     elementType, *upperBound);
+    Value nonNegativeIndices =
+        tosa::MaximumOp::create(rewriter, op.getLoc(), indices.getType(),
+                                indices, lowerBound)
+            .getResult();
+    Value clampedIndices =
+        tosa::MinimumOp::create(rewriter, op.getLoc(), indices.getType(),
+                                nonNegativeIndices, upperBoundValue)
+            .getResult();
 
-  for (Operation *user : group.users)
-    user->setOperand(/*indices=*/1, clampedIndices);
-}
+    rewriter.modifyOpInPlace(
+        op, [&] { op->setOperand(/*indices=*/1, clampedIndices); });
+    return success();
+  }
+
+private:
+  bool &hardeningFailed;
+};
 
 struct TosaGatherScatterHardeningPass
     : public tosa::impl::TosaGatherScatterHardeningPassBase<
@@ -204,17 +147,14 @@ struct TosaGatherScatterHardeningPass
   using Base::Base;
 
   void runOnOperation() override {
-    SmallVector<IndexUseGroup> groups;
-    // Do not partially harden the function when one operation cannot be made
-    // safe using statically bounded minimum and maximum operations.
-    if (failed(collectIndexUseGroups(getOperation(), groups))) {
+    bool hardeningFailed = false;
+    RewritePatternSet patterns(&getContext());
+    patterns.add<HardenIndexUsePattern<tosa::GatherOp>,
+                 HardenIndexUsePattern<tosa::ScatterOp>>(&getContext(),
+                                                         hardeningFailed);
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns))) ||
+        hardeningFailed)
       signalPassFailure();
-      return;
-    }
-
-    OpBuilder builder(&getContext());
-    for (IndexUseGroup &group : groups)
-      hardenIndexUseGroup(group, builder);
   }
 };
 

--- a/mlir/test/Dialect/Tosa/tosa-gather-scatter-hardening-invalid.mlir
+++ b/mlir/test/Dialect/Tosa/tosa-gather-scatter-hardening-invalid.mlir
@@ -1,0 +1,9 @@
+// RUN: not mlir-opt %s -tosa-gather-scatter-hardening 2>&1 | FileCheck %s
+
+func.func @dynamic_indexed_dimension(%arg0: tensor<3x?x5xi8>,
+                                     %arg1: tensor<3x6xi32>)
+    -> tensor<3x6x5xi8> {
+  // CHECK: error: 'tosa.gather' op requires a statically known indexed dimension for gather/scatter hardening
+  %0 = tosa.gather %arg0, %arg1 : (tensor<3x?x5xi8>, tensor<3x6xi32>) -> tensor<3x6x5xi8>
+  return %0 : tensor<3x6x5xi8>
+}

--- a/mlir/test/Dialect/Tosa/tosa-gather-scatter-hardening-invalid.mlir
+++ b/mlir/test/Dialect/Tosa/tosa-gather-scatter-hardening-invalid.mlir
@@ -1,9 +1,17 @@
-// RUN: not mlir-opt %s -tosa-gather-scatter-hardening 2>&1 | FileCheck %s
+// RUN: mlir-opt %s -tosa-gather-scatter-hardening -verify-diagnostics
 
-func.func @dynamic_indexed_dimension(%arg0: tensor<3x?x5xi8>,
-                                     %arg1: tensor<3x6xi32>)
-    -> tensor<3x6x5xi8> {
-  // CHECK: error: 'tosa.gather' op requires a statically known indexed dimension for gather/scatter hardening
-  %0 = tosa.gather %arg0, %arg1 : (tensor<3x?x5xi8>, tensor<3x6xi32>) -> tensor<3x6x5xi8>
-  return %0 : tensor<3x6x5xi8>
+// A correctly hardened gather must not hide a scatter whose indexed dimension
+// is dynamic, even when they share the same bounded indices.
+func.func @dynamic_indexed_dimension(
+    %values: tensor<1x21x1xi8>, %dynamic_values: tensor<1x?x1xi8>,
+    %indices: tensor<1x2xi32>, %updates: tensor<1x2x1xi8>)
+    -> (tensor<1x2x1xi8>, tensor<1x?x1xi8>) {
+  %zero = "tosa.const"() <{values = dense<0> : tensor<1x1xi32>}> : () -> tensor<1x1xi32>
+  %upper = "tosa.const"() <{values = dense<20> : tensor<1x1xi32>}> : () -> tensor<1x1xi32>
+  %0 = tosa.maximum %indices, %zero : (tensor<1x2xi32>, tensor<1x1xi32>) -> tensor<1x2xi32>
+  %1 = tosa.minimum %0, %upper : (tensor<1x2xi32>, tensor<1x1xi32>) -> tensor<1x2xi32>
+  %gather = tosa.gather %values, %1 : (tensor<1x21x1xi8>, tensor<1x2xi32>) -> tensor<1x2x1xi8>
+  // expected-error@+1 {{'tosa.scatter' op requires a statically known indexed dimension for gather/scatter hardening}}
+  %scatter = tosa.scatter %dynamic_values, %1, %updates : (tensor<1x?x1xi8>, tensor<1x2xi32>, tensor<1x2x1xi8>) -> tensor<1x?x1xi8>
+  return %gather, %scatter : tensor<1x2x1xi8>, tensor<1x?x1xi8>
 }

--- a/mlir/test/Dialect/Tosa/tosa-gather-scatter-hardening.mlir
+++ b/mlir/test/Dialect/Tosa/tosa-gather-scatter-hardening.mlir
@@ -1,9 +1,12 @@
 // RUN: mlir-opt %s -tosa-gather-scatter-hardening -split-input-file | FileCheck %s
 
 // CHECK-LABEL: func.func @gather(
-// CHECK: %[[CLAMP:.*]] = tosa.clamp %arg1 {max_val = 20 : i32, min_val = 0 : i32} : (tensor<3x6xi32>) -> tensor<3x6xi32>
+// CHECK: %[[ZERO:.*]] = "tosa.const"() <{values = dense<0> : tensor<1x1xi32>}> : () -> tensor<1x1xi32>
+// CHECK: %[[UPPER:.*]] = "tosa.const"() <{values = dense<20> : tensor<1x1xi32>}> : () -> tensor<1x1xi32>
+// CHECK: %[[NONNEGATIVE:.*]] = tosa.maximum %arg1, %[[ZERO]]
+// CHECK: %[[CLAMPED:.*]] = tosa.minimum %[[NONNEGATIVE]], %[[UPPER]]
 // CHECK: %[[OTHER_USE:.*]] = tosa.add %arg1, %arg2
-// CHECK: %[[GATHER:.*]] = tosa.gather %arg0, %[[CLAMP]]
+// CHECK: %[[GATHER:.*]] = tosa.gather %arg0, %[[CLAMPED]]
 // CHECK: return %[[GATHER]], %[[OTHER_USE]]
 func.func @gather(%arg0: tensor<3x21x5xi8>, %arg1: tensor<3x6xi32>,
                   %arg2: tensor<3x6xi32>)
@@ -15,14 +18,20 @@ func.func @gather(%arg0: tensor<3x21x5xi8>, %arg1: tensor<3x6xi32>,
 
 // -----
 
-// One clamp is shared by gather and scatter when their bounds match.
+// One bounding sequence is shared by gather and scatter when their bounds
+// match.
 
 // CHECK-LABEL: func.func @shared_indices(
-// CHECK: %[[CLAMP:.*]] = tosa.clamp %arg2 {max_val = 20 : i32, min_val = 0 : i32} : (tensor<2x4xi32>) -> tensor<2x4xi32>
-// CHECK-NOT: tosa.clamp
-// CHECK: %[[GATHER:.*]] = tosa.gather %arg0, %[[CLAMP]]
-// CHECK: %[[SCATTER:.*]] = tosa.scatter %arg1, %[[CLAMP]], %arg3
-// CHECK-NOT: tosa.clamp
+// CHECK: %[[ZERO:.*]] = "tosa.const"() <{values = dense<0> : tensor<1x1xi32>}> : () -> tensor<1x1xi32>
+// CHECK: %[[UPPER:.*]] = "tosa.const"() <{values = dense<20> : tensor<1x1xi32>}> : () -> tensor<1x1xi32>
+// CHECK: %[[NONNEGATIVE:.*]] = tosa.maximum %arg2, %[[ZERO]]
+// CHECK: %[[CLAMPED:.*]] = tosa.minimum %[[NONNEGATIVE]], %[[UPPER]]
+// CHECK-NOT: tosa.maximum
+// CHECK-NOT: tosa.minimum
+// CHECK: %[[GATHER:.*]] = tosa.gather %arg0, %[[CLAMPED]]
+// CHECK: %[[SCATTER:.*]] = tosa.scatter %arg1, %[[CLAMPED]], %arg3
+// CHECK-NOT: tosa.maximum
+// CHECK-NOT: tosa.minimum
 // CHECK: return %[[GATHER]], %[[SCATTER]]
 func.func @shared_indices(%arg0: tensor<2x21x3xf32>,
                           %arg1: tensor<2x21x3xf32>,
@@ -36,13 +45,19 @@ func.func @shared_indices(%arg0: tensor<2x21x3xf32>,
 
 // -----
 
-// Gather and scatter get separate clamps when their bounds differ.
+// Gather and scatter get separate bounding sequences when their bounds differ.
 
 // CHECK-LABEL: func.func @different_bounds(
-// CHECK-DAG: %[[GATHER_CLAMP:.*]] = tosa.clamp %arg2 {max_val = 20 : i32, min_val = 0 : i32} : (tensor<2x4xi32>) -> tensor<2x4xi32>
-// CHECK-DAG: %[[SCATTER_CLAMP:.*]] = tosa.clamp %arg2 {max_val = 51 : i32, min_val = 0 : i32} : (tensor<2x4xi32>) -> tensor<2x4xi32>
-// CHECK: %[[GATHER:.*]] = tosa.gather %arg0, %[[GATHER_CLAMP]]
-// CHECK: %[[SCATTER:.*]] = tosa.scatter %arg1, %[[SCATTER_CLAMP]], %arg3
+// CHECK: %[[SCATTER_ZERO:.*]] = "tosa.const"() <{values = dense<0> : tensor<1x1xi32>}> : () -> tensor<1x1xi32>
+// CHECK: %[[SCATTER_UPPER:.*]] = "tosa.const"() <{values = dense<51> : tensor<1x1xi32>}> : () -> tensor<1x1xi32>
+// CHECK: %[[SCATTER_NONNEGATIVE:.*]] = tosa.maximum %arg2, %[[SCATTER_ZERO]]
+// CHECK: %[[SCATTER_CLAMPED:.*]] = tosa.minimum %[[SCATTER_NONNEGATIVE]], %[[SCATTER_UPPER]]
+// CHECK: %[[GATHER_ZERO:.*]] = "tosa.const"() <{values = dense<0> : tensor<1x1xi32>}> : () -> tensor<1x1xi32>
+// CHECK: %[[GATHER_UPPER:.*]] = "tosa.const"() <{values = dense<20> : tensor<1x1xi32>}> : () -> tensor<1x1xi32>
+// CHECK: %[[GATHER_NONNEGATIVE:.*]] = tosa.maximum %arg2, %[[GATHER_ZERO]]
+// CHECK: %[[GATHER_CLAMPED:.*]] = tosa.minimum %[[GATHER_NONNEGATIVE]], %[[GATHER_UPPER]]
+// CHECK: %[[GATHER:.*]] = tosa.gather %arg0, %[[GATHER_CLAMPED]]
+// CHECK: %[[SCATTER:.*]] = tosa.scatter %arg1, %[[SCATTER_CLAMPED]], %arg3
 // CHECK: return %[[GATHER]], %[[SCATTER]]
 func.func @different_bounds(%arg0: tensor<2x21x3xf32>,
                             %arg1: tensor<2x52x3xf32>,
@@ -57,8 +72,11 @@ func.func @different_bounds(%arg0: tensor<2x21x3xf32>,
 // -----
 
 // CHECK-LABEL: func.func @i64_indices(
-// CHECK: %[[CLAMP:.*]] = tosa.clamp %arg1 {max_val = 26 : i64, min_val = 0 : i64} : (tensor<13x4xi64>) -> tensor<13x4xi64>
-// CHECK: tosa.scatter %arg0, %[[CLAMP]], %arg2
+// CHECK: %[[ZERO:.*]] = "tosa.const"() <{values = dense<0> : tensor<1x1xi64>}> : () -> tensor<1x1xi64>
+// CHECK: %[[UPPER:.*]] = "tosa.const"() <{values = dense<26> : tensor<1x1xi64>}> : () -> tensor<1x1xi64>
+// CHECK: %[[NONNEGATIVE:.*]] = tosa.maximum %arg1, %[[ZERO]]
+// CHECK: %[[CLAMPED:.*]] = tosa.minimum %[[NONNEGATIVE]], %[[UPPER]]
+// CHECK: tosa.scatter %arg0, %[[CLAMPED]], %arg2
 func.func @i64_indices(%arg0: tensor<13x27x3xi16>,
                        %arg1: tensor<13x4xi64>,
                        %arg2: tensor<13x4x3xi16>) -> tensor<13x27x3xi16> {
@@ -69,11 +87,14 @@ func.func @i64_indices(%arg0: tensor<13x27x3xi16>,
 // -----
 
 // An i32 index cannot represent K - 1 here, so its signed maximum is a safe
-// upper clamp bound.
+// upper bound.
 
 // CHECK-LABEL: func.func @large_indexed_dimension(
-// CHECK: %[[CLAMP:.*]] = tosa.clamp %arg1 {max_val = 2147483647 : i32, min_val = 0 : i32}
-// CHECK: tosa.gather %arg0, %[[CLAMP]]
+// CHECK: %[[ZERO:.*]] = "tosa.const"() <{values = dense<0> : tensor<1x1xi32>}> : () -> tensor<1x1xi32>
+// CHECK: %[[UPPER:.*]] = "tosa.const"() <{values = dense<2147483647> : tensor<1x1xi32>}> : () -> tensor<1x1xi32>
+// CHECK: %[[NONNEGATIVE:.*]] = tosa.maximum %arg1, %[[ZERO]]
+// CHECK: %[[CLAMPED:.*]] = tosa.minimum %[[NONNEGATIVE]], %[[UPPER]]
+// CHECK: tosa.gather %arg0, %[[CLAMPED]]
 func.func @large_indexed_dimension(
     %arg0: tensor<1x2147483649x1xi8>, %arg1: tensor<1x1xi32>)
     -> tensor<1x1x1xi8> {
@@ -84,20 +105,29 @@ func.func @large_indexed_dimension(
 // -----
 
 // CHECK-LABEL: func.func @already_hardened(
-// CHECK: %[[CLAMP:.*]] = tosa.clamp %arg1 {max_val = 20 : i32, min_val = 0 : i32}
-// CHECK-NOT: tosa.clamp
-// CHECK: tosa.gather %arg0, %[[CLAMP]]
+// CHECK: %[[ZERO:.*]] = "tosa.const"() <{values = dense<0> : tensor<1x1xi32>}> : () -> tensor<1x1xi32>
+// CHECK: %[[UPPER:.*]] = "tosa.const"() <{values = dense<20> : tensor<1x1xi32>}> : () -> tensor<1x1xi32>
+// CHECK: %[[NONNEGATIVE:.*]] = tosa.maximum %arg1, %[[ZERO]]
+// CHECK: %[[CLAMPED:.*]] = tosa.minimum %[[NONNEGATIVE]], %[[UPPER]]
+// CHECK-NOT: tosa.maximum
+// CHECK-NOT: tosa.minimum
+// CHECK: tosa.gather %arg0, %[[CLAMPED]]
 func.func @already_hardened(%arg0: tensor<3x21x5xi8>,
                             %arg1: tensor<3x6xi32>) -> tensor<3x6x5xi8> {
-  %0 = tosa.clamp %arg1 {max_val = 20 : i32, min_val = 0 : i32} : (tensor<3x6xi32>) -> tensor<3x6xi32>
-  %1 = tosa.gather %arg0, %0 : (tensor<3x21x5xi8>, tensor<3x6xi32>) -> tensor<3x6x5xi8>
-  return %1 : tensor<3x6x5xi8>
+  %0 = "tosa.const"() <{values = dense<0> : tensor<1x1xi32>}> : () -> tensor<1x1xi32>
+  %1 = "tosa.const"() <{values = dense<20> : tensor<1x1xi32>}> : () -> tensor<1x1xi32>
+  %2 = tosa.maximum %arg1, %0 : (tensor<3x6xi32>, tensor<1x1xi32>) -> tensor<3x6xi32>
+  %3 = tosa.minimum %2, %1 : (tensor<3x6xi32>, tensor<1x1xi32>) -> tensor<3x6xi32>
+  %4 = tosa.gather %arg0, %3 : (tensor<3x21x5xi8>, tensor<3x6xi32>) -> tensor<3x6x5xi8>
+  return %4 : tensor<3x6x5xi8>
 }
 
 // -----
 
 // CHECK-LABEL: func.func @no_gather_or_scatter(
-// CHECK-NOT: tosa.clamp
+// CHECK-NOT: tosa.const
+// CHECK-NOT: tosa.maximum
+// CHECK-NOT: tosa.minimum
 // CHECK: %[[ADD:.*]] = tosa.add %arg0, %arg1
 // CHECK: return %[[ADD]]
 func.func @no_gather_or_scatter(%arg0: tensor<2x4xi32>,

--- a/mlir/test/Dialect/Tosa/tosa-gather-scatter-hardening.mlir
+++ b/mlir/test/Dialect/Tosa/tosa-gather-scatter-hardening.mlir
@@ -1,0 +1,107 @@
+// RUN: mlir-opt %s -tosa-gather-scatter-hardening -split-input-file | FileCheck %s
+
+// CHECK-LABEL: func.func @gather(
+// CHECK: %[[CLAMP:.*]] = tosa.clamp %arg1 {max_val = 20 : i32, min_val = 0 : i32} : (tensor<3x6xi32>) -> tensor<3x6xi32>
+// CHECK: %[[OTHER_USE:.*]] = tosa.add %arg1, %arg2
+// CHECK: %[[GATHER:.*]] = tosa.gather %arg0, %[[CLAMP]]
+// CHECK: return %[[GATHER]], %[[OTHER_USE]]
+func.func @gather(%arg0: tensor<3x21x5xi8>, %arg1: tensor<3x6xi32>,
+                  %arg2: tensor<3x6xi32>)
+    -> (tensor<3x6x5xi8>, tensor<3x6xi32>) {
+  %0 = tosa.add %arg1, %arg2 : (tensor<3x6xi32>, tensor<3x6xi32>) -> tensor<3x6xi32>
+  %1 = tosa.gather %arg0, %arg1 : (tensor<3x21x5xi8>, tensor<3x6xi32>) -> tensor<3x6x5xi8>
+  return %1, %0 : tensor<3x6x5xi8>, tensor<3x6xi32>
+}
+
+// -----
+
+// One clamp is shared by gather and scatter when their bounds match.
+
+// CHECK-LABEL: func.func @shared_indices(
+// CHECK: %[[CLAMP:.*]] = tosa.clamp %arg2 {max_val = 20 : i32, min_val = 0 : i32} : (tensor<2x4xi32>) -> tensor<2x4xi32>
+// CHECK-NOT: tosa.clamp
+// CHECK: %[[GATHER:.*]] = tosa.gather %arg0, %[[CLAMP]]
+// CHECK: %[[SCATTER:.*]] = tosa.scatter %arg1, %[[CLAMP]], %arg3
+// CHECK-NOT: tosa.clamp
+// CHECK: return %[[GATHER]], %[[SCATTER]]
+func.func @shared_indices(%arg0: tensor<2x21x3xf32>,
+                          %arg1: tensor<2x21x3xf32>,
+                          %arg2: tensor<2x4xi32>,
+                          %arg3: tensor<2x4x3xf32>)
+    -> (tensor<2x4x3xf32>, tensor<2x21x3xf32>) {
+  %0 = tosa.gather %arg0, %arg2 : (tensor<2x21x3xf32>, tensor<2x4xi32>) -> tensor<2x4x3xf32>
+  %1 = tosa.scatter %arg1, %arg2, %arg3 : (tensor<2x21x3xf32>, tensor<2x4xi32>, tensor<2x4x3xf32>) -> tensor<2x21x3xf32>
+  return %0, %1 : tensor<2x4x3xf32>, tensor<2x21x3xf32>
+}
+
+// -----
+
+// Gather and scatter get separate clamps when their bounds differ.
+
+// CHECK-LABEL: func.func @different_bounds(
+// CHECK-DAG: %[[GATHER_CLAMP:.*]] = tosa.clamp %arg2 {max_val = 20 : i32, min_val = 0 : i32} : (tensor<2x4xi32>) -> tensor<2x4xi32>
+// CHECK-DAG: %[[SCATTER_CLAMP:.*]] = tosa.clamp %arg2 {max_val = 51 : i32, min_val = 0 : i32} : (tensor<2x4xi32>) -> tensor<2x4xi32>
+// CHECK: %[[GATHER:.*]] = tosa.gather %arg0, %[[GATHER_CLAMP]]
+// CHECK: %[[SCATTER:.*]] = tosa.scatter %arg1, %[[SCATTER_CLAMP]], %arg3
+// CHECK: return %[[GATHER]], %[[SCATTER]]
+func.func @different_bounds(%arg0: tensor<2x21x3xf32>,
+                            %arg1: tensor<2x52x3xf32>,
+                            %arg2: tensor<2x4xi32>,
+                            %arg3: tensor<2x4x3xf32>)
+    -> (tensor<2x4x3xf32>, tensor<2x52x3xf32>) {
+  %0 = tosa.gather %arg0, %arg2 : (tensor<2x21x3xf32>, tensor<2x4xi32>) -> tensor<2x4x3xf32>
+  %1 = tosa.scatter %arg1, %arg2, %arg3 : (tensor<2x52x3xf32>, tensor<2x4xi32>, tensor<2x4x3xf32>) -> tensor<2x52x3xf32>
+  return %0, %1 : tensor<2x4x3xf32>, tensor<2x52x3xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @i64_indices(
+// CHECK: %[[CLAMP:.*]] = tosa.clamp %arg1 {max_val = 26 : i64, min_val = 0 : i64} : (tensor<13x4xi64>) -> tensor<13x4xi64>
+// CHECK: tosa.scatter %arg0, %[[CLAMP]], %arg2
+func.func @i64_indices(%arg0: tensor<13x27x3xi16>,
+                       %arg1: tensor<13x4xi64>,
+                       %arg2: tensor<13x4x3xi16>) -> tensor<13x27x3xi16> {
+  %0 = tosa.scatter %arg0, %arg1, %arg2 : (tensor<13x27x3xi16>, tensor<13x4xi64>, tensor<13x4x3xi16>) -> tensor<13x27x3xi16>
+  return %0 : tensor<13x27x3xi16>
+}
+
+// -----
+
+// An i32 index cannot represent K - 1 here, so its signed maximum is a safe
+// upper clamp bound.
+
+// CHECK-LABEL: func.func @large_indexed_dimension(
+// CHECK: %[[CLAMP:.*]] = tosa.clamp %arg1 {max_val = 2147483647 : i32, min_val = 0 : i32}
+// CHECK: tosa.gather %arg0, %[[CLAMP]]
+func.func @large_indexed_dimension(
+    %arg0: tensor<1x2147483649x1xi8>, %arg1: tensor<1x1xi32>)
+    -> tensor<1x1x1xi8> {
+  %0 = tosa.gather %arg0, %arg1 : (tensor<1x2147483649x1xi8>, tensor<1x1xi32>) -> tensor<1x1x1xi8>
+  return %0 : tensor<1x1x1xi8>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @already_hardened(
+// CHECK: %[[CLAMP:.*]] = tosa.clamp %arg1 {max_val = 20 : i32, min_val = 0 : i32}
+// CHECK-NOT: tosa.clamp
+// CHECK: tosa.gather %arg0, %[[CLAMP]]
+func.func @already_hardened(%arg0: tensor<3x21x5xi8>,
+                            %arg1: tensor<3x6xi32>) -> tensor<3x6x5xi8> {
+  %0 = tosa.clamp %arg1 {max_val = 20 : i32, min_val = 0 : i32} : (tensor<3x6xi32>) -> tensor<3x6xi32>
+  %1 = tosa.gather %arg0, %0 : (tensor<3x21x5xi8>, tensor<3x6xi32>) -> tensor<3x6x5xi8>
+  return %1 : tensor<3x6x5xi8>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @no_gather_or_scatter(
+// CHECK-NOT: tosa.clamp
+// CHECK: %[[ADD:.*]] = tosa.add %arg0, %arg1
+// CHECK: return %[[ADD]]
+func.func @no_gather_or_scatter(%arg0: tensor<2x4xi32>,
+                                %arg1: tensor<2x4xi32>) -> tensor<2x4xi32> {
+  %0 = tosa.add %arg0, %arg1 : (tensor<2x4xi32>, tensor<2x4xi32>) -> tensor<2x4xi32>
+  return %0 : tensor<2x4xi32>
+}

--- a/mlir/test/Dialect/Tosa/tosa-gather-scatter-hardening.mlir
+++ b/mlir/test/Dialect/Tosa/tosa-gather-scatter-hardening.mlir
@@ -1,109 +1,202 @@
 // RUN: mlir-opt %s -tosa-gather-scatter-hardening -split-input-file | FileCheck %s
+// RUN: mlir-opt %s -tosa-gather-scatter-hardening -tosa-gather-scatter-hardening -split-input-file | FileCheck %s
 
+// Add a broadcastable clamp without changing other uses of the indices.
 // CHECK-LABEL: func.func @gather(
-// CHECK-DAG: %[[OTHER_USE:.*]] = tosa.add %arg1, %arg2
-// CHECK-DAG: %[[ZERO:.*]] = "tosa.const"() <{values = dense<0> : tensor<1x1xi32>}> : () -> tensor<1x1xi32>
-// CHECK-DAG: %[[UPPER:.*]] = "tosa.const"() <{values = dense<20> : tensor<1x1xi32>}> : () -> tensor<1x1xi32>
-// CHECK: %[[NONNEGATIVE:.*]] = tosa.maximum %arg1, %[[ZERO]]
-// CHECK: %[[CLAMPED:.*]] = tosa.minimum %[[NONNEGATIVE]], %[[UPPER]]
-// CHECK: %[[GATHER:.*]] = tosa.gather %arg0, %[[CLAMPED]]
-// CHECK: return %[[GATHER]], %[[OTHER_USE]]
-func.func @gather(%arg0: tensor<3x21x5xi8>, %arg1: tensor<3x6xi32>,
-                  %arg2: tensor<3x6xi32>)
+// CHECK-DAG: %[[ZERO:.*]] = "tosa.const"() <{values = dense<0> : tensor<1x1xi32>}>
+// CHECK-DAG: %[[UPPER:.*]] = "tosa.const"() <{values = dense<20> : tensor<1x1xi32>}>
+// CHECK-NEXT: %[[NONNEGATIVE:.*]] = tosa.maximum %arg1, %[[ZERO]]
+// CHECK-NEXT: %[[CLAMPED:.*]] = tosa.minimum %[[NONNEGATIVE]], %[[UPPER]]
+// CHECK-NEXT: %[[GATHER:.*]] = tosa.gather %arg0, %[[CLAMPED]]
+// CHECK-NEXT: return %[[GATHER]], %arg1
+func.func @gather(%values: tensor<3x21x5xi8>, %indices: tensor<3x6xi32>)
     -> (tensor<3x6x5xi8>, tensor<3x6xi32>) {
-  %0 = tosa.add %arg1, %arg2 : (tensor<3x6xi32>, tensor<3x6xi32>) -> tensor<3x6xi32>
-  %1 = tosa.gather %arg0, %arg1 : (tensor<3x21x5xi8>, tensor<3x6xi32>) -> tensor<3x6x5xi8>
-  return %1, %0 : tensor<3x6x5xi8>, tensor<3x6xi32>
+  %0 = tosa.gather %values, %indices : (tensor<3x21x5xi8>, tensor<3x6xi32>) -> tensor<3x6x5xi8>
+  return %0, %indices : tensor<3x6x5xi8>, tensor<3x6xi32>
 }
 
 // -----
 
-// Matching bounds produce equivalent, independent sequences for a subsequent
-// CSE pass to consolidate.
-
-// CHECK-LABEL: func.func @shared_indices(
-// CHECK-DAG: %[[ZERO:.*]] = "tosa.const"() <{values = dense<0> : tensor<1x1xi32>}> : () -> tensor<1x1xi32>
-// CHECK-DAG: %[[UPPER:.*]] = "tosa.const"() <{values = dense<20> : tensor<1x1xi32>}> : () -> tensor<1x1xi32>
-// CHECK: %[[GATHER_NONNEGATIVE:.*]] = tosa.maximum %arg2, %[[ZERO]]
-// CHECK: %[[GATHER_CLAMPED:.*]] = tosa.minimum %[[GATHER_NONNEGATIVE]], %[[UPPER]]
-// CHECK: %[[GATHER:.*]] = tosa.gather %arg0, %[[GATHER_CLAMPED]]
-// CHECK: %[[SCATTER_NONNEGATIVE:.*]] = tosa.maximum %arg2, %[[ZERO]]
-// CHECK: %[[SCATTER_CLAMPED:.*]] = tosa.minimum %[[SCATTER_NONNEGATIVE]], %[[UPPER]]
-// CHECK: %[[SCATTER:.*]] = tosa.scatter %arg1, %[[SCATTER_CLAMPED]], %arg3
-// CHECK: return %[[GATHER]], %[[SCATTER]]
-func.func @shared_indices(%arg0: tensor<2x21x3xf32>,
-                          %arg1: tensor<2x21x3xf32>,
-                          %arg2: tensor<2x4xi32>,
-                          %arg3: tensor<2x4x3xf32>)
-    -> (tensor<2x4x3xf32>, tensor<2x21x3xf32>) {
-  %0 = tosa.gather %arg0, %arg2 : (tensor<2x21x3xf32>, tensor<2x4xi32>) -> tensor<2x4x3xf32>
-  %1 = tosa.scatter %arg1, %arg2, %arg3 : (tensor<2x21x3xf32>, tensor<2x4xi32>, tensor<2x4x3xf32>) -> tensor<2x21x3xf32>
-  return %0, %1 : tensor<2x4x3xf32>, tensor<2x21x3xf32>
+// Recognize an existing maximum followed by minimum, with commuted operands.
+// CHECK-LABEL: func.func @already_hardened_maximum_first(
+// CHECK: %[[NONNEGATIVE:.*]] = tosa.maximum %arg1,
+// CHECK-NEXT: %[[CLAMPED:.*]] = tosa.minimum %[[NONNEGATIVE]],
+// CHECK-NEXT: %[[SCATTER:.*]] = tosa.scatter %arg0, %[[CLAMPED]], %arg2
+// CHECK-NEXT: return %[[SCATTER]]
+func.func @already_hardened_maximum_first(
+    %values: tensor<1x21x1xi8>, %indices: tensor<1x2xi32>,
+    %updates: tensor<1x2x1xi8>) -> tensor<1x21x1xi8> {
+  %zero = "tosa.const"() <{values = dense<0> : tensor<1x1xi32>}> : () -> tensor<1x1xi32>
+  %upper = "tosa.const"() <{values = dense<20> : tensor<1x1xi32>}> : () -> tensor<1x1xi32>
+  %0 = tosa.maximum %zero, %indices : (tensor<1x1xi32>, tensor<1x2xi32>) -> tensor<1x2xi32>
+  %1 = tosa.minimum %upper, %0 : (tensor<1x1xi32>, tensor<1x2xi32>) -> tensor<1x2xi32>
+  %2 = tosa.scatter %values, %1, %updates : (tensor<1x21x1xi8>, tensor<1x2xi32>, tensor<1x2x1xi8>) -> tensor<1x21x1xi8>
+  return %2 : tensor<1x21x1xi8>
 }
 
 // -----
 
-// CHECK-LABEL: func.func @i64_indices(
-// CHECK: %[[ZERO:.*]] = "tosa.const"() <{values = dense<0> : tensor<1x1xi64>}> : () -> tensor<1x1xi64>
-// CHECK: %[[UPPER:.*]] = "tosa.const"() <{values = dense<26> : tensor<1x1xi64>}> : () -> tensor<1x1xi64>
-// CHECK: %[[NONNEGATIVE:.*]] = tosa.maximum %arg1, %[[ZERO]]
-// CHECK: %[[CLAMPED:.*]] = tosa.minimum %[[NONNEGATIVE]], %[[UPPER]]
-// CHECK: tosa.scatter %arg0, %[[CLAMPED]], %arg2
-func.func @i64_indices(%arg0: tensor<13x27x3xi16>,
-                       %arg1: tensor<13x4xi64>,
-                       %arg2: tensor<13x4x3xi16>) -> tensor<13x27x3xi16> {
-  %0 = tosa.scatter %arg0, %arg1, %arg2 : (tensor<13x27x3xi16>, tensor<13x4xi64>, tensor<13x4x3xi16>) -> tensor<13x27x3xi16>
-  return %0 : tensor<13x27x3xi16>
+// Recognize minimum followed by maximum. Both inner operands are constants;
+// the data splat (25) must not hide the valid upper bound (20).
+// CHECK-LABEL: func.func @already_hardened_minimum_first(
+// CHECK-DAG: %[[UPPER:.*]] = "tosa.const"() <{values = dense<20> : tensor<1x1xi32>}>
+// CHECK-DAG: %[[DATA:.*]] = "tosa.const"() <{values = dense<25> : tensor<1x2xi32>}>
+// CHECK: %[[BOUNDED:.*]] = tosa.minimum %[[UPPER]], %[[DATA]]
+// CHECK-NEXT: %[[CLAMPED:.*]] = tosa.maximum %[[BOUNDED]],
+// CHECK-NEXT: %[[GATHER:.*]] = tosa.gather %arg0, %[[CLAMPED]]
+// CHECK-NEXT: return %[[GATHER]]
+func.func @already_hardened_minimum_first(%values: tensor<1x21x1xi8>)
+    -> tensor<1x2x1xi8> {
+  %zero = "tosa.const"() <{values = dense<0> : tensor<1x1xi32>}> : () -> tensor<1x1xi32>
+  %upper = "tosa.const"() <{values = dense<20> : tensor<1x1xi32>}> : () -> tensor<1x1xi32>
+  %data = "tosa.const"() <{values = dense<25> : tensor<1x2xi32>}> : () -> tensor<1x2xi32>
+  %0 = tosa.minimum %upper, %data : (tensor<1x1xi32>, tensor<1x2xi32>) -> tensor<1x2xi32>
+  %1 = tosa.maximum %0, %zero : (tensor<1x2xi32>, tensor<1x1xi32>) -> tensor<1x2xi32>
+  %2 = tosa.gather %values, %1 : (tensor<1x21x1xi8>, tensor<1x2xi32>) -> tensor<1x2x1xi8>
+  return %2 : tensor<1x2x1xi8>
 }
 
 // -----
 
-// An i32 index cannot represent K - 1 here, so its signed maximum is a safe
-// upper bound.
+// No inner op is needed: minimum(25, 20) produces 20, within [0, 20].
+// The first constant is out of bounds, so the second must be tried.
+// CHECK-LABEL: func.func @constant_indices(
+// CHECK-DAG: %[[DATA:.*]] = "tosa.const"() <{values = dense<25> : tensor<1x2xi32>}>
+// CHECK-DAG: %[[UPPER:.*]] = "tosa.const"() <{values = dense<20> : tensor<1x1xi32>}>
+// CHECK-NEXT: %[[BOUNDED:.*]] = tosa.minimum %[[DATA]], %[[UPPER]]
+// CHECK-NEXT: %[[GATHER:.*]] = tosa.gather %arg0, %[[BOUNDED]]
+// CHECK-NEXT: return %[[GATHER]]
+func.func @constant_indices(%values: tensor<1x21x1xi8>) -> tensor<1x2x1xi8> {
+  %data = "tosa.const"() <{values = dense<25> : tensor<1x2xi32>}> : () -> tensor<1x2xi32>
+  %upper = "tosa.const"() <{values = dense<20> : tensor<1x1xi32>}> : () -> tensor<1x1xi32>
+  %0 = tosa.minimum %data, %upper : (tensor<1x2xi32>, tensor<1x1xi32>) -> tensor<1x2xi32>
+  %1 = tosa.gather %values, %0 : (tensor<1x21x1xi8>, tensor<1x2xi32>) -> tensor<1x2x1xi8>
+  return %1 : tensor<1x2x1xi8>
+}
 
+// -----
+
+// Cap the upper bound at the largest representable index.
 // CHECK-LABEL: func.func @large_indexed_dimension(
-// CHECK: %[[ZERO:.*]] = "tosa.const"() <{values = dense<0> : tensor<1x1xi32>}> : () -> tensor<1x1xi32>
-// CHECK: %[[UPPER:.*]] = "tosa.const"() <{values = dense<2147483647> : tensor<1x1xi32>}> : () -> tensor<1x1xi32>
-// CHECK: %[[NONNEGATIVE:.*]] = tosa.maximum %arg1, %[[ZERO]]
-// CHECK: %[[CLAMPED:.*]] = tosa.minimum %[[NONNEGATIVE]], %[[UPPER]]
-// CHECK: tosa.gather %arg0, %[[CLAMPED]]
+// CHECK-DAG: %[[ZERO:.*]] = "tosa.const"() <{values = dense<0> : tensor<1x1xi32>}>
+// CHECK-DAG: %[[UPPER:.*]] = "tosa.const"() <{values = dense<2147483647> : tensor<1x1xi32>}>
+// CHECK-NEXT: %[[NONNEGATIVE:.*]] = tosa.maximum %arg1, %[[ZERO]]
+// CHECK-NEXT: %[[CLAMPED:.*]] = tosa.minimum %[[NONNEGATIVE]], %[[UPPER]]
+// CHECK-NEXT: %[[GATHER:.*]] = tosa.gather %arg0, %[[CLAMPED]]
+// CHECK-NEXT: return %[[GATHER]]
 func.func @large_indexed_dimension(
-    %arg0: tensor<1x2147483649x1xi8>, %arg1: tensor<1x1xi32>)
+    %values: tensor<1x2147483649x1xi8>, %indices: tensor<1x1xi32>)
     -> tensor<1x1x1xi8> {
-  %0 = tosa.gather %arg0, %arg1 : (tensor<1x2147483649x1xi8>, tensor<1x1xi32>) -> tensor<1x1x1xi8>
+  %0 = tosa.gather %values, %indices : (tensor<1x2147483649x1xi8>, tensor<1x1xi32>) -> tensor<1x1x1xi8>
   return %0 : tensor<1x1x1xi8>
 }
 
 // -----
 
-// CHECK-LABEL: func.func @already_hardened(
-// CHECK: %[[ZERO:.*]] = "tosa.const"() <{values = dense<0> : tensor<1x1xi32>}> : () -> tensor<1x1xi32>
-// CHECK: %[[UPPER:.*]] = "tosa.const"() <{values = dense<20> : tensor<1x1xi32>}> : () -> tensor<1x1xi32>
-// CHECK: %[[NONNEGATIVE:.*]] = tosa.maximum %arg1, %[[ZERO]]
-// CHECK: %[[CLAMPED:.*]] = tosa.minimum %[[NONNEGATIVE]], %[[UPPER]]
-// CHECK-NOT: tosa.maximum
-// CHECK-NOT: tosa.minimum
-// CHECK: tosa.gather %arg0, %[[CLAMPED]]
-func.func @already_hardened(%arg0: tensor<3x21x5xi8>,
-                            %arg1: tensor<3x6xi32>) -> tensor<3x6x5xi8> {
-  %0 = "tosa.const"() <{values = dense<0> : tensor<1x1xi32>}> : () -> tensor<1x1xi32>
-  %1 = "tosa.const"() <{values = dense<20> : tensor<1x1xi32>}> : () -> tensor<1x1xi32>
-  %2 = tosa.maximum %arg1, %0 : (tensor<3x6xi32>, tensor<1x1xi32>) -> tensor<3x6xi32>
-  %3 = tosa.minimum %2, %1 : (tensor<3x6xi32>, tensor<1x1xi32>) -> tensor<3x6xi32>
-  %4 = tosa.gather %arg0, %3 : (tensor<3x21x5xi8>, tensor<3x6xi32>) -> tensor<3x6x5xi8>
-  return %4 : tensor<3x6x5xi8>
+// An outer maximum can override a valid upper bound. Add a new clamp using
+// the i64 index type rather than accepting the existing [21, 21] range.
+// CHECK-LABEL: func.func @wrong_bound(
+// CHECK-DAG: %[[ZERO:.*]] = "tosa.const"() <{values = dense<0> : tensor<1x1xi64>}>
+// CHECK-DAG: %[[UPPER:.*]] = "tosa.const"() <{values = dense<20> : tensor<1x1xi64>}>
+// CHECK-DAG: %[[BAD_BOUND:.*]] = "tosa.const"() <{values = dense<21> : tensor<1x1xi64>}>
+// CHECK-NEXT: %[[BOUNDED:.*]] = tosa.minimum %arg1, %[[UPPER]]
+// CHECK-NEXT: %[[ORIGINAL:.*]] = tosa.maximum %[[BOUNDED]], %[[BAD_BOUND]]
+// CHECK-NEXT: %[[NONNEGATIVE:.*]] = tosa.maximum %[[ORIGINAL]], %[[ZERO]]
+// CHECK-NEXT: %[[CLAMPED:.*]] = tosa.minimum %[[NONNEGATIVE]], %[[UPPER]]
+// CHECK-NEXT: %[[SCATTER:.*]] = tosa.scatter %arg0, %[[CLAMPED]], %arg2
+// CHECK-NEXT: return %[[SCATTER]]
+func.func @wrong_bound(
+    %values: tensor<1x21x1xi8>, %indices: tensor<1x2xi64>,
+    %updates: tensor<1x2x1xi8>) -> tensor<1x21x1xi8> {
+  %upper = "tosa.const"() <{values = dense<20> : tensor<1x1xi64>}> : () -> tensor<1x1xi64>
+  %bad_bound = "tosa.const"() <{values = dense<21> : tensor<1x1xi64>}> : () -> tensor<1x1xi64>
+  %0 = tosa.minimum %indices, %upper : (tensor<1x2xi64>, tensor<1x1xi64>) -> tensor<1x2xi64>
+  %1 = tosa.maximum %0, %bad_bound : (tensor<1x2xi64>, tensor<1x1xi64>) -> tensor<1x2xi64>
+  %2 = tosa.scatter %values, %1, %updates : (tensor<1x21x1xi8>, tensor<1x2xi64>, tensor<1x2x1xi8>) -> tensor<1x21x1xi8>
+  return %2 : tensor<1x21x1xi8>
 }
 
 // -----
 
-// CHECK-LABEL: func.func @no_gather_or_scatter(
-// CHECK-NOT: tosa.const
-// CHECK-NOT: tosa.maximum
-// CHECK-NOT: tosa.minimum
-// CHECK: %[[ADD:.*]] = tosa.add %arg0, %arg1
-// CHECK: return %[[ADD]]
-func.func @no_gather_or_scatter(%arg0: tensor<2x4xi32>,
-                                %arg1: tensor<2x4xi32>) -> tensor<2x4xi32> {
-  %0 = tosa.add %arg0, %arg1 : (tensor<2x4xi32>, tensor<2x4xi32>) -> tensor<2x4xi32>
-  return %0 : tensor<2x4xi32>
+// A valid outer upper bound does not repair a negative inner lower bound.
+// CHECK-LABEL: func.func @invalid_inner_bound(
+// CHECK-DAG: %[[ZERO:.*]] = "tosa.const"() <{values = dense<0> : tensor<1x1xi32>}>
+// CHECK-DAG: %[[UPPER:.*]] = "tosa.const"() <{values = dense<20> : tensor<1x1xi32>}>
+// CHECK: %[[INNER:.*]] = tosa.maximum %arg1,
+// CHECK-NEXT: %[[ORIGINAL:.*]] = tosa.minimum %[[INNER]], %[[UPPER]]
+// CHECK-NEXT: %[[NONNEGATIVE:.*]] = tosa.maximum %[[ORIGINAL]], %[[ZERO]]
+// CHECK-NEXT: %[[CLAMPED:.*]] = tosa.minimum %[[NONNEGATIVE]], %[[UPPER]]
+// CHECK-NEXT: %[[GATHER:.*]] = tosa.gather %arg0, %[[CLAMPED]]
+// CHECK-NEXT: return %[[GATHER]]
+func.func @invalid_inner_bound(%values: tensor<1x21x1xi8>, %indices: tensor<1x2xi32>)
+    -> tensor<1x2x1xi8> {
+  %lower = "tosa.const"() <{values = dense<-1> : tensor<1x1xi32>}> : () -> tensor<1x1xi32>
+  %upper = "tosa.const"() <{values = dense<20> : tensor<1x1xi32>}> : () -> tensor<1x1xi32>
+  %0 = tosa.maximum %indices, %lower : (tensor<1x2xi32>, tensor<1x1xi32>) -> tensor<1x2xi32>
+  %1 = tosa.minimum %0, %upper : (tensor<1x2xi32>, tensor<1x1xi32>) -> tensor<1x2xi32>
+  %2 = tosa.gather %values, %1 : (tensor<1x21x1xi8>, tensor<1x2xi32>) -> tensor<1x2x1xi8>
+  return %2 : tensor<1x2x1xi8>
+}
+
+// -----
+
+// A negative outer minimum overrides the valid inner lower bound.
+// CHECK-LABEL: func.func @negative_outer_bound(
+// CHECK-DAG: %[[ZERO:.*]] = "tosa.const"() <{values = dense<0> : tensor<1x1xi32>}>
+// CHECK-DAG: %[[UPPER:.*]] = "tosa.const"() <{values = dense<20> : tensor<1x1xi32>}>
+// CHECK-DAG: %[[NEGATIVE:.*]] = "tosa.const"() <{values = dense<-1> : tensor<1x1xi32>}>
+// CHECK-NEXT: %[[INNER:.*]] = tosa.maximum %arg1, %[[ZERO]]
+// CHECK-NEXT: %[[ORIGINAL:.*]] = tosa.minimum %[[INNER]], %[[NEGATIVE]]
+// CHECK-NEXT: %[[NONNEGATIVE:.*]] = tosa.maximum %[[ORIGINAL]], %[[ZERO]]
+// CHECK-NEXT: %[[CLAMPED:.*]] = tosa.minimum %[[NONNEGATIVE]], %[[UPPER]]
+// CHECK-NEXT: %[[GATHER:.*]] = tosa.gather %arg0, %[[CLAMPED]]
+// CHECK-NEXT: return %[[GATHER]]
+func.func @negative_outer_bound(%values: tensor<1x21x1xi8>, %indices: tensor<1x2xi32>)
+    -> tensor<1x2x1xi8> {
+  %zero = "tosa.const"() <{values = dense<0> : tensor<1x1xi32>}> : () -> tensor<1x1xi32>
+  %upper = "tosa.const"() <{values = dense<-1> : tensor<1x1xi32>}> : () -> tensor<1x1xi32>
+  %0 = tosa.maximum %indices, %zero : (tensor<1x2xi32>, tensor<1x1xi32>) -> tensor<1x2xi32>
+  %1 = tosa.minimum %0, %upper : (tensor<1x2xi32>, tensor<1x1xi32>) -> tensor<1x2xi32>
+  %2 = tosa.gather %values, %1 : (tensor<1x21x1xi8>, tensor<1x2xi32>) -> tensor<1x2x1xi8>
+  return %2 : tensor<1x2x1xi8>
+}
+
+// -----
+
+// An upper bound alone does not prove that indices are nonnegative.
+// CHECK-LABEL: func.func @incomplete_clamp(
+// CHECK-DAG: %[[ZERO:.*]] = "tosa.const"() <{values = dense<0> : tensor<1x1xi32>}>
+// CHECK-DAG: %[[UPPER:.*]] = "tosa.const"() <{values = dense<20> : tensor<1x1xi32>}>
+// CHECK-NEXT: %[[ORIGINAL:.*]] = tosa.minimum %arg1, %[[UPPER]]
+// CHECK-NEXT: %[[NONNEGATIVE:.*]] = tosa.maximum %[[ORIGINAL]], %[[ZERO]]
+// CHECK-NEXT: %[[CLAMPED:.*]] = tosa.minimum %[[NONNEGATIVE]], %[[UPPER]]
+// CHECK-NEXT: %[[GATHER:.*]] = tosa.gather %arg0, %[[CLAMPED]]
+// CHECK-NEXT: return %[[GATHER]]
+func.func @incomplete_clamp(%values: tensor<1x21x1xi8>, %indices: tensor<1x2xi32>)
+    -> tensor<1x2x1xi8> {
+  %upper = "tosa.const"() <{values = dense<20> : tensor<1x1xi32>}> : () -> tensor<1x1xi32>
+  %0 = tosa.minimum %indices, %upper : (tensor<1x2xi32>, tensor<1x1xi32>) -> tensor<1x2xi32>
+  %1 = tosa.gather %values, %0 : (tensor<1x21x1xi8>, tensor<1x2xi32>) -> tensor<1x2x1xi8>
+  return %1 : tensor<1x2x1xi8>
+}
+
+// -----
+
+// With two constants, one in-range operand is insufficient: minimum(-1, 20)
+// produces -1 and still needs hardening.
+// CHECK-LABEL: func.func @unsafe_constant_indices(
+// CHECK-DAG: %[[ZERO:.*]] = "tosa.const"() <{values = dense<0> : tensor<1x1xi32>}>
+// CHECK-DAG: %[[UPPER:.*]] = "tosa.const"() <{values = dense<20> : tensor<1x1xi32>}>
+// CHECK-DAG: %[[DATA:.*]] = "tosa.const"() <{values = dense<-1> : tensor<1x2xi32>}>
+// CHECK-NEXT: %[[ORIGINAL:.*]] = tosa.minimum %[[DATA]], %[[UPPER]]
+// CHECK-NEXT: %[[NONNEGATIVE:.*]] = tosa.maximum %[[ORIGINAL]], %[[ZERO]]
+// CHECK-NEXT: %[[CLAMPED:.*]] = tosa.minimum %[[NONNEGATIVE]], %[[UPPER]]
+// CHECK-NEXT: %[[GATHER:.*]] = tosa.gather %arg0, %[[CLAMPED]]
+// CHECK-NEXT: return %[[GATHER]]
+func.func @unsafe_constant_indices(%values: tensor<1x21x1xi8>) -> tensor<1x2x1xi8> {
+  %data = "tosa.const"() <{values = dense<-1> : tensor<1x2xi32>}> : () -> tensor<1x2xi32>
+  %upper = "tosa.const"() <{values = dense<20> : tensor<1x1xi32>}> : () -> tensor<1x1xi32>
+  %0 = tosa.minimum %data, %upper : (tensor<1x2xi32>, tensor<1x1xi32>) -> tensor<1x2xi32>
+  %1 = tosa.gather %values, %0 : (tensor<1x21x1xi8>, tensor<1x2xi32>) -> tensor<1x2x1xi8>
+  return %1 : tensor<1x2x1xi8>
 }

--- a/mlir/test/Dialect/Tosa/tosa-gather-scatter-hardening.mlir
+++ b/mlir/test/Dialect/Tosa/tosa-gather-scatter-hardening.mlir
@@ -1,11 +1,11 @@
 // RUN: mlir-opt %s -tosa-gather-scatter-hardening -split-input-file | FileCheck %s
 
 // CHECK-LABEL: func.func @gather(
-// CHECK: %[[ZERO:.*]] = "tosa.const"() <{values = dense<0> : tensor<1x1xi32>}> : () -> tensor<1x1xi32>
-// CHECK: %[[UPPER:.*]] = "tosa.const"() <{values = dense<20> : tensor<1x1xi32>}> : () -> tensor<1x1xi32>
+// CHECK-DAG: %[[OTHER_USE:.*]] = tosa.add %arg1, %arg2
+// CHECK-DAG: %[[ZERO:.*]] = "tosa.const"() <{values = dense<0> : tensor<1x1xi32>}> : () -> tensor<1x1xi32>
+// CHECK-DAG: %[[UPPER:.*]] = "tosa.const"() <{values = dense<20> : tensor<1x1xi32>}> : () -> tensor<1x1xi32>
 // CHECK: %[[NONNEGATIVE:.*]] = tosa.maximum %arg1, %[[ZERO]]
 // CHECK: %[[CLAMPED:.*]] = tosa.minimum %[[NONNEGATIVE]], %[[UPPER]]
-// CHECK: %[[OTHER_USE:.*]] = tosa.add %arg1, %arg2
 // CHECK: %[[GATHER:.*]] = tosa.gather %arg0, %[[CLAMPED]]
 // CHECK: return %[[GATHER]], %[[OTHER_USE]]
 func.func @gather(%arg0: tensor<3x21x5xi8>, %arg1: tensor<3x6xi32>,
@@ -18,20 +18,18 @@ func.func @gather(%arg0: tensor<3x21x5xi8>, %arg1: tensor<3x6xi32>,
 
 // -----
 
-// One bounding sequence is shared by gather and scatter when their bounds
-// match.
+// Matching bounds produce equivalent, independent sequences for a subsequent
+// CSE pass to consolidate.
 
 // CHECK-LABEL: func.func @shared_indices(
-// CHECK: %[[ZERO:.*]] = "tosa.const"() <{values = dense<0> : tensor<1x1xi32>}> : () -> tensor<1x1xi32>
-// CHECK: %[[UPPER:.*]] = "tosa.const"() <{values = dense<20> : tensor<1x1xi32>}> : () -> tensor<1x1xi32>
-// CHECK: %[[NONNEGATIVE:.*]] = tosa.maximum %arg2, %[[ZERO]]
-// CHECK: %[[CLAMPED:.*]] = tosa.minimum %[[NONNEGATIVE]], %[[UPPER]]
-// CHECK-NOT: tosa.maximum
-// CHECK-NOT: tosa.minimum
-// CHECK: %[[GATHER:.*]] = tosa.gather %arg0, %[[CLAMPED]]
-// CHECK: %[[SCATTER:.*]] = tosa.scatter %arg1, %[[CLAMPED]], %arg3
-// CHECK-NOT: tosa.maximum
-// CHECK-NOT: tosa.minimum
+// CHECK-DAG: %[[ZERO:.*]] = "tosa.const"() <{values = dense<0> : tensor<1x1xi32>}> : () -> tensor<1x1xi32>
+// CHECK-DAG: %[[UPPER:.*]] = "tosa.const"() <{values = dense<20> : tensor<1x1xi32>}> : () -> tensor<1x1xi32>
+// CHECK: %[[GATHER_NONNEGATIVE:.*]] = tosa.maximum %arg2, %[[ZERO]]
+// CHECK: %[[GATHER_CLAMPED:.*]] = tosa.minimum %[[GATHER_NONNEGATIVE]], %[[UPPER]]
+// CHECK: %[[GATHER:.*]] = tosa.gather %arg0, %[[GATHER_CLAMPED]]
+// CHECK: %[[SCATTER_NONNEGATIVE:.*]] = tosa.maximum %arg2, %[[ZERO]]
+// CHECK: %[[SCATTER_CLAMPED:.*]] = tosa.minimum %[[SCATTER_NONNEGATIVE]], %[[UPPER]]
+// CHECK: %[[SCATTER:.*]] = tosa.scatter %arg1, %[[SCATTER_CLAMPED]], %arg3
 // CHECK: return %[[GATHER]], %[[SCATTER]]
 func.func @shared_indices(%arg0: tensor<2x21x3xf32>,
                           %arg1: tensor<2x21x3xf32>,
@@ -41,32 +39,6 @@ func.func @shared_indices(%arg0: tensor<2x21x3xf32>,
   %0 = tosa.gather %arg0, %arg2 : (tensor<2x21x3xf32>, tensor<2x4xi32>) -> tensor<2x4x3xf32>
   %1 = tosa.scatter %arg1, %arg2, %arg3 : (tensor<2x21x3xf32>, tensor<2x4xi32>, tensor<2x4x3xf32>) -> tensor<2x21x3xf32>
   return %0, %1 : tensor<2x4x3xf32>, tensor<2x21x3xf32>
-}
-
-// -----
-
-// Gather and scatter get separate bounding sequences when their bounds differ.
-
-// CHECK-LABEL: func.func @different_bounds(
-// CHECK: %[[SCATTER_ZERO:.*]] = "tosa.const"() <{values = dense<0> : tensor<1x1xi32>}> : () -> tensor<1x1xi32>
-// CHECK: %[[SCATTER_UPPER:.*]] = "tosa.const"() <{values = dense<51> : tensor<1x1xi32>}> : () -> tensor<1x1xi32>
-// CHECK: %[[SCATTER_NONNEGATIVE:.*]] = tosa.maximum %arg2, %[[SCATTER_ZERO]]
-// CHECK: %[[SCATTER_CLAMPED:.*]] = tosa.minimum %[[SCATTER_NONNEGATIVE]], %[[SCATTER_UPPER]]
-// CHECK: %[[GATHER_ZERO:.*]] = "tosa.const"() <{values = dense<0> : tensor<1x1xi32>}> : () -> tensor<1x1xi32>
-// CHECK: %[[GATHER_UPPER:.*]] = "tosa.const"() <{values = dense<20> : tensor<1x1xi32>}> : () -> tensor<1x1xi32>
-// CHECK: %[[GATHER_NONNEGATIVE:.*]] = tosa.maximum %arg2, %[[GATHER_ZERO]]
-// CHECK: %[[GATHER_CLAMPED:.*]] = tosa.minimum %[[GATHER_NONNEGATIVE]], %[[GATHER_UPPER]]
-// CHECK: %[[GATHER:.*]] = tosa.gather %arg0, %[[GATHER_CLAMPED]]
-// CHECK: %[[SCATTER:.*]] = tosa.scatter %arg1, %[[SCATTER_CLAMPED]], %arg3
-// CHECK: return %[[GATHER]], %[[SCATTER]]
-func.func @different_bounds(%arg0: tensor<2x21x3xf32>,
-                            %arg1: tensor<2x52x3xf32>,
-                            %arg2: tensor<2x4xi32>,
-                            %arg3: tensor<2x4x3xf32>)
-    -> (tensor<2x4x3xf32>, tensor<2x52x3xf32>) {
-  %0 = tosa.gather %arg0, %arg2 : (tensor<2x21x3xf32>, tensor<2x4xi32>) -> tensor<2x4x3xf32>
-  %1 = tosa.scatter %arg1, %arg2, %arg3 : (tensor<2x52x3xf32>, tensor<2x4xi32>, tensor<2x4x3xf32>) -> tensor<2x52x3xf32>
-  return %0, %1 : tensor<2x4x3xf32>, tensor<2x52x3xf32>
 }
 
 // -----


### PR DESCRIPTION
Add new TosaGatherScatterHardeningPass TOSA pass to clamp indices before
they are fed to a tosa.gather or tosa.scatter unless a suitable clamp
already exists. This enables avoiding out of bound accesses on
unstrusted indices in tosa.gather and tosa.scatter lowering.

The pass fails if the dimension indexed by the indices tensor of any of
the tosa.gather or tosa.scatter is dynamic since clamp has min/max as
attributes. The pass supports EXT-INT64 by using the same bitwidth in
clamp min/max attributes as the indices tensor element type. In case the
indexed dimension is bigger than can be represented in the element type
bitwidth the maximum bitwidth is used.

To keep IR minimal, several tosa.gather and tosa.scatter sharing the same
dimension sizes and indices tensor will share a single clamp.

Assisted-by: codex
Signed-off-by: Thomas Preud'homme <thomas.preudhomme@arm.com>
