### PR TITLE
[mlir][memref] Keep alignment and invariant in memref-emulate-wide-int

### DIFF
--- a/mlir/lib/Dialect/MemRef/Transforms/EmulateWideInt.cpp
+++ b/mlir/lib/Dialect/MemRef/Transforms/EmulateWideInt.cpp
@@ -68,7 +68,7 @@ struct ConvertMemRefLoad final : OpConversionPattern<memref::LoadOp> {
 
     rewriter.replaceOpWithNewOp<memref::LoadOp>(
         op, newResTy, adaptor.getMemref(), adaptor.getIndices(),
-        op.getNontemporal());
+        op.getNontemporalAttr(), op.getAlignmentAttr(), op.getInvariantAttr());
     return success();
   }
 };
@@ -91,7 +91,7 @@ struct ConvertMemRefStore final : OpConversionPattern<memref::StoreOp> {
 
     rewriter.replaceOpWithNewOp<memref::StoreOp>(
         op, adaptor.getValue(), adaptor.getMemref(), adaptor.getIndices(),
-        op.getNontemporal());
+        op.getNontemporalAttr(), op.getAlignmentAttr());
     return success();
   }
 };

--- a/mlir/test/Dialect/MemRef/emulate-wide-int.mlir
+++ b/mlir/test/Dialect/MemRef/emulate-wide-int.mlir
@@ -69,6 +69,23 @@ func.func @alloc_load_store_i64_nontemporal() {
 
 // -----
 
+// CHECK-LABEL: func @alloc_load_store_i64_attrs
+// CHECK:         [[C1:%.+]] = arith.constant dense<[1, 0]> : vector<2xi32>
+// CHECK-NEXT:    [[M:%.+]]  = memref.alloc() : memref<4xvector<2xi32>, 1>
+// CHECK-NEXT:    [[V:%.+]]  = memref.load [[M]][{{%.+}}] alignment(16) nontemporal(true) invariant(true) : memref<4xvector<2xi32>, 1>
+// CHECK-NEXT:    memref.store [[C1]], [[M]][{{%.+}}] alignment(16) nontemporal(true) : memref<4xvector<2xi32>, 1>
+// CHECK-NEXT:    return
+func.func @alloc_load_store_i64_attrs() {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : i64
+    %m = memref.alloc() : memref<4xi64, 1>
+    %v = memref.load %m[%c0] alignment(16) nontemporal(true) invariant(true) : memref<4xi64, 1>
+    memref.store %c1, %m[%c0] alignment(16) nontemporal(true) : memref<4xi64, 1>
+    return
+}
+
+// -----
+
 // Make sure we do not crash on unsupported types.
 func.func @alloc_i128() {
   // expected-error@+1 {{failed to legalize operation 'memref.alloc' that was explicitly marked illegal}}


### PR DESCRIPTION
`ConvertMemRefLoad` and `ConvertMemRefStore` forward `nontemporal` to the
rebuilt op but not `alignment`, nor `invariant` on the load; both
attributes were added after the pass:

```mlir
%v = memref.load %m[%c0] alignment(16) nontemporal(true) invariant(true) : memref<4xi64, 1>
// -memref-emulate-wide-int today
%v = memref.load %m[%c0] nontemporal(true) : memref<4xvector<2xi32>, 1>
```

The emulated memref has the same byte layout as the original (`iN` becomes
`vector<2xiN/2>`), so the same index names the same address and the
attributes still describe the access. This forwards all of them through
the attribute builder, next to the existing `nontemporal`.

Tests: one load/store case with all attributes, mirroring the existing
`@alloc_load_store_i64_nontemporal`.
