### PR TITLE
[orc-rt] Fix -Wctad-maybe-unsupported warning in unit test.

### DIFF
--- a/orc-rt/test/unit/bedrock/SessionTest.cpp
+++ b/orc-rt/test/unit/bedrock/SessionTest.cpp
@@ -107,7 +107,7 @@ private:
       if (MCA) {
         bool Notify;
         {
-          std::scoped_lock Lock(MCA->M);
+          std::scoped_lock<std::mutex> Lock(MCA->M);
           --MCA->Outstanding;
           Notify = MCA->Shutdown && MCA->Outstanding == 0;
         }


### PR DESCRIPTION
Avoid the warning by naming the mutex type on scoped_lock.

'std::scoped_lock' may not intend to support class template argument deduction