### PR TITLE
[NFC][LLVM] Remove TypeSize::multiplyCoefficientBy().

### DIFF
--- a/llvm/include/llvm/CodeGenTypes/LowLevelType.h
+++ b/llvm/include/llvm/CodeGenTypes/LowLevelType.h
@@ -483,8 +483,7 @@ public:
   /// \p Factor elements.
   LLT multiplyElements(int Factor) const {
     if (isVector()) {
-      return scalarOrVector(getElementCount().multiplyCoefficientBy(Factor),
-                            getElementType());
+      return scalarOrVector(getElementCount() * Factor, getElementType());
     }
 
     return fixed_vector(Factor, *this);

--- a/llvm/include/llvm/IR/DerivedTypes.h
+++ b/llvm/include/llvm/IR/DerivedTypes.h
@@ -626,9 +626,9 @@ public:
     if (!SizeTy->getPrimitiveSizeInBits().isKnownMultipleOf(EltSize))
       return nullptr;
 
-    ElementCount EC = SizeTy->getElementCount()
-                          .multiplyCoefficientBy(SizeTy->getScalarSizeInBits())
-                          .divideCoefficientBy(EltSize);
+    ElementCount EC =
+        (SizeTy->getElementCount() * SizeTy->getScalarSizeInBits())
+            .divideCoefficientBy(EltSize);
     return VectorType::get(EltTy->getScalarType(), EC);
   }
 

--- a/llvm/include/llvm/Support/TypeSize.h
+++ b/llvm/include/llvm/Support/TypeSize.h
@@ -385,6 +385,11 @@ public:
   friend constexpr TypeSize operator*(const TypeSize &LHS, const unsigned RHS) {
     return LHS * (ScalarTy)RHS;
   }
+  template <typename U = ScalarTy>
+  friend constexpr std::enable_if_t<!std::is_same_v<U, unsigned long>, TypeSize>
+  operator*(const TypeSize &LHS, const unsigned long RHS) {
+    return LHS * (ScalarTy)RHS;
+  }
   friend constexpr TypeSize operator*(const TypeSize &LHS, const int64_t RHS) {
     return LHS * (ScalarTy)RHS;
   }
@@ -395,6 +400,11 @@ public:
     return RHS * LHS;
   }
   friend constexpr TypeSize operator*(const int64_t LHS, const TypeSize &RHS) {
+    return RHS * LHS;
+  }
+  template <typename U = ScalarTy>
+  friend constexpr std::enable_if_t<!std::is_same_v<U, unsigned long>, TypeSize>
+  operator*(const unsigned long LHS, const TypeSize &RHS) {
     return RHS * LHS;
   }
   friend constexpr TypeSize operator*(const uint64_t LHS, const TypeSize &RHS) {

--- a/llvm/include/llvm/Support/TypeSize.h
+++ b/llvm/include/llvm/Support/TypeSize.h
@@ -253,26 +253,22 @@ public:
     return LeafTy::get(getKnownMinValue() / RHS, isScalable());
   }
 
-  constexpr LeafTy multiplyCoefficientBy(ScalarTy RHS) const {
-    return LeafTy::get(getKnownMinValue() * RHS, isScalable());
-  }
-
   constexpr LeafTy coefficientNextPowerOf2() const {
     return LeafTy::get(
         static_cast<ScalarTy>(llvm::NextPowerOf2(getKnownMinValue())),
         isScalable());
   }
 
-  /// Returns true if there exists a value X where RHS.multiplyCoefficientBy(X)
-  /// will result in a value whose quantity matches our own.
+  /// Returns true if there exists a value X where RHS*X will result in a value
+  /// whose quantity matches our own.
   constexpr bool
   hasKnownScalarFactor(const FixedOrScalableQuantity &RHS) const {
     return isScalable() == RHS.isScalable() &&
            getKnownMinValue() % RHS.getKnownMinValue() == 0;
   }
 
