### PR TITLE
[analyzer][NFC] Document and centralize the CallEvent argument/parameter index mapping

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CallEvent.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CallEvent.h
@@ -420,6 +420,9 @@ public:
   /// Returns memory location for a parameter variable within the callee stack
   /// frame. The behavior is undefined if the block count is different from the
   /// one that is there when call happens. May fail; returns null on failure.
+  ///
+  /// \param Index refers to the index of the declared parameter of the callee.
+  /// See getDeclaredParameterIndex().
   const ParamVarRegion *getParameterLocation(unsigned Index,
                                              unsigned BlockCount) const;
 
@@ -429,6 +432,9 @@ public:
   /// if we are supposed to construct an argument directly, we may still
   /// not do that because we don't know how (i.e., construction context is
   /// unavailable in the CFG or not supported by the analyzer).
+  ///
+  /// \param Index index of the argument as understood by the AST.
+  /// See getASTArgumentIndex().
   bool isArgumentConstructedDirectly(unsigned Index) const {
     // This assumes that the object was not yet removed from the state.
     return ExprEngine::getObjectUnderConstruction(
@@ -437,9 +443,13 @@ public:
   }
 
   /// Some calls have parameter numbering mismatched from argument numbering.
-  /// This function converts an argument index to the corresponding
-  /// parameter index. Returns std::nullopt is the argument doesn't correspond
+  /// This function converts an argument index as understood by the AST to the
+  /// index of the *declared* parameter of the callee that this argument
+  /// initializes. Returns std::nullopt if the argument doesn't correspond
   /// to any parameter variable.
+  ///
+  /// Note that \c clang::AnyCall::arguments() uses the opposite convention:
+  /// there the object argument is part of the argument list.
   virtual std::optional<unsigned>
   getAdjustedParameterIndex(unsigned ASTArgumentIndex) const {
     return ASTArgumentIndex;
@@ -450,6 +460,21 @@ public:
   /// as understood by CallEvent to the argument index as understood by the AST.
   virtual unsigned getASTArgumentIndex(unsigned CallArgumentIndex) const {
     return CallArgumentIndex;
+  }
+
+  /// Returns the declared parameter index that CallEvent argument
+  /// \p CallArgumentIndex (as understood by CallEvent) initializes or
+  /// std::nullopt if that argument does not initialize any declared parameter.
+  ///
+  /// This is the index to use with parameters() and getParameterLocation().
+  /// Note that this is not necessarily equal to \p CallArgumentIndex. For an
+  /// overloaded operator call, the object is passed as argument 0, but it is
+  /// not a declared parameter of an implicit ombject member function. For an
+  /// explicit object member function, the object is likewise passed as
+  /// argument 0, but there it is a declared parameter #0.
+  std::optional<unsigned>
+  getDeclaredParameterIndex(unsigned CallArgumentIndex) const {
+    return getAdjustedParameterIndex(getASTArgumentIndex(CallArgumentIndex));
   }
 
   /// Returns the construction context of the call, if it is a C++ constructor

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CallEvent.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CallEvent.h
@@ -423,7 +423,7 @@ public:
   ///
   /// \param Index refers to the index of the declared parameter of the callee.
   /// See getDeclaredParameterIndex().
-  const ParamVarRegion *getParameterLocation(unsigned Index,
+  const ParamVarRegion *getParameterLocation(std::optional<unsigned> Index,
                                              unsigned BlockCount) const;
 
   /// Returns true if on the current path, the argument was constructed by

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CallEvent.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CallEvent.h
@@ -451,7 +451,7 @@ public:
   /// Note that \c clang::AnyCall::arguments() uses the opposite convention:
   /// there the object argument is part of the argument list.
   virtual std::optional<unsigned>
-  getAdjustedParameterIndex(unsigned ASTArgumentIndex) const {
+  adjustASTArgIdxToDeclParamIdx(unsigned ASTArgumentIndex) const {
     return ASTArgumentIndex;
   }
 
@@ -474,7 +474,8 @@ public:
   /// argument 0, but there it is a declared parameter #0.
   std::optional<unsigned>
   getDeclaredParameterIndex(unsigned CallArgumentIndex) const {
-    return getAdjustedParameterIndex(getASTArgumentIndex(CallArgumentIndex));
+    return adjustASTArgIdxToDeclParamIdx(
+        getASTArgumentIndex(CallArgumentIndex));
   }
 
   /// Returns the construction context of the call, if it is a C++ constructor
@@ -794,7 +795,7 @@ public:
   }
 
   std::optional<unsigned>
-  getAdjustedParameterIndex(unsigned ASTArgumentIndex) const override {
+  adjustASTArgIdxToDeclParamIdx(unsigned ASTArgumentIndex) const override {
     // Ignore the object parameter that is not used for static member functions.
     if (ASTArgumentIndex == 0)
       return std::nullopt;
@@ -900,7 +901,7 @@ public:
   }
 
   std::optional<unsigned>
-  getAdjustedParameterIndex(unsigned ASTArgumentIndex) const override {
+  adjustASTArgIdxToDeclParamIdx(unsigned ASTArgumentIndex) const override {
     // For member operator calls argument 0 on the expression corresponds
     // to implicit this-parameter on the declaration.
     return (ASTArgumentIndex > 0)

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CallEvent.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CallEvent.h
@@ -421,9 +421,9 @@ public:
   /// frame. The behavior is undefined if the block count is different from the
   /// one that is there when call happens. May fail; returns null on failure.
   ///
-  /// \param Index refers to the index of the declared parameter of the callee.
+  /// \param DeclParamIdx refers to the index of the declared parameter of the callee.
   /// See getDeclaredParameterIndex().
-  const ParamVarRegion *getParameterLocation(std::optional<unsigned> Index,
+  const ParamVarRegion *getParameterLocation(std::optional<unsigned> DeclParamIdx,
                                              unsigned BlockCount) const;
 
   /// Returns true if on the current path, the argument was constructed by
@@ -433,12 +433,12 @@ public:
   /// not do that because we don't know how (i.e., construction context is
   /// unavailable in the CFG or not supported by the analyzer).
   ///
-  /// \param Index index of the argument as understood by the AST.
+  /// \param ASTArgIdx index of the argument as understood by the AST.
   /// See getASTArgumentIndex().
-  bool isArgumentConstructedDirectly(unsigned Index) const {
+  bool isArgumentConstructedDirectly(unsigned ASTArgIdx) const {
     // This assumes that the object was not yet removed from the state.
     return ExprEngine::getObjectUnderConstruction(
-               getState(), {getOriginExpr(), Index}, getStackFrame())
+               getState(), {getOriginExpr(), ASTArgIdx}, getStackFrame())
         .has_value();
   }
 

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/MemRegion.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/MemRegion.h
@@ -1073,6 +1073,10 @@ class ParamVarRegion : public VarRegion {
   friend class MemRegionManager;
 
   const Expr *OriginExpr;
+
+  /// Index of teh declared parameter of the callee that this region stands
+  /// for. This is not necessarily the index of the corresponding argument
+  /// in `OriginExpr`. See `CallEvent::getDeclaredParameterIndex()`.
   unsigned Index;
 
   ParamVarRegion(const Expr *OE, unsigned Idx, const MemRegion *SReg)
@@ -1095,7 +1099,8 @@ public:
 
   QualType getValueType() const override;
 
-  /// TODO: What does this return?
+  /// \returns the declared parameter of the callee that this region
+  /// stands for (`getStackFrame()->getDecl()->parameters()[getIndex()]`).
   const ParmVarDecl *getDecl() const override;
 
   bool canPrintPrettyAsExpr() const override;

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/MemRegion.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/MemRegion.h
@@ -1074,7 +1074,7 @@ class ParamVarRegion : public VarRegion {
 
   const Expr *OriginExpr;
 
-  /// Index of teh declared parameter of the callee that this region stands
+  /// Index of the declared parameter of the callee that this region stands
   /// for. This is not necessarily the index of the corresponding argument
   /// in `OriginExpr`. See `CallEvent::getDeclaredParameterIndex()`.
   unsigned Index;

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/MemRegion.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/MemRegion.h
@@ -1077,10 +1077,10 @@ class ParamVarRegion : public VarRegion {
   /// Index of the declared parameter of the callee that this region stands
   /// for. This is not necessarily the index of the corresponding argument
   /// in `OriginExpr`. See `CallEvent::getDeclaredParameterIndex()`.
-  unsigned Index;
+  unsigned DeclParamIdx;
 
   ParamVarRegion(const Expr *OE, unsigned Idx, const MemRegion *SReg)
-      : VarRegion(SReg, ParamVarRegionKind), OriginExpr(OE), Index(Idx) {
+      : VarRegion(SReg, ParamVarRegionKind), OriginExpr(OE), DeclParamIdx(Idx) {
     assert(!cast<StackSpaceRegion>(SReg)->getStackFrame()->inTopFrame());
     assert(OriginExpr);
   }
@@ -1091,7 +1091,7 @@ class ParamVarRegion : public VarRegion {
 public:
   LLVM_ATTRIBUTE_RETURNS_NONNULL
   const Expr *getOriginExpr() const { return OriginExpr; }
-  unsigned getIndex() const { return Index; }
+  unsigned getIndex() const { return DeclParamIdx; }
 
   void Profile(llvm::FoldingSetNodeID& ID) const override;
 

--- a/clang/lib/StaticAnalyzer/Core/CallEvent.cpp
+++ b/clang/lib/StaticAnalyzer/Core/CallEvent.cpp
@@ -449,8 +449,13 @@ static SVal processArgument(SVal Value, const Expr *ArgumentExpr,
 /// Or returns the cast argument if it needed a cast.
 /// Or returns 'Unknown' if it would need a cast but the callsite and the
 /// runtime definition don't match in terms of argument and parameter count.
-static SVal castArgToParamTypeIfNeeded(const CallEvent &Call, unsigned ArgIdx,
-                                       SVal ArgVal, SValBuilder &SVB) {
+///
+/// \param DeclParamIdx index of the declared parameter that \p ArgExpr
+/// initializes. See CallEvent::getDeclaredParameterIndex().
+static SVal castArgToParamTypeIfNeeded(const CallEvent &Call,
+                                       unsigned DeclParamIdx,
+                                       const Expr *ArgExpr, SVal ArgVal,
+                                       SValBuilder &SVB) {
   const auto *CallExprDecl = dyn_cast_or_null<FunctionDecl>(Call.getDecl());
   if (!CallExprDecl)
     return ArgVal;
@@ -466,13 +471,53 @@ static SVal castArgToParamTypeIfNeeded(const CallEvent &Call, unsigned ArgIdx,
     return ArgVal;
 
   // Only do this cast if the number arguments at the callsite matches with
-  // the parameters at the runtime definition.
+  // the parameters at the runtime definition. Note that this point is only
+  // reached for C functions without a prototype, so the argument indices
+  // and the declared parameter indices coincide.
   if (Call.getNumArgs() != Definition->getNumParams())
     return UnknownVal();
 
-  const Expr *ArgExpr = Call.getArgExpr(ArgIdx);
-  const ParmVarDecl *Param = Definition->getParamDecl(ArgIdx);
+  const ParmVarDecl *Param = Definition->getParamDecl(DeclParamIdx);
   return SVB.evalCast(ArgVal, Param->getType(), ArgExpr->getType());
+}
+
+/// Binds the value of a single argument to the region of the parameter it
+/// initializes in the callee's stack frame.
+///
+/// \param ParamDecl the declared parameter initialized by this argument.
+/// \param DeclParamIdx index of \p ParamDecl among the callee's declared
+/// parameters. See CallEvent::getDeclaredParameterIndex().
+/// \param ASTArgIdx index of \p ArgExpr in the origin expression's argument
+/// list. See CallEvent::getASTArgumentIndex(). Note that this is not
+/// necessarily equal to \p DeclParamIdx.
+static void addParameterValueToBindings(const StackFrame *CalleeSF,
+                                        CallEvent::BindingsTy &Bindings,
+                                        SValBuilder &SVB, const CallEvent &Call,
+                                        const ParmVarDecl *ParamDecl,
+                                        unsigned DeclParamIdx,
+                                        unsigned ASTArgIdx, const Expr *ArgExpr,
+                                        SVal ArgVal) {
+  assert(ParamDecl && "Formal parameter has no decl?");
+
+  // TODO: Support allocator calls.
+  if (Call.getKind() != CE_CXXAllocator)
+    if (Call.isArgumentConstructedDirectly(ASTArgIdx))
+      return;
+
+  // TODO: Allocators should receive the correct size and possibly alignment,
+  // determined in compile-time but not represented as arg-expressions,
+  // which makes getArgSVal() fail and return UnknownVal.
+  if (ArgVal.isUnknown())
+    return;
+
+  // Cast the argument value to match the type of the parameter in some
+  // edge-cases.
+  ArgVal = castArgToParamTypeIfNeeded(Call, DeclParamIdx, ArgExpr, ArgVal, SVB);
+
+  Loc ParamLoc = SVB.makeLoc(SVB.getRegionManager().getParamVarRegion(
+      Call.getOriginExpr(), DeclParamIdx, CalleeSF));
+  Bindings.emplace_back(ParamLoc,
+                        processArgument(ArgVal, ArgExpr, ParamDecl, SVB));
 }
 
 static void addParameterValuesToBindings(const StackFrame *CalleeSF,
@@ -480,38 +525,23 @@ static void addParameterValuesToBindings(const StackFrame *CalleeSF,
                                          SValBuilder &SVB,
                                          const CallEvent &Call,
                                          ArrayRef<ParmVarDecl *> parameters) {
-  MemRegionManager &MRMgr = SVB.getRegionManager();
-
-  // If the function has fewer parameters than the call has arguments, we simply
-  // do not bind any values to them.
-  unsigned NumArgs = Call.getNumArgs();
-  unsigned Idx = 0;
-  ArrayRef<ParmVarDecl*>::iterator I = parameters.begin(), E = parameters.end();
-  for (; I != E && Idx < NumArgs; ++I, ++Idx) {
-    assert(*I && "Formal parameter has no decl?");
-
-    // TODO: Support allocator calls.
-    if (Call.getKind() != CE_CXXAllocator)
-      if (Call.isArgumentConstructedDirectly(Call.getASTArgumentIndex(Idx)))
-        continue;
-
-    // TODO: Allocators should receive the correct size and possibly alignment,
-    // determined in compile-time but not represented as arg-expressions,
-    // which makes getArgSVal() fail and return UnknownVal.
-    SVal ArgVal = Call.getArgSVal(Idx);
-    const Expr *ArgExpr = Call.getArgExpr(Idx);
-
-    if (ArgVal.isUnknown())
+  for (unsigned Idx = 0, NumArgs = Call.getNumArgs(); Idx != NumArgs; ++Idx) {
+    // An argument that doesn't initialize a declared parameter, such as the
+    // object argument of an overloaded operator call.
+    std::optional<unsigned> DeclParamIdx = Call.getDeclaredParameterIndex(Idx);
+    if (!DeclParamIdx)
       continue;
 
-    // Cast the argument value to match the type of the parameter in some
-    // edge-cases.
-    ArgVal = castArgToParamTypeIfNeeded(Call, Idx, ArgVal, SVB);
+    // If the call has more arguments than the function has parameters, the
+    // extra ones are left unbound. Since the indices are monotonic, no later
+    // argument has a parameter either, so we can stop here.
+    if (*DeclParamIdx >= parameters.size())
+      break;
 
-    Loc ParamLoc = SVB.makeLoc(
-        MRMgr.getParamVarRegion(Call.getOriginExpr(), Idx, CalleeSF));
-    Bindings.push_back(
-        std::make_pair(ParamLoc, processArgument(ArgVal, ArgExpr, *I, SVB)));
+    addParameterValueToBindings(CalleeSF, Bindings, SVB, Call,
+                                parameters[*DeclParamIdx], *DeclParamIdx,
+                                Call.getASTArgumentIndex(Idx),
+                                Call.getArgExpr(Idx), Call.getArgSVal(Idx));
   }
 
   // FIXME: Variadic arguments are not handled at all right now.

--- a/clang/lib/StaticAnalyzer/Core/CallEvent.cpp
+++ b/clang/lib/StaticAnalyzer/Core/CallEvent.cpp
@@ -290,7 +290,7 @@ ProgramStateRef CallEvent::invalidateRegions(unsigned BlockCount,
     // currently hard to figure out.
     if (getKind() != CE_CXXAllocator)
       if (isArgumentConstructedDirectly(Idx))
-        if (auto AdjIdx = getAdjustedParameterIndex(Idx))
+        if (auto AdjIdx = adjustASTArgIdxToDeclParamIdx(Idx))
           if (const TypedValueRegion *TVR =
                   getParameterLocation(*AdjIdx, BlockCount))
             ValuesToInvalidate.push_back(loc::MemRegionVal(TVR));

--- a/clang/lib/StaticAnalyzer/Core/CallEvent.cpp
+++ b/clang/lib/StaticAnalyzer/Core/CallEvent.cpp
@@ -189,7 +189,8 @@ const StackFrame *CallEvent::getCalleeStackFrame(unsigned BlockCount) const {
 }
 
 const ParamVarRegion
-*CallEvent::getParameterLocation(std::optional<unsigned> Index, unsigned BlockCount) const {
+*CallEvent::getParameterLocation(std::optional<unsigned> Index,
+                                 unsigned BlockCount) const {
   if (!Index)
     return nullptr;
 

--- a/clang/lib/StaticAnalyzer/Core/CallEvent.cpp
+++ b/clang/lib/StaticAnalyzer/Core/CallEvent.cpp
@@ -189,7 +189,10 @@ const StackFrame *CallEvent::getCalleeStackFrame(unsigned BlockCount) const {
 }
 
 const ParamVarRegion
-*CallEvent::getParameterLocation(unsigned Index, unsigned BlockCount) const {
+*CallEvent::getParameterLocation(std::optional<unsigned> Index, unsigned BlockCount) const {
+  if (!Index)
+    return nullptr;
+
   const StackFrame *SF = getCalleeStackFrame(BlockCount);
   // We cannot construct a VarRegion without a stack frame.
   if (!SF)
@@ -197,7 +200,7 @@ const ParamVarRegion
 
   const ParamVarRegion *PVR =
       State->getStateManager().getRegionManager().getParamVarRegion(
-          getOriginExpr(), Index, SF);
+          getOriginExpr(), *Index, SF);
   return PVR;
 }
 

--- a/clang/lib/StaticAnalyzer/Core/CallEvent.cpp
+++ b/clang/lib/StaticAnalyzer/Core/CallEvent.cpp
@@ -189,9 +189,9 @@ const StackFrame *CallEvent::getCalleeStackFrame(unsigned BlockCount) const {
 }
 
 const ParamVarRegion
-*CallEvent::getParameterLocation(std::optional<unsigned> Index,
+*CallEvent::getParameterLocation(std::optional<unsigned> DeclParamIdx,
                                  unsigned BlockCount) const {
-  if (!Index)
+  if (!DeclParamIdx)
     return nullptr;
 
   const StackFrame *SF = getCalleeStackFrame(BlockCount);
@@ -201,7 +201,7 @@ const ParamVarRegion
 
   const ParamVarRegion *PVR =
       State->getStateManager().getRegionManager().getParamVarRegion(
-          getOriginExpr(), *Index, SF);
+          getOriginExpr(), *DeclParamIdx, SF);
   return PVR;
 }
 

--- a/clang/lib/StaticAnalyzer/Core/CallEvent.cpp
+++ b/clang/lib/StaticAnalyzer/Core/CallEvent.cpp
@@ -491,29 +491,25 @@ static SVal castArgToParamTypeIfNeeded(const CallEvent &Call,
 /// \param ParamDecl the declared parameter initialized by this argument.
 /// \param DeclParamIdx index of \p ParamDecl among the callee's declared
 /// parameters. See CallEvent::getDeclaredParameterIndex().
-/// \param ASTArgIdx index of \p ArgExpr in the origin expression's argument
-/// list. See CallEvent::getASTArgumentIndex(). Note that this is not
-/// necessarily equal to \p DeclParamIdx.
 static void addParameterValueToBindings(const StackFrame *CalleeSF,
                                         CallEvent::BindingsTy &Bindings,
                                         SValBuilder &SVB, const CallEvent &Call,
                                         const ParmVarDecl *ParamDecl,
-                                        unsigned DeclParamIdx,
-                                        unsigned ASTArgIdx, const Expr *ArgExpr,
-                                        SVal ArgVal) {
+                                        unsigned DeclParamIdx, unsigned Idx) {
   assert(ParamDecl && "Formal parameter has no decl?");
 
   // TODO: Support allocator calls.
   if (Call.getKind() != CE_CXXAllocator)
-    if (Call.isArgumentConstructedDirectly(ASTArgIdx))
+    if (Call.isArgumentConstructedDirectly(Call.getASTArgumentIndex(Idx)))
       return;
 
+  SVal ArgVal = Call.getArgSVal(Idx);
   // TODO: Allocators should receive the correct size and possibly alignment,
   // determined in compile-time but not represented as arg-expressions,
   // which makes getArgSVal() fail and return UnknownVal.
   if (ArgVal.isUnknown())
     return;
-
+  const Expr *ArgExpr = Call.getArgExpr(Idx);
   // Cast the argument value to match the type of the parameter in some
   // edge-cases.
   ArgVal = castArgToParamTypeIfNeeded(Call, DeclParamIdx, ArgExpr, ArgVal, SVB);
@@ -543,9 +539,7 @@ static void addParameterValuesToBindings(const StackFrame *CalleeSF,
       break;
 
     addParameterValueToBindings(CalleeSF, Bindings, SVB, Call,
-                                parameters[*DeclParamIdx], *DeclParamIdx,
-                                Call.getASTArgumentIndex(Idx),
-                                Call.getArgExpr(Idx), Call.getArgSVal(Idx));
+                                parameters[*DeclParamIdx], *DeclParamIdx, Idx);
   }
 
   // FIXME: Variadic arguments are not handled at all right now.

--- a/clang/lib/StaticAnalyzer/Core/ExprEngineCXX.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngineCXX.cpp
@@ -350,8 +350,13 @@ SVal ExprEngine::computeObjectUnderConstruction(
         // Operator arguments do not correspond to operator parameters
         // because this-argument is implemented as a normal argument in
         // operator call expressions but not in operator declarations.
-        const TypedValueRegion *TVR = Caller->getParameterLocation(
-            *Caller->getAdjustedParameterIndex(Idx), NumVisitedCaller);
+        std::optional<unsigned> DeclParamIdx =
+            Caller->getAdjustedParameterIndex(Idx);
+        if (!DeclParamIdx)
+          return std::nullopt;
+
+        const TypedValueRegion *TVR =
+            Caller->getParameterLocation(*DeclParamIdx, NumVisitedCaller);
         if (!TVR)
           return std::nullopt;
 

--- a/clang/lib/StaticAnalyzer/Core/ExprEngineCXX.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngineCXX.cpp
@@ -350,13 +350,8 @@ SVal ExprEngine::computeObjectUnderConstruction(
         // Operator arguments do not correspond to operator parameters
         // because this-argument is implemented as a normal argument in
         // operator call expressions but not in operator declarations.
-        std::optional<unsigned> DeclParamIdx =
-            Caller->getAdjustedParameterIndex(Idx);
-        if (!DeclParamIdx)
-          return std::nullopt;
-
-        const TypedValueRegion *TVR =
-            Caller->getParameterLocation(*DeclParamIdx, NumVisitedCaller);
+        const TypedValueRegion *TVR = Caller->getParameterLocation(
+            Caller->getAdjustedParameterIndex(Idx), NumVisitedCaller);
         if (!TVR)
           return std::nullopt;
 

--- a/clang/lib/StaticAnalyzer/Core/ExprEngineCXX.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngineCXX.cpp
@@ -351,7 +351,7 @@ SVal ExprEngine::computeObjectUnderConstruction(
         // because this-argument is implemented as a normal argument in
         // operator call expressions but not in operator declarations.
         const TypedValueRegion *TVR = Caller->getParameterLocation(
-            Caller->getAdjustedParameterIndex(Idx), NumVisitedCaller);
+            Caller->adjustASTArgIdxToDeclParamIdx(Idx), NumVisitedCaller);
         if (!TVR)
           return std::nullopt;
 


### PR DESCRIPTION
Currently the indices of `CallEvent`'s argument, its origin expression's argument and its callee's declared parameter are three different index spaces. Also the mapping between them was neither documented nor applied in every cases.

 - `ParamVarRegion::Index` is a declared parameter index (`ParamVarRegion::getDecl()`
   indexes `FunctionDecl::parameters()`, and the callee-side creator
   `MemRegionManager::getVarRegion()` uses `ParmVarDecl::getFunctionScopeIndex()`),
   but this was undocumented and `getDecl()` carried a
   `/// TODO: What does this return?`.
 - `addParameterValuesToBindings()` passed a CallEvent argument index straight
   into `getParamVarRegion()`. This happens to be correct today only because
   the two coincide for every existing CallEvent kind.
 - `castArgToParamTypeIfNeeded()` mixed both spaces in a single expression.

This PR introduces `CallEvent::getDeclaredParameterIndex()` to compose the two existing hooks: `declParamIdx(callIdx) == getAdjustedParameterIndex(getASTArgumentIndex(callIdx))`

Where the a declared parameter index is requried `getDeclaredParameterIndex()` can be used from now on. This identity holds for every `CallEvent` kind. `CXXStaticOperatorCall` and `CXXMemberOperatorCall`
are the only classes that override either hook, and composing their overrides
reproduces the raw argument index that the code passes today, so this PR is NFC.

In this PR I also split the body of `addParameterValuesToBindings()` into a helper that
binds one argument, and guard the unchecked `*getAdjustedParameterIndex()`
dereference in ExprEngineCXX.cpp.

This PR is the first part of follow up PRs that will model explicit object parameters as `CXXInstanceCalls` and differentiate between implicit and explicit object parameters.
