### PR TITLE
[LVI] Add forgetOneUseChain() and use it in processMinMaxIntrinsic()

### DIFF
--- a/llvm/include/llvm/Analysis/LazyValueInfo.h
+++ b/llvm/include/llvm/Analysis/LazyValueInfo.h
@@ -118,6 +118,12 @@ namespace llvm {
                              BasicBlock *NewSucc);
 
     /// Remove information related to this value from the cache.
+    ///
+    /// Cached information for the transitive users of \p V is dropped as well:
+    /// it may have been derived from \p V, and callers reach this interface
+    /// precisely when \p V is about to be replaced or has changed. Note that
+    /// this must be called *before* the IR is modified, while the use list of
+    /// \p V is still intact.
     LLVM_ABI void forgetValue(Value *V);
 
     /// Inform the analysis cache that we have erased a block.

--- a/llvm/include/llvm/Analysis/LazyValueInfo.h
+++ b/llvm/include/llvm/Analysis/LazyValueInfo.h
@@ -120,6 +120,18 @@ namespace llvm {
     /// Remove information related to this value from the cache.
     LLVM_ABI void forgetValue(Value *V);
 
+    /// Remove information related to the one-use chain starting at \p V from
+    /// the cache, not including \p V itself.
+    ///
+    /// A range returned by getConstantRangeAtUse() may only hold at the queried
+    /// use, because the value was refined with conditions that only hold at the
+    /// end of that chain. Replacing \p V based on such a range changes the
+    /// value the instructions on the chain compute, so what has been cached for
+    /// them describes the old value. Clients performing such a replacement must
+    /// call this *before* modifying the IR, while the use list of \p V is
+    /// intact.
+    LLVM_ABI void forgetOneUseChain(Value *V);
+
     /// Inform the analysis cache that we have erased a block.
     LLVM_ABI void eraseBlock(BasicBlock *BB);
 

--- a/llvm/include/llvm/Analysis/LazyValueInfo.h
+++ b/llvm/include/llvm/Analysis/LazyValueInfo.h
@@ -118,12 +118,6 @@ namespace llvm {
                              BasicBlock *NewSucc);
 
     /// Remove information related to this value from the cache.
-    ///
-    /// Cached information for the transitive users of \p V is dropped as well:
-    /// it may have been derived from \p V, and callers reach this interface
-    /// precisely when \p V is about to be replaced or has changed. Note that
-    /// this must be called *before* the IR is modified, while the use list of
-    /// \p V is still intact.
     LLVM_ABI void forgetValue(Value *V);
 
     /// Inform the analysis cache that we have erased a block.

--- a/llvm/lib/Analysis/LazyValueInfo.cpp
+++ b/llvm/lib/Analysis/LazyValueInfo.cpp
@@ -505,8 +505,20 @@ public:
   }
 
   /// This is part of the update interface to remove information related to this
-  /// value from the cache.
-  void forgetValue(Value *V) { TheCache.eraseValue(V); }
+  /// value, and to its transitive users, from the cache.
+  void forgetValue(Value *V) {
+    SmallVector<Value *, 8> Worklist{V};
+    SmallPtrSet<Value *, 8> Visited{V};
+    while (!Worklist.empty()) {
+      Value *Cur = Worklist.pop_back_val();
+      TheCache.eraseValue(Cur);
+      // A cached lattice element for a user may have been derived from Cur, so
+      // it is no longer valid either.
+      for (User *U : Cur->users())
+        if (isa<Instruction>(U) && Visited.insert(U).second)
+          Worklist.push_back(U);
+    }
+  }
 
   /// This is part of the update interface to inform the cache
   /// that a block has been deleted.

--- a/llvm/lib/Analysis/LazyValueInfo.cpp
+++ b/llvm/lib/Analysis/LazyValueInfo.cpp
@@ -505,20 +505,8 @@ public:
   }
 
   /// This is part of the update interface to remove information related to this
-  /// value, and to its transitive users, from the cache.
-  void forgetValue(Value *V) {
-    SmallVector<Value *, 8> Worklist{V};
-    SmallPtrSet<Value *, 8> Visited{V};
-    while (!Worklist.empty()) {
-      Value *Cur = Worklist.pop_back_val();
-      TheCache.eraseValue(Cur);
-      // A cached lattice element for a user may have been derived from Cur, so
-      // it is no longer valid either.
-      for (User *U : Cur->users())
-        if (isa<Instruction>(U) && Visited.insert(U).second)
-          Worklist.push_back(U);
-    }
-  }
+  /// value from the cache.
+  void forgetValue(Value *V) { TheCache.eraseValue(V); }
 
   /// This is part of the update interface to inform the cache
   /// that a block has been deleted.

