### PR TITLE
[libc] Enable Float80-type for x86_32

### DIFF
--- a/libc/src/__support/FPUtil/float80.h
+++ b/libc/src/__support/FPUtil/float80.h
@@ -26,8 +26,11 @@ namespace LIBC_NAMESPACE_DECL {
 namespace fputil {
 
 struct Float80 {
+#if __SIZEOF_LONG_DOUBLE__ == 12
+  UInt<96> bits;
+#else
   UInt128 bits;
-
+#endif
   LIBC_INLINE Float80() = default;
   LIBC_INLINE constexpr Float80(const Float80 &) = default;
   LIBC_INLINE constexpr Float80(Float80 &&) = default;


### PR DESCRIPTION
Enables for x86_32 by using Uint<96> 
```CPP
struct Float80 {
  #if __SIZEOF_LONG_DOUBLE__ == 12
    UInt<96> bits;
  #else
    UInt128 bits;
  #endif
 ```
for testing it on x86_32 
it needs -m32 and --msse2 extra flags other than your usual cmake for x86_32