### PR TITLE
[clang] Fix address spaces on prvalue

### DIFF
--- a/clang/lib/AST/Type.cpp
+++ b/clang/lib/AST/Type.cpp
@@ -3728,6 +3728,10 @@ QualType QualType::getNonLValueExprType(const ASTContext &Context) const {
       (!getTypePtr()->isDependentType() && !getTypePtr()->isRecordType()))
     return getUnqualifiedType();
 
+  // A prvalue should not have an address space.
+  if (hasAddressSpace())
+    return Context.removeAddrSpaceQualType(*this);
+
   return *this;
 }
 

--- a/clang/lib/Sema/SemaInit.cpp
+++ b/clang/lib/Sema/SemaInit.cpp
@@ -7682,9 +7682,8 @@ PerformConstructorInitialization(Sema &S,
 
     CurInit = S.CheckForImmediateInvocation(
         CXXTemporaryObjectExpr::Create(
-            S.Context, CalleeDecl,
-            Entity.getType().getNonReferenceType(), TSInfo,
-            ConstructorArgs, ParenOrBraceRange, HadMultipleCandidates,
+            S.Context, CalleeDecl, Entity.getType().getNonReferenceType(),
+            TSInfo, ConstructorArgs, ParenOrBraceRange, HadMultipleCandidates,
             IsListInitialization, IsStdInitListInitialization,
             ConstructorInitRequiresZeroInit),
         CalleeDecl);

--- a/clang/lib/Sema/SemaInit.cpp
+++ b/clang/lib/Sema/SemaInit.cpp
@@ -7683,7 +7683,7 @@ PerformConstructorInitialization(Sema &S,
     CurInit = S.CheckForImmediateInvocation(
         CXXTemporaryObjectExpr::Create(
             S.Context, CalleeDecl,
-            Entity.getType().getNonLValueExprType(S.Context), TSInfo,
+            Entity.getType().getNonReferenceType(), TSInfo,
             ConstructorArgs, ParenOrBraceRange, HadMultipleCandidates,
             IsListInitialization, IsStdInitListInitialization,
             ConstructorInitRequiresZeroInit),

--- a/clang/test/AST/ast-dump-address-space-prvalue.cpp
+++ b/clang/test/AST/ast-dump-address-space-prvalue.cpp
@@ -1,0 +1,91 @@
+// RUN: %clang_cc1 %s -ast-dump | FileCheck %s
+
+struct X { int a; };
+
+using GlobalX = X __attribute__((address_space(1)));
+
+GlobalX prvalue();
+GlobalX &lvalue();
+GlobalX &&xvalue();
+
+void test() {
+  // A prvalue should not have an address space even if the function's
+  // return type is address-space qualified.
+  // CHECK: VarDecl {{.*}} v 'X'
+  // CHECK: CallExpr {{.*}} 'X'{{$}}
+  auto v = prvalue();
+
+  // CHECK: VarDecl {{.*}} l '__attribute__((address_space(1))) X &'
+  // CHECK: CallExpr {{.*}}:'__attribute__((address_space(1))) X' lvalue
+  auto &l = lvalue();
+
+  // CHECK: VarDecl {{.*}} r '__attribute__((address_space(1))) X &&'
+  // CHECK: CallExpr {{.*}}:'__attribute__((address_space(1))) X' xvalue
+  auto &&r = xvalue();
+}
+
+struct S {
+  S(int);
+  void f() const;
+};
+
+using const_int = const int;
+using as1_int = __attribute__((address_space(1))) int;
+using const_S = const S;
+
+void qualifierTest() {
+  // const is retained on prvalues of class type; const qualified
+  // member function called.
+  // CHECK: MaterializeTemporaryExpr {{.*}} 'const_S':'const S' xvalue
+  // CHECK: CXXTemporaryObjectExpr {{.*}} 'const_S':'const S'
+  const_S{1}.f();
+
+  // const is dropped on prvalues of non-class type.
+  // CHECK: CXXFunctionalCastExpr {{.*}} 'int' functional cast to const_int
+  (void)(const_int{1});
+
+  // address space is dropped on prvalues of non-class type.
+  // CHECK: CXXFunctionalCastExpr {{.*}} 'int' functional cast to as1_int
+  (void)(as1_int{1});
+}
+
+void castTest() {
+  // The address space is dropped on the prvalue produced by a cast to a
+  // non-class type.
+  // CHECK: CStyleCastExpr {{.*}} 'int' <NoOp>
+  (void)(as1_int)0;
+  // CHECK: CXXFunctionalCastExpr {{.*}} 'int' functional cast to as1_int <NoOp>
+  (void)as1_int(0);
+  // CHECK: CXXStaticCastExpr {{.*}} 'int' static_cast<as1_int> <NoOp>
+  (void)static_cast<as1_int>(0);
+}
+
+as1_int &&rvalueRefInt();
+GlobalX &&rvalueRefX();
+
+void rvalueReferenceTest() {
+  // An rvalue reference is an xvalue naming an object, not a prvalue, so the
+  // address space is kept.
+  // CHECK: CallExpr {{.*}}:'__attribute__((address_space(1))) int' xvalue
+  (void)rvalueRefInt();
+  // CHECK: CallExpr {{.*}}:'__attribute__((address_space(1))) X' xvalue
+  (void)rvalueRefX();
+}
+
+void vaArgTest(__builtin_va_list va) {
+  // A __builtin_va_arg expression is a prvalue. Both const and the address
+  // space are dropped for non-class types.
+  // CHECK: VAArgExpr {{.*}} 'int'
+  __builtin_va_arg(va, const __attribute__((address_space(1))) int);
+
+  // const is retained but the address space is dropped for class types.
+  // CHECK: VAArgExpr {{.*}} 'const X'
+  __builtin_va_arg(va, const __attribute__((address_space(1))) X);
+}
+
+// A non-type template parameter of address-space-qualified type is a prvalue
+// of the unqualified type.
+// CHECK: NonTypeTemplateParmDecl {{.*}} 'int' {{.*}} N
+template <as1_int N> struct NT {};
+NT<0> nt;
+

--- a/clang/test/SemaCXX/address-space-prvalue.cpp
+++ b/clang/test/SemaCXX/address-space-prvalue.cpp
@@ -1,0 +1,25 @@
+// RUN: %clang_cc1 %s -ast-dump | FileCheck %s
+
+struct X { int a; };
+
+using GlobalX = X __attribute__((address_space(1)));
+
+GlobalX prvalue();
+GlobalX &lvalue();
+GlobalX &&xvalue();
+
+void test() {
+  // A prvalue should not have an address space even if the function's
+  // return type is address-space qualified.
+  // CHECK: VarDecl {{.*}} v 'X'
+  // CHECK: CallExpr {{.*}} 'X'{{$}}
+  auto v = prvalue();
+
+  // CHECK: VarDecl {{.*}} l '__attribute__((address_space(1))) X &'
+  // CHECK: CallExpr {{.*}}:'__attribute__((address_space(1))) X' lvalue
+  auto &l = lvalue();
+
+  // CHECK: VarDecl {{.*}} r '__attribute__((address_space(1))) X &&'
+  // CHECK: CallExpr {{.*}}:'__attribute__((address_space(1))) X' xvalue
+  auto &&r = xvalue();
+}

--- a/clang/test/SemaCXX/address-space-prvalue.cpp
+++ b/clang/test/SemaCXX/address-space-prvalue.cpp
@@ -1,25 +1,59 @@
-// RUN: %clang_cc1 %s -ast-dump | FileCheck %s
+// RUN: %clang_cc1 %s -fsyntax-only -verify
 
-struct X { int a; };
+struct S {                                     // #ctors
+  S(int);                                      // #sint
+  void f() const;                              // #f-const
+  void f() __attribute__((address_space(1)));  // #f-as \
+                                               // expected-error {{function type may not be qualified with an address space}}
+};
 
-using GlobalX = X __attribute__((address_space(1)));
+using const_int = const int;
+using as1_int = __attribute__((address_space(1))) int;
+using const_S = const S;
+using as1_S = __attribute__((address_space(1))) S;
 
-GlobalX prvalue();
-GlobalX &lvalue();
-GlobalX &&xvalue();
-
-void test() {
-  // A prvalue should not have an address space even if the function's
-  // return type is address-space qualified.
-  // CHECK: VarDecl {{.*}} v 'X'
-  // CHECK: CallExpr {{.*}} 'X'{{$}}
-  auto v = prvalue();
-
-  // CHECK: VarDecl {{.*}} l '__attribute__((address_space(1))) X &'
-  // CHECK: CallExpr {{.*}}:'__attribute__((address_space(1))) X' lvalue
-  auto &l = lvalue();
-
-  // CHECK: VarDecl {{.*}} r '__attribute__((address_space(1))) X &&'
-  // CHECK: CallExpr {{.*}}:'__attribute__((address_space(1))) X' xvalue
-  auto &&r = xvalue();
+void testQualifiers() {
+  // Ok; const is dropped on prvalues of non-class type.
+  (void)(const_int{1});
+  // Ok; address space is dropped on prvalues of non-class type.
+  (void)(as1_int{1});
+  // Ok; const is retained on prvalues of class type; const qualified
+  // member function called.
+  const_S{1}.f();
+  // Error; address space is retained on prvalues of class type, but no
+  // constructor or member function can be called.
+  as1_S{1}.f();
+  // expected-error@-1 {{no matching constructor for initialization of 'as1_S' (aka '__attribute__((address_space(1))) S')}}
+  // expected-error@-2 {{no matching member function for call to 'f'}}
+  // expected-note@#ctors 2 {{candidate constructor ignored: cannot be used to construct an object in address space '__attribute__((address_space(1)))'}}
+  // expected-note@#sint {{candidate constructor ignored: cannot be used to construct an object in address space '__attribute__((address_space(1)))'}}
+  // expected-note@#f-const {{candidate function not viable: 'this' object is in address space '1', but method expects object in generic address space}}
+  // expected-note@#f-as {{candidate function not viable: 'this' object is in address space '1', but method expects object in generic address space}}
 }
+
+void temporaryMaterializationTest() {
+  // An address-space-qualified class temporary retains the address space on
+  // the materialized object, so no constructor can be used.
+  as1_S{0};
+  // expected-error@-1 {{no matching constructor for initialization of 'as1_S' (aka '__attribute__((address_space(1))) S')}}
+  // expected-note@#ctors 2 {{candidate constructor ignored: cannot be used to construct an object in address space '__attribute__((address_space(1)))'}}
+  // expected-note@#sint {{candidate constructor ignored: cannot be used to construct an object in address space '__attribute__((address_space(1)))'}}
+}
+
+// FIXME: All qualifiers including address space are retained on array elements
+//        The code in getNonLValueExprType() to remove qualifiers from prvalues
+//        acts on the array type and not the element. The code to remove address
+//        spaces is never hit. I am not sure this if this is correct behavior.
+using int_array = const __attribute__((address_space(1))) int[1];
+using S_array = const __attribute__((address_space(1))) S[1];
+void arrayTest() {
+  // Passes because scalar elements can be initialized directly.
+  (void)(int_array{1});
+  // Errors because class elements cannot be constructed in the address space.
+  (void)(S_array{1});
+  // expected-error@-1 {{no viable conversion from 'int' to 'const __attribute__((address_space(1))) S'}}
+  // expected-note@#ctors {{candidate constructor (the implicit copy constructor) not viable: no known conversion from 'int' to 'const S &' for 1st argument}}
+  // expected-note@#ctors {{candidate constructor (the implicit move constructor) not viable: no known conversion from 'int' to 'S &&' for 1st argument}}
+  // expected-note@#sint {{candidate constructor ignored: cannot be used to construct an object in address space '__attribute__((address_space(1)))'}}
+}
+


### PR DESCRIPTION
C++ [basic.lval] specifies that non-class prvalues always have cv-unqualified types. Class prvalues can have cv-qualified types. In Clang this is done in `QualType::getNonLValueExprType()`. 

Address spaces are not cv qualifiers. It describes where an object is stored and since a prvalue does not have storage, it does not make sense to have an address space on a prvalue. Prior to this PR, for class prvalues `getNonLValueExprType()` returned the type unchanged, so the address space survived. 

This resulted in a crash for the following code downstream - 

```
struct Cplx { double re; double im; };

template <typename T> T opVal(const T &t) { return t; }

using GlobalCplx = __attribute__((opencl_global)) Cplx;

  // inside a SYCL kernel:
  //   *out = opVal(*p);   // p is a GlobalCplx*
```

`opVal` is called with a global pointer. `T` is deduced as `__global Cplx`. The call expression `opVal(*p)` produces `CallExpr`, a prvalue of type `__global Cplx`. When memory is allocated for the return, this memory is allocated in private memory. Because the prvalue is `__global`, the return memory gets a private -> global address space cast which is an illegal operation in SPIR-V. 

The underlying issue is that the prvalue should not have an address space. The address space should come from where it is stored, not the prvalue. This PR therefore strips the address space for the prvalue.

My first attempt to fix this caused a regression with an OpenCL test `temporaries.clcpp` because `getNonLValueExprType()` is also called by `PerformConstructorInitialization` to produce `CXXTemporaryObjectExpr`. `CXXTemporaryObjectExpr` is used to create a materialized object which has an address space. It is unclear to me whether the address space on `CXXTemporaryObjectExpr` is accurate. Maybe the address space should be applied only when materialization actually happens i.e when the prvalue is converted to xvalue in `TemporaryMaterializationConversion` but it looks like currently this just takes the type of `CXXTemporaryObjectExpr`. To limit the scope of this PR, I did not modify anything here. I changed `PerformConstructorInitialization` to call `getNonReferenceType()` which will be identical to the old `getNonLValueExprType()` since this site is only reached for constructor initialization, so the entity type is always a C++ class type. 

Assisted by Claude for test writing.