### PR TITLE
[clang][Sema] Fix false-positive -Wshadow for friend functions

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -492,6 +492,8 @@ features cannot lower the translation-unit ABI level;
   `operator delete`, since such a delete expression never invokes the
   destructor. (#GH65524)
 
+- Fixed a false-positive `-Wshadow` warning when a function parameter in an inline-defined friend function shares the name of a non-static class member variable. (#GH221190)
+
 ### Improvements to Clang's time-trace
 
 ### Improvements to Coverage Mapping

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -8627,12 +8627,12 @@ void Sema::CheckShadow(NamedDecl *D, NamedDecl *ShadowedDecl,
   DeclContext *NewDC = D->getDeclContext();
 
   if (FieldDecl *FD = dyn_cast<FieldDecl>(ShadowedDecl)) {
-    if (const auto *MD =
-            dyn_cast<CXXMethodDecl>(getFunctionLevelDeclContext())) {
-      // Fields aren't shadowed in C++ static members or in member functions
-      // with an explicit object parameter.
+    DeclContext *FnDC = getFunctionLevelDeclContext();
+    if (const auto *MD = dyn_cast<CXXMethodDecl>(FnDC)) {
       if (MD->isStatic() || MD->isExplicitObjectMemberFunction())
         return;
+    } else if (isa<FunctionDecl>(FnDC)) {
+      return;
     }
     // Fields shadowed by constructor parameters are a special case. Usually
     // the constructor initializes the field with the parameter.

--- a/clang/test/SemaCXX/warn-shadow.cpp
+++ b/clang/test/SemaCXX/warn-shadow.cpp
@@ -90,6 +90,22 @@ class A {
   }
 };
 
+class FriendFunction {
+  int x; // expected-note {{previous declaration is here}}
+  friend bool operator==(const FriendFunction &f, int x) {
+    return f.x == x;
+  }
+  void test(int x) { // expected-warning {{declaration shadows a field of 'FriendFunction'}}
+  }
+};
+
+struct NSDMILambda {
+  int a; // expected-note {{previous declaration is here}}
+  int x = [this] {
+    int a = 0; // expected-warning {{declaration shadows a field of 'NSDMILambda'}}
+    return a;
+  }();
+};
 struct path {
   using value_type = char;
   typedef char value_type2;


### PR DESCRIPTION
A friend function defined inline in a class body has no implicit `this`, so a parameter with the same name as a field cannot actually shadow it. `CheckShadow` only exempted static members and members with an explicit object parameter,  it never handled the case where the enclosing function isn't a member function at all, which fell through to the generic diagnostic. In this PR I extend the exemption to cover that case and added the regression test.

In this PR, I used Claude to help navigate the codebase and explain key functions.
Fixes #221190