### PR TITLE
[llvm][llvm-readobj] Print COFF RawDataSize as hex

### DIFF
--- a/lld/test/COFF/arm64ec-export-thunks.test
+++ b/lld/test/COFF/arm64ec-export-thunks.test
@@ -72,7 +72,7 @@ RUN: llvm-readobj --sections exports.dll | FileCheck --check-prefix=A64XRM %s
 A64XRM:      Name: .a64xrm (2E 61 36 34 78 72 6D 00)
 A64XRM-NEXT: VirtualSize: 0x18
 A64XRM-NEXT: VirtualAddress: 0x6000
-A64XRM-NEXT: RawDataSize: 512
+A64XRM-NEXT: RawDataSize: 0x200
 A64XRM-NEXT: PointerToRawData:
 A64XRM-NEXT: PointerToRelocations: 0x0
 A64XRM-NEXT: PointerToLineNumbers: 0x0

--- a/lld/test/COFF/arm64ec-import.test
+++ b/lld/test/COFF/arm64ec-import.test
@@ -171,7 +171,7 @@ RUN: llvm-readobj --headers out-size.dll | FileCheck --check-prefix=RDATA-HEADER
 RDATA-HEADER:      Name: .rdata (2E 72 64 61 74 61 00 00)
 RDATA-HEADER-NEXT: VirtualSize: 0x2030
 RDATA-HEADER-NEXT: VirtualAddress: 0x3000
-RDATA-HEADER-NEXT: RawDataSize: 8240
+RDATA-HEADER-NEXT: RawDataSize: 0x2030
 
 #--- test.s
     .section .test, "r"

--- a/lld/test/COFF/baserel.test
+++ b/lld/test/COFF/baserel.test
@@ -60,7 +60,7 @@
 # BASEREL-HEADER:      Name: .reloc (2E 72 65 6C 6F 63 00 00)
 # BASEREL-HEADER-NEXT: VirtualSize: 0x20
 # BASEREL-HEADER-NEXT: VirtualAddress: 0x5000
-# BASEREL-HEADER-NEXT: RawDataSize: 512
+# BASEREL-HEADER-NEXT: RawDataSize: 0x200
 # BASEREL-HEADER-NEXT: PointerToRawData: 0xC00
 # BASEREL-HEADER-NEXT: PointerToRelocations: 0x0
 # BASEREL-HEADER-NEXT: PointerToLineNumbers: 0x0

--- a/lld/test/COFF/code-merge.s
+++ b/lld/test/COFF/code-merge.s
@@ -12,7 +12,7 @@
 # CHECK-NEXT:     Name: .testbss (2E 74 65 73 74 62 73 73)
 # CHECK-NEXT:     VirtualSize: 0x18
 # CHECK-NEXT:     VirtualAddress: 0x1000
-# CHECK-NEXT:     RawDataSize: 512
+# CHECK-NEXT:     RawDataSize: 0x200
 # CHECK-NEXT:     PointerToRawData: 0x400
 # CHECK-NEXT:     PointerToRelocations: 0x0
 # CHECK-NEXT:     PointerToLineNumbers: 0x0
@@ -29,7 +29,7 @@
 # CHECK-NEXT:     Name: .testd (2E 74 65 73 74 64 00 00)
 # CHECK-NEXT:     VirtualSize: 0x18
 # CHECK-NEXT:     VirtualAddress: 0x2000
-# CHECK-NEXT:     RawDataSize: 512
+# CHECK-NEXT:     RawDataSize: 0x200
 # CHECK-NEXT:     PointerToRawData: 0x600
 # CHECK-NEXT:     PointerToRelocations: 0x0
 # CHECK-NEXT:     PointerToLineNumbers: 0x0
@@ -45,7 +45,7 @@
 # CHECK-NEXT:     Name: .testx3 (2E 74 65 73 74 78 33 00)
 # CHECK-NEXT:     VirtualSize: 0x12
 # CHECK-NEXT:     VirtualAddress: 0x3000
-# CHECK-NEXT:     RawDataSize: 512
+# CHECK-NEXT:     RawDataSize: 0x200
 # CHECK-NEXT:     PointerToRawData: 0x800
 # CHECK-NEXT:     PointerToRelocations: 0x0
 # CHECK-NEXT:     PointerToLineNumbers: 0x0
@@ -62,7 +62,7 @@
 # CHECK-NEXT:     Name: .testx4 (2E 74 65 73 74 78 34 00)
 # CHECK-NEXT:     VirtualSize: 0x14
 # CHECK-NEXT:     VirtualAddress: 0x4000
-# CHECK-NEXT:     RawDataSize: 512
+# CHECK-NEXT:     RawDataSize: 0x200
 # CHECK-NEXT:     PointerToRawData: 0xA00
 # CHECK-NEXT:     PointerToRelocations: 0x0
 # CHECK-NEXT:     PointerToLineNumbers: 0x0

--- a/lld/test/COFF/common-replacement.s
+++ b/lld/test/COFF/common-replacement.s
@@ -15,7 +15,7 @@
 # SECTIONS:         Name: .data (2E 64 61 74 61 00 00 00)
 # SECTIONS-NEXT:    VirtualSize: 0x8
 # SECTIONS-NEXT:    VirtualAddress: 0x3000
-# SECTIONS-NEXT:    RawDataSize: 512
+# SECTIONS-NEXT:    RawDataSize: 0x200
 
 
         .text

--- a/lld/test/COFF/merge-data-bss.test
+++ b/lld/test/COFF/merge-data-bss.test
@@ -6,7 +6,7 @@
 # CHECK:      Name: .data
 # CHECK-NEXT: VirtualSize: 0x2018
 # CHECK-NEXT: VirtualAddress: 0x3000
-# CHECK-NEXT: RawDataSize: 512
+# CHECK-NEXT: RawDataSize: 0x200
 # CHECK-NOT: Name: .other
 
 --- !COFF

--- a/lld/test/COFF/nodbgdirmerge.test
+++ b/lld/test/COFF/nodbgdirmerge.test
@@ -13,7 +13,7 @@ CHECKNOTMERGED:     Number: 3
 CHECKNOTMERGED-NEXT:     Name: .cvinfo
 CHECKNOTMERGED-NEXT:     VirtualSize: 0x3D
 CHECKNOTMERGED-NEXT:     VirtualAddress: 0x3000
