### PR TITLE
[libc++][NFC] Avoid empty namespace in `<__concepts/common_with.h>`

### DIFF
--- a/libcxx/include/__concepts/common_with.h
+++ b/libcxx/include/__concepts/common_with.h
@@ -21,9 +21,9 @@
 #  pragma GCC system_header
 #endif
 
-_LIBCPP_BEGIN_NAMESPACE_STD
-
 #if _LIBCPP_STD_VER >= 20
+
+_LIBCPP_BEGIN_NAMESPACE_STD
 
 // [concept.common]
 
@@ -45,8 +45,8 @@ concept common_with =
             add_lvalue_reference_t<const _Up>>>;
 // clang-format on
 
-#endif // _LIBCPP_STD_VER >= 20
-
 _LIBCPP_END_NAMESPACE_STD
+
+#endif // _LIBCPP_STD_VER >= 20
 
 #endif // _LIBCPP___CONCEPTS_COMMON_WITH_H


### PR DESCRIPTION
...in pre-C++20 modes. This fixes complaining from clang-tidy checks in CI.