### PR TITLE
[CI] Remove psutil from Windows container

### DIFF
--- a/.github/workflows/containers/github-action-ci-windows/Dockerfile
+++ b/.github/workflows/containers/github-action-ci-windows/Dockerfile
@@ -57,9 +57,6 @@ RUN git clone --depth 1 --branch 2026.06.24 https://github.com/microsoft/vcpkg.g
     rmdir /S /Q C:\vcpkg\downloads && \
     rmdir /S /Q C:\vcpkg\.git
 
-# Testing requires psutil
-RUN pip install psutil
-
 # configure Python encoding
 ENV PYTHONIOENCODING=UTF-8
 


### PR DESCRIPTION
This is not hash-pinned which introduces a security hole, and is installed anyways (almost certainly to a different version) everytime we run the monolithic-windows.sh script. This will slightly reduce the size of the windows container image.