### PR TITLE
[CodeGen] Increase CCState::UsedRegs inline capacity (NFC)

### DIFF
--- a/llvm/include/llvm/CodeGen/CallingConvLower.h
+++ b/llvm/include/llvm/CodeGen/CallingConvLower.h
@@ -182,7 +182,7 @@ private:
 
   uint64_t StackSize;
   Align MaxStackArgAlign;
-  SmallVector<uint32_t, 16> UsedRegs;
+  SmallVector<uint32_t, 32> UsedRegs;
   SmallVector<CCValAssign, 4> PendingLocs;
   SmallVector<ISD::ArgFlagsTy, 4> PendingArgFlags;
 


### PR DESCRIPTION
CCState::UsedRegs holds one bit per target register. Its inline capacity of 16 x 32-bit words only covers 512 registers, causing heap allocations for AArch64 (895), RISCV (645), and PowerPC (612). Increase it to 32, covering up to 1024 registers and keeping the storage inline for these targets.

Assisted-by: codex