### PR TITLE
[Analysis] Remove dead WriteDOTGraphToFile (NFC)

### DIFF
--- a/llvm/include/llvm/Analysis/DOTGraphTraitsPass.h
+++ b/llvm/include/llvm/Analysis/DOTGraphTraitsPass.h
@@ -316,27 +316,6 @@ private:
   std::string Name;
 };
 
-template <typename GraphT>
-void WriteDOTGraphToFile(Function &F, GraphT &&Graph,
-                         std::string FileNamePrefix, bool IsSimple) {
-  std::string Filename = FileNamePrefix + "." + F.getName().str();
-  shortenFileName(Filename);
-  Filename = Filename + ".dot";
-  std::error_code EC;
-
-  errs() << "Writing '" << Filename << "'...";
-
-  raw_fd_ostream File(Filename, EC, sys::fs::OF_TextWithCRLF);
-  std::string GraphName = DOTGraphTraits<GraphT>::getGraphName(Graph);
-  std::string Title = GraphName + " for '" + F.getName().str() + "' function";
-
-  if (!EC)
-    WriteGraph(File, Graph, IsSimple, Title);
-  else
-    errs() << "  error opening file for writing!";
-  errs() << "\n";
-}
-
 } // end namespace llvm
 
 #endif


### PR DESCRIPTION
The last callers were migrated to DOTGraphTraitsPrinter on May 16, 2022
in commit 7dce9eb6e507d48d0b79bfb408592936d378cc28.

Assisted-by: Antigravity
