### PR TITLE
[HLSL] Implement the SV_IsFrontFace semantic

### DIFF
--- a/clang/lib/CodeGen/CGHLSLRuntime.cpp
+++ b/clang/lib/CodeGen/CGHLSLRuntime.cpp
@@ -1073,15 +1073,20 @@ static Value *buildVectorInput(IRBuilder<> &B, Function *F, llvm::Type *Ty) {
 }
 
 static void addSPIRVBuiltinDecoration(llvm::GlobalVariable *GV,
-                                      unsigned BuiltIn) {
+                                      unsigned BuiltIn,
+                                      bool NeedsFlat = false) {
   LLVMContext &Ctx = GV->getContext();
   IRBuilder<> B(GV->getContext());
-  MDNode *Operands = MDNode::get(
+  SmallVector<Metadata *, 2> Decorations;
+  Decorations.push_back(MDNode::get(
       Ctx,
       {ConstantAsMetadata::get(B.getInt32(/* Spirv::Decoration::BuiltIn */ 11)),
-       ConstantAsMetadata::get(B.getInt32(BuiltIn))});
-  MDNode *Decoration = MDNode::get(Ctx, {Operands});
-  GV->addMetadata("spirv.Decorations", *Decoration);
+       ConstantAsMetadata::get(B.getInt32(BuiltIn))}));
+  if (NeedsFlat)
+    Decorations.push_back(
+        MDNode::get(Ctx, {ConstantAsMetadata::get(
+                             B.getInt32(/* Spirv::Decoration::Flat */ 14))}));
+  GV->addMetadata("spirv.Decorations", *MDNode::get(Ctx, Decorations));
 }
 
 static void addLocationDecoration(llvm::GlobalVariable *GV, unsigned Location) {
@@ -1116,13 +1121,13 @@ static bool inputRequiresFlatDecoration(llvm::Type *Ty) {
 
 static llvm::Value *createSPIRVBuiltinLoad(IRBuilder<> &B, llvm::Module &M,
                                            llvm::Type *Ty, const Twine &Name,
-                                           unsigned BuiltInID) {
+                                           unsigned BuiltInID, bool NeedsFlat) {
   auto *GV = new llvm::GlobalVariable(
       M, Ty, /* isConstant= */ true, llvm::GlobalValue::ExternalLinkage,
       /* Initializer= */ nullptr, Name, /* insertBefore= */ nullptr,
       llvm::GlobalVariable::GeneralDynamicTLSModel,
       /* AddressSpace */ 7, /* isExternallyInitialized= */ true);
-  addSPIRVBuiltinDecoration(GV, BuiltInID);
+  addSPIRVBuiltinDecoration(GV, BuiltInID, NeedsFlat);
   GV->setVisibility(llvm::GlobalValue::HiddenVisibility);
   return B.CreateLoad(Ty, GV);
 }
@@ -1476,13 +1481,16 @@ llvm::Value *CGHLSLRuntime::emitSystemSemanticLoad(
   const auto *ShaderAttr = FD->getAttr<HLSLShaderAttr>();
   assert(ShaderAttr && "Entry point has no shader attribute");
   llvm::Triple::EnvironmentType ST = ShaderAttr->getType();
+  // PSIn non-float BuiltIns must be Flat; only floats can interpolate
+  bool NeedsFlat =
+      ST == Triple::EnvironmentType::Pixel && inputRequiresFlatDecoration(Type);
 
   if (SemanticName == "SV_POSITION") {
     if (ST == Triple::EnvironmentType::Pixel) {
       if (CGM.getTarget().getTriple().isSPIRV())
         return createSPIRVBuiltinLoad(B, CGM.getModule(), Type,
                                       Semantic->getAttrName()->getName(),
-                                      /* BuiltIn::FragCoord */ 15);
+                                      /* BuiltIn::FragCoord */ 15, NeedsFlat);
       if (CGM.getTarget().getTriple().isDXIL())
         return emitDXILUserSemanticLoad(B, Type, Decl, Semantic, Index,
                                         Signature);
@@ -1499,8 +1507,20 @@ llvm::Value *CGHLSLRuntime::emitSystemSemanticLoad(
       if (CGM.getTarget().getTriple().isSPIRV())
         return createSPIRVBuiltinLoad(B, CGM.getModule(), Type,
                                       Semantic->getAttrName()->getName(),
-                                      /* BuiltIn::VertexIndex */ 42);
+                                      /* BuiltIn::VertexIndex */ 42, NeedsFlat);
       else
+        return emitDXILUserSemanticLoad(B, Type, Decl, Semantic, Index,
+                                        Signature);
+    }
+  }
+
+  if (SemanticName == "SV_ISFRONTFACE") {
+    if (ST == Triple::EnvironmentType::Pixel) {
+      if (CGM.getTarget().getTriple().isSPIRV())
+        return createSPIRVBuiltinLoad(B, CGM.getModule(), Type,
+                                      Semantic->getAttrName()->getName(),
+                                      /* BuiltIn::FrontFacing */ 17, NeedsFlat);
+      if (CGM.getTarget().getTriple().isDXIL())
         return emitDXILUserSemanticLoad(B, Type, Decl, Semantic, Index,
                                         Signature);
     }

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -883,6 +883,9 @@ static bool isVkPipelineBuiltin(const ASTContext &AstContext, FunctionDecl *FD,
   if (SemanticName == "SV_VERTEXID")
     return true;
 
+  if (SemanticName == "SV_ISFRONTFACE")
+    return ST == llvm::Triple::Pixel && IsInput;
+
   return false;
 }
 
@@ -1108,6 +1111,12 @@ void SemaHLSL::checkSemanticAnnotation(
   if (SemanticName == "SV_VERTEXID") {
     diagnoseSemanticStageMismatch(SemanticAttr, ST, SC.CurrentIOType,
                                   {{llvm::Triple::Vertex, IOType::In}});
+    return;
+  }
+
+  if (SemanticName == "SV_ISFRONTFACE") {
+    diagnoseSemanticStageMismatch(SemanticAttr, ST, SC.CurrentIOType,
+                                  {{llvm::Triple::Pixel, IOType::In}});
     return;
   }
 
@@ -1992,6 +2001,17 @@ void SemaHLSL::diagnoseSystemSemanticAttr(Decl *D, const ParsedAttr &AL,
     uint64_t SizeInBits = SemaRef.Context.getTypeSize(ValueType);
     if (!ValueType->isUnsignedIntegerType() || SizeInBits != 32)
       Diag(AL.getLoc(), diag::err_hlsl_attr_invalid_type) << AL << "uint";
+    D->addAttr(createSemanticAttr<HLSLParsedSemanticAttr>(AL, Index));
+    return;
+  }
+
+  if (SemanticName == "SV_ISFRONTFACE") {
+    if (!ValueType->isBooleanType())
+      Diag(AL.getLoc(), diag::err_hlsl_attr_invalid_type) << AL << "bool";
+    if (IsOutput)
+      Diag(AL.getLoc(), diag::err_hlsl_semantic_output_not_supported) << AL;
+    if (Index.has_value())
+      Diag(AL.getLoc(), diag::err_hlsl_semantic_indexing_not_supported) << AL;
     D->addAttr(createSemanticAttr<HLSLParsedSemanticAttr>(AL, Index));
     return;
   }

--- a/clang/test/CodeGenHLSL/semantics/SV_IsFrontFace.ps.hlsl
+++ b/clang/test/CodeGenHLSL/semantics/SV_IsFrontFace.ps.hlsl
@@ -1,0 +1,23 @@
+// RUN: %clang_cc1 -triple spirv-pc-vulkan1.3-pixel -x hlsl -emit-llvm -finclude-default-header -disable-llvm-passes -o - %s | FileCheck %s --check-prefix=CHECK-SPIRV
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-pixel -x hlsl -emit-llvm -finclude-default-header -disable-llvm-passes -o - %s | FileCheck %s --check-prefix=CHECK-DXIL
+
+// CHECK-SPIRV: @SV_IsFrontFace = external hidden thread_local addrspace(7) externally_initialized constant i1, !spirv.Decorations ![[#MD_0:]]
+
+// CHECK: define void @main() {{.*}} {
+float4 main(bool ff : SV_IsFrontFace) : SV_Target {
+  // CHECK-SPIRV: %[[FF:.*]] = load i1, ptr addrspace(7) @SV_IsFrontFace
+  // CHECK-SPIRV: %[[R:.*]] = call spir_func <4 x float> @_Z4mainb(i1 %[[FF]])
+
+  // CHECK-DXIL: %[[INPUT:.*]] = call i32 @llvm.dx.load.input.i32(i32 0, i32 0, i8 0, i32 poison)
+  // CHECK-DXIL: %[[BOOL:.*]] = icmp ne i32 %[[INPUT]], 0
+  // CHECK-DXIL: %[[R:.*]] = call <4 x float> @_Z4mainb(i1 %[[BOOL]])
+  return ff ? float4(1, 0, 0, 1) : float4(0, 0, 1, 1);
+}
+
+// Two decorations in ONE node — this is the assertion that step 5 works.
+// CHECK-SPIRV-DAG: ![[#MD_0]] = !{![[#MD_1:]], ![[#MD_2:]]}
+// CHECK-SPIRV-DAG: ![[#MD_1]] = !{i32 11, i32 17}
+//                                      |       `-> BuiltIn FrontFacing (ID 17)
+//                                      `-> SPIR-V decoration 'BuiltIn' (11)
+// CHECK-SPIRV-DAG: ![[#MD_2]] = !{i32 14}
+//                                      `-> SPIR-V decoration 'Flat' (14)

--- a/clang/test/SemaHLSL/Semantics/isfrontface.output.hlsl
+++ b/clang/test/SemaHLSL/Semantics/isfrontface.output.hlsl
@@ -1,0 +1,9 @@
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library -finclude-default-header -x hlsl -verify -o - %s
+// RUN: %clang_cc1 -triple spirv-pc-vulkan1.3-library -finclude-default-header -x hlsl -verify -o - %s
+
+[shader("pixel")]
+float4 main(out bool ff : SV_IsFrontFace) : SV_Target {
+// expected-error@-1 {{semantic 'SV_IsFrontFace' does not support output}}
+  ff = true;
+  return float4(0, 0, 0, 1);
+}

--- a/clang/test/SemaHLSL/Semantics/isfrontface.ps.hlsl
+++ b/clang/test/SemaHLSL/Semantics/isfrontface.ps.hlsl
@@ -1,0 +1,21 @@
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library -finclude-default-header -x hlsl -verify -o - %s
+// RUN: %clang_cc1 -triple spirv-pc-vulkan1.3-library -finclude-default-header -x hlsl -verify -o - %s
+
+float4 bad_uint(uint ff : SV_IsFrontFace) : SV_Target { return float4(ff); }
+// expected-error@-1 {{attribute 'SV_IsFrontFace' only applies to a field or parameter of type 'bool'}}
+
+float4 bad_float(float ff : SV_IsFrontFace) : SV_Target { return float4(ff); }
+// expected-error@-1 {{attribute 'SV_IsFrontFace' only applies to a field or parameter of type 'bool'}}
+
+float4 bad_int(int ff : SV_IsFrontFace) : SV_Target { return float4(ff); }
+// expected-error@-1 {{attribute 'SV_IsFrontFace' only applies to a field or parameter of type 'bool'}}
+
+float4 bad_vec(bool3 ff : SV_IsFrontFace) : SV_Target { return float4(ff.x); }
+// expected-error@-1 {{attribute 'SV_IsFrontFace' only applies to a field or parameter of type 'bool'}}
+//   `isBooleanType()` is scalar-only, so bool3 is rejected without an extra shape check.
+
+// Indexing is not permitted on SV_IsFrontFace.
+float4 bad_index(bool ff : SV_IsFrontFace1) : SV_Target { return float4(ff); }
+// expected-error@-1 {{semantic 'SV_IsFrontFace' does not allow indexing}}
+
+float4 ok(bool ff : SV_IsFrontFace) : SV_Target { return float4(ff); }

--- a/clang/test/SemaHLSL/Semantics/isfrontface.vs.hlsl
+++ b/clang/test/SemaHLSL/Semantics/isfrontface.vs.hlsl
@@ -1,0 +1,7 @@
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-vertex -finclude-default-header -x hlsl -verify -o - %s
+// RUN: %clang_cc1 -triple spirv-pc-vulkan1.3-vertex -finclude-default-header -x hlsl -verify -o - %s
+
+float4 main(bool ff : SV_IsFrontFace) : SV_Position {
+// expected-error@-1 {{attribute 'SV_IsFrontFace' is unsupported in 'vertex' shaders, requires pixel}}
+  return float4(1, 1, 1, 1);
+}


### PR DESCRIPTION
Fixes #136979

Adds type validation, stage restriction, and SPIR-V lowering for `SV_IsFrontFace`.

- Sema: `bool` only, rejected at non-pixel stages, as an output, and with an index.
- SPIR-V: lowers to `BuiltIn FrontFacing` with `Flat` decoration.
- DXIL: delegates to `emitDXILUserSemanticLoad`.
- LIT: sema tests (wrong type, wrong stage, output direction) and codegen test (BuiltIn + Flat metadata, no Location).
- Infra: `addSPIRVBuiltinDecoration` extended to emit a combined `BuiltIn`+`Flat` decoration node; new `NeedsFlat` arg is computed in `emitSystemSemanticLoad` from stage and type.

@dnovillo @pow2clk

Assisted by LLM