### PR TITLE
[flang][openmp] Add missing REQUIRES line for -triple amdgcn-amd-amdhsa

### DIFF
--- a/flang/test/Lower/OpenMP/target-update-derived-type.f90
+++ b/flang/test/Lower/OpenMP/target-update-derived-type.f90
@@ -4,6 +4,8 @@
 ! RUN: %flang_fc1 -emit-hlfir -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa,nvptx64-nvidia-cuda %s -o - | FileCheck %s --check-prefix=MIXED
 ! RUN: %flang_fc1 -triple amdgcn-amd-amdhsa -emit-hlfir -fopenmp -fopenmp-is-target-device %s -o - | FileCheck %s --check-prefix=DEVICE
 
+!REQUIRES: amdgpu-registered-target
+
 module target_update_derived_type
   type :: wavefun
     real(8) :: ferwe


### PR DESCRIPTION
This fails on build without amd target

```
 error: unable to create target: 'No available targets are compatible with triple "amdgcn-amd-amdhsa"'
```