### PR TITLE
Mips: Drop use of AllowFPOpFusion

### DIFF
--- a/llvm/lib/Target/Mips/MipsInstrInfo.td
+++ b/llvm/lib/Target/Mips/MipsInstrInfo.td
@@ -266,9 +266,6 @@ def HasVirt  : Predicate<"Subtarget->hasVirt()">,
                AssemblerPredicate<(all_of FeatureVirt)>;
 def HasGINV  : Predicate<"Subtarget->hasGINV()">,
                AssemblerPredicate<(all_of FeatureGINV)>;
-// TODO: Add support for FPOpFusion::Standard
-def AllowFPOpFusion : Predicate<"TM.Options.AllowFPOpFusion =="
-                                " FPOpFusion::Fast">;
 //===----------------------------------------------------------------------===//
 // Mips GPR size adjectives.
 // They are mutually exclusive.
@@ -535,10 +532,6 @@ class ABI_N64 {
 
 class ABI_NOT_N64 {
   list<Predicate> AdditionalPredicates = [IsNotN64];
-}
-
-class FPOP_FUSION_FAST {
-  list <Predicate> AdditionalPredicates = [AllowFPOpFusion];
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Target/Mips/MipsMSAInstrInfo.td
+++ b/llvm/lib/Target/Mips/MipsMSAInstrInfo.td
@@ -3051,19 +3051,19 @@ def FTRUNC_S_D : FTRUNC_S_D_ENC, FTRUNC_S_D_DESC;
 def FTRUNC_U_W : FTRUNC_U_W_ENC, FTRUNC_U_W_DESC;
 def FTRUNC_U_D : FTRUNC_U_D_ENC, FTRUNC_U_D_DESC;
 
-def : MipsPat<(fsub MSA128WOpnd:$wd, (fmul MSA128WOpnd:$ws, MSA128WOpnd:$wt)),
+def : MipsPat<(fsub_contract MSA128WOpnd:$wd, (fmul_contract MSA128WOpnd:$ws, MSA128WOpnd:$wt)),
               (FMSUB_W MSA128WOpnd:$wd, MSA128WOpnd:$ws, MSA128WOpnd:$wt)>,
-              ISA_MIPS1, ASE_MSA, FPOP_FUSION_FAST;
-def : MipsPat<(fsub MSA128DOpnd:$wd, (fmul MSA128DOpnd:$ws, MSA128DOpnd:$wt)),
+              ISA_MIPS1, ASE_MSA;
+def : MipsPat<(fsub_contract MSA128DOpnd:$wd, (fmul_contract MSA128DOpnd:$ws, MSA128DOpnd:$wt)),
               (FMSUB_D MSA128DOpnd:$wd, MSA128DOpnd:$ws, MSA128DOpnd:$wt)>,
-              ISA_MIPS1, ASE_MSA, FPOP_FUSION_FAST;
+              ISA_MIPS1, ASE_MSA;
 
-def : MipsPat<(fadd MSA128WOpnd:$wd, (fmul MSA128WOpnd:$ws, MSA128WOpnd:$wt)),
+def : MipsPat<(fadd_contract MSA128WOpnd:$wd, (fmul_contract MSA128WOpnd:$ws, MSA128WOpnd:$wt)),
               (FMADD_W MSA128WOpnd:$wd, MSA128WOpnd:$ws, MSA128WOpnd:$wt)>,
-              ISA_MIPS1, ASE_MSA, FPOP_FUSION_FAST;
-def : MipsPat<(fadd MSA128DOpnd:$wd, (fmul MSA128DOpnd:$ws, MSA128DOpnd:$wt)),
+              ISA_MIPS1, ASE_MSA;
+def : MipsPat<(fadd_contract MSA128DOpnd:$wd, (fmul_contract MSA128DOpnd:$ws, MSA128DOpnd:$wt)),
               (FMADD_D MSA128DOpnd:$wd, MSA128DOpnd:$ws, MSA128DOpnd:$wt)>,
-              ISA_MIPS1, ASE_MSA, FPOP_FUSION_FAST;
+              ISA_MIPS1, ASE_MSA;
 
 def HADD_S_H : HADD_S_H_ENC, HADD_S_H_DESC;
 def HADD_S_W : HADD_S_W_ENC, HADD_S_W_DESC;

--- a/llvm/lib/Target/Mips/MipsSEISelLowering.cpp
+++ b/llvm/lib/Target/Mips/MipsSEISelLowering.cpp
@@ -2001,9 +2001,8 @@ SDValue MipsSETargetLowering::lowerINTRINSIC_WO_CHAIN(SDValue Op,
                        Op->getOperand(2));
   case Intrinsic::mips_fadd_w:
   case Intrinsic::mips_fadd_d:
-    // TODO: If intrinsics have fast-math-flags, propagate them.
     return DAG.getNode(ISD::FADD, DL, Op->getValueType(0), Op->getOperand(1),
-                       Op->getOperand(2));
+                       Op->getOperand(2), Op->getFlags());
   // Don't lower mips_fcaf_[wd] since LLVM folds SETFALSE condcodes away
   case Intrinsic::mips_fceq_w:
   case Intrinsic::mips_fceq_d:
@@ -2087,9 +2086,8 @@ SDValue MipsSETargetLowering::lowerINTRINSIC_WO_CHAIN(SDValue Op,
                        Op->getOperand(1), Op->getOperand(2), Op->getOperand(3));
   case Intrinsic::mips_fmul_w:
   case Intrinsic::mips_fmul_d:
-    // TODO: If intrinsics have fast-math-flags, propagate them.
     return DAG.getNode(ISD::FMUL, DL, Op->getValueType(0), Op->getOperand(1),
-                       Op->getOperand(2));
+                       Op->getOperand(2), Op->getFlags());
   case Intrinsic::mips_fmsub_w:
   case Intrinsic::mips_fmsub_d: {
     // TODO: If intrinsics have fast-math-flags, propagate them.
@@ -2104,9 +2102,8 @@ SDValue MipsSETargetLowering::lowerINTRINSIC_WO_CHAIN(SDValue Op,
     return DAG.getNode(ISD::FSQRT, DL, Op->getValueType(0), Op->getOperand(1));
   case Intrinsic::mips_fsub_w:
   case Intrinsic::mips_fsub_d:
-    // TODO: If intrinsics have fast-math-flags, propagate them.
     return DAG.getNode(ISD::FSUB, DL, Op->getValueType(0), Op->getOperand(1),
-                       Op->getOperand(2));
+                       Op->getOperand(2), Op->getFlags());
   case Intrinsic::mips_ftrunc_u_w:
   case Intrinsic::mips_ftrunc_u_d:
     return DAG.getNode(ISD::FP_TO_UINT, DL, Op->getValueType(0),

--- a/llvm/test/CodeGen/Mips/fp-contract.ll
+++ b/llvm/test/CodeGen/Mips/fp-contract.ll
@@ -1,17 +1,14 @@
-; Test that the compiled does not fuse fmul and fadd into fmadd when no -fp-contract=fast
-; option is set (the same applies for fmul, fsub and fmsub).
+; Test that fmul and fadd are fused into fmadd only when the contract fast-math
+; flag is present on the operations (likewise fmul, fsub and fmsub).
 
-; RUN: llc -mtriple=mipsel -mattr=+msa,+fp64,+mips32r2 < %s \
-; RUN:   | FileCheck %s --check-prefixes=CHECK-CONTRACT-OFF
-; RUN: llc -mtriple=mipsel -mattr=+msa,+fp64,+mips32r2 -fp-contract=off < %s \
-; RUN:   | FileCheck %s --check-prefixes=CHECK-CONTRACT-OFF
-; RUN: llc -mtriple=mips -mattr=+msa,+fp64,+mips32r2 -fp-contract=fast < %s \
-; RUN:   | FileCheck %s --check-prefixes=CHECK-CONTRACT-FAST
+; RUN: llc -mtriple=mipsel -mattr=+msa,+fp64,+mips32r2 < %s | FileCheck %s
+; RUN: llc -mtriple=mips -mattr=+msa,+fp64,+mips32r2 < %s | FileCheck %s
 
 declare <4 x float> @llvm.mips.fmul.w(<4 x float>, <4 x float>)
 declare <4 x float> @llvm.mips.fadd.w(<4 x float>, <4 x float>)
 declare <4 x float> @llvm.mips.fsub.w(<4 x float>, <4 x float>)
 
+; Without the contract flag, fmul and fadd stay separate.
 define void @foo(ptr %agg.result, ptr %acc, ptr %a, ptr %b) {
 entry:
   %0 = load <4 x float>, ptr %a, align 16
@@ -21,11 +18,12 @@ entry:
   %4 = call <4 x float> @llvm.mips.fadd.w(<4 x float> %3, <4 x float> %2)
   store <4 x float> %4, ptr %agg.result, align 16
   ret void
-  ; CHECK-CONTRACT-OFF: fmul.w
-  ; CHECK-CONTRACT-OFF: fadd.w
-  ; CHECK-CONTRACT-FAST: fmadd.w
+  ; CHECK-LABEL: foo:
+  ; CHECK: fmul.w
+  ; CHECK: fadd.w
 }
 
+; Without the contract flag, fmul and fsub stay separate.
 define void @boo(ptr %agg.result, ptr %acc, ptr %a, ptr %b) {
 entry:
   %0 = load <4 x float>, ptr %a, align 16
@@ -35,7 +33,35 @@ entry:
   %4 = call <4 x float> @llvm.mips.fsub.w(<4 x float> %3, <4 x float> %2)
   store <4 x float> %4, ptr %agg.result, align 16
   ret void
-  ; CHECK-CONTRACT-OFF: fmul.w
-  ; CHECK-CONTRACT-OFF: fsub.w
-  ; CHECK-CONTRACT-FAST: fmsub.w
+  ; CHECK-LABEL: boo:
+  ; CHECK: fmul.w
+  ; CHECK: fsub.w
+}
+
+; With the contract flag, fmul and fadd fuse into fmadd.
+define void @foo_contract(ptr %agg.result, ptr %acc, ptr %a, ptr %b) {
+entry:
+  %0 = load <4 x float>, ptr %a, align 16
+  %1 = load <4 x float>, ptr %b, align 16
+  %2 = call contract <4 x float> @llvm.mips.fmul.w(<4 x float> %0, <4 x float> %1)
+  %3 = load <4 x float>, ptr %acc, align 16
+  %4 = call contract <4 x float> @llvm.mips.fadd.w(<4 x float> %3, <4 x float> %2)
+  store <4 x float> %4, ptr %agg.result, align 16
+  ret void
+  ; CHECK-LABEL: foo_contract:
+  ; CHECK: fmadd.w
+}
+
+; With the contract flag, fmul and fsub fuse into fmsub.
+define void @boo_contract(ptr %agg.result, ptr %acc, ptr %a, ptr %b) {
+entry:
+  %0 = load <4 x float>, ptr %a, align 16
+  %1 = load <4 x float>, ptr %b, align 16
+  %2 = call contract <4 x float> @llvm.mips.fmul.w(<4 x float> %0, <4 x float> %1)
+  %3 = load <4 x float>, ptr %acc, align 16
+  %4 = call contract <4 x float> @llvm.mips.fsub.w(<4 x float> %3, <4 x float> %2)
+  store <4 x float> %4, ptr %agg.result, align 16
+  ret void
+  ; CHECK-LABEL: boo_contract:
+  ; CHECK: fmsub.w
 }


### PR DESCRIPTION
Fuse MSA fmadd/fmsub based on the contract flag. Fix a few
places dropping the flags during legalization.

The handling here of fusion isn't ideal. isFMAFasterThanFMulAndFAdd
is not implemented, so these patterns are doing a lot heavier and
less optimal work than the DAGCombiner logic will do.

Co-authored-by: Claude (Claude-Opus-4.8) <noreply@anthropic.com>