### PR TITLE
[BOLT][DWARF] Remap file indexes in rebuilt line tables

### DIFF
--- a/bolt/include/bolt/Core/BinaryContext.h
+++ b/bolt/include/bolt/Core/BinaryContext.h
@@ -382,6 +382,14 @@ public:
     return DwarfLineTablesCUMap[CUID];
   }
 
+  unsigned getOutputDwarfFileIndex(unsigned CUID,
+                                   unsigned InputFileIndex) const {
+    const auto It = DwarfLineTablesCUMap.find(CUID);
+    return It == DwarfLineTablesCUMap.end()
+               ? InputFileIndex
+               : It->second.translateFileIndex(InputFileIndex);
+  }
+
   Expected<unsigned> getDwarfFile(StringRef Directory, StringRef FileName,
                                   unsigned FileNumber,
                                   std::optional<MD5::MD5Result> Checksum,

--- a/bolt/include/bolt/Core/DebugData.h
+++ b/bolt/include/bolt/Core/DebugData.h
@@ -818,6 +818,10 @@ private:
   /// Raw data representing complete debug line section for the unit.
   StringRef RawData;
 
+  /// Maps file indexes from the input line table to the indexes assigned while
+  /// rebuilding the output table.
+  std::unordered_map<unsigned, unsigned> InputToOutputFileIndex;
+
   /// DWARF version and format for this line table.
   uint16_t DwarfVersion = 0;
   dwarf::DwarfFormat Format = dwarf::DWARF32;
@@ -838,6 +842,15 @@ public:
     assert(RawData.empty() && "cannot use with raw data");
     return Header.tryGetFile(Directory, FileName, Checksum, Source,
                              DwarfVersion, FileNumber);
+  }
+
+  void mapFileIndex(unsigned InputIndex, unsigned OutputIndex) {
+    InputToOutputFileIndex[InputIndex] = OutputIndex;
+  }
+
+  unsigned translateFileIndex(unsigned InputIndex) const {
+    const auto It = InputToOutputFileIndex.find(InputIndex);
+    return It == InputToOutputFileIndex.end() ? InputIndex : It->second;
   }
 
   /// Return label at the start of the emitted debug line for the unit.

--- a/bolt/lib/Core/BinaryContext.cpp
+++ b/bolt/lib/Core/BinaryContext.cpp
@@ -2110,8 +2110,10 @@ void BinaryContext::preprocessDebugInfo() {
       std::optional<MD5::MD5Result> Checksum;
       if (DwarfVersion >= 5 && LineTable->Prologue.ContentTypes.HasMD5)
         Checksum = LineTable->Prologue.FileNames[I].Checksum;
-      cantFail(getDwarfFile(Dir, FileName, 0, Checksum, std::nullopt, CUID,
-                            DwarfVersion));
+      const unsigned InputFileIndex = I + Offset;
+      const unsigned OutputFileIndex = cantFail(getDwarfFile(
+          Dir, FileName, 0, Checksum, std::nullopt, CUID, DwarfVersion));
+      BinaryLineTable.mapFileIndex(InputFileIndex, OutputFileIndex);
     }
   }
 

--- a/bolt/lib/Core/BinaryEmitter.cpp
+++ b/bolt/lib/Core/BinaryEmitter.cpp
@@ -679,8 +679,9 @@ SMLoc BinaryEmitter::emitLineInfo(const BinaryFunction &BF, SMLoc NewLoc,
                             MCSymbol &InstrLabel,
                             const DWARFDebugLine::Row &CurrentRow) {
     const uint64_t TargetUnitIndex = TargetCU.getOffset();
-    unsigned TargetFilenum = CurrentRow.File;
     const uint32_t CurrentUnitIndex = RowReference.DwCompileUnitIndex;
+    unsigned TargetFilenum =
+        BC.getOutputDwarfFileIndex(CurrentUnitIndex, CurrentRow.File);
     // If the CU id from the current instruction location does not
     // match the target CU id, it means that we have come across some
     // inlined code (by BOLT).  We must look up the CU for the instruction's

--- a/bolt/lib/Core/DIEBuilder.cpp
+++ b/bolt/lib/Core/DIEBuilder.cpp
@@ -891,6 +891,11 @@ void DIEBuilder::cloneScalarAttribute(
     return;
   }
 
+  if (AttrSpec.Attr == dwarf::DW_AT_decl_file ||
+      AttrSpec.Attr == dwarf::DW_AT_call_file)
+    Value =
+        BC.getOutputDwarfFileIndex(InputDIE.getDwarfUnit()->getOffset(), Value);
+
   Die.addValue(getState().DIEAlloc, AttrSpec.Attr, AttrSpec.Form,
                DIEInteger(Value));
 }

