### PR TITLE
[Clang][OpenACC] Fixed getExtValue Call on Invalid Gang Dim

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -686,6 +686,9 @@ features cannot lower the translation-unit ABI level;
   `this` via a member access through a dependent base class.
 - Fixed `DiagnoseUnguardedAvailability::TraverseIfStmt` dereferencing a nullptr
   on `if consteval {}`. (#GH220004)
+- Fixed an assertion when the `dim` argument to an OpenACC `gang` clause
+  evaluated to a value not representable by a signed integer, such as an
+  unsigned wrap around. (#GH221418)
 
 ### OpenACC Specific Changes
 

--- a/clang/lib/Sema/SemaOpenACCClause.cpp
+++ b/clang/lib/Sema/SemaOpenACCClause.cpp
@@ -1159,7 +1159,7 @@ ExprResult CheckGangDimExpr(SemaOpenACC &S, Expr *E) {
 
   if (!ICE || *ICE <= 0 || ICE > 3) {
     S.Diag(Res.get()->getBeginLoc(), diag::err_acc_gang_dim_value)
-        << ICE.has_value() << ICE.value_or(llvm::APSInt{}).getExtValue();
+        << ICE.has_value() << ICE.value_or(llvm::APSInt{});
     return ExprError();
   }
 
@@ -2045,7 +2045,7 @@ ExprResult SemaOpenACC::CheckTileSizeExpr(Expr *SizeExpr) {
   // where each tile size is a constant positive integer expression or asterisk.
   if (!ICE || *ICE <= 0) {
     Diag(SizeExpr->getBeginLoc(), diag::err_acc_size_expr_value)
-        << ICE.has_value() << ICE.value_or(llvm::APSInt{}).getExtValue();
+        << ICE.has_value() << ICE.value_or(llvm::APSInt{});
     return ExprError();
   }
 
@@ -2073,7 +2073,7 @@ ExprResult SemaOpenACC::CheckCollapseLoopCount(Expr *LoopCount) {
   // expression.
   if (!ICE || *ICE <= 0) {
     Diag(LoopCount->getBeginLoc(), diag::err_acc_collapse_loop_count)
-        << ICE.has_value() << ICE.value_or(llvm::APSInt{}).getExtValue();
+        << ICE.has_value() << ICE.value_or(llvm::APSInt{});
     return ExprError();
   }
 

--- a/clang/test/SemaOpenACC/routine-construct-clauses.cpp
+++ b/clang/test/SemaOpenACC/routine-construct-clauses.cpp
@@ -103,6 +103,7 @@ static constexpr int One() { return 1; }
 static constexpr int Two() { return 2; }
 static constexpr int Three() { return 3; }
 static constexpr int Four() { return 4; }
+static constexpr unsigned long LargeUnsigned() { return -42; }
 };
 // 'dim' must be 1, 2, or 3.
 // expected-error@+1{{argument to 'gang' clause dimension must be 1, 2, or 3: evaluated to -5}}
@@ -114,6 +115,8 @@ static constexpr int Four() { return 4; }
 #pragma acc routine(Func) gang(dim:HasFuncs::Three())
 // expected-error@+1{{argument to 'gang' clause dimension must be 1, 2, or 3: evaluated to 4}}
 #pragma acc routine(Func) gang(dim:HasFuncs::Four())
+// expected-error-re@+1{{argument to 'gang' clause dimension must be 1, 2, or 3: evaluated to {{.*}}}}
+#pragma acc routine(Func) gang(dim:HasFuncs::LargeUnsigned())
 
 template<typename T>
 struct DependentT {


### PR DESCRIPTION
**Problem**
When an invalid 'gang dim' value is used in `CheckGangDimExpr`, the function prints the value into the diagnostic message by calling `getExtValue`. This function asserts on values that can't fit into a signed integer.

**Solution**
`APSInt` has a `<<` operator anyway so just use that.


The fix causes the message to print with the following formatting: 
```
test.cpp:5:40: error: argument to 'gang' clause dimension must be 1, 2, or 3: evaluated to 18'446'744'073'709'551'574
    5 | #pragma acc routine(S::foo) gang(dim : S::foo())
      |                                        ^
1 warning and 1 error generated.
```
Fixes #221418