### PR TITLE
[clang-format] Fix crash on adjacent configured macro calls

### DIFF
--- a/clang/lib/Format/UnwrappedLineParser.cpp
+++ b/clang/lib/Format/UnwrappedLineParser.cpp
@@ -5199,9 +5199,19 @@ std::optional<llvm::SmallVector<llvm::SmallVector<FormatToken *, 8>, 1>>
 UnwrappedLineParser::parseMacroCall() {
   std::optional<llvm::SmallVector<llvm::SmallVector<FormatToken *, 8>, 1>> Args;
   assert(Line->Tokens.empty());
-  nextToken();
-  if (FormatTok->isNot(tok::l_paren))
+  // Not nextToken(), which would already expand a directly following macro
+  // call before the expansion of this one is inserted.
+  auto ConsumeLastTokenOfCall = [this] {
+    flushComments(isOnNewLine(*FormatTok));
+    pushToken(FormatTok);
+    FormatTok = Tokens->getNextToken();
+  };
+  if (Tokens->peekNextToken(/*SkipComment=*/true)->isNot(tok::l_paren)) {
+    ConsumeLastTokenOfCall();
     return Args;
+  }
+  nextToken();
+  assert(FormatTok->is(tok::l_paren));
   unsigned Position = Tokens->getPosition();
   FormatToken *Tok = FormatTok;
   nextToken();
@@ -5223,7 +5233,7 @@ UnwrappedLineParser::parseMacroCall() {
       }
       Args->push_back({});
       pushTokens(std::next(ArgStart), Line->Tokens.end(), Args->back());
-      nextToken();
+      ConsumeLastTokenOfCall();
       return Args;
     }
     case tok::comma: {

--- a/clang/unittests/Format/FormatTestMacroExpansion.cpp
+++ b/clang/unittests/Format/FormatTestMacroExpansion.cpp
@@ -77,8 +77,7 @@ int f;
 ID(
     namespace foo {
     int a;
-    }
-) // namespace k
+    }) // namespace k
 )",
             format(R"(
 int a;
@@ -313,6 +312,37 @@ TEST_F(FormatTestMacroExpansion, ObjectLikeMacroCalledWithArgsDoesNotHang) {
                 "}",
                 Style);
   verifyNoCrash("CASE(1, \"1\");", Style);
+}
+
+TEST_F(FormatTestMacroExpansion, ExpandsAdjacentMacroCallsInOrder) {
+  FormatStyle Style = getLLVMStyle();
+  Style.Macros.push_back("ID(x)=x");
+
+  verifyFormat("ID(a;)\n"
+               "ID(\n"
+               "    // c\n"
+               "    b;)",
+               Style);
+}
+
+TEST_F(FormatTestMacroExpansion, TokensAfterMacroCallAreNotPartOfCall) {
+  FormatStyle Style = getLLVMStyle();
+  Style.Macros.push_back("ID(x)=x");
+
+  verifyFormat("ID(a;) // c\n"
+               "ID(b;)",
+               "ID(\n"
+               "    a;) // c\n"
+               "ID(b;)",
+               Style);
+  verifyFormat("int x = ID(1) // c\n"
+               "        + 2;",
+               Style);
+  verifyFormat("ID(a;)\n"
+               "#if X\n"
+               "int b;\n"
+               "#endif",
+               Style);
 }
 
 } // namespace


### PR DESCRIPTION
`parseMacroCall()` used `nextToken()` to consume the end of a configured macro call, which also processed the following token. For adjacent macro calls, this could expand the second call first and leave macro reconstruction state out of order, causing a crash when the second expansion starts with a comment.

This commit changes `parseMacroCall()` to consume the last token without processing the following token, preserving source-order expansion. It also prevents trailing comments from becoming part of the reconstructed macro call.

Fixes #190721

Assisted-by: DeepSeek Flash v4
