### PR TITLE
[Support] Fix -Wunused-template from debugString

### DIFF
--- a/llvm/include/llvm/Support/LSP/Transport.h
+++ b/llvm/include/llvm/Support/LSP/Transport.h
@@ -28,7 +28,7 @@
 
 namespace llvm {
 // Simple helper function that returns a string as printed from a op.
-template <typename T> static std::string debugString(T &&Op) {
+template <typename T> std::string debugString(T &&Op) {
   std::string InstrStr;
   llvm::raw_string_ostream Os(InstrStr);
   Os << Op;

--- a/llvm/include/llvm/Support/LSP/Transport.h
+++ b/llvm/include/llvm/Support/LSP/Transport.h
@@ -27,13 +27,6 @@
 #include <memory>
 
 namespace llvm {
-// Simple helper function that returns a string as printed from a op.
-template <typename T> std::string debugString(T &&Op) {
-  std::string InstrStr;
-  llvm::raw_string_ostream Os(InstrStr);
-  Os << Op;
-  return Os.str();
-}
 namespace lsp {
 class MessageHandler;
 
@@ -217,6 +210,14 @@ public:
       Logger::info("--> {0}", Method);
       Transport.notify(Method, llvm::json::Value(Params));
     };
+  }
+
+  // Simple helper function that returns a string as printed from a op.
+  template <typename T> static std::string debugString(T &&Op) {
+    std::string InstrStr;
+    llvm::raw_string_ostream Os(InstrStr);
+    Os << Op;
+    return Os.str();
   }
 
   /// Create an OutgoingRequest function that, when called, sends a request with

--- a/llvm/unittests/Support/LSP/Transport.cpp
+++ b/llvm/unittests/Support/LSP/Transport.cpp
@@ -182,7 +182,7 @@ TEST_F(TransportInputTest, OutgoingRequestJSONParseFailure) {
         llvm::Error err = result.takeError();
         EXPECT_EQ(id, 109);
         ASSERT_TRUE((bool)err);
-        EXPECT_THAT(debugString(err),
+        EXPECT_THAT(MessageHandler::debugString(err),
                     HasSubstr("failed to decode "
                               "reply:outgoing-request-json-parse-failure(109) "
                               "response: missing value at (root).character"));


### PR DESCRIPTION
This is not used in the header (outside of a non-instantiated template),
so triggers -Wunused-template. Move it into the class definition to
prevent this without adding any namespace pollution.
