### PR TITLE
[clang-tidy][NFC] Disable misc-include-cleaner check

### DIFF
--- a/clang-tools-extra/clang-tidy/.clang-tidy
+++ b/clang-tools-extra/clang-tidy/.clang-tidy
@@ -19,7 +19,7 @@ Checks: >
   google-readability-casting,
   misc-const-correctness,
   -misc-explicit-constructor,
-  misc-include-cleaner,
+  -misc-include-cleaner,
   modernize-*,
   -modernize-avoid-c-arrays,
   -modernize-pass-by-value,


### PR DESCRIPTION
This checks seem to give too many FP, disabling it for now.
E.g. it wants to always remove `SmallString.h` even if the header is actually needed.