### PR TITLE
[ARM] Prevent use of the VFP calling convention when +soft-float is enabled

### DIFF
--- a/llvm/lib/Target/ARM/ARMTargetMachine.cpp
+++ b/llvm/lib/Target/ARM/ARMTargetMachine.cpp
@@ -197,8 +197,8 @@ MachineFunctionInfo *ARMBaseTargetMachine::createMachineFunctionInfo(
     BumpPtrAllocator &Allocator, const Function &F,
     const TargetSubtargetInfo *STI) const {
   const auto *ARMSTI = static_cast<const ARMSubtarget *>(STI);
-  bool FPRegsUnavailable = !ARMSTI->hasFPRegs() || ARMSTI->isThumb1Only();
-  if (FPRegsUnavailable) {
+  if (!ARMSTI->hasFPRegs() || ARMSTI->isThumb1Only() ||
+      ARMSTI->useSoftFloat()) {
     const StringRef FPRegsUnavailableMsg =
         ", but floating-point registers are unavailable";
     const ARMTargetLowering *TLI = ARMSTI->getTargetLowering();
@@ -287,8 +287,8 @@ ARMBaseTargetMachine::getSubtargetImpl(const Function &F) const {
     Key += "denormal-fp-math=" + DM.str();
 
   FloatABI::ABIType FloatABI = getFloatABI(*F.getParent());
-  // It is legal to have FloatABI::Hard with +soft-float for targets with SIMD
-  // registers, but no floating-point hardware (mve+nofp)
+  // It is legal to have FloatABI::Hard for targets with SIMD registers
+  // but no floating-point hardware (mve+nofp).
   Key += FloatABI == FloatABI::Hard ? "+hard-float-abi" : "+soft-float-abi";
 
   ARM::ARMABI ABI = getEffectiveABI(*F.getParent());

--- a/llvm/test/CodeGen/ARM/GlobalISel/arm-isel-fp.ll
+++ b/llvm/test/CodeGen/ARM/GlobalISel/arm-isel-fp.ll
@@ -2,14 +2,14 @@
 ; RUN: llc -mtriple arm-linux-gnueabi -mattr=+vfp2,+soft-float -float-abi=soft -global-isel %s -o - | FileCheck %s -check-prefix CHECK -check-prefix SOFT-AEABI
 ; RUN: llc -mtriple arm-linux-gnu- -mattr=+vfp2,+soft-float -float-abi=soft -global-isel %s -o - | FileCheck %s -check-prefix CHECK -check-prefix SOFT-DEFAULT
 
-define arm_aapcscc float @test_frem_float(float %x, float %y) {
+define float @test_frem_float(float %x, float %y) {
 ; CHECK-LABEL: test_frem_float:
 ; CHECK: bl fmodf
   %r = frem float %x, %y
   ret float %r
 }
 
-define arm_aapcscc double @test_frem_double(double %x, double %y) {
+define double @test_frem_double(double %x, double %y) {
 ; CHECK-LABEL: test_frem_double:
 ; CHECK: bl fmod
   %r = frem double %x, %y
@@ -17,7 +17,7 @@ define arm_aapcscc double @test_frem_double(double %x, double %y) {
 }
 
 declare float @llvm.pow.f32(float %x, float %y)
-define arm_aapcscc float @test_fpow_float(float %x, float %y) {
+define float @test_fpow_float(float %x, float %y) {
 ; CHECK-LABEL: test_fpow_float:
 ; CHECK: bl powf
   %r = call float @llvm.pow.f32(float %x, float %y)
@@ -25,14 +25,14 @@ define arm_aapcscc float @test_fpow_float(float %x, float %y) {
 }
 
 declare double @llvm.pow.f64(double %x, double %y)
-define arm_aapcscc double @test_fpow_double(double %x, double %y) {
+define double @test_fpow_double(double %x, double %y) {
 ; CHECK-LABEL: test_fpow_double:
 ; CHECK: bl pow
   %r = call double @llvm.pow.f64(double %x, double %y)
   ret double %r
 }
 
-define arm_aapcscc float @test_add_float(float %x, float %y) {
+define float @test_add_float(float %x, float %y) {
 ; CHECK-LABEL: test_add_float:
 ; HARD: vadd.f32
 ; SOFT-AEABI: bl __aeabi_fadd
@@ -41,7 +41,7 @@ define arm_aapcscc float @test_add_float(float %x, float %y) {
   ret float %r
 }
 
-define arm_aapcscc double @test_add_double(double %x, double %y) {
+define double @test_add_double(double %x, double %y) {
 ; CHECK-LABEL: test_add_double:
 ; HARD: vadd.f64
 ; SOFT-AEABI: bl __aeabi_dadd
@@ -50,7 +50,7 @@ define arm_aapcscc double @test_add_double(double %x, double %y) {
   ret double %r
 }
 
-define arm_aapcscc float @test_sub_float(float %x, float %y) {
+define float @test_sub_float(float %x, float %y) {
 ; CHECK-LABEL: test_sub_float:
 ; HARD: vsub.f32
 ; SOFT-AEABI: bl __aeabi_fsub
@@ -59,7 +59,7 @@ define arm_aapcscc float @test_sub_float(float %x, float %y) {
   ret float %r
 }
 
-define arm_aapcscc double @test_sub_double(double %x, double %y) {
+define double @test_sub_double(double %x, double %y) {
 ; CHECK-LABEL: test_sub_double:
 ; HARD: vsub.f64
 ; SOFT-AEABI: bl __aeabi_dsub
@@ -67,7 +67,8 @@ define arm_aapcscc double @test_sub_double(double %x, double %y) {
   %r = fsub double %x, %y
   ret double %r
 }
-define arm_aapcs_vfpcc i32 @test_cmp_float_ogt(float %x, float %y) {
+
+define i32 @test_cmp_float_ogt(float %x, float %y) {
 ; CHECK-LABEL: test_cmp_float_ogt
 ; HARD: vcmp.f32
 ; HARD: vmrs APSR_nzcv, fpscr
@@ -80,7 +81,7 @@ entry:
   ret i32 %r
 }
 
-define arm_aapcs_vfpcc i32 @test_cmp_float_one(float %x, float %y) {
+define i32 @test_cmp_float_one(float %x, float %y) {
 ; CHECK-LABEL: test_cmp_float_one
 ; HARD: vcmp.f32
 ; HARD: vmrs APSR_nzcv, fpscr

--- a/llvm/test/CodeGen/ARM/eabihf-no-fpregs.ll
+++ b/llvm/test/CodeGen/ARM/eabihf-no-fpregs.ll
@@ -1,6 +1,7 @@
 ; RUN: not llc --mtriple=armv7-none-eabi --mattr=-fpregs < %s -o /dev/null 2>&1 | FileCheck %s --implicit-check-not=error:
 ; RUN: not llc --mtriple=armv7-none-eabihf --mattr=-fpregs < %s -o /dev/null 2>&1 | FileCheck %s --check-prefixes=CHECK,EABIHF --implicit-check-not=error:
 ; RUN: not llc --mtriple=thumbv6-none-eabihf --mcpu=arm1176jzf-s < %s -o /dev/null 2>&1 | FileCheck %s --check-prefixes=CHECK,EABIHF --implicit-check-not=error:
+; RUN: not llc --mtriple=armv7-none-eabihf --mattr=+soft-float < %s -o /dev/null 2>&1 | FileCheck %s --check-prefixes=CHECK,EABIHF --implicit-check-not=error:
 
 ; EABIHF: error: <unknown>:0:0: in function default_pcs void (): calling convention is hard-float, but floating-point registers are unavailable
 define void @default_pcs() {

--- a/llvm/test/CodeGen/ARM/inlineasm-operand-implicit-cast.ll
+++ b/llvm/test/CodeGen/ARM/inlineasm-operand-implicit-cast.ll
@@ -70,7 +70,7 @@ define arm_aapcscc float @zerobits_float_convoluted_soft() #0 {
 }
 
 ; Check support for returning several double in GPR
-define double @zerobits_double_convoluted_soft() #0 {
+define arm_aapcscc double @zerobits_double_convoluted_soft() #0 {
 ; CHECK-LABEL: zerobits_double_convoluted_soft
 ; CHECK: mov r0, #0
 ; CHECK-NEXT: mov r1, #0


### PR DESCRIPTION
This check was implemented in #111334 for -fpregs and Thumb1 cases, but
+soft-float is a distinct case that can lead to the same silent calling
convention mismatches.

Fix tests that were using +soft-float and the VFP calling convention.

Clarify comment about hard-float support on mve+nofp cores.