### PR TITLE
[clang][Sema] Use DenseMap for SpecialMemberCache (NFC)

### DIFF
--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -9348,16 +9348,12 @@ public:
     void setKind(Kind K) { Pair.setInt(K); }
   };
 
-  class SpecialMemberOverloadResultEntry : public llvm::FastFoldingSetNode,
-                                           public SpecialMemberOverloadResult {
-  public:
-    SpecialMemberOverloadResultEntry(const llvm::FoldingSetNodeID &ID)
-        : FastFoldingSetNode(ID) {}
-  };
+  using SpecialMemberCacheKey = std::pair<const CXXRecordDecl *, unsigned>;
 
   /// A cache of special member function overload resolution results
   /// for C++ records.
-  llvm::FoldingSet<SpecialMemberOverloadResultEntry> SpecialMemberCache;
+  llvm::DenseMap<SpecialMemberCacheKey, SpecialMemberOverloadResult>
+      SpecialMemberCache;
 
   enum class AcceptableKind { Visible, Reachable };
 

--- a/clang/lib/Sema/SemaLookup.cpp
+++ b/clang/lib/Sema/SemaLookup.cpp
@@ -3383,6 +3383,19 @@ void Sema::LookupOverloadedOperatorName(OverloadedOperatorKind Op, Scope *S,
   Functions.append(Operators.begin(), Operators.end());
 }
 
