### PR TITLE
[mlir][gpu] Keep memref.load/store attributes in decompose-memrefs

### DIFF
--- a/mlir/lib/Dialect/GPU/Transforms/DecomposeMemRefs.cpp
+++ b/mlir/lib/Dialect/GPU/Transforms/DecomposeMemRefs.cpp
@@ -142,7 +142,9 @@ struct FlattenLoad : public OpRewritePattern<memref::LoadOp> {
 
     Location loc = op.getLoc();
     Value flatMemref = getFlatMemref(rewriter, loc, memref, op.getIndices());
-    rewriter.replaceOpWithNewOp<memref::LoadOp>(op, flatMemref, ValueRange{});
+    rewriter.replaceOpWithNewOp<memref::LoadOp>(
+        op, flatMemref, ValueRange{}, op.getNontemporalAttr(),
+        op.getAlignmentAttr(), op.getInvariantAttr());
     return success();
   }
 };
@@ -165,7 +167,9 @@ struct FlattenStore : public OpRewritePattern<memref::StoreOp> {
     Location loc = op.getLoc();
     Value flatMemref = getFlatMemref(rewriter, loc, memref, op.getIndices());
     Value value = op.getValue();
-    rewriter.replaceOpWithNewOp<memref::StoreOp>(op, value, flatMemref);
+    rewriter.replaceOpWithNewOp<memref::StoreOp>(
+        op, value, flatMemref, ValueRange{}, op.getNontemporalAttr(),
+        op.getAlignmentAttr());
     return success();
   }
 };

--- a/mlir/test/Dialect/GPU/decompose-memrefs.mlir
+++ b/mlir/test/Dialect/GPU/decompose-memrefs.mlir
@@ -135,3 +135,57 @@ func.func @decompose_subview_strided(%arg0 : memref<?x?x?xf32>) {
   }
   return
 }
+
+// -----
+
+//       CHECK: #[[MAP:.*]] = affine_map<()[s0, s1, s2, s3, s4] -> (s0 * s1 + s2 * s3 + s4)>
+//       CHECK: @decompose_store_attrs
+//  CHECK-SAME: (%[[VAL:.*]]: f32, %[[MEM:.*]]: memref<?x?x?xf32>)
+//       CHECK:  %[[BASE:.*]], %[[OFFSET:.*]], %[[SIZES:.*]]:3, %[[STRIDES:.*]]:3 = memref.extract_strided_metadata %[[MEM]]
+//       CHECK:  gpu.launch
+//  CHECK-SAME:  threads(%[[TX:.*]], %[[TY:.*]], %[[TZ:.*]]) in
+//       CHECK:  %[[IDX:.*]] = affine.apply #[[MAP]]()[%[[TX]], %[[STRIDES]]#0, %[[TY]], %[[STRIDES]]#1, %[[TZ]]]
+//       CHECK:  %[[PTR:.*]] = memref.reinterpret_cast %[[BASE]] to offset: [%[[IDX]]], sizes: [], strides: [] : memref<f32> to memref<f32, strided<[], offset: ?>>
+//       CHECK:  memref.store %[[VAL]], %[[PTR]][] alignment(16) nontemporal(true) : memref<f32, strided<[], offset: ?>>
+func.func @decompose_store_attrs(%arg0 : f32, %arg1 : memref<?x?x?xf32>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %block_dim0 = memref.dim %arg1, %c0 : memref<?x?x?xf32>
+  %block_dim1 = memref.dim %arg1, %c1 : memref<?x?x?xf32>
+  %block_dim2 = memref.dim %arg1, %c2 : memref<?x?x?xf32>
+  gpu.launch blocks(%bx, %by, %bz) in (%grid_x = %c1, %grid_y = %c1, %grid_z = %c1)
+             threads(%tx, %ty, %tz) in (%block_x = %block_dim0, %block_y = %block_dim1, %block_z = %block_dim2) {
+    memref.store %arg0, %arg1[%tx, %ty, %tz] alignment(16) nontemporal(true) : memref<?x?x?xf32>
+    gpu.terminator
+  }
+  return
+}
+
+// -----
+
+//       CHECK: #[[MAP:.*]] = affine_map<()[s0, s1, s2, s3, s4] -> (s0 * s1 + s2 * s3 + s4)>
+//       CHECK: @decompose_load_attrs
+//  CHECK-SAME: (%[[MEM:.*]]: memref<?x?x?xf32>)
+//       CHECK:  %[[BASE:.*]], %[[OFFSET:.*]], %[[SIZES:.*]]:3, %[[STRIDES:.*]]:3 = memref.extract_strided_metadata %[[MEM]]
+//       CHECK:  gpu.launch
+//  CHECK-SAME:  threads(%[[TX:.*]], %[[TY:.*]], %[[TZ:.*]]) in
+//       CHECK:  %[[IDX:.*]] = affine.apply #[[MAP]]()[%[[TX]], %[[STRIDES]]#0, %[[TY]], %[[STRIDES]]#1, %[[TZ]]]
+//       CHECK:  %[[PTR:.*]] = memref.reinterpret_cast %[[BASE]] to offset: [%[[IDX]]], sizes: [], strides: [] : memref<f32> to memref<f32, strided<[], offset: ?>>
+//       CHECK:  %[[RES:.*]] = memref.load %[[PTR]][] alignment(16) nontemporal(true) invariant(true) : memref<f32, strided<[], offset: ?>>
+//       CHECK:  "test.test"(%[[RES]]) : (f32) -> ()
+func.func @decompose_load_attrs(%arg0 : memref<?x?x?xf32>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %block_dim0 = memref.dim %arg0, %c0 : memref<?x?x?xf32>
+  %block_dim1 = memref.dim %arg0, %c1 : memref<?x?x?xf32>
+  %block_dim2 = memref.dim %arg0, %c2 : memref<?x?x?xf32>
+  gpu.launch blocks(%bx, %by, %bz) in (%grid_x = %c1, %grid_y = %c1, %grid_z = %c1)
+             threads(%tx, %ty, %tz) in (%block_x = %block_dim0, %block_y = %block_dim1, %block_z = %block_dim2) {
+    %res = memref.load %arg0[%tx, %ty, %tz] alignment(16) nontemporal(true) invariant(true) : memref<?x?x?xf32>
+    "test.test"(%res) : (f32) -> ()
+    gpu.terminator
+  }
+  return
+}


### PR DESCRIPTION
`gpu-decompose-memrefs` rewrites a `memref.load`/`memref.store` inside a
`gpu.launch` into a `reinterpret_cast` to the linearised offset plus a
0-d access, but rebuilds the op from the new memref only. `nontemporal`,
`alignment` and `invariant` are dropped from the load, `nontemporal` and
`alignment` from the store:

```mlir
%res = memref.load %arg0[%tx, %ty, %tz] alignment(16) nontemporal(true) invariant(true) : memref<?x?x?xf32>
// becomes
%1 = memref.load %reinterpret_cast[] : memref<f32, strided<[], offset: ?>>
```

The rewrite accesses the same element with the same type, so all of
them still hold on the new op. Pass them to the builder; the attribute
form is the one that also carries `invariant`.

Tests: a load and a store case next to the existing `@decompose_load`
and `@decompose_store`.


AI tool use: I worked on this patch together with an AI assistant (Claude Code).
Every line of the change and the tests was reviewed and verified by me, and I am
accountable for it.

Assisted-by: Claude Code