-  /// Returns a value X where RHS.multiplyCoefficientBy(X) will result in a
-  /// value whose quantity matches our own.
+  /// Returns a value X where RHS*X will result in a value whose quantity
+  /// matches our own.
   constexpr ScalarTy
   getKnownScalarFactor(const FixedOrScalableQuantity &RHS) const {
     assert(hasKnownScalarFactor(RHS) && "Expected RHS to be a known factor!");

--- a/llvm/lib/CodeGen/GlobalISel/CallLowering.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/CallLowering.cpp
@@ -659,8 +659,7 @@ void CallLowering::buildCopyToRegs(MachineIRBuilder &B,
   LLT DstTy = MRI.getType(DstRegs[0]);
   LLT CoverTy = getCoverTy(SrcTy, PartTy);
   if (SrcTy.isVector() && DstRegs.size() > 1) {
-    TypeSize FullCoverSize =
-        DstTy.getSizeInBits().multiplyCoefficientBy(DstRegs.size());
+    TypeSize FullCoverSize = DstTy.getSizeInBits() * DstRegs.size();
 
     LLT EltTy = SrcTy.getElementType();
     TypeSize EltSize = EltTy.getSizeInBits();

--- a/llvm/lib/CodeGen/GlobalISel/Utils.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/Utils.cpp
@@ -1160,8 +1160,8 @@ LLT llvm::getLCMType(LLT OrigTy, LLT TargetTy) {
       int GCDMinElts = std::gcd(OrigTy.getElementCount().getKnownMinValue(),
                                 TargetTy.getElementCount().getKnownMinValue());
       // Prefer the original element type.
-      ElementCount Mul = OrigTy.getElementCount().multiplyCoefficientBy(
-          TargetTy.getElementCount().getKnownMinValue());
+      ElementCount Mul = OrigTy.getElementCount() *
+                         TargetTy.getElementCount().getKnownMinValue();
       return LLT::vector(Mul.divideCoefficientBy(GCDMinElts),
                          OrigTy.getElementType());
     }

--- a/llvm/lib/CodeGen/SelectionDAG/LegalizeVectorTypes.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/LegalizeVectorTypes.cpp
@@ -7442,8 +7442,8 @@ void DAGTypeLegalizer::WidenVecRes_VECTOR_INTERLEAVE(SDNode *N) {
   SDValue Interleaved =
       DAG.getNode(ISD::VECTOR_INTERLEAVE, DL, WidenVTs, WidenOps);
 
-  EVT PackedWidenVT = EVT::getVectorVT(*DAG.getContext(), EltVT,
-                                       WidenEC.multiplyCoefficientBy(Factor));
+  EVT PackedWidenVT =
+      EVT::getVectorVT(*DAG.getContext(), EltVT, WidenEC * Factor);
   SmallVector<SDValue, 8> Slices(Factor);
   for (unsigned Idx = 0; Idx != Factor; ++Idx)
     Slices[Idx] = Interleaved.getValue(Idx);
@@ -7451,8 +7451,8 @@ void DAGTypeLegalizer::WidenVecRes_VECTOR_INTERLEAVE(SDNode *N) {
   SDValue Packed = DAG.getNode(ISD::CONCAT_VECTORS, DL, PackedWidenVT, Slices);
 
   for (unsigned Idx = 0U; Idx < Factor; ++Idx) {
-    SDValue Narrow = DAG.getExtractSubvector(
-        DL, VT, Packed, OrigEC.multiplyCoefficientBy(Idx).getKnownMinValue());
+    SDValue Narrow = DAG.getExtractSubvector(DL, VT, Packed,
+                                             OrigEC.getKnownMinValue() * Idx);
     SDValue Wide =
         DAG.getInsertSubvector(DL, DAG.getPOISON(WidenVT), Narrow, /*Idx=*/0U);
     SetWidenedVector(SDValue(N, Idx), Wide);
@@ -7490,10 +7490,9 @@ void DAGTypeLegalizer::WidenVecRes_VECTOR_DEINTERLEAVE(SDNode *N) {
   // not concat the widened operands but the original ones to effectively
   // generate a "packed" concated and widened vector, before extracting new
   // operand vectors with the widened type.
-  EVT PackedWidenVT = EVT::getVectorVT(*DAG.getContext(), EltVT,
-                                       WidenEC.multiplyCoefficientBy(Factor));
-  EVT ConcatVT = EVT::getVectorVT(*DAG.getContext(), EltVT,
-                                  OrigEC.multiplyCoefficientBy(Factor));
+  EVT PackedWidenVT =
+      EVT::getVectorVT(*DAG.getContext(), EltVT, WidenEC * Factor);
+  EVT ConcatVT = EVT::getVectorVT(*DAG.getContext(), EltVT, OrigEC * Factor);
   SDValue ConcatOp = DAG.getNode(ISD::CONCAT_VECTORS, DL, ConcatVT, N->ops());
   SDValue PackedWidenVec = DAG.getInsertSubvector(
       DL, DAG.getUNDEF(PackedWidenVT), ConcatOp, /*Idx=*/0U);
@@ -7501,9 +7500,8 @@ void DAGTypeLegalizer::WidenVecRes_VECTOR_DEINTERLEAVE(SDNode *N) {
   // Extract the new widened operand vectors.
   SmallVector<SDValue, 8> NewOps(Factor, SDValue());
   for (unsigned Idx = 0U; Idx < Factor; ++Idx) {
-    NewOps[Idx] = DAG.getExtractSubvector(
-        DL, WidenVT, PackedWidenVec,
-        WidenEC.multiplyCoefficientBy(Idx).getKnownMinValue());
+    NewOps[Idx] = DAG.getExtractSubvector(DL, WidenVT, PackedWidenVec,
+                                          WidenEC.getKnownMinValue() * Idx);
   }
 
   SmallVector<EVT, 8> NewVTs(Factor, WidenVT);

--- a/llvm/lib/Target/AArch64/GISel/AArch64PostLegalizerCombiner.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64PostLegalizerCombiner.cpp
@@ -459,9 +459,8 @@ void applyCombineMulCMLT(MachineInstr &MI, MachineRegisterInfo &MRI,
                          MachineIRBuilder &B, Register &SrcReg) {
   Register DstReg = MI.getOperand(0).getReg();
   LLT DstTy = MRI.getType(DstReg);
-  LLT HalfTy =
-      DstTy.changeElementCount(DstTy.getElementCount().multiplyCoefficientBy(2))
-          .changeElementSize(DstTy.getScalarSizeInBits() / 2);
+  LLT HalfTy = DstTy.changeElementCount(DstTy.getElementCount() * 2)
+                   .changeElementSize(DstTy.getScalarSizeInBits() / 2);
 
   Register ZeroVec = B.buildConstant(HalfTy, 0).getReg(0);
   Register CastReg =

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -2003,7 +2003,7 @@ RISCVTargetLowering::RISCVTargetLowering(const TargetMachine &TM,
           continue;
         ElementCount EC = VT.getVectorElementCount();
         unsigned Scale = VT.getVectorElementType() == MVT::i64 ? 8 : 4;
-        MVT ArgVT = MVT::getVectorVT(MVT::i8, EC.multiplyCoefficientBy(Scale));
+        MVT ArgVT = MVT::getVectorVT(MVT::i8, EC * Scale);
         setPartialReduceMLAAction(MLAOps, VT, ArgVT, Custom);
       }
     }
@@ -5968,8 +5968,7 @@ static SDValue getWideningSpread(SDValue V, unsigned Factor, unsigned Index,
     Result = DAG.getNode(ISD::SHL, DL, WideVT, Result,
                          DAG.getConstant(EltBits * Index, DL, WideVT));
   // Make sure to use original element type
-  MVT ResultVT = MVT::getVectorVT(VT.getVectorElementType(),
-                                  EC.multiplyCoefficientBy(Factor));
+  MVT ResultVT = MVT::getVectorVT(VT.getVectorElementType(), EC * Factor);
   return DAG.getBitcast(ResultVT, Result);
 }
 
@@ -6053,13 +6052,12 @@ static SDValue getWideningInterleave(SDValue EvenV, SDValue OddV,
   // Bitcast from <vscale x n * ty*2> to <vscale x 2*n x ty>
   MVT ResultContainerVT = MVT::getVectorVT(
       VecVT.getVectorElementType(), // Make sure to use original type
-      VecContainerVT.getVectorElementCount().multiplyCoefficientBy(2));
+      VecContainerVT.getVectorElementCount() * 2);
   Interleaved = DAG.getBitcast(ResultContainerVT, Interleaved);
 
   // Convert back to a fixed vector if needed
-  MVT ResultVT =
-      MVT::getVectorVT(VecVT.getVectorElementType(),
-                       VecVT.getVectorElementCount().multiplyCoefficientBy(2));
+  MVT ResultVT = MVT::getVectorVT(VecVT.getVectorElementType(),
+                                  VecVT.getVectorElementCount() * 2);
   if (ResultVT.isFixedLengthVector())
     Interleaved =
         convertFromScalableVector(ResultVT, Interleaved, DAG, Subtarget);
@@ -14453,8 +14451,7 @@ SDValue RISCVTargetLowering::lowerVECTOR_DEINTERLEAVE(SDValue Op,
   // Concatenate the vectors as one vector to deinterleave
   MVT ConcatVT =
       MVT::getVectorVT(VecVT.getVectorElementType(),
-                       VecVT.getVectorElementCount().multiplyCoefficientBy(
-                           PowerOf2Ceil(Factor)));
+                       VecVT.getVectorElementCount() * PowerOf2Ceil(Factor));
   if (Ops.size() < PowerOf2Ceil(Factor))
     Ops.append(PowerOf2Ceil(Factor) - Factor, DAG.getUNDEF(VecVT));
   SDValue Concat = DAG.getNode(ISD::CONCAT_VECTORS, DL, ConcatVT, Ops);
@@ -14507,8 +14504,7 @@ SDValue RISCVTargetLowering::lowerVECTOR_DEINTERLEAVE(SDValue Op,
   MachinePointerInfo PtrInfo;
   if (IsFixedVector) {
     // Calculating the stack size.
-    ElementCount ActualConcatEC =
-        VecVT.getVectorElementCount().multiplyCoefficientBy(Factor);
+    ElementCount ActualConcatEC = VecVT.getVectorElementCount() * Factor;
     EVT ConcatEVT = EVT::getVectorVT(
         *DAG.getContext(), VecVT.getVectorElementType(), ActualConcatEC);
     StackPtr = DAG.CreateStackTemporary(ConcatEVT.getStoreSize(), Alignment);
@@ -14737,9 +14733,8 @@ SDValue RISCVTargetLowering::lowerVECTOR_INTERLEAVE(SDValue Op,
                                         DAG, Subtarget);
   } else {
     // Otherwise, fallback to using vrgathere16.vv
-    MVT ConcatVT =
-      MVT::getVectorVT(VecVT.getVectorElementType(),
-                       VecVT.getVectorElementCount().multiplyCoefficientBy(2));
+    MVT ConcatVT = MVT::getVectorVT(VecVT.getVectorElementType(),
+                                    VecVT.getVectorElementCount() * 2);
     SDValue Concat = DAG.getNode(ISD::CONCAT_VECTORS, DL, ConcatVT,
                                  Op.getOperand(0), Op.getOperand(1));
 

--- a/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
@@ -811,8 +811,7 @@ Value *VPInstruction::generate(VPTransformState &State) {
       return Builder.CreateCmp(CmpInst::Predicate::ICMP_ULT, VIVElem0, ScalarTC,
                                Name);
 
-    ElementCount EC = State.VF.multiplyCoefficientBy(Multiplier);
-    auto *PredTy = VectorType::get(Builder.getInt1Ty(), EC);
+    auto *PredTy = VectorType::get(Builder.getInt1Ty(), State.VF * Multiplier);
     return Builder.CreateIntrinsic(Intrinsic::get_active_lane_mask,
                                    {PredTy, ScalarTC->getType()},
                                    {VIVElem0, ScalarTC}, nullptr, Name);

--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
@@ -231,8 +231,7 @@ class SinkStoreInfo {
     ElementCount MaxVF = *max_element(VFs, ElementCount::isKnownLT);
     if (MaxVF.isScalable())
       return false;
-    return Distance->abs().uge(
-        MaxVF.multiplyCoefficientBy(MaxStoreSize).getFixedValue());
+    return Distance->abs().uge(MaxVF.getFixedValue() * MaxStoreSize);
   }
 
 public:
@@ -2041,7 +2040,7 @@ static bool isConditionTrueViaVFAndUF(VPValue *Cond, VPlan &Plan,
   assert(!isa<SCEVCouldNotCompute>(VectorTripCount) &&
          "Trip count SCEV must be computable");
   ScalarEvolution &SE = *PSE.getSE();
-  ElementCount NumElements = BestVF.multiplyCoefficientBy(BestUF);
+  ElementCount NumElements = BestVF * BestUF;
   const SCEV *C = SE.getElementCount(VectorTripCount->getType(), NumElements);
   return SE.isKnownPredicate(CmpInst::ICMP_EQ, VectorTripCount, C);
 }
@@ -2122,7 +2121,7 @@ static bool simplifyBranchConditionForVFAndUF(VPlan &Plan, ElementCount BestVF,
     assert(!isa<SCEVCouldNotCompute>(VectorTripCount) &&
            "Trip count SCEV must be computable");
     ScalarEvolution &SE = *PSE.getSE();
-    ElementCount NumElements = BestVF.multiplyCoefficientBy(BestUF);
+    ElementCount NumElements = BestVF * BestUF;
     const SCEV *C = SE.getElementCount(VectorTripCount->getType(), NumElements);
     if (!SE.isKnownPredicate(CmpInst::ICMP_ULE, VectorTripCount, C))
       return false;

--- a/llvm/unittests/Support/TypeSizeTest.cpp
+++ b/llvm/unittests/Support/TypeSizeTest.cpp
@@ -55,8 +55,7 @@ static_assert(CEElementCountFixed3.coefficientNextPowerOf2() ==
               CEElementCountFixed4);
 static_assert(ElementCount::getFixed(8).divideCoefficientBy(2) ==
               ElementCount::getFixed(4));
-static_assert(ElementCount::getFixed(8).multiplyCoefficientBy(3) ==
-              ElementCount::getFixed(24));
+static_assert(ElementCount::getFixed(8) * 3 == ElementCount::getFixed(24));
 static_assert(ElementCount::getFixed(8).isKnownMultipleOf(2));
 static_assert(!ElementCount::getFixed(8).isKnownMultipleOf(0));
 


### PR DESCRIPTION
TypeSize implements operator*() that does the same operation.