+static Sema::SpecialMemberCacheKey
+makeSpecialMemberCacheKey(const CXXRecordDecl *RD, CXXSpecialMemberKind SM,
+                          bool ConstArg, bool VolatileArg, bool RValueThis,
+                          bool ConstThis, bool VolatileThis) {
+  unsigned Flags = llvm::to_underlying(SM) << 5;
+  Flags |= ConstArg << 4;
+  Flags |= VolatileArg << 3;
+  Flags |= RValueThis << 2;
+  Flags |= ConstThis << 1;
+  Flags |= VolatileThis;
+  return {RD, Flags};
+}
+
 Sema::SpecialMemberOverloadResult
 Sema::LookupSpecialMember(CXXRecordDecl *RD, CXXSpecialMemberKind SM,
                           bool ConstArg, bool VolatileArg, bool RValueThis,
@@ -3402,27 +3415,14 @@ Sema::LookupSpecialMember(CXXRecordDecl *RD, CXXSpecialMemberKind SM,
   // FIXME: Get the caller to pass in a location for the lookup.
   SourceLocation LookupLoc = RD->getLocation();
 
-  llvm::FoldingSetNodeID ID;
-  ID.AddPointer(RD);
-  ID.AddInteger(llvm::to_underlying(SM));
-  ID.AddInteger(ConstArg);
-  ID.AddInteger(VolatileArg);
-  ID.AddInteger(RValueThis);
-  ID.AddInteger(ConstThis);
-  ID.AddInteger(VolatileThis);
+  SpecialMemberCacheKey Key = makeSpecialMemberCacheKey(
+      RD, SM, ConstArg, VolatileArg, RValueThis, ConstThis, VolatileThis);
 
-  llvm::FoldingSetInsertToken Token;
-  SpecialMemberOverloadResultEntry *Result =
-      SpecialMemberCache.lookup(ID, Token);
+  auto [It, Inserted] = SpecialMemberCache.try_emplace(Key);
+  if (!Inserted)
+    return It->second;
 
-  // This was already cached
-  if (Result)
-    return *Result;
-
-  Result = BumpAlloc.Allocate<SpecialMemberOverloadResultEntry>();
-  Result = new (Result) SpecialMemberOverloadResultEntry(ID);
-  SpecialMemberCache.insert(Result, Token);
-
+  SpecialMemberOverloadResult Result;
   if (SM == CXXSpecialMemberKind::Destructor) {
     if (RD->needsImplicitDestructor()) {
       runWithSufficientStackSpace(RD->getLocation(), [&] {
@@ -3430,11 +3430,11 @@ Sema::LookupSpecialMember(CXXRecordDecl *RD, CXXSpecialMemberKind SM,
       });
     }
     CXXDestructorDecl *DD = RD->getDestructor();
-    Result->setMethod(DD);
-    Result->setKind(DD && !DD->isDeleted()
-                        ? SpecialMemberOverloadResult::Success
-                        : SpecialMemberOverloadResult::NoMemberOrDeleted);
-    return *Result;
+    Result.setMethod(DD);
+    Result.setKind(DD && !DD->isDeleted()
+                       ? SpecialMemberOverloadResult::Success
+                       : SpecialMemberOverloadResult::NoMemberOrDeleted);
+    return SpecialMemberCache[Key] = Result;
   }
 
   // Prepare for overload resolution. Here we construct a synthetic argument
@@ -3532,9 +3532,9 @@ Sema::LookupSpecialMember(CXXRecordDecl *RD, CXXSpecialMemberKind SM,
     // destructor.
     assert(SM == CXXSpecialMemberKind::DefaultConstructor &&
            "lookup for a constructor or assignment operator was empty");
-    Result->setMethod(nullptr);
-    Result->setKind(SpecialMemberOverloadResult::NoMemberOrDeleted);
-    return *Result;
+    Result.setMethod(nullptr);
+    Result.setKind(SpecialMemberOverloadResult::NoMemberOrDeleted);
+    return SpecialMemberCache[Key] = Result;
   }
 
   // Copy the candidates as our processing of them may load new declarations
@@ -3582,27 +3582,27 @@ Sema::LookupSpecialMember(CXXRecordDecl *RD, CXXSpecialMemberKind SM,
   OverloadCandidateSet::iterator Best;
   switch (OCS.BestViableFunction(*this, LookupLoc, Best)) {
     case OR_Success:
-      Result->setMethod(cast<CXXMethodDecl>(Best->Function));
-      Result->setKind(SpecialMemberOverloadResult::Success);
+      Result.setMethod(cast<CXXMethodDecl>(Best->Function));
+      Result.setKind(SpecialMemberOverloadResult::Success);
       break;
 
     case OR_Deleted:
-      Result->setMethod(cast<CXXMethodDecl>(Best->Function));
-      Result->setKind(SpecialMemberOverloadResult::NoMemberOrDeleted);
+      Result.setMethod(cast<CXXMethodDecl>(Best->Function));
+      Result.setKind(SpecialMemberOverloadResult::NoMemberOrDeleted);
       break;
 
     case OR_Ambiguous:
-      Result->setMethod(nullptr);
-      Result->setKind(SpecialMemberOverloadResult::Ambiguous);
+      Result.setMethod(nullptr);
+      Result.setKind(SpecialMemberOverloadResult::Ambiguous);
       break;
 
     case OR_No_Viable_Function:
-      Result->setMethod(nullptr);
-      Result->setKind(SpecialMemberOverloadResult::NoMemberOrDeleted);
+      Result.setMethod(nullptr);
+      Result.setKind(SpecialMemberOverloadResult::NoMemberOrDeleted);
       break;
   }
 
-  return *Result;
+  return SpecialMemberCache[Key] = Result;
 }
 
 CXXConstructorDecl *Sema::LookupDefaultConstructor(CXXRecordDecl *Class) {

--- a/llvm/include/llvm/ADT/FoldingSet.h
+++ b/llvm/include/llvm/ADT/FoldingSet.h
@@ -754,22 +754,6 @@ private:
 };
 
 //===----------------------------------------------------------------------===//
-/// This is a subclass of FoldingSetNode which stores a FoldingSetNodeID value
-/// rather than requiring the node to recompute it each time it is needed. This
-/// trades space for speed (which can be significant if the ID is long), and it
-/// also permits nodes to drop information that would otherwise only be required
-/// for recomputing an ID.
-class FastFoldingSetNode : public FoldingSetNode {
-  FoldingSetNodeID FastID;
-
-protected:
-  explicit FastFoldingSetNode(const FoldingSetNodeID &ID) : FastID(ID) {}
-
-public:
-  void Profile(FoldingSetNodeID &ID) const { ID.AddNodeID(FastID); }
-};
-
-//===----------------------------------------------------------------------===//
 // Partial specializations of FoldingSetTrait.
 
 template <typename T> struct FoldingSetTrait<T *> {


### PR DESCRIPTION
This patch replaces llvm::FoldingSet with llvm::DenseMap for
SpecialMemberCache in Sema.

SpecialMemberCache is fundamentally a key-value cache that maps a class
and qualification flags to a SpecialMemberOverloadResult.  The current
implementation is heavy because each entry in FoldingSet requires a
160-byte SpecialMemberOverloadResultEntry on the bump allocator arena.

LookupSpecialMember returns SpecialMemberOverloadResult by value.  As
such, there is no need to use the bump allocator for pointer stability.

This patch also removes FastFoldingSetNode as we are removing the last
use.

Assisted-by: Antigravity
