### PR TITLE
[Clang] Fixed Assertion Checking For Destructor On 'annot_cxxscope' Token

### DIFF
--- a/clang/lib/Parse/ParseExprCXX.cpp
+++ b/clang/lib/Parse/ParseExprCXX.cpp
@@ -112,21 +112,25 @@ bool Parser::ParseOptionalCXXScopeSpecifier(
   assert(getLangOpts().CPlusPlus &&
          "Call sites of this function should be guarded by checking for C++");
 
-  if (Tok.is(tok::annot_cxxscope)) {
-    assert(!LastII && "want last identifier but have already annotated scope");
-    assert(!MayBePseudoDestructor && "unexpected annot_cxxscope");
-    Actions.RestoreNestedNameSpecifierAnnotation(Tok.getAnnotationValue(),
-                                                 Tok.getAnnotationRange(),
-                                                 SS);
-    ConsumeAnnotationToken();
-    return false;
-  }
-
   // Has to happen before any "return false"s in this function.
   bool CheckForDestructor = false;
   if (MayBePseudoDestructor && *MayBePseudoDestructor) {
     CheckForDestructor = true;
     *MayBePseudoDestructor = false;
+  }
+
+  if (Tok.is(tok::annot_cxxscope)) {
+    assert(!LastII && "want last identifier but have already annotated scope");
+    if (CheckForDestructor && Tok.is(tok::tilde)) {
+      *MayBePseudoDestructor = true;
+      return false;
+    }
+
+    Actions.RestoreNestedNameSpecifierAnnotation(Tok.getAnnotationValue(),
+                                                 Tok.getAnnotationRange(),
+                                                 SS);
+    ConsumeAnnotationToken();
+    return false;
   }
 
   if (LastII)

--- a/clang/test/Parser/gh220186.cpp
+++ b/clang/test/Parser/gh220186.cpp
@@ -1,0 +1,10 @@
+// RUN: %clang_cc1 -std=c++23 -fsyntax-only -verify %s
+
+void foo1() { (auto()->bar::); }
+// expected-error@-1 {{use of undeclared identifier 'bar'}}
+// expected-error@-2 {{initializer for functional-style cast to 'auto' is empty}}
+// expected-error@-3 {{expected unqualified-id}}
+
+void foo2() { (auto()->bar::~bar()); }
+// expected-error@-1 {{use of undeclared identifier 'bar'}}
+// expected-error@-2 {{initializer for functional-style cast to 'auto' is empty}}


### PR DESCRIPTION
**Problem**
`ParseOptionalCXXScopeSpecifier` is called with a `MayBePseudoDestructor` argument present, meaning it has to check for `~` symbols, but the token stream contains an `annot_cxxscope` token instead of regular tokens which for some reason was forbidden by the previous implementation.

**Solution**
Added the missing logic to `ParseOptionalCXXScopeSpecifier` which is consistent with the other `~` checks in this function and created tests to verify the output.

**Reasoning**
1.) The function already has code to handle an `annot_cxxscope` token and the reproducer shows it is possible to encounter a following `~`.
2.) The other places in this function that encounter a `~` work in the same way, by setting the flag and returning.

Fixes #220186