### PR TITLE
CodeGen: Remove TargetOptions::NoTrappingFPMath

### DIFF
--- a/llvm/docs/CommandGuide/llc.md
+++ b/llvm/docs/CommandGuide/llc.md
@@ -128,10 +128,6 @@ Enable optimizations that assume no NAN values.
 Enable FP math optimizations that assume the sign of 0 is insignificant.
 :::
 
-:::{option} --enable-no-trapping-fp-math
-Enable setting the FP exceptions build attribute not to use exceptions.
-:::
-
 :::{option} --stats
 Print statistics recorded by code-generation passes.
 :::

--- a/llvm/include/llvm/CodeGen/CommandFlags.h
+++ b/llvm/include/llvm/CodeGen/CommandFlags.h
@@ -60,8 +60,6 @@ LLVM_ABI CodeGenFileType getFileType();
 
 LLVM_ABI FramePointerKind getFramePointerUsage();
 
-LLVM_ABI bool getEnableNoTrappingFPMath();
-
 LLVM_ABI DenormalMode::DenormalModeKind getDenormalFPMath();
 LLVM_ABI DenormalMode::DenormalModeKind getDenormalFP32Math();
 

--- a/llvm/include/llvm/Target/TargetOptions.h
+++ b/llvm/include/llvm/Target/TargetOptions.h
@@ -119,7 +119,7 @@ enum CodeObjectVersionKind {
 class TargetOptions {
 public:
   TargetOptions()
-      : NoTrappingFPMath(true), EnableAIXExtendedAltivecABI(false),
+      : EnableAIXExtendedAltivecABI(false),
         HonorSignDependentRoundingFPMathOption(false), NoZerosInBSS(false),
         GuaranteedTailCallOpt(false), StackSymbolOrdering(true),
         EnableFastISel(false), EnableGlobalISel(false), UseInitArray(false),
@@ -140,11 +140,6 @@ public:
         PPCGenScalarMASSEntries(false), JMCInstrument(false),
         EnableCFIFixup(false), MisExpect(false), XCOFFReadOnlyPointers(false),
         VerifyArgABICompliance(true) {}
-
-  /// NoTrappingFPMath - This flag is enabled when the
-  /// -enable-no-trapping-fp-math is specified on the command line. This
-  /// specifies that there are no trap handlers to handle exceptions.
-  unsigned NoTrappingFPMath : 1;
 
   /// EnableAIXExtendedAltivecABI - This flag returns true when -vec-extabi is
   /// specified. The code generator is then able to use both volatile and

--- a/llvm/lib/CodeGen/CommandFlags.cpp
+++ b/llvm/lib/CodeGen/CommandFlags.cpp
@@ -76,7 +76,6 @@ CGOPT_EXP(uint64_t, LargeDataThreshold)
 CGOPT(ExceptionHandling, ExceptionModel)
 CGOPT_EXP(CodeGenFileType, FileType)
 CGOPT(FramePointerKind, FramePointerUsage)
-CGOPT(bool, EnableNoTrappingFPMath)
 CGOPT(bool, EnableAIXExtendedAltivecABI)
 CGOPT(DenormalMode::DenormalModeKind, DenormalFPMath)
 CGOPT(DenormalMode::DenormalModeKind, DenormalFP32Math)
@@ -231,13 +230,6 @@ codegen::RegisterCodeGenFlags::RegisterCodeGenFlags() {
           clEnumValN(FramePointerKind::None, "none",
                      "Enable frame pointer elimination")));
   CGBINDOPT(FramePointerUsage);
-
-  static cl::opt<bool> EnableNoTrappingFPMath(
-      "enable-no-trapping-fp-math",
-      cl::desc("Enable setting the FP exceptions build "
-               "attribute not to use exceptions"),
-      cl::init(false));
-  CGBINDOPT(EnableNoTrappingFPMath);
 
   static const auto DenormFlagEnumOptions = cl::values(
       clEnumValN(DenormalMode::IEEE, "ieee", "IEEE 754 denormal numbers"),
@@ -585,7 +577,6 @@ TargetOptions
 codegen::InitTargetOptionsFromCodeGenFlags(const Triple &TheTriple) {
   TargetOptions Options;
   Options.AllowFPOpFusion = getFuseFPOps();
-  Options.NoTrappingFPMath = getEnableNoTrappingFPMath();
 
   Options.HonorSignDependentRoundingFPMathOption =
       getEnableHonorSignDependentRoundingFPMath();

--- a/llvm/lib/Target/ARM/ARMAsmPrinter.cpp
+++ b/llvm/lib/Target/ARM/ARMAsmPrinter.cpp
@@ -781,8 +781,7 @@ void ARMAsmPrinter::emitAttributes() {
     if (unsigned TagVal = Ex->getZExtValue())
       ATS.emitAttribute(ARMBuildAttrs::ABI_FP_exceptions, TagVal);
   } else if (checkFunctionsAttributeConsistency(*MMI->getModule(),
-                                                "no-trapping-math", "true") ||
-             TM.Options.NoTrappingFPMath)
+                                                "no-trapping-math", "true"))
     ATS.emitAttribute(ARMBuildAttrs::ABI_FP_exceptions,
                       ARMBuildAttrs::Not_Allowed);
   else {

--- a/llvm/test/CodeGen/ARM/build-attributes.ll
+++ b/llvm/test/CodeGen/ARM/build-attributes.ll
@@ -41,7 +41,6 @@
 ; RUN: llc < %s -mtriple=armv7-linux-gnueabi -mcpu=cortex-a17 | FileCheck %s --check-prefix=CORTEX-A17-DEFAULT
 ; RUN: llc < %s -mtriple=armv7-linux-gnueabi -mcpu=cortex-a17 -mattr=-vfp2sp | FileCheck %s --check-prefix=CORTEX-A17-NOFPU
 
-; RUN: llc < %s -mtriple=armv7-linux-gnueabi -mcpu=cortex-a15 -enable-no-trapping-fp-math | FileCheck %s --check-prefix=NO-TRAPPING-MATH
 ; RUN: llc < %s -mtriple=armv7-linux-gnueabi -mcpu=cortex-a15 -denormal-fp-math=ieee | FileCheck %s --check-prefix=DENORMAL-IEEE
 ; RUN: llc < %s -mtriple=armv7-linux-gnueabi -mcpu=cortex-a15 -denormal-fp-math=preserve-sign | FileCheck %s --check-prefix=DENORMAL-PRESERVE-SIGN
 ; RUN: llc < %s -mtriple=armv7-linux-gnueabi -mcpu=cortex-a15 -denormal-fp-math=positive-zero | FileCheck %s --check-prefix=DENORMAL-POSITIVE-ZERO
@@ -740,8 +739,7 @@
 
 ; CORTEX-A17-NOFPU-NOT:   .eabi_attribute 19
 
-; Test flags -enable-no-trapping-fp-math and -denormal-fp-math:
-; NO-TRAPPING-MATH:  .eabi_attribute 21, 0
+; Test flag -denormal-fp-math:
 ; DENORMAL-IEEE:  .eabi_attribute 20, 1
 ; DENORMAL-PRESERVE-SIGN:  .eabi_attribute 20, 2
 ; DENORMAL-POSITIVE-ZERO:  .eabi_attribute 20, 0

--- a/llvm/test/CodeGen/ARM/eabi-attribute-no-trapping-math.ll
+++ b/llvm/test/CodeGen/ARM/eabi-attribute-no-trapping-math.ll
@@ -1,0 +1,33 @@
+; Check how no-trapping-math maps to attribute ABI_FP_exceptions across
+; multiple functions. The backend only reports no-trapping-math (exceptions
+; Not_Allowed, i.e. 21, 0) when every function definition agrees; a single
+; disagreeing function taints the module back to the default (21, 1).
+
+; RUN: split-file %s %t
+; RUN: llc -mtriple=armv7-linux-gnueabi -mcpu=cortex-a15 < %t/agree.ll | FileCheck %s --check-prefix=AGREE
+; RUN: llc -mtriple=armv7-linux-gnueabi -mcpu=cortex-a15 < %t/taint.ll | FileCheck %s --check-prefix=TAINT
+
+; AGREE: .eabi_attribute 21, 0 @ Tag_ABI_FP_exceptions
+; TAINT: .eabi_attribute 21, 1 @ Tag_ABI_FP_exceptions
+
+;--- agree.ll
+define i32 @f0() "no-trapping-math"="true" {
+entry:
+  ret i32 42
+}
+
+define i32 @f1() "no-trapping-math"="true" {
+entry:
+  ret i32 42
+}
+
+;--- taint.ll
+define i32 @f0() "no-trapping-math"="true" {
+entry:
+  ret i32 42
+}
+
+define i32 @f1() {
+entry:
+  ret i32 42
+}


### PR DESCRIPTION
This was replaced by the no-trapping-math attribute.
The one ARMAsmPrinter use already accounts for it.

no-trapping-math should probably replaced by !strictfp, but that's
another problem.