--- a/bolt/lib/Core/DebugData.cpp
+++ b/bolt/lib/Core/DebugData.cpp
@@ -1021,7 +1021,8 @@ static void emitDwarfSetLineAddrAbs(MCStreamer &OS,
 static inline void emitBinaryDwarfLineTable(
     MCStreamer *MCOS, MCDwarfLineTableParams Params,
     const DWARFDebugLine::LineTable *Table,
-    const std::vector<DwarfLineTable::RowSequence> &InputSequences) {
+    const std::vector<DwarfLineTable::RowSequence> &InputSequences,
+    const DwarfLineTable &OutputTable) {
   if (InputSequences.empty())
     return;
 
@@ -1063,8 +1064,9 @@ static inline void emitBinaryDwarfLineTable(
       int64_t LineDelta = static_cast<int64_t>(Row.Line) - LastLine;
       const uint64_t Address = Row.Address.Address;
 
-      if (FileNum != Row.File) {
-        FileNum = Row.File;
+      const unsigned OutputFile = OutputTable.translateFileIndex(Row.File);
+      if (FileNum != OutputFile) {
+        FileNum = OutputFile;
         MCOS->emitInt8(dwarf::DW_LNS_set_file);
         MCOS->emitULEB128IntValue(FileNum);
       }
@@ -1224,7 +1226,7 @@ void DwarfLineTable::emitCU(MCStreamer *MCOS, MCDwarfLineTableParams Params,
     emitDwarfLineTable(MCOS, LineSec.first, LineSec.second);
 
   // Emit line tables for the original code.
-  emitBinaryDwarfLineTable(MCOS, Params, InputTable, InputSequences);
+  emitBinaryDwarfLineTable(MCOS, Params, InputTable, InputSequences, *this);
 
   // This is the end of the section, so set the value of the symbol at the end
   // of this section (that was used in a previous expression).

--- a/bolt/test/X86/dwarf5-debug-line-duplicate-files.s
+++ b/bolt/test/X86/dwarf5-debug-line-duplicate-files.s
@@ -1,0 +1,157 @@
+# REQUIRES: system-linux
+
+# RUN: llvm-mc -filetype=obj -triple x86_64-unknown-linux %s -o %t.o
+# RUN: %clang %cflags %t.o -o %t.exe -Wl,-q
+# RUN: llvm-dwarfdump --show-form --verbose --debug-line %t.exe | FileCheck --check-prefix=PRE %s
+# RUN: llvm-bolt %t.exe -o %t.bolt --update-debug-sections
+# RUN: llvm-dwarfdump --verify %t.bolt
+# RUN: llvm-dwarfdump --show-form --verbose --debug-line --debug-info %t.bolt | FileCheck --check-prefix=POST %s
+
+## BOLT rebuilds processed line tables through MC, which intentionally interns
+## duplicate file entries. Check that references to input file indexes are
+## remapped to the indexes in the rebuilt table.
+
+# PRE: file_names[  0]:
+# PRE-NEXT: name: "main.cpp"
+# PRE: file_names[  1]:
+# PRE-NEXT: name: "main.cpp"
+# PRE: file_names[  2]:
+# PRE-NEXT: name: "header.h"
+
+# POST: DW_AT_name [DW_FORM_string] ("main")
+# POST: DW_AT_decl_file [DW_FORM_data1] ("./header.h")
+# POST: DW_AT_call_file [DW_FORM_data1] ("./header.h")
+# POST: file_names[  0]:
+# POST-NEXT: name: "main.cpp"
+# POST: file_names[  1]:
+# POST-NEXT: name: "header.h"
+# POST-NOT: file_names[  2]:
+# POST: {{0x[0-9a-f]+}}{{ +}}7{{ +}}0{{ +}}1{{ +}}0
+
+        .text
+        .globl  main
+        .p2align 4, 0x90
+        .type   main,@function
+main:
+.Lfunc_begin0:
+        xorl    %eax, %eax
+        retq
+.Lfunc_end0:
+        .size   main, .Lfunc_end0-main
+
+        .section .debug_abbrev,"",@progbits
+        .byte   1                       # Abbrev code
+        .byte   17                      # DW_TAG_compile_unit
+        .byte   1                       # DW_CHILDREN_yes
+        .byte   37                      # DW_AT_producer
+        .byte   8                       # DW_FORM_string
+        .byte   19                      # DW_AT_language
+        .byte   5                       # DW_FORM_data2
+        .byte   3                       # DW_AT_name
+        .byte   8                       # DW_FORM_string
+        .byte   27                      # DW_AT_comp_dir
+        .byte   8                       # DW_FORM_string
+        .byte   16                      # DW_AT_stmt_list
+        .byte   23                      # DW_FORM_sec_offset
+        .byte   17                      # DW_AT_low_pc
+        .byte   1                       # DW_FORM_addr
+        .byte   18                      # DW_AT_high_pc
+        .byte   6                       # DW_FORM_data4
+        .byte   0
+        .byte   0
+        .byte   2                       # Abbrev code
+        .byte   46                      # DW_TAG_subprogram
+        .byte   0                       # DW_CHILDREN_no
+        .byte   17                      # DW_AT_low_pc
+        .byte   1                       # DW_FORM_addr
+        .byte   18                      # DW_AT_high_pc
+        .byte   6                       # DW_FORM_data4
+        .byte   3                       # DW_AT_name
+        .byte   8                       # DW_FORM_string
+        .byte   58                      # DW_AT_decl_file
+        .byte   11                      # DW_FORM_data1
+        .byte   59                      # DW_AT_decl_line
+        .byte   11                      # DW_FORM_data1
+        .byte   88                      # DW_AT_call_file
+        .byte   11                      # DW_FORM_data1
+        .byte   0
+        .byte   0
+        .byte   0
+
+        .section .debug_info,"",@progbits
+.Lcu_begin0:
+        .long   .Ldebug_info_end0-.Ldebug_info_start0
+.Ldebug_info_start0:
+        .short  5                       # DWARF version
+        .byte   1                       # DW_UT_compile
+        .byte   8                       # Address size
+        .long   .debug_abbrev
+        .byte   1                       # DW_TAG_compile_unit
+        .asciz  "test producer"
+        .short  33                      # DW_LANG_C_plus_plus_14
+        .asciz  "main.cpp"
+        .asciz  "."
+        .long   .Lline_table_start0
+        .quad   .Lfunc_begin0
+        .long   .Lfunc_end0-.Lfunc_begin0
+        .byte   2                       # DW_TAG_subprogram
+        .quad   .Lfunc_begin0
+        .long   .Lfunc_end0-.Lfunc_begin0
+        .asciz  "main"
+        .byte   2                       # Input file index for header.h
+        .byte   7
+        .byte   2                       # Input call file index for header.h
+        .byte   0                       # End children
+.Ldebug_info_end0:
+
+        .section .debug_line,"",@progbits
+.Lline_table_start0:
+        .long   .Lline_table_end0-.Lline_table_start1
+.Lline_table_start1:
+        .short  5                       # DWARF version
+        .byte   8                       # Address size
+        .byte   0                       # Segment selector size
+        .long   .Lline_prologue_end0-.Lline_prologue_start0
+.Lline_prologue_start0:
+        .byte   1                       # Minimum instruction length
+        .byte   1                       # Maximum operations per instruction
+        .byte   1                       # Default is_stmt
+        .byte   -5                      # Line base
+        .byte   14                      # Line range
+        .byte   13                      # Opcode base
+        .byte   0, 1, 1, 1, 1, 0, 0, 0, 1, 0, 0, 1
+        .byte   1                       # Directory format count
+        .byte   1                       # DW_LNCT_path
+        .byte   8                       # DW_FORM_string
+        .uleb128 1                      # Directory count
+        .asciz  "."
+        .byte   2                       # File format count
+        .byte   1                       # DW_LNCT_path
+        .byte   8                       # DW_FORM_string
+        .byte   2                       # DW_LNCT_directory_index
+        .byte   11                      # DW_FORM_data1
+        .uleb128 3                      # File count
+        .asciz  "main.cpp"
+        .byte   0
+        .asciz  "main.cpp"             # Duplicate root entry
+        .byte   0
+        .asciz  "header.h"
+        .byte   0
+.Lline_prologue_end0:
+        .byte   0                       # DW_LNE_set_address
+        .uleb128 9
+        .byte   2
+        .quad   .Lfunc_begin0
+        .byte   4                       # DW_LNS_set_file
+        .uleb128 2                      # Input file index for header.h
+        .byte   3                       # DW_LNS_advance_line
+        .sleb128 6
+        .byte   1                       # DW_LNS_copy
+        .byte   2                       # DW_LNS_advance_pc
+        .uleb128 .Lfunc_end0-.Lfunc_begin0
+        .byte   0                       # DW_LNE_end_sequence
+        .uleb128 1
+        .byte   1
+.Lline_table_end0:
+
+        .section ".note.GNU-stack","",@progbits

--- a/bolt/test/X86/dwarf5-split-dwarf4-monolithic.test
+++ b/bolt/test/X86/dwarf5-split-dwarf4-monolithic.test
@@ -184,7 +184,7 @@
 # helper1.cpp
 # POSTCHECK: version = 0x0005
 # POSTCHECK: DW_TAG_skeleton_unit [12]
-# POSTCHECK-NEXT: DW_AT_stmt_list [DW_FORM_sec_offset]  (0x000000fe)
+# POSTCHECK-NEXT: DW_AT_stmt_list [DW_FORM_sec_offset]  (0x000000fa)
 # POSTCHECK-NEXT: DW_AT_str_offsets_base [DW_FORM_sec_offset] (0x00000018)
 # POSTCHECK-NEXT: DW_AT_comp_dir [DW_FORM_strx1]  (indexed (00000000) string = ".")
 # POSTCHECK-NEXT: DW_AT_GNU_pubnames [DW_FORM_flag_present] (true)


### PR DESCRIPTION
The MC line-table builder interns duplicate file entries. BOLT rebuilt the output file table through MC but continued to emit input indexes in line rows and DW_AT_decl_file and DW_AT_call_file attributes. Removing a duplicate could therefore make those references select the wrong file or an index outside the output table.

Record the input-to-output index assigned while rebuilding each table and translate every index when emitting rows and DIE attributes.

Assisted-by: OpenAI Codex