### PR TITLE
[IR] Unique attribute sets and lists in a UniquingSet. NFC

### DIFF
--- a/llvm/include/llvm/ADT/Hashing.h
+++ b/llvm/include/llvm/ADT/Hashing.h
@@ -179,6 +179,8 @@ struct is_hashable_data : std::bool_constant<((is_integral_or_enum<T>::value ||
                                                std::is_pointer<T>::value) &&
                                               64 % sizeof(T) == 0)> {};
 
+template <typename T> struct is_hashable_data<const T> : is_hashable_data<T> {};
+
 // Special case std::pair to detect when both types are viable and when there
 // is no alignment-derived padding in the pair. This is a bit of a lie because
 // std::pair isn't truly POD, but it's close enough in all reasonable

--- a/llvm/include/llvm/IR/Attributes.h
+++ b/llvm/include/llvm/IR/Attributes.h
@@ -18,6 +18,7 @@
 #include "llvm-c/Types.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/BitmaskEnum.h"
+#include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Config/llvm-config.h"
 #include "llvm/Support/Alignment.h"
@@ -29,6 +30,7 @@
 #include <cstdint>
 #include <optional>
 #include <string>
+#include <type_traits>
 #include <utility>
 
 namespace llvm {
@@ -40,7 +42,6 @@ class AttributeListImpl;
 class AttributeSetNode;
 class ConstantRange;
 class ConstantRangeList;
-class FoldingSetNodeID;
 class Function;
 class LLVMContext;
 class Instruction;
@@ -375,8 +376,6 @@ public:
   /// Less-than operator. Useful for sorting the attributes list.
   LLVM_ABI bool operator<(Attribute A) const;
 
-  LLVM_ABI void Profile(FoldingSetNodeID &ID) const;
-
   /// Return a raw pointer that uniquely identifies this attribute.
   void *getRawPointer() const {
     return pImpl;
@@ -533,6 +532,17 @@ template <> struct DenseMapInfo<AttributeSet, void> {
 
   static bool isEqual(AttributeSet LHS, AttributeSet RHS) { return LHS == RHS; }
 };
+
+namespace hashing::detail {
+// Attribute and AttributeSet are trivial wrappers whose operator== is pointer
+// equality, so hashing the bytes is equivalent to hashing the values. Define
+// is_hashable_data to pick the contiguous hash_combine_range path.
+template <> struct is_hashable_data<Attribute> : std::true_type {};
+template <> struct is_hashable_data<AttributeSet> : std::true_type {};
+static_assert(std::has_unique_object_representations_v<Attribute> &&
+                  std::has_unique_object_representations_v<AttributeSet>,
+              "hashing the bytes requires unique object representations");
+} // namespace hashing::detail
 
 //===----------------------------------------------------------------------===//
 /// \class

--- a/llvm/lib/IR/AttributeImpl.h
+++ b/llvm/lib/IR/AttributeImpl.h
@@ -351,14 +351,7 @@ public:
   iterator begin() const { return getTrailingObjects(); }
   iterator end() const { return begin() + NumAttrs; }
 
-  void Profile(FoldingSetNodeID &ID) const {
-    Profile(ID, ArrayRef(begin(), end()));
-  }
-
-  static void Profile(FoldingSetNodeID &ID, ArrayRef<Attribute> AttrList) {
-    for (const auto &Attr : AttrList)
-      Attr.Profile(ID);
-  }
+  ArrayRef<Attribute> getKey() const { return getTrailingObjects(NumAttrs); }
 };
 
 //===----------------------------------------------------------------------===//
@@ -402,8 +395,9 @@ public:
   iterator begin() const { return getTrailingObjects(); }
   iterator end() const { return begin() + NumAttrSets; }
 
-  void Profile(FoldingSetNodeID &ID) const;
-  static void Profile(FoldingSetNodeID &ID, ArrayRef<AttributeSet> Nodes);
+  ArrayRef<AttributeSet> getKey() const {
+    return getTrailingObjects(NumAttrSets);
+  }
 
   void dump() const;
 };

