### PR TITLE
[libcxx] Move premerge jobs to k8s mode runner set

### DIFF
--- a/.github/workflows/libcxx-pr-conformance-tests.yaml
+++ b/.github/workflows/libcxx-pr-conformance-tests.yaml
@@ -115,6 +115,7 @@ jobs:
         with:
           persist-credentials: false
       - name: ${{ matrix.config }}
+        shell: bash
         run: |
           python3 -m venv --system-site-packages .venv
           source .venv/bin/activate

--- a/.github/workflows/libcxx-pr-conformance-tests.yaml
+++ b/.github/workflows/libcxx-pr-conformance-tests.yaml
@@ -37,7 +37,9 @@ concurrency:
 jobs:
   stage1:
     if: github.repository_owner == 'llvm'
-    runs-on: llvm-premerge-libcxx-runners
+    runs-on: llvm-premerge-linux-32-runners
+    container:
+      image: ghcr.io/llvm/libcxx-linux-builder:6d3cf7f436a01f4622fb660e413a4020209777b8
     continue-on-error: false
     strategy:
       fail-fast: false
@@ -80,7 +82,9 @@ jobs:
             **/crash_diagnostics/*
   stage2:
     if: github.repository_owner == 'llvm'
-    runs-on: llvm-premerge-libcxx-runners
+    runs-on: llvm-premerge-linux-32-runners
+    container:
+      image: ghcr.io/llvm/libcxx-linux-builder:6d3cf7f436a01f4622fb660e413a4020209777b8
     needs: [ stage1 ]
     continue-on-error: false
     strategy:
@@ -132,7 +136,9 @@ jobs:
             **/crash_diagnostics/*
   stage3:
     if: github.repository_owner == 'llvm'
-    runs-on: llvm-premerge-libcxx-runners
+    runs-on: llvm-premerge-linux-32-runners
+    container:
+      image: ghcr.io/llvm/libcxx-linux-builder:6d3cf7f436a01f4622fb660e413a4020209777b8
     needs: [ stage2 ]
     continue-on-error: false
     strategy:

--- a/.github/workflows/libcxx-pr-conformance-tests.yaml
+++ b/.github/workflows/libcxx-pr-conformance-tests.yaml
@@ -61,6 +61,7 @@ jobs:
         with:
           persist-credentials: false
       - name: ${{ matrix.config }}.${{ matrix.cxx }}
+        shell: bash
         run: |
           python3 -m venv --system-site-packages .venv
           source .venv/bin/activate
@@ -180,6 +181,7 @@ jobs:
         with:
           persist-credentials: false
       - name: ${{ matrix.config }}
+        shell: bash
         run: |
           python3 -m venv --system-site-packages .venv
           source .venv/bin/activate

--- a/.github/workflows/libcxx-pr-test-tools.yml
+++ b/.github/workflows/libcxx-pr-test-tools.yml
@@ -31,7 +31,9 @@ concurrency:
 jobs:
   test-tools:
     if: github.repository_owner == 'llvm'
-    runs-on: llvm-premerge-libcxx-runners
+    runs-on: llvm-premerge-linux-32-runners
+    container:
+      image: ghcr.io/llvm/libcxx-linux-builder:6d3cf7f436a01f4622fb660e413a4020209777b8
     env:
       CC: clang-23
       CXX: clang++-23

--- a/.github/workflows/libcxx-pr-test-tools.yml
+++ b/.github/workflows/libcxx-pr-test-tools.yml
@@ -45,12 +45,14 @@ jobs:
           fetch-tags: true
 
       - name: Set up Python dependencies
+        shell: bash
         run: |
           python3 -m venv .venv
           source .venv/bin/activate
           pip install -r libcxx/utils/requirements.txt
 
       - name: Run the tooling smoke test
+        shell: bash
         run: |
           source .venv/bin/activate
           libcxx/utils/ci/run-buildbot test-tools


### PR DESCRIPTION
This allows setting the container image in the workflow definition which should vastly simplify maintenance. The issues that we were running into previously with jobs randomly aborting (and getting marked as passed) have been fixed with some cluster-side config changes.