### PR TITLE
[CIR][NFC] Use declarative llvmOp lowering for coroutine intrinsics

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -4907,6 +4907,7 @@ def CIR_CoroIdOp : CIR_CoroIntrinsicOp<"id",
     (`coro.alloc`, `coro.begin`, `coro.free`, etc.), tying them all to the
     same coroutine instance.
   }];
+  let llvmOp = "CoroIdOp";
 }
 
 //===----------------------------------------------------------------------===//
@@ -4921,6 +4922,7 @@ def CIR_CoroAllocOp : CIR_CoroIntrinsicOp<"alloc", (ins Token:$id),
     allocated frame. Returns `true` if the coroutine frame must be allocated,
     or `false` otherwise.
   }];
+  let llvmOp = "CoroAllocOp";
 }
 
 //===----------------------------------------------------------------------===//
@@ -4936,6 +4938,7 @@ def CIR_CoroBeginOp : CIR_CoroIntrinsicOp<"begin",
     from `coro.intrinsic.id`, and `coroframeAddr` points to the memory used
     for the coroutine frame. Returns the coroutine handle.
   }];
+  let llvmOp = "CoroBeginOp";
 }
 
 //===----------------------------------------------------------------------===//
@@ -4954,6 +4957,7 @@ def CIR_CoroEndOp : CIR_CoroIntrinsicOp<"end",
     indicates whether this occurrence of `coro.intrinsic.end` lies on the
     unwind path (`true`) or the normal control-flow path (`false`).
   }];
+  let llvmOp = "CoroEndOp";
 }
 
 //===----------------------------------------------------------------------===//
@@ -4970,6 +4974,7 @@ def CIR_CoroFreeOp : CIR_CoroIntrinsicOp<"free",
     be passed to the deallocation function to free the coroutine frame, or a
     null pointer if the coroutine frame was not dynamically allocated.
   }];
+  let llvmOp = "CoroFreeOp";
 }
 
 //===----------------------------------------------------------------------===//
@@ -4982,6 +4987,7 @@ def CIR_CoroSizeOp : CIR_CoroIntrinsicOp<"size", (ins),
   let description = [{
     Returns the size, in bytes, of the coroutine frame.
   }];
+  let llvmOp = "CoroSizeOp";
 }
 
 //===----------------------------------------------------------------------===//

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -5587,58 +5587,6 @@ mlir::LogicalResult CIRToLLVMTokenNoneOpLowering::matchAndRewrite(
   return mlir::success();
 }
 
-mlir::LogicalResult CIRToLLVMCoroFreeOpLowering::matchAndRewrite(
-    cir::CoroFreeOp op, OpAdaptor adaptor,
-    mlir::ConversionPatternRewriter &rewriter) const {
-  rewriter.replaceOpWithNewOp<mlir::LLVM::CoroFreeOp>(
-      op, mlir::LLVM::LLVMPointerType::get(rewriter.getContext()),
-      adaptor.getId(), adaptor.getCoroframe());
-  return mlir::success();
-}
-
-mlir::LogicalResult CIRToLLVMCoroEndOpLowering::matchAndRewrite(
-    cir::CoroEndOp op, OpAdaptor adaptor,
-    mlir::ConversionPatternRewriter &rewriter) const {
-  rewriter.replaceOpWithNewOp<mlir::LLVM::CoroEndOp>(
-      op, mlir::LLVM::LLVMVoidType::get(rewriter.getContext()),
-      adaptor.getHandle(), adaptor.getUnwind(), adaptor.getResultToken());
-  return mlir::success();
-}
-
-mlir::LogicalResult CIRToLLVMCoroAllocOpLowering::matchAndRewrite(
-    cir::CoroAllocOp op, OpAdaptor adaptor,
-    mlir::ConversionPatternRewriter &rewriter) const {
-  rewriter.replaceOpWithNewOp<mlir::LLVM::CoroAllocOp>(op, rewriter.getI1Type(),
-                                                       adaptor.getId());
-  return mlir::success();
-}
-
-mlir::LogicalResult CIRToLLVMCoroBeginOpLowering::matchAndRewrite(
-    cir::CoroBeginOp op, OpAdaptor adaptor,
-    mlir::ConversionPatternRewriter &rewriter) const {
-  rewriter.replaceOpWithNewOp<mlir::LLVM::CoroBeginOp>(
-      op, mlir::LLVM::LLVMPointerType::get(rewriter.getContext()),
-      adaptor.getId(), adaptor.getCoroframeAddr());
-  return mlir::success();
-}
-
-mlir::LogicalResult CIRToLLVMCoroIdOpLowering::matchAndRewrite(
-    cir::CoroIdOp op, OpAdaptor adaptor,
-    mlir::ConversionPatternRewriter &rewriter) const {
-  rewriter.replaceOpWithNewOp<mlir::LLVM::CoroIdOp>(
-      op, mlir::TokenType::get(rewriter.getContext()), adaptor.getAlign(),
-      adaptor.getPromise(), adaptor.getCoroaddr(), adaptor.getFnaddrs());
-  return mlir::success();
-}
-
-mlir::LogicalResult CIRToLLVMCoroSizeOpLowering::matchAndRewrite(
-    cir::CoroSizeOp op, OpAdaptor adaptor,
-    mlir::ConversionPatternRewriter &rewriter) const {
-  rewriter.replaceOpWithNewOp<mlir::LLVM::CoroSizeOp>(
-      op, getTypeConverter()->convertType(op.getType()));
-  return mlir::success();
-}
-
 mlir::LogicalResult CIRToLLVMCpuIdOpLowering::matchAndRewrite(
     cir::CpuIdOp op, OpAdaptor adaptor,
     mlir::ConversionPatternRewriter &rewriter) const {


### PR DESCRIPTION
This PR switches the coroutine intrinsic ops (`cir.coro.intrinsic.id`, `.alloc`, `.begin`, `.end`, `.free`, `.size`) to use the declarative `llvmOp` field instead of hand-written lowering patterns.