### PR TITLE
[LICM] Preserve nsw when reassociating integer adds

### DIFF
--- a/llvm/lib/Transforms/Scalar/LICM.cpp
+++ b/llvm/lib/Transforms/Scalar/LICM.cpp
@@ -3008,6 +3008,15 @@ static bool hoistBOAssociation(Instruction &I, Loop &L,
     Flags.AllKnownNonZero = false;
     Flags.mergeFlags(*BO);
     Flags.mergeFlags(*BO0);
+    // If C1 + C2 cannot signed-overflow, both reassociated adds preserve nsw.
+    // Record this fact in AllKnownNonNegative for applyFlags().
+    SimplifyQuery SQ(L.getHeader()->getDataLayout(), DT, AC,
+                     Preheader->getTerminator());
+    if (Opcode == Instruction::Add && Flags.HasNSW && !Flags.HasNUW &&
+        computeOverflowForSignedAdd(C1, C2, SQ) ==
+            OverflowResult::NeverOverflows)
+      Flags.AllKnownNonNegative = true;
+
     // If `Inv` was not constant-folded, a new Instruction has been created.
     if (auto *I = dyn_cast<Instruction>(Inv))
       Flags.applyFlags(*I);

--- a/llvm/lib/Transforms/Scalar/LICM.cpp
+++ b/llvm/lib/Transforms/Scalar/LICM.cpp
@@ -3008,19 +3008,23 @@ static bool hoistBOAssociation(Instruction &I, Loop &L,
     Flags.AllKnownNonZero = false;
     Flags.mergeFlags(*BO);
     Flags.mergeFlags(*BO0);
-    // If C1 + C2 cannot signed-overflow, both reassociated adds preserve nsw.
-    // Record this fact in AllKnownNonNegative for applyFlags().
+    // If `Inv` was not constant-folded, a new Instruction has been created.
+    auto *InvI = dyn_cast<Instruction>(Inv);
+    if (InvI)
+      Flags.applyFlags(*InvI);
+    Flags.applyFlags(*NewBO);
+
+    // The original nsw flags guarantee that LV + C1 + C2 is representable.
+    // If C1 + C2 is representable too, both reassociated adds keep nsw.
     SimplifyQuery SQ(L.getHeader()->getDataLayout(), DT, AC,
                      Preheader->getTerminator());
     if (Opcode == Instruction::Add && Flags.HasNSW && !Flags.HasNUW &&
         computeOverflowForSignedAdd(C1, C2, SQ) ==
-            OverflowResult::NeverOverflows)
-      Flags.AllKnownNonNegative = true;
-
-    // If `Inv` was not constant-folded, a new Instruction has been created.
-    if (auto *I = dyn_cast<Instruction>(Inv))
-      Flags.applyFlags(*I);
-    Flags.applyFlags(*NewBO);
+            OverflowResult::NeverOverflows) {
+      if (InvI)
+        InvI->setHasNoSignedWrap();
+      NewBO->setHasNoSignedWrap();
+    }
   }
 
   BO->replaceAllUsesWith(NewBO);

--- a/llvm/test/Transforms/LICM/hoist-binop.ll
+++ b/llvm/test/Transforms/LICM/hoist-binop.ll
@@ -347,7 +347,7 @@ loop:
   br label %loop
 }
 
