### PR TITLE
[orc-rt] Check HandlerRan flag in unit test.

### DIFF
--- a/orc-rt/test/unit/support/ErrorExceptionInteropTest.cpp
+++ b/orc-rt/test/unit/support/ErrorExceptionInteropTest.cpp
@@ -171,6 +171,8 @@ TEST(ErrorExceptionInteropTest, ThrowErrorAndCatchAsException) {
     } catch (...) {
       ADD_FAILURE() << "Caught unexpected error type";
     }
+
+    EXPECT_TRUE(HandlerRan) << "Handler never ran";
   });
 }
 


### PR DESCRIPTION
Verifies that the expected catch handler ran, and eliminates an unused variable warning.