### PR TITLE
[MLIR][GPU] Added FoldSelfCopy pattern to gpu memcpy

### DIFF
--- a/mlir/lib/Dialect/GPU/IR/GPUDialect.cpp
+++ b/mlir/lib/Dialect/GPU/IR/GPUDialect.cpp
@@ -2089,6 +2089,35 @@ LogicalResult MemcpyOp::verify() {
 
 namespace {
 
+/// Fold gpu.memcpy(%x, %x).
+struct FoldSelfCopy : public OpRewritePattern<MemcpyOp> {
+  using OpRewritePattern<MemcpyOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(MemcpyOp memcpyOp,
+                                PatternRewriter &rewriter) const override {
+    if (memcpyOp.getSrc() != memcpyOp.getDst())
+      return failure();
+
+    // Synchronous self-copy is a no-op.
+    if (!memcpyOp.getAsyncToken()) {
+      rewriter.eraseOp(memcpyOp);
+      return success();
+    }
+
+    ValueRange asyncDependencies = memcpyOp.getAsyncDependencies();
+
+    // If only 1 dependency, replace `memcpyOp` with the dependency.
+    if (asyncDependencies.size() == 1)
+      rewriter.replaceOp(memcpyOp, asyncDependencies.front());
+
+    // If several dependencies, replace `memcpyOp` with a `gpu.wait`.
+    rewriter.replaceOpWithNewOp<WaitOp>(
+        memcpyOp, memcpyOp.getAsyncToken().getType(), asyncDependencies);
+
+    return success();
+  }
+};
+
 /// Erases a common case of copy ops where a destination value is used only by
 /// the copy op, alloc and dealloc ops.
 struct EraseTrivialCopyOp : public OpRewritePattern<MemcpyOp> {
@@ -2126,7 +2155,12 @@ struct EraseTrivialCopyOp : public OpRewritePattern<MemcpyOp> {
 
 void MemcpyOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                            MLIRContext *context) {
-  results.add<EraseTrivialCopyOp>(context);
+  results.add<EraseTrivialCopyOp, FoldSelfCopy>(context);
+}
+
+LogicalResult MemcpyOp::fold(FoldAdaptor adaptor,
+                             SmallVectorImpl<::mlir::OpFoldResult> &results) {
+  return memref::foldMemRefCast(*this);
 }
 
 //===----------------------------------------------------------------------===//
@@ -2196,11 +2230,6 @@ LogicalResult SubgroupMmaComputeOp::verify() {
     return emitError("operand shapes do not satisfy matmul constraints");
 
   return success();
-}
-
-LogicalResult MemcpyOp::fold(FoldAdaptor adaptor,
-                             SmallVectorImpl<::mlir::OpFoldResult> &results) {
-  return memref::foldMemRefCast(*this);
 }
 
 LogicalResult MemsetOp::fold(FoldAdaptor adaptor,

--- a/mlir/test/Dialect/GPU/canonicalize.mlir
+++ b/mlir/test/Dialect/GPU/canonicalize.mlir
@@ -157,6 +157,61 @@ func.func @fold_memcpy_op(%arg0: i1) {
 
 // -----
 
+// CHECK-LABEL: func @synhcronous_self_memcpy
+func.func @synhcronous_self_memcpy(%arg0: memref<2xf16>)
+{
+  gpu.memcpy %arg0, %arg0 : memref<2xf16>, memref<2xf16>
+  return
+}
+
+// CHECK-NOT: gpu.memcpy
+
+// -----
+
+// CHECK-LABEL: func @asynchronous_self_memcpy1
+func.func @asynchronous_self_memcpy1(%arg0: memref<2xf16>) {
+  %1 = gpu.wait async
+  %memref, %asyncToken = gpu.alloc async [%1] () : memref<2xf16>
+  gpu.wait [%1]
+  %2 = gpu.wait async
+  %3 = gpu.memcpy async [%2] %memref, %memref : memref<2xf16>, memref<2xf16>
+  gpu.wait [%2]
+  return
+}
+
+// CHECK-NOT: gpu.memcpy
+
+// -----
+
+// CHECK-LABEL: func @asynchronous_self_memcpy2(
+// CHECK-SAME:    %[[ARG0:.*]]: memref<2xf16>
+func.func @asynchronous_self_memcpy2(%arg0: memref<2xf16>) {
+    // CHECK: %[[T0:.*]] = gpu.wait async
+    %1 = gpu.wait async
+    
+    // CHECK: %{{.*}}, %[[T1:.*]] = gpu.alloc async [%[[T0]]] () : memref<2xf16>
+    // CHECK: %{{.*}}, %[[T2:.*]] = gpu.alloc async [%[[T0]]] () : memref<2xf16>
+    %memref, %asyncToken = gpu.alloc async [%1] () : memref<2xf16>
+    %memref1, %asyncToken1 = gpu.alloc async [%1] () : memref<2xf16>
+
+    // CHECK-NOT: gpu.memcpy {{.*}} %[[ARG0]], %[[ARG0]]
+    // CHECK: %[[T3:.*]] = gpu.wait async [%[[T1]], %[[T2]]]
+    %3 = gpu.memcpy async [%asyncToken, %asyncToken1] %arg0, %arg0 : memref<2xf16>, memref<2xf16>
+    
+    // CHECK: gpu.wait [%[[T3]]]
+    gpu.wait [%3]
+    
+    // CHECK: gpu.memcpy async [%[[T3]]] %[[ARG0]], %{{.*}}
+    // CHECK: gpu.memcpy async [%[[T3]]] %[[ARG0]], %{{.*}}
+    %4 = gpu.memcpy async [%3] %arg0, %memref : memref<2xf16>, memref<2xf16>
+    %5 = gpu.memcpy async [%3] %arg0, %memref1 : memref<2xf16>, memref<2xf16>
+
+    gpu.wait [%4, %5]
+    return
+}
+
+// -----
+
 // We cannot fold memcpy here as dest is a block argument.
 // CHECK-LABEL: func @do_not_fold_memcpy_op1
 func.func @do_not_fold_memcpy_op1(%arg0: i1, %arg1: memref<2xf16>) {


### PR DESCRIPTION
Added a canonicalization pattern for the gpu.memcpy operation. The purpose of the pattern is to fold self copies, i.e 
```
gpu.memcpy(%a, %a) : memref<2xf16>, memref<2xf16>
```
or 
```
    func.func @main(%arg0: memref<100xf16, 1>)
    {
        %1 = gpu.wait async 
        %2 = gpu.memcpy async [%1]  %arg0, %arg0: memref<100xf16, 1>, memref<100xf16, 1>
        gpu.wait[%2]
        return 
    }
```
The only complexity with this pattern is how to deal with the asynchronous case when the ```memcpy``` operation produces an asyncToken. In the case where the ```memcpy``` has just one async dependency, the pattern will simply replace the users of the result of the ```memcpy``` with its async dependency. When there are several async dependencies, the ```memcpy``` can instead be replaced by a ```wait``` which takes in the ```memcpy```'s dependencies.

AI Declaration: I used gemini to help write the lit-tests
