### PR TITLE
[mlir][linalg] Check the strides and the dropped dims before vectorizing insert_slice

### DIFF
--- a/mlir/lib/Dialect/Linalg/Transforms/Vectorization.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/Vectorization.cpp
@@ -65,7 +65,9 @@ vectorizeConvolution(RewriterBase &rewriter, LinalgOp convOp,
 ///   * inferred from the static dims in the input and output tensors.
 /// Bails out if:
 ///   * vector sizes are not user-provided, and
-///   * at least one dim is dynamic (in both the input and output tensors).
+///   * at least one dim is dynamic (in both the input and output tensors),
+/// or if the strides are not 1, or if the source is not inserted into the
+/// most minor dims of the destination.
 ///
 /// Before:
 ///     !t_in_type = tensor<1x2x3xf32>
@@ -1990,6 +1992,20 @@ vectorizeInsertSliceOpPrecondition(tensor::InsertSliceOp sliceOp,
   if (!VectorType::isValidElementType(sourceType.getElementType()))
     return failure();
 
+  // The source is read in full and written at the slice offsets with a minor
+  // identity map. That only matches tensor.insert_slice when the strides are
+  // 1 and the source is inserted into the most minor dims of the destination,
+  // i.e. when any rank-reduced dims are the leading ones.
+  if (!sliceOp.hasUnitStride()) {
+    LDBG() << "Only unit strides are supported";
+    return failure();
+  }
+  int64_t rankDiff = sliceOp.getResultType().getRank() - sourceType.getRank();
+  if (sliceOp.getDroppedDims().find_last() >= rankDiff) {
+    LDBG() << "Only inserts into the most minor dims are supported";
+    return failure();
+  }
+
   // Get the pad value.
   // TransferReadOp (which is used to vectorize InsertSliceOp), requires a
   // scalar padding value. Note that:
@@ -3030,9 +3046,8 @@ vectorizeAsInsertSliceOp(RewriterBase &rewriter, tensor::InsertSliceOp sliceOp,
     } else if (!resultType.isDynamicDim(i)) {
       // Source shape is not statically known, but result shape is.
       // Vectorize with size of result shape. This may be larger than the
-      // source size.
-      // FIXME: Using rankDiff implies that the source tensor is inserted at
-      // the end of the destination tensor. However, that's not required.
+      // source size. The precondition guarantees that the source is inserted
+      // into the most minor dims of the result, so this is the matching dim.
       vecShape.push_back(resultType.getDimSize(rankDiff + i));
     } else {
       // Neither source nor result dim of padOp is static. Cannot vectorize

--- a/mlir/test/Dialect/Linalg/vectorization/insert-slice.mlir
+++ b/mlir/test/Dialect/Linalg/vectorization/insert-slice.mlir
@@ -222,3 +222,34 @@ func.func private @insert_slice_non_zero_offset_for_dyn_dim(%source: tensor<?x3x
     transform.yield
   }
  }
+
+// -----
+
+// The rank-reduced dim is the leading one, so the source maps onto the most
+// minor dims of the destination and the write is a plain transfer_write at
+// the slice offsets.
+
+func.func private @insert_slice_rank_reducing_leading_dim(%source: tensor<8x4xi32>, %init: tensor<2x8x4xi32>) -> tensor<2x8x4xi32> {
+  %c1 = arith.constant 1 : index
+  %res = tensor.insert_slice %source into %init[%c1, 0, 0] [1, 8, 4] [1, 1, 1] : tensor<8x4xi32> into tensor<2x8x4xi32>
+
+  return %res : tensor<2x8x4xi32>
+}
+
+// CHECK-LABEL:   func.func private @insert_slice_rank_reducing_leading_dim(
+// CHECK-SAME:      %[[SRC:.*]]: tensor<8x4xi32>,
+// CHECK-SAME:      %[[INIT:.*]]: tensor<2x8x4xi32>) -> tensor<2x8x4xi32> {
+// CHECK:           %[[C_1:.*]] = arith.constant 1 : index
+// CHECK:           %[[READ:.*]] = vector.transfer_read %[[SRC]]{{.*}} : tensor<8x4xi32>, vector<8x4xi32>
+// CHECK:           %[[C_0:.*]] = arith.constant 0 : index
+// CHECK:           %[[C_0_1:.*]] = arith.constant 0 : index
+// CHECK:           %[[RES:.*]] = vector.transfer_write %[[READ]], %[[INIT]][%[[C_1]], %[[C_0]], %[[C_0_1]]] {in_bounds = [true, true]} : vector<8x4xi32>, tensor<2x8x4xi32>
+// CHECK:           return %[[RES]] : tensor<2x8x4xi32>
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
+    %0 = transform.structured.match ops{["tensor.insert_slice"]} in %arg0 : (!transform.any_op) -> !transform.any_op
+    transform.structured.vectorize %0 : !transform.any_op
+    transform.yield
+  }
+}

