### PR TITLE
[libclang/python] Make the value of a true bool enum 1, not -1

### DIFF
--- a/clang/bindings/python/clang/cindex.py
+++ b/clang/bindings/python/clang/cindex.py
@@ -2147,6 +2147,7 @@ class Cursor(Structure):
             if underlying_type.kind == TypeKind.ENUM:
                 underlying_type = underlying_type.get_declaration().enum_type
             if underlying_type.kind in (
+                TypeKind.BOOL,
                 TypeKind.CHAR_U,
                 TypeKind.UCHAR,
                 TypeKind.CHAR16,

--- a/clang/bindings/python/tests/cindex/test_cursor.py
+++ b/clang/bindings/python/tests/cindex/test_cursor.py
@@ -705,6 +705,23 @@ int add(float a, float b) { return a + b; }
         self.assertEqual(ham.kind, CursorKind.ENUM_CONSTANT_DECL)
         self.assertEqual(ham.enum_value, 200)
 
+    def test_enum_values_bool(self):
+        tu = get_tu("enum ON : bool { NO = false, YES = true };", lang="cpp")
+        enum = get_cursor(tu, "ON")
+        self.assertIsNotNone(enum)
+
+        self.assertEqual(enum.kind, CursorKind.ENUM_DECL)
+
+        enum_constants = list(enum.get_children())
+        self.assertEqual(len(enum_constants), 2)
+
+        no, yes = enum_constants
+
+        self.assertEqual(no.kind, CursorKind.ENUM_CONSTANT_DECL)
+        self.assertEqual(no.enum_value, 0)
+        self.assertEqual(yes.kind, CursorKind.ENUM_CONSTANT_DECL)
+        self.assertEqual(yes.enum_value, 1)
+
     def test_annotation_attribute(self):
         tu = get_tu(
             'int foo (void) __attribute__ ((annotate("here be annotation attribute")));'

--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -133,6 +133,8 @@ features cannot lower the translation-unit ABI level;
   As a result, the `__str__` representation of its return values changed.
   Like other libclang enums, it now follows the `CompletionChunkKind.VARIANT_NAME` scheme instead of `VariantName`.
 
+- `Cursor` instance's `enum_value` method now returns 1 instead of -1 for `true` bool enumeration values
+
 ### OpenCL Potentially Breaking Changes
 
 ## What's New in Clang {{env.config.release}}?


### PR DESCRIPTION
When converted to int a bool value is either 0 or 1, but the enum_value of a bool enum was reported as either 0 or -1 in the Python bindings.

Make bool enums take the unsigned value code path so that 0 or +1 is returned instead.

If merged this will resolve #221326 