### PR TITLE
[libc] Refactor sysinfo

### DIFF
--- a/libc/src/__support/OSUtil/linux/syscall_wrappers/sysinfo.h
+++ b/libc/src/__support/OSUtil/linux/syscall_wrappers/sysinfo.h
@@ -24,8 +24,8 @@
 namespace LIBC_NAMESPACE_DECL {
 namespace linux_syscalls {
 
-LIBC_INLINE ErrorOr<int> sysinfo(struct sysinfo *info) {
-  return syscall_checked<int>(SYS_sysinfo, info);
+LIBC_INLINE int sysinfo(struct sysinfo *info) {
+  return LIBC_NAMESPACE::syscall_impl<int>(SYS_sysinfo, info);
 }
 
 } // namespace linux_syscalls

--- a/libc/src/stdlib/linux/getloadavg.cpp
+++ b/libc/src/stdlib/linux/getloadavg.cpp
@@ -26,9 +26,8 @@ LLVM_LIBC_FUNCTION(int, getloadavg, (double loadavg[], int nelem)) {
     return 0;
 
   struct sysinfo info;
-  auto result = linux_syscalls::sysinfo(&info);
-  if (!result) {
-    libc_errno = result.error();
+  int result = linux_syscalls::sysinfo(&info);
+  if (result < 0) {
     return -1;
   }
 

--- a/libc/src/sys/sysinfo/linux/sysinfo.cpp
+++ b/libc/src/sys/sysinfo/linux/sysinfo.cpp
@@ -22,9 +22,9 @@
 namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(int, sysinfo, (struct sysinfo * info)) {
-  auto result = linux_syscalls::sysinfo(info);
-  if (!result) {
-    libc_errno = result.error();
+  int result = linux_syscalls::sysinfo(info);
+  if (result < 0) {
+    libc_errno = -result;
     return -1;
   }
   return 0;

--- a/libc/src/unistd/linux/sysconf.cpp
+++ b/libc/src/unistd/linux/sysconf.cpp
@@ -100,9 +100,9 @@ long get_nprocessors_onln() {
 
 long get_phys_pages() {
   struct ::sysinfo info;
-  ErrorOr<int> ret = linux_syscalls::sysinfo(&info);
-  if (!ret) {
-    libc_errno = -ret.error();
+  int ret = linux_syscalls::sysinfo(&info);
+  if (ret < 0) {
+    libc_errno = -ret;
     return -1;
   }
   cpp::optional<unsigned long> page_size = auxv::get(AT_PAGESZ);


### PR DESCRIPTION
Refactor the sysinfo linux wrapper to use int type instead of ErrorOR.

Suggested-by:  michaelrj-google (https://github.com/llvm/llvm-project/pull/221049)
