### PR TITLE
[lldb-dap] Fix runInTerminal error message serialization

### DIFF
--- a/lldb/tools/lldb-dap/RunInTerminal.cpp
+++ b/lldb/tools/lldb-dap/RunInTerminal.cpp
@@ -49,7 +49,7 @@ RunInTerminalMessageError::RunInTerminalMessageError(StringRef error)
     : RunInTerminalMessage(eRunInTerminalMessageKindError), error(error) {}
 
 json::Value RunInTerminalMessageError::ToJSON() const {
-  return json::Object{{"kind", "error"}, {"value", error}};
+  return json::Object{{"kind", "error"}, {"error", error}};
 }
 
 RunInTerminalMessageDidAttach::RunInTerminalMessageDidAttach()

--- a/lldb/unittests/DAP/CMakeLists.txt
+++ b/lldb/unittests/DAP/CMakeLists.txt
@@ -15,6 +15,7 @@ add_lldb_unittest(DAPTests
   ProtocolRequestsTest.cpp
   ProtocolTypesTest.cpp
   ProtocolUtilsTest.cpp
+  RunInTerminalTest.cpp
   TestBase.cpp
   VariablesTest.cpp
 

--- a/lldb/unittests/DAP/RunInTerminalTest.cpp
+++ b/lldb/unittests/DAP/RunInTerminalTest.cpp
@@ -1,0 +1,28 @@
+//===-- RunInTerminalTest.cpp --------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "RunInTerminal.h"
+#include "llvm/Testing/Support/Error.h"
+#include "gtest/gtest.h"
+#include <thread>
+
+using namespace lldb_dap;
+using namespace llvm;
+
+TEST(RunInTerminalTest, ErrorRoundTrip) {
+  Expected<std::shared_ptr<FifoFile>> fifo = CreateRunInTerminalCommFile();
+  ASSERT_THAT_EXPECTED(fifo, Succeeded());
+
+  RunInTerminalLauncherCommChannel launcher((*fifo)->GetPath());
+  (*fifo)->Connect();
+  RunInTerminalDebugAdapterCommChannel adapter(*fifo);
+
+  std::thread sender([&launcher]() { launcher.NotifyError("boom"); });
+  EXPECT_EQ(adapter.GetLauncherError(), "boom");
+  sender.join();
+}


### PR DESCRIPTION

`RunInTerminalMessageError::ToJSON()` serializes the error message using the `"value"` field, while `ParseJSONMessage()` expects the `"error"` field.

When the runInTerminal launcher fails, the debug adapter cannot deserialize the launcher error and reports an `Incorrect JSON message` error instead of preserving the original diagnostic.

This patch makes the serialized field name match the parser and adds a round-trip test covering launcher error propagation.