--- a/llvm/lib/IR/Attributes.cpp
+++ b/llvm/lib/IR/Attributes.cpp
@@ -801,10 +801,6 @@ bool Attribute::operator<(Attribute A) const {
   return *pImpl < *A.pImpl;
 }
 
-void Attribute::Profile(FoldingSetNodeID &ID) const {
-  ID.AddPointer(pImpl);
-}
-
 enum AttributeProperty {
   FnAttr = (1 << 0),
   ParamAttr = (1 << 1),
@@ -1277,10 +1273,8 @@ std::string AttributeSet::getAsString(bool InAttrGrp) const {
 
 bool AttributeSet::hasParentContext(LLVMContext &C) const {
   assert(hasAttributes() && "empty AttributeSet doesn't refer to any context");
-  FoldingSetNodeID ID;
-  SetNode->Profile(ID);
   FoldingSetInsertToken Token;
-  return C.pImpl->AttrsSetNodes.lookup(ID, Token) == SetNode;
+  return C.pImpl->AttrsSetNodes.lookup(SetNode->getKey(), Token) == SetNode;
 }
 
 AttributeSet::iterator AttributeSet::begin() const {
@@ -1325,20 +1319,12 @@ AttributeSetNode *AttributeSetNode::get(LLVMContext &C,
 
 AttributeSetNode *AttributeSetNode::getSorted(LLVMContext &C,
                                               ArrayRef<Attribute> SortedAttrs) {
+  assert(llvm::is_sorted(SortedAttrs) && "Expected sorted attributes!");
   if (SortedAttrs.empty())
     return nullptr;
 
-  // Build a key to look up the existing attributes.
-  LLVMContextImpl *pImpl = C.pImpl;
-  FoldingSetNodeID ID;
-
-  assert(llvm::is_sorted(SortedAttrs) && "Expected sorted attributes!");
-  for (const auto &Attr : SortedAttrs)
-    Attr.Profile(ID);
-
   FoldingSetInsertToken Token;
-  AttributeSetNode *PA =
-    pImpl->AttrsSetNodes.lookup(ID, Token);
+  AttributeSetNode *PA = C.pImpl->AttrsSetNodes.lookup(SortedAttrs, Token);
 
   // If we didn't find any existing attributes of the same shape then create a
   // new one and insert it.
@@ -1346,7 +1332,7 @@ AttributeSetNode *AttributeSetNode::getSorted(LLVMContext &C,
     // Coallocate entries after the AttributeSetNode itself.
     void *Mem = ::operator new(totalSizeToAlloc<Attribute>(SortedAttrs.size()));
     PA = new (Mem) AttributeSetNode(SortedAttrs);
-    pImpl->AttrsSetNodes.insert(PA, Token);
+    C.pImpl->AttrsSetNodes.insert(PA, Token);
   }
 
   // Return the AttributeSetNode that we found or created.
@@ -1512,16 +1498,6 @@ AttributeListImpl::AttributeListImpl(ArrayRef<AttributeSet> Sets)
         AvailableSomewhereAttrs.addAttribute(I.getKindAsEnum());
 }
 
-void AttributeListImpl::Profile(FoldingSetNodeID &ID) const {
-  Profile(ID, ArrayRef(begin(), end()));
-}
-
-void AttributeListImpl::Profile(FoldingSetNodeID &ID,
-                                ArrayRef<AttributeSet> Sets) {
-  for (const auto &Set : Sets)
-    ID.AddPointer(Set.SetNode);
-}
-
 bool AttributeListImpl::hasAttrSomewhere(Attribute::AttrKind Kind,
                                         unsigned *Index) const {
   if (!AvailableSomewhereAttrs.hasAttribute(Kind))
@@ -1555,12 +1531,8 @@ AttributeList AttributeList::getImpl(LLVMContext &C,
   assert(!AttrSets.empty() && "pointless AttributeListImpl");
 
   LLVMContextImpl *pImpl = C.pImpl;
-  FoldingSetNodeID ID;
-  AttributeListImpl::Profile(ID, AttrSets);
-
   FoldingSetInsertToken Token;
-  AttributeListImpl *PA =
-      pImpl->AttrsLists.lookup(ID, Token);
+  AttributeListImpl *PA = pImpl->AttrsLists.lookup(AttrSets, Token);
 
   // If we didn't find any existing attributes of the same shape then
   // create a new one and insert it.
@@ -2085,10 +2057,8 @@ AttributeSet AttributeList::getAttributes(unsigned Index) const {
 
 bool AttributeList::hasParentContext(LLVMContext &C) const {
   assert(!isEmpty() && "an empty attribute list has no parent context");
-  FoldingSetNodeID ID;
-  pImpl->Profile(ID);
   FoldingSetInsertToken Token;
-  return C.pImpl->AttrsLists.lookup(ID, Token) == pImpl;
+  return C.pImpl->AttrsLists.lookup(pImpl->getKey(), Token) == pImpl;
 }
 
 AttributeList::iterator AttributeList::begin() const {

--- a/llvm/lib/IR/LLVMContextImpl.h
+++ b/llvm/lib/IR/LLVMContextImpl.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_LIB_IR_LLVMCONTEXTIMPL_H
 #define LLVM_LIB_IR_LLVMCONTEXTIMPL_H
 
+#include "AttributeImpl.h"
 #include "ConstantsContext.h"
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/APInt.h"
@@ -52,12 +53,7 @@
 
 namespace llvm {
 
-class AttributeImpl;
-class AttributeListImpl;
-class AttributeSetNode;
 class BasicBlock;
-class ConstantRangeAttributeImpl;
-class ConstantRangeListAttributeImpl;
 struct DiagnosticHandler;
 class DbgMarker;
 class ElementCount;
@@ -1629,8 +1625,8 @@ public:
       FPSplatConstants;
 
   FoldingSet<AttributeImpl> AttrsSet;
-  FoldingSet<AttributeListImpl> AttrsLists;
-  FoldingSet<AttributeSetNode> AttrsSetNodes;
+  UniquingSet<AttributeListImpl> AttrsLists;
+  UniquingSet<AttributeSetNode> AttrsSetNodes;
 
   StringMap<MDString, BumpPtrAllocator> MDStringCache;
   DenseMap<Value *, ValueAsMetadata *> ValuesAsMetadata;

--- a/llvm/unittests/ADT/HashingTest.cpp
+++ b/llvm/unittests/ADT/HashingTest.cpp
@@ -42,6 +42,12 @@ struct NonPOD {
 namespace hashing {
 namespace detail {
 template <> struct is_hashable_data<LargeTestInteger> : std::true_type {};
+
+// A specialization for T also covers const T.
+static_assert(is_hashable_data<const LargeTestInteger>::value);
+static_assert(!is_hashable_data<const NonPOD>::value);
+static_assert(is_hashable_data<const int>::value);
+static_assert(is_hashable_data<const int *>::value);
 } // namespace detail
 } // namespace hashing
 


### PR DESCRIPTION
Switch to UniquingSet to remove FoldingSetNodeID serialization overhead
on every AttributeSet::get and AttributeList::get.

Attribute and AttributeSet are single-pointer wrappers whose operator==
is pointer equality. Specializing `is_hashable_data` selects the fast
`hash_combine_range_impl` overload that calls `combine_bytes` directly,
skipping copying element by element.

`hash_combine_range` deduces its element type as `const T`, so
`is_hashable_data<const T>` now follows `is_hashable_data<T>` and a type
need only specialize the unqualified form.

Aided by Opus 5
