### PR TITLE
[compiler-rt][ubsan] Fix trailing whitespace in SUMMARY line when function is unknown

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_report.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_report.cpp
@@ -61,7 +61,7 @@ void ReportErrorSummary(const char *error_type, const AddressInfo &info,
   InternalScopedString buff;
   buff.AppendF("%s ", error_type);
   StackTracePrinter::GetOrInit()->RenderFrame(
-      &buff, "%L %F", 0, info.address, &info,
+      &buff, info.function ? "%L %F" : "%L", 0, info.address, &info,
       common_flags()->symbolize_vs_style, common_flags()->strip_path_prefix);
   ReportErrorSummary(buff.data(), alt_tool_name);
 }

--- a/compiler-rt/test/ubsan/TestCases/Integer/summary.cpp
+++ b/compiler-rt/test/ubsan/TestCases/Integer/summary.cpp
@@ -7,7 +7,7 @@
 
 int main() {
   (void)(uint64_t(10000000000000000000ull) + uint64_t(9000000000000000000ull));
-  // CHECK-NOTYPE: SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior {{.*}}summary.cpp:[[@LINE-1]]:44
-  // CHECK-TYPE: SUMMARY: UndefinedBehaviorSanitizer: unsigned-integer-overflow {{.*}}summary.cpp:[[@LINE-2]]:44
+  // CHECK-NOTYPE: SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior {{.*}}summary.cpp:[[@LINE-1]]:44{{$}}
+  // CHECK-TYPE: SUMMARY: UndefinedBehaviorSanitizer: unsigned-integer-overflow {{.*}}summary.cpp:[[@LINE-2]]:44{{$}}
   return 0;
 }


### PR DESCRIPTION
Fixes #30851. ReportErrorSummary always rendered "%L %F", but %F expands to nothing when the function name is unknown, leaving a dangling space at the end of the line. Instead, oly add the function name if it is known.