### PR TITLE
[mlir][bufferization] Expose checkPreBufferizationAssumptions helper

### DIFF
--- a/mlir/include/mlir/Dialect/Bufferization/Transforms/OneShotAnalysis.h
+++ b/mlir/include/mlir/Dialect/Bufferization/Transforms/OneShotAnalysis.h
@@ -272,6 +272,12 @@ private:
   DenseMap<TypeID, std::unique_ptr<Extension>> extensions;
 };
 
+/// Perform various checks on the input IR to see if it contains IR constructs
+/// that are unsupported by One-Shot Bufferize.
+LogicalResult checkPreBufferizationAssumptions(Operation *op,
+                                               const DominanceInfo &domInfo,
+                                               OneShotAnalysisState &state);
+
 /// Analyze `op` and its nested ops. Bufferization decisions are stored in
 /// `state`.
 LogicalResult analyzeOp(Operation *op, OneShotAnalysisState &state,

--- a/mlir/lib/Dialect/Bufferization/Transforms/OneShotAnalysis.cpp
+++ b/mlir/lib/Dialect/Bufferization/Transforms/OneShotAnalysis.cpp
@@ -1185,11 +1185,8 @@ LogicalResult OneShotAnalysisState::analyzeOp(Operation *op,
   return success();
 }
 
-/// Perform various checks on the input IR to see if it contains IR constructs
-/// that are unsupported by One-Shot Bufferize.
-static LogicalResult
-checkPreBufferizationAssumptions(Operation *op, const DominanceInfo &domInfo,
-                                 OneShotAnalysisState &state) {
+LogicalResult bufferization::checkPreBufferizationAssumptions(
+    Operation *op, const DominanceInfo &domInfo, OneShotAnalysisState &state) {
   const BufferizationOptions &options = state.getOptions();
 
   // Note: This walk cannot be combined with the one below because interface


### PR DESCRIPTION
Downstream users of bufferization may want to run this check without invoking the entire one-shot module analysis. If the check is not run and invalid IR is encountered, OneShotBufferize tends to crash rather than emitting a nice error message.

This patch simply exposes `checkPreBufferizationAssumptions` to the header file so it is accessible to other users.