### PR TITLE
[SPIRV] Fix unreach crash on AtomicRMW spv_ptrcast

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVLegalizePointerCast.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVLegalizePointerCast.cpp
@@ -815,6 +815,17 @@ class SPIRVLegalizePointerCastImpl {
         }
       }
 
+      if (AtomicRMWInst *AI = dyn_cast<AtomicRMWInst>(User)) {
+        B.SetInsertPoint(AI);
+        Type *ToTy = GR->findDeducedElementType(CastedOperand);
+        assert(ToTy &&
+               "AtomicRMWInst should always have a deduced element type");
+        GR->buildAssignPtr(B, ToTy, OriginalOperand);
+        AI->setOperand(AtomicRMWInst::getPointerOperandIndex(),
+                       OriginalOperand);
+        continue;
+      }
+
       llvm_unreachable("Unsupported ptrcast user. Please fix.");
     }
 

--- a/llvm/test/CodeGen/SPIRV/atomicrmw-ptrcast.ll
+++ b/llvm/test/CodeGen/SPIRV/atomicrmw-ptrcast.ll
@@ -1,0 +1,20 @@
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv-unknown-vulkan-compute %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan-compute %s -o - -filetype=obj | spirv-val %}
+
+declare ptr addrspace(11) @llvm.spv.ptrcast(ptr addrspace(11), metadata, i32)
+
+define void @test_atomic_rmw_ptrcast(ptr addrspace(11) %ptr) {
+; CHECK: OpAtomicAnd
+entry:
+  %casted = call ptr addrspace(11) @llvm.spv.ptrcast(ptr addrspace(11) %ptr, metadata !"i32", i32 11)
+  %atomic = atomicrmw and ptr addrspace(11) %casted, i32 1 syncscope("device") monotonic, align 4
+  ret void
+}
+
+define void @test_atomic_rmw_ptrcast_add(ptr addrspace(11) %ptr) {
+; CHECK: OpAtomicIAdd
+entry:
+  %casted = call ptr addrspace(11) @llvm.spv.ptrcast(ptr addrspace(11) %ptr, metadata !"i32", i32 11)
+  %atomic = atomicrmw add ptr addrspace(11) %casted, i32 1 syncscope("device") monotonic, align 4
+  ret void
+}


### PR DESCRIPTION
added support for atomic operations in the pointer legalization pass that replaces the `spv_ptrcast` with the extracted real pointer and registering its type

(added test - im not sure of the test cause when i tried to generate CHECK statements the script didn't generated SPIR-V CHECK lines - so tried to add handwritten CHECK statements)

but the test should work fine - https://godbolt.org/z/1M84s31fx

Fixes: #221370 