-CHECKNOTMERGED-NEXT:     RawDataSize: 512
+CHECKNOTMERGED-NEXT:     RawDataSize: 0x200
 CHECKNOTMERGED-NEXT:     PointerToRawData: 0x800
 CHECKNOTMERGED-NEXT:     PointerToRelocations: 0
 CHECKNOTMERGED-NEXT:     PointerToLineNumbers: 0

--- a/lld/test/COFF/secrel-common.s
+++ b/lld/test/COFF/secrel-common.s
@@ -25,7 +25,7 @@
 # CHECK:     Number: 3
 # CHECK:     Name: .data (2E 64 61 74 61 00 00 00)
 # CHECK:     VirtualSize: 0x204
-# CHECK:     RawDataSize: 512
+# CHECK:     RawDataSize: 0x200
 # CHECK:   }
 # CHECK-NOT: Section
 # CHECK: ]

--- a/lldb/test/Shell/SymbolFile/NativePDB/globals-bss.cpp
+++ b/lldb/test/Shell/SymbolFile/NativePDB/globals-bss.cpp
@@ -19,7 +19,7 @@ int main(int argc, char **argv) {
 // BSS:         Name: .data
 // BSS-NEXT:    VirtualSize: 0x4
 // BSS-NEXT:    VirtualAddress:
-// BSS-NEXT:    RawDataSize: 0
+// BSS-NEXT:    RawDataSize: 0x0
 // BSS-NEXT:    PointerToRawData: 0x0
 // BSS-NEXT:    PointerToRelocations: 0x0
 // BSS-NEXT:    PointerToLineNumbers: 0x0

--- a/llvm/test/MC/AArch64/seh-large-func-multi-epilog.s
+++ b/llvm/test/MC/AArch64/seh-large-func-multi-epilog.s
@@ -11,7 +11,7 @@
 // CHECK-NEXT:    Name: .xdata (2E 78 64 61 74 61 00 00)
 // CHECK-NEXT:    VirtualSize: 0x0
 // CHECK-NEXT:    VirtualAddress: 0x0
-// CHECK-NEXT:    RawDataSize: 80
+// CHECK-NEXT:    RawDataSize: 0x50
 // CHECK-NEXT:    PointerToRawData: 0x1251AC
 // CHECK-NEXT:    PointerToRelocations: 0x0
 // CHECK-NEXT:    PointerToLineNumbers: 0x0
@@ -28,7 +28,7 @@
 // CHECK-NEXT:    Name: .pdata (2E 70 64 61 74 61 00 00)
 // CHECK-NEXT:    VirtualSize: 0x0
 // CHECK-NEXT:    VirtualAddress: 0x0
-// CHECK-NEXT:    RawDataSize: 16
+// CHECK-NEXT:    RawDataSize: 0x10
 // CHECK-NEXT:    PointerToRawData: 0x1251FC
 // CHECK-NEXT:    PointerToRelocations: 0x12520C
 // CHECK-NEXT:    PointerToLineNumbers: 0x0

--- a/llvm/test/MC/AArch64/seh-large-func.s
+++ b/llvm/test/MC/AArch64/seh-large-func.s
@@ -8,7 +8,7 @@
 // CHECK-NEXT:     Name: .xdata (2E 78 64 61 74 61 00 00)
 // CHECK-NEXT:     VirtualSize: 0x0
 // CHECK-NEXT:     VirtualAddress: 0x0
-// CHECK-NEXT:     RawDataSize: 52
+// CHECK-NEXT:     RawDataSize: 0x34
 // CHECK-NEXT:     PointerToRawData: 0x3D0A20
 // CHECK-NEXT:     PointerToRelocations: 0x0
 // CHECK-NEXT:     PointerToLineNumbers: 0x0
@@ -25,7 +25,7 @@
 // CHECK-NEXT:     Name: .pdata (2E 70 64 61 74 61 00 00)
 // CHECK-NEXT:     VirtualSize: 0x0
 // CHECK-NEXT:     VirtualAddress: 0x0
-// CHECK-NEXT:     RawDataSize: 40
+// CHECK-NEXT:     RawDataSize: 0x28
 // CHECK-NEXT:     PointerToRawData: 0x3D0A54
 // CHECK-NEXT:     PointerToRelocations: 0x3D0A7C
 // CHECK-NEXT:     PointerToLineNumbers: 0x0

--- a/llvm/test/MC/AArch64/seh.s
+++ b/llvm/test/MC/AArch64/seh.s
@@ -21,7 +21,7 @@
 // CHECK-NEXT:   }
 // CHECK:        Section {
 // CHECK:          Name: .xdata
-// CHECK:          RawDataSize: 108
+// CHECK:          RawDataSize: 0x6C
 // CHECK:          RelocationCount: 1
 // CHECK:          Characteristics [
 // CHECK-NEXT:       ALIGN_4BYTES

--- a/llvm/test/MC/AArch64/win-import-call-optimization.s
+++ b/llvm/test/MC/AArch64/win-import-call-optimization.s
@@ -34,7 +34,7 @@ tail_call:
 // CHECK-LABEL: Name: .impcall (2E 69 6D 70 63 61 6C 6C)
 // CHECK-NEXT:  VirtualSize: 0x0
 // CHECK-NEXT:  VirtualAddress: 0x0
-// CHECK-NEXT:  RawDataSize: 52
+// CHECK-NEXT:  RawDataSize: 0x34
 // CHECK-NEXT:  PointerToRawData: 0x150
 // CHECK-NEXT:  PointerToRelocations: 0x0
 // CHECK-NEXT:  PointerToLineNumbers: 0x0

--- a/llvm/test/MC/ARM/seh.s
+++ b/llvm/test/MC/ARM/seh.s
@@ -22,7 +22,7 @@
 // CHECK-NEXT:   }
 // CHECK:        Section {
 // CHECK:          Name: .xdata
-// CHECK:          RawDataSize: 100
+// CHECK:          RawDataSize: 0x64
 // CHECK:          RelocationCount: 1
 // CHECK:          Characteristics [
 // CHECK-NEXT:       ALIGN_4BYTES

--- a/llvm/test/MC/COFF/addrsig.s
+++ b/llvm/test/MC/COFF/addrsig.s
@@ -3,7 +3,7 @@
 // CHECK:      Name: .llvm_addrsig
 // CHECK-NEXT: VirtualSize: 0x0
 // CHECK-NEXT: VirtualAddress: 0x0
-// CHECK-NEXT: RawDataSize: 6
+// CHECK-NEXT: RawDataSize: 0x6
 // CHECK-NEXT: PointerToRawData:
 // CHECK-NEXT: PointerToRelocations: 0x0
 // CHECK-NEXT: PointerToLineNumbers: 0x0

--- a/llvm/test/MC/COFF/align-nops.s
+++ b/llvm/test/MC/COFF/align-nops.s
@@ -18,7 +18,7 @@ f0:
 //CHECK:          Name: .text
 //CHECK-NEXT:     VirtualSize
 //CHECK-NEXT:     VirtualAddress
-//CHECK-NEXT:     RawDataSize: 16
+//CHECK-NEXT:     RawDataSize: 0x10
 //CHECK-NEXT:     PointerToRawData
 //CHECK-NEXT:     PointerToRelocations
 //CHECK-NEXT:     PointerToLineNumbers
@@ -37,7 +37,7 @@ f0:
 //CHECK:          Name: .data
 //CHECK-NEXT:     VirtualSize:
 //CHECK-NEXT:     VirtualAddress:
-//CHECK-NEXT:     RawDataSize: 16
+//CHECK-NEXT:     RawDataSize: 0x10
 //CHECK-NEXT:     PointerToRawData:
 //CHECK-NEXT:     PointerToRelocations:
 //CHECK-NEXT:     PointerToLineNumbers:

--- a/llvm/test/MC/COFF/basic-coff-64.s
+++ b/llvm/test/MC/COFF/basic-coff-64.s
@@ -39,7 +39,7 @@ _main:                                  # @main
 // CHECK:     Name:                 .text
 // CHECK:     VirtualSize:          0
 // CHECK:     VirtualAddress:       0
-// CHECK:     RawDataSize:          [[TextSize:[0-9]+]]
+// CHECK:     RawDataSize:          0x[[#%X,TextSize:]]
 // CHECK:     PointerToRawData:     0x{{[0-9A-F]+}}
 // CHECK:     PointerToRelocations: 0x{{[0-9A-F]+}}
 // CHECK:     PointerToLineNumbers: 0x0
@@ -61,7 +61,7 @@ _main:                                  # @main
 // CHECK:     Name:                 .data
 // CHECK:     VirtualSize:          0
 // CHECK:     VirtualAddress:       0
-// CHECK:     RawDataSize:          [[DataSize:[0-9]+]]
+// CHECK:     RawDataSize:          0x[[#%X,DataSize:]]
 // CHECK:     PointerToRawData:     0x{{[0-9A-F]+}}
 // CHECK:     PointerToRelocations: 0x0
 // CHECK:     PointerToLineNumbers: 0x0
@@ -90,7 +90,7 @@ _main:                                  # @main
 // CHECK:     StorageClass:   Static
 // CHECK:     AuxSymbolCount: 1
 // CHECK:     AuxSectionDef {
-// CHECK:       Length: [[TextSize]]
+// CHECK:       Length: [[#%u,TextSize]]
 // CHECK:       RelocationCount: 2
 // CHECK:       LineNumberCount: 0
 // CHECK:       Checksum: 0x8E1B6D20
@@ -107,7 +107,7 @@ _main:                                  # @main
 // CHECK:     StorageClass:   Static
 // CHECK:     AuxSymbolCount: 1
 // CHECK:     AuxSectionDef {
-// CHECK:       Length: [[DataSize]]
+// CHECK:       Length: [[#%u,DataSize]]
 // CHECK:       RelocationCount: 0
 // CHECK:       LineNumberCount: 0
 // CHECK:       Checksum: 0x2B95CA92

--- a/llvm/test/MC/COFF/basic-coff.s
+++ b/llvm/test/MC/COFF/basic-coff.s
@@ -39,7 +39,7 @@ L_.str:                                 # @.str
 // CHECK:     Name:                 .text
 // CHECK:     VirtualSize:          0
 // CHECK:     VirtualAddress:       0
-// CHECK:     RawDataSize:          {{[0-9]+}}
+// CHECK:     RawDataSize:          0x{{[0-9A-F]+}}
 // CHECK:     PointerToRawData:     0x{{[0-9A-F]+}}
 // CHECK:     PointerToRelocations: 0x{{[0-9A-F]+}}
 // CHECK:     PointerToLineNumbers: 0x0
@@ -61,7 +61,7 @@ L_.str:                                 # @.str
 // CHECK:     Name:                 .data
 // CHECK:     VirtualSize:          0
 // CHECK:     VirtualAddress:       0
-// CHECK:     RawDataSize:          {{[0-9]+}}
+// CHECK:     RawDataSize:          0x{{[0-9A-F]+}}
 // CHECK:     PointerToRawData:     0x{{[0-9A-F]+}}
 // CHECK:     PointerToRelocations: 0x0
 // CHECK:     PointerToLineNumbers: 0x0

--- a/llvm/test/MC/COFF/bss.s
+++ b/llvm/test/MC/COFF/bss.s
@@ -12,4 +12,4 @@ _g0:
 // CHECK:      Name:            .bss
 // CHECK-NEXT: VirtualSize:     0
 // CHECK-NEXT: VirtualAddress:  0
-// CHECK-NEXT: RawDataSize:     4
+// CHECK-NEXT: RawDataSize:     0x4

--- a/llvm/test/MC/COFF/cgprofile.s
+++ b/llvm/test/MC/COFF/cgprofile.s
@@ -18,7 +18,7 @@ late3:
 # CHECK:      Name: .llvm.call-graph-profile
 # CHECK-NEXT: VirtualSize:
 # CHECK-NEXT: VirtualAddress:
-# CHECK-NEXT: RawDataSize: 48
+# CHECK-NEXT: RawDataSize: 0x30
 # CHECK-NEXT: PointerToRawData:
 # CHECK-NEXT: PointerToRelocations:
 # CHECK-NEXT: PointerToLineNumbers:

--- a/llvm/test/MC/COFF/module-asm.ll
+++ b/llvm/test/MC/COFF/module-asm.ll
@@ -11,7 +11,7 @@ module asm "  ret"
 ; CHECK:            Name:                      .text
 ; CHECK-NEXT:       VirtualSize:               0
 ; CHECK-NEXT:       VirtualAddress:            0
-; CHECK-NEXT:       RawDataSize:               {{[0-9]+}}
+; CHECK-NEXT:       RawDataSize:               0x{{[0-9A-F]+}}
 ; CHECK-NEXT:       PointerToRawData:          0x{{[0-9A-F]+}}
 ; CHECK-NEXT:       PointerToRelocations:      0x{{[0-9A-F]+}}
 ; CHECK-NEXT:       PointerToLineNumbers:      0x0

--- a/llvm/test/MC/COFF/section.s
+++ b/llvm/test/MC/COFF/section.s
@@ -221,12 +221,12 @@
 // CHECK:       Section {
 // CHECK-NEXT:    Number:
 // CHECK-NEXT:    Name: data1
-// CHECK:         RawDataSize: 16
+// CHECK:         RawDataSize: 0x10
 
 // CHECK:       Section {
 // CHECK-NEXT:    Number:
 // CHECK-NEXT:    Name: data2
-// CHECK:         RawDataSize: 8
+// CHECK:         RawDataSize: 0x8
 
 .section .data3,"dw"; .quad 1
 
@@ -247,7 +247,7 @@
 // CHECK:       Section {
 // CHECK-NEXT:    Number:
 // CHECK-NEXT:    Name: .data3
-// CHECK:         RawDataSize: 16
+// CHECK:         RawDataSize: 0x10
 // CHECK:         Characteristics [
 // CHECK-NEXT:      IMAGE_SCN_ALIGN_1BYTES
 // CHECK-NEXT:      IMAGE_SCN_CNT_INITIALIZED_DATA
@@ -258,7 +258,7 @@
 // CHECK:       Section {
 // CHECK-NEXT:    Number:
 // CHECK-NEXT:    Name: .data4
-// CHECK:         RawDataSize: 16
+// CHECK:         RawDataSize: 0x10
 // CHECK:         Characteristics [
 // CHECK-NEXT:      IMAGE_SCN_ALIGN_1BYTES
 // CHECK-NEXT:      IMAGE_SCN_CNT_INITIALIZED_DATA
@@ -269,7 +269,7 @@
 // CHECK:       Section {
 // CHECK-NEXT:    Number:
 // CHECK-NEXT:    Name: .data5
-// CHECK:         RawDataSize: 8
+// CHECK:         RawDataSize: 0x8
 // CHECK:         Characteristics [
 // CHECK-NEXT:      IMAGE_SCN_ALIGN_1BYTES
 // CHECK-NEXT:      IMAGE_SCN_CNT_INITIALIZED_DATA

--- a/llvm/test/MC/COFF/seh-align1.s
+++ b/llvm/test/MC/COFF/seh-align1.s
@@ -5,7 +5,7 @@
 // CHECK:      Sections [
 // CHECK:        Section {
 // CHECK:          Name: .xdata
-// CHECK:          RawDataSize: 8
+// CHECK:          RawDataSize: 0x8
 // CHECK:          RelocationCount: 0
 // CHECK:          Characteristics [
 // CHECK-NEXT:       ALIGN_4BYTES
@@ -20,7 +20,7 @@
 // CHECK-NEXT:   }
 // CHECK:        Section {
 // CHECK:          Name: .pdata
-// CHECK:          RawDataSize: 12
+// CHECK:          RawDataSize: 0xC
 // CHECK:          RelocationCount: 3
 // CHECK:          Characteristics [
 // CHECK-NEXT:       IMAGE_SCN_ALIGN_4BYTES

--- a/llvm/test/MC/COFF/seh-align2.s
+++ b/llvm/test/MC/COFF/seh-align2.s
@@ -5,7 +5,7 @@
 // CHECK:      Sections [
 // CHECK:        Section {
 // CHECK:          Name: .xdata
-// CHECK:          RawDataSize: 16
+// CHECK:          RawDataSize: 0x10
 // CHECK:          RelocationCount: 1
 // CHECK:          Characteristics [
 // CHECK-NEXT:       ALIGN_4BYTES
@@ -21,7 +21,7 @@
 // CHECK-NEXT:   }
 // CHECK-NEXT:   Section {
 // CHECK:          Name: .pdata
-// CHECK:          RawDataSize: 12
+// CHECK:          RawDataSize: 0xC
 // CHECK:          RelocationCount: 3
 // CHECK:          Characteristics [
 // CHECK-NEXT:       IMAGE_SCN_ALIGN_4BYTES

--- a/llvm/test/MC/COFF/seh-align3.s
+++ b/llvm/test/MC/COFF/seh-align3.s
@@ -5,7 +5,7 @@
 // CHECK:      Sections [
 // CHECK:        Section {
 // CHECK:          Name: .xdata
-// CHECK:          RawDataSize: 16
+// CHECK:          RawDataSize: 0x10
 // CHECK:          RelocationCount: 1
 // CHECK:          Characteristics [
 // CHECK-NEXT:       ALIGN_4BYTES
@@ -21,7 +21,7 @@
 // CHECK-NEXT:   }
 // CHECK-NEXT:   Section {
 // CHECK:          Name: .pdata
-// CHECK:          RawDataSize: 12
+// CHECK:          RawDataSize: 0xC
 // CHECK:          RelocationCount: 3
 // CHECK:          Characteristics [
 // CHECK-NEXT:       IMAGE_SCN_ALIGN_4BYTES

--- a/llvm/test/MC/COFF/seh-section.s
+++ b/llvm/test/MC/COFF/seh-section.s
@@ -5,7 +5,7 @@
 // CHECK:      Name: .xdata
 // CHECK-NEXT: VirtualSize
 // CHECK-NEXT: VirtualAddress
-// CHECK-NEXT: RawDataSize: 8
+// CHECK-NEXT: RawDataSize: 0x8
 // CHECK-NEXT: PointerToRawData
 // CHECK-NEXT: PointerToRelocations
 // CHECK-NEXT: PointerToLineNumbers
@@ -23,7 +23,7 @@
 // CHECK:      Name: .xdata
 // CHECK-NEXT: VirtualSize
 // CHECK-NEXT: VirtualAddress
-// CHECK-NEXT: RawDataSize: 8
+// CHECK-NEXT: RawDataSize: 0x8
 // CHECK-NEXT: PointerToRawData
 // CHECK-NEXT: PointerToRelocations
 // CHECK-NEXT: PointerToLineNumbers
@@ -41,7 +41,7 @@
 // CHECK:      Name: .xdata
 // CHECK-NEXT: VirtualSize
 // CHECK-NEXT: VirtualAddress
-// CHECK-NEXT: RawDataSize: 8
+// CHECK-NEXT: RawDataSize: 0x8
 // CHECK-NEXT: PointerToRawData
 // CHECK-NEXT: PointerToRelocations
 // CHECK-NEXT: PointerToLineNumbers

--- a/llvm/test/MC/COFF/seh.s
+++ b/llvm/test/MC/COFF/seh.s
@@ -15,7 +15,7 @@
 // CHECK-NEXT:   }
 // CHECK:        Section {
 // CHECK:          Name: .xdata
-// CHECK:          RawDataSize: 80
+// CHECK:          RawDataSize: 0x50
 // CHECK:          RelocationCount: 7
 // CHECK:          Characteristics [
 // CHECK-NEXT:       ALIGN_4BYTES

--- a/llvm/test/MC/COFF/symbol-fragment-offset-64.s
+++ b/llvm/test/MC/COFF/symbol-fragment-offset-64.s
@@ -50,7 +50,7 @@ _main:                                  # @main
 // CHECK:     Name:                      .text
 // CHECK:     VirtualSize:               0
 // CHECK:     VirtualAddress:            0
-// CHECK:     RawDataSize:               {{[0-9]+}}
+// CHECK:     RawDataSize:               0x{{[0-9A-F]+}}
 // CHECK:     PointerToRawData:          0x{{[0-9A-F]+}}
 // CHECK:     PointerToRelocations:      0x{{[0-9A-F]+}}
 // CHECK:     PointerToLineNumbers:      0x0
@@ -81,7 +81,7 @@ _main:                                  # @main
 // CHECK:     Name:                      .data
 // CHECK:     VirtualSize:               0
 // CHECK:     VirtualAddress:            0
-// CHECK:     RawDataSize:               {{[0-9]+}}
+// CHECK:     RawDataSize:               0x{{[0-9A-F]+}}
 // CHECK:     PointerToRawData:          0x{{[0-9A-F]+}}
 // CHECK:     PointerToRelocations:      0x0
 // CHECK:     PointerToLineNumbers:      0x0

--- a/llvm/test/MC/COFF/symbol-fragment-offset.s
+++ b/llvm/test/MC/COFF/symbol-fragment-offset.s
@@ -50,7 +50,7 @@ L_.str2:
 // CHECK:     Name:                      .text
 // CHECK:     VirtualSize:               0
 // CHECK:     VirtualAddress:            0
-// CHECK:     RawDataSize:               {{[0-9]+}}
+// CHECK:     RawDataSize:               0x{{[0-9A-F]+}}
 // CHECK:     PointerToRawData:          0x{{[0-9A-F]+}}
 // CHECK:     PointerToRelocations:      0x{{[0-9A-F]+}}
 // CHECK:     PointerToLineNumbers:      0x0
@@ -81,7 +81,7 @@ L_.str2:
 // CHECK:     Name:                      .data
 // CHECK:     VirtualSize:               0
 // CHECK:     VirtualAddress:            0
-// CHECK:     RawDataSize:               {{[0-9]+}}
+// CHECK:     RawDataSize:               0x{{[0-9A-F]+}}
 // CHECK:     PointerToRawData:          0x{{[0-9A-F]+}}
 // CHECK:     PointerToRelocations:      0x0
 // CHECK:     PointerToLineNumbers:      0x0

--- a/llvm/test/MC/X86/win-import-call-optimization.s
+++ b/llvm/test/MC/X86/win-import-call-optimization.s
@@ -37,7 +37,7 @@ tail_call:
 // CHECK-LABEL: Name: .retplne (2E 72 65 74 70 6C 6E 65)
 // CHECK-NEXT:  VirtualSize: 0x0
 // CHECK-NEXT:  VirtualAddress: 0x0
-// CHECK-NEXT:  RawDataSize: 44
+// CHECK-NEXT:  RawDataSize: 0x2C
 // CHECK-NEXT:  PointerToRawData:
 // CHECK-NEXT:  PointerToRelocations:
 // CHECK-NEXT:  PointerToLineNumbers:

--- a/llvm/test/tools/llvm-ar/arm64x-split.yaml
+++ b/llvm/test/tools/llvm-ar/arm64x-split.yaml
@@ -16,7 +16,7 @@
 # CHECK-NEXT:     Name: .obj.arm64ec (2F 34 00 00 00 00 00 00)
 # CHECK-NEXT:     VirtualSize: 0x0
 # CHECK-NEXT:     VirtualAddress: 0x0
-# CHECK-NEXT:     RawDataSize: 0
+# CHECK-NEXT:     RawDataSize: 0x0
 # CHECK-NEXT:     PointerToRawData: 0x0
 # CHECK-NEXT:     PointerToRelocations: 0x0
 # CHECK-NEXT:     PointerToLineNumbers: 0x0
@@ -34,7 +34,7 @@
 # CHECK-NEXT:     Name: .data (2E 64 61 74 61 00 00 00)
 # CHECK-NEXT:     VirtualSize: 0x0
 # CHECK-NEXT:     VirtualAddress: 0x0
-# CHECK-NEXT:     RawDataSize: 4
+# CHECK-NEXT:     RawDataSize: 0x4
 # CHECK-NEXT:     PointerToRawData: 0x66
 # CHECK-NEXT:     PointerToRelocations: 0x6A
 # CHECK-NEXT:     PointerToLineNumbers: 0x0
@@ -95,7 +95,7 @@
 # CHECK-NEXT:     Name: .data (2E 64 61 74 61 00 00 00)
 # CHECK-NEXT:     VirtualSize: 0x0
 # CHECK-NEXT:     VirtualAddress: 0x0
-# CHECK-NEXT:     RawDataSize: 4
+# CHECK-NEXT:     RawDataSize: 0x4
 # CHECK-NEXT:     PointerToRawData: 0x3C
 # CHECK-NEXT:     PointerToRelocations: 0x0
 # CHECK-NEXT:     PointerToLineNumbers: 0x0

--- a/llvm/test/tools/llvm-objcopy/COFF/add-gnu-debuglink.test
+++ b/llvm/test/tools/llvm-objcopy/COFF/add-gnu-debuglink.test
@@ -15,13 +15,13 @@ SECTIONS:          Number: 4
 SECTIONS-NEXT:     Name: .pdata
 SECTIONS-NEXT:     VirtualSize: 0x18
 SECTIONS-NEXT:     VirtualAddress: 0x4000
-SECTIONS-NEXT:     RawDataSize: 512
+SECTIONS-NEXT:     RawDataSize: 0x200
 SECTIONS:        Section {
 SECTIONS-NEXT:     Number: 5
 SECTIONS-NEXT:     Name: .gnu_debuglink
 SECTIONS-NEXT:     VirtualSize: 0x2C
 SECTIONS-NEXT:     VirtualAddress: 0x5000
-SECTIONS-NEXT:     RawDataSize: 512
+SECTIONS-NEXT:     RawDataSize: 0x200
 SECTIONS-NEXT:     PointerToRawData:
 SECTIONS-NEXT:     PointerToRelocations:
 SECTIONS-NEXT:     PointerToLineNumbers:

--- a/llvm/test/tools/llvm-objcopy/COFF/add-section-and-set-flags.test
+++ b/llvm/test/tools/llvm-objcopy/COFF/add-section-and-set-flags.test
@@ -9,7 +9,7 @@
 # CHECK:       Name: .test.section1
 # CHECK-NEXT:  VirtualSize: 0x9
 # CHECK-NEXT:  VirtualAddress: 0x0
-# CHECK-NEXT:  RawDataSize: 9
+# CHECK-NEXT:  RawDataSize: 0x9
 # CHECK:       Characteristics [
 # CHECK-NEXT:      IMAGE_SCN_CNT_CODE
 # CHECK-NEXT:      IMAGE_SCN_MEM_EXECUTE
@@ -20,7 +20,7 @@
 # CHECK:       Name: .test.section2
 # CHECK-NEXT:  VirtualSize: 0x9
 # CHECK-NEXT:  VirtualAddress: 0x9
-# CHECK-NEXT:  RawDataSize: 9
+# CHECK-NEXT:  RawDataSize: 0x9
 # CHECK:       Characteristics [
 # CHECK-NEXT:    IMAGE_SCN_CNT_INITIALIZED_DATA
 # CHECK-NEXT:    IMAGE_SCN_MEM_READ

--- a/llvm/test/tools/llvm-objcopy/COFF/empty-sections.s
+++ b/llvm/test/tools/llvm-objcopy/COFF/empty-sections.s
@@ -25,13 +25,13 @@
 # INPUT:          Name: .data
 # INPUT-NEXT:     VirtualSize: 0x0
 # INPUT-NEXT:     VirtualAddress: 0x0
-# INPUT-NEXT:     RawDataSize: 0
+# INPUT-NEXT:     RawDataSize: 0x0
 # INPUT-NEXT:     PointerToRawData: 0x8D
 
 # OUTPUT:         Name: .data
 # OUTPUT-NEXT:    VirtualSize: 0x0
 # OUTPUT-NEXT:    VirtualAddress: 0x0
-# OUTPUT-NEXT:    RawDataSize: 0
+# OUTPUT-NEXT:    RawDataSize: 0x0
 # OUTPUT-NEXT:    PointerToRawData: 0x0{{$}}
 
     .text

--- a/llvm/test/tools/llvm-objcopy/COFF/only-keep-debug-rdata.test
+++ b/llvm/test/tools/llvm-objcopy/COFF/only-keep-debug-rdata.test
@@ -12,34 +12,34 @@ CHECK-NEXT:   Number: 1
 CHECK-NEXT:   Name: .text (2E 74 65 78 74 00 00 00)
 CHECK-NEXT:   VirtualSize: 0x12
 CHECK-NEXT:   VirtualAddress: 0x1000
-CHECK-NEXT:   RawDataSize: 0
+CHECK-NEXT:   RawDataSize: 0x0
 CHECK:       Section {
 CHECK-NEXT:   Number: 2
 CHECK-NEXT:   Name: .rdata (2E 72 64 61 74 61 00 00)
 CHECK-NEXT:   VirtualSize: 0x6D
 CHECK-NEXT:   VirtualAddress: 0x2000
-CHECK-NEXT:   RawDataSize: 512
+CHECK-NEXT:   RawDataSize: 0x200
 CHECK:       Section {
 CHECK-NEXT:   Number: 3
 CHECK-NEXT:   Name: .debug_abbrev (2F 34 00 00 00 00 00 00)
 CHECK-NEXT:   VirtualSize: 0x4E
 CHECK-NEXT:   VirtualAddress: 0x3000
-CHECK-NEXT:   RawDataSize: 512
+CHECK-NEXT:   RawDataSize: 0x200
 CHECK:       Section {
 CHECK-NEXT:   Number: 4
 CHECK-NEXT:   Name: .debug_info (2F 32 39 00 00 00 00 00)
 CHECK-NEXT:   VirtualSize: 0x74
 CHECK-NEXT:   VirtualAddress: 0x4000
-CHECK-NEXT:   RawDataSize: 512
+CHECK-NEXT:   RawDataSize: 0x200
 CHECK:       Section {
 CHECK-NEXT:   Number: 5
 CHECK-NEXT:   Name: .debug_line (2F 34 31 00 00 00 00 00)
 CHECK-NEXT:   VirtualSize: 0x3C
 CHECK-NEXT:   VirtualAddress: 0x5000
-CHECK-NEXT:   RawDataSize: 512
+CHECK-NEXT:   RawDataSize: 0x200
 CHECK:       Section {
 CHECK-NEXT:   Number: 6
 CHECK-NEXT:   Name: .debug_str (2F 31 38 00 00 00 00 00)
 CHECK-NEXT:   VirtualSize: 0xD9
 CHECK-NEXT:   VirtualAddress: 0x6000
-CHECK-NEXT:   RawDataSize: 512
+CHECK-NEXT:   RawDataSize: 0x200

--- a/llvm/test/tools/llvm-objcopy/COFF/only-keep-debug.test
+++ b/llvm/test/tools/llvm-objcopy/COFF/only-keep-debug.test
@@ -17,43 +17,43 @@ SECTIONS-NEXT:   Number: 1
 SECTIONS-NEXT:   Name: .text
 SECTIONS-NEXT:   VirtualSize: 0x4
 SECTIONS-NEXT:   VirtualAddress:
-SECTIONS-NEXT:   RawDataSize: 0
+SECTIONS-NEXT:   RawDataSize: 0x0
 SECTIONS:       Section {
 SECTIONS-NEXT:   Number: 2
 SECTIONS-NEXT:   Name: .rdata
 SECTIONS-NEXT:   VirtualSize: 0x4
 SECTIONS-NEXT:   VirtualAddress:
-SECTIONS-NEXT:   RawDataSize: 0
+SECTIONS-NEXT:   RawDataSize: 0x0
 SECTIONS:       Section {
 SECTIONS-NEXT:   Number: 3
 SECTIONS-NEXT:   Name: .buildid
 SECTIONS-NEXT:   VirtualSize: 0x4
 SECTIONS-NEXT:   VirtualAddress:
-SECTIONS-NEXT:   RawDataSize: 512
+SECTIONS-NEXT:   RawDataSize: 0x200
 SECTIONS:       Section {
 SECTIONS-NEXT:   Number: 4
 SECTIONS-NEXT:   Name: .reloc
 SECTIONS-NEXT:   VirtualSize: 0x4
 SECTIONS-NEXT:   VirtualAddress:
-SECTIONS-NEXT:   RawDataSize: 0
+SECTIONS-NEXT:   RawDataSize: 0x0
 SECTIONS:       Section {
 SECTIONS-NEXT:   Number: 5
 SECTIONS-NEXT:   Name: .debug_discardable
 SECTIONS-NEXT:   VirtualSize: 0x4
 SECTIONS-NEXT:   VirtualAddress:
-SECTIONS-NEXT:   RawDataSize: 512
+SECTIONS-NEXT:   RawDataSize: 0x200
 SECTIONS:       Section {
 SECTIONS-NEXT:   Number: 6
 SECTIONS-NEXT:   Name: .debug_undiscardable
 SECTIONS-NEXT:   VirtualSize: 0x4
 SECTIONS-NEXT:   VirtualAddress:
-SECTIONS-NEXT:   RawDataSize: 512
+SECTIONS-NEXT:   RawDataSize: 0x200
 SECTIONS:       Section {
 SECTIONS-NEXT:   Number: 7
 SECTIONS-NEXT:   Name: .unflagged
 SECTIONS-NEXT:   VirtualSize: 0x4
 SECTIONS-NEXT:   VirtualAddress:
-SECTIONS-NEXT:   RawDataSize: 512
+SECTIONS-NEXT:   RawDataSize: 0x200
 
 SYMBOLS:      SYMBOL TABLE:
 SYMBOLS-NEXT: main

--- a/llvm/test/tools/llvm-objcopy/COFF/update-section.test
+++ b/llvm/test/tools/llvm-objcopy/COFF/update-section.test
@@ -9,7 +9,7 @@
 # CHECK-NEXT:     Number: 1
 # CHECK-NEXT:     Name: .text
 # CHECK-NOT:    }
-# CHECK:          RawDataSize: 4
+# CHECK:          RawDataSize: 0x4
 # CHECK:          Hex dump of section '.text':
 # CHECK-NEXT:     0x00000000 41414142 AAAB
 
@@ -18,7 +18,7 @@
 # SMALLER-NEXT:   Number: 1
 # SMALLER-NEXT:   Name: .text
 # SMALLER-NOT:  }
-# SMALLER:        RawDataSize: 3
+# SMALLER:        RawDataSize: 0x3
 # SMALLER:        Hex dump of section '.text':
 # SMALLER-NEXT:   0x00000000 414141 AAA
 
@@ -28,12 +28,12 @@
 # MULTIPLE-NEXT:  Number: 1
 # MULTIPLE-NEXT:  Name: .text
 # MULTIPLE-NOT: }
-# MULTIPLE:       RawDataSize: 4
+# MULTIPLE:       RawDataSize: 0x4
 # MULTIPLE:     Section {
 # MULTIPLE-NEXT:  Number: 2
 # MULTIPLE-NEXT:  Name: .other
 # MULTIPLE-NOT: }
-# MULTIPLE:       RawDataSize: 4
+# MULTIPLE:       RawDataSize: 0x4
 # MULTIPLE:       Hex dump of section '.text':
 # MULTIPLE-NEXT:  0x00000000 41414142 AAAB
 # MULTIPLE:       Hex dump of section '.other':

--- a/llvm/test/tools/llvm-offload-wrapper/coff-opt-ref.ll
+++ b/llvm/test/tools/llvm-offload-wrapper/coff-opt-ref.ll
@@ -17,10 +17,10 @@
 ; CHECK: icmp ne ptr getelementptr inbounds ([1 x %struct.__tgt_offload_entry], ptr @__start_llvm_offload_entries, i32 0, i32 1), @__stop_llvm_offload_entries
 
 ; OBJ: Name: llvm_offload_entries{{[$]}}OA
-; OBJ: RawDataSize: 56
+; OBJ: RawDataSize: 0x38
 ; OBJ: IMAGE_SCN_ALIGN_8BYTES
 ; OBJ: Name: llvm_offload_entries{{[$]}}OZ
-; OBJ: RawDataSize: 56
+; OBJ: RawDataSize: 0x38
 ; OBJ: IMAGE_SCN_ALIGN_8BYTES
 
 ; MAP:      {{[0-9A-Fa-f]+}}:00000000 00000038H llvm_offload_entries{{[$]}}OA DATA

--- a/llvm/test/tools/llvm-readobj/COFF/arm64x-hybridobj.yaml
+++ b/llvm/test/tools/llvm-readobj/COFF/arm64x-hybridobj.yaml
@@ -12,7 +12,7 @@
 # CHECK-NEXT:     Name: .data (2E 64 61 74 61 00 00 00)
 # CHECK-NEXT:     VirtualSize: 0x0
 # CHECK-NEXT:     VirtualAddress: 0x0
-# CHECK-NEXT:     RawDataSize: 4
+# CHECK-NEXT:     RawDataSize: 0x4
 # CHECK-NEXT:     PointerToRawData: 0x64
 # CHECK-NEXT:     PointerToRelocations: 0x0
 # CHECK-NEXT:     PointerToLineNumbers: 0x0
@@ -30,7 +30,7 @@
 # CHECK-NEXT:     Name: .obj.arm64ec (2F 34 00 00 00 00 00 00)
 # CHECK-NEXT:     VirtualSize: 0x7A
 # CHECK-NEXT:     VirtualAddress: 0x0
-# CHECK-NEXT:     RawDataSize: 122
+# CHECK-NEXT:     RawDataSize: 0x7A
 # CHECK-NEXT:     PointerToRawData: 0x68
 # CHECK-NEXT:     PointerToRelocations: 0x0
 # CHECK-NEXT:     PointerToLineNumbers: 0x0
@@ -53,7 +53,7 @@
 # CHECK-NEXT:       Name: .data (2E 64 61 74 61 00 00 00)
 # CHECK-NEXT:       VirtualSize: 0x0
 # CHECK-NEXT:       VirtualAddress: 0x0
-# CHECK-NEXT:       RawDataSize: 4
+# CHECK-NEXT:       RawDataSize: 0x4
 # CHECK-NEXT:       PointerToRawData: 0x3C
 # CHECK-NEXT:       PointerToRelocations: 0x0
 # CHECK-NEXT:       PointerToLineNumbers: 0x0

--- a/llvm/test/tools/llvm-readobj/COFF/bigobj.test
+++ b/llvm/test/tools/llvm-readobj/COFF/bigobj.test
@@ -21,7 +21,7 @@ CHECK-NEXT:     Number: 1
 CHECK-NEXT:     Name: .text (2E 74 65 78 74 00 00 00)
 CHECK-NEXT:     VirtualSize: 0x0
 CHECK-NEXT:     VirtualAddress: 0x0
-CHECK-NEXT:     RawDataSize: 0
+CHECK-NEXT:     RawDataSize: 0x0
 CHECK-NEXT:     PointerToRawData: 0x0
 CHECK-NEXT:     PointerToRelocations: 0x0
 CHECK-NEXT:     PointerToLineNumbers: 0x0
@@ -39,7 +39,7 @@ CHECK-NEXT:     Number: 2
 CHECK-NEXT:     Name: .data (2E 64 61 74 61 00 00 00)
 CHECK-NEXT:     VirtualSize: 0x0
 CHECK-NEXT:     VirtualAddress: 0x0
-CHECK-NEXT:     RawDataSize: 0
+CHECK-NEXT:     RawDataSize: 0x0
 CHECK-NEXT:     PointerToRawData: 0x0
 CHECK-NEXT:     PointerToRelocations: 0x0
 CHECK-NEXT:     PointerToLineNumbers: 0x0
@@ -57,7 +57,7 @@ CHECK-NEXT:     Number: 3
 CHECK-NEXT:     Name: .bss (2E 62 73 73 00 00 00 00)
 CHECK-NEXT:     VirtualSize: 0x0
 CHECK-NEXT:     VirtualAddress: 0x0
-CHECK-NEXT:     RawDataSize: 0
+CHECK-NEXT:     RawDataSize: 0x0
 CHECK-NEXT:     PointerToRawData: 0x0
 CHECK-NEXT:     PointerToRelocations: 0x0
 CHECK-NEXT:     PointerToLineNumbers: 0x0

--- a/llvm/test/tools/llvm-readobj/COFF/sections-ext.test
+++ b/llvm/test/tools/llvm-readobj/COFF/sections-ext.test
@@ -11,7 +11,7 @@
 # CHECK-NEXT:     Name: .text (2E 74 65 78 74 00 00 00)
 # CHECK-NEXT:     VirtualSize: 0x0
 # CHECK-NEXT:     VirtualAddress: 0x0
-# CHECK-NEXT:     RawDataSize: 22
+# CHECK-NEXT:     RawDataSize: 0x16
 # CHECK-NEXT:     PointerToRawData: 0x64
 # CHECK-NEXT:     PointerToRelocations: 0x7A
 # CHECK-NEXT:     PointerToLineNumbers: 0x0

--- a/llvm/test/tools/llvm-readobj/COFF/sections.test
+++ b/llvm/test/tools/llvm-readobj/COFF/sections.test
@@ -8,7 +8,7 @@
 # CHECK-NEXT:     Name: .text (2E 74 65 78 74 00 00 00)
 # CHECK-NEXT:     VirtualSize: 0x0
 # CHECK-NEXT:     VirtualAddress: 0x0
-# CHECK-NEXT:     RawDataSize: 22
+# CHECK-NEXT:     RawDataSize: 0x16
 # CHECK-NEXT:     PointerToRawData: 0x64
 # CHECK-NEXT:     PointerToRelocations: 0x7A
 # CHECK-NEXT:     PointerToLineNumbers: 0x0
@@ -26,7 +26,7 @@
 # CHECK-NEXT:     Name: .data (2E 64 61 74 61 00 00 00)
 # CHECK-NEXT:     VirtualSize: 0x0
 # CHECK-NEXT:     VirtualAddress: 0x0
-# CHECK-NEXT:     RawDataSize: 13
+# CHECK-NEXT:     RawDataSize: 0xD
 # CHECK-NEXT:     PointerToRawData: 0x98
 # CHECK-NEXT:     PointerToRelocations: 0x0
 # CHECK-NEXT:     PointerToLineNumbers: 0x0

--- a/llvm/test/tools/yaml2obj/COFF/xrelocs.yaml
+++ b/llvm/test/tools/yaml2obj/COFF/xrelocs.yaml
@@ -8,7 +8,7 @@
 # CHECK-OBJ-NEXT:   Section {
 # CHECK-OBJ-NEXT:     Number: 1
 # CHECK-OBJ-NEXT:     Name: .data
-# CHECK-OBJ:          RawDataSize: 16
+# CHECK-OBJ:          RawDataSize: 0x10
 # CHECK-OBJ:          RelocationCount: 65535
 # CHECK-OBJ:          Characteristics [
 # CHECK-OBJ-NEXT:       IMAGE_SCN_ALIGN_16BYTES

--- a/llvm/tools/llvm-readobj/COFFDumper.cpp
+++ b/llvm/tools/llvm-readobj/COFFDumper.cpp
@@ -1608,7 +1608,7 @@ void COFFDumper::printSectionHeaders() {
     W.printBinary("Name", Name, Section->Name);
     W.printHex("VirtualSize", Section->VirtualSize);
     W.printHex("VirtualAddress", Section->VirtualAddress);
-    W.printNumber("RawDataSize", Section->SizeOfRawData);
+    W.printHex("RawDataSize", Section->SizeOfRawData);
     W.printHex("PointerToRawData", Section->PointerToRawData);
     W.printHex("PointerToRelocations", Section->PointerToRelocations);
     W.printHex("PointerToLineNumbers", Section->PointerToLinenumbers);


### PR DESCRIPTION
To match VirtualSize, and Microsoft's dumpbin which prints both as hex:
SECTION HEADER #1
   .text name
   440B4 virtual size
    1000 virtual address (0000000140001000 to 00000001400450B3)
   44200 size of raw data

llvm-readobj before this change:
    VirtualSize: 0x3478
    VirtualAddress: 0x74000
    RawDataSize: 3584

And after:
    VirtualSize: 0x3478
    VirtualAddress: 0x74000
    RawDataSize: 0xe00

This was pointed out on https://github.com/llvm/llvm-project/issues/220618, where I was having to manually convert the numbers to compare them.