### PR TITLE
[ADT][MemProf] Optimize set_subtract with removed-set output and use in MemProf

### DIFF
--- a/llvm/include/llvm/ADT/SetOperations.h
+++ b/llvm/include/llvm/ADT/SetOperations.h
@@ -133,16 +133,42 @@ template <class S1Ty, class S2Ty> void set_subtract(S1Ty &S1, const S2Ty &S2) {
     S1.erase(E);
 }
 
-/// set_subtract(A, B, C, D) - Compute A := A - B, set C to the elements of B
-/// removed from A (A ^ B), and D to the elements of B not found in and removed
-/// from A (B - A).
+/// set_subtract(A, B, C) - Compute A := A - B, and set C to the elements of B
+/// removed from A (A ^ B).
+///
+/// Selects the set to iterate based on the relative sizes of A and B for better
+/// efficiency.
 template <class S1Ty, class S2Ty>
-void set_subtract(S1Ty &S1, const S2Ty &S2, S1Ty &Removed, S1Ty &Remaining) {
+void set_subtract(S1Ty &S1, const S2Ty &S2, S1Ty &Removed) {
+  // If S1 is smaller than S2, iterate on S1 provided that S2 supports efficient
+  // lookups via contains() and S1 supports remove_if().
+  using ElemTy = decltype(*S1.begin());
+  if constexpr (detail::HasMemberContains<S2Ty, ElemTy>) {
+    auto Pred = [&S2, &Removed](const auto &E) {
+      if (S2.contains(E)) {
+        Removed.insert(E);
+        return true;
+      }
+      return false;
+    };
+    if constexpr (detail::HasMemberRemoveIf<S1Ty, decltype(Pred)>) {
+      // Place the runtime size check inside HasMemberRemoveIf so that for
+      // container types that do not support remove_if, the size check is
+      // eliminated at compile time and execution falls directly through to
+      // the fallback loop below.
+      if (S1.size() < S2.size()) {
+        S1.remove_if(Pred);
+        return;
+      }
+    }
+  }
+
+  // Fallback when S1 is not smaller, S2 doesn't support contains() (e.g. S2
+  // is a vector), or S1 doesn't support remove_if(). Iterate over S2 and
+  // erase from S1.
   for (const auto &E : S2)
     if (S1.erase(E))
       Removed.insert(E);
-    else
-      Remaining.insert(E);
 }
 
 /// set_is_subset(A, B) - Return true iff A in B

--- a/llvm/lib/Transforms/IPO/MemProfContextDisambiguation.cpp
+++ b/llvm/lib/Transforms/IPO/MemProfContextDisambiguation.cpp
@@ -1588,18 +1588,18 @@ void CallsiteContextGraph<DerivedCCG, FuncTy, CallTy>::connectNewNode(
   for (auto EI = OrigEdges.begin(); EI != OrigEdges.end();) {
     auto Edge = *EI;
     DenseSet<uint32_t> NewEdgeContextIds;
-    DenseSet<uint32_t> NotFoundContextIds;
     // Remove any matching context ids from Edge, return set that were found and
-    // removed, these are the new edge's context ids. Also update the remaining
-    // (not found ids).
-    set_subtract(Edge->getContextIds(), RemainingContextIds, NewEdgeContextIds,
-                 NotFoundContextIds);
+    // removed, these are the new edge's context ids.
+    set_subtract(Edge->getContextIds(), RemainingContextIds, NewEdgeContextIds);
+    // If no matching context ids for this edge, skip it.
+    if (NewEdgeContextIds.empty()) {
+      ++EI;
+      continue;
+    }
     // Update the remaining context ids set for the later edges. This is a
     // compile time optimization.
     if (RecursiveContextIds.empty()) {
-      // No recursive ids, so all of the previously remaining context ids that
-      // were not seen on this edge are the new remaining set.
-      RemainingContextIds.swap(NotFoundContextIds);
+      set_subtract(RemainingContextIds, NewEdgeContextIds);
     } else {
       // Keep the recursive ids in the remaining set as we expect to see those
       // on another edge. We can remove the non-recursive remaining ids that
@@ -1612,11 +1612,6 @@ void CallsiteContextGraph<DerivedCCG, FuncTy, CallTy>::connectNewNode(
       DenseSet<uint32_t> NonRecursiveRemainingCurEdgeIds =
           set_difference(NewEdgeContextIds, RecursiveContextIds);
       set_subtract(RemainingContextIds, NonRecursiveRemainingCurEdgeIds);
-    }
-    // If no matching context ids for this edge, skip it.
-    if (NewEdgeContextIds.empty()) {
-      ++EI;
-      continue;
     }
     if (TowardsCallee) {
       uint8_t NewAllocType = computeAllocType(NewEdgeContextIds);

--- a/llvm/unittests/ADT/SetOperationsTest.cpp
+++ b/llvm/unittests/ADT/SetOperationsTest.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/ADT/SetOperations.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
@@ -207,52 +208,106 @@ TEST(SetOperationsTest, SetSubtractSmallVector) {
   EXPECT_THAT(Set1, UnorderedElementsAre(&A[1]));
 }
 
-TEST(SetOperationsTest, SetSubtractRemovedRemaining) {
-  std::set<int> Removed, Remaining;
+TEST(SetOperationsTest, SetSubtractRemoved) {
+  std::set<int> Removed;
 
   std::set<int> Set1 = {1, 2, 3, 4};
   std::set<int> Set2 = {3, 4, 5, 6};
 
-  set_subtract(Set1, Set2, Removed, Remaining);
+  set_subtract(Set1, Set2, Removed);
   // Set1 should get Set1 - Set2, leaving only {1, 2}.
   EXPECT_THAT(Set1, UnorderedElementsAre(1, 2));
   // Set2 should not be touched.
   EXPECT_THAT(Set2, UnorderedElementsAre(3, 4, 5, 6));
-  // We should get back that {3, 4} from Set2 were removed from Set1, and {5, 6}
-  // were not removed from Set1.
+  // We should get back that {3, 4} from Set2 were removed from Set1.
   EXPECT_THAT(Removed, UnorderedElementsAre(3, 4));
-  EXPECT_THAT(Remaining, UnorderedElementsAre(5, 6));
 
   Set1 = {1, 2, 3, 4};
   Set2 = {1, 2, 3, 4};
   Removed.clear();
-  Remaining.clear();
 
-  set_subtract(Set1, Set2, Removed, Remaining);
+  set_subtract(Set1, Set2, Removed);
   // Set1 should get Set1 - Set2, which should be empty.
   EXPECT_THAT(Set1, IsEmpty());
   // Set2 should not be touched.
   EXPECT_THAT(Set2, UnorderedElementsAre(1, 2, 3, 4));
-  // Set should get back that all of Set2 was removed from Set1, and nothing
-  // left in Set2 was not removed from Set1.
+  // Set should get back that all of Set2 was removed from Set1.
   EXPECT_THAT(Removed, UnorderedElementsAre(1, 2, 3, 4));
-  EXPECT_THAT(Remaining, IsEmpty());
 
   Set1 = {1, 2, 3, 4};
   Set2 = {5, 6};
   Removed.clear();
-  Remaining.clear();
 
-  set_subtract(Set1, Set2, Removed, Remaining);
+  set_subtract(Set1, Set2, Removed);
   // Set1 should get Set1 - Set2, which should be Set1 as they are
   // non-overlapping.
   EXPECT_THAT(Set1, UnorderedElementsAre(1, 2, 3, 4));
   // Set2 should not be touched.
   EXPECT_THAT(Set2, UnorderedElementsAre(5, 6));
   EXPECT_THAT(Removed, IsEmpty());
-  // Set should get back that none of Set2 was removed from Set1, and all
-  // of Set2 was not removed from Set1.
-  EXPECT_THAT(Remaining, UnorderedElementsAre(5, 6));
+}
+
+TEST(SetOperationsTest, SetSubtractRemovedSmallPtrSet) {
+  int A[4];
+
+  // Set1.size() < Set2.size()
+  SmallPtrSet<int *, 4> Removed;
+  SmallPtrSet<int *, 4> Set1 = {&A[0], &A[1]};
+  SmallPtrSet<int *, 4> Set2 = {&A[1], &A[2], &A[3]};
+  set_subtract(Set1, Set2, Removed);
+  EXPECT_THAT(Set1, UnorderedElementsAre(&A[0]));
+  EXPECT_THAT(Set2, UnorderedElementsAre(&A[1], &A[2], &A[3]));
+  EXPECT_THAT(Removed, UnorderedElementsAre(&A[1]));
+
+  // Set1.size() > Set2.size()
+  Removed.clear();
+  Set1 = {&A[0], &A[1], &A[2]};
+  Set2 = {&A[0], &A[2]};
+  set_subtract(Set1, Set2, Removed);
+  EXPECT_THAT(Set1, UnorderedElementsAre(&A[1]));
+  EXPECT_THAT(Set2, UnorderedElementsAre(&A[0], &A[2]));
+  EXPECT_THAT(Removed, UnorderedElementsAre(&A[0], &A[2]));
+}
+
+TEST(SetOperationsTest, SetSubtractRemovedSmallVector) {
+  int A[4];
+
+  // Set1.size() < Set2.size()
+  SmallPtrSet<int *, 4> Removed;
+  SmallPtrSet<int *, 4> Set1 = {&A[0], &A[1]};
+  SmallVector<int *> Set2 = {&A[1], &A[2], &A[3]};
+  set_subtract(Set1, Set2, Removed);
+  EXPECT_THAT(Set1, UnorderedElementsAre(&A[0]));
+  EXPECT_THAT(Removed, UnorderedElementsAre(&A[1]));
+
+  // Set1.size() > Set2.size()
+  Removed.clear();
+  Set1 = {&A[0], &A[1], &A[2]};
+  Set2 = {&A[0], &A[2]};
+  set_subtract(Set1, Set2, Removed);
+  EXPECT_THAT(Set1, UnorderedElementsAre(&A[1]));
+  EXPECT_THAT(Removed, UnorderedElementsAre(&A[0], &A[2]));
+}
+
+TEST(SetOperationsTest, SetSubtractRemovedDenseSet) {
+  DenseSet<int> Removed;
+
+  // Set1.size() < Set2.size()
+  DenseSet<int> Set1 = {1, 2};
+  DenseSet<int> Set2 = {2, 3, 4};
+  set_subtract(Set1, Set2, Removed);
+  EXPECT_THAT(Set1, UnorderedElementsAre(1));
+  EXPECT_THAT(Set2, UnorderedElementsAre(2, 3, 4));
+  EXPECT_THAT(Removed, UnorderedElementsAre(2));
+
+  // Set1.size() > Set2.size()
+  Removed.clear();
+  Set1 = {1, 2, 3};
+  Set2 = {1, 3};
+  set_subtract(Set1, Set2, Removed);
+  EXPECT_THAT(Set1, UnorderedElementsAre(2));
+  EXPECT_THAT(Set2, UnorderedElementsAre(1, 3));
+  EXPECT_THAT(Removed, UnorderedElementsAre(1, 3));
 }
 
 TEST(SetOperationsTest, SetIsSubset) {


### PR DESCRIPTION
Add a 3-argument set_subtract(A, B, Removed) that computes A := A - B
and records elements of B removed from A (A ^ B) in Removed. When
A.size() < B.size(), B supports contains(), and A supports remove_if(),
we iterate over A via remove_if() instead of iterating over B, improving
efficiency.

Remove the legacy 4-argument set_subtract(A, B, Removed, Remaining),
which was only used by MemProfContextDisambiguation.cpp and is now
redundant since Remaining can be updated via a separate 2-argument
set_subtract.

Update MemProfContextDisambiguation to use the 3-argument set_subtract,
and update SetOperations unit tests.
