### PR TITLE
[clang][bytecode] Cache Is(Unnamed)BitFields bools in `Record::Field`

### DIFF
--- a/clang/lib/AST/ByteCode/Record.h
+++ b/clang/lib/AST/ByteCode/Record.h
@@ -29,16 +29,21 @@ public:
     const FieldDecl *Decl;
     const Descriptor *Desc;
     unsigned Offset;
+    bool IsBitField;
+    bool IsUnnamedBitField;
 
-    bool isBitField() const { return Decl->isBitField(); }
-    bool isUnnamedBitField() const { return Decl->isUnnamedBitField(); }
+    bool isBitField() const { return IsBitField; }
+    bool isUnnamedBitField() const { return IsUnnamedBitField; }
     unsigned bitWidth() const {
       assert(isBitField());
       return Decl->getBitWidthValue();
     }
 
     Field(const FieldDecl *D, const Descriptor *Desc, unsigned Offset)
-        : Decl(D), Desc(Desc), Offset(Offset) {}
+        : Decl(D), Desc(Desc), Offset(Offset) {
+      IsBitField = Decl->isBitField();
+      IsUnnamedBitField = IsBitField && Decl->isUnnamedBitField();
+    }
   };
 
   /// Describes a base class.


### PR DESCRIPTION
We need to query those a lot and we can save them in the padding bytes of `Record::Field`.