### PR TITLE
[mlir][AMDGPU] Keep alignment when lowering masked loads and stores

### DIFF
--- a/mlir/lib/Dialect/AMDGPU/Transforms/MaskedloadToLoad.cpp
+++ b/mlir/lib/Dialect/AMDGPU/Transforms/MaskedloadToLoad.cpp
@@ -54,7 +54,8 @@ static Value createVectorLoadForMaskedLoad(OpBuilder &builder, Location loc,
                                            bool passthru) {
   VectorType vectorType = maskedOp.getVectorType();
   Value load = vector::LoadOp::create(
-      builder, loc, vectorType, maskedOp.getBase(), maskedOp.getIndices());
+      builder, loc, vectorType, maskedOp.getBase(), maskedOp.getIndices(),
+      /*nontemporal=*/false, maskedOp.getMaybeAlign());
   if (passthru)
     load = arith::SelectOp::create(builder, loc, vectorType, maskedOp.getMask(),
                                    load, maskedOp.getPassThru());
@@ -225,7 +226,8 @@ struct FullMaskedStoreToConditionalStore
 
     auto trueBuilder = [&](OpBuilder &builder, Location loc) {
       vector::StoreOp::create(rewriter, loc, storeOp.getValueToStore(),
-                              storeOp.getBase(), storeOp.getIndices());
+                              storeOp.getBase(), storeOp.getIndices(),
+                              /*nontemporal=*/false, storeOp.getMaybeAlign());
       scf::YieldOp::create(rewriter, loc);
     };
     auto ifOp =

--- a/mlir/test/Dialect/AMDGPU/maskedload-to-load.mlir
+++ b/mlir/test/Dialect/AMDGPU/maskedload-to-load.mlir
@@ -167,3 +167,47 @@ func.func @full_mask_maskedstore_to_store(%arg0: memref<8x8xf16>, %arg1: index, 
 // CHECK-NOT: vector.maskedstore
 // CHECK: scf.if %[[PRED]]
 // CHECK:   vector.store
+
+// -----
+
+// CHECK-LABEL: func @maskedload_fatrawbuffer_alignment(
+// CHECK-SAME: %[[ARG0:.*]]: memref<8x8xf32, #amdgpu.address_space<fat_raw_buffer>>
+// CHECK-SAME: %[[ARG1:.*]]: index
+// CHECK-SAME: %[[ARG2:.*]]: vector<4xi1>
+// CHECK-SAME: %[[ARG3:.*]]: vector<4xf32>
+func.func @maskedload_fatrawbuffer_alignment(%mem : memref<8x8xf32, #amdgpu.address_space<fat_raw_buffer>>, %idx : index, %mask : vector<4xi1>, %passthru : vector<4xf32>) -> vector<4xf32> {
+  %res = vector.maskedload %mem[%idx, %idx], %mask, %passthru alignment = 16 : memref<8x8xf32, #amdgpu.address_space<fat_raw_buffer>>, vector<4xi1>, vector<4xf32> into vector<4xf32>
+  return %res : vector<4xf32>
+}
+// CHECK: scf.if
+// CHECK: vector.maskedload %[[ARG0]][%[[ARG1]], %[[ARG1]]], %[[ARG2]], %[[ARG3]] alignment = 16
+// CHECK: } else {
+// CHECK: vector.load %[[ARG0]][%[[ARG1]], %[[ARG1]]] alignment = 16
+
+// -----
+
+// CHECK-LABEL: func.func @full_select_maskedload_to_load_alignment
+// CHECK-SAME: %[[MEM:.+]]: memref<8x8xf16>,
+// CHECK-SAME: %[[IDX:.+]]: index,
+func.func @full_select_maskedload_to_load_alignment(%arg0: memref<8x8xf16>, %arg1: index, %arg2: i1, %arg3: vector<4xf16>) -> vector<4xf16> {
+  %0 = vector.broadcast %arg2 : i1 to vector<4xi1>
+  %1 = vector.maskedload %arg0[%arg1, %arg1], %0, %arg3 alignment = 16 : memref<8x8xf16>, vector<4xi1>, vector<4xf16> into vector<4xf16>
+  return %1 : vector<4xf16>
+}
+// CHECK: scf.if
+// CHECK:   vector.load %[[MEM]][%[[IDX]], %[[IDX]]] alignment = 16
+
+// -----
+
+// CHECK-LABEL: func.func @full_mask_maskedstore_to_store_alignment
+// CHECK-SAME: %[[MEM:.+]]: memref<8x8xf16>,
+// CHECK-SAME: %[[IDX:.+]]: index,
+// CHECK-SAME: %[[PRED:.+]]: i1,
+// CHECK-SAME: %[[VAL:.+]]: vector<4xf16>)
+func.func @full_mask_maskedstore_to_store_alignment(%arg0: memref<8x8xf16>, %arg1: index, %arg2: i1, %arg3: vector<4xf16>) {
+  %0 = vector.broadcast %arg2 : i1 to vector<4xi1>
+  vector.maskedstore %arg0[%arg1, %arg1], %0, %arg3 alignment = 16 : memref<8x8xf16>, vector<4xi1>, vector<4xf16>
+  return
+}
+// CHECK: scf.if
+// CHECK:   vector.store %[[VAL]], %[[MEM]][%[[IDX]], %[[IDX]]] alignment = 16


### PR DESCRIPTION
The `amdgpu-maskedload-to-load` patterns rebuild a `vector.maskedload`
as `vector.load` (and a full-mask `vector.maskedstore` as
`vector.store`) from the original base and indices, but do not forward
the `alignment` attribute. The lowered op then falls back to the
element alignment in `convert-vector-to-llvm`:

```mlir
%0 = vector.maskedload %mem[%i, %i], %mask, %pass alignment = 16 : memref<8x8xf16>, vector<4xi1>, vector<4xf16> into vector<4xf16>
```

```
// before: llvm.load %p {alignment = 2 : i64}  : !llvm.ptr -> vector<4xf16>
// after:  llvm.load %p {alignment = 16 : i64} : !llvm.ptr -> vector<4xf16>
```

The rewritten access uses the same base, indices and vector type, so
the alignment the user asserted on the masked op still holds. Pass it
through the `vector.load`/`vector.store` builders, the same way
`AffineToStandard` forwards it.

Tests: one case per creation site (fat raw buffer with an arbitrary
mask, full-mask load, full-mask store).
