### PR TITLE
[CHR] Use branch uniformity profiles to select scopes

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/ControlHeightReduction.cpp
+++ b/llvm/lib/Transforms/Instrumentation/ControlHeightReduction.cpp
@@ -376,6 +376,11 @@ class CHR {
   OptimizationRemarkEmitter &ORE;
   CHRStats Stats;
 
+  // A function attachment indicates that uniformity profile data is available.
+  // This preserves CHR's existing behavior when no uniformity profile was
+  // collected.
+  bool HasUniformityProfile = F.getMetadata(LLVMContext::MD_uniformity_profile);
+
   // All the true-biased regions in the function
   DenseSet<Region *> TrueBiasedRegionsGlobal;
   // All the false-biased regions in the function
@@ -1326,9 +1331,42 @@ static bool hasAtLeastTwoBiasedBranches(CHRScope *Scope) {
   return NumBiased >= CHRMergeThreshold;
 }
 
+static Instruction *
+findBranchWithoutUniformityProfile(const DenseSet<Region *> &Regions) {
+  for (Region *R : Regions) {
+    Instruction *Branch = R->getEntry()->getTerminator();
+    if (!Branch->getMetadata(LLVMContext::MD_branch_uniformity_profile))
+      return Branch;
+  }
+  return nullptr;
+}
+
 void CHR::filterScopes(SmallVectorImpl<CHRScope *> &Input,
                        SmallVectorImpl<CHRScope *> &Output) {
   for (CHRScope *Scope : Input) {
+    // Branch weights count individual lanes. A divergent branch can therefore
+    // look strongly biased even when every wave executes both paths. Avoid
+    // applying CHR to such a scope because duplicating its control flow may
+    // increase live ranges and register pressure without eliminating control
+    // flow for the wave. Select-only scopes are unaffected because branch
+    // uniformity profile describes only conditional branches.
+    if (HasUniformityProfile) {
+      Instruction *BranchWithoutUniformityProfile =
+          findBranchWithoutUniformityProfile(Scope->TrueBiasedRegions);
+      if (!BranchWithoutUniformityProfile)
+        BranchWithoutUniformityProfile =
+            findBranchWithoutUniformityProfile(Scope->FalseBiasedRegions);
+      if (BranchWithoutUniformityProfile) {
+        ORE.emit([&]() {
+          return OptimizationRemarkMissed(DEBUG_TYPE, "BranchNotKnownUniform",
+                                          BranchWithoutUniformityProfile)
+                 << "drop scope containing a branch that is not known to be "
+                    "uniform";
+        });
+        continue;
+      }
+    }
+
     // Filter out the ones with only one region and no subs.
     if (!hasAtLeastTwoBiasedBranches(Scope)) {
       CHR_DEBUG(dbgs() << "Filtered out by biased branches truthy-regions "

--- a/llvm/test/Transforms/PGOProfile/chr-uniformity-profile.ll
+++ b/llvm/test/Transforms/PGOProfile/chr-uniformity-profile.ll
@@ -1,0 +1,174 @@
+; RUN: opt < %s -passes='require<profile-summary>,function(chr,instcombine,simplifycfg)' -S | FileCheck %s
+
+declare void @foo()
+
+; Preserve the existing behavior when a function has no uniformity profile.
+define void @no_profile(ptr %ptr) !prof !14 {
+; CHECK-LABEL: define void @no_profile(
+; CHECK: entry.split.nonchr:
+entry:
+  %value = load i32, ptr %ptr
+  %bit0 = and i32 %value, 1
+  %cond0 = icmp eq i32 %bit0, 0
+  br i1 %cond0, label %bb1, label %bb0, !prof !15
+
+bb0:
+  call void @foo()
+  br label %bb1
+
+bb1:
+  %bit1 = and i32 %value, 2
+  %cond1 = icmp eq i32 %bit1, 0
+  br i1 %cond1, label %exit, label %bb2, !prof !15
+
+bb2:
+  call void @foo()
+  br label %exit
+
+exit:
+  ret void
+}
+
+; Uniform branches remain eligible for CHR when uniformity profile is
+; present.
+define void @uniform(ptr %ptr) !prof !14 !uniformity.profile !16 {
+; CHECK-LABEL: define void @uniform(
+; CHECK: entry.split.nonchr:
+entry:
+  %value = load i32, ptr %ptr
+  %bit0 = and i32 %value, 1
+  %cond0 = icmp eq i32 %bit0, 0
+  br i1 %cond0, label %bb1, label %bb0, !prof !15,
+      !branch.uniformity.profile !16
+
+bb0:
+  call void @foo()
+  br label %bb1
+
+bb1:
+  %bit1 = and i32 %value, 2
+  %cond1 = icmp eq i32 %bit1, 0
+  br i1 %cond1, label %exit, label %bb2, !prof !15,
+      !branch.uniformity.profile !16
+
+bb2:
+  call void @foo()
+  br label %exit
+
+exit:
+  ret void
+}
+
+; With uniformity profile, a branch without branch-uniformity metadata
+; is not known to be uniform. Do not apply CHR to a scope containing one.
+define void @not_known_uniform(ptr %ptr) !prof !14 !uniformity.profile !16 {
+; CHECK-LABEL: define void @not_known_uniform(
+; CHECK-NOT: split
+; CHECK: ret void
+entry:
+  %value = load i32, ptr %ptr
+  %bit0 = and i32 %value, 1
+  %cond0 = icmp eq i32 %bit0, 0
+  br i1 %cond0, label %bb1, label %bb0, !prof !15,
+      !branch.uniformity.profile !16
+
+bb0:
+  call void @foo()
+  br label %bb1
+
+bb1:
+  %bit1 = and i32 %value, 2
+  %cond1 = icmp eq i32 %bit1, 0
+  br i1 %cond1, label %exit, label %bb2, !prof !15
+
+bb2:
+  call void @foo()
+  br label %exit
+
+exit:
+  ret void
+}
+
+; A scope with a branch that is not known uniform does not disable a separate
+; uniform scope in the same function.
+define void @per_scope(ptr %uniform_ptr, ptr %divergent_ptr) !prof !14 !uniformity.profile !16 {
+; CHECK-LABEL: define void @per_scope(
+; CHECK: entry.split.nonchr:
+; CHECK-NOT: after.uniform.split.nonchr:
+; CHECK: after.uniform:
+entry:
+  %uniform_value = load i32, ptr %uniform_ptr
+  %uniform_bit0 = and i32 %uniform_value, 1
+  %uniform_cond0 = icmp eq i32 %uniform_bit0, 0
+  br i1 %uniform_cond0, label %uniform.bb1, label %uniform.bb0, !prof !15,
+      !branch.uniformity.profile !16
+
+uniform.bb0:
+  call void @foo()
+  br label %uniform.bb1
+
+uniform.bb1:
+  %uniform_bit1 = and i32 %uniform_value, 2
+  %uniform_cond1 = icmp eq i32 %uniform_bit1, 0
+  br i1 %uniform_cond1, label %after.uniform, label %uniform.bb2, !prof !15,
+      !branch.uniformity.profile !16
+
+uniform.bb2:
+  call void @foo()
+  br label %after.uniform
+
+after.uniform:
+  %divergent_value = load i32, ptr %divergent_ptr
+  %divergent_bit0 = and i32 %divergent_value, 1
+  %divergent_cond0 = icmp eq i32 %divergent_bit0, 0
+  br i1 %divergent_cond0, label %divergent.bb1, label %divergent.bb0,
+      !prof !15
+
+divergent.bb0:
+  call void @foo()
+  br label %divergent.bb1
+
+divergent.bb1:
+  %divergent_bit1 = and i32 %divergent_value, 2
+  %divergent_cond1 = icmp eq i32 %divergent_bit1, 0
+  br i1 %divergent_cond1, label %exit, label %divergent.bb2, !prof !15
+
+divergent.bb2:
+  call void @foo()
+  br label %exit
+
+exit:
+  ret void
+}
+
+; Select-only scopes are not described by branch-uniformity profile and keep
+; their existing behavior.
+define i32 @select_only(i32 %value) !prof !14 !uniformity.profile !16 {
+; CHECK-LABEL: define i32 @select_only(
+; CHECK: entry.split.nonchr:
+entry:
+  %bit0 = and i32 %value, 1
+  %cond0 = icmp eq i32 %bit0, 0
+  %sum0 = select i1 %cond0, i32 %value, i32 42, !prof !15
+  %bit1 = and i32 %value, 2
+  %cond1 = icmp eq i32 %bit1, 0
+  %sum1 = select i1 %cond1, i32 %sum0, i32 43, !prof !15
+  ret i32 %sum1
+}
+
+!llvm.module.flags = !{!0}
+!0 = !{i32 1, !"ProfileSummary", !1}
+!1 = !{!2, !3, !4, !5, !6, !7, !8, !9}
+!2 = !{!"ProfileFormat", !"InstrProf"}
+!3 = !{!"TotalCount", i64 10000}
+!4 = !{!"MaxCount", i64 10}
+!5 = !{!"MaxInternalCount", i64 1}
+!6 = !{!"MaxFunctionCount", i64 1000}
+!7 = !{!"NumCounts", i64 1}
+!8 = !{!"NumFunctions", i64 1}
+!9 = !{!"DetailedSummary", !10}
+!10 = !{!11}
+!11 = !{i32 999999, i64 1, i32 1}
+!14 = !{!"function_entry_count", i64 100}
+!15 = !{!"branch_weights", i32 0, i32 1}
+!16 = !{}


### PR DESCRIPTION
Device PGO branch weights count lanes, so a divergent branch can look strongly biased even when every wave executes both paths. CHR may then duplicate control flow and increase register pressure without avoiding the work on the other path.

When a function has `uniformity.profile`, this PR requires every conditional branch in a candidate CHR scope to have `branch.uniformity.profile`. If a branch is not known to be uniform, CHR skips that scope. Missing metadata is not treated as proof of divergence; it means only that uniform execution was not established by the profile.

Functions without the availability marker keep CHR's existing behavior. Scopes containing biased scalar Boolean selects are also skipped when uniformity profile data is available: these selects can use mask operations, while introducing control flow can extend predicate live ranges. Scopes containing only non-Boolean selects keep their existing behavior.

Depends on: #221629.

RFC: https://discourse.llvm.org/t/rfc-profile-based-block-and-branch-uniformity-metadata/91764/9

Review this patch: https://github.com/yxsamliu/llvm-project/compare/760103188c6081b3bfd202d30210962375244129...6e0d0341349bb3fe2fcf6757e091ab23aba6cc8f