### PR TITLE
[OpenMP] [Flang] Add Fortran integer(kind=8) overloads for omp_lib APIs

### DIFF
--- a/flang/test/Lower/OpenMP/omp-lib-integer-wrappers.f90
+++ b/flang/test/Lower/OpenMP/omp-lib-integer-wrappers.f90
@@ -1,0 +1,148 @@
+! REQUIRES: openmp_runtime
+
+! RUN: %flang_fc1 -emit-hlfir %openmp_flags %s -o - 2>&1 | FileCheck %s
+! RUN: bbc %openmp_flags -emit-hlfir -o - %s 2>&1 | FileCheck %s
+! RUN: %flang_fc1 -emit-fir %openmp_flags %s -o - 2>&1 | FileCheck %s
+! RUN: bbc -emit-fir %openmp_flags -o - %s 2>&1 | FileCheck %s
+!
+! Test that omp_lib generic interfaces select the default bind(c) entry for
+! omp_integer_kind arguments and the kmp_*_8 entries for integer(8).
+
+program main
+  use omp_lib
+  integer(omp_integer_kind) :: i4
+  integer(8) :: i8
+  integer(omp_integer_kind) :: ires
+  integer(omp_sched_kind) :: sched_kind
+  integer(kmp_affinity_mask_kind) :: mask
+  integer(omp_integer_kind) :: ids4(1)
+  integer(8) :: ids8(1)
+  integer(omp_integer_kind) :: parts4(1)
+  integer(8) :: parts8(1)
+
+  i4 = 4
+  i8 = 8_8
+
+  call omp_set_num_threads(i4)
+  call omp_set_num_threads(i8)
+
+  call omp_set_max_active_levels(i4)
+  call omp_set_max_active_levels(i8)
+
+  call omp_set_default_device(i4)
+  call omp_set_default_device(i8)
+
+  call omp_set_num_teams(i4)
+  call omp_set_num_teams(i8)
+
+  call omp_set_teams_thread_limit(i4)
+  call omp_set_teams_thread_limit(i8)
+
+  call kmp_set_stacksize(i4)
+  call kmp_set_stacksize(i8)
+
+  call kmp_set_blocktime(i4)
+  call kmp_set_blocktime(i8)
+
+  call kmp_set_library(i4)
+  call kmp_set_library(i8)
+
+  call kmp_set_disp_num_buffers(i4)
+  call kmp_set_disp_num_buffers(i8)
+
+  ires = omp_get_ancestor_thread_num(i4)
+  ires = omp_get_ancestor_thread_num(i8)
+
+  ires = omp_get_team_size(i4)
+  ires = omp_get_team_size(i8)
+
+  ires = omp_get_place_num_procs(i4)
+  ires = omp_get_place_num_procs(i8)
+
+  call omp_set_schedule(omp_sched_static, i4)
+  call omp_set_schedule(omp_sched_static, i8)
+
+  call omp_get_schedule(sched_kind, i4)
+  call omp_get_schedule(sched_kind, i8)
+
+  ires = omp_pause_resource(omp_pause_soft, i4)
+  ires = omp_pause_resource(omp_pause_soft, i8)
+
+  call kmp_create_affinity_mask(mask)
+  ires = kmp_set_affinity_mask_proc(i4, mask)
+  ires = kmp_set_affinity_mask_proc(i8, mask)
+
+  ires = kmp_unset_affinity_mask_proc(i4, mask)
+  ires = kmp_unset_affinity_mask_proc(i8, mask)
+
+  ires = kmp_get_affinity_mask_proc(i4, mask)
+  ires = kmp_get_affinity_mask_proc(i8, mask)
+
+  call omp_get_place_proc_ids(i4, ids4)
+  call omp_get_place_proc_ids(i8, ids8)
+
+  call omp_get_partition_place_nums(parts4)
+  call omp_get_partition_place_nums(parts8)
+end program
+
+! CHECK-NOT: not yet implemented: intrinsic:
+
+! CHECK: fir.call @omp_set_num_threads(
+! CHECK: fir.call @kmp_set_num_threads_8(
+
+! CHECK: fir.call @omp_set_max_active_levels(
+! CHECK: fir.call @kmp_set_max_active_levels_8(
+
+! CHECK: fir.call @omp_set_default_device(
+! CHECK: fir.call @kmp_set_default_device_8(
+
+! CHECK: fir.call @omp_set_num_teams(
+! CHECK: fir.call @kmp_set_num_teams_8(
+
+! CHECK: fir.call @omp_set_teams_thread_limit(
+! CHECK: fir.call @kmp_set_teams_thread_limit_8(
+
+! CHECK: fir.call @kmp_set_stacksize(
+! CHECK: fir.call @kmp_set_stacksize_8(
+
+! CHECK: fir.call @kmp_set_blocktime(
+! CHECK: fir.call @kmp_set_blocktime_8(
+
+! CHECK: fir.call @kmp_set_library(
+! CHECK: fir.call @kmp_set_library_8(
+
+! CHECK: fir.call @kmp_set_disp_num_buffers(
+! CHECK: fir.call @kmp_set_disp_num_buffers_8(
+
+! CHECK: fir.call @omp_get_ancestor_thread_num(
+! CHECK: fir.call @kmp_get_ancestor_thread_num_8(
+
+! CHECK: fir.call @omp_get_team_size(
+! CHECK: fir.call @kmp_get_team_size_8(
+
+! CHECK: fir.call @omp_get_place_num_procs(
+! CHECK: fir.call @kmp_get_place_num_procs_8(
+
+! CHECK: fir.call @omp_set_schedule(
+! CHECK: fir.call @kmp_set_schedule_8(
+
+! CHECK: fir.call @omp_get_schedule(
+! CHECK: fir.call @kmp_get_schedule_8(
+
+! CHECK: fir.call @omp_pause_resource(
+! CHECK: fir.call @kmp_pause_resource_8(
+
+! CHECK: fir.call @kmp_set_affinity_mask_proc(
+! CHECK: fir.call @kmp_set_affinity_mask_proc_8(
+
+! CHECK: fir.call @kmp_unset_affinity_mask_proc(
+! CHECK: fir.call @kmp_unset_affinity_mask_proc_8(
+
+! CHECK: fir.call @kmp_get_affinity_mask_proc(
+! CHECK: fir.call @kmp_get_affinity_mask_proc_8(
+
+! CHECK: fir.call @omp_get_place_proc_ids(
+! CHECK: fir.call @kmp_get_place_proc_ids_8(
+
+! CHECK: fir.call @omp_get_partition_place_nums(
+! CHECK: fir.call @kmp_get_partition_place_nums_8(

--- a/llvm/include/llvm/Frontend/OpenMP/OMPKinds.def
+++ b/llvm/include/llvm/Frontend/OpenMP/OMPKinds.def
@@ -237,28 +237,36 @@ __OMP_RTL(omp_get_dynamic, false, Int32, )
 __OMP_RTL(omp_get_cancellation, false, Int32, )
 __OMP_RTL(omp_get_nested, false, Int32, )
 __OMP_RTL(omp_get_schedule, false, Void, Int32Ptr, Int32Ptr)
+__OMP_RTL(kmp_get_schedule_8, false, Void, Int32Ptr, Int64Ptr)
 __OMP_RTL(omp_get_thread_limit, false, Int32, )
 __OMP_RTL(omp_get_supported_active_levels, false, Int32, )
 __OMP_RTL(omp_get_max_active_levels, false, Int32, )
 __OMP_RTL(omp_get_level, false, Int32, )
 __OMP_RTL(omp_get_ancestor_thread_num, false, Int32, Int32)
+__OMP_RTL(kmp_get_ancestor_thread_num_8, false, Int32, Int64)
 __OMP_RTL(omp_get_team_size, false, Int32, Int32)
+__OMP_RTL(kmp_get_team_size_8, false, Int32, Int64)
 __OMP_RTL(omp_get_active_level, false, Int32, )
 __OMP_RTL(omp_in_final, false, Int32, )
 __OMP_RTL(omp_get_proc_bind, false, Int32, )
 __OMP_RTL(omp_get_num_places, false, Int32, )
 __OMP_RTL(omp_get_num_procs, false, Int32, )
 __OMP_RTL(omp_get_place_proc_ids, false, Void, Int32, Int32Ptr)
+__OMP_RTL(kmp_get_place_proc_ids_8, false, Void, Int64, Int64Ptr)
 __OMP_RTL(omp_get_place_num, false, Int32, )
 __OMP_RTL(omp_get_partition_num_places, false, Int32, )
 __OMP_RTL(omp_get_partition_place_nums, false, Void, Int32Ptr)
+__OMP_RTL(kmp_get_partition_place_nums_8, false, Void, Int64Ptr)
 __OMP_RTL(omp_get_wtime, false, Double,)
 
 __OMP_RTL(omp_set_num_threads, false, Void, Int32)
+__OMP_RTL(kmp_set_num_threads_8, false, Void, Int64)
 __OMP_RTL(omp_set_dynamic, false, Void, Int32)
 __OMP_RTL(omp_set_nested, false, Void, Int32)
 __OMP_RTL(omp_set_schedule, false, Void, Int32, Int32)
+__OMP_RTL(kmp_set_schedule_8, false, Void, Int32, Int64)
 __OMP_RTL(omp_set_max_active_levels, false, Void, Int32)
+__OMP_RTL(kmp_set_max_active_levels_8, false, Void, Int64)
 
 __OMP_RTL(__kmpc_master, false, Int32, IdentPtr, Int32)
 __OMP_RTL(__kmpc_end_master, false, Void, IdentPtr, Int32)
@@ -733,12 +741,18 @@ __OMP_RTL_ATTRS(
     omp_get_schedule, GetterArgWriteAttrs, AttributeSet(),
     ParamAttrs(AttributeSet(NoCaptureAttr, EnumAttr(WriteOnly)),
                AttributeSet(NoCaptureAttr, EnumAttr(WriteOnly))))
+__OMP_RTL_ATTRS(
+    kmp_get_schedule_8, GetterArgWriteAttrs, AttributeSet(),
+    ParamAttrs(AttributeSet(NoCaptureAttr, EnumAttr(WriteOnly)),
+               AttributeSet(NoCaptureAttr, EnumAttr(WriteOnly))))
 __OMP_RTL_ATTRS(omp_get_thread_limit, GetterAttrs, SExt, ParamAttrs())
 __OMP_RTL_ATTRS(omp_get_supported_active_levels, GetterAttrs, SExt, ParamAttrs())
 __OMP_RTL_ATTRS(omp_get_max_active_levels, GetterAttrs, SExt, ParamAttrs())
 __OMP_RTL_ATTRS(omp_get_level, GetterAttrs, SExt, ParamAttrs())
 __OMP_RTL_ATTRS(omp_get_ancestor_thread_num, GetterAttrs, SExt, ParamAttrs(SExt))
+__OMP_RTL_ATTRS(kmp_get_ancestor_thread_num_8, GetterAttrs, SExt, ParamAttrs())
 __OMP_RTL_ATTRS(omp_get_team_size, GetterAttrs, SExt, ParamAttrs(SExt))
+__OMP_RTL_ATTRS(kmp_get_team_size_8, GetterAttrs, SExt, ParamAttrs())
 __OMP_RTL_ATTRS(omp_get_active_level, GetterAttrs, SExt, ParamAttrs())
 __OMP_RTL_ATTRS(omp_in_final, GetterAttrs, SExt, ParamAttrs())
 __OMP_RTL_ATTRS(omp_get_proc_bind, GetterAttrs, SExt, ParamAttrs())
@@ -747,20 +761,31 @@ __OMP_RTL_ATTRS(omp_get_num_procs, GetterAttrs, SExt, ParamAttrs())
 __OMP_RTL_ATTRS(omp_get_place_proc_ids, GetterArgWriteAttrs, AttributeSet(),
                 ParamAttrs(SExt, AttributeSet(NoCaptureAttr,
                                               EnumAttr(WriteOnly))))
+__OMP_RTL_ATTRS(kmp_get_place_proc_ids_8, GetterArgWriteAttrs, AttributeSet(),
+                ParamAttrs(AttributeSet(),
+                           AttributeSet(NoCaptureAttr, EnumAttr(WriteOnly))))
 __OMP_RTL_ATTRS(omp_get_place_num, GetterAttrs, SExt, ParamAttrs())
 __OMP_RTL_ATTRS(omp_get_partition_num_places, GetterAttrs, SExt, ParamAttrs())
 __OMP_RTL_ATTRS(omp_get_partition_place_nums, GetterArgWriteAttrs, AttributeSet(),
                 ParamAttrs())
+__OMP_RTL_ATTRS(kmp_get_partition_place_nums_8, GetterArgWriteAttrs,
+                AttributeSet(), ParamAttrs())
 __OMP_RTL_ATTRS(omp_get_wtime, GetterAttrs, AttributeSet(), ParamAttrs())
 
 __OMP_RTL_ATTRS(omp_set_num_threads, SetterAttrs, AttributeSet(),
                 ParamAttrs(SExt))
+__OMP_RTL_ATTRS(kmp_set_num_threads_8, SetterAttrs, AttributeSet(),
+                ParamAttrs())
 __OMP_RTL_ATTRS(omp_set_dynamic, SetterAttrs, AttributeSet(), ParamAttrs(SExt))
 __OMP_RTL_ATTRS(omp_set_nested, SetterAttrs, AttributeSet(), ParamAttrs(SExt))
 __OMP_RTL_ATTRS(omp_set_schedule, SetterAttrs, AttributeSet(),
                 ParamAttrs(SExt, SExt))
+__OMP_RTL_ATTRS(kmp_set_schedule_8, SetterAttrs, AttributeSet(),
+                ParamAttrs(SExt, AttributeSet()))
 __OMP_RTL_ATTRS(omp_set_max_active_levels, SetterAttrs, AttributeSet(),
                 ParamAttrs(SExt))
+__OMP_RTL_ATTRS(kmp_set_max_active_levels_8, SetterAttrs, AttributeSet(),
+                ParamAttrs())
 
 __OMP_RTL_ATTRS(__kmpc_master, InaccessibleArgOnlyAttrs, SExt,
                 ParamAttrs(ReadOnlyPtrAttrs, SExt))

--- a/openmp/device/include/Interface.h
+++ b/openmp/device/include/Interface.h
@@ -44,6 +44,7 @@ int omp_get_dynamic(void);
 ///
 ///{
 void omp_set_num_threads(int);
+void kmp_set_num_threads_8(int64_t);
 int omp_get_max_threads(void);
 ///}
 

--- a/openmp/device/src/State.cpp
+++ b/openmp/device/src/State.cpp
@@ -383,6 +383,14 @@ int omp_get_dynamic(void) { return 0; }
 
 void omp_set_num_threads(int V) { icv::NThreads = V; }
 
+void kmp_set_num_threads_8(int64_t V) {
+  if (V > INT32_MAX)
+    V = INT32_MAX;
+  else if (V < INT32_MIN)
+    V = INT32_MIN;
+  omp_set_num_threads((int)V);
+}
+
 int omp_get_max_threads(void) {
   int NT = icv::NThreads;
   return NT > 0 ? NT : mapping::getMaxTeamThreads();

--- a/openmp/module/omp_lib.F90.var
+++ b/openmp/module/omp_lib.F90.var
@@ -244,16 +244,177 @@
         integer (kind=omp_interop_rc_kind), parameter, public :: omp_irc_type_str = -5
         integer (kind=omp_interop_rc_kind), parameter, public :: omp_irc_other = -6
 
-        interface
 
 !         ***
 !         *** omp_* entry points
 !         ***
 
+        interface omp_set_num_threads
           subroutine omp_set_num_threads(num_threads) bind(c)
             use omp_lib_kinds
             integer (kind=omp_integer_kind), value :: num_threads
           end subroutine omp_set_num_threads
+
+          subroutine kmp_set_num_threads_8(num_threads) bind(c)
+            integer (kind=8), value :: num_threads
+          end subroutine kmp_set_num_threads_8
+        end interface omp_set_num_threads
+
+        interface omp_set_max_active_levels
+          subroutine omp_set_max_active_levels(max_levels) bind(c)
+            use omp_lib_kinds
+            integer (kind=omp_integer_kind), value :: max_levels
+          end subroutine omp_set_max_active_levels
+
+          subroutine kmp_set_max_active_levels_8(max_levels) bind(c)
+            integer (kind=8), value :: max_levels
+          end subroutine kmp_set_max_active_levels_8
+        end interface omp_set_max_active_levels
+
+        interface omp_get_ancestor_thread_num
+          function omp_get_ancestor_thread_num(level) bind(c)
+            use omp_lib_kinds
+            integer (kind=omp_integer_kind) omp_get_ancestor_thread_num
+            integer (kind=omp_integer_kind), value :: level
+          end function omp_get_ancestor_thread_num
+
+          function kmp_get_ancestor_thread_num_8(level) bind(c)
+            use omp_lib_kinds
+            integer (kind=omp_integer_kind) kmp_get_ancestor_thread_num_8
+            integer (kind=8), value :: level
+          end function kmp_get_ancestor_thread_num_8
+        end interface omp_get_ancestor_thread_num
+
+        interface omp_get_team_size
+          function omp_get_team_size(level) bind(c)
+            use omp_lib_kinds
+            integer (kind=omp_integer_kind) omp_get_team_size
+            integer (kind=omp_integer_kind), value :: level
+          end function omp_get_team_size
+
+          function kmp_get_team_size_8(level) bind(c)
+            use omp_lib_kinds
+            integer (kind=omp_integer_kind) kmp_get_team_size_8
+            integer (kind=8), value :: level
+          end function kmp_get_team_size_8
+        end interface omp_get_team_size
+
+        interface omp_set_schedule
+          subroutine omp_set_schedule(kind, chunk_size) bind(c)
+            use omp_lib_kinds
+            integer (kind=omp_sched_kind), value :: kind
+            integer (kind=omp_integer_kind), value :: chunk_size
+          end subroutine omp_set_schedule
+
+          subroutine kmp_set_schedule_8(kind, chunk_size) bind(c)
+            use omp_lib_kinds
+            integer (kind=omp_sched_kind), value :: kind
+            integer (kind=8), value :: chunk_size
+          end subroutine kmp_set_schedule_8
+        end interface omp_set_schedule
+
+        interface omp_get_schedule
+          subroutine omp_get_schedule(kind, chunk_size) bind(c)
+            use omp_lib_kinds
+            integer (kind=omp_sched_kind) kind
+            integer (kind=omp_integer_kind) chunk_size
+          end subroutine omp_get_schedule
+
+          subroutine kmp_get_schedule_8(kind, chunk_size) bind(c)
+            use omp_lib_kinds
+            integer (kind=omp_sched_kind) kind
+            integer (kind=8) chunk_size
+          end subroutine kmp_get_schedule_8
+        end interface omp_get_schedule
+
+        interface omp_get_place_num_procs
+          function omp_get_place_num_procs(place_num) bind(c)
+            use omp_lib_kinds
+            integer (kind=omp_integer_kind), value :: place_num
+            integer (kind=omp_integer_kind) omp_get_place_num_procs
+          end function omp_get_place_num_procs
+
+          function kmp_get_place_num_procs_8(place_num) bind(c)
+            use omp_lib_kinds
+            integer (kind=8), value :: place_num
+            integer (kind=omp_integer_kind) kmp_get_place_num_procs_8
+          end function kmp_get_place_num_procs_8
+        end interface omp_get_place_num_procs
+
+        interface omp_get_place_proc_ids
+          subroutine omp_get_place_proc_ids(place_num, ids) bind(c)
+            use omp_lib_kinds
+            integer (kind=omp_integer_kind), value :: place_num
+            integer (kind=omp_integer_kind) ids(*)
+          end subroutine omp_get_place_proc_ids
+
+          subroutine kmp_get_place_proc_ids_8(place_num, ids) bind(c)
+            integer (kind=8), value :: place_num
+            integer (kind=8) ids(*)
+          end subroutine kmp_get_place_proc_ids_8
+        end interface omp_get_place_proc_ids
+
+        interface omp_get_partition_place_nums
+          subroutine omp_get_partition_place_nums(place_nums) bind(c)
+            use omp_lib_kinds
+            integer (kind=omp_integer_kind) place_nums(*)
+          end subroutine omp_get_partition_place_nums
+
+          subroutine kmp_get_partition_place_nums_8(place_nums) bind(c)
+            integer (kind=8) place_nums(*)
+          end subroutine kmp_get_partition_place_nums_8
+        end interface omp_get_partition_place_nums
+
+        interface omp_set_default_device
+          subroutine omp_set_default_device(device_num) bind(c)
+            use omp_lib_kinds
+            integer (kind=omp_integer_kind), value :: device_num
+          end subroutine omp_set_default_device
+
+          subroutine kmp_set_default_device_8(device_num) bind(c)
+            integer (kind=8), value :: device_num
+          end subroutine kmp_set_default_device_8
+        end interface omp_set_default_device
+
+        interface omp_pause_resource
+          function omp_pause_resource(kind, device_num) bind(c)
+            use omp_lib_kinds
+            integer (kind=omp_pause_resource_kind), value :: kind
+            integer (kind=omp_integer_kind), value :: device_num
+            integer (kind=omp_integer_kind) omp_pause_resource
+          end function omp_pause_resource
+
+          function kmp_pause_resource_8(kind, device_num) bind(c)
+            use omp_lib_kinds
+            integer (kind=omp_pause_resource_kind), value :: kind
+            integer (kind=8), value :: device_num
+            integer (kind=omp_integer_kind) kmp_pause_resource_8
+          end function kmp_pause_resource_8
+        end interface omp_pause_resource
+
+        interface omp_set_num_teams
+          subroutine omp_set_num_teams(num_teams) bind(c)
+            use omp_lib_kinds
+            integer (kind=omp_integer_kind), value :: num_teams
+          end subroutine omp_set_num_teams
+
+          subroutine kmp_set_num_teams_8(num_teams) bind(c)
+            integer (kind=8), value :: num_teams
+          end subroutine kmp_set_num_teams_8
+        end interface omp_set_num_teams
+
+        interface omp_set_teams_thread_limit
+          subroutine omp_set_teams_thread_limit(thread_limit) bind(c)
+            use omp_lib_kinds
+            integer (kind=omp_integer_kind), value :: thread_limit
+          end subroutine omp_set_teams_thread_limit
+
+          subroutine kmp_set_teams_thread_limit_8(thread_limit) bind(c)
+            integer (kind=8), value :: thread_limit
+          end subroutine kmp_set_teams_thread_limit_8
+        end interface omp_set_teams_thread_limit
+
+        interface
 
           subroutine omp_set_dynamic(dynamic_threads) bind(c)
             use omp_lib_kinds
@@ -310,11 +471,6 @@
             integer (kind=omp_integer_kind) omp_get_thread_limit
           end function omp_get_thread_limit
 
-          subroutine omp_set_max_active_levels(max_levels) bind(c)
-            use omp_lib_kinds
-            integer (kind=omp_integer_kind), value :: max_levels
-          end subroutine omp_set_max_active_levels
-
           function omp_get_max_active_levels() bind(c)
             use omp_lib_kinds
             integer (kind=omp_integer_kind) omp_get_max_active_levels
@@ -330,30 +486,6 @@
             integer (kind=omp_integer_kind) omp_get_active_level
           end function omp_get_active_level
 
-          function omp_get_ancestor_thread_num(level) bind(c)
-            use omp_lib_kinds
-            integer (kind=omp_integer_kind) omp_get_ancestor_thread_num
-            integer (kind=omp_integer_kind), value :: level
-          end function omp_get_ancestor_thread_num
-
-          function omp_get_team_size(level) bind(c)
-            use omp_lib_kinds
-            integer (kind=omp_integer_kind) omp_get_team_size
-            integer (kind=omp_integer_kind), value :: level
-          end function omp_get_team_size
-
-          subroutine omp_set_schedule(kind, chunk_size) bind(c)
-            use omp_lib_kinds
-            integer (kind=omp_sched_kind), value :: kind
-            integer (kind=omp_integer_kind), value :: chunk_size
-          end subroutine omp_set_schedule
-
-          subroutine omp_get_schedule(kind, chunk_size) bind(c)
-            use omp_lib_kinds
-            integer (kind=omp_sched_kind) kind
-            integer (kind=omp_integer_kind) chunk_size
-          end subroutine omp_get_schedule
-
           function omp_get_proc_bind() bind(c)
             use omp_lib_kinds
             integer (kind=omp_proc_bind_kind) omp_get_proc_bind
@@ -364,18 +496,6 @@
             integer (kind=omp_integer_kind) omp_get_num_places
           end function omp_get_num_places
 
-          function omp_get_place_num_procs(place_num) bind(c)
-            use omp_lib_kinds
-            integer (kind=omp_integer_kind), value :: place_num
-            integer (kind=omp_integer_kind) omp_get_place_num_procs
-          end function omp_get_place_num_procs
-
-          subroutine omp_get_place_proc_ids(place_num, ids) bind(c)
-            use omp_lib_kinds
-            integer (kind=omp_integer_kind), value :: place_num
-            integer (kind=omp_integer_kind) ids(*)
-          end subroutine omp_get_place_proc_ids
-
           function omp_get_place_num() bind(c)
             use omp_lib_kinds
             integer (kind=omp_integer_kind) omp_get_place_num
@@ -385,11 +505,6 @@
             use omp_lib_kinds
             integer (kind=omp_integer_kind) omp_get_partition_num_places
           end function omp_get_partition_num_places
-
-          subroutine omp_get_partition_place_nums(place_nums) bind(c)
-            use omp_lib_kinds
-            integer (kind=omp_integer_kind) place_nums(*)
-          end subroutine omp_get_partition_place_nums
 
           function omp_get_wtime() bind(c)
             use omp_lib_kinds
@@ -405,11 +520,6 @@
             use omp_lib_kinds
             integer (kind=omp_integer_kind) omp_get_default_device
           end function omp_get_default_device
-
-          subroutine omp_set_default_device(device_num) bind(c)
-            use omp_lib_kinds
-            integer (kind=omp_integer_kind), value :: device_num
-          end subroutine omp_set_default_device
 
           function omp_get_num_devices() bind(c)
             use omp_lib_kinds
@@ -445,13 +555,6 @@
             use omp_lib_kinds
             integer (kind=omp_integer_kind) omp_get_device_num
           end function omp_get_device_num
-
-          function omp_pause_resource(kind, device_num) bind(c)
-            use omp_lib_kinds
-            integer (kind=omp_pause_resource_kind), value :: kind
-            integer (kind=omp_integer_kind), value :: device_num
-            integer (kind=omp_integer_kind) omp_pause_resource
-          end function omp_pause_resource
 
           function omp_pause_resource_all(kind) bind(c)
             use omp_lib_kinds
@@ -640,20 +743,11 @@
             integer (kind=kmp_size_t_kind) :: omp_capture_affinity
           end function omp_capture_affinity
 
-          subroutine omp_set_num_teams(num_teams) bind(c)
-            use omp_lib_kinds
-            integer (kind=omp_integer_kind), value :: num_teams
-          end subroutine omp_set_num_teams
 
           function omp_get_max_teams() bind(c)
             use omp_lib_kinds
             integer (kind=omp_integer_kind) omp_get_max_teams
           end function omp_get_max_teams
-
-          subroutine omp_set_teams_thread_limit(thread_limit) bind(c)
-            use omp_lib_kinds
-            integer (kind=omp_integer_kind), value :: thread_limit
-          end subroutine omp_set_teams_thread_limit
 
           function omp_get_teams_thread_limit() bind(c)
             use omp_lib_kinds
@@ -932,25 +1026,112 @@
             integer, intent(in) :: num_resources
             integer, intent(in) :: resources(*)
           end function omp_get_submemspace
+        end interface
 
 !         ***
 !         *** kmp_* entry points
 !         ***
 
+        interface kmp_set_stacksize
           subroutine kmp_set_stacksize(size) bind(c)
             use omp_lib_kinds
             integer (kind=omp_integer_kind), value :: size
           end subroutine kmp_set_stacksize
 
-          subroutine kmp_set_stacksize_s(size) bind(c)
-            use omp_lib_kinds
-            integer (kind=kmp_size_t_kind), value :: size
-          end subroutine kmp_set_stacksize_s
+          subroutine kmp_set_stacksize_8(size) bind(c)
+            integer (kind=8), value :: size
+          end subroutine kmp_set_stacksize_8
+        end interface kmp_set_stacksize
 
+        interface kmp_set_blocktime
           subroutine kmp_set_blocktime(msec) bind(c)
             use omp_lib_kinds
             integer (kind=omp_integer_kind), value :: msec
           end subroutine kmp_set_blocktime
+
+          subroutine kmp_set_blocktime_8(msec) bind(c)
+            integer (kind=8), value :: msec
+          end subroutine kmp_set_blocktime_8
+        end interface kmp_set_blocktime
+
+        interface kmp_set_library
+          subroutine kmp_set_library(libnum) bind(c)
+            use omp_lib_kinds
+            integer (kind=omp_integer_kind), value :: libnum
+          end subroutine kmp_set_library
+
+          subroutine kmp_set_library_8(libnum) bind(c)
+            integer (kind=8), value :: libnum
+          end subroutine kmp_set_library_8
+        end interface kmp_set_library
+
+        interface kmp_set_disp_num_buffers
+          subroutine kmp_set_disp_num_buffers(num) bind(c)
+            use omp_lib_kinds
+            integer (kind=omp_integer_kind), value :: num
+          end subroutine kmp_set_disp_num_buffers
+
+          subroutine kmp_set_disp_num_buffers_8(num) bind(c)
+            integer (kind=8), value :: num
+          end subroutine kmp_set_disp_num_buffers_8
+        end interface kmp_set_disp_num_buffers
+
+        interface kmp_set_affinity_mask_proc
+          function kmp_set_affinity_mask_proc(proc, mask) bind(c)
+            use omp_lib_kinds
+            integer (kind=omp_integer_kind) kmp_set_affinity_mask_proc
+            integer (kind=omp_integer_kind), value :: proc
+            integer (kind=kmp_affinity_mask_kind) mask
+          end function kmp_set_affinity_mask_proc
+
+          function kmp_set_affinity_mask_proc_8(proc, mask) bind(c)
+            use omp_lib_kinds
+            integer (kind=omp_integer_kind) kmp_set_affinity_mask_proc_8
+            integer (kind=8), value :: proc
+            integer (kind=kmp_affinity_mask_kind) mask
+          end function kmp_set_affinity_mask_proc_8
+        end interface kmp_set_affinity_mask_proc
+
+        interface kmp_unset_affinity_mask_proc
+          function kmp_unset_affinity_mask_proc(proc, mask) bind(c)
+            use omp_lib_kinds
+            integer (kind=omp_integer_kind) kmp_unset_affinity_mask_proc
+            integer (kind=omp_integer_kind), value :: proc
+            integer (kind=kmp_affinity_mask_kind) mask
+          end function kmp_unset_affinity_mask_proc
+
+          function kmp_unset_affinity_mask_proc_8(proc, mask) bind(c)
+            use omp_lib_kinds
+            integer (kind=omp_integer_kind) kmp_unset_affinity_mask_proc_8
+            integer (kind=8), value :: proc
+            integer (kind=kmp_affinity_mask_kind) mask
+          end function kmp_unset_affinity_mask_proc_8
+        end interface kmp_unset_affinity_mask_proc
+
+        interface kmp_get_affinity_mask_proc
+          function kmp_get_affinity_mask_proc(proc, mask) bind(c)
+            use omp_lib_kinds
+            integer (kind=omp_integer_kind) kmp_get_affinity_mask_proc
+            integer (kind=omp_integer_kind), value :: proc
+            integer (kind=kmp_affinity_mask_kind) mask
+          end function kmp_get_affinity_mask_proc
+
+          function kmp_get_affinity_mask_proc_8(proc, mask) bind(c)
+            use omp_lib_kinds
+            integer (kind=omp_integer_kind) kmp_get_affinity_mask_proc_8
+            integer (kind=8), value :: proc
+            integer (kind=kmp_affinity_mask_kind) mask
+          end function kmp_get_affinity_mask_proc_8
+        end interface kmp_get_affinity_mask_proc
+
+        interface
+          subroutine kmp_set_stacksize_s(size) bind(c)
+            use omp_lib_kinds
+            integer (kind=kmp_size_t_kind), value :: size
+          end subroutine kmp_set_stacksize_s
+        end interface
+
+        interface
 
           subroutine kmp_set_library_serial() bind(c)
           end subroutine kmp_set_library_serial
@@ -960,12 +1141,9 @@
 
           subroutine kmp_set_library_throughput() bind(c)
           end subroutine kmp_set_library_throughput
+        end interface
 
-          subroutine kmp_set_library(libnum) bind(c)
-            use omp_lib_kinds
-            integer (kind=omp_integer_kind), value :: libnum
-          end subroutine kmp_set_library
-
+        interface
           subroutine kmp_set_defaults(string)
             character (len=*) :: string
           end subroutine kmp_set_defaults
@@ -989,12 +1167,9 @@
             use omp_lib_kinds
             integer (kind=omp_integer_kind) kmp_get_library
           end function kmp_get_library
+        end interface
 
-          subroutine kmp_set_disp_num_buffers(num) bind(c)
-            use omp_lib_kinds
-            integer (kind=omp_integer_kind), value :: num
-          end subroutine kmp_set_disp_num_buffers
-
+        interface
           function kmp_set_affinity(mask) bind(c)
             use omp_lib_kinds
             integer (kind=omp_integer_kind) kmp_set_affinity
@@ -1021,28 +1196,9 @@
             use omp_lib_kinds
             integer (kind=kmp_affinity_mask_kind) mask
           end subroutine kmp_destroy_affinity_mask
+        end interface
 
-          function kmp_set_affinity_mask_proc(proc, mask) bind(c)
-            use omp_lib_kinds
-            integer (kind=omp_integer_kind) kmp_set_affinity_mask_proc
-            integer (kind=omp_integer_kind), value :: proc
-            integer (kind=kmp_affinity_mask_kind) mask
-          end function kmp_set_affinity_mask_proc
-
-          function kmp_unset_affinity_mask_proc(proc, mask) bind(c)
-            use omp_lib_kinds
-            integer (kind=omp_integer_kind) kmp_unset_affinity_mask_proc
-            integer (kind=omp_integer_kind), value :: proc
-            integer (kind=kmp_affinity_mask_kind) mask
-          end function kmp_unset_affinity_mask_proc
-
-          function kmp_get_affinity_mask_proc(proc, mask) bind(c)
-            use omp_lib_kinds
-            integer (kind=omp_integer_kind) kmp_get_affinity_mask_proc
-            integer (kind=omp_integer_kind), value :: proc
-            integer (kind=kmp_affinity_mask_kind) mask
-          end function kmp_get_affinity_mask_proc
-
+        interface
           function kmp_malloc(size) bind(c)
             use omp_lib_kinds
             integer (kind=kmp_pointer_kind) kmp_malloc
@@ -1152,6 +1308,7 @@
 
         ! make the above routine definitions public
         public :: omp_set_num_threads
+        public :: kmp_set_num_threads_8
         public :: omp_set_dynamic
         public :: omp_set_nested
         public :: omp_get_num_threads
@@ -1164,24 +1321,33 @@
         public :: omp_get_nested
         public :: omp_get_thread_limit
         public :: omp_set_max_active_levels
+        public :: kmp_set_max_active_levels_8
         public :: omp_get_max_active_levels
         public :: omp_get_level
         public :: omp_get_active_level
         public :: omp_get_ancestor_thread_num
+        public :: kmp_get_ancestor_thread_num_8
         public :: omp_get_team_size
+        public :: kmp_get_team_size_8
         public :: omp_set_schedule
+        public :: kmp_set_schedule_8
         public :: omp_get_schedule
+        public :: kmp_get_schedule_8
         public :: omp_get_proc_bind
         public :: omp_get_num_places
         public :: omp_get_place_num_procs
+        public :: kmp_get_place_num_procs_8
         public :: omp_get_place_proc_ids
+        public :: kmp_get_place_proc_ids_8
         public :: omp_get_place_num
         public :: omp_get_partition_num_places
         public :: omp_get_partition_place_nums
+        public :: kmp_get_partition_place_nums_8
         public :: omp_get_wtime
         public :: omp_get_wtick
         public :: omp_get_default_device
         public :: omp_set_default_device
+        public :: kmp_set_default_device_8
         public :: omp_get_num_devices
         public :: omp_get_num_teams
         public :: omp_get_team_num
@@ -1190,6 +1356,7 @@
         public :: omp_get_initial_device
         public :: omp_get_device_num
         public :: omp_pause_resource
+        public :: kmp_pause_resource_8
         public :: omp_pause_resource_all
         public :: omp_get_supported_active_levels
         public :: omp_fulfill_event
@@ -1216,8 +1383,10 @@
         public :: omp_display_affinity
         public :: omp_capture_affinity
         public :: omp_set_num_teams
+        public :: kmp_set_num_teams_8
         public :: omp_get_max_teams
         public :: omp_set_teams_thread_limit
+        public :: kmp_set_teams_thread_limit_8
         public :: omp_get_teams_thread_limit
         public :: omp_display_env
         public :: omp_target_alloc
@@ -1241,26 +1410,33 @@
         public :: omp_free
         public :: omp_in_explicit_task
         public :: kmp_set_stacksize
+        public :: kmp_set_stacksize_8
         public :: kmp_set_stacksize_s
         public :: kmp_set_blocktime
+        public :: kmp_set_blocktime_8
         public :: kmp_set_library_serial
         public :: kmp_set_library_turnaround
         public :: kmp_set_library_throughput
         public :: kmp_set_library
+        public :: kmp_set_library_8
         public :: kmp_set_defaults
         public :: kmp_get_stacksize
         public :: kmp_get_stacksize_s
         public :: kmp_get_blocktime
         public :: kmp_get_library
         public :: kmp_set_disp_num_buffers
+        public :: kmp_set_disp_num_buffers_8
         public :: kmp_set_affinity
         public :: kmp_get_affinity
         public :: kmp_get_affinity_max_proc
         public :: kmp_create_affinity_mask
         public :: kmp_destroy_affinity_mask
         public :: kmp_set_affinity_mask_proc
+        public :: kmp_set_affinity_mask_proc_8
         public :: kmp_unset_affinity_mask_proc
+        public :: kmp_unset_affinity_mask_proc_8
         public :: kmp_get_affinity_mask_proc
+        public :: kmp_get_affinity_mask_proc_8
         public :: kmp_malloc
         public :: kmp_aligned_malloc
         public :: kmp_calloc

--- a/openmp/runtime/src/dllexports
+++ b/openmp/runtime/src/dllexports
@@ -428,6 +428,7 @@ omp_set_lock                                714
 omp_set_nest_lock                           715
 omp_set_nested                              716
 omp_set_num_threads                         717
+kmp_set_num_threads_8                       824
 omp_test_lock                               718
 omp_test_nest_lock                          719
 omp_unset_lock                              720
@@ -436,6 +437,28 @@ omp_unset_nest_lock                         721
 ompc_set_dynamic                            722
 ompc_set_nested                             723
 ompc_set_num_threads                        724
+kmpc_set_num_threads_8                      825
+
+# 64-bit integer variants used by Fortran and language bindings.
+kmp_get_affinity_mask_proc_8                826
+kmp_set_affinity_mask_proc_8                827
+kmp_set_blocktime_8                         828
+kmp_set_disp_num_buffers_8                  829
+kmp_set_library_8                           830
+kmp_set_stacksize_8                         831
+kmp_unset_affinity_mask_proc_8              832
+kmp_get_ancestor_thread_num_8               833
+kmp_get_partition_place_nums_8              834
+kmp_get_place_num_procs_8                   835
+kmp_get_schedule_8                          836
+kmp_get_team_size_8                         837
+kmp_pause_resource_8                        838
+kmp_set_default_device_8                    839
+kmp_set_max_active_levels_8                 840
+kmp_set_num_teams_8                         841
+kmp_set_schedule_8                          842
+kmp_set_teams_thread_limit_8                843
+kmp_get_place_proc_ids_8                    844
 
 kmp_calloc                                  725
 kmp_free                                    726

--- a/openmp/runtime/src/include/omp.h.var
+++ b/openmp/runtime/src/include/omp.h.var
@@ -62,10 +62,13 @@
 
     /* set API functions */
     extern void   __KAI_KMPC_CONVENTION  omp_set_num_threads (int);
+    extern void   __KAI_KMPC_CONVENTION  kmp_set_num_threads_8 (int64_t);
     extern void   __KAI_KMPC_CONVENTION  omp_set_dynamic     (int);
     extern void   __KAI_KMPC_CONVENTION  omp_set_nested      (int);
     extern void   __KAI_KMPC_CONVENTION  omp_set_max_active_levels (int);
+    extern void   __KAI_KMPC_CONVENTION  kmp_set_max_active_levels_8 (int64_t);
     extern void   __KAI_KMPC_CONVENTION  omp_set_schedule          (omp_sched_t, int);
+    extern void   __KAI_KMPC_CONVENTION  kmp_set_schedule_8        (omp_sched_t, int64_t);
 
     /* query API functions */
     extern int    __KAI_KMPC_CONVENTION  omp_get_num_threads  (void);
@@ -79,10 +82,13 @@
     extern int    __KAI_KMPC_CONVENTION  omp_get_active_level        (void);
     extern int    __KAI_KMPC_CONVENTION  omp_get_level               (void);
     extern int    __KAI_KMPC_CONVENTION  omp_get_ancestor_thread_num (int);
+    extern int    __KAI_KMPC_CONVENTION  kmp_get_ancestor_thread_num_8 (int64_t);
     extern int    __KAI_KMPC_CONVENTION  omp_get_team_size           (int);
+    extern int    __KAI_KMPC_CONVENTION  kmp_get_team_size_8         (int64_t);
     extern int    __KAI_KMPC_CONVENTION  omp_get_thread_limit        (void);
     extern int    __KAI_KMPC_CONVENTION  omp_get_max_active_levels   (void);
     extern void   __KAI_KMPC_CONVENTION  omp_get_schedule            (omp_sched_t *, int *);
+    extern void   __KAI_KMPC_CONVENTION  kmp_get_schedule_8          (omp_sched_t *, int64_t *);
     extern int    __KAI_KMPC_CONVENTION  omp_get_max_task_priority   (void);
 
     /* lock API functions */
@@ -138,6 +144,7 @@
     /* OpenMP 4.0 */
     extern int  __KAI_KMPC_CONVENTION  omp_get_default_device (void);
     extern void __KAI_KMPC_CONVENTION  omp_set_default_device (int);
+    extern void __KAI_KMPC_CONVENTION  kmp_set_default_device_8 (int64_t);
     extern int  __KAI_KMPC_CONVENTION  omp_is_initial_device (void);
     extern int  __KAI_KMPC_CONVENTION  omp_get_num_devices (void);
     extern int  __KAI_KMPC_CONVENTION  omp_get_num_teams (void);
@@ -259,17 +266,21 @@
     /* kmp API functions */
     extern int    __KAI_KMPC_CONVENTION  kmp_get_stacksize          (void);
     extern void   __KAI_KMPC_CONVENTION  kmp_set_stacksize          (int);
+    extern void   __KAI_KMPC_CONVENTION  kmp_set_stacksize_8        (int64_t);
     extern size_t __KAI_KMPC_CONVENTION  kmp_get_stacksize_s        (void);
     extern void   __KAI_KMPC_CONVENTION  kmp_set_stacksize_s        (size_t);
     extern int    __KAI_KMPC_CONVENTION  kmp_get_blocktime          (void);
     extern int    __KAI_KMPC_CONVENTION  kmp_get_library            (void);
     extern void   __KAI_KMPC_CONVENTION  kmp_set_blocktime          (int);
+    extern void   __KAI_KMPC_CONVENTION  kmp_set_blocktime_8        (int64_t);
     extern void   __KAI_KMPC_CONVENTION  kmp_set_library            (int);
+    extern void   __KAI_KMPC_CONVENTION  kmp_set_library_8          (int64_t);
     extern void   __KAI_KMPC_CONVENTION  kmp_set_library_serial     (void);
     extern void   __KAI_KMPC_CONVENTION  kmp_set_library_turnaround (void);
     extern void   __KAI_KMPC_CONVENTION  kmp_set_library_throughput (void);
     extern void   __KAI_KMPC_CONVENTION  kmp_set_defaults           (char const *);
     extern void   __KAI_KMPC_CONVENTION  kmp_set_disp_num_buffers   (int);
+    extern void   __KAI_KMPC_CONVENTION  kmp_set_disp_num_buffers_8 (int64_t);
 
     /* Intel affinity API */
     typedef void * kmp_affinity_mask_t;
@@ -280,8 +291,11 @@
     extern void   __KAI_KMPC_CONVENTION  kmp_create_affinity_mask     (kmp_affinity_mask_t *);
     extern void   __KAI_KMPC_CONVENTION  kmp_destroy_affinity_mask    (kmp_affinity_mask_t *);
     extern int    __KAI_KMPC_CONVENTION  kmp_set_affinity_mask_proc   (int, kmp_affinity_mask_t *);
+    extern int    __KAI_KMPC_CONVENTION  kmp_set_affinity_mask_proc_8 (int64_t, kmp_affinity_mask_t *);
     extern int    __KAI_KMPC_CONVENTION  kmp_unset_affinity_mask_proc (int, kmp_affinity_mask_t *);
+    extern int    __KAI_KMPC_CONVENTION  kmp_unset_affinity_mask_proc_8 (int64_t, kmp_affinity_mask_t *);
     extern int    __KAI_KMPC_CONVENTION  kmp_get_affinity_mask_proc   (int, kmp_affinity_mask_t *);
+    extern int    __KAI_KMPC_CONVENTION  kmp_get_affinity_mask_proc_8 (int64_t, kmp_affinity_mask_t *);
 
     /* OpenMP 4.0 affinity API */
     typedef enum omp_proc_bind_t {
@@ -297,10 +311,13 @@
     /* OpenMP 4.5 affinity API */
     extern int  __KAI_KMPC_CONVENTION omp_get_num_places (void);
     extern int  __KAI_KMPC_CONVENTION omp_get_place_num_procs (int);
+    extern int  __KAI_KMPC_CONVENTION kmp_get_place_num_procs_8 (int64_t);
     extern void __KAI_KMPC_CONVENTION omp_get_place_proc_ids (int, int *);
+    extern void __KAI_KMPC_CONVENTION kmp_get_place_proc_ids_8 (int64_t, int64_t *);
     extern int  __KAI_KMPC_CONVENTION omp_get_place_num (void);
     extern int  __KAI_KMPC_CONVENTION omp_get_partition_num_places (void);
     extern void __KAI_KMPC_CONVENTION omp_get_partition_place_nums (int *);
+    extern void __KAI_KMPC_CONVENTION kmp_get_partition_place_nums_8 (int64_t *);
 
     extern void * __KAI_KMPC_CONVENTION  kmp_malloc  (size_t);
     extern void * __KAI_KMPC_CONVENTION  kmp_aligned_malloc  (size_t, size_t);
@@ -533,14 +550,17 @@
       omp_pause_stop_tool = 3
     } omp_pause_resource_t;
     extern int __KAI_KMPC_CONVENTION omp_pause_resource(omp_pause_resource_t, int);
+    extern int __KAI_KMPC_CONVENTION kmp_pause_resource_8(omp_pause_resource_t, int64_t);
     extern int __KAI_KMPC_CONVENTION omp_pause_resource_all(omp_pause_resource_t);
 
     extern int __KAI_KMPC_CONVENTION omp_get_supported_active_levels(void);
 
     /* OpenMP 5.1 */
     extern void __KAI_KMPC_CONVENTION omp_set_num_teams(int num_teams);
+    extern void __KAI_KMPC_CONVENTION kmp_set_num_teams_8(int64_t num_teams);
     extern int __KAI_KMPC_CONVENTION omp_get_max_teams(void);
     extern void __KAI_KMPC_CONVENTION omp_set_teams_thread_limit(int limit);
+    extern void __KAI_KMPC_CONVENTION kmp_set_teams_thread_limit_8(int64_t limit);
     extern int __KAI_KMPC_CONVENTION omp_get_teams_thread_limit(void);
 
     /* OpenMP 5.1 Display Environment */

--- a/openmp/runtime/src/kmp.h
+++ b/openmp/runtime/src/kmp.h
@@ -4100,6 +4100,7 @@ void kmpc_set_blocktime(int arg);
 void ompc_set_nested(int flag);
 void ompc_set_dynamic(int flag);
 void ompc_set_num_threads(int arg);
+void kmpc_set_num_threads_8(kmp_int64 arg);
 
 extern void __kmp_push_current_task_to_thread(kmp_info_t *this_thr,
                                               kmp_team_t *team, int tid);

--- a/openmp/runtime/src/kmp_csupport.cpp
+++ b/openmp/runtime/src/kmp_csupport.cpp
@@ -2040,6 +2040,14 @@ void ompc_set_num_threads(int arg) {
   __kmp_set_num_threads(arg, __kmp_entry_gtid());
 }
 
+void kmpc_set_num_threads_8(kmp_int64 arg) {
+  if (arg > (kmp_int64)INT_MAX)
+    arg = INT_MAX;
+  else if (arg < (kmp_int64)INT_MIN)
+    arg = INT_MIN;
+  __kmp_set_num_threads((int)arg, __kmp_entry_gtid());
+}
+
 void ompc_set_dynamic(int flag) {
   kmp_info_t *thread;
 

--- a/openmp/runtime/src/kmp_ftn_entry.h
+++ b/openmp/runtime/src/kmp_ftn_entry.h
@@ -54,9 +54,19 @@ extern "C" {
 // This macro helps to reduce code duplication.
 #ifdef PASS_ARGS_BY_VALUE
 #define KMP_DEREF
+#define KMP_FTN_PASS(x) (x)
 #else
 #define KMP_DEREF *
+#define KMP_FTN_PASS(x) (&(x))
 #endif
+
+static int __kmp_ftn_int64_to_int(kmp_int64 value) {
+  if (value > (kmp_int64)INT_MAX)
+    return INT_MAX;
+  if (value < (kmp_int64)INT_MIN)
+    return INT_MIN;
+  return (int)value;
+}
 
 // For API with specific C vs. Fortran interfaces (ompc_* exists in
 // kmp_csupport.cpp), only create GOMP versioned symbols of the API for the
@@ -75,6 +85,11 @@ void FTN_STDCALL FTN_SET_STACKSIZE(int KMP_DEREF arg) {
   // __kmp_aux_set_stacksize initializes the library if needed
   __kmp_aux_set_stacksize((size_t)KMP_DEREF arg);
 #endif
+}
+
+void FTN_STDCALL FTN_SET_STACKSIZE_8(kmp_int64 KMP_DEREF arg) {
+  int arg32 = __kmp_ftn_int64_to_int(KMP_DEREF arg);
+  FTN_SET_STACKSIZE(KMP_FTN_PASS(arg32));
 }
 
 void FTN_STDCALL FTN_SET_STACKSIZE_S(size_t KMP_DEREF arg) {
@@ -122,6 +137,11 @@ void FTN_STDCALL FTN_SET_BLOCKTIME(int KMP_DEREF arg) {
   __kmp_aux_convert_blocktime(&bt);
   __kmp_aux_set_blocktime(bt, thread, tid);
 #endif
+}
+
+void FTN_STDCALL FTN_SET_BLOCKTIME_8(kmp_int64 KMP_DEREF arg) {
+  int arg32 = __kmp_ftn_int64_to_int(KMP_DEREF arg);
+  FTN_SET_BLOCKTIME(KMP_FTN_PASS(arg32));
 }
 
 // Gets blocktime in units used for KMP_BLOCKTIME, ms otherwise
@@ -198,6 +218,11 @@ void FTN_STDCALL FTN_SET_LIBRARY(int KMP_DEREF arg) {
 #endif
 }
 
+void FTN_STDCALL FTN_SET_LIBRARY_8(kmp_int64 KMP_DEREF arg) {
+  int arg32 = __kmp_ftn_int64_to_int(KMP_DEREF arg);
+  FTN_SET_LIBRARY(KMP_FTN_PASS(arg32));
+}
+
 int FTN_STDCALL FTN_GET_LIBRARY(void) {
 #ifdef KMP_STUB
   return __kmps_get_library();
@@ -221,6 +246,11 @@ void FTN_STDCALL FTN_SET_DISP_NUM_BUFFERS(int KMP_DEREF arg) {
     __kmp_dispatch_num_buffers = num_buffers;
   }
 #endif
+}
+
+void FTN_STDCALL FTN_SET_DISP_NUM_BUFFERS_8(kmp_int64 KMP_DEREF arg) {
+  int arg32 = __kmp_ftn_int64_to_int(KMP_DEREF arg);
+  FTN_SET_DISP_NUM_BUFFERS(KMP_FTN_PASS(arg32));
 }
 
 int FTN_STDCALL FTN_SET_AFFINITY(void **mask) {
@@ -314,6 +344,12 @@ int FTN_STDCALL FTN_SET_AFFINITY_MASK_PROC(int KMP_DEREF proc, void **mask) {
 #endif
 }
 
+int FTN_STDCALL FTN_SET_AFFINITY_MASK_PROC_8(kmp_int64 KMP_DEREF proc,
+                                             void **mask) {
+  int proc32 = __kmp_ftn_int64_to_int(KMP_DEREF proc);
+  return FTN_SET_AFFINITY_MASK_PROC(KMP_FTN_PASS(proc32), mask);
+}
+
 int FTN_STDCALL FTN_UNSET_AFFINITY_MASK_PROC(int KMP_DEREF proc, void **mask) {
 #if defined(KMP_STUB) || !KMP_AFFINITY_SUPPORTED
   return -1;
@@ -324,6 +360,12 @@ int FTN_STDCALL FTN_UNSET_AFFINITY_MASK_PROC(int KMP_DEREF proc, void **mask) {
   __kmp_assign_root_init_mask();
   return __kmp_aux_unset_affinity_mask_proc(KMP_DEREF proc, mask);
 #endif
+}
+
+int FTN_STDCALL FTN_UNSET_AFFINITY_MASK_PROC_8(kmp_int64 KMP_DEREF proc,
+                                               void **mask) {
+  int proc32 = __kmp_ftn_int64_to_int(KMP_DEREF proc);
+  return FTN_UNSET_AFFINITY_MASK_PROC(KMP_FTN_PASS(proc32), mask);
 }
 
 int FTN_STDCALL FTN_GET_AFFINITY_MASK_PROC(int KMP_DEREF proc, void **mask) {
@@ -338,6 +380,12 @@ int FTN_STDCALL FTN_GET_AFFINITY_MASK_PROC(int KMP_DEREF proc, void **mask) {
 #endif
 }
 
+int FTN_STDCALL FTN_GET_AFFINITY_MASK_PROC_8(kmp_int64 KMP_DEREF proc,
+                                             void **mask) {
+  int proc32 = __kmp_ftn_int64_to_int(KMP_DEREF proc);
+  return FTN_GET_AFFINITY_MASK_PROC(KMP_FTN_PASS(proc32), mask);
+}
+
 /* ------------------------------------------------------------------------ */
 
 /* sets the requested number of threads for the next parallel region */
@@ -347,6 +395,12 @@ void FTN_STDCALL KMP_EXPAND_NAME(FTN_SET_NUM_THREADS)(int KMP_DEREF arg) {
 #else
   __kmp_set_num_threads(KMP_DEREF arg, __kmp_entry_gtid());
 #endif
+}
+
+/* Same as omp_set_num_threads, but accepts a 64-bit integer argument. */
+void FTN_STDCALL FTN_SET_NUM_THREADS_8(kmp_int64 KMP_DEREF arg) {
+  int arg32 = __kmp_ftn_int64_to_int(KMP_DEREF arg);
+  KMP_EXPAND_NAME(FTN_SET_NUM_THREADS)(KMP_FTN_PASS(arg32));
 }
 
 /* returns the number of threads in current team */
@@ -851,6 +905,12 @@ void FTN_STDCALL KMP_EXPAND_NAME(FTN_SET_SCHEDULE)(kmp_sched_t KMP_DEREF kind,
 #endif
 }
 
+void FTN_STDCALL FTN_SET_SCHEDULE_8(kmp_sched_t KMP_DEREF kind,
+                                    kmp_int64 KMP_DEREF modifier) {
+  int modifier32 = __kmp_ftn_int64_to_int(KMP_DEREF modifier);
+  KMP_EXPAND_NAME(FTN_SET_SCHEDULE)(kind, KMP_FTN_PASS(modifier32));
+}
+
 void FTN_STDCALL KMP_EXPAND_NAME(FTN_GET_SCHEDULE)(kmp_sched_t *kind,
                                                    int *modifier) {
 #ifdef KMP_STUB
@@ -861,6 +921,12 @@ void FTN_STDCALL KMP_EXPAND_NAME(FTN_GET_SCHEDULE)(kmp_sched_t *kind,
 #endif
 }
 
+void FTN_STDCALL FTN_GET_SCHEDULE_8(kmp_sched_t *kind, kmp_int64 *modifier) {
+  int modifier32;
+  KMP_EXPAND_NAME(FTN_GET_SCHEDULE)(kind, &modifier32);
+  *modifier = modifier32;
+}
+
 void FTN_STDCALL KMP_EXPAND_NAME(FTN_SET_MAX_ACTIVE_LEVELS)(int KMP_DEREF arg) {
 #ifdef KMP_STUB
 // Nothing.
@@ -868,6 +934,11 @@ void FTN_STDCALL KMP_EXPAND_NAME(FTN_SET_MAX_ACTIVE_LEVELS)(int KMP_DEREF arg) {
   /* TO DO: We want per-task implementation of this internal control */
   __kmp_set_max_active_levels(__kmp_entry_gtid(), KMP_DEREF arg);
 #endif
+}
+
+void FTN_STDCALL FTN_SET_MAX_ACTIVE_LEVELS_8(kmp_int64 KMP_DEREF arg) {
+  int arg32 = __kmp_ftn_int64_to_int(KMP_DEREF arg);
+  KMP_EXPAND_NAME(FTN_SET_MAX_ACTIVE_LEVELS)(KMP_FTN_PASS(arg32));
 }
 
 int FTN_STDCALL KMP_EXPAND_NAME(FTN_GET_MAX_ACTIVE_LEVELS)(void) {
@@ -909,12 +980,22 @@ KMP_EXPAND_NAME(FTN_GET_ANCESTOR_THREAD_NUM)(int KMP_DEREF level) {
 #endif
 }
 
+int FTN_STDCALL FTN_GET_ANCESTOR_THREAD_NUM_8(kmp_int64 KMP_DEREF level) {
+  int level32 = __kmp_ftn_int64_to_int(KMP_DEREF level);
+  return KMP_EXPAND_NAME(FTN_GET_ANCESTOR_THREAD_NUM)(KMP_FTN_PASS(level32));
+}
+
 int FTN_STDCALL KMP_EXPAND_NAME(FTN_GET_TEAM_SIZE)(int KMP_DEREF level) {
 #ifdef KMP_STUB
   return (KMP_DEREF level) ? (-1) : (1);
 #else
   return __kmp_get_team_size(__kmp_entry_gtid(), KMP_DEREF level);
 #endif
+}
+
+int FTN_STDCALL FTN_GET_TEAM_SIZE_8(kmp_int64 KMP_DEREF level) {
+  int level32 = __kmp_ftn_int64_to_int(KMP_DEREF level);
+  return KMP_EXPAND_NAME(FTN_GET_TEAM_SIZE)(KMP_FTN_PASS(level32));
 }
 
 int FTN_STDCALL KMP_EXPAND_NAME(FTN_GET_THREAD_LIMIT)(void) {
@@ -1010,6 +1091,11 @@ int FTN_STDCALL KMP_EXPAND_NAME(FTN_GET_PLACE_NUM_PROCS)(int place_num) {
 #endif
 }
 
+int FTN_STDCALL FTN_GET_PLACE_NUM_PROCS_8(kmp_int64 KMP_DEREF place_num) {
+  return KMP_EXPAND_NAME(FTN_GET_PLACE_NUM_PROCS)(
+      __kmp_ftn_int64_to_int(KMP_DEREF place_num));
+}
+
 void FTN_STDCALL KMP_EXPAND_NAME(FTN_GET_PLACE_PROC_IDS)(int place_num,
                                                          int *ids) {
 #if defined(KMP_STUB) || !KMP_AFFINITY_SUPPORTED
@@ -1041,6 +1127,22 @@ void FTN_STDCALL KMP_EXPAND_NAME(FTN_GET_PLACE_PROC_IDS)(int place_num,
     ids[j++] = i;
   }
 #endif
+}
+
+void FTN_STDCALL FTN_GET_PLACE_PROC_IDS_8(kmp_int64 KMP_DEREF place_num,
+                                          kmp_int64 *ids) {
+  int place_num32 = __kmp_ftn_int64_to_int(KMP_DEREF place_num);
+  int n = KMP_EXPAND_NAME(FTN_GET_PLACE_NUM_PROCS)(place_num32);
+  int *ids32;
+  if (n <= 0)
+    return;
+  ids32 = (int *)KMP_INTERNAL_MALLOC(sizeof(int) * n);
+  if (ids32 == NULL)
+    return;
+  KMP_EXPAND_NAME(FTN_GET_PLACE_PROC_IDS)(place_num32, ids32);
+  for (int i = 0; i < n; ++i)
+    ids[i] = ids32[i];
+  KMP_INTERNAL_FREE(ids32);
 }
 
 int FTN_STDCALL KMP_EXPAND_NAME(FTN_GET_PLACE_NUM)(void) {
@@ -1127,6 +1229,39 @@ KMP_EXPAND_NAME(FTN_GET_PARTITION_PLACE_NUMS)(int *place_nums) {
 #endif
 }
 
+void FTN_STDCALL FTN_GET_PARTITION_PLACE_NUMS_8(kmp_int64 *place_nums) {
+#if defined(KMP_STUB) || !KMP_AFFINITY_SUPPORTED
+// Nothing.
+#else
+  int i, gtid, place_num, first_place, last_place, start, end;
+  kmp_info_t *thread;
+  if (!TCR_4(__kmp_init_middle)) {
+    __kmp_middle_initialize();
+  }
+  if (!KMP_AFFINITY_CAPABLE())
+    return;
+  gtid = __kmp_entry_gtid();
+  thread = __kmp_thread_from_gtid(gtid);
+  if (thread->th.th_team->t.t_level == 0 && !__kmp_affinity.flags.reset) {
+    __kmp_assign_root_init_mask();
+  }
+  first_place = thread->th.th_first_place;
+  last_place = thread->th.th_last_place;
+  if (first_place < 0 || last_place < 0)
+    return;
+  if (first_place <= last_place) {
+    start = first_place;
+    end = last_place;
+  } else {
+    start = last_place;
+    end = first_place;
+  }
+  for (i = 0, place_num = start; place_num <= end; ++place_num, ++i) {
+    place_nums[i] = place_num;
+  }
+#endif
+}
+
 int FTN_STDCALL KMP_EXPAND_NAME(FTN_GET_NUM_TEAMS)(void) {
 #ifdef KMP_STUB
   return 1;
@@ -1158,6 +1293,11 @@ void FTN_STDCALL KMP_EXPAND_NAME(FTN_SET_DEFAULT_DEVICE)(int KMP_DEREF arg) {
   __kmp_entry_thread()->th.th_current_task->td_icvs.default_device =
       KMP_DEREF arg;
 #endif
+}
+
+void FTN_STDCALL FTN_SET_DEFAULT_DEVICE_8(kmp_int64 KMP_DEREF arg) {
+  int arg32 = __kmp_ftn_int64_to_int(KMP_DEREF arg);
+  KMP_EXPAND_NAME(FTN_SET_DEFAULT_DEVICE)(KMP_FTN_PASS(arg32));
 }
 
 // Get number of NON-HOST devices.
@@ -1598,6 +1738,12 @@ int FTN_STDCALL KMP_EXPAND_NAME(FTN_PAUSE_RESOURCE)(kmp_pause_status_t kind,
 #endif
 }
 
+int FTN_STDCALL FTN_PAUSE_RESOURCE_8(kmp_pause_status_t kind,
+                                     kmp_int64 KMP_DEREF device_num) {
+  return KMP_EXPAND_NAME(FTN_PAUSE_RESOURCE)(
+      kind, __kmp_ftn_int64_to_int(KMP_DEREF device_num));
+}
+
 // Compiler will ensure that this is only called from host in sequential region
 int FTN_STDCALL
     KMP_EXPAND_NAME(FTN_PAUSE_RESOURCE_ALL)(kmp_pause_status_t kind) {
@@ -1653,6 +1799,11 @@ void FTN_STDCALL FTN_SET_NUM_TEAMS(int KMP_DEREF num_teams) {
 #endif
 }
 
+void FTN_STDCALL FTN_SET_NUM_TEAMS_8(kmp_int64 KMP_DEREF num_teams) {
+  int num_teams32 = __kmp_ftn_int64_to_int(KMP_DEREF num_teams);
+  FTN_SET_NUM_TEAMS(KMP_FTN_PASS(num_teams32));
+}
+
 int FTN_STDCALL FTN_GET_MAX_TEAMS(void) {
 #ifdef KMP_STUB
   return 1;
@@ -1687,6 +1838,11 @@ void FTN_STDCALL FTN_SET_TEAMS_THREAD_LIMIT(int KMP_DEREF limit) {
   }
   __kmp_set_teams_thread_limit(KMP_DEREF limit);
 #endif
+}
+
+void FTN_STDCALL FTN_SET_TEAMS_THREAD_LIMIT_8(kmp_int64 KMP_DEREF limit) {
+  int limit32 = __kmp_ftn_int64_to_int(KMP_DEREF limit);
+  FTN_SET_TEAMS_THREAD_LIMIT(KMP_FTN_PASS(limit32));
 }
 
 int FTN_STDCALL FTN_GET_TEAMS_THREAD_LIMIT(void) {

--- a/openmp/runtime/src/kmp_ftn_os.h
+++ b/openmp/runtime/src/kmp_ftn_os.h
@@ -21,26 +21,33 @@
 #if KMP_FTN_ENTRIES == KMP_FTN_PLAIN
 
 #define FTN_SET_STACKSIZE kmp_set_stacksize
+#define FTN_SET_STACKSIZE_8 kmp_set_stacksize_8
 #define FTN_SET_STACKSIZE_S kmp_set_stacksize_s
 #define FTN_GET_STACKSIZE kmp_get_stacksize
 #define FTN_GET_STACKSIZE_S kmp_get_stacksize_s
 #define FTN_SET_BLOCKTIME kmp_set_blocktime
+#define FTN_SET_BLOCKTIME_8 kmp_set_blocktime_8
 #define FTN_GET_BLOCKTIME kmp_get_blocktime
 #define FTN_SET_LIBRARY_SERIAL kmp_set_library_serial
 #define FTN_SET_LIBRARY_TURNAROUND kmp_set_library_turnaround
 #define FTN_SET_LIBRARY_THROUGHPUT kmp_set_library_throughput
 #define FTN_SET_LIBRARY kmp_set_library
+#define FTN_SET_LIBRARY_8 kmp_set_library_8
 #define FTN_GET_LIBRARY kmp_get_library
 #define FTN_SET_DEFAULTS kmp_set_defaults
 #define FTN_SET_DISP_NUM_BUFFERS kmp_set_disp_num_buffers
+#define FTN_SET_DISP_NUM_BUFFERS_8 kmp_set_disp_num_buffers_8
 #define FTN_SET_AFFINITY kmp_set_affinity
 #define FTN_GET_AFFINITY kmp_get_affinity
 #define FTN_GET_AFFINITY_MAX_PROC kmp_get_affinity_max_proc
 #define FTN_CREATE_AFFINITY_MASK kmp_create_affinity_mask
 #define FTN_DESTROY_AFFINITY_MASK kmp_destroy_affinity_mask
 #define FTN_SET_AFFINITY_MASK_PROC kmp_set_affinity_mask_proc
+#define FTN_SET_AFFINITY_MASK_PROC_8 kmp_set_affinity_mask_proc_8
 #define FTN_UNSET_AFFINITY_MASK_PROC kmp_unset_affinity_mask_proc
+#define FTN_UNSET_AFFINITY_MASK_PROC_8 kmp_unset_affinity_mask_proc_8
 #define FTN_GET_AFFINITY_MASK_PROC kmp_get_affinity_mask_proc
+#define FTN_GET_AFFINITY_MASK_PROC_8 kmp_get_affinity_mask_proc_8
 
 #define FTN_MALLOC kmp_malloc
 #define FTN_ALIGNED_MALLOC kmp_aligned_malloc
@@ -51,6 +58,7 @@
 #define FTN_GET_NUM_KNOWN_THREADS kmp_get_num_known_threads
 
 #define FTN_SET_NUM_THREADS omp_set_num_threads
+#define FTN_SET_NUM_THREADS_8 kmp_set_num_threads_8
 #define FTN_GET_NUM_THREADS omp_get_num_threads
 #define FTN_GET_MAX_THREADS omp_get_max_threads
 #define FTN_GET_THREAD_NUM omp_get_thread_num
@@ -62,13 +70,18 @@
 #define FTN_IN_PARALLEL omp_in_parallel
 #define FTN_GET_THREAD_LIMIT omp_get_thread_limit
 #define FTN_SET_SCHEDULE omp_set_schedule
+#define FTN_SET_SCHEDULE_8 kmp_set_schedule_8
 #define FTN_GET_SCHEDULE omp_get_schedule
+#define FTN_GET_SCHEDULE_8 kmp_get_schedule_8
 #define FTN_SET_MAX_ACTIVE_LEVELS omp_set_max_active_levels
+#define FTN_SET_MAX_ACTIVE_LEVELS_8 kmp_set_max_active_levels_8
 #define FTN_GET_MAX_ACTIVE_LEVELS omp_get_max_active_levels
 #define FTN_GET_ACTIVE_LEVEL omp_get_active_level
 #define FTN_GET_LEVEL omp_get_level
 #define FTN_GET_ANCESTOR_THREAD_NUM omp_get_ancestor_thread_num
+#define FTN_GET_ANCESTOR_THREAD_NUM_8 kmp_get_ancestor_thread_num_8
 #define FTN_GET_TEAM_SIZE omp_get_team_size
+#define FTN_GET_TEAM_SIZE_8 kmp_get_team_size_8
 #define FTN_IN_FINAL omp_in_final
 #define FTN_GET_PROC_BIND omp_get_proc_bind
 #define FTN_GET_NUM_TEAMS omp_get_num_teams
@@ -97,6 +110,7 @@
 #define FTN_GET_NUM_DEVICES omp_get_num_devices
 #define FTN_GET_DEFAULT_DEVICE omp_get_default_device
 #define FTN_SET_DEFAULT_DEVICE omp_set_default_device
+#define FTN_SET_DEFAULT_DEVICE_8 kmp_set_default_device_8
 #define FTN_IS_INITIAL_DEVICE omp_is_initial_device
 
 #define FTN_GET_CANCELLATION omp_get_cancellation
@@ -105,10 +119,13 @@
 #define FTN_GET_MAX_TASK_PRIORITY omp_get_max_task_priority
 #define FTN_GET_NUM_PLACES omp_get_num_places
 #define FTN_GET_PLACE_NUM_PROCS omp_get_place_num_procs
+#define FTN_GET_PLACE_NUM_PROCS_8 kmp_get_place_num_procs_8
 #define FTN_GET_PLACE_PROC_IDS omp_get_place_proc_ids
+#define FTN_GET_PLACE_PROC_IDS_8 kmp_get_place_proc_ids_8
 #define FTN_GET_PLACE_NUM omp_get_place_num
 #define FTN_GET_PARTITION_NUM_PLACES omp_get_partition_num_places
 #define FTN_GET_PARTITION_PLACE_NUMS omp_get_partition_place_nums
+#define FTN_GET_PARTITION_PLACE_NUMS_8 kmp_get_partition_place_nums_8
 #define FTN_GET_INITIAL_DEVICE omp_get_initial_device
 #ifdef KMP_STUB
 #define FTN_TARGET_ALLOC omp_target_alloc
@@ -147,14 +164,17 @@
 #define FTN_DISPLAY_AFFINITY omp_display_affinity
 #define FTN_CAPTURE_AFFINITY omp_capture_affinity
 #define FTN_PAUSE_RESOURCE omp_pause_resource
+#define FTN_PAUSE_RESOURCE_8 kmp_pause_resource_8
 #define FTN_PAUSE_RESOURCE_ALL omp_pause_resource_all
 #define FTN_GET_SUPPORTED_ACTIVE_LEVELS omp_get_supported_active_levels
 #define FTN_DISPLAY_ENV omp_display_env
 #define FTN_IN_EXPLICIT_TASK omp_in_explicit_task
 #define FTN_FULFILL_EVENT omp_fulfill_event
 #define FTN_SET_NUM_TEAMS omp_set_num_teams
+#define FTN_SET_NUM_TEAMS_8 kmp_set_num_teams_8
 #define FTN_GET_MAX_TEAMS omp_get_max_teams
 #define FTN_SET_TEAMS_THREAD_LIMIT omp_set_teams_thread_limit
+#define FTN_SET_TEAMS_THREAD_LIMIT_8 kmp_set_teams_thread_limit_8
 #define FTN_GET_TEAMS_THREAD_LIMIT omp_get_teams_thread_limit
 
 #define FTN_GET_NUM_INTEROP_PROPERTIES omp_get_num_interop_properties
@@ -172,26 +192,33 @@
 #if KMP_FTN_ENTRIES == KMP_FTN_APPEND
 
 #define FTN_SET_STACKSIZE kmp_set_stacksize_
+#define FTN_SET_STACKSIZE_8 kmp_set_stacksize_8_
 #define FTN_SET_STACKSIZE_S kmp_set_stacksize_s_
 #define FTN_GET_STACKSIZE kmp_get_stacksize_
 #define FTN_GET_STACKSIZE_S kmp_get_stacksize_s_
 #define FTN_SET_BLOCKTIME kmp_set_blocktime_
+#define FTN_SET_BLOCKTIME_8 kmp_set_blocktime_8_
 #define FTN_GET_BLOCKTIME kmp_get_blocktime_
 #define FTN_SET_LIBRARY_SERIAL kmp_set_library_serial_
 #define FTN_SET_LIBRARY_TURNAROUND kmp_set_library_turnaround_
 #define FTN_SET_LIBRARY_THROUGHPUT kmp_set_library_throughput_
 #define FTN_SET_LIBRARY kmp_set_library_
+#define FTN_SET_LIBRARY_8 kmp_set_library_8_
 #define FTN_GET_LIBRARY kmp_get_library_
 #define FTN_SET_DEFAULTS kmp_set_defaults_
 #define FTN_SET_DISP_NUM_BUFFERS kmp_set_disp_num_buffers_
+#define FTN_SET_DISP_NUM_BUFFERS_8 kmp_set_disp_num_buffers_8_
 #define FTN_SET_AFFINITY kmp_set_affinity_
 #define FTN_GET_AFFINITY kmp_get_affinity_
 #define FTN_GET_AFFINITY_MAX_PROC kmp_get_affinity_max_proc_
 #define FTN_CREATE_AFFINITY_MASK kmp_create_affinity_mask_
 #define FTN_DESTROY_AFFINITY_MASK kmp_destroy_affinity_mask_
 #define FTN_SET_AFFINITY_MASK_PROC kmp_set_affinity_mask_proc_
+#define FTN_SET_AFFINITY_MASK_PROC_8 kmp_set_affinity_mask_proc_8_
 #define FTN_UNSET_AFFINITY_MASK_PROC kmp_unset_affinity_mask_proc_
+#define FTN_UNSET_AFFINITY_MASK_PROC_8 kmp_unset_affinity_mask_proc_8_
 #define FTN_GET_AFFINITY_MASK_PROC kmp_get_affinity_mask_proc_
+#define FTN_GET_AFFINITY_MASK_PROC_8 kmp_get_affinity_mask_proc_8_
 
 #define FTN_MALLOC kmp_malloc_
 #define FTN_ALIGNED_MALLOC kmp_aligned_malloc_
@@ -202,6 +229,7 @@
 #define FTN_GET_NUM_KNOWN_THREADS kmp_get_num_known_threads_
 
 #define FTN_SET_NUM_THREADS omp_set_num_threads_
+#define FTN_SET_NUM_THREADS_8 kmp_set_num_threads_8_
 #define FTN_GET_NUM_THREADS omp_get_num_threads_
 #define FTN_GET_MAX_THREADS omp_get_max_threads_
 #define FTN_GET_THREAD_NUM omp_get_thread_num_
@@ -213,13 +241,18 @@
 #define FTN_IN_PARALLEL omp_in_parallel_
 #define FTN_GET_THREAD_LIMIT omp_get_thread_limit_
 #define FTN_SET_SCHEDULE omp_set_schedule_
+#define FTN_SET_SCHEDULE_8 kmp_set_schedule_8_
 #define FTN_GET_SCHEDULE omp_get_schedule_
+#define FTN_GET_SCHEDULE_8 kmp_get_schedule_8_
 #define FTN_SET_MAX_ACTIVE_LEVELS omp_set_max_active_levels_
+#define FTN_SET_MAX_ACTIVE_LEVELS_8 kmp_set_max_active_levels_8_
 #define FTN_GET_MAX_ACTIVE_LEVELS omp_get_max_active_levels_
 #define FTN_GET_ACTIVE_LEVEL omp_get_active_level_
 #define FTN_GET_LEVEL omp_get_level_
 #define FTN_GET_ANCESTOR_THREAD_NUM omp_get_ancestor_thread_num_
+#define FTN_GET_ANCESTOR_THREAD_NUM_8 kmp_get_ancestor_thread_num_8_
 #define FTN_GET_TEAM_SIZE omp_get_team_size_
+#define FTN_GET_TEAM_SIZE_8 kmp_get_team_size_8_
 #define FTN_IN_FINAL omp_in_final_
 #define FTN_GET_PROC_BIND omp_get_proc_bind_
 #define FTN_GET_NUM_TEAMS omp_get_num_teams_
@@ -248,6 +281,7 @@
 #define FTN_GET_NUM_DEVICES omp_get_num_devices_
 #define FTN_GET_DEFAULT_DEVICE omp_get_default_device_
 #define FTN_SET_DEFAULT_DEVICE omp_set_default_device_
+#define FTN_SET_DEFAULT_DEVICE_8 kmp_set_default_device_8_
 #define FTN_IS_INITIAL_DEVICE omp_is_initial_device_
 
 #define FTN_GET_CANCELLATION omp_get_cancellation_
@@ -256,10 +290,13 @@
 #define FTN_GET_MAX_TASK_PRIORITY omp_get_max_task_priority_
 #define FTN_GET_NUM_PLACES omp_get_num_places_
 #define FTN_GET_PLACE_NUM_PROCS omp_get_place_num_procs_
+#define FTN_GET_PLACE_NUM_PROCS_8 kmp_get_place_num_procs_8_
 #define FTN_GET_PLACE_PROC_IDS omp_get_place_proc_ids_
+#define FTN_GET_PLACE_PROC_IDS_8 kmp_get_place_proc_ids_8_
 #define FTN_GET_PLACE_NUM omp_get_place_num_
 #define FTN_GET_PARTITION_NUM_PLACES omp_get_partition_num_places_
 #define FTN_GET_PARTITION_PLACE_NUMS omp_get_partition_place_nums_
+#define FTN_GET_PARTITION_PLACE_NUMS_8 kmp_get_partition_place_nums_8_
 #define FTN_GET_INITIAL_DEVICE omp_get_initial_device_
 #ifdef KMP_STUB
 #define FTN_TARGET_ALLOC omp_target_alloc_
@@ -298,14 +335,17 @@
 #define FTN_DISPLAY_AFFINITY omp_display_affinity_
 #define FTN_CAPTURE_AFFINITY omp_capture_affinity_
 #define FTN_PAUSE_RESOURCE omp_pause_resource_
+#define FTN_PAUSE_RESOURCE_8 kmp_pause_resource_8_
 #define FTN_PAUSE_RESOURCE_ALL omp_pause_resource_all_
 #define FTN_GET_SUPPORTED_ACTIVE_LEVELS omp_get_supported_active_levels_
 #define FTN_DISPLAY_ENV omp_display_env_
 #define FTN_IN_EXPLICIT_TASK omp_in_explicit_task_
 #define FTN_FULFILL_EVENT omp_fulfill_event_
 #define FTN_SET_NUM_TEAMS omp_set_num_teams_
+#define FTN_SET_NUM_TEAMS_8 kmp_set_num_teams_8_
 #define FTN_GET_MAX_TEAMS omp_get_max_teams_
 #define FTN_SET_TEAMS_THREAD_LIMIT omp_set_teams_thread_limit_
+#define FTN_SET_TEAMS_THREAD_LIMIT_8 kmp_set_teams_thread_limit_8_
 #define FTN_GET_TEAMS_THREAD_LIMIT omp_get_teams_thread_limit_
 
 #define FTN_GET_NUM_INTEROP_PROPERTIES omp_get_num_interop_properties_
@@ -323,26 +363,33 @@
 #if KMP_FTN_ENTRIES == KMP_FTN_UPPER
 
 #define FTN_SET_STACKSIZE KMP_SET_STACKSIZE
+#define FTN_SET_STACKSIZE_8 KMP_SET_STACKSIZE_8
 #define FTN_SET_STACKSIZE_S KMP_SET_STACKSIZE_S
 #define FTN_GET_STACKSIZE KMP_GET_STACKSIZE
 #define FTN_GET_STACKSIZE_S KMP_GET_STACKSIZE_S
 #define FTN_SET_BLOCKTIME KMP_SET_BLOCKTIME
+#define FTN_SET_BLOCKTIME_8 KMP_SET_BLOCKTIME_8
 #define FTN_GET_BLOCKTIME KMP_GET_BLOCKTIME
 #define FTN_SET_LIBRARY_SERIAL KMP_SET_LIBRARY_SERIAL
 #define FTN_SET_LIBRARY_TURNAROUND KMP_SET_LIBRARY_TURNAROUND
 #define FTN_SET_LIBRARY_THROUGHPUT KMP_SET_LIBRARY_THROUGHPUT
 #define FTN_SET_LIBRARY KMP_SET_LIBRARY
+#define FTN_SET_LIBRARY_8 KMP_SET_LIBRARY_8
 #define FTN_GET_LIBRARY KMP_GET_LIBRARY
 #define FTN_SET_DEFAULTS KMP_SET_DEFAULTS
 #define FTN_SET_DISP_NUM_BUFFERS KMP_SET_DISP_NUM_BUFFERS
+#define FTN_SET_DISP_NUM_BUFFERS_8 KMP_SET_DISP_NUM_BUFFERS_8
 #define FTN_SET_AFFINITY KMP_SET_AFFINITY
 #define FTN_GET_AFFINITY KMP_GET_AFFINITY
 #define FTN_GET_AFFINITY_MAX_PROC KMP_GET_AFFINITY_MAX_PROC
 #define FTN_CREATE_AFFINITY_MASK KMP_CREATE_AFFINITY_MASK
 #define FTN_DESTROY_AFFINITY_MASK KMP_DESTROY_AFFINITY_MASK
 #define FTN_SET_AFFINITY_MASK_PROC KMP_SET_AFFINITY_MASK_PROC
+#define FTN_SET_AFFINITY_MASK_PROC_8 KMP_SET_AFFINITY_MASK_PROC_8
 #define FTN_UNSET_AFFINITY_MASK_PROC KMP_UNSET_AFFINITY_MASK_PROC
+#define FTN_UNSET_AFFINITY_MASK_PROC_8 KMP_UNSET_AFFINITY_MASK_PROC_8
 #define FTN_GET_AFFINITY_MASK_PROC KMP_GET_AFFINITY_MASK_PROC
+#define FTN_GET_AFFINITY_MASK_PROC_8 KMP_GET_AFFINITY_MASK_PROC_8
 
 #define FTN_MALLOC KMP_MALLOC
 #define FTN_ALIGNED_MALLOC KMP_ALIGNED_MALLOC
@@ -353,6 +400,7 @@
 #define FTN_GET_NUM_KNOWN_THREADS KMP_GET_NUM_KNOWN_THREADS
 
 #define FTN_SET_NUM_THREADS OMP_SET_NUM_THREADS
+#define FTN_SET_NUM_THREADS_8 KMP_SET_NUM_THREADS_8
 #define FTN_GET_NUM_THREADS OMP_GET_NUM_THREADS
 #define FTN_GET_MAX_THREADS OMP_GET_MAX_THREADS
 #define FTN_GET_THREAD_NUM OMP_GET_THREAD_NUM
@@ -364,13 +412,18 @@
 #define FTN_IN_PARALLEL OMP_IN_PARALLEL
 #define FTN_GET_THREAD_LIMIT OMP_GET_THREAD_LIMIT
 #define FTN_SET_SCHEDULE OMP_SET_SCHEDULE
+#define FTN_SET_SCHEDULE_8 KMP_SET_SCHEDULE_8
 #define FTN_GET_SCHEDULE OMP_GET_SCHEDULE
+#define FTN_GET_SCHEDULE_8 KMP_GET_SCHEDULE_8
 #define FTN_SET_MAX_ACTIVE_LEVELS OMP_SET_MAX_ACTIVE_LEVELS
+#define FTN_SET_MAX_ACTIVE_LEVELS_8 KMP_SET_MAX_ACTIVE_LEVELS_8
 #define FTN_GET_MAX_ACTIVE_LEVELS OMP_GET_MAX_ACTIVE_LEVELS
 #define FTN_GET_ACTIVE_LEVEL OMP_GET_ACTIVE_LEVEL
 #define FTN_GET_LEVEL OMP_GET_LEVEL
 #define FTN_GET_ANCESTOR_THREAD_NUM OMP_GET_ANCESTOR_THREAD_NUM
+#define FTN_GET_ANCESTOR_THREAD_NUM_8 KMP_GET_ANCESTOR_THREAD_NUM_8
 #define FTN_GET_TEAM_SIZE OMP_GET_TEAM_SIZE
+#define FTN_GET_TEAM_SIZE_8 KMP_GET_TEAM_SIZE_8
 #define FTN_IN_FINAL OMP_IN_FINAL
 #define FTN_GET_PROC_BIND OMP_GET_PROC_BIND
 #define FTN_GET_NUM_TEAMS OMP_GET_NUM_TEAMS
@@ -399,6 +452,7 @@
 #define FTN_GET_NUM_DEVICES OMP_GET_NUM_DEVICES
 #define FTN_GET_DEFAULT_DEVICE OMP_GET_DEFAULT_DEVICE
 #define FTN_SET_DEFAULT_DEVICE OMP_SET_DEFAULT_DEVICE
+#define FTN_SET_DEFAULT_DEVICE_8 KMP_SET_DEFAULT_DEVICE_8
 #define FTN_IS_INITIAL_DEVICE OMP_IS_INITIAL_DEVICE
 
 #define FTN_GET_CANCELLATION OMP_GET_CANCELLATION
@@ -407,10 +461,13 @@
 #define FTN_GET_MAX_TASK_PRIORITY OMP_GET_MAX_TASK_PRIORITY
 #define FTN_GET_NUM_PLACES OMP_GET_NUM_PLACES
 #define FTN_GET_PLACE_NUM_PROCS OMP_GET_PLACE_NUM_PROCS
+#define FTN_GET_PLACE_NUM_PROCS_8 KMP_GET_PLACE_NUM_PROCS_8
 #define FTN_GET_PLACE_PROC_IDS OMP_GET_PLACE_PROC_IDS
+#define FTN_GET_PLACE_PROC_IDS_8 KMP_GET_PLACE_PROC_IDS_8
 #define FTN_GET_PLACE_NUM OMP_GET_PLACE_NUM
 #define FTN_GET_PARTITION_NUM_PLACES OMP_GET_PARTITION_NUM_PLACES
 #define FTN_GET_PARTITION_PLACE_NUMS OMP_GET_PARTITION_PLACE_NUMS
+#define FTN_GET_PARTITION_PLACE_NUMS_8 KMP_GET_PARTITION_PLACE_NUMS_8
 #define FTN_GET_INITIAL_DEVICE OMP_GET_INITIAL_DEVICE
 #ifdef KMP_STUB
 #define FTN_TARGET_ALLOC OMP_TARGET_ALLOC
@@ -447,14 +504,17 @@
 #define FTN_DISPLAY_AFFINITY OMP_DISPLAY_AFFINITY
 #define FTN_CAPTURE_AFFINITY OMP_CAPTURE_AFFINITY
 #define FTN_PAUSE_RESOURCE OMP_PAUSE_RESOURCE
+#define FTN_PAUSE_RESOURCE_8 KMP_PAUSE_RESOURCE_8
 #define FTN_PAUSE_RESOURCE_ALL OMP_PAUSE_RESOURCE_ALL
 #define FTN_GET_SUPPORTED_ACTIVE_LEVELS OMP_GET_SUPPORTED_ACTIVE_LEVELS
 #define FTN_DISPLAY_ENV OMP_DISPLAY_ENV
 #define FTN_IN_EXPLICIT_TASK OMP_IN_EXPLICIT_TASK
 #define FTN_FULFILL_EVENT OMP_FULFILL_EVENT
 #define FTN_SET_NUM_TEAMS OMP_SET_NUM_TEAMS
+#define FTN_SET_NUM_TEAMS_8 KMP_SET_NUM_TEAMS_8
 #define FTN_GET_MAX_TEAMS OMP_GET_MAX_TEAMS
 #define FTN_SET_TEAMS_THREAD_LIMIT OMP_SET_TEAMS_THREAD_LIMIT
+#define FTN_SET_TEAMS_THREAD_LIMIT_8 KMP_SET_TEAMS_THREAD_LIMIT_8
 #define FTN_GET_TEAMS_THREAD_LIMIT OMP_GET_TEAMS_THREAD_LIMIT
 
 #define FTN_GET_NUM_INTEROP_PROPERTIES OMP_GET_NUM_INTEROP_PROPERTIES
@@ -472,26 +532,33 @@
 #if KMP_FTN_ENTRIES == KMP_FTN_UAPPEND
 
 #define FTN_SET_STACKSIZE KMP_SET_STACKSIZE_
+#define FTN_SET_STACKSIZE_8 KMP_SET_STACKSIZE_8_
 #define FTN_SET_STACKSIZE_S KMP_SET_STACKSIZE_S_
 #define FTN_GET_STACKSIZE KMP_GET_STACKSIZE_
 #define FTN_GET_STACKSIZE_S KMP_GET_STACKSIZE_S_
 #define FTN_SET_BLOCKTIME KMP_SET_BLOCKTIME_
+#define FTN_SET_BLOCKTIME_8 KMP_SET_BLOCKTIME_8_
 #define FTN_GET_BLOCKTIME KMP_GET_BLOCKTIME_
 #define FTN_SET_LIBRARY_SERIAL KMP_SET_LIBRARY_SERIAL_
 #define FTN_SET_LIBRARY_TURNAROUND KMP_SET_LIBRARY_TURNAROUND_
 #define FTN_SET_LIBRARY_THROUGHPUT KMP_SET_LIBRARY_THROUGHPUT_
 #define FTN_SET_LIBRARY KMP_SET_LIBRARY_
+#define FTN_SET_LIBRARY_8 KMP_SET_LIBRARY_8_
 #define FTN_GET_LIBRARY KMP_GET_LIBRARY_
 #define FTN_SET_DEFAULTS KMP_SET_DEFAULTS_
 #define FTN_SET_DISP_NUM_BUFFERS KMP_SET_DISP_NUM_BUFFERS_
+#define FTN_SET_DISP_NUM_BUFFERS_8 KMP_SET_DISP_NUM_BUFFERS_8_
 #define FTN_SET_AFFINITY KMP_SET_AFFINITY_
 #define FTN_GET_AFFINITY KMP_GET_AFFINITY_
 #define FTN_GET_AFFINITY_MAX_PROC KMP_GET_AFFINITY_MAX_PROC_
 #define FTN_CREATE_AFFINITY_MASK KMP_CREATE_AFFINITY_MASK_
 #define FTN_DESTROY_AFFINITY_MASK KMP_DESTROY_AFFINITY_MASK_
 #define FTN_SET_AFFINITY_MASK_PROC KMP_SET_AFFINITY_MASK_PROC_
+#define FTN_SET_AFFINITY_MASK_PROC_8 KMP_SET_AFFINITY_MASK_PROC_8_
 #define FTN_UNSET_AFFINITY_MASK_PROC KMP_UNSET_AFFINITY_MASK_PROC_
+#define FTN_UNSET_AFFINITY_MASK_PROC_8 KMP_UNSET_AFFINITY_MASK_PROC_8_
 #define FTN_GET_AFFINITY_MASK_PROC KMP_GET_AFFINITY_MASK_PROC_
+#define FTN_GET_AFFINITY_MASK_PROC_8 KMP_GET_AFFINITY_MASK_PROC_8_
 
 #define FTN_MALLOC KMP_MALLOC_
 #define FTN_ALIGNED_MALLOC KMP_ALIGNED_MALLOC_
@@ -502,6 +569,7 @@
 #define FTN_GET_NUM_KNOWN_THREADS KMP_GET_NUM_KNOWN_THREADS_
 
 #define FTN_SET_NUM_THREADS OMP_SET_NUM_THREADS_
+#define FTN_SET_NUM_THREADS_8 KMP_SET_NUM_THREADS_8_
 #define FTN_GET_NUM_THREADS OMP_GET_NUM_THREADS_
 #define FTN_GET_MAX_THREADS OMP_GET_MAX_THREADS_
 #define FTN_GET_THREAD_NUM OMP_GET_THREAD_NUM_
@@ -513,13 +581,18 @@
 #define FTN_IN_PARALLEL OMP_IN_PARALLEL_
 #define FTN_GET_THREAD_LIMIT OMP_GET_THREAD_LIMIT_
 #define FTN_SET_SCHEDULE OMP_SET_SCHEDULE_
+#define FTN_SET_SCHEDULE_8 KMP_SET_SCHEDULE_8_
 #define FTN_GET_SCHEDULE OMP_GET_SCHEDULE_
+#define FTN_GET_SCHEDULE_8 KMP_GET_SCHEDULE_8_
 #define FTN_SET_MAX_ACTIVE_LEVELS OMP_SET_MAX_ACTIVE_LEVELS_
+#define FTN_SET_MAX_ACTIVE_LEVELS_8 KMP_SET_MAX_ACTIVE_LEVELS_8_
 #define FTN_GET_MAX_ACTIVE_LEVELS OMP_GET_MAX_ACTIVE_LEVELS_
 #define FTN_GET_ACTIVE_LEVEL OMP_GET_ACTIVE_LEVEL_
 #define FTN_GET_LEVEL OMP_GET_LEVEL_
 #define FTN_GET_ANCESTOR_THREAD_NUM OMP_GET_ANCESTOR_THREAD_NUM_
+#define FTN_GET_ANCESTOR_THREAD_NUM_8 KMP_GET_ANCESTOR_THREAD_NUM_8_
 #define FTN_GET_TEAM_SIZE OMP_GET_TEAM_SIZE_
+#define FTN_GET_TEAM_SIZE_8 KMP_GET_TEAM_SIZE_8_
 #define FTN_IN_FINAL OMP_IN_FINAL_
 #define FTN_GET_PROC_BIND OMP_GET_PROC_BIND_
 #define FTN_GET_NUM_TEAMS OMP_GET_NUM_TEAMS_
@@ -548,6 +621,7 @@
 #define FTN_GET_NUM_DEVICES OMP_GET_NUM_DEVICES_
 #define FTN_GET_DEFAULT_DEVICE OMP_GET_DEFAULT_DEVICE_
 #define FTN_SET_DEFAULT_DEVICE OMP_SET_DEFAULT_DEVICE_
+#define FTN_SET_DEFAULT_DEVICE_8 KMP_SET_DEFAULT_DEVICE_8_
 #define FTN_IS_INITIAL_DEVICE OMP_IS_INITIAL_DEVICE_
 
 #define FTN_GET_CANCELLATION OMP_GET_CANCELLATION_
@@ -556,10 +630,13 @@
 #define FTN_GET_MAX_TASK_PRIORITY OMP_GET_MAX_TASK_PRIORITY_
 #define FTN_GET_NUM_PLACES OMP_GET_NUM_PLACES_
 #define FTN_GET_PLACE_NUM_PROCS OMP_GET_PLACE_NUM_PROCS_
+#define FTN_GET_PLACE_NUM_PROCS_8 KMP_GET_PLACE_NUM_PROCS_8_
 #define FTN_GET_PLACE_PROC_IDS OMP_GET_PLACE_PROC_IDS_
+#define FTN_GET_PLACE_PROC_IDS_8 KMP_GET_PLACE_PROC_IDS_8_
 #define FTN_GET_PLACE_NUM OMP_GET_PLACE_NUM_
 #define FTN_GET_PARTITION_NUM_PLACES OMP_GET_PARTITION_NUM_PLACES_
 #define FTN_GET_PARTITION_PLACE_NUMS OMP_GET_PARTITION_PLACE_NUMS_
+#define FTN_GET_PARTITION_PLACE_NUMS_8 KMP_GET_PARTITION_PLACE_NUMS_8_
 #define FTN_GET_INITIAL_DEVICE OMP_GET_INITIAL_DEVICE_
 #ifdef KMP_STUB
 #define FTN_TARGET_ALLOC OMP_TARGET_ALLOC_
@@ -598,14 +675,17 @@
 #define FTN_DISPLAY_AFFINITY OMP_DISPLAY_AFFINITY_
 #define FTN_CAPTURE_AFFINITY OMP_CAPTURE_AFFINITY_
 #define FTN_PAUSE_RESOURCE OMP_PAUSE_RESOURCE_
+#define FTN_PAUSE_RESOURCE_8 KMP_PAUSE_RESOURCE_8_
 #define FTN_PAUSE_RESOURCE_ALL OMP_PAUSE_RESOURCE_ALL_
 #define FTN_GET_SUPPORTED_ACTIVE_LEVELS OMP_GET_SUPPORTED_ACTIVE_LEVELS_
 #define FTN_DISPLAY_ENV OMP_DISPLAY_ENV_
 #define FTN_IN_EXPLICIT_TASK OMP_IN_EXPLICIT_TASK_
 #define FTN_FULFILL_EVENT OMP_FULFILL_EVENT_
 #define FTN_SET_NUM_TEAMS OMP_SET_NUM_TEAMS_
+#define FTN_SET_NUM_TEAMS_8 KMP_SET_NUM_TEAMS_8_
 #define FTN_GET_MAX_TEAMS OMP_GET_MAX_TEAMS_
 #define FTN_SET_TEAMS_THREAD_LIMIT OMP_SET_TEAMS_THREAD_LIMIT_
+#define FTN_SET_TEAMS_THREAD_LIMIT_8 KMP_SET_TEAMS_THREAD_LIMIT_8_
 #define FTN_GET_TEAMS_THREAD_LIMIT OMP_GET_TEAMS_THREAD_LIMIT_
 
 #define FTN_GET_NUM_INTEROP_PROPERTIES OMP_GET_NUM_INTEROP_PROPERTIES_

--- a/openmp/runtime/src/kmp_stub.cpp
+++ b/openmp/runtime/src/kmp_stub.cpp
@@ -32,6 +32,7 @@
 #define omp_get_team_size ompc_get_team_size
 
 #define omp_set_num_threads ompc_set_num_threads
+#define kmp_set_num_threads_8 kmpc_set_num_threads_8
 #define omp_set_dynamic ompc_set_dynamic
 #define omp_set_nested ompc_set_nested
 #define omp_set_affinity_format ompc_set_affinity_format
@@ -88,6 +89,7 @@ static size_t __kmps_init() {
 
 /* set API functions */
 void omp_set_num_threads(omp_int_t num_threads) { i; }
+void kmp_set_num_threads_8(int64_t num_threads) { i; }
 void omp_set_dynamic(omp_int_t dynamic) {
   i;
   __kmps_set_dynamic(dynamic);

--- a/openmp/runtime/test/api/kmp_integer_8_apis.f90
+++ b/openmp/runtime/test/api/kmp_integer_8_apis.f90
@@ -1,0 +1,277 @@
+! REQUIRES: flang
+! RUN: %flang %flags %openmp_flags %s -o %t.exe
+! RUN: %t.exe
+
+! Fortran coverage of the 64-bit integer libomp entry points.
+!
+! The specific kmp_*_8 procedures are never named here. Every call uses the
+! generic omp_*/kmp_* name with integer(8) actual arguments, so generic
+! resolution in omp_lib is what selects the kmp_*_8 entry points. The 32-bit
+! getters are used to verify the effects.
+
+program kmp_integer_8_apis
+  use omp_lib
+  implicit none
+  integer :: fails, i
+  integer, parameter :: repetitions = 10
+
+  fails = 0
+
+  call test_disp_num_buffers()
+  call test_stacksize()
+  call test_blocktime()
+  call test_library()
+
+  do i = 1, repetitions
+    call test_num_threads_and_team()
+    call test_schedule()
+    call test_max_active_levels()
+    call test_teams()
+    call test_default_device()
+    call test_places()
+    call test_affinity_mask()
+  end do
+
+  call test_pause_resource()
+
+  if (fails /= 0) then
+    print *, fails, ' check(s) failed'
+    error stop 1
+  end if
+  print *, 'passed'
+
+contains
+
+  subroutine check(cond, msg)
+    logical, intent(in) :: cond
+    character(len=*), intent(in) :: msg
+    if (.not. cond) then
+      print *, 'FAIL: ', trim(msg)
+      fails = fails + 1
+    end if
+  end subroutine check
+
+  subroutine test_disp_num_buffers()
+    call kmp_set_disp_num_buffers(8_8)
+  end subroutine test_disp_num_buffers
+
+  subroutine test_stacksize()
+    integer(8) :: want
+    integer(kmp_size_t_kind) :: got_s
+    want = 8_8 * 1024_8 * 1024_8
+    call kmp_set_stacksize(want)
+    call check(kmp_get_stacksize() == int(want, kind=omp_integer_kind), &
+         'kmp_set_stacksize(integer(8)) vs kmp_get_stacksize')
+    got_s = kmp_get_stacksize_s()
+    call check(got_s == int(want, kind=kmp_size_t_kind), &
+         'kmp_set_stacksize(integer(8)) vs kmp_get_stacksize_s')
+  end subroutine test_stacksize
+
+  subroutine test_blocktime()
+    call kmp_set_blocktime(200_8)
+    call check(kmp_get_blocktime() == 200, 'kmp_set_blocktime(integer(8))')
+  end subroutine test_blocktime
+
+  subroutine test_library()
+    ! enum library_type: none=0, serial=1, turnaround=2, throughput=3
+    call kmp_set_library(3_8)
+    call check(kmp_get_library() == 3, 'kmp_set_library(integer(8)) throughput')
+    call kmp_set_library(2_8)
+    call check(kmp_get_library() == 2, 'kmp_set_library(integer(8)) turnaround')
+  end subroutine test_library
+
+  subroutine test_num_threads_and_team()
+    integer :: nthreads, nthreads_lib, team_err
+    integer(8) :: level0, level1
+
+    nthreads = 0
+    nthreads_lib = -1
+    team_err = 0
+    level0 = 0_8
+    level1 = 1_8
+
+    call omp_set_dynamic(.false.)
+    call omp_set_num_threads(2_8)
+    call check(omp_get_max_threads() == 2, &
+         'omp_set_num_threads(integer(8)) max_threads')
+
+    call check(omp_get_ancestor_thread_num(level0) == 0, &
+         'omp_get_ancestor_thread_num(0_8) serial')
+    call check(omp_get_team_size(level0) == 1, &
+         'omp_get_team_size(0_8) serial')
+
+    !$omp parallel
+    if (omp_get_ancestor_thread_num(level1) /= omp_get_thread_num() .or. &
+        omp_get_team_size(level1) /= omp_get_num_threads() .or. &
+        omp_get_ancestor_thread_num(level0) /= 0 .or. &
+        omp_get_team_size(level0) /= 1) then
+      !$omp atomic
+      team_err = team_err + 1
+    end if
+    !$omp atomic
+    nthreads = nthreads + 1
+    !$omp single
+    nthreads_lib = omp_get_num_threads()
+    !$omp end single
+    !$omp end parallel
+
+    call check(team_err == 0, &
+         'omp_get_ancestor_thread_num / omp_get_team_size with integer(8)')
+    call check(nthreads == 2 .and. nthreads_lib == 2, 'parallel team size')
+
+    call omp_set_num_threads(int(huge(0_4), kind=8) + 1000_8)
+    call check(omp_get_max_threads() == huge(0_4), &
+         'omp_set_num_threads(integer(8)) clamp to INT_MAX')
+    call omp_set_num_threads(2_8)
+  end subroutine test_num_threads_and_team
+
+  subroutine test_schedule()
+    integer(omp_sched_kind) :: kind
+    integer(8) :: chunk
+
+    kind = omp_sched_static
+    chunk = 0_8
+    call omp_set_schedule(omp_sched_dynamic, 7_8)
+    call omp_get_schedule(kind, chunk)
+    call check(kind == omp_sched_dynamic .and. chunk == 7_8, &
+         'omp_set/get_schedule with integer(8) chunk, dynamic')
+
+    call omp_set_schedule(omp_sched_guided, 1_8)
+    call omp_get_schedule(kind, chunk)
+    call check(kind == omp_sched_guided .and. chunk == 1_8, &
+         'omp_set/get_schedule with integer(8) chunk, guided')
+  end subroutine test_schedule
+
+  subroutine test_max_active_levels()
+    call omp_set_max_active_levels(1_8)
+    call check(omp_get_max_active_levels() == 1, &
+         'omp_set_max_active_levels(1_8)')
+    call omp_set_max_active_levels(2_8)
+    call check(omp_get_max_active_levels() >= 1, &
+         'omp_set_max_active_levels(2_8)')
+  end subroutine test_max_active_levels
+
+  subroutine test_teams()
+    call omp_set_num_teams(5_8)
+    call check(omp_get_max_teams() == 5, 'omp_set_num_teams(5_8)')
+    call omp_set_teams_thread_limit(7_8)
+    call check(omp_get_teams_thread_limit() == 7, &
+         'omp_set_teams_thread_limit(7_8)')
+  end subroutine test_teams
+
+  subroutine test_default_device()
+    integer :: orig, after8, after32
+    orig = omp_get_default_device()
+    call omp_set_default_device(0_8)
+    after8 = omp_get_default_device()
+    call omp_set_default_device(0)
+    after32 = omp_get_default_device()
+    call check(after8 == after32, &
+         'omp_set_default_device: integer(8) vs default integer')
+    call omp_set_default_device(orig)
+  end subroutine test_default_device
+
+  subroutine test_places()
+    integer :: nplaces, n32, n8, npart, i
+    integer(omp_integer_kind), allocatable :: ids32(:), p32(:)
+    integer(8), allocatable :: ids8(:), p8(:)
+    integer(8) :: dummy(1)
+
+    nplaces = omp_get_num_places()
+    if (nplaces > 0) then
+      n32 = omp_get_place_num_procs(0)
+      n8 = omp_get_place_num_procs(0_8)
+      call check(n32 == n8, 'omp_get_place_num_procs(0_8)')
+      if (n32 > 0) then
+        allocate(ids32(n32), ids8(n32))
+        call omp_get_place_proc_ids(0, ids32)
+        call omp_get_place_proc_ids(0_8, ids8)
+        do i = 1, n32
+          call check(ids32(i) == int(ids8(i), kind=omp_integer_kind), &
+               'omp_get_place_proc_ids with integer(8) element')
+        end do
+        deallocate(ids32, ids8)
+      end if
+    else
+      call check(omp_get_place_num_procs(0_8) == omp_get_place_num_procs(0), &
+           'omp_get_place_num_procs(0_8) with no places')
+    end if
+
+    npart = omp_get_partition_num_places()
+    if (npart > 0) then
+      allocate(p32(npart), p8(npart))
+      call omp_get_partition_place_nums(p32)
+      call omp_get_partition_place_nums(p8)
+      do i = 1, npart
+        call check(p32(i) == int(p8(i), kind=omp_integer_kind), &
+             'omp_get_partition_place_nums with integer(8) element')
+      end do
+      deallocate(p32, p8)
+    else
+      dummy(1) = -1_8
+      call omp_get_partition_place_nums(dummy)
+    end if
+  end subroutine test_places
+
+  subroutine test_affinity_mask()
+    integer(kmp_affinity_mask_kind) :: mask
+    integer :: max_proc, rc_set, rc_set32
+    integer(8) :: proc0
+
+    proc0 = 0_8
+    call kmp_create_affinity_mask(mask)
+    max_proc = kmp_get_affinity_max_proc()
+    rc_set = kmp_set_affinity_mask_proc(proc0, mask)
+    rc_set32 = kmp_set_affinity_mask_proc(0, mask)
+    call check(rc_set == rc_set32, &
+         'kmp_set_affinity_mask_proc: integer(8) vs default integer')
+    if (rc_set == 0 .and. max_proc > 0) then
+      call check(kmp_get_affinity_mask_proc(proc0, mask) == 1, &
+           'kmp_get_affinity_mask_proc(integer(8)) after set')
+      call check(kmp_unset_affinity_mask_proc(proc0, mask) == 0, &
+           'kmp_unset_affinity_mask_proc(integer(8))')
+      call check(kmp_get_affinity_mask_proc(proc0, mask) == 0, &
+           'kmp_get_affinity_mask_proc(integer(8)) after unset')
+    else
+      rc_set = kmp_get_affinity_mask_proc(proc0, mask)
+      rc_set = kmp_unset_affinity_mask_proc(proc0, mask)
+    end if
+    call kmp_destroy_affinity_mask(mask)
+  end subroutine test_affinity_mask
+
+  subroutine test_pause_resource()
+    integer :: my_dev, nthreads
+    integer(8) :: device8
+
+    my_dev = omp_get_initial_device()
+    device8 = int(my_dev, kind=8)
+    nthreads = 0
+    !$omp parallel
+    !$omp single
+    nthreads = omp_get_num_threads()
+    !$omp end single
+    !$omp end parallel
+    call check(nthreads > 0, 'threads before pause')
+
+    call check(omp_pause_resource(omp_pause_soft, device8) == 0, &
+         'omp_pause_resource(integer(8) device) soft')
+    nthreads = 0
+    !$omp parallel
+    !$omp single
+    nthreads = omp_get_num_threads()
+    !$omp end single
+    !$omp end parallel
+    call check(nthreads > 0, 'threads after pause soft')
+
+    call check(omp_pause_resource(omp_pause_hard, device8) == 0, &
+         'omp_pause_resource(integer(8) device) hard')
+    nthreads = 0
+    !$omp parallel
+    !$omp single
+    nthreads = omp_get_num_threads()
+    !$omp end single
+    !$omp end parallel
+    call check(nthreads > 0, 'threads after pause hard')
+  end subroutine test_pause_resource
+
+end program kmp_integer_8_apis


### PR DESCRIPTION
Fortran code that uses integer(8) arguments, including -fdefault-integer-8, did not match omp_lib interfaces declared with omp_integer_kind (typically kind 4). Added *_8 specific procedures to named generic interfaces in omp_lib, exported matching Fortran and C runtime entry points, and implemented the *_8 functions as thin wrappers that saturate-convert arguments to 32-bit and call the existing APIs.

Assisted by Cursor in generating the repetitive code and testcase