### PR TITLE
[memprof] check path in opendir interceptor

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_common_interceptors.inc
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_common_interceptors.inc
@@ -3583,7 +3583,8 @@ INTERCEPTOR(int, sysinfo, void *info) {
 INTERCEPTOR(__sanitizer_dirent *, opendir, const char *path) {
   void *ctx;
   COMMON_INTERCEPTOR_ENTER(ctx, opendir, path);
-  COMMON_INTERCEPTOR_READ_RANGE(ctx, path, internal_strlen(path) + 1);
+  if (path)
+    COMMON_INTERCEPTOR_READ_RANGE(ctx, path, internal_strlen(path) + 1);
   __sanitizer_dirent *res = REAL(opendir)(path);
   if (res)
     COMMON_INTERCEPTOR_DIR_ACQUIRE(ctx, path);

--- a/compiler-rt/test/memprof/TestCases/opendir_null.cpp
+++ b/compiler-rt/test/memprof/TestCases/opendir_null.cpp
@@ -1,0 +1,16 @@
+// REQUIRES: linux
+
+// RUN: %clangxx -DSHARED_LIB -fPIC -shared %s -o %t.so
+// RUN: %clangxx_memprof %s -o %t
+// RUN: env LD_PRELOAD=%t.so %run %t
+
+#include <dirent.h>
+
+#if defined(SHARED_LIB)
+extern "C" DIR *opendir(const char *) { return nullptr; }
+#else
+int main(int argc, char **argv) {
+  const char *path = argc > 1 ? argv[1] : nullptr;
+  return opendir(path) != nullptr;
+}
+#endif

--- a/compiler-rt/test/sanitizer_common/TestCases/Posix/opendir_null.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Posix/opendir_null.cpp
@@ -1,7 +1,7 @@
 // REQUIRES: linux
 
-// RUN: %clangxx -DSHARED_LIB -fPIC -shared %s -o %t.so
-// RUN: %clangxx_memprof %s -o %t
+// RUN: %clangxx -fno-sanitize=all -DSHARED_LIB -fPIC -shared %s -o %t.so
+// RUN: %clangxx %s -o %t
 // RUN: env LD_PRELOAD=%t.so %run %t
 
 #include <dirent.h>

--- a/compiler-rt/test/sanitizer_common/TestCases/Posix/opendir_null.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Posix/opendir_null.cpp
@@ -1,16 +1,19 @@
 // REQUIRES: linux
 
-// RUN: %clangxx -fno-sanitize=all -DSHARED_LIB -fPIC -shared %s -o %t.so
-// RUN: %clangxx %s -o %t
-// RUN: env LD_PRELOAD=%t.so %run %t
+// RUN: split-file %s %t
+// RUN: %clangxx -fno-sanitize=all -fPIC -shared %t/shared.cpp -o %t/shared.so
+// RUN: %clangxx %t/main.cpp -o %t/main
+// RUN: env LD_PRELOAD=%t/shared.so %run %t/main
 
+//--- shared.cpp
 #include <dirent.h>
 
-#if defined(SHARED_LIB)
 extern "C" DIR *opendir(const char *) { return nullptr; }
-#else
+
+//--- main.cpp
+#include <dirent.h>
+
 int main(int argc, char **argv) {
   const char *path = argc > 1 ? argv[1] : nullptr;
   return opendir(path) != nullptr;
 }
-#endif


### PR DESCRIPTION
The sanitizer `opendir` interceptor unconditionally calls `internal_strlen(path)` before forwarding to the real function.
Passing `nullptr` therefore causes the sanitizer runtime itself to dereference address zero.

Add a unit test using a `LD_PRELOAD` shim to verify that a null path reaches the real implementation without crashing the interceptor.