-; Hoist ADD but don't copy NSW even if both ops have it.
+; Hoist ADD but don't copy NSW when the invariant operands may overflow.
 define void @add_no_nsw_2(i64 %c1, i64 %c2) {
 ; CHECK-LABEL: @add_no_nsw_2(
 ; CHECK-NEXT:  entry:
@@ -426,6 +426,152 @@ loop:
   %index = phi i64 [ 0, %entry ], [ %index.next, %loop ]
   %step.add = add nsw i64 %index, %c1
   %index.next = add nuw nsw i64 %step.add, %c2
+  br label %loop
+}
+
+; Preserve NSW for constant invariant operands and enable hoistAdd().
+define void @add_nsw_constant_operands(i32 %start) {
+; CHECK-LABEL: @add_nsw_constant_operands(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    br label [[LOOP:%.*]]
+; CHECK:       loop:
+; CHECK-NEXT:    [[IV:%.*]] = phi i32 [ [[START:%.*]], [[ENTRY:%.*]] ], [ [[NEXT:%.*]], [[LOOP]] ]
+; CHECK-NEXT:    [[CONDITION:%.*]] = icmp sgt i32 [[IV]], -13
+; CHECK-NEXT:    call void @llvm.assume(i1 [[CONDITION]])
+; CHECK-NEXT:    [[NEXT]] = add i32 [[IV]], 1
+; CHECK-NEXT:    br label [[LOOP]]
+;
+entry:
+  br label %loop
+
+loop:
+  %iv = phi i32 [ %start, %entry ], [ %next, %loop ]
+  %add1 = add nsw i32 %iv, 2
+  %add2 = add nsw i32 %add1, 4
+  %condition = icmp sgt i32 %add2, -7
+  call void @llvm.assume(i1 %condition)
+  %next = add i32 %iv, 1
+  br label %loop
+}
+
+; Preserve NSW when KnownBits proves nonconstant invariant operands safe.
+define void @add_nsw_nonconstant_operands(i32 %start, i16 %c1, i16 %c2) {
+; CHECK-LABEL: @add_nsw_nonconstant_operands(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[C1_EXT:%.*]] = zext i16 [[C1:%.*]] to i32
+; CHECK-NEXT:    [[C2_EXT:%.*]] = zext i16 [[C2:%.*]] to i32
+; CHECK-NEXT:    [[INVARIANT_OP:%.*]] = add nsw i32 [[C1_EXT]], [[C2_EXT]]
+; CHECK-NEXT:    br label [[LOOP:%.*]]
+; CHECK:       loop:
+; CHECK-NEXT:    [[IV:%.*]] = phi i32 [ [[START:%.*]], [[ENTRY:%.*]] ], [ [[NEXT:%.*]], [[LOOP]] ]
+; CHECK-NEXT:    [[ADD2_REASS:%.*]] = add nsw i32 [[IV]], [[INVARIANT_OP]]
+; CHECK-NEXT:    call void @use(i32 [[ADD2_REASS]])
+; CHECK-NEXT:    [[NEXT]] = add i32 [[IV]], 1
+; CHECK-NEXT:    br label [[LOOP]]
+;
+entry:
+  %c1.ext = zext i16 %c1 to i32
+  %c2.ext = zext i16 %c2 to i32
+  br label %loop
+
+loop:
+  %iv = phi i32 [ %start, %entry ], [ %next, %loop ]
+  %add1 = add nsw i32 %iv, %c1.ext
+  %add2 = add nsw i32 %add1, %c2.ext
+  call void @use(i32 %add2)
+  %next = add i32 %iv, 1
+  br label %loop
+}
+
+; Preserve NSW for vector invariant operands.
+define void @add_nsw_vector_operands(<2 x i32> %start, <2 x i16> %c1, <2 x i16> %c2) {
+; CHECK-LABEL: @add_nsw_vector_operands(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[C1_EXT:%.*]] = zext <2 x i16> [[C1:%.*]] to <2 x i32>
+; CHECK-NEXT:    [[C2_EXT:%.*]] = zext <2 x i16> [[C2:%.*]] to <2 x i32>
+; CHECK-NEXT:    [[INVARIANT_OP:%.*]] = add nsw <2 x i32> [[C1_EXT]], [[C2_EXT]]
+; CHECK-NEXT:    br label [[LOOP:%.*]]
+; CHECK:       loop:
+; CHECK-NEXT:    [[IV:%.*]] = phi <2 x i32> [ [[START:%.*]], [[ENTRY:%.*]] ], [ [[NEXT:%.*]], [[LOOP]] ]
+; CHECK-NEXT:    [[ADD2_REASS:%.*]] = add nsw <2 x i32> [[IV]], [[INVARIANT_OP]]
+; CHECK-NEXT:    call void @use(<2 x i32> [[ADD2_REASS]])
+; CHECK-NEXT:    [[NEXT]] = add <2 x i32> [[IV]], splat (i32 1)
+; CHECK-NEXT:    br label [[LOOP]]
+;
+entry:
+  %c1.ext = zext <2 x i16> %c1 to <2 x i32>
+  %c2.ext = zext <2 x i16> %c2 to <2 x i32>
+  br label %loop
+
+loop:
+  %iv = phi <2 x i32> [ %start, %entry ], [ %next, %loop ]
+  %add1 = add nsw <2 x i32> %iv, %c1.ext
+  %add2 = add nsw <2 x i32> %add1, %c2.ext
+  call void @use(<2 x i32> %add2)
+  %next = add <2 x i32> %iv, <i32 1, i32 1>
+  br label %loop
+}
+
+; Preserve NSW when dominating assumptions prove invariant operands safe.
+define void @add_nsw_assumed_operands(i32 %start, i32 %c1, i32 %c2) {
+; CHECK-LABEL: @add_nsw_assumed_operands(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[C1_OK:%.*]] = icmp ult i32 [[C1:%.*]], 100
+; CHECK-NEXT:    call void @llvm.assume(i1 [[C1_OK]])
+; CHECK-NEXT:    [[C2_OK:%.*]] = icmp ult i32 [[C2:%.*]], 100
+; CHECK-NEXT:    call void @llvm.assume(i1 [[C2_OK]])
+; CHECK-NEXT:    [[INVARIANT_OP:%.*]] = add nsw i32 [[C1]], [[C2]]
+; CHECK-NEXT:    br label [[LOOP:%.*]]
+; CHECK:       loop:
+; CHECK-NEXT:    [[IV:%.*]] = phi i32 [ [[START:%.*]], [[ENTRY:%.*]] ], [ [[NEXT:%.*]], [[LOOP]] ]
+; CHECK-NEXT:    [[ADD2_REASS:%.*]] = add nsw i32 [[IV]], [[INVARIANT_OP]]
+; CHECK-NEXT:    call void @use(i32 [[ADD2_REASS]])
+; CHECK-NEXT:    [[NEXT]] = add i32 [[IV]], 1
+; CHECK-NEXT:    br label [[LOOP]]
+;
+entry:
+  %c1.ok = icmp ult i32 %c1, 100
+  call void @llvm.assume(i1 %c1.ok)
+  %c2.ok = icmp ult i32 %c2, 100
+  call void @llvm.assume(i1 %c2.ok)
+  br label %loop
+
+loop:
+  %iv = phi i32 [ %start, %entry ], [ %next, %loop ]
+  %add1 = add nsw i32 %iv, %c1
+  %add2 = add nsw i32 %add1, %c2
+  call void @use(i32 %add2)
+  %next = add i32 %iv, 1
+  br label %loop
+}
+
+; Don't preserve NSW if only the outer add has it, even when the invariant
+; operands cannot overflow.
+define void @add_only_outer_nsw(i32 %start, i16 %c1, i16 %c2) {
+; CHECK-LABEL: @add_only_outer_nsw(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[C1_EXT:%.*]] = zext i16 [[C1:%.*]] to i32
+; CHECK-NEXT:    [[C2_EXT:%.*]] = zext i16 [[C2:%.*]] to i32
+; CHECK-NEXT:    [[INVARIANT_OP:%.*]] = add i32 [[C1_EXT]], [[C2_EXT]]
+; CHECK-NEXT:    br label [[LOOP:%.*]]
+; CHECK:       loop:
+; CHECK-NEXT:    [[IV:%.*]] = phi i32 [ [[START:%.*]], [[ENTRY:%.*]] ], [ [[NEXT:%.*]], [[LOOP]] ]
+; CHECK-NEXT:    [[ADD2_REASS:%.*]] = add i32 [[IV]], [[INVARIANT_OP]]
+; CHECK-NEXT:    call void @use(i32 [[ADD2_REASS]])
+; CHECK-NEXT:    [[NEXT]] = add i32 [[IV]], 1
+; CHECK-NEXT:    br label [[LOOP]]
+;
+entry:
+  %c1.ext = zext i16 %c1 to i32
+  %c2.ext = zext i16 %c2 to i32
+  br label %loop
+
+loop:
+  %iv = phi i32 [ %start, %entry ], [ %next, %loop ]
+  %add1 = add i32 %iv, %c1.ext
+  %add2 = add nsw i32 %add1, %c2.ext
+  call void @use(i32 %add2)
+  %next = add i32 %iv, 1
   br label %loop
 }
 
@@ -1078,4 +1224,5 @@ loop:
   br label %loop
 }
 
+declare void @llvm.assume(i1)
 declare void @use()

--- a/llvm/test/Transforms/LICM/hoist-binop.ll
+++ b/llvm/test/Transforms/LICM/hoist-binop.ll
@@ -429,7 +429,7 @@ loop:
   br label %loop
 }
 
