### PR TITLE
[libc++] Fix `optional<T>::transform` into `optional<T&>`

### DIFF
--- a/libcxx/include/__optional/optional_ref.h
+++ b/libcxx/include/__optional/optional_ref.h
@@ -78,6 +78,9 @@ public:
   static_assert(!is_same_v<remove_cv_t<_Tp>, nullopt_t>, "instantiation of optional with nullopt_t is ill-formed");
 
 private:
+  template <class>
+  friend class optional;
+
   _Tp* __value_ = nullptr;
 
   template <class _Up>

--- a/libcxx/test/std/utilities/optional/optional.monadic/transform.pass.cpp
+++ b/libcxx/test/std/utilities/optional/optional.monadic/transform.pass.cpp
@@ -321,6 +321,39 @@ constexpr bool test_ref() {
     assert(&(*o2) == &j);
   }
 
+  // optional<T> -> optional<T&> GH #220332
+  { // &, &&
+    int i = 42;
+    int j = 43;
+    int k = 44;
+
+    std::optional<int> opt{i};
+
+    std::same_as<std::optional<int&>> decltype(auto) o = opt.transform([&](auto) -> int& { return j; });
+    assert(o == 43);
+    assert(&(*o) == &j);
+
+    std::same_as<std::optional<int&>> decltype(auto) o2 = std::move(opt).transform([&](auto) -> int& { return k; });
+    assert(o2 == 44);
+    assert(&(*o2) == &k);
+  }
+
+  { // const&, const&&
+    int i = 42;
+    int j = 43;
+    int k = 44;
+
+    const std::optional<int> opt{i};
+
+    std::same_as<std::optional<int&>> decltype(auto) o = opt.transform([&](auto) -> int& { return j; });
+    assert(o == 43);
+    assert(&(*o) == &j);
+
+    std::same_as<std::optional<int&>> decltype(auto) o2 = std::move(opt).transform([&](auto) -> int& { return k; });
+    assert(o2 == 44);
+    assert(&(*o2) == &k);
+  }
+
   return true;
 }
 #endif

--- a/libcxx/test/std/utilities/optional/optional.monadic/transform.pass.cpp
+++ b/libcxx/test/std/utilities/optional/optional.monadic/transform.pass.cpp
@@ -321,7 +321,7 @@ constexpr bool test_ref() {
     assert(&(*o2) == &j);
   }
 
-  // optional<T> -> optional<T&> GH #220332
+  // optional<T> -> optional<T&>, https://llvm.org/PR220332
   { // &, &&
     int i = 42;
     int j = 43;


### PR DESCRIPTION
Resolves #220332

- Make `optional<T>` a friend of `optional<T&>`, and add tests.