### PR TITLE
[lldb][test] Increase gdbremote_testcase timeout

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-server/gdbremote_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-server/gdbremote_testcase.py
@@ -60,7 +60,7 @@ class GdbRemoteTestCaseFactory(type):
 @requireSocketPermission  # the tests talk to the debug monitor over a socket
 class GdbRemoteTestCaseBase(Base, metaclass=GdbRemoteTestCaseFactory):
     # Default time out in seconds. The timeout is increased tenfold under Asan.
-    DEFAULT_TIMEOUT = 20 * (10 if ("ASAN_OPTIONS" in os.environ) else 1)
+    DEFAULT_TIMEOUT = 60 * (10 if ("ASAN_OPTIONS" in os.environ) else 1)
     # Default sleep time in seconds. The sleep time is doubled under Asan.
     DEFAULT_SLEEP = 5 * (2 if ("ASAN_OPTIONS" in os.environ) else 1)
 


### PR DESCRIPTION
TestLldbGdbServer.py is randomly timing out on slow machines. This bumps the timout to a minute by default.