-; Preserve NSW for constant invariant operands and enable hoistAdd().
+; Preserve NSW for constant operands and enable hoistAdd().
 define void @add_nsw_constant_operands(i32 %start) {
 ; CHECK-LABEL: @add_nsw_constant_operands(
 ; CHECK-NEXT:  entry:
@@ -465,7 +465,7 @@ define void @add_nsw_nonconstant_operands(i32 %start, i16 %c1, i16 %c2) {
 ; CHECK:       loop:
 ; CHECK-NEXT:    [[IV:%.*]] = phi i32 [ [[START:%.*]], [[ENTRY:%.*]] ], [ [[NEXT:%.*]], [[LOOP]] ]
 ; CHECK-NEXT:    [[ADD2_REASS:%.*]] = add nsw i32 [[IV]], [[INVARIANT_OP]]
-; CHECK-NEXT:    call void @use(i32 [[ADD2_REASS]])
+; CHECK-NEXT:    call void @use.i32(i32 [[ADD2_REASS]])
 ; CHECK-NEXT:    [[NEXT]] = add i32 [[IV]], 1
 ; CHECK-NEXT:    br label [[LOOP]]
 ;
@@ -478,7 +478,7 @@ loop:
   %iv = phi i32 [ %start, %entry ], [ %next, %loop ]
   %add1 = add nsw i32 %iv, %c1.ext
   %add2 = add nsw i32 %add1, %c2.ext
-  call void @use(i32 %add2)
+  call void @use.i32(i32 %add2)
   %next = add i32 %iv, 1
   br label %loop
 }
@@ -494,7 +494,7 @@ define void @add_nsw_vector_operands(<2 x i32> %start, <2 x i16> %c1, <2 x i16> 
 ; CHECK:       loop:
 ; CHECK-NEXT:    [[IV:%.*]] = phi <2 x i32> [ [[START:%.*]], [[ENTRY:%.*]] ], [ [[NEXT:%.*]], [[LOOP]] ]
 ; CHECK-NEXT:    [[ADD2_REASS:%.*]] = add nsw <2 x i32> [[IV]], [[INVARIANT_OP]]
-; CHECK-NEXT:    call void @use(<2 x i32> [[ADD2_REASS]])
+; CHECK-NEXT:    call void @use.v2i32(<2 x i32> [[ADD2_REASS]])
 ; CHECK-NEXT:    [[NEXT]] = add <2 x i32> [[IV]], splat (i32 1)
 ; CHECK-NEXT:    br label [[LOOP]]
 ;
@@ -507,7 +507,7 @@ loop:
   %iv = phi <2 x i32> [ %start, %entry ], [ %next, %loop ]
   %add1 = add nsw <2 x i32> %iv, %c1.ext
   %add2 = add nsw <2 x i32> %add1, %c2.ext
-  call void @use(<2 x i32> %add2)
+  call void @use.v2i32(<2 x i32> %add2)
   %next = add <2 x i32> %iv, <i32 1, i32 1>
   br label %loop
 }
@@ -525,7 +525,7 @@ define void @add_nsw_assumed_operands(i32 %start, i32 %c1, i32 %c2) {
 ; CHECK:       loop:
 ; CHECK-NEXT:    [[IV:%.*]] = phi i32 [ [[START:%.*]], [[ENTRY:%.*]] ], [ [[NEXT:%.*]], [[LOOP]] ]
 ; CHECK-NEXT:    [[ADD2_REASS:%.*]] = add nsw i32 [[IV]], [[INVARIANT_OP]]
-; CHECK-NEXT:    call void @use(i32 [[ADD2_REASS]])
+; CHECK-NEXT:    call void @use.i32(i32 [[ADD2_REASS]])
 ; CHECK-NEXT:    [[NEXT]] = add i32 [[IV]], 1
 ; CHECK-NEXT:    br label [[LOOP]]
 ;
@@ -540,7 +540,7 @@ loop:
   %iv = phi i32 [ %start, %entry ], [ %next, %loop ]
   %add1 = add nsw i32 %iv, %c1
   %add2 = add nsw i32 %add1, %c2
-  call void @use(i32 %add2)
+  call void @use.i32(i32 %add2)
   %next = add i32 %iv, 1
   br label %loop
 }
@@ -557,7 +557,7 @@ define void @add_only_outer_nsw(i32 %start, i16 %c1, i16 %c2) {
 ; CHECK:       loop:
 ; CHECK-NEXT:    [[IV:%.*]] = phi i32 [ [[START:%.*]], [[ENTRY:%.*]] ], [ [[NEXT:%.*]], [[LOOP]] ]
 ; CHECK-NEXT:    [[ADD2_REASS:%.*]] = add i32 [[IV]], [[INVARIANT_OP]]
-; CHECK-NEXT:    call void @use(i32 [[ADD2_REASS]])
+; CHECK-NEXT:    call void @use.i32(i32 [[ADD2_REASS]])
 ; CHECK-NEXT:    [[NEXT]] = add i32 [[IV]], 1
 ; CHECK-NEXT:    br label [[LOOP]]
 ;
@@ -570,7 +570,7 @@ loop:
   %iv = phi i32 [ %start, %entry ], [ %next, %loop ]
   %add1 = add i32 %iv, %c1.ext
   %add2 = add nsw i32 %add1, %c2.ext
-  call void @use(i32 %add2)
+  call void @use.i32(i32 %add2)
   %next = add i32 %iv, 1
   br label %loop
 }
@@ -1225,4 +1225,6 @@ loop:
 }
 
 declare void @llvm.assume(i1)
+declare void @use.i32(i32)
+declare void @use.v2i32(<2 x i32>)
 declare void @use()


### PR DESCRIPTION
When LICM reassociates (LV + C1) + C2 into LV + (C1 + C2), it currently drops nsw unless both original additions also have nuw.

After applying the usual OverflowTracking flags, set nsw directly on both generated additions when both original additions have nsw and value tracking proves that C1 + C2 cannot overflow in signed arithmetic. This enables hoistAdd() later in the same LICM run.

Tests cover constant operands, scalar and vector operands proven safe through known bits, operands constrained by dominating assumptions, and the case where only the outer addition has nsw.

[Alive2 proof](https://alive2.llvm.org/ce/#z%3AMYewtgDglgNgpgJwM4FIDMBBAhACh6SWRdDAQxigDc4UAmAYRAgBcoQA7VTAcm7vqQgArgmA0eAEzjAYpBDVoAGFAHYAQnUVQAHP01QAjJtUARYwBZFMGJTAA6JKQkS7AdyjMAFnZDUEAMxgQVzsdHB09JR0AShRFDCkZOQVFShAoCQsrG3tSJCQhMDhwg1j4uIS4fyh2FIilFEskUXDdBtoAVhtIrTblTuAjBn0%2Bug7gWliG9QrjdvHPaQBrOEyGtDMlYHIYYxmotvp9IeUVTeVLa1sHJxd3Lx8%2FQODQ7Va58aGjg4%2BJsow5v0Or5EM9XMYNpo4AAPZgIUjAZiUchCFKqDQ%2FYZRE6mX6LYArNbfRRGcrtIHsECPUFBcHrc7QkAIY4fEEBWk9OGo2bk7bWTRpDJZK65fKFYqGD6U6ns4L%2FQFjW44yFKW6aTh03ofbpYoGDHn9IG3WgQ85qpQakYfJU9MYTA2aeTMK3zY2zM6zeJSaq1F0XRTMADmzHe8x1xPqeq%2Bfrtkz2GjJhrt%2BMJps0fN20wxWt1kum50a2Wujmcbg83jZYNeoajPUjsfl5LGlY59KhsPhiORMG5WZdEZxHvmwBTqx6pIBTc60pbwTTSkZzOxrKereJXJoifTOwF6TW%2FpFdjyBSKJSlVNnrkbSc6NWRCCgpHYzrbquc6qQmvrA2jw5NW%2FmeQChgF9lBVRRzUUS1MSBcMPjvORH2fB0lCdGNOiAoQQPdMx4m4aIpnoaoQMQDAkDAEgcEIvwkDYdgSDQIA%3D) of the reassociation. The llvm.assume models the separately established fact that C1 + C2 cannot overflow in signed arithmetic. The public example uses i8 to finish quickly; the same proof also succeeds locally with i32.

Fixes #220897