### PR TITLE
[lld] Set WrapNamespaceBodyWithEmptyLines: Never

### DIFF
--- a/lld/.clang-format
+++ b/lld/.clang-format
@@ -1,1 +1,2 @@
 BasedOnStyle: LLVM
+WrapNamespaceBodyWithEmptyLines: Never


### PR DESCRIPTION
77% of anonymous namespaces in lld start without an empty line, as do 59% of
namespace bodies overall. lld/ELF is the most consistent at 95% and 87%.

Requires clang-format 20.
