### PR TITLE
[InstCombine] Propagate demanded elements through trivially-vectorizable intrinsics

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
@@ -1991,6 +1991,18 @@ Value *InstCombinerImpl::SimplifyDemandedVectorElts(Value *V,
       PoisonElts = PoisonElts2 & PoisonElts3;
       break;
     }
+    case Intrinsic::fma:
+    case Intrinsic::fmuladd: {
+      // Elementwise: each result lane uses only the matching operand lane, so
+      // the demand passes through unchanged to every operand.
+      simplifyAndSetOp(II, 0, DemandedElts, PoisonElts2);
+      simplifyAndSetOp(II, 1, DemandedElts, PoisonElts3);
+      APInt PoisonEltsAcc(VWidth, 0);
+      simplifyAndSetOp(II, 2, DemandedElts, PoisonEltsAcc);
+      // A result lane is poison if any operand lane is poison.
+      PoisonElts = PoisonElts2 | PoisonElts3 | PoisonEltsAcc;
+      break;
+    }
     default: {
       // Handle target specific intrinsics
       std::optional<Value *> V = targetSimplifyDemandedVectorEltsIntrinsic(

--- a/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
@@ -14,6 +14,7 @@
 #include "InstCombineInternal.h"
 #include "llvm/ADT/SmallBitVector.h"
 #include "llvm/Analysis/ValueTracking.h"
+#include "llvm/Analysis/VectorUtils.h"
 #include "llvm/IR/GetElementPtrTypeIterator.h"
 #include "llvm/IR/IntrinsicInst.h"
 #include "llvm/IR/PatternMatch.h"
@@ -1991,18 +1992,6 @@ Value *InstCombinerImpl::SimplifyDemandedVectorElts(Value *V,
       PoisonElts = PoisonElts2 & PoisonElts3;
       break;
     }
-    case Intrinsic::fma:
-    case Intrinsic::fmuladd: {
-      // Elementwise: each result lane uses only the matching operand lane, so
-      // the demand passes through unchanged to every operand.
-      simplifyAndSetOp(II, 0, DemandedElts, PoisonElts2);
-      simplifyAndSetOp(II, 1, DemandedElts, PoisonElts3);
-      APInt PoisonEltsAcc(VWidth, 0);
-      simplifyAndSetOp(II, 2, DemandedElts, PoisonEltsAcc);
-      // A result lane is poison if any operand lane is poison.
-      PoisonElts = PoisonElts2 | PoisonElts3 | PoisonEltsAcc;
-      break;
-    }
     default: {
       // Handle target specific intrinsics
       std::optional<Value *> V = targetSimplifyDemandedVectorEltsIntrinsic(
@@ -2010,6 +1999,27 @@ Value *InstCombinerImpl::SimplifyDemandedVectorElts(Value *V,
           simplifyAndSetOp);
       if (V)
         return *V;
+
+      // Trivially vectorizable intrinsics operate elementwise: each result lane
+      // uses only the matching lane of the (vector) operands, so the demand
+      // passes through unchanged to every vector operand.
+      Intrinsic::ID IID = II->getIntrinsicID();
+      if (isTriviallyVectorizable(IID)) {
+        APInt PoisonEltsAcc(VWidth, 0);
+        for (Use &Arg : II->args()) {
+          unsigned OpNo = Arg.getOperandNo();
+          // Scalar operands do not carry per-lane demand.
+          if (isVectorIntrinsicWithScalarOpAtArg(IID, OpNo, /*TTI=*/nullptr))
+            continue;
+          APInt OpPoisonElts(VWidth, 0);
+          simplifyAndSetOp(II, OpNo, DemandedElts, OpPoisonElts);
+          PoisonEltsAcc |= OpPoisonElts;
+        }
+        // A result lane is poison if any operand lane is poison, but only for
+        // intrinsics that are known to propagate poison elementwise.
+        if (intrinsicPropagatesPoison(IID))
+          PoisonElts = PoisonEltsAcc;
+      }
       break;
     }
     } // switch on IntrinsicID

--- a/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
@@ -2005,7 +2005,6 @@ Value *InstCombinerImpl::SimplifyDemandedVectorElts(Value *V,
       // passes through unchanged to every vector operand.
       Intrinsic::ID IID = II->getIntrinsicID();
       if (isTriviallyVectorizable(IID)) {
-        APInt PoisonEltsAcc(VWidth, 0);
         for (Use &Arg : II->args()) {
           unsigned OpNo = Arg.getOperandNo();
           // Scalar operands do not carry per-lane demand.
@@ -2013,12 +2012,7 @@ Value *InstCombinerImpl::SimplifyDemandedVectorElts(Value *V,
             continue;
           APInt OpPoisonElts(VWidth, 0);
           simplifyAndSetOp(II, OpNo, DemandedElts, OpPoisonElts);
-          PoisonEltsAcc |= OpPoisonElts;
         }
-        // A result lane is poison if any operand lane is poison, but only for
-        // intrinsics that are known to propagate poison elementwise.
-        if (intrinsicPropagatesPoison(IID))
-          PoisonElts = PoisonEltsAcc;
       }
       break;
     }

--- a/llvm/test/Transforms/InstCombine/fma.ll
+++ b/llvm/test/Transforms/InstCombine/fma.ll
@@ -995,3 +995,32 @@ define half @fma_non_negone(half %x, half %y) {
   %sub = call half @llvm.fma.f16(half %x, half -1.5, half %y)
   ret half %sub
 }
+
+declare <4 x float> @llvm.fma.v4f32(<4 x float>, <4 x float>, <4 x float>)
+declare <4 x float> @llvm.fmuladd.v4f32(<4 x float>, <4 x float>, <4 x float>)
+
+; fma is elementwise, so an undemanded result lane makes the matching operand
+; lane undemanded too: the insert into the dropped lane is removed.
+define <4 x float> @fma_undemanded_elt(<4 x float> %a, <4 x float> %b, <4 x float> %c, float %x) {
+; CHECK-LABEL: @fma_undemanded_elt(
+; CHECK-NEXT:    [[FMA:%.*]] = call <4 x float> @llvm.fma.v4f32(<4 x float> [[A:%.*]], <4 x float> [[B:%.*]], <4 x float> [[C:%.*]])
+; CHECK-NEXT:    [[R:%.*]] = shufflevector <4 x float> [[FMA]], <4 x float> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 poison>
+; CHECK-NEXT:    ret <4 x float> [[R]]
+;
+  %a3 = insertelement <4 x float> %a, float %x, i64 3
+  %fma = call <4 x float> @llvm.fma.v4f32(<4 x float> %a3, <4 x float> %b, <4 x float> %c)
+  %r = shufflevector <4 x float> %fma, <4 x float> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 poison>
+  ret <4 x float> %r
+}
+
+define <4 x float> @fmuladd_undemanded_elt(<4 x float> %a, <4 x float> %b, <4 x float> %c, float %x) {
+; CHECK-LABEL: @fmuladd_undemanded_elt(
+; CHECK-NEXT:    [[FMA:%.*]] = call <4 x float> @llvm.fmuladd.v4f32(<4 x float> [[A:%.*]], <4 x float> [[B:%.*]], <4 x float> [[C:%.*]])
+; CHECK-NEXT:    [[R:%.*]] = shufflevector <4 x float> [[FMA]], <4 x float> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 poison>
+; CHECK-NEXT:    ret <4 x float> [[R]]
+;
+  %b3 = insertelement <4 x float> %b, float %x, i64 3
+  %fma = call <4 x float> @llvm.fmuladd.v4f32(<4 x float> %a, <4 x float> %b3, <4 x float> %c)
+  %r = shufflevector <4 x float> %fma, <4 x float> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 poison>
+  ret <4 x float> %r
+}

--- a/llvm/test/Transforms/InstCombine/minmax-fold.ll
+++ b/llvm/test/Transforms/InstCombine/minmax-fold.ll
@@ -1416,7 +1416,7 @@ define i8 @PR14613_smax(i8 %x) {
 
 define i8 @PR46271(<2 x i8> %x) {
 ; CHECK-LABEL: @PR46271(
-; CHECK-NEXT:    [[NOT:%.*]] = call <2 x i8> @llvm.smax.v2i8(<2 x i8> [[X:%.*]], <2 x i8> splat (i8 -1))
+; CHECK-NEXT:    [[NOT:%.*]] = call <2 x i8> @llvm.smax.v2i8(<2 x i8> [[X:%.*]], <2 x i8> <i8 poison, i8 -1>)
 ; CHECK-NEXT:    [[R:%.*]] = extractelement <2 x i8> [[NOT]], i64 1
 ; CHECK-NEXT:    [[R1:%.*]] = xor i8 [[R]], -1
 ; CHECK-NEXT:    ret i8 [[R1]]

--- a/llvm/test/Transforms/InstCombine/vec_demanded_elts.ll
+++ b/llvm/test/Transforms/InstCombine/vec_demanded_elts.ll
@@ -1345,3 +1345,31 @@ define <11 x i32> @wide_insert_chain_out_of_range(i32 %a0, i32 %bad, i32 %a1, i3
   %v10 = insertelement <11 x i32> %v9, i32 %a10, i64 10
   ret <11 x i32> %v10
 }
+
+; abs is elementwise, so dropping result lane 3 drops the same lane of the
+; vector operand and removes the insert. Its i1 flag is a scalar operand and
+; must be left alone.
+define <4 x i32> @abs_undemanded_elt(<4 x i32> %a, i32 %x) {
+; CHECK-LABEL: @abs_undemanded_elt(
+; CHECK-NEXT:    [[ABS:%.*]] = call <4 x i32> @llvm.abs.v4i32(<4 x i32> [[A:%.*]], i1 false)
+; CHECK-NEXT:    [[R:%.*]] = shufflevector <4 x i32> [[ABS]], <4 x i32> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 poison>
+; CHECK-NEXT:    ret <4 x i32> [[R]]
+;
+  %a3 = insertelement <4 x i32> %a, i32 %x, i64 3
+  %abs = call <4 x i32> @llvm.abs.v4i32(<4 x i32> %a3, i1 false)
+  %r = shufflevector <4 x i32> %abs, <4 x i32> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 poison>
+  ret <4 x i32> %r
+}
+
+; Same for is.fpclass, whose i32 test mask is a scalar operand.
+define <4 x i1> @is_fpclass_undemanded_elt(<4 x float> %a, float %x) {
+; CHECK-LABEL: @is_fpclass_undemanded_elt(
+; CHECK-NEXT:    [[CLS:%.*]] = call <4 x i1> @llvm.is.fpclass.v4f32(<4 x float> [[A:%.*]], /* (norm) */ i32 264)
+; CHECK-NEXT:    [[R:%.*]] = shufflevector <4 x i1> [[CLS]], <4 x i1> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 poison>
+; CHECK-NEXT:    ret <4 x i1> [[R]]
+;
+  %a3 = insertelement <4 x float> %a, float %x, i64 3
+  %cls = call <4 x i1> @llvm.is.fpclass.v4f32(<4 x float> %a3, i32 264)
+  %r = shufflevector <4 x i1> %cls, <4 x i1> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 poison>
+  ret <4 x i1> %r
+}


### PR DESCRIPTION
`SimplifyDemandedVectorElts` now handles trivially-vectorizable intrinsics (llvm.fma, llvm.fmuladd, llvm.abs, ...). They are elementwise (result lane i depends only on lane i of each vector operand), so the demanded-element mask is propagated unchanged to every vector operand; scalar operands are left alone. Poison is not propagated, since the per-operand masks conflate undef and poison.

Adds InstCombine tests showing an insert into an undemanded lane being dropped.

Assisted-by: Claude Code (Anthropic)