--- a/mlir/test/Dialect/Linalg/vectorization/unsupported.mlir
+++ b/mlir/test/Dialect/Linalg/vectorization/unsupported.mlir
@@ -411,3 +411,41 @@ module attributes {transform.with_named_sequence} {
     transform.yield
   }
 }
+
+// -----
+
+// A stride of 3 along the first dim cannot be expressed by the
+// vector.transfer_write that the insert is vectorized to.
+
+func.func @insert_slice_non_unit_stride(%src: tensor<2x4xf32>, %dest: tensor<8x4xf32>) -> tensor<8x4xf32> {
+  // expected-error @+1 {{Attempted to vectorize, but failed}}
+  %res = tensor.insert_slice %src into %dest[0, 0] [2, 4] [3, 1] : tensor<2x4xf32> into tensor<8x4xf32>
+  return %res : tensor<8x4xf32>
+}
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
+    %0 = transform.structured.match ops{["tensor.insert_slice"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    transform.structured.vectorize %0 : !transform.any_op
+    transform.yield
+  }
+}
+
+// -----
+
+// The rank-reduced dim is the middle one, so the source does not map onto the
+// most minor dims of the destination.
+
+func.func @insert_slice_rank_reducing_non_minor_dim(%src: tensor<8x4xf32>, %dest: tensor<8x1x4xf32>) -> tensor<8x1x4xf32> {
+  // expected-error @+1 {{Attempted to vectorize, but failed}}
+  %res = tensor.insert_slice %src into %dest[0, 0, 0] [8, 1, 4] [1, 1, 1] : tensor<8x4xf32> into tensor<8x1x4xf32>
+  return %res : tensor<8x1x4xf32>
+}
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
+    %0 = transform.structured.match ops{["tensor.insert_slice"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    transform.structured.vectorize %0 : !transform.any_op
+    transform.yield
+  }
+}


### PR DESCRIPTION
`vectorizeAsInsertSliceOp` reads the whole source and writes it back with
a minor identity map at the slice offsets, but its precondition never
looks at the strides or at which dims a rank-reducing insert drops. The
`vector.transfer_write` it produces then stores the source somewhere else
than the `tensor.insert_slice` did:

```mlir
// Rows 0 and 1 of %dst instead of rows 0 and 3.
tensor.insert_slice %src into %dst[0, 0] [2, 4] [3, 1] : tensor<2x4xf32> into tensor<8x4xf32>

// A vector<8x4xf32> along dims 1 and 2 of %dst with in_bounds = [false, true],
// so only row 0 of %src is kept.
tensor.insert_slice %src into %dst[0, 0, 0] [8, 1, 4] [1, 1, 1] : tensor<8x4xf32> into tensor<8x1x4xf32>
```

`PadOpVectorizationWithInsertSlicePattern` rejects both shapes. Do the
same in the precondition: bail unless the strides are 1 and the dropped
dims of a rank-reducing insert are the leading ones, which is the case the
existing tests cover and the case the FIXME on the vector shape
computation assumes.

Tests: the two shapes above in `unsupported.mlir`, plus a rank-reducing
insert that drops the leading dim in `insert-slice.mlir` to pin down that
it still vectorizes.
