### PR TITLE
[GlobalISel] Skip mul_by_neg_one when the mul has nuw.

### DIFF
--- a/llvm/include/llvm/Target/GlobalISel/Combine.td
+++ b/llvm/include/llvm/Target/GlobalISel/Combine.td
@@ -1209,9 +1209,10 @@ def trunc_shift: GICombineRule <
 >;
 
 // Transform (mul x, -1) -> (sub 0, x)
+// The sub inherits the mul's flags, and (sub nuw 0, x) is only valid for x = 0.
 def mul_by_neg_one: GICombineRule <
   (defs root:$dst),
-  (match (G_MUL $dst, $x, -1)),
+  (match (G_MUL $dst, $x, -1, (MIFlags (not NoUWrap)))),
   (apply (G_SUB $dst, 0, $x))
 >;
 

--- a/llvm/test/CodeGen/AArch64/GlobalISel/combine-mul.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/combine-mul.mir
@@ -144,6 +144,28 @@ body:             |
     $x0 = COPY %2(i64)
 ...
 ---
+name:            mul_nuw_by_neg_one
+alignment:       4
+tracksRegLiveness: true
+frameInfo:
+  maxAlignment:    1
+machineFunctionInfo: {}
+body:             |
+  bb.0:
+    liveins: $x0
+    ; CHECK-LABEL: name: mul_nuw_by_neg_one
+    ; CHECK: liveins: $x0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(i64) = COPY $x0
+    ; CHECK-NEXT: [[C:%[0-9]+]]:_(i64) = G_CONSTANT i64 -1
+    ; CHECK-NEXT: [[MUL:%[0-9]+]]:_(i64) = nuw G_MUL [[COPY]], [[C]]
+    ; CHECK-NEXT: $x0 = COPY [[MUL]](i64)
+    %0:_(i64) = COPY $x0
+    %1:_(i64) = G_CONSTANT i64 -1
+    %2:_(i64) = nuw G_MUL %0, %1(i64)
+    $x0 = COPY %2(i64)
+...
+---
 name:            mul_vector_by_neg_one
 alignment:       4
 tracksRegLiveness: true


### PR DESCRIPTION
`mul_by_neg_one` rewrites `(mul x, -1)` to `(sub 0, x)` and the combiner copies the flags of the matched `G_MUL` onto the new `G_SUB`.

With `nuw` this changes the meaning: `(mul nuw x, -1)` is defined for x = 0 and x = 1, but `(sub nuw 0, x)` is poison for every x other than 0, so known bits fold the result to zero. The rule now only fires when the mul has no `nuw` flag.
