### PR TITLE
[mlir] Set WrapNamespaceBodyWithEmptyLines: Never

### DIFF
--- a/mlir/.clang-format
+++ b/mlir/.clang-format
@@ -1,3 +1,4 @@
 BasedOnStyle: LLVM
 AlwaysBreakTemplateDeclarations: Yes
 LineEnding: LF
+WrapNamespaceBodyWithEmptyLines: Never


### PR DESCRIPTION
MLIR predominantly writes namespace bodies without a wrapping empty line: in
mlir/lib and mlir/include 35% of bodies start with an empty line and 32% end
with one.

```
namespace ns { // no empty line below
struct A {
};
} // namespace ns  // no empty live above
```

New code drifts the other way, partly related to LLM preference. Pin the
majority style using a clang-format 20 feature to stop further damage.
