### PR TITLE
[mlir][VectorToSCF] Decline transfer ops masked by vector.mask

### DIFF
--- a/mlir/lib/Conversion/VectorToSCF/VectorToSCF.cpp
+++ b/mlir/lib/Conversion/VectorToSCF/VectorToSCF.cpp
@@ -553,6 +553,9 @@ static LogicalResult checkPrepareXferOp(OpTy xferOp, PatternRewriter &rewriter,
   if (xferOp->hasAttr(kPassLabel))
     return rewriter.notifyMatchFailure(
         xferOp, "kPassLabel is present (vector-to-scf lowering in progress)");
+  if (xferOp.isMasked())
+    return rewriter.notifyMatchFailure(
+        xferOp, "masked by vector.mask, lower the mask first");
   if (xferOp.getVectorType().getRank() <= options.targetRank)
     return rewriter.notifyMatchFailure(
         xferOp, "xferOp vector rank <= transformation target rank");
@@ -1078,6 +1081,9 @@ struct ScalableTransposeTransferWriteConversion
                                 PatternRewriter &rewriter) const override {
     if (failed(checkLowerTensors(writeOp, rewriter)))
       return failure();
+    if (writeOp.isMasked())
+      return rewriter.notifyMatchFailure(
+          writeOp, "masked by vector.mask, lower the mask first");
 
     VectorType vectorType = writeOp.getVectorType();
 
@@ -1304,6 +1310,9 @@ struct UnrollTransferReadConversion
           xferOp, "vector rank is less or equal to target rank");
     if (failed(checkLowerTensors(xferOp, rewriter)))
       return failure();
