### PR TITLE
[lldb][test] Merge demangling tests into one test

### DIFF
--- a/lldb/unittests/Core/MangledTest.cpp
+++ b/lldb/unittests/Core/MangledTest.cpp
@@ -838,77 +838,78 @@ DemanglingInfoCorrectnessTestCase g_demangling_correctness_test_cases[] = {
 #include "llvm/Testing/Demangle/DemangleTestCases.inc"
 };
 
-struct DemanglingInfoCorrectnessTestFixutre
-    : public ::testing::TestWithParam<DemanglingInfoCorrectnessTestCase> {};
+TEST(MangledTest, DemanglingInfoCorrectness) {
+  for (const auto &[mangled, demangled] : g_demangling_correctness_test_cases) {
+    SCOPED_TRACE(mangled);
 
-TEST_P(DemanglingInfoCorrectnessTestFixutre, Correctness) {
-  auto [mangled, demangled] = GetParam();
+    llvm::itanium_demangle::ManglingParser<TestAllocator> Parser(
+        mangled, mangled + ::strlen(mangled));
 
-  llvm::itanium_demangle::ManglingParser<TestAllocator> Parser(
-      mangled, mangled + ::strlen(mangled));
+    const auto *Root = Parser.parse();
 
-  const auto *Root = Parser.parse();
+    EXPECT_NE(nullptr, Root);
+    if (!Root)
+      continue;
 
-  ASSERT_NE(nullptr, Root);
+    auto OB =
+        std::unique_ptr<TrackingOutputBuffer, TrackingOutputBufferDeleter>(
+            new TrackingOutputBuffer());
+    Root->print(*OB);
 
-  auto OB = std::unique_ptr<TrackingOutputBuffer, TrackingOutputBufferDeleter>(
-      new TrackingOutputBuffer());
-  Root->print(*OB);
+    // Filter out cases which would never show up in frames. We only care
+    // about function names.
+    if (Root->getKind() !=
+            llvm::itanium_demangle::Node::Kind::KFunctionEncoding &&
+        Root->getKind() != llvm::itanium_demangle::Node::Kind::KDotSuffix)
+      continue;
 
-  // Filter out cases which would never show up in frames. We only care about
-  // function names.
-  if (Root->getKind() !=
-          llvm::itanium_demangle::Node::Kind::KFunctionEncoding &&
-      Root->getKind() != llvm::itanium_demangle::Node::Kind::KDotSuffix)
-    return;
+    EXPECT_TRUE(OB->NameInfo.hasBasename());
+    if (!OB->NameInfo.hasBasename())
+      continue;
 
-  ASSERT_TRUE(OB->NameInfo.hasBasename());
+    auto tracked_name = llvm::StringRef(*OB);
 
-  auto tracked_name = llvm::StringRef(*OB);
+    std::string reconstructed_name;
 
-  std::string reconstructed_name;
+    auto return_left = CPlusPlusLanguage::GetDemangledReturnTypeLHS(
+        tracked_name, OB->NameInfo);
+    EXPECT_THAT_EXPECTED(return_left, llvm::Succeeded());
+    reconstructed_name += *return_left;
 
-  auto return_left =
-      CPlusPlusLanguage::GetDemangledReturnTypeLHS(tracked_name, OB->NameInfo);
-  EXPECT_THAT_EXPECTED(return_left, llvm::Succeeded());
-  reconstructed_name += *return_left;
+    auto scope =
+        CPlusPlusLanguage::GetDemangledScope(tracked_name, OB->NameInfo);
+    EXPECT_THAT_EXPECTED(scope, llvm::Succeeded());
+    reconstructed_name += *scope;
 
-  auto scope = CPlusPlusLanguage::GetDemangledScope(tracked_name, OB->NameInfo);
-  EXPECT_THAT_EXPECTED(scope, llvm::Succeeded());
-  reconstructed_name += *scope;
+    auto basename =
+        CPlusPlusLanguage::GetDemangledBasename(tracked_name, OB->NameInfo);
+    reconstructed_name += basename;
 
-  auto basename =
-      CPlusPlusLanguage::GetDemangledBasename(tracked_name, OB->NameInfo);
-  reconstructed_name += basename;
+    auto template_args = CPlusPlusLanguage::GetDemangledTemplateArguments(
+        tracked_name, OB->NameInfo);
+    EXPECT_THAT_EXPECTED(template_args, llvm::Succeeded());
+    reconstructed_name += *template_args;
 
-  auto template_args = CPlusPlusLanguage::GetDemangledTemplateArguments(
-      tracked_name, OB->NameInfo);
-  EXPECT_THAT_EXPECTED(template_args, llvm::Succeeded());
-  reconstructed_name += *template_args;
+    auto args = CPlusPlusLanguage::GetDemangledFunctionArguments(tracked_name,
+                                                                 OB->NameInfo);
+    EXPECT_THAT_EXPECTED(args, llvm::Succeeded());
+    reconstructed_name += *args;
 
-  auto args = CPlusPlusLanguage::GetDemangledFunctionArguments(tracked_name,
-                                                               OB->NameInfo);
-  EXPECT_THAT_EXPECTED(args, llvm::Succeeded());
-  reconstructed_name += *args;
+    auto return_right = CPlusPlusLanguage::GetDemangledReturnTypeRHS(
+        tracked_name, OB->NameInfo);
+    EXPECT_THAT_EXPECTED(return_right, llvm::Succeeded());
+    reconstructed_name += *return_right;
 
-  auto return_right =
-      CPlusPlusLanguage::GetDemangledReturnTypeRHS(tracked_name, OB->NameInfo);
-  EXPECT_THAT_EXPECTED(return_right, llvm::Succeeded());
-  reconstructed_name += *return_right;
+    auto qualifiers = CPlusPlusLanguage::GetDemangledFunctionQualifiers(
+        tracked_name, OB->NameInfo);
+    EXPECT_THAT_EXPECTED(qualifiers, llvm::Succeeded());
+    reconstructed_name += *qualifiers;
 
-  auto qualifiers = CPlusPlusLanguage::GetDemangledFunctionQualifiers(
-      tracked_name, OB->NameInfo);
-  EXPECT_THAT_EXPECTED(qualifiers, llvm::Succeeded());
-  reconstructed_name += *qualifiers;
+    auto suffix = CPlusPlusLanguage::GetDemangledFunctionSuffix(tracked_name,
+                                                                OB->NameInfo);
+    EXPECT_THAT_EXPECTED(suffix, llvm::Succeeded());
+    reconstructed_name += *suffix;
 
-  auto suffix =
-      CPlusPlusLanguage::GetDemangledFunctionSuffix(tracked_name, OB->NameInfo);
-  EXPECT_THAT_EXPECTED(suffix, llvm::Succeeded());
-  reconstructed_name += *suffix;
-
-  EXPECT_EQ(reconstructed_name, demangled);
+    EXPECT_EQ(reconstructed_name, demangled);
+  }
 }
-
-INSTANTIATE_TEST_SUITE_P(
-    DemanglingInfoCorrectnessTests, DemanglingInfoCorrectnessTestFixutre,
-    ::testing::ValuesIn(g_demangling_correctness_test_cases));


### PR DESCRIPTION
The XML test report that LIT generates describes the outcome of every test in the test suite. Currently, the test report for the LLDB unit tests alone is about 5MiB of which 4.7MiB (about 94%) are used to describe all 30'000 DemanglingInfoCorrectnessTest instances names (they don't have any output on success, so this is just used to describe the test names).

This patch merges all these test instances into one. To make test failures still easy to parse, this patch changes test function to use a gtest scrope (which annotates failures with the mangled name) and use non-fatal checks to continue testing when one test fails.

This reduces the test report size overhead of these tests from 4.7MiB to about 100B.

assisted-by: claude