### PR TITLE
[flang][cuda] Inline scalar-to-array assignments in CUDA Fortran device code at -O0

### DIFF
--- a/flang/include/flang/Optimizer/HLFIR/Passes.td
+++ b/flang/include/flang/Optimizer/HLFIR/Passes.td
@@ -97,11 +97,17 @@ def SeparateAllocatableAssign : Pass<"separate-allocatable-assign"> {
 def InlineHLFIRAssign : Pass<"inline-hlfir-assign"> {
   let summary = "Inline hlfir.assign operations";
   let options = [Option<
-      "onlyScalarRHS", "only-scalar-rhs", "bool", /*default=*/"false",
-      "Only inline assignments where RHS is a numeric or logical scalar "
-      "broadcast "
-      "to an array LHS. Used at O0 to avoid runtime calls in "
-      "device code without inlining all array assignments.">];
+                     "onlyScalarRHS", "only-scalar-rhs", "bool",
+                     /*default=*/"false",
+                     "Only inline assignments where RHS is a numeric or "
+                     "logical scalar broadcast "
+                     "to an array LHS. Used at O0 to avoid runtime calls in "
+                     "device code without inlining all array assignments.">,
+                 Option<"onlyCUDADeviceContext", "only-cuda-device-context",
+                        "bool", /*default=*/"false",
+                        "Only inline assignments in CUDA Fortran device "
+                        "code. Used at O0, where a module holds both host "
+                        "and device subprograms, to leave host code alone.">];
 }
 
 def InlineHLFIRCopy : Pass<"inline-hlfir-copy"> {

--- a/flang/include/flang/Tools/CrossToolHelpers.h
+++ b/flang/include/flang/Tools/CrossToolHelpers.h
@@ -172,6 +172,7 @@ struct MLIRToLLVMPassPipelineConfig : public FlangEPCallBacks {
                                       ///< functions.
   bool NSWOnLoopVarInc = true; ///< Add nsw flag to loop variable increments.
   bool EnableOpenACC = false; ///< Enable OpenACC lowering.
+  bool EnableCUDA = false; ///< Enable CUDA Fortran lowering.
   bool EnableOpenMP = false; ///< Enable OpenMP lowering.
   bool EnableOpenMPIsTargetDevice =
       false; ///< Compiling for an OpenMP target device.

--- a/flang/lib/Frontend/FrontendActions.cpp
+++ b/flang/lib/Frontend/FrontendActions.cpp
@@ -638,9 +638,8 @@ void CodeGenAction::lowerHLFIRToFIR() {
       ci.getInvocation().getLoweringOpts().getFPMaxminBehavior();
   if (ci.getInvocation().getLangOpts().OpenMPIsTargetDevice)
     config.EnableOpenMPIsTargetDevice = true;
-  // Use the parser options rather than the frontend options: they are seeded
-  // from the latter, and beginSourceFile additionally enables CUDA there for
-  // a .cuf/.CUF input, which -x cuda alone does not cover.
+  // Parser options, not frontend options: they are seeded from the frontend
+  // ones and additionally get CUDA enabled for a .cuf/.CUF input.
   if (ci.getInvocation().getFortranOpts().features.IsEnabled(
           Fortran::common::LanguageFeature::CUDA))
     config.EnableCUDA = true;

--- a/flang/lib/Frontend/FrontendActions.cpp
+++ b/flang/lib/Frontend/FrontendActions.cpp
@@ -638,6 +638,12 @@ void CodeGenAction::lowerHLFIRToFIR() {
       ci.getInvocation().getLoweringOpts().getFPMaxminBehavior();
   if (ci.getInvocation().getLangOpts().OpenMPIsTargetDevice)
     config.EnableOpenMPIsTargetDevice = true;
+  // Use the parser options rather than the frontend options: they are seeded
+  // from the latter, and beginSourceFile additionally enables CUDA there for
+  // a .cuf/.CUF input, which -x cuda alone does not cover.
+  if (ci.getInvocation().getFortranOpts().features.IsEnabled(
+          Fortran::common::LanguageFeature::CUDA))
+    config.EnableCUDA = true;
   // Create the pass pipeline
   fir::createHLFIRToFIRPassPipeline(pm, enableOpenMP, config);
   (void)mlir::applyPassManagerCLOptions(pm);

--- a/flang/lib/Optimizer/HLFIR/Transforms/InlineHLFIRAssign.cpp
+++ b/flang/lib/Optimizer/HLFIR/Transforms/InlineHLFIRAssign.cpp
@@ -41,10 +41,9 @@ static llvm::cl::opt<bool> inlineAllocatableExprAssignFlag(
                    "hlfir.expr (e.g., from hlfir.elemental)"),
     llvm::cl::init(false));
 
-/// Will \p op run on the device? An OpenMP target device compilation is
-/// device-only, so the whole module qualifies. A CUDA Fortran module instead
-/// holds both host subprograms and device code, making this a per-operation
-/// question that cuf::isCUDADeviceContext answers.
+/// Returns true if \p op runs on the device. CUDA Fortran mixes host and
+/// device code, so that check is per-operation; an OpenMP target device
+/// module is all device.
 static bool isDeviceCode(mlir::Operation *op) {
   if (cuf::isCUDADeviceContext(op))
     return true;
@@ -104,13 +103,12 @@ public:
       return rewriter.notifyMatchFailure(
           assign, "onlyScalarRHS: skipping array-to-array assignment");
 
-    // onlyScalarRHS is the O0 mode, where this pass runs solely to keep
-    // Fortran runtime calls out of device code. Leave host code alone there:
-    // it keeps the runtime call so that a line breakpoint on a scalar-to-array
-    // assignment hits once instead of once per element.
+    // onlyScalarRHS is the O0 mode, which exists only to keep runtime calls
+    // out of device code. Host code keeps the call so that a breakpoint on
+    // the assignment fires once, not once per element.
     if (onlyScalarRHS && !isDeviceCode(assign))
-      return rewriter.notifyMatchFailure(
-          assign, "onlyScalarRHS: skipping host code");
+      return rewriter.notifyMatchFailure(assign,
+                                         "onlyScalarRHS: skipping host code");
 
     mlir::Type rhsEleTy = rhs.getFortranElementType();
     if (!fir::isa_trivial(rhsEleTy))
@@ -380,10 +378,9 @@ public:
   void runOnOperation() override {
     mlir::MLIRContext *context = &getContext();
 
-    // In onlyScalarRHS (O0) mode, skip host code entirely rather than relying
-    // on the pattern to reject it: the greedy driver folds and removes dead
-    // ops as it walks, which would perturb host code at O0 even when no
-    // assignment is rewritten.
+    // Bail out before the greedy driver runs: it folds and removes dead ops
+    // as it walks, which would perturb host code at O0 even though the
+    // pattern rewrites nothing there.
     if (onlyScalarRHS) {
       bool anyDeviceAssign = false;
       getOperation()->walk([&](hlfir::AssignOp assign) {

--- a/flang/lib/Optimizer/HLFIR/Transforms/InlineHLFIRAssign.cpp
+++ b/flang/lib/Optimizer/HLFIR/Transforms/InlineHLFIRAssign.cpp
@@ -17,10 +17,10 @@
 #include "flang/Optimizer/Builder/FIRBuilder.h"
 #include "flang/Optimizer/Builder/HLFIRTools.h"
 #include "flang/Optimizer/Builder/MutableBox.h"
+#include "flang/Optimizer/Dialect/CUF/Attributes/CUFAttr.h"
 #include "flang/Optimizer/HLFIR/HLFIROps.h"
 #include "flang/Optimizer/HLFIR/Passes.h"
 #include "flang/Optimizer/OpenMP/Passes.h"
-#include "mlir/Dialect/OpenMP/OpenMPDialect.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Support/LLVM.h"
@@ -41,16 +41,16 @@ static llvm::cl::opt<bool> inlineAllocatableExprAssignFlag(
                    "hlfir.expr (e.g., from hlfir.elemental)"),
     llvm::cl::init(false));
 
-/// Returns true if \p op runs on the device. CUDA Fortran mixes host and
-/// device code, so that check is per-operation; an OpenMP target device
-/// module is all device.
-static bool isDeviceCode(mlir::Operation *op) {
+/// Returns true if \p op is CUDA Fortran device code. attributes(host,device)
+/// counts: this pass runs before the device copy is outlined, so the one
+/// func.func here becomes both copies.
+static bool isCUDADeviceCode(mlir::Operation *op) {
   if (cuf::isCUDADeviceContext(op))
     return true;
-  if (auto mod = op->getParentOfType<mlir::ModuleOp>())
-    if (auto offloadMod = llvm::dyn_cast<mlir::omp::OffloadModuleInterface>(
-            mod.getOperation()))
-      return offloadMod.getIsTargetDevice();
+  if (auto func = op->getParentOfType<mlir::func::FuncOp>())
+    if (auto procAttr =
+            func->getAttrOfType<cuf::ProcAttributeAttr>(cuf::getProcAttrName()))
+      return procAttr.getValue() == cuf::ProcAttribute::HostDevice;
   return false;
 }
 
@@ -80,10 +80,13 @@ namespace {
 class InlineHLFIRAssignConversion
     : public mlir::OpRewritePattern<hlfir::AssignOp> {
   bool onlyScalarRHS;
+  bool onlyCUDADeviceContext;
 
 public:
-  InlineHLFIRAssignConversion(mlir::MLIRContext *context, bool onlyScalarRHS)
-      : OpRewritePattern(context), onlyScalarRHS(onlyScalarRHS) {}
+  InlineHLFIRAssignConversion(mlir::MLIRContext *context, bool onlyScalarRHS,
+                              bool onlyCUDADeviceContext)
+      : OpRewritePattern(context), onlyScalarRHS(onlyScalarRHS),
+        onlyCUDADeviceContext(onlyCUDADeviceContext) {}
 
   llvm::LogicalResult
   matchAndRewrite(hlfir::AssignOp assign,
@@ -103,12 +106,10 @@ public:
       return rewriter.notifyMatchFailure(
           assign, "onlyScalarRHS: skipping array-to-array assignment");
 
-    // onlyScalarRHS is the O0 mode, which exists only to keep runtime calls
-    // out of device code. Host code keeps the call so that a breakpoint on
-    // the assignment fires once, not once per element.
-    if (onlyScalarRHS && !isDeviceCode(assign))
-      return rewriter.notifyMatchFailure(assign,
-                                         "onlyScalarRHS: skipping host code");
+    // Host code keeps the runtime call so that a breakpoint on the assignment
+    // fires once, not once per element.
+    if (onlyCUDADeviceContext && !isCUDADeviceCode(assign))
+      return rewriter.notifyMatchFailure(assign, "skipping host code");
 
     mlir::Type rhsEleTy = rhs.getFortranElementType();
     if (!fir::isa_trivial(rhsEleTy))
@@ -381,10 +382,10 @@ public:
     // Bail out before the greedy driver runs: it folds and removes dead ops
     // as it walks, which would perturb host code at O0 even though the
     // pattern rewrites nothing there.
-    if (onlyScalarRHS) {
+    if (onlyCUDADeviceContext) {
       bool anyDeviceAssign = false;
       getOperation()->walk([&](hlfir::AssignOp assign) {
-        if (!isDeviceCode(assign))
+        if (!isCUDADeviceCode(assign))
           return mlir::WalkResult::advance();
         anyDeviceAssign = true;
         return mlir::WalkResult::interrupt();
@@ -399,7 +400,8 @@ public:
         mlir::GreedySimplifyRegionLevel::Disabled);
 
     mlir::RewritePatternSet patterns(context);
-    patterns.insert<InlineHLFIRAssignConversion>(context, onlyScalarRHS);
+    patterns.insert<InlineHLFIRAssignConversion>(context, onlyScalarRHS,
+                                                 onlyCUDADeviceContext);
 
     // Optionally add the allocatable expr assignment pattern
     if (inlineAllocatableExprAssignFlag) {

--- a/flang/lib/Optimizer/HLFIR/Transforms/InlineHLFIRAssign.cpp
+++ b/flang/lib/Optimizer/HLFIR/Transforms/InlineHLFIRAssign.cpp
@@ -13,12 +13,14 @@
 #include "flang/Optimizer/Analysis/AliasAnalysis.h"
 #include "flang/Optimizer/Analysis/ArraySectionAnalyzer.h"
 #include "flang/Optimizer/Builder/BoxValue.h"
+#include "flang/Optimizer/Builder/CUFCommon.h"
 #include "flang/Optimizer/Builder/FIRBuilder.h"
 #include "flang/Optimizer/Builder/HLFIRTools.h"
 #include "flang/Optimizer/Builder/MutableBox.h"
 #include "flang/Optimizer/HLFIR/HLFIROps.h"
 #include "flang/Optimizer/HLFIR/Passes.h"
 #include "flang/Optimizer/OpenMP/Passes.h"
+#include "mlir/Dialect/OpenMP/OpenMPDialect.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Support/LLVM.h"
@@ -38,6 +40,20 @@ static llvm::cl::opt<bool> inlineAllocatableExprAssignFlag(
     llvm::cl::desc("Enable inlining of allocatable assignments when RHS is an "
                    "hlfir.expr (e.g., from hlfir.elemental)"),
     llvm::cl::init(false));
+
+/// Will \p op run on the device? An OpenMP target device compilation is
+/// device-only, so the whole module qualifies. A CUDA Fortran module instead
+/// holds both host subprograms and device code, making this a per-operation
+/// question that cuf::isCUDADeviceContext answers.
+static bool isDeviceCode(mlir::Operation *op) {
+  if (cuf::isCUDADeviceContext(op))
+    return true;
+  if (auto mod = op->getParentOfType<mlir::ModuleOp>())
+    if (auto offloadMod = llvm::dyn_cast<mlir::omp::OffloadModuleInterface>(
+            mod.getOperation()))
+      return offloadMod.getIsTargetDevice();
+  return false;
+}
 
 namespace {
 /// Expand hlfir.assign of array RHS to array LHS into a loop nest
@@ -87,6 +103,14 @@ public:
     if (onlyScalarRHS && rhs.isArray())
       return rewriter.notifyMatchFailure(
           assign, "onlyScalarRHS: skipping array-to-array assignment");
+
+    // onlyScalarRHS is the O0 mode, where this pass runs solely to keep
+    // Fortran runtime calls out of device code. Leave host code alone there:
+    // it keeps the runtime call so that a line breakpoint on a scalar-to-array
+    // assignment hits once instead of once per element.
+    if (onlyScalarRHS && !isDeviceCode(assign))
+      return rewriter.notifyMatchFailure(
+          assign, "onlyScalarRHS: skipping host code");
 
     mlir::Type rhsEleTy = rhs.getFortranElementType();
     if (!fir::isa_trivial(rhsEleTy))
@@ -355,6 +379,22 @@ public:
 
   void runOnOperation() override {
     mlir::MLIRContext *context = &getContext();
+
+    // In onlyScalarRHS (O0) mode, skip host code entirely rather than relying
+    // on the pattern to reject it: the greedy driver folds and removes dead
+    // ops as it walks, which would perturb host code at O0 even when no
+    // assignment is rewritten.
+    if (onlyScalarRHS) {
+      bool anyDeviceAssign = false;
+      getOperation()->walk([&](hlfir::AssignOp assign) {
+        if (!isDeviceCode(assign))
+          return mlir::WalkResult::advance();
+        anyDeviceAssign = true;
+        return mlir::WalkResult::interrupt();
+      });
+      if (!anyDeviceAssign)
+        return;
+    }
 
     mlir::GreedyRewriteConfig config;
     // Prevent the pattern driver from merging blocks.

--- a/flang/lib/Optimizer/Passes/Pipelines.cpp
+++ b/flang/lib/Optimizer/Passes/Pipelines.cpp
@@ -317,14 +317,16 @@ void createHLFIRToFIRPassPipeline(mlir::PassManager &pm,
       addNestedPassToAllTopLevelOperations<PassConstructor>(
           pm, hlfir::createInlineHLFIRCopy);
     }
-  } else if (config.EnableOpenMPIsTargetDevice &&
-             enableOpenMP == EnableOpenMP::Full) {
+  } else if ((config.EnableOpenMPIsTargetDevice &&
+              enableOpenMP == EnableOpenMP::Full) ||
+             config.EnableCUDA) {
     // At O0, only inline scalar-to-array broadcasts when compiling for an
-    // OpenMP target device. This avoids emitting Fortran runtime calls
-    // (e.g. _FortranAAssign) that use malloc/free in device code generated
-    // by OpenMP target offloading. Restricting this to target-device
-    // compilation preserves the runtime call on the host at -O0 so that a
-    // line breakpoint on a scalar-to-array assignment hits once instead of
+    // OpenMP target device or with CUDA Fortran. This avoids emitting Fortran
+    // runtime calls (e.g. _FortranAAssign) that use malloc/free in device
+    // code, and whose call graph also inflates the worst-case stack frame the
+    // device linker must reserve for the calling kernel. Restricting this to
+    // those compilations preserves the runtime call at -O0 elsewhere so that
+    // a line breakpoint on a scalar-to-array assignment hits once instead of
     // once per element.
     addNestedPassToAllTopLevelOperations(pm, [&]() {
       return hlfir::createInlineHLFIRAssign({/*onlyScalarRHS=*/true});

--- a/flang/lib/Optimizer/Passes/Pipelines.cpp
+++ b/flang/lib/Optimizer/Passes/Pipelines.cpp
@@ -317,19 +317,25 @@ void createHLFIRToFIRPassPipeline(mlir::PassManager &pm,
       addNestedPassToAllTopLevelOperations<PassConstructor>(
           pm, hlfir::createInlineHLFIRCopy);
     }
-  } else if ((config.EnableOpenMPIsTargetDevice &&
-              enableOpenMP == EnableOpenMP::Full) ||
-             config.EnableCUDA) {
+  } else if (config.EnableOpenMPIsTargetDevice &&
+             enableOpenMP == EnableOpenMP::Full) {
     // At O0, only inline scalar-to-array broadcasts when compiling for an
-    // OpenMP target device or with CUDA Fortran. This avoids emitting Fortran
-    // runtime calls (e.g. _FortranAAssign) that use malloc/free in device
-    // code, and whose call graph also inflates the worst-case stack frame the
-    // device linker must reserve for the calling kernel. Restricting this to
-    // those compilations preserves the runtime call at -O0 elsewhere so that
-    // a line breakpoint on a scalar-to-array assignment hits once instead of
+    // OpenMP target device. This avoids emitting Fortran runtime calls
+    // (e.g. _FortranAAssign) that use malloc/free in device code generated
+    // by OpenMP target offloading. Restricting this to target-device
+    // compilation preserves the runtime call on the host at -O0 so that a
+    // line breakpoint on a scalar-to-array assignment hits once instead of
     // once per element.
     addNestedPassToAllTopLevelOperations(pm, [&]() {
       return hlfir::createInlineHLFIRAssign({/*onlyScalarRHS=*/true});
+    });
+  } else if (config.EnableCUDA) {
+    // Same at O0 for CUDA Fortran device code, where the runtime call also
+    // inflates the stack frame the device linker reserves for the kernel.
+    // The module holds host code too, hence onlyCUDADeviceContext.
+    addNestedPassToAllTopLevelOperations(pm, [&]() {
+      return hlfir::createInlineHLFIRAssign(
+          {/*onlyScalarRHS=*/true, /*onlyCUDADeviceContext=*/true});
     });
   }
   pm.addPass(hlfir::createLowerHLFIROrderedAssignments(

--- a/flang/test/Lower/CUDA/scalar-to-array-assign-device-O0.cuf
+++ b/flang/test/Lower/CUDA/scalar-to-array-assign-device-O0.cuf
@@ -1,15 +1,7 @@
-! At -O0, a scalar-to-array broadcast assignment in CUDA Fortran device code
-! must still be inlined, so that no _FortranAAssign runtime call (which
-! internally uses malloc/free) is emitted into device code. Such a call also
-! drags its callees into the kernel's call graph, inflating the worst-case
-! stack frame the device linker has to reserve for that kernel.
-!
-! Host code keeps the runtime call at -O0, so that a line breakpoint on a
-! scalar-to-array assignment hits once instead of once per element. A CUDA
-! Fortran module holds both, so the distinction is per-function.
-!
-! CUDA Fortran is enabled here by the .cuf suffix rather than -x cuda, which
-! covers both ways the language feature gets turned on.
+! At -O0, a scalar-to-array broadcast must be inlined in device code to keep
+! _FortranAAssign out of the kernel's call graph. Host code keeps the call so
+! that a breakpoint on the assignment fires once, not once per element.
+! CUDA Fortran is enabled here by the .cuf suffix rather than -x cuda.
 
 ! RUN: %flang_fc1 -emit-fir -O0 %s -o - | FileCheck %s
 

--- a/flang/test/Lower/CUDA/scalar-to-array-assign-device-O0.cuf
+++ b/flang/test/Lower/CUDA/scalar-to-array-assign-device-O0.cuf
@@ -14,6 +14,14 @@ contains
     out(1) = arr(1)
   end subroutine
 
+  ! Inlined too, since this one func.func becomes both copies.
+  attributes(host,device) subroutine hostdev_broadcast(out)
+    integer(4) :: out(*)
+    integer(4) :: arr(4)
+    arr = 11
+    out(1) = arr(1)
+  end subroutine
+
   subroutine host_broadcast(out)
     integer(4) :: out(*)
     integer(4) :: arr(4)
@@ -23,6 +31,11 @@ contains
 end module
 
 ! CHECK-LABEL: func.func @_QMmPdevice_broadcast
+! CHECK-NOT:     fir.call @_FortranAAssign
+! CHECK:         fir.do_loop
+! CHECK-NOT:     fir.call @_FortranAAssign
+
+! CHECK-LABEL: func.func @_QMmPhostdev_broadcast
 ! CHECK-NOT:     fir.call @_FortranAAssign
 ! CHECK:         fir.do_loop
 ! CHECK-NOT:     fir.call @_FortranAAssign

--- a/flang/test/Lower/CUDA/scalar-to-array-assign-device-O0.cuf
+++ b/flang/test/Lower/CUDA/scalar-to-array-assign-device-O0.cuf
@@ -1,0 +1,39 @@
+! At -O0, a scalar-to-array broadcast assignment in CUDA Fortran device code
+! must still be inlined, so that no _FortranAAssign runtime call (which
+! internally uses malloc/free) is emitted into device code. Such a call also
+! drags its callees into the kernel's call graph, inflating the worst-case
+! stack frame the device linker has to reserve for that kernel.
+!
+! Host code keeps the runtime call at -O0, so that a line breakpoint on a
+! scalar-to-array assignment hits once instead of once per element. A CUDA
+! Fortran module holds both, so the distinction is per-function.
+!
+! CUDA Fortran is enabled here by the .cuf suffix rather than -x cuda, which
+! covers both ways the language feature gets turned on.
+
+! RUN: %flang_fc1 -emit-fir -O0 %s -o - | FileCheck %s
+
+module m
+contains
+  attributes(global) subroutine device_broadcast(out)
+    integer(4), device :: out(*)
+    integer(4) :: arr(4)
+    arr = 11
+    out(1) = arr(1)
+  end subroutine
+
+  subroutine host_broadcast(out)
+    integer(4) :: out(*)
+    integer(4) :: arr(4)
+    arr = 11
+    out(1) = arr(1)
+  end subroutine
+end module
+
+! CHECK-LABEL: func.func @_QMmPdevice_broadcast
+! CHECK-NOT:     fir.call @_FortranAAssign
+! CHECK:         fir.do_loop
+! CHECK-NOT:     fir.call @_FortranAAssign
+
+! CHECK-LABEL: func.func @_QMmPhost_broadcast
+! CHECK:         fir.call @_FortranAAssign


### PR DESCRIPTION
At -O0, `arr = 11` lowers to a `_FortranAAssign` call. In device code the runtime function's callees join the kernel's call graph, so the device linker reserves a worst-case stack frame for every kernel reaching it: `65,720` bytes per thread for a kernel with one such assignment, versus `0` at -O1.

`InlineHLFIRAssign` already runs at -O0 with `onlyScalarRHS` for OpenMP target device compilations. This extends that carve-out to CUDA Fortran. Since a CUDA Fortran module holds both host and device code, the decision is per-operation via `cuf::isCUDADeviceContext`, and host code keeps the runtime call.

Only scalar-to-array broadcast is covered.