### PR TITLE
[LLVM][libc] Defer lowering of constant intrinsics in full LTO

### DIFF
--- a/llvm/lib/Passes/PassBuilderPipelines.cpp
+++ b/llvm/lib/Passes/PassBuilderPipelines.cpp
@@ -1582,7 +1582,9 @@ PassBuilder::buildModuleOptimizationPipeline(OptimizationLevel Level,
   }
 
   OptimizePM.addPass(Float2IntPass());
-  OptimizePM.addPass(LowerConstantIntrinsicsPass());
+  // Defer until LTO post-link where some constants may become known.
+  if (!isLTOPreLink(LTOPhase))
+    OptimizePM.addPass(LowerConstantIntrinsicsPass());
 
   if (EnableMatrix) {
     OptimizePM.addPass(LowerMatrixIntrinsicsPass());
@@ -2122,6 +2124,9 @@ PassBuilder::buildLTODefaultPipeline(OptimizationLevel Level,
   MPM.addPass(NoRecurseLTOInferencePass());
   // Stop here at -O1.
   if (Level == OptimizationLevel::O1) {
+    MPM.addPass(createModuleToFunctionPassAdaptor(
+        LowerConstantIntrinsicsPass(), PTO.EagerlyInvalidateAnalyses));
+
     // The LowerTypeTestsPass needs to run to lower type metadata and the
     // type.test intrinsics. The pass does nothing if CFI is disabled.
     MPM.addPass(LowerTypeTestsPass(ExportSummary, nullptr));
@@ -2287,6 +2292,8 @@ PassBuilder::buildLTODefaultPipeline(OptimizationLevel Level,
   MainFPM.addPass(DSEPass());
   MainFPM.addPass(MoveAutoInitPass());
   MainFPM.addPass(MergedLoadStoreMotionPass());
+
+  MainFPM.addPass(LowerConstantIntrinsicsPass());
 
   invokeVectorizerStartEPCallbacks(MainFPM, Level);
 

--- a/llvm/test/Other/new-pm-defaults.ll
+++ b/llvm/test/Other/new-pm-defaults.ll
@@ -229,7 +229,7 @@
 ; CHECK-EP-OPTIMIZER-EARLY: Running pass: NoOpModulePass
 ; CHECK-DEFAULT-NEXT: Running pass: DropUnnecessaryAssumesPass
 ; CHECK-O-NEXT: Running pass: Float2IntPass
-; CHECK-O-NEXT: Running pass: LowerConstantIntrinsicsPass on foo
+; CHECK-DEFAULT-NEXT: Running pass: LowerConstantIntrinsicsPass on foo
 ; CHECK-MATRIX: Running pass: LowerMatrixIntrinsicsPass on f
 ; CHECK-MATRIX-NEXT: Running pass: EarlyCSEPass on f
 ; CHECK-O3-NEXT: Running pass: ControlHeightReductionPass

--- a/llvm/test/Other/new-pm-lto-defaults.ll
+++ b/llvm/test/Other/new-pm-lto-defaults.ll
@@ -66,6 +66,7 @@
 ; CHECK-O-NEXT: Running pass: WholeProgramDevirtPass
 ; CHECK-O-NEXT: Running pass: NoRecurseLTOInferencePass
 ; CHECK-O23-NEXT: Running pass: CoroEarlyPass
+; CHECK-O1-NEXT: Running pass: LowerConstantIntrinsicsPass on foo
 ; CHECK-O1-NEXT: Running pass: LowerTypeTestsPass
 ; CHECK-O23-NEXT: Running pass: GlobalOptPass
 ; CHECK-O23-NEXT: Running pass: PromotePass
@@ -118,6 +119,7 @@
 ; CHECK-O23-NEXT: Running analysis: CycleAnalysis
 ; CHECK-O23-NEXT: Running pass: MoveAutoInitPass on foo
 ; CHECK-O23-NEXT: Running pass: MergedLoadStoreMotionPass on foo
+; CHECK-O23-NEXT: Running pass: LowerConstantIntrinsicsPass on foo
 ; CHECK-EP-VECTORIZER-START-NEXT: Running pass: NoOpFunctionPass on foo
 ; CHECK-O23-NEXT: Running pass: LoopSimplifyPass on foo
 ; CHECK-O23-NEXT: Running pass: LCSSAPass on foo

--- a/llvm/test/Transforms/PhaseOrdering/lto-is-constant.ll
+++ b/llvm/test/Transforms/PhaseOrdering/lto-is-constant.ll
@@ -1,0 +1,26 @@
+; RUN: split-file %s %t
+; RUN: opt -passes='default<O3>' -S %t/main.ll | FileCheck %s --check-prefix=DEFAULT
+; RUN: opt -passes='lto-pre-link<O3>' -S %t/main.ll | FileCheck %s --check-prefix=PRELINK
+; RUN: llvm-link %t/main.ll %t/foo.ll -S | opt -passes='lto<O3>' -S | FileCheck %s --check-prefix=LTO
+
+; DEFAULT-LABEL: define {{.*}} @test(
+; DEFAULT: ret i1 false
+
+; PRELINK-LABEL: define {{.*}} @test(
+; PRELINK: call i1 @llvm.is.constant.i32
+; PRELINK: ret i1
+
+; LTO-LABEL: define {{.*}} @test(
+; LTO: ret i1 true
+
+;--- main.ll
+@foo = external global i32
+
+define i1 @test() {
+  %v = load i32, ptr @foo
+  %c = call i1 @llvm.is.constant.i32(i32 %v)
+  ret i1 %c
+}
+
+;--- foo.ll
+t@foo = constant i32 42

--- a/llvm/test/Transforms/PhaseOrdering/lto-is-constant.ll
+++ b/llvm/test/Transforms/PhaseOrdering/lto-is-constant.ll
@@ -23,4 +23,4 @@ define i1 @test() {
 }
 
 ;--- foo.ll
-t@foo = constant i32 42
+@foo = constant i32 42


### PR DESCRIPTION
Summary:
This PR defers the lowering of the constant intrinsics. Currently it was
inheriting the default module pipeline and being done pessimistically in
the pre-link LTO phase. This means that some objects which would become
known constants were returned as failures. Doing this in the post-link
phase is more optimistic.

I included the `libc` change that justifies this in the PR, but it can
be split out if needed. The observation is that the ExpandVariadics pass
will lower most variadic calls on the GPU to an alloca of known size.
Using this opportunistically saves us a spill to stack ordinarily needed
to copy back the size from the GPU. Without this, every use of GPU
printf resulted in a spill to stack memory.

Hopefully this is benign enough.
