### PR TITLE
[BOLT][DWARF] Emit empty ranges for removed code

### DIFF
--- a/bolt/lib/Rewrite/DWARFRewriter.cpp
+++ b/bolt/lib/Rewrite/DWARFRewriter.cpp
@@ -1284,14 +1284,12 @@ void DWARFRewriter::updateUnitDebugInfo(
               std::move(OutputRanges), CachedRanges);
           OutputRanges.clear();
         } else if (OutputRanges.empty()) {
-          OutputRanges.push_back({0, RangesOrError.get().front().HighPC});
+          OutputRanges.push_back({0, 0});
         }
       } else if (!RangesOrError) {
         consumeError(RangesOrError.takeError());
       } else {
-        OutputRanges.push_back({0, !RangesOrError->empty()
-                                       ? RangesOrError.get().front().HighPC
-                                       : 0});
+        OutputRanges.push_back({0, 0});
       }
       DIEValue LowPCVal = Die->findAttribute(dwarf::DW_AT_low_pc);
       DIEValue HighPCVal = Die->findAttribute(dwarf::DW_AT_high_pc);

--- a/bolt/test/X86/dwarf4-deleted-range.s
+++ b/bolt/test/X86/dwarf4-deleted-range.s
@@ -9,6 +9,8 @@
 # CHECK: 		DW_TAG_inlined_subroutine
 # CHECK:      DW_AT_low_pc
 # CHECK-SAME: 0x0000000000000000
+# CHECK:      DW_AT_high_pc
+# CHECK-SAME: 0x0000000000000000
 
 # CHECK:    DW_TAG_GNU_call_site
 # CHECK:      DW_AT_low_pc

--- a/bolt/test/X86/dwarf4-df-inlined-subroutine-lowpc-0.test
+++ b/bolt/test/X86/dwarf4-df-inlined-subroutine-lowpc-0.test
@@ -21,10 +21,10 @@
 ; BOLT-MAIN-SAME: (cu + 0x0043 => {0x00000043} "_Z7doStuffi")
 ; BOLT-MAIN: DW_AT_low_pc [DW_FORM_GNU_addr_index]
 ; BOLT-MAIN-SAME: (indexed (00000003) address = <unresolved>)
-; BOLT-MAIN: DW_AT_high_pc [DW_FORM_data4] (0x00000015)
+; BOLT-MAIN: DW_AT_high_pc [DW_FORM_data4] (0x00000000)
 ; BOLT-MAIN: DW_TAG_inlined_subroutine
 ; BOLT-MAIN: DW_AT_abstract_origin [DW_FORM_ref4]
 ; BOLT-MAIN-SAME: (cu + 0x005a => {0x0000005a} "_Z11doStuffSamei")
 ; BOLT-MAIN: DW_AT_low_pc [DW_FORM_GNU_addr_index]
 ; BOLT-MAIN-SAME: (indexed (00000003) address = <unresolved>)
-; BOLT-MAIN: DW_AT_high_pc [DW_FORM_data4] (0x0000000f)
+; BOLT-MAIN: DW_AT_high_pc [DW_FORM_data4] (0x00000000)

--- a/bolt/test/X86/dwarf5-deleted-range.s
+++ b/bolt/test/X86/dwarf5-deleted-range.s
@@ -5,9 +5,12 @@
 # RUN: llvm-bolt %t.exe -o %t.bolt --update-debug-sections
 # RUN: llvm-dwarfdump --show-children --name=main --debug-info %t.bolt \
 # RUN:   | FileCheck %s
+# RUN: llvm-dwarfdump --verify %t.bolt
 
 # CHECK: 		DW_TAG_inlined_subroutine
 # CHECK:      DW_AT_low_pc
+# CHECK-SAME: 0x0000000000000000
+# CHECK:      DW_AT_high_pc
 # CHECK-SAME: 0x0000000000000000
 
 # CHECK:    DW_TAG_call_site

--- a/bolt/test/X86/dwarf5-df-inlined-subroutine-gc-sections-range.test
+++ b/bolt/test/X86/dwarf5-df-inlined-subroutine-gc-sections-range.test
@@ -94,11 +94,11 @@
 ; BOLT-MAIN: DW_AT_call_line
 ; BOLT-MAIN: DW_AT_call_column
 ; BOLT-MAIN: DW_AT_low_pc [DW_FORM_addrx]  (indexed (00000000) address = <unresolved>)
-; BOLT-MAIN: DW_AT_high_pc [DW_FORM_data4] (0x0000001a)
+; BOLT-MAIN: DW_AT_high_pc [DW_FORM_data4] (0x00000000)
 ; BOLT-MAIN: DW_TAG_inlined_subroutine
 ; BOLT-MAIN: DW_AT_abstract_origin [DW_FORM_ref4]  (cu + 0x0072 => {0x00000072} "_Z8doStuff2i")
 ; BOLT-MAIN: DW_AT_call_file
 ; BOLT-MAIN: DW_AT_call_line
 ; BOLT-MAIN: DW_AT_call_column
 ; BOLT-MAIN: DW_AT_low_pc [DW_FORM_addrx]  (indexed (00000000) address = <unresolved>)
-; BOLT-MAIN: DW_AT_high_pc [DW_FORM_data4] (0x0000002d)
+; BOLT-MAIN: DW_AT_high_pc [DW_FORM_data4] (0x00000000)

--- a/bolt/test/X86/dwarf5-df-inlined-subroutine-range-0.test
+++ b/bolt/test/X86/dwarf5-df-inlined-subroutine-range-0.test
@@ -21,7 +21,7 @@
 ; BOLT-MAIN: DW_AT_call_line
 ; BOLT-MAIN: DW_AT_call_column
 ; BOLT-MAIN: DW_AT_low_pc [DW_FORM_addrx]  (indexed (00000002) address = <unresolved>)
-; BOLT-MAIN: DW_AT_high_pc [DW_FORM_data4] (0x0000002d)
+; BOLT-MAIN: DW_AT_high_pc [DW_FORM_data4] (0x00000000)
 
 ; BOLT-MAIN: DW_TAG_inlined_subroutine
 ; BOLT-MAIN: DW_AT_abstract_origin [DW_FORM_ref4]  (cu + 0x005a => {0x0000005a} "_Z11doStuffSamei")
@@ -29,4 +29,4 @@
 ; BOLT-MAIN: DW_AT_call_line [DW_FORM_data1] (16)
 ; BOLT-MAIN: DW_AT_call_column [DW_FORM_data1] (29)
 ; BOLT-MAIN: DW_AT_low_pc [DW_FORM_addrx]  (indexed (00000002) address = <unresolved>)
-; BOLT-MAIN: DW_AT_high_pc [DW_FORM_data4] (0x00000042)
+; BOLT-MAIN: DW_AT_high_pc [DW_FORM_data4] (0x00000000)


### PR DESCRIPTION
When a DIE has no surviving translated code range, BOLT set its low PC to zero but reused the input high PC. For high-PC-as-size forms this emitted a non-empty range starting at address zero and described code that is not present in the rewritten binary.

Emit [0, 0) for ranges that cannot be associated with a function or translate to no output code.

Assisted-by: OpenAI Codex