### PR TITLE
[LICM] Compute funclet block colors lazily on first use

### DIFF
--- a/llvm/include/llvm/Analysis/MustExecute.h
+++ b/llvm/include/llvm/Analysis/MustExecute.h
@@ -54,11 +54,14 @@ class raw_ostream;
 /// changes.
 class LoopSafetyInfo {
   // Used to update funclet bundle operands.
-  DenseMap<BasicBlock *, ColorVector> BlockColors;
+  mutable DenseMap<BasicBlock *, ColorVector> BlockColors;
 
   // Cache whether (the start of) this block is guaranteed to execute if the
   // loop is entered.
   mutable DenseMap<const BasicBlock *, bool> GuaranteedToExecute;
+
+  // Whether an attempt to compute BlockColors has already been made.
+  mutable bool BlockColorsComputed = false;
 
   bool allLoopPathsLeadToBlockImpl(const BasicBlock *BB,
                                    const DominatorTree *DT) const;
@@ -66,11 +69,11 @@ class LoopSafetyInfo {
 protected:
   const Loop *CurLoop;
 
-  /// Computes block colors.
-  LLVM_ABI void computeBlockColors();
-
 public:
   /// Returns block colors map that is used to update funclet operand bundles.
+  /// The map is computed on first use; callers should avoid querying it
+  /// speculatively (e.g. while inspecting ordinary instructions) because
+  /// computing it walks the entire function.
   LLVM_ABI const DenseMap<BasicBlock *, ColorVector> &getBlockColors() const;
 
   /// Copy colors of block \p Old into the block \p New.

--- a/llvm/lib/Analysis/MustExecute.cpp
+++ b/llvm/lib/Analysis/MustExecute.cpp
@@ -28,10 +28,23 @@ using namespace llvm;
 
 const DenseMap<BasicBlock *, ColorVector> &
 LoopSafetyInfo::getBlockColors() const {
+  // Compute funclet colors if we might sink/hoist in a function with a funclet
+  // personality routine. This traverses the whole function, so it is done
+  // lazily, on first use, instead of every time a safety info is constructed.
+  if (!BlockColorsComputed) {
+    BlockColorsComputed = true;
+    Function *Fn = CurLoop->getHeader()->getParent();
+    if (Fn->hasPersonalityFn())
+      if (Constant *PersonalityFn = Fn->getPersonalityFn())
+        if (isScopedEHPersonality(classifyEHPersonality(PersonalityFn)))
+          BlockColors = colorEHFunclets(*Fn);
+  }
   return BlockColors;
 }
 
 void LoopSafetyInfo::copyColors(BasicBlock *New, BasicBlock *Old) {
+  assert(BlockColorsComputed &&
+         "getBlockColors() must be queried before updating block colors");
   ColorVector &ColorsForNewBlock = BlockColors[New];
   ColorVector &ColorsForOldBlock = BlockColors[Old];
   ColorsForNewBlock = ColorsForOldBlock;
@@ -62,8 +75,6 @@ void SimpleLoopSafetyInfo::computeLoopSafetyInfo() {
     if (MayThrow)
       break;
   }
-
-  computeBlockColors();
 }
 
 bool ICFLoopSafetyInfo::blockMayThrow(const BasicBlock *BB) const {
@@ -85,7 +96,6 @@ void ICFLoopSafetyInfo::computeLoopSafetyInfo() {
       MayThrow = true;
       break;
     }
-  computeBlockColors();
 }
 
 void ICFLoopSafetyInfo::insertInstructionTo(const Instruction *Inst,
@@ -97,16 +107,6 @@ void ICFLoopSafetyInfo::insertInstructionTo(const Instruction *Inst,
 void ICFLoopSafetyInfo::removeInstruction(const Instruction *Inst) {
   ICF.removeInstruction(Inst);
   MW.removeInstruction(Inst);
-}
-
-void LoopSafetyInfo::computeBlockColors() {
-  // Compute funclet colors if we might sink/hoist in a function with a funclet
-  // personality routine.
-  Function *Fn = CurLoop->getHeader()->getParent();
-  if (Fn->hasPersonalityFn())
-    if (Constant *PersonalityFn = Fn->getPersonalityFn())
-      if (isScopedEHPersonality(classifyEHPersonality(PersonalityFn)))
-        BlockColors = colorEHFunclets(*Fn);
 }
 
 /// Return true if we can prove that the given ExitBlock is not reached on the

--- a/llvm/lib/Transforms/Scalar/LICM.cpp
+++ b/llvm/lib/Transforms/Scalar/LICM.cpp
@@ -1427,7 +1427,6 @@ static bool isNotUsedOrFoldableInLoop(const Instruction &I, const Loop *CurLoop,
                                       const LoopSafetyInfo *SafetyInfo,
                                       TargetTransformInfo *TTI,
                                       bool &FoldableInLoop, bool LoopNestMode) {
-  const auto &BlockColors = SafetyInfo->getBlockColors();
   bool IsFoldable = isFoldableInLoop(I, CurLoop, TTI);
   for (const User *U : I.users()) {
     const Instruction *UI = cast<Instruction>(U);
@@ -1439,10 +1438,14 @@ static bool isNotUsedOrFoldableInLoop(const Instruction &I, const Loop *CurLoop,
 
       // We need to sink a callsite to a unique funclet.  Avoid sinking if the
       // phi use is too muddled.
-      if (isa<CallInst>(I))
+      if (isa<CallInst>(I)) {
+        // Computing the block colors walks the whole function, so only query
+        // the map when a color-dependent decision is actually needed.
+        const auto &BlockColors = SafetyInfo->getBlockColors();
         if (!BlockColors.empty() &&
             BlockColors.find(const_cast<BasicBlock *>(BB))->second.size() != 1)
           return false;
+      }
 
       if (LoopNestMode) {
         while (isa<PHINode>(UI) && UI->hasOneUser() &&


### PR DESCRIPTION
## Problem

Compiling serde-generated deserialization for structs with many `String` fields scales nonlinearly on the `x86_64-pc-windows-msvc` target (reported in https://github.com/rust-lang/rust/issues/162283): 128 fields take 62.7s to compile vs 1.3s at 16 fields, while the generated MIR/IR grows only linearly.

The serde-generated `visit_map` lowers to a very large function (~7k LLVM blocks at 128 fields) with a long chain of cleanup pads, because rustc uses the scoped Windows personality `__CxxFrameHandler3` on this target. LICM constructs an `ICFLoopSafetyInfo` for **every loop**, and `computeLoopSafetyInfo` eagerly calls `colorEHFunclets` over the entire function whenever scoped EH is in use. Both the loop count (~552) and the function size grow with the field count, so the total coloring work is roughly O(loops x blocks).

Instrumentation by the issue reporter (EVIDENCE.md) at 128 fields: 552 colorings of `visit_map`, 2.7M cumulative blocks colored, 4.91s spent inside `colorEHFunclets` alone — about 36% of the full default<O3> pipeline time (13.46s).

## Change

Make block coloring lazy:

- `getBlockColors()` computes the map on first use, from the loop recorded at construction time; `computeLoopSafetyInfo()` no longer colors the function. (This supersedes the old `computeBlockColors()` hook entirely.)
- LICM's `isNotUsedOrFoldableInLoop` no longer requests the map while inspecting ordinary instructions; it requests it only when sinking a call through a PHI, the one case where the color actually matters there.

Functions without a scoped-EH personality behave exactly as before (the map stays empty). For scoped-EH functions, the map is a pure function of the CFG and each safety-info object lives for exactly one compute cycle, so transformations are unchanged. `copyColors` now asserts that the map was computed first; its only in-tree caller (`splitPredecessorsOfLoopExit`) always goes through `canSplitPredecessors`, which queries `getBlockColors()` beforehand. A code search over the tree confirms `getBlockColors`/`copyColors` have no consumers outside `MustExecute.h/.cpp` and `LICM.cpp`.

Rebased onto post-#221238 main (the `LoopSafetyInfo` redesign that stores `CurLoop` and computes in the constructor) — the earlier `ColoredFunc`/invalidation plumbing is no longer needed since each object corresponds to one computation cycle.

## Validation status

I could not build LLVM locally, so this has not been lit-tested on this tree. However, the issue reporter validated this exact approach on LLVM 22.1.8: the optimized IR of the reproduction was byte-for-byte identical (sha256-verified) and all 9,422 supported transform tests (incl. 148 LICM tests) passed on their instrumented build. `llvm/test/Transforms/LICM/funclet.ll` covers the funclet-bundle sink path that depends on block colors. The rebase onto the #221238 redesign was done by re-deriving the same transformation on top of the new API; all `getBlockColors`/`copyColors` call sites were audited. A pre-merge `check-llvm` transform run would cover it fully.

Reported timings from the same evidence: full default<O3> pipeline on the 128-field repro drops 13.40s -> 8.33s. Happy to iterate on the design or add tests if reviewers can suggest a good lit-testable angle for this.

## AI tool use disclosure

Per the LLVM AI Tool Use Policy: this change was developed with the assistance of an AI coding agent under the direction of the submitting user, including locating the relevant code paths, drafting the patch and this description, and performing the rebase onto the #221238 redesign. I reviewed the full diff, audited every consumer of the color map in the tree, and take full responsibility for this contribution.