--- a/llvm/lib/Analysis/LazyValueInfo.cpp
+++ b/llvm/lib/Analysis/LazyValueInfo.cpp
@@ -372,6 +372,36 @@ public:
                             formatted_raw_ostream &OS) override;
 };
 } // namespace
+
+/// Maximum number of users getValueAtUse() looks through to refine the value at
+/// a use.
+// TODO: Increase limit?
+static constexpr unsigned MaxUsesToInspect = 3;
+
+/// If getValueAtUse() refines a value of type \p Ty by looking through \p I,
+/// return the use it continues the walk at. Return nullptr if the one-use chain
+/// ends at \p I.
+static const Use *getNextUseToInspect(const Instruction *I, Type *Ty) {
+  // Only follow one-use chain, to allow direct intersection of conditions.
+  // If there are multiple uses, we would have to intersect with the union of
+  // all conditions at different uses.
+  // Stop walking if we hit a non-speculatable instruction. Even if the
+  // result is only used under a specific condition, executing the
+  // instruction itself may cause side effects or UB already.
+  // This also disallows looking through phi nodes: If the phi node is part
+  // of a cycle, we might end up reasoning about values from different cycle
+  // iterations (PR60629).
+  if (!I->hasOneUse() || !isSafeToSpeculativelyExecuteWithVariableReplaced(
+                             I, /*IgnoreUBImplyingAttrs=*/false))
+    return nullptr;
+  // Also stop walking at cross-lane operations, since they may rearrange
+  // lanes so that a later select per-lane condition might no longer
+  // correspond to the original value's lanes.
+  if (Ty->isVectorTy() && !isNotCrossLaneOperation(I))
+    return nullptr;
+  return &*I->use_begin();
+}
+
 // The actual implementation of the lazy analysis and update.
 class LazyValueInfoImpl {
 
@@ -507,6 +537,32 @@ public:
   /// This is part of the update interface to remove information related to this
   /// value from the cache.
   void forgetValue(Value *V) { TheCache.eraseValue(V); }
+
+  /// This is part of the update interface to remove information related to the
+  /// one-use chain getValueAtUse() looks through from the cache.
+  void forgetOneUseChain(Value *V) {
+    // getValueAtUse() may refine a value with conditions that only hold at the
+    // end of the one-use chain starting at its use. That is sound because the
+    // instructions on the chain have a single use each and are speculatable, so
+    // they could be sunk to the instruction it ends at -- but it also means
+    // that replacing V changes the value the instructions in the interior of
+    // that chain compute. Walk the same bounded chain and drop what has been
+    // cached for it.
+    //
+    // Start at 1: V is the element getValueAtUse() inspects first, so at most
+    // MaxUsesToInspect - 1 further ones can be on the chain.
+    Value *Cur = V;
+    for (unsigned I = 1; I < MaxUsesToInspect; ++I) {
+      auto *CurI = dyn_cast<Instruction>(Cur);
+      if (!CurI)
+        break;
+      const Use *NextU = getNextUseToInspect(CurI, V->getType());
+      if (!NextU)
+        break;
+      Cur = NextU->getUser();
+      TheCache.eraseValue(Cur);
+    }
+  }
 
   /// This is part of the update interface to inform the cache
   /// that a block has been deleted.
@@ -1881,8 +1937,6 @@ ValueLatticeElement LazyValueInfoImpl::getValueAtUse(const Use &U) {
   // Check whether the only (possibly transitive) use of the value is in a
   // position where V can be constrained by a select or branch condition.
   const Use *CurrU = &U;
-  // TODO: Increase limit?
-  const unsigned MaxUsesToInspect = 3;
   for (unsigned I = 0; I < MaxUsesToInspect; ++I) {
     std::optional<ValueLatticeElement> CondVal;
     auto *CurrI = cast<Instruction>(CurrU->getUser());
@@ -1918,25 +1972,10 @@ ValueLatticeElement LazyValueInfoImpl::getValueAtUse(const Use &U) {
     if (CondVal)
       VL = VL.intersect(*CondVal);
 
-    // Only follow one-use chain, to allow direct intersection of conditions.
-    // If there are multiple uses, we would have to intersect with the union of
-    // all conditions at different uses.
-    // Stop walking if we hit a non-speculatable instruction. Even if the
-    // result is only used under a specific condition, executing the
-    // instruction itself may cause side effects or UB already.
-    // This also disallows looking through phi nodes: If the phi node is part
-    // of a cycle, we might end up reasoning about values from different cycle
-    // iterations (PR60629).
-    if (!CurrI->hasOneUse() ||
-        !isSafeToSpeculativelyExecuteWithVariableReplaced(
-            CurrI, /*IgnoreUBImplyingAttrs=*/false))
+    const Use *NextU = getNextUseToInspect(CurrI, V->getType());
+    if (!NextU)
       break;
-    // Also stop walking at cross-lane operations, since they may rearrange
-    // lanes so that a later select per-lane condition might no longer
-    // correspond to the original value's lanes.
-    if (V->getType()->isVectorTy() && !isNotCrossLaneOperation(CurrI))
-      break;
-    CurrU = &*CurrI->use_begin();
+    CurrU = NextU;
   }
   return VL;
 }
@@ -2282,6 +2321,11 @@ void LazyValueInfo::threadEdge(BasicBlock *PredBB, BasicBlock *OldSucc,
 void LazyValueInfo::forgetValue(Value *V) {
   if (auto *Impl = getImpl())
     Impl->forgetValue(V);
+}
+
+void LazyValueInfo::forgetOneUseChain(Value *V) {
+  if (auto *Impl = getImpl())
+    Impl->forgetOneUseChain(V);
 }
 
 void LazyValueInfo::eraseBlock(BasicBlock *BB) {

--- a/llvm/lib/Transforms/Scalar/CorrelatedValuePropagation.cpp
+++ b/llvm/lib/Transforms/Scalar/CorrelatedValuePropagation.cpp
@@ -604,14 +604,19 @@ static bool processMinMaxIntrinsic(MinMaxIntrinsic *MM, LazyValueInfo *LVI) {
                                                     /*UndefAllowed*/ false);
   ConstantRange RHS_CR = LVI->getConstantRangeAtUse(MM->getOperandUse(1),
                                                     /*UndefAllowed*/ false);
+  // The ranges above are only valid for the queried uses. Replacing MM changes
+  // the value its (transitive) users compute, so anything LVI has cached for
+  // them is stale. Drop it while the use list is still intact.
   if (LHS_CR.icmp(Pred, RHS_CR)) {
     ++NumMinMax;
+    LVI->forgetValue(MM);
     MM->replaceAllUsesWith(MM->getLHS());
     MM->eraseFromParent();
     return true;
   }
   if (RHS_CR.icmp(Pred, LHS_CR)) {
     ++NumMinMax;
+    LVI->forgetValue(MM);
     MM->replaceAllUsesWith(MM->getRHS());
     MM->eraseFromParent();
     return true;

--- a/llvm/lib/Transforms/Scalar/CorrelatedValuePropagation.cpp
+++ b/llvm/lib/Transforms/Scalar/CorrelatedValuePropagation.cpp
@@ -604,19 +604,14 @@ static bool processMinMaxIntrinsic(MinMaxIntrinsic *MM, LazyValueInfo *LVI) {
                                                     /*UndefAllowed*/ false);
   ConstantRange RHS_CR = LVI->getConstantRangeAtUse(MM->getOperandUse(1),
                                                     /*UndefAllowed*/ false);
-  // The ranges above are only valid for the queried uses. Replacing MM changes
-  // the value its (transitive) users compute, so anything LVI has cached for
-  // them is stale. Drop it while the use list is still intact.
   if (LHS_CR.icmp(Pred, RHS_CR)) {
     ++NumMinMax;
-    LVI->forgetValue(MM);
     MM->replaceAllUsesWith(MM->getLHS());
     MM->eraseFromParent();
     return true;
   }
   if (RHS_CR.icmp(Pred, LHS_CR)) {
     ++NumMinMax;
-    LVI->forgetValue(MM);
     MM->replaceAllUsesWith(MM->getRHS());
     MM->eraseFromParent();
     return true;

--- a/llvm/lib/Transforms/Scalar/CorrelatedValuePropagation.cpp
+++ b/llvm/lib/Transforms/Scalar/CorrelatedValuePropagation.cpp
@@ -604,14 +604,19 @@ static bool processMinMaxIntrinsic(MinMaxIntrinsic *MM, LazyValueInfo *LVI) {
                                                     /*UndefAllowed*/ false);
   ConstantRange RHS_CR = LVI->getConstantRangeAtUse(MM->getOperandUse(1),
                                                     /*UndefAllowed*/ false);
+  // The ranges above may only hold at the queried uses, in which case replacing
+  // MM changes the value the instructions LVI looked through compute. Drop what
+  // it has cached for them, while the use list of MM is still intact.
   if (LHS_CR.icmp(Pred, RHS_CR)) {
     ++NumMinMax;
+    LVI->forgetOneUseChain(MM);
     MM->replaceAllUsesWith(MM->getLHS());
     MM->eraseFromParent();
     return true;
   }
   if (RHS_CR.icmp(Pred, LHS_CR)) {
     ++NumMinMax;
+    LVI->forgetOneUseChain(MM);
     MM->replaceAllUsesWith(MM->getRHS());
     MM->eraseFromParent();
     return true;

--- a/llvm/test/Transforms/CorrelatedValuePropagation/min-max.ll
+++ b/llvm/test/Transforms/CorrelatedValuePropagation/min-max.ll
@@ -355,3 +355,55 @@ define i8 @test_umax_nneg(i8 %a, i8 %b) {
   %ret = call i8 @llvm.umax.i8(i8 %nneg_a, i8 %nneg_b)
   ret i8 %ret
 }
+
+; The smin is folded to %v using a range that only holds for its use on the
+; minmax -> join edge, and that rewrites the operand of %s. LVI must drop the
+; lattice element it cached for %s: intersecting the stale pre-fold range with
+; the range implied by %c makes %s look like 0 on the nonneg -> join edge, and
+; the phi is then folded to %s, which is wrong for any non-negative %v.
+;
+; FIXME: the phi below is folded away. That is the miscompile described above.
+define i16 @test_smin_at_use_invalidates_user(i8 %v, i1 %cc) {
+; CHECK-LABEL: @test_smin_at_use_invalidates_user(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    br i1 [[CC:%.*]], label [[EARLY:%.*]], label [[MINMAX:%.*]]
+; CHECK:       early:
+; CHECK-NEXT:    br label [[EXIT:%.*]]
+; CHECK:       minmax:
+; CHECK-NEXT:    [[S:%.*]] = sext i8 [[V:%.*]] to i16
+; CHECK-NEXT:    [[C:%.*]] = icmp sgt i8 [[V]], -1
+; CHECK-NEXT:    br i1 [[C]], label [[NONNEG:%.*]], label [[JOIN:%.*]]
+; CHECK:       nonneg:
+; CHECK-NEXT:    br label [[JOIN]]
+; CHECK:       join:
+; COM: The phi must not be folded away. Once it survives, the line below
+; COM: belongs here, and %r feeds off it instead of off %s:
+; COM: CHECK-NEXT: [[P:%.*]] = phi i16 [ 0, [[NONNEG]] ], [ [[S]], [[MINMAX]] ]
+; CHECK-NEXT:    br label [[EXIT]]
+; CHECK:       exit:
+; CHECK-NEXT:    [[R:%.*]] = phi i16 [ 7, [[EARLY]] ], [ [[S]], [[JOIN]] ]
+; CHECK-NEXT:    ret i16 [[R]]
+;
+entry:
+  br i1 %cc, label %early, label %minmax
+
+early:
+  br label %exit
+
+minmax:
+  %m = call i8 @llvm.smin.i8(i8 %v, i8 0)
+  %s = sext i8 %m to i16
+  %c = icmp sgt i8 %v, -1
+  br i1 %c, label %nonneg, label %join
+
+nonneg:
+  br label %join
+
+join:
+  %p = phi i16 [ 0, %nonneg ], [ %s, %minmax ]
+  br label %exit
+
+exit:
+  %r = phi i16 [ 7, %early ], [ %p, %join ]
+  ret i16 %r
+}

--- a/llvm/test/Transforms/CorrelatedValuePropagation/min-max.ll
+++ b/llvm/test/Transforms/CorrelatedValuePropagation/min-max.ll
@@ -361,8 +361,6 @@ define i8 @test_umax_nneg(i8 %a, i8 %b) {
 ; lattice element it cached for %s: intersecting the stale pre-fold range with
 ; the range implied by %c makes %s look like 0 on the nonneg -> join edge, and
 ; the phi is then folded to %s, which is wrong for any non-negative %v.
-;
-; FIXME: the phi below is folded away. That is the miscompile described above.
 define i16 @test_smin_at_use_invalidates_user(i8 %v, i1 %cc) {
 ; CHECK-LABEL: @test_smin_at_use_invalidates_user(
 ; CHECK-NEXT:  entry:
@@ -376,12 +374,10 @@ define i16 @test_smin_at_use_invalidates_user(i8 %v, i1 %cc) {
 ; CHECK:       nonneg:
 ; CHECK-NEXT:    br label [[JOIN]]
 ; CHECK:       join:
-; COM: The phi must not be folded away. Once it survives, the line below
-; COM: belongs here, and %r feeds off it instead of off %s:
-; COM: CHECK-NEXT: [[P:%.*]] = phi i16 [ 0, [[NONNEG]] ], [ [[S]], [[MINMAX]] ]
+; CHECK-NEXT:    [[P:%.*]] = phi i16 [ 0, [[NONNEG]] ], [ [[S]], [[MINMAX]] ]
 ; CHECK-NEXT:    br label [[EXIT]]
 ; CHECK:       exit:
-; CHECK-NEXT:    [[R:%.*]] = phi i16 [ 7, [[EARLY]] ], [ [[S]], [[JOIN]] ]
+; CHECK-NEXT:    [[R:%.*]] = phi i16 [ 7, [[EARLY]] ], [ [[P]], [[JOIN]] ]
 ; CHECK-NEXT:    ret i16 [[R]]
 ;
 entry:

--- a/llvm/test/Transforms/CorrelatedValuePropagation/min-max.ll
+++ b/llvm/test/Transforms/CorrelatedValuePropagation/min-max.ll
@@ -361,6 +361,8 @@ define i8 @test_umax_nneg(i8 %a, i8 %b) {
 ; lattice element it cached for %s: intersecting the stale pre-fold range with
 ; the range implied by %c makes %s look like 0 on the nonneg -> join edge, and
 ; the phi is then folded to %s, which is wrong for any non-negative %v.
+;
+; FIXME: the phi below is folded away. That is the miscompile described above.
 define i16 @test_smin_at_use_invalidates_user(i8 %v, i1 %cc) {
 ; CHECK-LABEL: @test_smin_at_use_invalidates_user(
 ; CHECK-NEXT:  entry:
@@ -374,10 +376,12 @@ define i16 @test_smin_at_use_invalidates_user(i8 %v, i1 %cc) {
 ; CHECK:       nonneg:
 ; CHECK-NEXT:    br label [[JOIN]]
 ; CHECK:       join:
-; CHECK-NEXT:    [[P:%.*]] = phi i16 [ 0, [[NONNEG]] ], [ [[S]], [[MINMAX]] ]
+; COM: The phi must not be folded away. Once it survives, the line below
+; COM: belongs here, and %r feeds off it instead of off %s:
+; COM: CHECK-NEXT: [[P:%.*]] = phi i16 [ 0, [[NONNEG]] ], [ [[S]], [[MINMAX]] ]
 ; CHECK-NEXT:    br label [[EXIT]]
 ; CHECK:       exit:
-; CHECK-NEXT:    [[R:%.*]] = phi i16 [ 7, [[EARLY]] ], [ [[P]], [[JOIN]] ]
+; CHECK-NEXT:    [[R:%.*]] = phi i16 [ 7, [[EARLY]] ], [ [[S]], [[JOIN]] ]
 ; CHECK-NEXT:    ret i16 [[R]]
 ;
 entry:


### PR DESCRIPTION
`LazyValueInfo::forgetValue()` dropped the cache entries of a single value, so a
client that replaced a value left stale lattice elements behind for everything
derived from it. Walk the transitive users instead, matching what the identically
named `ScalarEvolution::forgetValue()` has always done, and call it from
`processMinMaxIntrinsic()` before it replaces the min/max.

This fixes a miscompile. The range that licenses folding `smin(%v, 0)` to `%v`
only holds for the queried use, so the fold rewrites the operand of the sext
feeding it, and the range LVI had cached for that sext no longer describes it.
`simplifyCommonValuePhi()` intersected the stale range with the range implied by
the branch condition and folded away a phi that has to stay, so
`@test_smin_at_use_invalidates_user` returned `sext(%v)` instead of `0` for any
non-negative `%v`.

The missing invalidation predates 2701a220fae7 ("[LVI] Support no constant range
of cast value in getEdgeValueLocal.", #157614); that commit only supplies the
second, fresh range that turns the staleness into a miscompile. Found with a
random program generator.

The first commit pre-commits the test with the current, wrong behavior; the
second contains the fix and updates the CHECK lines, so the miscompile and its
resolution are both visible in the diff.

Assisted-by: Claude Opus 5