### PR TITLE
MC: Move BinutilsVersion from TargetOptions to MCTargetOptions

### DIFF
--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -40,6 +40,7 @@
 #include "llvm/IR/Verifier.h"
 #include "llvm/IRPrinter/IRPrintingPasses.h"
 #include "llvm/LTO/LTOBackend.h"
+#include "llvm/MC/MCTargetOptions.h"
 #include "llvm/MC/TargetRegistry.h"
 #include "llvm/Object/OffloadBinary.h"
 #include "llvm/Passes/PassBuilder.h"
@@ -403,8 +404,8 @@ static bool initTargetOptions(const CompilerInstance &CI,
     break;
   }
 
-  Options.BinutilsVersion =
-      llvm::TargetMachine::parseBinutilsVersion(CodeGenOpts.BinutilsVersion);
+  Options.MCOptions.BinutilsVersion =
+      llvm::MCTargetOptions::parseBinutilsVersion(CodeGenOpts.BinutilsVersion);
   Options.UseInitArray = CodeGenOpts.UseInitArray;
   Options.DisableIntegratedAS = CodeGenOpts.DisableIntegratedAS;
 

--- a/llvm/include/llvm/MC/MCTargetOptions.h
+++ b/llvm/include/llvm/MC/MCTargetOptions.h
@@ -14,6 +14,7 @@
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/Compression.h"
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace llvm {
@@ -80,6 +81,9 @@ public:
 
   int DwarfVersion = 0;
 
+  /// If greater than 0, overrides the default MCAsmInfo binutils version.
+  std::pair<int, int> BinutilsVersion = {0, 0};
+
   enum DwarfDirectory {
     // Force disable
     DisableDwarfDirectory,
@@ -127,6 +131,10 @@ public:
   bool LargeEHEncoding = false;
 
   LLVM_ABI MCTargetOptions();
+
+  /// Parse a binutils version string ("major[.minor]" or "none") into a
+  /// (major, minor) pair. "none" maps to {INT_MAX, INT_MAX}.
+  LLVM_ABI static std::pair<int, int> parseBinutilsVersion(StringRef Version);
 
   /// getABIName - If this returns a non-empty string this represents the
   /// textual name of the ABI that we want the backend to use, e.g. o32, or

--- a/llvm/include/llvm/Target/TargetMachine.h
+++ b/llvm/include/llvm/Target/TargetMachine.h
@@ -475,8 +475,6 @@ public:
   static constexpr unsigned DefaultSjLjDataSize = 32;
   virtual unsigned getSjLjDataSize() const { return DefaultSjLjDataSize; }
 
-  static std::pair<int, int> parseBinutilsVersion(StringRef Version);
-
   /// getAddressSpaceForPseudoSourceKind - Given the kind of memory
   /// (e.g. stack) the target returns the corresponding address space.
   virtual unsigned getAddressSpaceForPseudoSourceKind(unsigned Kind) const {

--- a/llvm/include/llvm/Target/TargetOptions.h
+++ b/llvm/include/llvm/Target/TargetOptions.h
@@ -141,10 +141,6 @@ public:
         EnableCFIFixup(false), MisExpect(false), XCOFFReadOnlyPointers(false),
         VerifyArgABICompliance(true) {}
 
-  /// If greater than 0, override the default value of
-  /// MCAsmInfo::BinutilsVersion.
-  std::pair<int, int> BinutilsVersion{0, 0};
-
   /// NoTrappingFPMath - This flag is enabled when the
   /// -enable-no-trapping-fp-math is specified on the command line. This
   /// specifies that there are no trap handlers to handle exceptions.

--- a/llvm/lib/CodeGen/CodeGenTargetMachineImpl.cpp
+++ b/llvm/lib/CodeGen/CodeGenTargetMachineImpl.cpp
@@ -69,9 +69,6 @@ void CodeGenTargetMachineImpl::initAsmInfo() {
                        "Make sure you include the correct TargetSelect.h"
                        "and that InitializeAllTargetMCs() is being invoked!");
 
-  if (Options.BinutilsVersion.first > 0)
-    TmpAsmInfo->setBinutilsVersion(Options.BinutilsVersion);
-
   if (Options.DisableIntegratedAS) {
     TmpAsmInfo->setUseIntegratedAssembler(false);
     // If there is explict option disable integratedAS, we can't use it for

--- a/llvm/lib/MC/MCAsmInfo.cpp
+++ b/llvm/lib/MC/MCAsmInfo.cpp
@@ -47,6 +47,8 @@ MCAsmInfo::MCAsmInfo(const MCTargetOptions &Options) : TargetOptions(Options) {
     SupportsExtendedDwarfLocDirective = DwarfExtendedLoc == Enable;
   if (UseLEB128Directives != cl::boolOrDefault::BOU_UNSET)
     HasLEB128Directives = UseLEB128Directives == cl::boolOrDefault::BOU_TRUE;
+  if (Options.BinutilsVersion.first > 0)
+    BinutilsVersion = Options.BinutilsVersion;
 }
 
 MCAsmInfo::~MCAsmInfo() = default;

--- a/llvm/lib/MC/MCTargetOptions.cpp
+++ b/llvm/lib/MC/MCTargetOptions.cpp
@@ -8,6 +8,7 @@
 
 #include "llvm/MC/MCTargetOptions.h"
 #include "llvm/ADT/StringRef.h"
+#include <climits>
 
 using namespace llvm;
 
@@ -21,6 +22,15 @@ MCTargetOptions::MCTargetOptions()
       MCUseDwarfDirectory(DefaultDwarfDirectory),
       EmitCompactUnwindNonCanonical(false), EmitSFrameUnwind(false),
       PPCUseFullRegisterNames(false), LargeEHEncoding(false) {}
+
+std::pair<int, int> MCTargetOptions::parseBinutilsVersion(StringRef Version) {
+  if (Version == "none")
+    return {INT_MAX, INT_MAX}; // Make binutilsIsAtLeast() return true.
+  std::pair<int, int> Ret;
+  if (!Version.consumeInteger(10, Ret.first) && Version.consume_front("."))
+    Version.consumeInteger(10, Ret.second);
+  return Ret;
+}
 
 StringRef MCTargetOptions::getABIName() const {
   return ABIName;

--- a/llvm/lib/Target/TargetMachine.cpp
+++ b/llvm/lib/Target/TargetMachine.cpp
@@ -321,15 +321,6 @@ TargetIRAnalysis TargetMachine::getTargetIRAnalysis() const {
       [this](const Function &F) { return this->getTargetTransformInfo(F); });
 }
 
-std::pair<int, int> TargetMachine::parseBinutilsVersion(StringRef Version) {
-  if (Version == "none")
-    return {INT_MAX, INT_MAX}; // Make binutilsIsAtLeast() return true.
-  std::pair<int, int> Ret;
-  if (!Version.consumeInteger(10, Ret.first) && Version.consume_front("."))
-    Version.consumeInteger(10, Ret.second);
-  return Ret;
-}
-
 StringRef TargetMachine::getTargetABIName(const Module &M) const {
   if (const auto *MD = cast_or_null<MDString>(M.getModuleFlag("target-abi")))
     return MD->getString();

--- a/llvm/tools/llc/llc.cpp
+++ b/llvm/tools/llc/llc.cpp
@@ -560,8 +560,8 @@ static int compileModule(char **argv, SmallVectorImpl<PassPlugin> &PluginList,
           << "X86 backend ignores --fp-contract setting; use IR fast-math "
              "flags instead.";
 
-    Options.BinutilsVersion =
-        TargetMachine::parseBinutilsVersion(BinutilsVersion);
+    Options.MCOptions.BinutilsVersion =
+        MCTargetOptions::parseBinutilsVersion(BinutilsVersion);
     Options.MCOptions.ShowMCEncoding = ShowMCEncoding;
     Options.MCOptions.AsmVerbose = AsmVerbose;
     Options.MCOptions.PreserveAsmComments = PreserveComments;


### PR DESCRIPTION
BinutilsVersion has no codegen use and only used by MCAsmInfo to check
ELF assembler features.

Co-authored-by: Claude (claude-opus-4.8) <noreply@anthropic.com>