### PR TITLE
[flang] Add flag to exclude string literal in isCompilerGenerated

### DIFF
--- a/flang/include/flang/Optimizer/Support/InternalNames.h
+++ b/flang/include/flang/Optimizer/Support/InternalNames.h
@@ -196,7 +196,10 @@ struct NameUniquer {
   static bool isSpecialSymbol(llvm::StringRef name);
 
   /// Returns true if the passed name denotes a compiler generated name.
-  static bool isCompilerGenerated(llvm::StringRef name);
+  /// If \p excludeStringLiterals is true, string literals are excluded from the
+  /// check.
+  static bool isCompilerGenerated(llvm::StringRef name,
+                                  bool excludeStringLiterals = true);
 
 private:
   static std::string intAsString(std::int64_t i);

--- a/flang/lib/Optimizer/Support/InternalNames.cpp
+++ b/flang/lib/Optimizer/Support/InternalNames.cpp
@@ -441,7 +441,8 @@ bool fir::NameUniquer::isSpecialSymbol(llvm::StringRef name) {
   return !name.empty() && (name[0] == '.' || name[0] == 'X');
 }
 
-bool fir::NameUniquer::isCompilerGenerated(llvm::StringRef name) {
+bool fir::NameUniquer::isCompilerGenerated(llvm::StringRef name,
+                                           bool excludeStringLiterals) {
   auto [nameKind, deconstructed] = fir::NameUniquer::deconstruct(name);
 
   // Names that are not mangled by flang belong to the user (e.g. BIND(C)
@@ -449,10 +450,13 @@ bool fir::NameUniquer::isCompilerGenerated(llvm::StringRef name) {
   if (nameKind == fir::NameUniquer::NameKind::NOT_UNIQUED)
     return false;
 
-  // Anything in the compiler-generated namespace (_QQ...): string literals,
-  // read-only array constants, runtime tables, etc.
-  if (nameKind == fir::NameUniquer::NameKind::GENERATED)
+  // Anything in the compiler-generated namespace (_QQ...): read-only array
+  // constants, runtime tables, etc.
+  if (nameKind == fir::NameUniquer::NameKind::GENERATED) {
+    if (excludeStringLiterals && name.starts_with("_QQcl"))
+      return false;
     return true;
+  }
 
   // Runtime type information is mangled as ordinary variables whose parse name
   // starts with one of the separator markers, e.g. _QMmod1E.dt.struct or

--- a/flang/unittests/Optimizer/InternalNamesTest.cpp
+++ b/flang/unittests/Optimizer/InternalNamesTest.cpp
@@ -295,6 +295,12 @@ TEST(InternalNamesTest, isCompilerGenerated) {
   ASSERT_FALSE(NameUniquer::isCompilerGenerated("_QMmod1Emytype"));
   ASSERT_FALSE(NameUniquer::isCompilerGenerated("_QMmod1EmytypeK4KN6"));
   ASSERT_FALSE(NameUniquer::isCompilerGenerated("_QMmod1EmytypeK4KN6"));
+  // Test for string literals
+  ASSERT_FALSE(NameUniquer::isCompilerGenerated(
+      "_QQcl.2E2F6669725F7064745F6578616D706C652E66393000"));
+  ASSERT_TRUE(NameUniquer::isCompilerGenerated(
+      "_QQcl.2E2F6669725F7064745F6578616D706C652E66393000",
+      /*excludeStringLiterals=*/false));
 }
 
 // main() from gtest_main


### PR DESCRIPTION
Add a flag to exclude string literals read-array constant from isCompilerGenerated. On by default. 