+    if (xferOp.isMasked())
+      return rewriter.notifyMatchFailure(
+          xferOp, "masked by vector.mask, lower the mask first");
     if (xferOp.getVectorType().getElementType() !=
         xferOp.getShapedType().getElementType())
       return rewriter.notifyMatchFailure(
@@ -1450,6 +1459,9 @@ struct UnrollTransferWriteConversion
 
     if (failed(checkLowerTensors(xferOp, rewriter)))
       return failure();
+    if (xferOp.isMasked())
+      return rewriter.notifyMatchFailure(
+          xferOp, "masked by vector.mask, lower the mask first");
     // Transfer ops that modify the element type are not supported atm.
     if (inputVectorTy.getElementType() !=
         xferOp.getShapedType().getElementType())
@@ -1660,6 +1672,9 @@ struct TransferOp1dConversion : public VectorToSCFPattern<OpTy> {
     // TODO: support 0-d corner case.
     if (xferOp.getTransferRank() == 0)
       return failure();
+    if (xferOp.isMasked())
+      return rewriter.notifyMatchFailure(
+          xferOp, "masked by vector.mask, lower the mask first");
     auto map = xferOp.getPermutationMap();
     auto memRefType = dyn_cast<MemRefType>(xferOp.getShapedType());
 

--- a/mlir/test/Conversion/VectorToSCF/vector-to-scf.mlir
+++ b/mlir/test/Conversion/VectorToSCF/vector-to-scf.mlir
@@ -923,3 +923,75 @@ func.func private @transfer_write_no_alloc_scope()
 %cst = arith.constant dense<0.0> : vector<2x3xf32>
 %m = memref.alloc() : memref<2x3xf32>
 vector.transfer_write %cst, %m[%c0, %c0] : vector<2x3xf32>, memref<2x3xf32>
+
+// -----
+
+// Negative tests: a transfer op inside `vector.mask` is left alone, since the
+// mask region can only hold that one op. The mask has to be lowered first.
+
+// CHECK-LABEL: @masked_transfer_read
+// CHECK:       vector.mask %{{.*}} { vector.transfer_read
+// CHECK-NOT:   scf.for
+// FULL-UNROLL-LABEL: @masked_transfer_read
+// FULL-UNROLL:       vector.mask %{{.*}} { vector.transfer_read
+// FULL-UNROLL-NOT:   vector.extract
+// TARGET-RANK-ZERO-LABEL: @masked_transfer_read
+// TARGET-RANK-ZERO:       vector.mask %{{.*}} { vector.transfer_read
+// TARGET-RANK-ZERO-NOT:   vector.extract
+func.func @masked_transfer_read(%mem: memref<?x?xf32>, %mask: vector<4x8xi1>) -> vector<4x8xf32> {
+  %c0 = arith.constant 0 : index
+  %pad = arith.constant 0.0 : f32
+  %0 = vector.mask %mask { vector.transfer_read %mem[%c0, %c0], %pad : memref<?x?xf32>, vector<4x8xf32> } : vector<4x8xi1> -> vector<4x8xf32>
+  return %0 : vector<4x8xf32>
+}
+
+// -----
+
+// CHECK-LABEL: @masked_transfer_write
+// CHECK:       vector.mask %{{.*}} { vector.transfer_write
+// CHECK-NOT:   scf.for
+// FULL-UNROLL-LABEL: @masked_transfer_write
+// FULL-UNROLL:       vector.mask %{{.*}} { vector.transfer_write
+// FULL-UNROLL-NOT:   vector.extract
+// TARGET-RANK-ZERO-LABEL: @masked_transfer_write
+// TARGET-RANK-ZERO:       vector.mask %{{.*}} { vector.transfer_write
+// TARGET-RANK-ZERO-NOT:   vector.extract
+func.func @masked_transfer_write(%vec: vector<4x8xf32>, %mem: memref<?x?xf32>, %mask: vector<4x8xi1>) {
+  %c0 = arith.constant 0 : index
+  vector.mask %mask { vector.transfer_write %vec, %mem[%c0, %c0] : vector<4x8xf32>, memref<?x?xf32> } : vector<4x8xi1>
+  return
+}
+
+// -----
+
+// CHECK-LABEL: @masked_transfer_read_1d_strided
+// CHECK:       vector.mask %{{.*}} { vector.transfer_read
+// CHECK-NOT:   scf.for
+// FULL-UNROLL-LABEL: @masked_transfer_read_1d_strided
+// FULL-UNROLL:       vector.mask %{{.*}} { vector.transfer_read
+// FULL-UNROLL-NOT:   scf.for
+// TARGET-RANK-ZERO-LABEL: @masked_transfer_read_1d_strided
+// TARGET-RANK-ZERO:       vector.mask %{{.*}} { vector.transfer_read
+// TARGET-RANK-ZERO-NOT:   scf.for
+func.func @masked_transfer_read_1d_strided(%mem: memref<?x?xf32>, %mask: vector<8xi1>) -> vector<8xf32> {
+  %c0 = arith.constant 0 : index
+  %pad = arith.constant 0.0 : f32
+  %0 = vector.mask %mask { vector.transfer_read %mem[%c0, %c0], %pad {permutation_map = affine_map<(d0, d1) -> (d0)>} : memref<?x?xf32>, vector<8xf32> } : vector<8xi1> -> vector<8xf32>
+  return %0 : vector<8xf32>
+}
+
+// -----
+
+// CHECK-LABEL: @masked_scalable_transpose_store
+// CHECK:       vector.mask %{{.*}} { vector.transfer_write
+// CHECK-NOT:   scf.for
+// FULL-UNROLL-LABEL: @masked_scalable_transpose_store
+// FULL-UNROLL:       vector.mask %{{.*}} { vector.transfer_write
+// FULL-UNROLL-NOT:   scf.for
+func.func @masked_scalable_transpose_store(%vec: vector<[4]x4xf32>, %mem: memref<?x?xf32>, %a: index, %b: index) {
+  %c0 = arith.constant 0 : index
+  %transpose = vector.transpose %vec, [1, 0] : vector<[4]x4xf32> to vector<4x[4]xf32>
+  %mask = vector.create_mask %a, %b : vector<4x[4]xi1>
+  vector.mask %mask { vector.transfer_write %transpose, %mem[%c0, %c0] : vector<4x[4]xf32>, memref<?x?xf32> } : vector<4x[4]xi1>
+  return
+}


### PR DESCRIPTION
The transfer op patterns in `convert-vector-to-scf` unpack a
`vector.transfer_read`/`vector.transfer_write` into a loop, a buffer and
lower-rank transfer ops, but never check whether the op sits inside a
`vector.mask`. In that case all of it lands in the mask region and the
pass fails:

```mlir
func.func @w(%v: vector<4x8xf32>, %m: vector<4x8xi1>, %mem: memref<?x?xf32>) {
  %c0 = arith.constant 0 : index
  vector.mask %m { vector.transfer_write %v, %mem[%c0, %c0] : vector<4x8xf32>, memref<?x?xf32> } : vector<4x8xi1>
  return
}
```

```
error: 'vector.mask' op expects only one operation to mask
```

The unrolled, 1-D and scalable-transpose paths do the same, and the
transfer ops they emit carry no mask at all, since `getMask()` only sees
the mask operand. This declines masked transfer ops in every pattern;
`-lower-vector-mask` turns the `vector.mask` into a mask operand, which
the patterns already handle, and that is the order the in-tree
integration tests use.

Tests: four negative cases, labelled with the pattern each one targets:
the progressive/unrolled read and write patterns, `TransferOp1dConversion`
and `ScalableTransposeTransferWriteConversion`.

AI tool use: I worked on this patch together with an AI assistant (Claude Code).
Every line of the change and the tests was reviewed and verified by me, and I am
accountable for it.

Assisted-by: Claude Code
