### PR TITLE
[CI] Require hashes for premerge python dep installation

### DIFF
--- a/.ci/utils.sh
+++ b/.ci/utils.sh
@@ -79,7 +79,7 @@ function start-group {
 }
 
 export PIP_BREAK_SYSTEM_PACKAGES=1
-pip install -q -r "${MONOREPO_ROOT}"/.ci/all_requirements.txt
+pip install --require-hashes -q -r "${MONOREPO_ROOT}"/.ci/all_requirements.txt
 
 # The ARM64 builders run on AWS and don't have access to the GCS cache.
 if [[ -n "$GITHUB_ACTIONS" ]] && [[ "$RUNNER_ARCH" != "ARM64" ]]; then


### PR DESCRIPTION
This is best practice and the requirements file is already a lockfile with hashes.