### PR TITLE
Enable ClangIR Build By Default

### DIFF
--- a/clang/CMakeLists.txt
+++ b/clang/CMakeLists.txt
@@ -190,14 +190,12 @@ if(CLANG_ENABLE_LIBXML2)
   endif()
 endif()
 
+cmake_dependent_option(CLANG_ENABLE_CIR "Build ClangIR support into the compiler" ON "NOT CLANG_BUILT_STANDALONE" OFF)
+
 if(CLANG_ENABLE_CIR)
   if (CLANG_BUILT_STANDALONE)
     message(FATAL_ERROR
       "ClangIR is not yet supported in the standalone build.")
-  endif()
-  if (NOT "${LLVM_ENABLE_PROJECTS}" MATCHES "MLIR|mlir")
-    message(FATAL_ERROR
-      "Cannot build ClangIR without MLIR in LLVM_ENABLE_PROJECTS")
   endif()
 endif()
 

--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -837,6 +837,11 @@ The `alpha.cplusplus.UseAfterLifetimeEnd` checker was renamed to `alpha.core.Use
 
 #### Improvements
 
+### Clang IR Improvements
+
+- Clang IR has now been enabled in builds by default, and should work with most workloads. However this is still an experimental flag and a work-in-progress.
+
+
 ## Additional Information
 
 A wide variety of additional information is available on the [Clang web

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -201,6 +201,17 @@ if ("flang" IN_LIST LLVM_ENABLE_PROJECTS)
   endif ()
 endif()
 
+# Clang defaults to CLANG_ENABLE_CIR now, so we need to auto-add MLIR unless it
+# was explicitly disabled.
+if ("clang" IN_LIST LLVM_ENABLE_PROJECTS)
+  if (NOT DEFINED CLANG_ENABLE_CIR OR CLANG_ENABLE_CIR)
+    if (NOT "mlir" IN_LIST LLVM_ENABLE_PROJECTS)
+      message(STATUS "Enabling MLIR as a dependency of ClangIR")
+      list(APPEND LLVM_ENABLE_PROJECTS "mlir")
+    endif()
+  endif()
+endif()
+
 if ("lldb" IN_LIST LLVM_ENABLE_PROJECTS)
   if (NOT "clang" IN_LIST LLVM_ENABLE_PROJECTS)
     message(STATUS "Enabling clang as a dependency of lldb")


### PR DESCRIPTION
This is subject to an RFC:

https://discourse.llvm.org/t/rfc-enable-clangir-build-by-default/91730

This patch enables building ClangIR (and thus MLIR) by default in clang builds.  The project has hit a maturity level where we believe this is a good time to do it.  See the RFC for details.