### PR TITLE
[BOLT][AArch64] Don't patch short-range PC-relative refs in un-emitte…

### DIFF
--- a/bolt/lib/Core/BinaryFunction.cpp
+++ b/bolt/lib/Core/BinaryFunction.cpp
@@ -1667,6 +1667,7 @@ bool BinaryFunction::scanExternalRefs() {
     // Handle calls and branches separately as symbolization doesn't work for
     // them yet.
     MCSymbol *BranchTargetSymbol = nullptr;
+    SmallVector<const MCSymbol *, 1> RefSymbols;
     if (BC.MIB->isCall(Instruction) || BC.MIB->isBranch(Instruction)) {
       uint64_t TargetAddress = 0;
       BC.MIB->evaluateBranch(Instruction, AbsoluteInstrAddr, Size,
@@ -1697,12 +1698,17 @@ bool BinaryFunction::scanExternalRefs() {
                                   Emitter.LocalCtx.get());
     } else {
       analyzeInstructionForFuncReference(Instruction);
-      const bool NeedsPatch = llvm::any_of(
-          MCPlus::primeOperands(Instruction), [&](const MCOperand &Op) {
-            return Op.isExpr() &&
-                   !ignoreReference(BC.MIB->getTargetSymbol(Op.getExpr()));
-          });
-      if (!NeedsPatch)
+      // Symbols referenced by this instruction that belong to functions we are
+      // going to move. Note that AArch64 instructions have at most one such
+      // operand, but the code below does not rely on it.
+      for (const MCOperand &Op : MCPlus::primeOperands(Instruction)) {
+        if (!Op.isExpr())
+          continue;
+        const MCSymbol *Symbol = BC.MIB->getTargetSymbol(Op.getExpr());
+        if (!ignoreReference(Symbol))
+          RefSymbols.push_back(Symbol);
+      }
+      if (RefSymbols.empty())
         continue;
     }
 
@@ -1795,6 +1801,28 @@ bool BinaryFunction::scanExternalRefs() {
     // relocations.
     if (BC.isAArch64()) {
       if (!BranchTargetSymbol) {
+        // A bare PC-relative reference, such as ADR or LDR (literal), reaches
+        // only +/-1MB, while the target is likely to end up much further away
+        // once it is moved. Such an instruction cannot be patched in place, and
+        // cannot be relaxed into an ADRP form either since that requires an
+        // extra instruction slot (see AArch64RelaxationPass, which does exactly
+        // that for emitted code, relying on a NOP left by the linker). Hence we
+        // keep the target in place instead. Note that ADRP is excluded by
+        // hasPCRelOperand(), and that linker-relaxed sequences have already
+        // been handled above.
+        if (BC.MIB->hasPCRelOperand(Instruction)) {
+          for (const MCSymbol *Symbol : RefSymbols) {
+            BC.errs()
+                << "BOLT-WARNING: unable to update PC-relative reference to "
+                << Symbol->getName() << " at 0x"
+                << Twine::utohexstr(AbsoluteInstrAddr)
+                << ". Will not optimize the target\n";
+            if (BinaryFunction *TargetBF = BC.getFunctionForSymbol(Symbol))
+              TargetBF->setIgnored();
+          }
+          continue;
+        }
+
         LLVM_DEBUG(BC.printInstruction(dbgs(), Instruction, AbsoluteInstrAddr));
         InstructionPatches.push_back({AbsoluteInstrAddr, Instruction});
         continue;

--- a/bolt/test/AArch64/pcrel-patch-funcs-list.s
+++ b/bolt/test/AArch64/pcrel-patch-funcs-list.s
@@ -1,0 +1,46 @@
+## Same failure as pcrel-patch-skipped-func.s, reached through an inclusion list
+## instead of an exclusion list: with --funcs, everything not named is ignored
+## without going through mustSkip().
+##
+## https://github.com/llvm/llvm-project/issues/194938
+
+# REQUIRES: system-linux
+
+# RUN: llvm-mc -filetype=obj -triple aarch64-unknown-unknown %s -o %t.o
+# RUN: %clang %cflags %t.o -o %t.exe -nostdlib -fuse-ld=lld -Wl,-q
+# RUN: llvm-bolt %t.exe -o %t.bolt --funcs='target_fn.*' 2>&1 \
+# RUN:   | FileCheck %s --check-prefix=CHECK-BOLT
+# RUN: llvm-objdump -d --disassemble-symbols=victim %t.bolt | FileCheck %s
+
+# CHECK-BOLT: BOLT-WARNING: unable to update PC-relative reference to
+# CHECK-BOLT-NOT: BOLT-ERROR
+
+# CHECK-LABEL: <victim>:
+# CHECK: adr x8
+
+  .text
+  .globl _start
+  .type _start, %function
+_start:
+  mov w0, #5
+  bl target_fn
+  bl victim
+  mov w8, #93
+  svc #0
+  .size _start, .-_start
+
+## Local symbol: the ADR below carries no relocation.
+  .type target_fn, %function
+target_fn:
+  mul w0, w0, w0
+  add w0, w0, #1
+  ret
+  .size target_fn, .-target_fn
+
+  .globl victim
+  .type victim, %function
+victim:
+  adr x8, target_fn
+  blr x8
+  ret
+  .size victim, .-victim

--- a/bolt/test/AArch64/pcrel-patch-ignored-after-disasm.s
+++ b/bolt/test/AArch64/pcrel-patch-ignored-after-disasm.s
@@ -1,0 +1,59 @@
+## Same failure as pcrel-patch-skipped-func.s, but the function is ignored by
+## BOLT's own decision *after* it was disassembled, so the scan happens in
+## BinaryFunction::setIgnored() rather than in
+## RewriteInstance::disassembleFunctions(). A guard placed at the latter call
+## site does not cover this path.
+##
+## Here a data pointer into the middle of one of victim's instructions makes
+## BOLT report corrupted control flow and ignore the function. No BOLT options
+## are needed at all.
+##
+## https://github.com/llvm/llvm-project/issues/194938
+
+# REQUIRES: system-linux
+
+# RUN: llvm-mc -filetype=obj -triple aarch64-unknown-unknown %s -o %t.o
+# RUN: %clang %cflags %t.o -o %t.exe -nostdlib -fuse-ld=lld -Wl,-q
+# RUN: llvm-bolt %t.exe -o %t.bolt 2>&1 | FileCheck %s --check-prefix=CHECK-BOLT
+# RUN: llvm-objdump -d --disassemble-symbols=victim %t.bolt | FileCheck %s
+
+## The function is dropped from processing, but BOLT must not fail.
+# CHECK-BOLT: corrupted control flow detected in function victim
+# CHECK-BOLT: BOLT-WARNING: unable to update PC-relative reference to
+# CHECK-BOLT-NOT: BOLT-ERROR
+
+# CHECK-LABEL: <victim>:
+# CHECK: adr x8
+
+  .text
+  .globl _start
+  .type _start, %function
+_start:
+  mov w0, #5
+  bl target_fn
+  bl victim
+  mov w8, #93
+  svc #0
+  .size _start, .-_start
+
+## Local symbol: the ADR below carries no relocation.
+  .type target_fn, %function
+target_fn:
+  mul w0, w0, w0
+  add w0, w0, #1
+  ret
+  .size target_fn, .-target_fn
+
+  .globl victim
+  .type victim, %function
+victim:
+  adr x8, target_fn
+  blr x8
+  ret
+  .size victim, .-victim
+
+## Pointer into the middle of victim's first instruction.
+  .data
+  .p2align 3
+badptr:
+  .quad victim+2

--- a/bolt/test/AArch64/pcrel-patch-ldr-literal.s
+++ b/bolt/test/AArch64/pcrel-patch-ldr-literal.s
@@ -1,0 +1,63 @@
+## Same failure class as pcrel-patch-skipped-func.s, but through LDR (literal)
+## instead of ADR. LDR (literal) has the same +/-1MB reach and the same
+## assembler-resolution behaviour for a local symbol in the same section, so it
+## produces an unencodable patch with an LDRLiteral19 fixup:
+##
+##   BOLT-ERROR: JITLink failed: ... section .local.text.__BP_0: relocation
+##   target 0x400000 ... is out of range of LDRLiteral19 fixup ...
+##
+## A fix that only looks at ADR does not cover this.
+##
+## https://github.com/llvm/llvm-project/issues/194938
+
+# REQUIRES: system-linux
+
+# RUN: llvm-mc -filetype=obj -triple aarch64-unknown-unknown %s -o %t.o
+# RUN: %clang %cflags %t.o -o %t.exe -nostdlib -fuse-ld=lld -Wl,-q
+## The only relocation in the binary is the CALL26 for the global bl target:
+## the LDR (literal) below was resolved by the assembler.
+# RUN: llvm-readobj -r %t.exe | FileCheck %s --check-prefix=CHECK-RELOC
+# RUN: llvm-bolt %t.exe -o %t.bolt --funcs='target_fn.*' 2>&1 \
+# RUN:   | FileCheck %s --check-prefix=CHECK-BOLT
+# RUN: llvm-objdump -d --disassemble-symbols=victim %t.bolt | FileCheck %s
+
+# CHECK-RELOC: R_AARCH64_CALL26 victim
+# CHECK-RELOC-NOT: R_AARCH64_LD_PREL_LO19
+
+# CHECK-BOLT: BOLT-WARNING: unable to update PC-relative reference to
+# CHECK-BOLT-NOT: BOLT-ERROR
+
+## The target is kept in place, so the reference stays valid and the function
+## address is unchanged.
+# RUN: llvm-nm %t.exe | grep -w target_fn > %t.orig.sym
+# RUN: llvm-nm %t.bolt | grep -w target_fn > %t.new.sym
+# RUN: diff %t.orig.sym %t.new.sym
+
+# CHECK-LABEL: <victim>:
+# CHECK: ldr x8
+
+  .text
+  .globl _start
+  .type _start, %function
+_start:
+  mov w0, #5
+  bl target_fn
+  bl victim
+  mov w8, #93
+  svc #0
+  .size _start, .-_start
+
+## Local symbol: the LDR (literal) below carries no relocation.
+  .type target_fn, %function
+target_fn:
+  mul w0, w0, w0
+  add w0, w0, #1
+  ret
+  .size target_fn, .-target_fn
+
+  .globl victim
+  .type victim, %function
+victim:
+  ldr x8, target_fn
+  ret
+  .size victim, .-victim

--- a/bolt/test/AArch64/pcrel-patch-lite-mode.s
+++ b/bolt/test/AArch64/pcrel-patch-lite-mode.s
@@ -1,0 +1,55 @@
+## Same failure as pcrel-patch-skipped-func.s, but reached through the default
+## AArch64 configuration: lite mode. Functions without profile data are ignored
+## (RewriteInstance.cpp, shouldProcess()), so a non-profiled function holding an
+## assembler-resolved ADR to a hot function produces an instruction patch that
+## cannot be encoded once the hot function moves.
+##
+## No --skip-funcs here: only a profile.
+##
+## https://github.com/llvm/llvm-project/issues/194938
+
+# REQUIRES: system-linux
+
+# RUN: llvm-mc -filetype=obj -triple aarch64-unknown-unknown %s -o %t.o
+# RUN: %clang %cflags %t.o -o %t.exe -nostdlib -fuse-ld=lld -Wl,-q
+# RUN: echo "0 [unknown] 0 1 target_fn/1 0 0 100" > %t.fdata
+# RUN: llvm-bolt %t.exe -o %t.bolt --data %t.fdata --lite 2>&1 \
+# RUN:   | FileCheck %s --check-prefix=CHECK-BOLT
+# RUN: llvm-objdump -d --disassemble-symbols=victim %t.bolt | FileCheck %s
+
+# CHECK-BOLT: BOLT-WARNING: unable to update PC-relative reference to
+# CHECK-BOLT-NOT: BOLT-ERROR
+
+## victim is not emitted; its ADR is preserved.
+# CHECK-LABEL: <victim>:
+# CHECK: adr x8
+
+  .text
+  .globl _start
+  .type _start, %function
+_start:
+  mov w0, #5
+  bl target_fn
+  bl victim
+  mov w8, #93
+  svc #0
+  .size _start, .-_start
+
+## Local symbol, so the ADR below is resolved by the assembler and no
+## R_AARCH64_ADR_PREL_LO21 relocation is emitted for it.
+  .type target_fn, %function
+target_fn:
+  mul w0, w0, w0
+  add w0, w0, #1
+  ret
+  .size target_fn, .-target_fn
+
+## No profile data: ignored in lite mode, but its function pointer
+## materialization still references a function BOLT moves.
+  .globl victim
+  .type victim, %function
+victim:
+  adr x8, target_fn
+  blr x8
+  ret
+  .size victim, .-victim

--- a/bolt/test/AArch64/pcrel-patch-skipped-func.s
+++ b/bolt/test/AArch64/pcrel-patch-skipped-func.s
@@ -1,0 +1,70 @@
+## Check that BOLT does not create an unencodable instruction patch for a
+## short-range PC-relative reference in a function it was asked to skip. Here
+## the reference is an ADR; see pcrel-patch-ldr-literal.s for the LDR (literal)
+## form, which fails the same way.
+##
+## The ADR target is resolved by the assembler, so the binary carries no
+## R_AARCH64_ADR_PREL_LO21 relocation and BOLT's symbolizer is the only source
+## of the reference, which bypasses the existing ADR guard in
+## scanExternalRefs().
+##
+## Without a fix:
+##   BOLT-ERROR: JITLink failed: ... section .local.text.__BP_0: relocation
+##   target 0x400014 ... is out of range of ADRLiteral21 fixup ...
+##
+## https://github.com/llvm/llvm-project/issues/194938
+
+# REQUIRES: system-linux
+
+# RUN: llvm-mc -filetype=obj -triple aarch64-unknown-unknown %s -o %t.o
+# RUN: %clang %cflags %t.o -o %t.exe -nostdlib -fuse-ld=lld -Wl,-q
+# RUN: llvm-bolt %t.exe -o %t.bolt --skip-funcs=skip_me 2>&1 \
+# RUN:   | FileCheck %s --check-prefix=CHECK-BOLT
+# RUN: llvm-objdump -d --disassemble-symbols=skip_me %t.bolt | FileCheck %s
+
+# CHECK-BOLT: BOLT-WARNING: unable to update PC-relative reference to
+# CHECK-BOLT-NOT: BOLT-ERROR
+
+## The skipped function is preserved in .bolt.org.text and its ADR is left
+## alone, still reaching the data at its original address.
+# CHECK-LABEL: <skip_me>:
+# CHECK: adr x8
+
+  .text
+  .globl _start
+  .type _start, %function
+_start:
+  mov w0, #1
+  bl skip_me
+  bl hot_func
+  mov w8, #93
+  svc #0
+  .size _start, .-_start
+
+## Data in .text, referenced by skip_me via ADR. BOLT registers this untyped
+## local label as a function holding a constant island and emits it into the new
+## text, which is where the ADR reference would have to point.
+  .p2align 2
+my_data:
+  .word 0x10, 0x20, 0x30, 0x40
+
+  .globl skip_me
+  .type skip_me, %function
+skip_me:
+  cmp w0, #3
+  b.hi .Lbad
+  adr x8, my_data
+  ldr w0, [x8, w0, uxtw #2]
+  ret
+.Lbad:
+  mov w0, #-1
+  ret
+  .size skip_me, .-skip_me
+
+  .globl hot_func
+  .type hot_func, %function
+hot_func:
+  mul w0, w0, w0
+  add w0, w0, #1
+  ret
+  .size hot_func, .-hot_func


### PR DESCRIPTION
[BOLT][AArch64] Don't patch short-range PC-relative refs in un-emitted code

scanExternalRefs() updates references in functions that BOLT does not emit by creating instruction patches. For a bare PC-relative reference, such as ADR or LDR (literal), the patch cannot be encoded once the referenced function is moved: both forms reach only +/-1MB, while the new code is typically several MB away. JITLink then reports the fixup as out of range and BOLT fails, e.g.:

  BOLT-ERROR: JITLink failed: In graph in-memory object file, section
  .local.text.__BP_0: relocation target 0x400014 (<anonymous symbol>:0x400000 +
  0x14) is out of range of ADRLiteral21 fixup at address 0x400000 (__BP_0,
  0x10230 + 0x0)

There is an existing check for this, but it only runs when the instruction has a relocation. For a local symbol in the same section the assembler resolves the reference itself, in which case the reference is created by the symbolizer from the instruction's immediate and getRelocationAt() returns nothing.

Keep the target in place in that case instead of emitting an unencodable patch. This mirrors AArch64RelaxationPass, which relaxes such references into an ADRP form for emitted code and gives up when there is no instruction slot available; in un-emitted code there is no slot to use.

The tests cover the ways a function can end up not being emitted: --skip-funcs, lite mode, --funcs, and BOLT ignoring a function on its own after disassembly.

Fixes #194938