### PR TITLE
[CI][Github] Hash-pin AArch64 CI image

### DIFF
--- a/.github/workflows/premerge.yaml
+++ b/.github/workflows/premerge.yaml
@@ -41,7 +41,7 @@ jobs:
       # job.  The depot containers are running on VMs, so we can use a
       # container.  This helps ensure the build environment is as close
       # as possible on both the depot runners and the llvm-premerge runners.
-      image: ${{ (startsWith(matrix.runs-on, 'depot-ubuntu-24.04-arm') && format('ghcr.io/{0}/arm64v8/ci-ubuntu-24.04:24942433bc8a@sha256:224c58f5d5f3f1d4b8f36dd3873b00a5d60c28065693165d875a9454ed914233',github.repository_owner) ) || null }}
+      image: ${{ (startsWith(matrix.runs-on, 'depot-ubuntu-24.04-arm') && format('ghcr.io/{0}/arm64v8/ci-ubuntu-24.04:24942433bc8a',github.repository_owner) ) || null }}
       # --privileged is needed to run the lldb tests that disable aslr.
       # The SCCACHE environment variables are need to be copied from the host
       # to the container to make sure it is configured correctly to use the

--- a/.github/workflows/premerge.yaml
+++ b/.github/workflows/premerge.yaml
@@ -41,7 +41,7 @@ jobs:
       # job.  The depot containers are running on VMs, so we can use a
       # container.  This helps ensure the build environment is as close
       # as possible on both the depot runners and the llvm-premerge runners.
-      image: ${{ (startsWith(matrix.runs-on, 'depot-ubuntu-24.04-arm') && format('ghcr.io/{0}/arm64v8/ci-ubuntu-24.04',github.repository_owner) ) || null }}
+      image: ${{ (startsWith(matrix.runs-on, 'depot-ubuntu-24.04-arm') && format('ghcr.io/{0}/arm64v8/ci-ubuntu-24.04:latest@sha256:224c58f5d5f3f1d4b8f36dd3873b00a5d60c28065693165d875a9454ed914233',github.repository_owner) ) || null }}
       # --privileged is needed to run the lldb tests that disable aslr.
       # The SCCACHE environment variables are need to be copied from the host
       # to the container to make sure it is configured correctly to use the

--- a/.github/workflows/premerge.yaml
+++ b/.github/workflows/premerge.yaml
@@ -41,7 +41,7 @@ jobs:
       # job.  The depot containers are running on VMs, so we can use a
       # container.  This helps ensure the build environment is as close
       # as possible on both the depot runners and the llvm-premerge runners.
-      image: ${{ (startsWith(matrix.runs-on, 'depot-ubuntu-24.04-arm') && format('ghcr.io/{0}/arm64v8/ci-ubuntu-24.04:latest@sha256:224c58f5d5f3f1d4b8f36dd3873b00a5d60c28065693165d875a9454ed914233',github.repository_owner) ) || null }}
+      image: ${{ (startsWith(matrix.runs-on, 'depot-ubuntu-24.04-arm') && format('ghcr.io/{0}/arm64v8/ci-ubuntu-24.04:24942433bc8a@sha256:224c58f5d5f3f1d4b8f36dd3873b00a5d60c28065693165d875a9454ed914233',github.repository_owner) ) || null }}
       # --privileged is needed to run the lldb tests that disable aslr.
       # The SCCACHE environment variables are need to be copied from the host
       # to the container to make sure it is configured correctly to use the


### PR DESCRIPTION
Otherwise we end up picking up the latest version of the image that uses clang 23 which causes issues. This also is security best practice as described in our security best practices doc.

Fixes #221470.