### PR TITLE
[analyzer] Fix crash destructing element of a sugared array type

### DIFF
--- a/clang/lib/StaticAnalyzer/Core/ExprEngineCXX.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngineCXX.cpp
@@ -107,11 +107,8 @@ SVal ExprEngine::makeElementRegion(ProgramStateRef State, SVal LValue,
   SValBuilder &SVB = State->getStateManager().getSValBuilder();
   ASTContext &Ctx = SVB.getContext();
 
-  if (const ArrayType *AT = Ctx.getAsArrayType(Ty)) {
-    while (AT) {
-      Ty = AT->getElementType();
-      AT = dyn_cast<ArrayType>(AT->getElementType());
-    }
+  if (Ctx.getAsArrayType(Ty)) {
+    Ty = Ctx.getBaseElementType(Ty);
     LValue = State->getLValue(Ty, SVB.makeArrayIndex(Idx), LValue);
     IsArray = true;
   }

--- a/clang/lib/StaticAnalyzer/Core/ExprEngineCXX.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngineCXX.cpp
@@ -106,8 +106,8 @@ SVal ExprEngine::makeElementRegion(ProgramStateRef State, SVal LValue,
                                    QualType &Ty, bool &IsArray, unsigned Idx) {
   SValBuilder &SVB = State->getStateManager().getSValBuilder();
 
-  if (const ASTContext &Ctx = SVB.getContext(); Ctx.getAsArrayType(Ty)) {
-    Ty = Ctx.getBaseElementType(Ty);
+  if (Ty->isArrayType()) {
+    Ty = SVB.getContext().getBaseElementType(Ty);
     LValue = State->getLValue(Ty, SVB.makeArrayIndex(Idx), LValue);
     IsArray = true;
   }

--- a/clang/lib/StaticAnalyzer/Core/ExprEngineCXX.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngineCXX.cpp
@@ -105,9 +105,8 @@ void ExprEngine::performTrivialCopy(ExplodedNodeSet &Dst, ExplodedNode *Pred,
 SVal ExprEngine::makeElementRegion(ProgramStateRef State, SVal LValue,
                                    QualType &Ty, bool &IsArray, unsigned Idx) {
   SValBuilder &SVB = State->getStateManager().getSValBuilder();
-  ASTContext &Ctx = SVB.getContext();
 
-  if (Ctx.getAsArrayType(Ty)) {
+  if (ASTContext &Ctx = SVB.getContext(); Ctx.getAsArrayType(Ty)) {
     Ty = Ctx.getBaseElementType(Ty);
     LValue = State->getLValue(Ty, SVB.makeArrayIndex(Idx), LValue);
     IsArray = true;

--- a/clang/lib/StaticAnalyzer/Core/ExprEngineCXX.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngineCXX.cpp
@@ -106,7 +106,7 @@ SVal ExprEngine::makeElementRegion(ProgramStateRef State, SVal LValue,
                                    QualType &Ty, bool &IsArray, unsigned Idx) {
   SValBuilder &SVB = State->getStateManager().getSValBuilder();
 
-  if (ASTContext &Ctx = SVB.getContext(); Ctx.getAsArrayType(Ty)) {
+  if (const ASTContext &Ctx = SVB.getContext(); Ctx.getAsArrayType(Ty)) {
     Ty = Ctx.getBaseElementType(Ty);
     LValue = State->getLValue(Ty, SVB.makeArrayIndex(Idx), LValue);
     IsArray = true;

--- a/clang/test/Analysis/dtor-array.cpp
+++ b/clang/test/Analysis/dtor-array.cpp
@@ -326,6 +326,13 @@ void multidimensionalMember(){
   clang_analyzer_eval(EvalOrderArr[3] == 0); // expected-warning {{TRUE}}
 }
 
+void typedefMultidimensionalNoCrash(){
+  // The inner dimension is hidden behind a typedef, so the element type of the
+  // outer array is a TypedefType rather than a ConstantArrayType.
+  typedef EvalOrder EvalOrderRow[2];
+  EvalOrderRow arr[2]; // no-crash
+}
+
 void *memset(void *, int, size_t);
 void clang_analyzer_dumpElementCount(InlineDtor *);
 


### PR DESCRIPTION
ExprEngine::makeElementRegion falls short trying to determine the element type of an array that involves a type aliasing a static array type.

This leads to a crash in ExprEngine::ProcessMemberDtor where it assumes that element type is a CXXRecordDecl, while it is still a type alias to a static array type.

getBaseElementType is the canonical way to desugar and peel off the array dimensions.

Assisted by Claude Opus 5

--
CPP-8838