### PR TITLE
[clang-tidy][docs] Rewrite readability check docs to Markdown [2/5]

### DIFF
--- a/clang-tools-extra/docs/clang-tidy/checks/readability/function-cognitive-complexity.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/function-cognitive-complexity.md
@@ -10,10 +10,14 @@ version 1.2 (19 April 2017).
 
 ## Options
 
+(readability-function-cognitive-complexity-threshold)=
+
 ```{option} Threshold
 Flag functions with Cognitive Complexity exceeding this number.
 Default is `25`.
 ```
+
+(readability-function-cognitive-complexity-describe-basic-increments)=
 
 ```{option} DescribeBasicIncrements
 When `true`, for each function exceeding the complexity threshold
@@ -21,6 +25,8 @@ the check will issue additional diagnostics on every piece of code (loop,
 `if` statement, etc.) which contributes to that complexity. See also the
 examples below. Default is `true`.
 ```
+
+(readability-function-cognitive-complexity-ignore-macros)=
 
 ```{option} IgnoreMacros
 When `true`, the check will ignore code inside macros. Note that
@@ -152,8 +158,8 @@ int function3(bool var1, bool var2) {
 ```
 
 In the last example, the check will flag `function3` if the
-{option}`Threshold` is set to `2` or smaller. If the
-{option}`DescribeBasicIncrements` is set to `true`,
+[`Threshold`](#readability-function-cognitive-complexity-threshold) is set to `2` or smaller. If the
+[`DescribeBasicIncrements`](#readability-function-cognitive-complexity-describe-basic-increments) is set to `true`,
 it will additionally flag the two `if` statements with the amounts by which they
 increase to the complexity of the function and the current nesting level.
 

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/function-cognitive-complexity.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/function-cognitive-complexity.md
@@ -152,8 +152,8 @@ int function3(bool var1, bool var2) {
 ```
 
 In the last example, the check will flag `function3` if the
-{option}`Threshold` option is set to `2` or smaller. If the
-{option}`DescribeBasicIncrements` option is set to `true`,
+{option}`Threshold` is set to `2` or smaller. If the
+{option}`DescribeBasicIncrements` is set to `true`,
 it will additionally flag the two `if` statements with the amounts by which they
 increase to the complexity of the function and the current nesting level.
 

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/function-cognitive-complexity.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/function-cognitive-complexity.md
@@ -1,166 +1,168 @@
-.. title:: clang-tidy - readability-function-cognitive-complexity
+```{title} clang-tidy - readability-function-cognitive-complexity
+```
 
-readability-function-cognitive-complexity
-=========================================
+# readability-function-cognitive-complexity
 
 Checks function Cognitive Complexity metric.
 
-The metric is implemented as per the `COGNITIVE COMPLEXITY by SonarSource
-<https://www.sonarsource.com/docs/CognitiveComplexity.pdf>`_ specification
+The metric is implemented as per the [COGNITIVE COMPLEXITY by SonarSource](https://www.sonarsource.com/docs/CognitiveComplexity.pdf) specification
 version 1.2 (19 April 2017).
 
-Options
--------
+## Options
 
-.. option:: Threshold
+```{option} Threshold
+Flag functions with Cognitive Complexity exceeding this number.
+Default is `25`.
+```
 
-   Flag functions with Cognitive Complexity exceeding this number.
-   The default is `25`.
+```{option} DescribeBasicIncrements
+When `true`, for each function exceeding the complexity threshold
+the check will issue additional diagnostics on every piece of code (loop,
+`if` statement, etc.) which contributes to that complexity. See also the
+examples below. Default is `true`.
+```
 
-.. option:: DescribeBasicIncrements
+```{option} IgnoreMacros
+When `true`, the check will ignore code inside macros. Note that
+any macro arguments are ignored, even if they should count to the complexity.
+As this might change in the future, this option isn't guaranteed to be
+forward-compatible. Default is `false`.
+```
 
-   If set to `true`, then for each function exceeding the complexity threshold
-   the check will issue additional diagnostics on every piece of code (loop,
-   `if` statement, etc.) which contributes to that complexity. See also the
-   examples below. Default is `true`.
-
-.. option:: IgnoreMacros
-
-   If set to `true`, the check will ignore code inside macros. Note, that also
-   any macro arguments are ignored, even if they should count to the complexity.
-   As this might change in the future, this option isn't guaranteed to be
-   forward-compatible. Default is `false`.
-
-Building blocks
----------------
+## Building blocks
 
 There are three basic building blocks of a Cognitive Complexity metric:
 
-Increment
-^^^^^^^^^
+### Increment
 
 The following structures increase the function's Cognitive Complexity metric
 (by `1`):
 
-* Conditional operators:
+- Conditional operators:
 
-   - ``if()``
-   - ``else if()``
-   - ``else``
-   - ``cond ? true : false``
+  - `if()`
+  - `else if()`
+  - `else`
+  - `cond ? true : false`
 
-* ``switch()``
-* Loops:
+- `switch()`
 
-   - ``for()``
-   - C++11 range-based ``for()``
-   - ``while()``
-   - ``do while()``
+- Loops:
 
-* ``catch ()``
-* ``goto LABEL``, ``goto *(&&LABEL))``,
-* sequences of binary logical operators:
+  - `for()`
+  - C++11 range-based `for()`
+  - `while()`
+  - `do while()`
 
-   - ``boolean1 || boolean2``
-   - ``boolean1 && boolean2``
+- `catch ()`
 
-Nesting level
-^^^^^^^^^^^^^
+- `goto LABEL`, `goto *(&&LABEL))`,
+
+- sequences of binary logical operators:
+
+  - `boolean1 || boolean2`
+  - `boolean1 && boolean2`
+
+### Nesting level
 
 While by itself the nesting level does not change the function's Cognitive
 Complexity metric, it is tracked, and is used by the next, third building
 block. The following structures increase the nesting level (by `1`):
 
-* Conditional operators:
+- Conditional operators:
 
-   - ``if()``
-   - ``else if()``
-   - ``else``
-   - ``cond ? true : false``
+  - `if()`
+  - `else if()`
+  - `else`
+  - `cond ? true : false`
 
-* ``switch()``
-* Loops:
+- `switch()`
 
-   - ``for()``
-   - C++11 range-based ``for()``
-   - ``while()``
-   - ``do while()``
+- Loops:
 
-* ``catch ()``
-* Nested functions:
+  - `for()`
+  - C++11 range-based `for()`
+  - `while()`
+  - `do while()`
 
-   - C++11 Lambda
-   - Nested ``class``
-   - Nested ``struct``
-* GNU statement expression
-* Apple Block Declaration
+- `catch ()`
 
-Nesting increment
-^^^^^^^^^^^^^^^^^
+- Nested functions:
 
-This is where the previous basic building block, `Nesting level`_, matters.
+  - C++11 Lambda
+  - Nested `class`
+  - Nested `struct`
+
+- GNU statement expression
+
+- Apple Block Declaration
+
+### Nesting increment
+
+This is where the previous basic building block,
+[Nesting level](#nesting-level), matters.
 The following structures increase the function's Cognitive Complexity metric by
-the current `Nesting level`_:
+the current [Nesting level](#nesting-level):
 
-* Conditional operators:
+- Conditional operators:
 
-   - ``if()``
-   - ``cond ? true : false``
+  - `if()`
+  - `cond ? true : false`
 
-* ``switch()``
-* Loops:
+- `switch()`
 
-   - ``for()``
-   - C++11 range-based ``for()``
-   - ``while()``
-   - ``do while()``
+- Loops:
 
-* ``catch ()``
+  - `for()`
+  - C++11 range-based `for()`
+  - `while()`
+  - `do while()`
 
-Examples
---------
+- `catch ()`
+
+## Examples
 
 The simplest case. This function has Cognitive Complexity of `0`.
 
-.. code-block:: c++
-
-  void function0() {}
+```c++
+void function0() {}
+```
 
 Slightly better example. This function has Cognitive Complexity of `1`.
 
-.. code-block:: c++
-
-  int function1(bool var) {
-    if(var) // +1, nesting level +1
-      return 42;
-    return 0;
-  }
+```c++
+int function1(bool var) {
+  if(var) // +1, nesting level +1
+    return 42;
+  return 0;
+}
+```
 
 Full example. This function has Cognitive Complexity of `3`.
 
-.. code-block:: c++
-
-  int function3(bool var1, bool var2) {
-    if(var1) { // +1, nesting level +1
-      if(var2)  // +2 (1 + current nesting level of 1), nesting level +1
-        return 42;
-    }
-
-    return 0;
+```c++
+int function3(bool var1, bool var2) {
+  if(var1) { // +1, nesting level +1
+    if(var2)  // +2 (1 + current nesting level of 1), nesting level +1
+      return 42;
   }
 
-In the last example, the check will flag `function3` if the option Threshold is
-set to `2` or smaller. If the option DescribeBasicIncrements is set to `true`,
+  return 0;
+}
+```
+
+In the last example, the check will flag `function3` if the
+{option}`Threshold` option is set to `2` or smaller. If the
+{option}`DescribeBasicIncrements` option is set to `true`,
 it will additionally flag the two `if` statements with the amounts by which they
 increase to the complexity of the function and the current nesting level.
 
-
-Limitations
------------
+## Limitations
 
 The metric is implemented with two notable exceptions:
-   * `preprocessor conditionals` (``#ifdef``, ``#if``, ``#elif``, ``#else``,
-     ``#endif``) are not accounted for.
-   * `each method in a recursion cycle` is not accounted for. It can't be fully
-     implemented, because cross-translational-unit analysis would be needed,
-     which is currently not possible in clang-tidy.
+
+- `preprocessor conditionals` (`#ifdef`, `#if`, `#elif`, `#else`,
+  `#endif`) are not accounted for.
+- `each method in a recursion cycle` is not accounted for. It can't be fully
+  implemented, because cross-translational-unit analysis would be needed,
+  which is currently not possible in clang-tidy.

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/function-size.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/function-size.md
@@ -1,55 +1,54 @@
-.. title:: clang-tidy - readability-function-size
+```{title} clang-tidy - readability-function-size
+```
 
-readability-function-size
-=========================
+# readability-function-size
 
 `google-readability-function-size` redirects here as an alias for this check.
 
 Checks for large functions based on various metrics.
 
-Options
--------
+## Options
 
-.. option:: LineThreshold
+```{option} LineThreshold
+Flag functions exceeding this number of lines. Default is `none` (ignore the
+number of lines).
+```
 
-   Flag functions exceeding this number of lines. The default is `none` (ignore
-   the number of lines).
+```{option} StatementThreshold
+Flag functions exceeding this number of statements. This may differ
+significantly from the number of lines for macro-heavy code. Default is
+`800`.
+```
 
-.. option:: StatementThreshold
+```{option} BranchThreshold
+Flag functions exceeding this number of control statements. Default is
+`none` (ignore the number of branches).
+```
 
-   Flag functions exceeding this number of statements. This may differ
-   significantly from the number of lines for macro-heavy code. The default is
-   `800`.
+```{option} ParameterThreshold
+Flag functions that exceed a specified number of parameters. Default
+is `none` (ignore the number of parameters).
+```
 
-.. option:: BranchThreshold
+```{option} NestingThreshold
+Flag compound statements which create next nesting level after
+{option}`NestingThreshold`. This may differ significantly from the expected
+value for macro-heavy code. Default is `none` (ignore the nesting level).
+```
 
-   Flag functions exceeding this number of control statements. The default is
-   `none` (ignore the number of branches).
+```{option} VariableThreshold
+Flag functions exceeding this number of variables declared in the body.
+Please note that function parameters and variables declared in lambdas,
+GNU Statement Expressions, and nested class inline functions are not counted.
+Default is `none` (ignore the number of variables).
+```
 
-.. option:: ParameterThreshold
+```{option} CountMemberInitAsStmt
+When `true`, count class member initializers in constructors as statements.
+Default is `true`.
+```
 
-   Flag functions that exceed a specified number of parameters. The default
-   is `none` (ignore the number of parameters).
-
-.. option:: NestingThreshold
-
-    Flag compound statements which create next nesting level after
-    `NestingThreshold`. This may differ significantly from the expected value
-    for macro-heavy code. The default is `none` (ignore the nesting level).
-
-.. option:: VariableThreshold
-
-   Flag functions exceeding this number of variables declared in the body.
-   The default is `none` (ignore the number of variables).
-   Please note that function parameters and variables declared in lambdas,
-   GNU Statement Expressions, and nested class inline functions are not counted.
-
-.. option:: CountMemberInitAsStmt
-
-   When `true`, count class member initializers in constructors as statements.
-   Default is `true`.
-
-.. option:: IgnoreMacros
-
-   If set to `true`, the check will not count statements, branches, nesting
-   levels, or variable declarations inside macros. Default is `false`.
+```{option} IgnoreMacros
+When `true`, the check will not count statements, branches, nesting
+levels, or variable declarations inside macros. Default is `false`.
+```

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/function-size.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/function-size.md
@@ -9,10 +9,14 @@ Checks for large functions based on various metrics.
 
 ## Options
 
+(readability-function-size-line-threshold)=
+
 ```{option} LineThreshold
 Flag functions exceeding this number of lines. Default is `none` (ignore the
 number of lines).
 ```
+
+(readability-function-size-statement-threshold)=
 
 ```{option} StatementThreshold
 Flag functions exceeding this number of statements. This may differ
@@ -20,21 +24,29 @@ significantly from the number of lines for macro-heavy code. Default is
 `800`.
 ```
 
+(readability-function-size-branch-threshold)=
+
 ```{option} BranchThreshold
 Flag functions exceeding this number of control statements. Default is
 `none` (ignore the number of branches).
 ```
+
+(readability-function-size-parameter-threshold)=
 
 ```{option} ParameterThreshold
 Flag functions that exceed a specified number of parameters. Default
 is `none` (ignore the number of parameters).
 ```
 
+(readability-function-size-nesting-threshold)=
+
 ```{option} NestingThreshold
 Flag compound statements which create next nesting level after
-{option}`NestingThreshold`. This may differ significantly from the expected
+[`NestingThreshold`](#readability-function-size-nesting-threshold). This may differ significantly from the expected
 value for macro-heavy code. Default is `none` (ignore the nesting level).
 ```
+
+(readability-function-size-variable-threshold)=
 
 ```{option} VariableThreshold
 Flag functions exceeding this number of variables declared in the body.
@@ -43,10 +55,14 @@ GNU Statement Expressions, and nested class inline functions are not counted.
 Default is `none` (ignore the number of variables).
 ```
 
+(readability-function-size-count-member-init-as-stmt)=
+
 ```{option} CountMemberInitAsStmt
 When `true`, count class member initializers in constructors as statements.
 Default is `true`.
 ```
+
+(readability-function-size-ignore-macros)=
 
 ```{option} IgnoreMacros
 When `true`, the check will not count statements, branches, nesting

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/identifier-length.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/identifier-length.md
@@ -12,40 +12,52 @@ if they are short-lived.
 
 The following options are described below:
 
-- {option}`MinimumVariableNameLength`, {option}`IgnoredVariableNames`
-- {option}`MinimumBindingNameLength`, {option}`IgnoredBindingNames`
-- {option}`MinimumParameterNameLength`,
+- [`MinimumVariableNameLength`](#readability-identifier-length-minimum-variable-name-length),
+  [`IgnoredVariableNames`](#readability-identifier-length-ignored-variable-names)
+- [`MinimumBindingNameLength`](#readability-identifier-length-minimum-binding-name-length),
+  [`IgnoredBindingNames`](#readability-identifier-length-ignored-binding-names)
+- [`MinimumParameterNameLength`](#readability-identifier-length-minimum-parameter-name-length),
   [`IgnoredParameterNames`](#readability-identifier-length-ignored-parameter-names)
-- {option}`MinimumLoopCounterNameLength`, {option}`IgnoredLoopCounterNames`
-- {option}`MinimumExceptionNameLength`,
-  {option}`IgnoredExceptionVariableNames`
-- {option}`LineCountThreshold`
+- [`MinimumLoopCounterNameLength`](#readability-identifier-length-minimum-loop-counter-name-length),
+  [`IgnoredLoopCounterNames`](#readability-identifier-length-ignored-loop-counter-names)
+- [`MinimumExceptionNameLength`](#readability-identifier-length-minimum-exception-name-length),
+  [`IgnoredExceptionVariableNames`](#readability-identifier-length-ignored-exception-variable-names)
+- [`LineCountThreshold`](#readability-identifier-length-line-count-threshold)
+
+(readability-identifier-length-minimum-variable-name-length)=
 
 ````{option} MinimumVariableNameLength
 All variables (other than loop counter, exception names and function
 parameters) are expected to have at least a length of
-{option}`MinimumVariableNameLength`. Setting it to `0` or `1` disables the
-check entirely. Default is `3`.
+[`MinimumVariableNameLength`](#readability-identifier-length-minimum-variable-name-length).
+Setting it to `0` or `1` disables the check entirely. Default is `3`.
 
 ```c++
 int i = 42;    // warns that 'i' is too short
 ```
 ````
 
+(readability-identifier-length-ignored-variable-names)=
+
 ```{option} IgnoredVariableNames
 Specifies a regular expression for variable names that are
 to be ignored. Default is empty string, so no names are ignored.
 ```
 
+(readability-identifier-length-minimum-binding-name-length)=
+
 ````{option} MinimumBindingNameLength
 All variables introduced by structured bindings are expected to have at
-least a length of {option}`MinimumBindingNameLength`. Setting it to `0` or `1`
-disables the check entirely. Default is `2`.
+least a length of
+[`MinimumBindingNameLength`](#readability-identifier-length-minimum-binding-name-length).
+Setting it to `0` or `1` disables the check entirely. Default is `2`.
 
 ```c++
 auto [a] = get_result();    // warns that 'a' is too short
 ```
 ````
+
+(readability-identifier-length-ignored-binding-names)=
 
 ```{option} IgnoredBindingNames
 Specifies a regular expression for variable names introduced by structured
@@ -53,10 +65,12 @@ bindings that are to be ignored. The `^[_]$` value allows the `_` idiom to
 specify that the value is discarded on purpose. Default is `^[_]$`.
 ```
 
+(readability-identifier-length-minimum-parameter-name-length)=
+
 ````{option} MinimumParameterNameLength
 All function parameter names are expected to have a length of at least
-{option}`MinimumParameterNameLength`. Setting it to `0` or `1` disables the
-check entirely. Default is `3`.
+[`MinimumParameterNameLength`](#readability-identifier-length-minimum-parameter-name-length).
+Setting it to `0` or `1` disables the check entirely. Default is `3`.
 
 ```c++
 int doubler(int x)   // warns that x is too short
@@ -73,10 +87,13 @@ Specifies a regular expression for parameters that are to be ignored.
 Default is `^[n]$` for historical reasons.
 ```
 
+(readability-identifier-length-minimum-loop-counter-name-length)=
+
 ````{option} MinimumLoopCounterNameLength
 Loop counter variables are expected to have a length of at least
-{option}`MinimumLoopCounterNameLength` characters. Setting it to `0` or `1`
-disables the check entirely. Default is `2`.
+[`MinimumLoopCounterNameLength`](#readability-identifier-length-minimum-loop-counter-name-length)
+characters. Setting it to `0` or `1` disables the check entirely. Default is
+`2`.
 
 ```c++
 // This warns that 'q' is too short.
@@ -85,6 +102,8 @@ for (int q = 0; q < size; ++ q) {
 }
 ```
 ````
+
+(readability-identifier-length-ignored-loop-counter-names)=
 
 ````{option} IgnoredLoopCounterNames
 Specifies a regular expression for counter names that are to be ignored.
@@ -100,10 +119,12 @@ for (int i = 0; i < size; ++ i) {
 ```
 ````
 
+(readability-identifier-length-minimum-exception-name-length)=
+
 ````{option} MinimumExceptionNameLength
 Exception clause variables are expected to have a length of at least
-{option}`MinimumExceptionNameLength`. Setting it to `0` or `1` disables the
-check entirely. Default is `2`.
+[`MinimumExceptionNameLength`](#readability-identifier-length-minimum-exception-name-length).
+Setting it to `0` or `1` disables the check entirely. Default is `2`.
 
 ```c++
 try {
@@ -115,6 +136,8 @@ catch (const std::exception& x) {
 }
 ```
 ````
+
+(readability-identifier-length-ignored-exception-variable-names)=
 
 ````{option} IgnoredExceptionVariableNames
 Specifies a regular expression for exception variable names that are to
@@ -130,6 +153,8 @@ catch (const std::exception& e) {
 }
 ```
 ````
+
+(readability-identifier-length-line-count-threshold)=
 
 ````{option} LineCountThreshold
 Defines the minimum number of lines required between declaration and last

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/identifier-length.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/identifier-length.md
@@ -1,147 +1,148 @@
-.. title:: clang-tidy - readability-identifier-length
+```{title} clang-tidy - readability-identifier-length
+```
 
-readability-identifier-length
-=============================
+# readability-identifier-length
 
 This check finds variables and function parameters whose length are too short.
 The desired name length is configurable. Special short names which should be
 ignored can be specified. Local variables with short names can also be ignored
 if they are short-lived.
 
-Options
--------
+## Options
 
 The following options are described below:
 
- - :option:`MinimumVariableNameLength`, :option:`IgnoredVariableNames`
- - :option:`MinimumBindingNameLength`, :option:`IgnoredBindingNames`
- - :option:`MinimumParameterNameLength`, :option:`IgnoredParameterNames`
- - :option:`MinimumLoopCounterNameLength`, :option:`IgnoredLoopCounterNames`
- - :option:`MinimumExceptionNameLength`,
-   :option:`IgnoredExceptionVariableNames`
- - :option:`LineCountThreshold`
+- {option}`MinimumVariableNameLength`, {option}`IgnoredVariableNames`
+- {option}`MinimumBindingNameLength`, {option}`IgnoredBindingNames`
+- {option}`MinimumParameterNameLength`,
+  [`IgnoredParameterNames`](#readability-identifier-length-ignored-parameter-names)
+- {option}`MinimumLoopCounterNameLength`, {option}`IgnoredLoopCounterNames`
+- {option}`MinimumExceptionNameLength`,
+  {option}`IgnoredExceptionVariableNames`
+- {option}`LineCountThreshold`
 
-.. option:: MinimumVariableNameLength
+````{option} MinimumVariableNameLength
+All variables (other than loop counter, exception names and function
+parameters) are expected to have at least a length of
+{option}`MinimumVariableNameLength`. Setting it to `0` or `1` disables the
+check entirely. Default is `3`.
 
-    All variables (other than loop counter, exception names and function
-    parameters) are expected to have at least a length of
-    `MinimumVariableNameLength` (default is `3`). Setting it to `0` or `1`
-    disables the check entirely.
+```c++
+int i = 42;    // warns that 'i' is too short
+```
+````
 
-    .. code-block:: c++
+```{option} IgnoredVariableNames
+Specifies a regular expression for variable names that are
+to be ignored. Default is empty string, so no names are ignored.
+```
 
-      int i = 42;    // warns that 'i' is too short
+````{option} MinimumBindingNameLength
+All variables introduced by structured bindings are expected to have at
+least a length of {option}`MinimumBindingNameLength`. Setting it to `0` or `1`
+disables the check entirely. Default is `2`.
 
-.. option:: IgnoredVariableNames
+```c++
+auto [a] = get_result();    // warns that 'a' is too short
+```
+````
 
-    Specifies a regular expression for variable names that are
-    to be ignored. The default value is empty, thus no names are ignored.
+```{option} IgnoredBindingNames
+Specifies a regular expression for variable names introduced by structured
+bindings that are to be ignored. The `^[_]$` value allows the `_` idiom to
+specify that the value is discarded on purpose. Default is `^[_]$`.
+```
 
-.. option:: MinimumBindingNameLength
+````{option} MinimumParameterNameLength
+All function parameter names are expected to have a length of at least
+{option}`MinimumParameterNameLength`. Setting it to `0` or `1` disables the
+check entirely. Default is `3`.
 
-    All variables introduced by structured bindings are expected to have at
-    least a length of `MinimumBindingNameLength` (default is `2`). Setting it
-    to `0` or `1` disables the check entirely.
+```c++
+int doubler(int x)   // warns that x is too short
+{
+   return 2 * x;
+}
+```
+````
 
-    .. code-block:: c++
+(readability-identifier-length-ignored-parameter-names)=
 
-      auto [a] = get_result();    // warns that 'a' is too short
+```{option} IgnoredParameterNames
+Specifies a regular expression for parameters that are to be ignored.
+Default is `^[n]$` for historical reasons.
+```
 
-.. option:: IgnoredBindingNames
+````{option} MinimumLoopCounterNameLength
+Loop counter variables are expected to have a length of at least
+{option}`MinimumLoopCounterNameLength` characters. Setting it to `0` or `1`
+disables the check entirely. Default is `2`.
 
-    Specifies a regular expression for variable names introduced by structured
-    bindings that are to be ignored. The default value is `^[_]$`, to allow the
-    use of the `_` idiom to specify that the value is discarded on purpose.
+```c++
+// This warns that 'q' is too short.
+for (int q = 0; q < size; ++ q) {
+   // ...
+}
+```
+````
 
-.. option:: MinimumParameterNameLength
+````{option} IgnoredLoopCounterNames
+Specifies a regular expression for counter names that are to be ignored.
+Default is `^[ijk_]$`; the first three symbols are included for historical
+reasons and the last one since it is frequently used as a "don't care"
+value, specifically in tools such as Google Benchmark.
 
-    All function parameter names are expected to have a length of at least
-    `MinimumParameterNameLength` (default is `3`). Setting it to `0` or `1`
-    disables the check entirely.
+```c++
+// This does not warn by default, for historical reasons.
+for (int i = 0; i < size; ++ i) {
+    // ...
+}
+```
+````
 
-    .. code-block:: c++
+````{option} MinimumExceptionNameLength
+Exception clause variables are expected to have a length of at least
+{option}`MinimumExceptionNameLength`. Setting it to `0` or `1` disables the
+check entirely. Default is `2`.
 
-         int doubler(int x)   // warns that x is too short
-         {
-            return 2 * x;
-         }
+```c++
+try {
+    // ...
+}
+// This warns that 'e' is too short.
+catch (const std::exception& x) {
+    // ...
+}
+```
+````
 
-.. option:: IgnoredParameterNames
+````{option} IgnoredExceptionVariableNames
+Specifies a regular expression for exception variable names that are to
+be ignored. Default is `^[e]$` mainly for historical reasons.
 
-    Specifies a regular expression for parameters that are to be ignored.
-    The default value is `^[n]$` for historical reasons.
+```c++
+try {
+    // ...
+}
+// This does not warn by default, for historical reasons.
+catch (const std::exception& e) {
+    // ...
+}
+```
+````
 
-.. option:: MinimumLoopCounterNameLength
+````{option} LineCountThreshold
+Defines the minimum number of lines required between declaration and last
+use for a diagnostic to be issued. This option only affects the behavior
+regarding local variables: a warning is always issued when a global variable
+has a short name, because globals can potentially be used across multiple
+files. Default is `0`, which corresponds to all variables being flagged.
 
-    Loop counter variables are expected to have a length of at least
-    `MinimumLoopCounterNameLength` characters (default is `2`). Setting it to
-    `0` or `1` disables the check entirely.
-
-    .. code-block:: c++
-
-      // This warns that 'q' is too short.
-      for (int q = 0; q < size; ++ q) {
-         // ...
-      }
-
-.. option:: IgnoredLoopCounterNames
-
-    Specifies a regular expression for counter names that are to be ignored.
-    The default value is `^[ijk_]$`; the first three symbols for historical
-    reasons and the last one since it is frequently used as a "don't care"
-    value, specifically in tools such as Google Benchmark.
-
-    .. code-block:: c++
-
-      // This does not warn by default, for historical reasons.
-      for (int i = 0; i < size; ++ i) {
-          // ...
-      }
-
-.. option:: MinimumExceptionNameLength
-
-    Exception clause variables are expected to have a length of at least
-    `MinimumExceptionNameLength` (default is `2`). Setting it to `0` or `1`
-    disables the check entirely.
-
-    .. code-block:: c++
-
-      try {
-          // ...
-      }
-      // This warns that 'e' is too short.
-      catch (const std::exception& x) {
-          // ...
-      }
-
-.. option:: IgnoredExceptionVariableNames
-
-    Specifies a regular expression for exception variable names that are to
-    be ignored. The default value is `^[e]$` mainly for historical reasons.
-
-    .. code-block:: c++
-
-      try {
-          // ...
-      }
-      // This does not warn by default, for historical reasons.
-      catch (const std::exception& e) {
-          // ...
-      }
-
-.. option:: LineCountThreshold
-
-    Defines the minimum number of lines required between declaration and last
-    use for a diagnostic to be issued. The default value for this option is 0,
-    which corresponds to all variables being flagged. This option only affects
-    the behavior regarding local variables: a warning is always issued when a
-    global variable has a short name, because globals can potentially be used
-    across multiple files.
-
-    .. code-block:: c++
-
-      // In this example, a warning will be issued if LineCountThreshold < N
-      int a = 0;      // First line (declaration line)
-      a = 1;          // Second line
-                      // ...
-      last_use_of(a); // N-th line
+```c++
+// In this example, a warning will be issued if LineCountThreshold < N
+int a = 0;      // First line (declaration line)
+a = 1;          // Second line
+                // ...
+last_use_of(a); // N-th line
+```
+````

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/identifier-naming.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/identifier-naming.md
@@ -1,7 +1,7 @@
-.. title:: clang-tidy - readability-identifier-naming
+```{title} clang-tidy - readability-identifier-naming
+```
 
-readability-identifier-naming
-=============================
+# readability-identifier-naming
 
 Checks for identifiers naming style mismatch.
 
@@ -11,14 +11,14 @@ another if a mismatch is detected
 
 Casing types include:
 
- - ``lower_case``
- - ``UPPER_CASE``
- - ``camelBack``
- - ``CamelCase``
- - ``camel_Snake_Back``
- - ``Camel_Snake_Case``
- - ``aNy_CasE``
- - ``Leading_upper_snake_case``
+- `lower_case`
+- `UPPER_CASE`
+- `camelBack`
+- `CamelCase`
+- `camel_Snake_Back`
+- `Camel_Snake_Case`
+- `aNy_CasE`
+- `Leading_upper_snake_case`
 
 It also supports a fixed prefix and suffix that will be prepended or appended
 to the identifiers, regardless of the casing.
@@ -31,3057 +31,3051 @@ The naming of virtual methods is reported where they occur in the base class,
 but not where they are overridden, as it can't be fixed locally there.
 This also applies for pseudo-override patterns like CRTP.
 
-``Leading_upper_snake_case`` is a naming convention where the first word is
-capitalized followed by lower case word(s) separated by underscore(s) '_'.
+`Leading_upper_snake_case` is a naming convention where the first word is
+capitalized followed by lower case word(s) separated by underscore(s) '\_'.
 Examples include: `Cap_snake_case`, `Cobra_case`, `Foo_bar_baz`,
 and `Master_copy_8gb`.
 
 Hungarian notation can be customized using different *HungarianPrefix*
 settings. The options and their corresponding values are:
 
- - ``Off`` - the default setting
- - ``On`` - example: ``int iVariable``
- - ``LowerCase`` - example: ``int i_Variable``
- - ``CamelCase`` - example: ``int IVariable``
+- `Off` - the default setting
+- `On` - example: `int iVariable`
+- `LowerCase` - example: `int i_Variable`
+- `CamelCase` - example: `int IVariable`
 
 The check only enforces style on kinds of identifiers which have been
 configured, so an empty config effectively disables it.
-The :option:`DefaultCase` option can be used to enforce style on all kinds of
+The {option}`DefaultCase` option can be used to enforce style on all kinds of
 identifiers, then optionally overriden for specific kinds which are desired
 with a different case.
 
 For example using values of:
 
-  - DefaultCase of ``lower_case``
-  - MacroDefinitionCase of ``UPPER_CASE``
-  - TemplateParameterCase of ``CamelCase``
+- {option}`DefaultCase` of `lower_case`
+- {option}`MacroDefinitionCase` of `UPPER_CASE`
+- {option}`TemplateParameterCase` of `CamelCase`
 
 Identifies and transforms names as follows:
 
 Before:
 
-.. code-block:: c++
-
-  #define macroDefinition
-  template <typename typenameParameter>
-  int functionDeclaration(typenameParameter paramVal, int paramCount);
+```c++
+#define macroDefinition
+template <typename typenameParameter>
+int functionDeclaration(typenameParameter paramVal, int paramCount);
+```
 
 After:
 
-.. code-block:: c++
+```c++
+#define MACRO_DEFINITION
+template <typename TypenameParameter>
+int function_declarations(TypenameParameter param_val, int param_count);
+```
 
-  #define MACRO_DEFINITION
-  template <typename TypenameParameter>
-  int function_declarations(TypenameParameter param_val, int param_count);
-
-Options summary
----------------
+## Options summary
 
 The available options are summarized below:
 
 **General options**
 
- - :option:`AggressiveDependentMemberLookup`
- - :option:`AllowTrailingUnderscore`
- - :option:`CheckAnonFieldInParent`
- - :option:`GetConfigPerFile`
- - :option:`IgnoreMainLikeFunctions`
- - :option:`TypedefInheritAnonTagConfig`
+- {option}`AggressiveDependentMemberLookup`
+- {option}`AllowTrailingUnderscore`
+- {option}`CheckAnonFieldInParent`
+- {option}`GetConfigPerFile`
+- {option}`IgnoreMainLikeFunctions`
+- {option}`TypedefInheritAnonTagConfig`
 
 **Specific options**
 
- - :option:`DefaultCase`, :option:`DefaultPrefix`,
-   :option:`DefaultSuffix`, :option:`DefaultIgnoredRegexp`,
-   :option:`DefaultHungarianPrefix`
- - :option:`AbstractClassCase`, :option:`AbstractClassPrefix`,
-   :option:`AbstractClassSuffix`, :option:`AbstractClassIgnoredRegexp`,
-   :option:`AbstractClassHungarianPrefix`
- - :option:`ClassCase`, :option:`ClassPrefix`, :option:`ClassSuffix`,
-   :option:`ClassIgnoredRegexp`, :option:`ClassHungarianPrefix`
- - :option:`ClassConstexprCase`, :option:`ClassConstexprPrefix`,
-   :option:`ClassConstexprSuffix`, :option:`ClassConstexprIgnoredRegexp`,
-   :option:`ClassConstexprHungarianPrefix`
- - :option:`ClassConstantCase`, :option:`ClassConstantPrefix`,
-   :option:`ClassConstantSuffix`, :option:`ClassConstantIgnoredRegexp`,
-   :option:`ClassConstantHungarianPrefix`
- - :option:`ClassMemberCase`, :option:`ClassMemberPrefix`,
-   :option:`ClassMemberSuffix`, :option:`ClassMemberIgnoredRegexp`,
-   :option:`ClassMemberHungarianPrefix`
- - :option:`ClassMethodCase`, :option:`ClassMethodPrefix`,
-   :option:`ClassMethodSuffix`, :option:`ClassMethodIgnoredRegexp`
- - :option:`ConceptCase`, :option:`ConceptPrefix`, :option:`ConceptSuffix`,
-   :option:`ConceptIgnoredRegexp`
- - :option:`ConstantCase`, :option:`ConstantPrefix`, :option:`ConstantSuffix`,
-   :option:`ConstantIgnoredRegexp`, :option:`ConstantHungarianPrefix`
- - :option:`ConstantMemberCase`, :option:`ConstantMemberPrefix`,
-   :option:`ConstantMemberSuffix`, :option:`ConstantMemberIgnoredRegexp`,
-   :option:`ConstantMemberHungarianPrefix`
- - :option:`ConstantParameterCase`, :option:`ConstantParameterPrefix`,
-   :option:`ConstantParameterSuffix`, :option:`ConstantParameterIgnoredRegexp`,
-   :option:`ConstantParameterHungarianPrefix`
- - :option:`ConstantPointerParameterCase`,
-   :option:`ConstantPointerParameterPrefix`,
-   :option:`ConstantPointerParameterSuffix`,
-   :option:`ConstantPointerParameterIgnoredRegexp`,
-   :option:`ConstantPointerParameterHungarianPrefix`
- - :option:`ConstexprFunctionCase`, :option:`ConstexprFunctionPrefix`,
-   :option:`ConstexprFunctionSuffix`, :option:`ConstexprFunctionIgnoredRegexp`
- - :option:`ConstexprMethodCase`, :option:`ConstexprMethodPrefix`,
-   :option:`ConstexprMethodSuffix`, :option:`ConstexprMethodIgnoredRegexp`
- - :option:`ConstexprVariableCase`, :option:`ConstexprVariablePrefix`,
-   :option:`ConstexprVariableSuffix`, :option:`ConstexprVariableIgnoredRegexp`,
-   :option:`ConstexprVariableHungarianPrefix`
- - :option:`EnumCase`, :option:`EnumPrefix`, :option:`EnumSuffix`,
-   :option:`EnumIgnoredRegexp`
- - :option:`EnumConstantCase`, :option:`EnumConstantPrefix`,
-   :option:`EnumConstantSuffix`, :option:`EnumConstantIgnoredRegexp`,
-   :option:`EnumConstantHungarianPrefix`
- - :option:`FunctionCase`, :option:`FunctionPrefix`, :option:`FunctionSuffix`,
-   :option:`FunctionIgnoredRegexp`
- - :option:`GlobalConstexprVariableCase`,
-   :option:`GlobalConstexprVariablePrefix`,
-   :option:`GlobalConstexprVariableSuffix`,
-   :option:`GlobalConstexprVariableIgnoredRegexp`,
-   :option:`GlobalConstexprVariableHungarianPrefix`
- - :option:`GlobalConstantCase`, :option:`GlobalConstantPrefix`,
-   :option:`GlobalConstantSuffix`, :option:`GlobalConstantIgnoredRegexp`,
-   :option:`GlobalConstantHungarianPrefix`
- - :option:`GlobalConstantPointerCase`,
-   :option:`GlobalConstantPointerPrefix`,
-   :option:`GlobalConstantPointerSuffix`,
-   :option:`GlobalConstantPointerIgnoredRegexp`,
-   :option:`GlobalConstantPointerHungarianPrefix`
- - :option:`GlobalFunctionCase`, :option:`GlobalFunctionPrefix`,
-   :option:`GlobalFunctionSuffix`, :option:`GlobalFunctionIgnoredRegexp`
- - :option:`GlobalPointerCase`, :option:`GlobalPointerPrefix`,
-   :option:`GlobalPointerSuffix`, :option:`GlobalPointerIgnoredRegexp`,
-   :option:`GlobalPointerHungarianPrefix`
- - :option:`GlobalVariableCase`, :option:`GlobalVariablePrefix`,
-   :option:`GlobalVariableSuffix`, :option:`GlobalVariableIgnoredRegexp`,
-   :option:`GlobalVariableHungarianPrefix`
- - :option:`InlineNamespaceCase`, :option:`InlineNamespacePrefix`,
-   :option:`InlineNamespaceSuffix`, :option:`InlineNamespaceIgnoredRegexp`
- - :option:`LambdaCaptureCase`, :option:`LambdaCapturePrefix`,
-   :option:`LambdaCaptureSuffix`, :option:`LambdaCaptureIgnoredRegexp`,
-   :option:`LambdaCaptureHungarianPrefix`
- - :option:`LocalConstexprVariableCase`,
-   :option:`LocalConstexprVariablePrefix`,
-   :option:`LocalConstexprVariableSuffix`,
-   :option:`LocalConstexprVariableIgnoredRegexp`,
-   :option:`LocalConstexprVariableHungarianPrefix`
- - :option:`LocalConstantCase`, :option:`LocalConstantPrefix`,
-   :option:`LocalConstantSuffix`, :option:`LocalConstantIgnoredRegexp`,
-   :option:`LocalConstantHungarianPrefix`
- - :option:`LocalConstantPointerCase`,
-   :option:`LocalConstantPointerPrefix`,
-   :option:`LocalConstantPointerSuffix`,
-   :option:`LocalConstantPointerIgnoredRegexp`,
-   :option:`LocalConstantPointerHungarianPrefix`
- - :option:`LocalPointerCase`, :option:`LocalPointerPrefix`,
-   :option:`LocalPointerSuffix`, :option:`LocalPointerIgnoredRegexp`,
-   :option:`LocalPointerHungarianPrefix`
- - :option:`LocalVariableCase`, :option:`LocalVariablePrefix`,
-   :option:`LocalVariableSuffix`, :option:`LocalVariableIgnoredRegexp`,
-   :option:`LocalVariableHungarianPrefix`
- - :option:`MacroDefinitionCase`, :option:`MacroDefinitionPrefix`,
-   :option:`MacroDefinitionSuffix`, :option:`MacroDefinitionIgnoredRegexp`
- - :option:`MemberCase`, :option:`MemberPrefix`, :option:`MemberSuffix`,
-   :option:`MemberIgnoredRegexp`, :option:`MemberHungarianPrefix`
- - :option:`MethodCase`, :option:`MethodPrefix`, :option:`MethodSuffix`,
-   :option:`MethodIgnoredRegexp`
- - :option:`NamespaceCase`, :option:`NamespacePrefix`,
-   :option:`NamespaceSuffix`, :option:`NamespaceIgnoredRegexp`
- - :option:`ParameterCase`, :option:`ParameterPrefix`,
-   :option:`ParameterSuffix`, :option:`ParameterIgnoredRegexp`,
-   :option:`ParameterHungarianPrefix`
- - :option:`ParameterPackCase`, :option:`ParameterPackPrefix`,
-   :option:`ParameterPackSuffix`, :option:`ParameterPackIgnoredRegexp`
- - :option:`PointerParameterCase`, :option:`PointerParameterPrefix`,
-   :option:`PointerParameterSuffix`, :option:`PointerParameterIgnoredRegexp`,
-   :option:`PointerParameterHungarianPrefix`
- - :option:`PrivateMemberCase`, :option:`PrivateMemberPrefix`,
-   :option:`PrivateMemberSuffix`, :option:`PrivateMemberIgnoredRegexp`,
-   :option:`PrivateMemberHungarianPrefix`
- - :option:`PrivateMethodCase`, :option:`PrivateMethodPrefix`,
-   :option:`PrivateMethodSuffix`, :option:`PrivateMethodIgnoredRegexp`
- - :option:`ProtectedMemberCase`, :option:`ProtectedMemberPrefix`,
-   :option:`ProtectedMemberSuffix`, :option:`ProtectedMemberIgnoredRegexp`,
-   :option:`ProtectedMemberHungarianPrefix`
- - :option:`ProtectedMethodCase`, :option:`ProtectedMethodPrefix`,
-   :option:`ProtectedMethodSuffix`, :option:`ProtectedMethodIgnoredRegexp`
- - :option:`PublicMemberCase`, :option:`PublicMemberPrefix`,
-   :option:`PublicMemberSuffix`, :option:`PublicMemberIgnoredRegexp`,
-   :option:`PublicMemberHungarianPrefix`
- - :option:`PublicMethodCase`, :option:`PublicMethodPrefix`,
-   :option:`PublicMethodSuffix`, :option:`PublicMethodIgnoredRegexp`
- - :option:`ScopedEnumConstantCase`, :option:`ScopedEnumConstantPrefix`,
-   :option:`ScopedEnumConstantSuffix`,
-   :option:`ScopedEnumConstantIgnoredRegexp`
- - :option:`StaticConstexprVariableCase`,
-   :option:`StaticConstexprVariablePrefix`,
-   :option:`StaticConstexprVariableSuffix`,
-   :option:`StaticConstexprVariableIgnoredRegexp`,
-   :option:`StaticConstexprVariableHungarianPrefix`
- - :option:`StaticConstantCase`, :option:`StaticConstantPrefix`,
-   :option:`StaticConstantSuffix`, :option:`StaticConstantIgnoredRegexp`,
-   :option:`StaticConstantHungarianPrefix`
- - :option:`StaticVariableCase`, :option:`StaticVariablePrefix`,
-   :option:`StaticVariableSuffix`, :option:`StaticVariableIgnoredRegexp`,
-   :option:`StaticVariableHungarianPrefix`
- - :option:`StructCase`, :option:`StructPrefix`, :option:`StructSuffix`,
-   :option:`StructIgnoredRegexp`
- - :option:`TemplateParameterCase`, :option:`TemplateParameterPrefix`,
-   :option:`TemplateParameterSuffix`, :option:`TemplateParameterIgnoredRegexp`
- - :option:`TemplateTemplateParameterCase`,
-   :option:`TemplateTemplateParameterPrefix`,
-   :option:`TemplateTemplateParameterSuffix`,
-   :option:`TemplateTemplateParameterIgnoredRegexp`
- - :option:`TypeAliasCase`, :option:`TypeAliasPrefix`,
-   :option:`TypeAliasSuffix`, :option:`TypeAliasIgnoredRegexp`
- - :option:`TypedefCase`, :option:`TypedefPrefix`, :option:`TypedefSuffix`,
-   :option:`TypedefIgnoredRegexp`
- - :option:`TypeTemplateParameterCase`,
-   :option:`TypeTemplateParameterPrefix`,
-   :option:`TypeTemplateParameterSuffix`,
-   :option:`TypeTemplateParameterIgnoredRegexp`
- - :option:`UnionCase`, :option:`UnionPrefix`, :option:`UnionSuffix`,
-   :option:`UnionIgnoredRegexp`
- - :option:`ValueTemplateParameterCase`,
-   :option:`ValueTemplateParameterPrefix`,
-   :option:`ValueTemplateParameterSuffix`,
-   :option:`ValueTemplateParameterIgnoredRegexp`
- - :option:`VariableCase`, :option:`VariablePrefix`, :option:`VariableSuffix`,
-   :option:`VariableIgnoredRegexp`, :option:`VariableHungarianPrefix`
- - :option:`VirtualMethodCase`, :option:`VirtualMethodPrefix`,
-   :option:`VirtualMethodSuffix`, :option:`VirtualMethodIgnoredRegexp`
+- {option}`DefaultCase`, {option}`DefaultPrefix`,
+  {option}`DefaultSuffix`, {option}`DefaultIgnoredRegexp`,
+  {option}`DefaultHungarianPrefix`
+- {option}`AbstractClassCase`, {option}`AbstractClassPrefix`,
+  {option}`AbstractClassSuffix`, {option}`AbstractClassIgnoredRegexp`,
+  {option}`AbstractClassHungarianPrefix`
+- {option}`ClassCase`, {option}`ClassPrefix`, {option}`ClassSuffix`,
+  {option}`ClassIgnoredRegexp`, {option}`ClassHungarianPrefix`
+- {option}`ClassConstexprCase`, {option}`ClassConstexprPrefix`,
+  {option}`ClassConstexprSuffix`, {option}`ClassConstexprIgnoredRegexp`,
+  {option}`ClassConstexprHungarianPrefix`
+- {option}`ClassConstantCase`, {option}`ClassConstantPrefix`,
+  {option}`ClassConstantSuffix`, {option}`ClassConstantIgnoredRegexp`,
+  {option}`ClassConstantHungarianPrefix`
+- {option}`ClassMemberCase`, {option}`ClassMemberPrefix`,
+  {option}`ClassMemberSuffix`, {option}`ClassMemberIgnoredRegexp`,
+  {option}`ClassMemberHungarianPrefix`
+- {option}`ClassMethodCase`, {option}`ClassMethodPrefix`,
+  {option}`ClassMethodSuffix`, {option}`ClassMethodIgnoredRegexp`
+- {option}`ConceptCase`, {option}`ConceptPrefix`, {option}`ConceptSuffix`,
+  {option}`ConceptIgnoredRegexp`
+- {option}`ConstantCase`, {option}`ConstantPrefix`, {option}`ConstantSuffix`,
+  {option}`ConstantIgnoredRegexp`, {option}`ConstantHungarianPrefix`
+- {option}`ConstantMemberCase`, {option}`ConstantMemberPrefix`,
+  {option}`ConstantMemberSuffix`, {option}`ConstantMemberIgnoredRegexp`,
+  {option}`ConstantMemberHungarianPrefix`
+- {option}`ConstantParameterCase`, {option}`ConstantParameterPrefix`,
+  {option}`ConstantParameterSuffix`, {option}`ConstantParameterIgnoredRegexp`,
+  {option}`ConstantParameterHungarianPrefix`
+- {option}`ConstantPointerParameterCase`,
+  {option}`ConstantPointerParameterPrefix`,
+  {option}`ConstantPointerParameterSuffix`,
+  {option}`ConstantPointerParameterIgnoredRegexp`,
+  {option}`ConstantPointerParameterHungarianPrefix`
+- {option}`ConstexprFunctionCase`, {option}`ConstexprFunctionPrefix`,
+  {option}`ConstexprFunctionSuffix`, {option}`ConstexprFunctionIgnoredRegexp`
+- {option}`ConstexprMethodCase`, {option}`ConstexprMethodPrefix`,
+  {option}`ConstexprMethodSuffix`, {option}`ConstexprMethodIgnoredRegexp`
+- {option}`ConstexprVariableCase`, {option}`ConstexprVariablePrefix`,
+  {option}`ConstexprVariableSuffix`, {option}`ConstexprVariableIgnoredRegexp`,
+  {option}`ConstexprVariableHungarianPrefix`
+- {option}`EnumCase`, {option}`EnumPrefix`, {option}`EnumSuffix`,
+  {option}`EnumIgnoredRegexp`
+- {option}`EnumConstantCase`, {option}`EnumConstantPrefix`,
+  {option}`EnumConstantSuffix`, {option}`EnumConstantIgnoredRegexp`,
+  {option}`EnumConstantHungarianPrefix`
+- {option}`FunctionCase`, {option}`FunctionPrefix`, {option}`FunctionSuffix`,
+  {option}`FunctionIgnoredRegexp`
+- {option}`GlobalConstexprVariableCase`,
+  {option}`GlobalConstexprVariablePrefix`,
+  {option}`GlobalConstexprVariableSuffix`,
+  {option}`GlobalConstexprVariableIgnoredRegexp`,
+  {option}`GlobalConstexprVariableHungarianPrefix`
+- {option}`GlobalConstantCase`, {option}`GlobalConstantPrefix`,
+  {option}`GlobalConstantSuffix`, {option}`GlobalConstantIgnoredRegexp`,
+  {option}`GlobalConstantHungarianPrefix`
+- {option}`GlobalConstantPointerCase`,
+  {option}`GlobalConstantPointerPrefix`,
+  {option}`GlobalConstantPointerSuffix`,
+  {option}`GlobalConstantPointerIgnoredRegexp`,
+  {option}`GlobalConstantPointerHungarianPrefix`
+- {option}`GlobalFunctionCase`, {option}`GlobalFunctionPrefix`,
+  {option}`GlobalFunctionSuffix`, {option}`GlobalFunctionIgnoredRegexp`
+- {option}`GlobalPointerCase`, {option}`GlobalPointerPrefix`,
+  {option}`GlobalPointerSuffix`, {option}`GlobalPointerIgnoredRegexp`,
+  {option}`GlobalPointerHungarianPrefix`
+- {option}`GlobalVariableCase`, {option}`GlobalVariablePrefix`,
+  {option}`GlobalVariableSuffix`, {option}`GlobalVariableIgnoredRegexp`,
+  {option}`GlobalVariableHungarianPrefix`
+- {option}`InlineNamespaceCase`, {option}`InlineNamespacePrefix`,
+  {option}`InlineNamespaceSuffix`, {option}`InlineNamespaceIgnoredRegexp`
+- {option}`LambdaCaptureCase`, {option}`LambdaCapturePrefix`,
+  {option}`LambdaCaptureSuffix`, {option}`LambdaCaptureIgnoredRegexp`,
+  {option}`LambdaCaptureHungarianPrefix`
+- {option}`LocalConstexprVariableCase`,
+  {option}`LocalConstexprVariablePrefix`,
+  {option}`LocalConstexprVariableSuffix`,
+  {option}`LocalConstexprVariableIgnoredRegexp`,
+  {option}`LocalConstexprVariableHungarianPrefix`
+- {option}`LocalConstantCase`, {option}`LocalConstantPrefix`,
+  {option}`LocalConstantSuffix`, {option}`LocalConstantIgnoredRegexp`,
+  {option}`LocalConstantHungarianPrefix`
+- {option}`LocalConstantPointerCase`,
+  {option}`LocalConstantPointerPrefix`,
+  {option}`LocalConstantPointerSuffix`,
+  {option}`LocalConstantPointerIgnoredRegexp`,
+  {option}`LocalConstantPointerHungarianPrefix`
+- {option}`LocalPointerCase`, {option}`LocalPointerPrefix`,
+  {option}`LocalPointerSuffix`, {option}`LocalPointerIgnoredRegexp`,
+  {option}`LocalPointerHungarianPrefix`
+- {option}`LocalVariableCase`, {option}`LocalVariablePrefix`,
+  {option}`LocalVariableSuffix`, {option}`LocalVariableIgnoredRegexp`,
+  {option}`LocalVariableHungarianPrefix`
+- {option}`MacroDefinitionCase`, {option}`MacroDefinitionPrefix`,
+  {option}`MacroDefinitionSuffix`, {option}`MacroDefinitionIgnoredRegexp`
+- {option}`MemberCase`, {option}`MemberPrefix`, {option}`MemberSuffix`,
+  {option}`MemberIgnoredRegexp`, {option}`MemberHungarianPrefix`
+- {option}`MethodCase`, {option}`MethodPrefix`, {option}`MethodSuffix`,
+  {option}`MethodIgnoredRegexp`
+- {option}`NamespaceCase`, {option}`NamespacePrefix`,
+  {option}`NamespaceSuffix`, {option}`NamespaceIgnoredRegexp`
+- {option}`ParameterCase`, {option}`ParameterPrefix`,
+  {option}`ParameterSuffix`, {option}`ParameterIgnoredRegexp`,
+  {option}`ParameterHungarianPrefix`
+- {option}`ParameterPackCase`, {option}`ParameterPackPrefix`,
+  {option}`ParameterPackSuffix`, {option}`ParameterPackIgnoredRegexp`
+- {option}`PointerParameterCase`, {option}`PointerParameterPrefix`,
+  {option}`PointerParameterSuffix`, {option}`PointerParameterIgnoredRegexp`,
+  {option}`PointerParameterHungarianPrefix`
+- {option}`PrivateMemberCase`, {option}`PrivateMemberPrefix`,
+  {option}`PrivateMemberSuffix`, {option}`PrivateMemberIgnoredRegexp`,
+  {option}`PrivateMemberHungarianPrefix`
+- {option}`PrivateMethodCase`, {option}`PrivateMethodPrefix`,
+  {option}`PrivateMethodSuffix`, {option}`PrivateMethodIgnoredRegexp`
+- {option}`ProtectedMemberCase`, {option}`ProtectedMemberPrefix`,
+  {option}`ProtectedMemberSuffix`, {option}`ProtectedMemberIgnoredRegexp`,
+  {option}`ProtectedMemberHungarianPrefix`
+- {option}`ProtectedMethodCase`, {option}`ProtectedMethodPrefix`,
+  {option}`ProtectedMethodSuffix`, {option}`ProtectedMethodIgnoredRegexp`
+- {option}`PublicMemberCase`, {option}`PublicMemberPrefix`,
+  {option}`PublicMemberSuffix`, {option}`PublicMemberIgnoredRegexp`,
+  {option}`PublicMemberHungarianPrefix`
+- {option}`PublicMethodCase`, {option}`PublicMethodPrefix`,
+  {option}`PublicMethodSuffix`, {option}`PublicMethodIgnoredRegexp`
+- {option}`ScopedEnumConstantCase`, {option}`ScopedEnumConstantPrefix`,
+  {option}`ScopedEnumConstantSuffix`,
+  {option}`ScopedEnumConstantIgnoredRegexp`
+- {option}`StaticConstexprVariableCase`,
+  {option}`StaticConstexprVariablePrefix`,
+  {option}`StaticConstexprVariableSuffix`,
+  {option}`StaticConstexprVariableIgnoredRegexp`,
+  {option}`StaticConstexprVariableHungarianPrefix`
+- {option}`StaticConstantCase`, {option}`StaticConstantPrefix`,
+  {option}`StaticConstantSuffix`, {option}`StaticConstantIgnoredRegexp`,
+  {option}`StaticConstantHungarianPrefix`
+- {option}`StaticVariableCase`, {option}`StaticVariablePrefix`,
+  {option}`StaticVariableSuffix`, {option}`StaticVariableIgnoredRegexp`,
+  {option}`StaticVariableHungarianPrefix`
+- {option}`StructCase`, {option}`StructPrefix`, {option}`StructSuffix`,
+  {option}`StructIgnoredRegexp`
+- {option}`TemplateParameterCase`, {option}`TemplateParameterPrefix`,
+  {option}`TemplateParameterSuffix`, {option}`TemplateParameterIgnoredRegexp`
+- {option}`TemplateTemplateParameterCase`,
+  {option}`TemplateTemplateParameterPrefix`,
+  {option}`TemplateTemplateParameterSuffix`,
+  {option}`TemplateTemplateParameterIgnoredRegexp`
+- {option}`TypeAliasCase`, {option}`TypeAliasPrefix`,
+  {option}`TypeAliasSuffix`, {option}`TypeAliasIgnoredRegexp`
+- {option}`TypedefCase`, {option}`TypedefPrefix`, {option}`TypedefSuffix`,
+  {option}`TypedefIgnoredRegexp`
+- {option}`TypeTemplateParameterCase`,
+  {option}`TypeTemplateParameterPrefix`,
+  {option}`TypeTemplateParameterSuffix`,
+  {option}`TypeTemplateParameterIgnoredRegexp`
+- {option}`UnionCase`, {option}`UnionPrefix`, {option}`UnionSuffix`,
+  {option}`UnionIgnoredRegexp`
+- {option}`ValueTemplateParameterCase`,
+  {option}`ValueTemplateParameterPrefix`,
+  {option}`ValueTemplateParameterSuffix`,
+  {option}`ValueTemplateParameterIgnoredRegexp`
+- {option}`VariableCase`, {option}`VariablePrefix`, {option}`VariableSuffix`,
+  {option}`VariableIgnoredRegexp`, {option}`VariableHungarianPrefix`
+- {option}`VirtualMethodCase`, {option}`VirtualMethodPrefix`,
+  {option}`VirtualMethodSuffix`, {option}`VirtualMethodIgnoredRegexp`
 
-
-Options description
--------------------
+## Options description
 
 A detailed description of each option is presented below:
 
-.. option:: DefaultCase
+```{option} DefaultCase
+When defined, the check will ensure all names by default conform to the
+selected casing.
+```
 
-    When defined, the check will ensure all names by default conform to the
-    selected casing.
+```{option} DefaultPrefix
+When defined, the check will ensure all names by default will add the
+prefix with the given value (regardless of casing).
+```
 
-.. option:: DefaultPrefix
+```{option} DefaultIgnoredRegexp
+Identifier naming checks won't be enforced for all names by default
+matching this regular expression.
+```
 
-    When defined, the check will ensure all names by default will add the
-    prefix with the given value (regardless of casing).
+```{option} DefaultSuffix
+When defined, the check will ensure all names by default will add the
+suffix with the given value (regardless of casing).
+```
 
-.. option:: DefaultIgnoredRegexp
+```{option} DefaultHungarianPrefix
+When enabled, the check ensures that the declared identifier will
+have a Hungarian notation prefix based on the declared type.
+```
 
-    Identifier naming checks won't be enforced for all names by default
-    matching this regular expression.
+```{option} AbstractClassCase
+When defined, the check will ensure abstract class names conform to the
+selected casing.
+```
 
-.. option:: DefaultSuffix
+```{option} AbstractClassPrefix
+When defined, the check will ensure abstract class names will add the
+prefix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure all names by default will add the
-    suffix with the given value (regardless of casing).
+```{option} AbstractClassIgnoredRegexp
+Identifier naming checks won't be enforced for abstract class names
+matching this regular expression.
+```
 
-.. option:: DefaultHungarianPrefix
+```{option} AbstractClassSuffix
+When defined, the check will ensure abstract class names will add the
+suffix with the given value (regardless of casing).
+```
 
-    When enabled, the check ensures that the declared identifier will
-    have a Hungarian notation prefix based on the declared type.
-
-.. option:: AbstractClassCase
-
-    When defined, the check will ensure abstract class names conform to the
-    selected casing.
-
-.. option:: AbstractClassPrefix
-
-    When defined, the check will ensure abstract class names will add the
-    prefix with the given value (regardless of casing).
-
-.. option:: AbstractClassIgnoredRegexp
-
-    Identifier naming checks won't be enforced for abstract class names
-    matching this regular expression.
-
-.. option:: AbstractClassSuffix
-
-    When defined, the check will ensure abstract class names will add the
-    suffix with the given value (regardless of casing).
-
-.. option:: AbstractClassHungarianPrefix
-
-    When enabled, the check ensures that the declared identifier will
-    have a Hungarian notation prefix based on the declared type.
+```{option} AbstractClassHungarianPrefix
+When enabled, the check ensures that the declared identifier will
+have a Hungarian notation prefix based on the declared type.
+```
 
 For example using values of:
 
-   - AbstractClassCase of ``lower_case``
-   - AbstractClassPrefix of ``pre_``
-   - AbstractClassSuffix of ``_post``
-   - AbstractClassHungarianPrefix of ``On``
-
+- {option}`AbstractClassCase` of `lower_case`
+- {option}`AbstractClassPrefix` of `pre_`
+- {option}`AbstractClassSuffix` of `_post`
+- {option}`AbstractClassHungarianPrefix` of `On`
 
 Identifies and/or transforms abstract class names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    class ABSTRACT_CLASS {
-    public:
-      ABSTRACT_CLASS();
-    };
+```c++
+class ABSTRACT_CLASS {
+public:
+  ABSTRACT_CLASS();
+};
+```
 
 After:
 
-.. code-block:: c++
+```c++
+class pre_abstract_class_post {
+public:
+  pre_abstract_class_post();
+};
+```
 
-    class pre_abstract_class_post {
-    public:
-      pre_abstract_class_post();
-    };
-
-.. option:: AggressiveDependentMemberLookup
-
-    When set to `true` the check will look in dependent base classes for dependent
-    member references that need changing. This can lead to errors with template
-    specializations so the default value is `false`.
+```{option} AggressiveDependentMemberLookup
+When `true`, the check will look in dependent base classes for dependent
+member references that need changing. This can lead to errors with template
+specializations. Default is `false`.
+```
 
 For example using values of:
 
-   - ClassMemberCase of ``lower_case``
+- {option}`ClassMemberCase` of `lower_case`
 
 Before:
 
-.. code-block:: c++
+```c++
+template <typename T>
+struct Base {
+  T BadNamedMember;
+};
 
-    template <typename T>
-    struct Base {
-      T BadNamedMember;
-    };
+template <typename T>
+struct Derived : Base<T> {
+  void reset() {
+    this->BadNamedMember = 0;
+  }
+};
+```
 
-    template <typename T>
-    struct Derived : Base<T> {
-      void reset() {
-        this->BadNamedMember = 0;
-      }
-    };
+After if {option}`AggressiveDependentMemberLookup` is `false`:
 
-After if AggressiveDependentMemberLookup is `false`:
+```c++
+template <typename T>
+struct Base {
+  T bad_named_member;
+};
 
-.. code-block:: c++
+template <typename T>
+struct Derived : Base<T> {
+  void reset() {
+    this->BadNamedMember = 0;
+  }
+};
+```
 
-    template <typename T>
-    struct Base {
-      T bad_named_member;
-    };
+After if {option}`AggressiveDependentMemberLookup` is `true`:
 
-    template <typename T>
-    struct Derived : Base<T> {
-      void reset() {
-        this->BadNamedMember = 0;
-      }
-    };
+```c++
+template <typename T>
+struct Base {
+  T bad_named_member;
+};
 
-After if AggressiveDependentMemberLookup is `true`:
+template <typename T>
+struct Derived : Base<T> {
+  void reset() {
+    this->bad_named_member = 0;
+  }
+};
+```
 
-.. code-block:: c++
-
-    template <typename T>
-    struct Base {
-      T bad_named_member;
-    };
-
-    template <typename T>
-    struct Derived : Base<T> {
-      void reset() {
-        this->bad_named_member = 0;
-      }
-    };
-
-.. option:: AllowTrailingUnderscore
-
-    When set to `true`, a single trailing underscore is allowed on any
-    identifier, in addition to whatever casing, prefix and suffix are
-    otherwise configured for its kind.
+```{option} AllowTrailingUnderscore
+When `true`, a single trailing underscore is allowed on any identifier, in
+addition to whatever casing, prefix and suffix are otherwise configured for
+its kind.
+```
 
 For example using values:
 
-   - :option:`AllowTrailingUnderscore` is `true`
-   - :option:`LocalVariableCase` is `camelBack`
+- {option}`AllowTrailingUnderscore` is `true`
+- {option}`LocalVariableCase` is `camelBack`
 
 Transforms names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    void f(int value) {
-      int Value_ = value;
-    }
+```c++
+void f(int value) {
+  int Value_ = value;
+}
+```
 
 After:
 
-.. code-block:: c++
+```c++
+void f(int value) {
+  int value_ = value;
+}
+```
 
-    void f(int value) {
-      int value_ = value;
-    }
-
-.. option:: CheckAnonFieldInParent
-
-    When set to `true`, fields in anonymous records (i.e. anonymous
-    unions and structs) will be treated as names in the enclosing scope
-    rather than public members of the anonymous record for the purpose
-    of name checking.
+```{option} CheckAnonFieldInParent
+When `true`, fields in anonymous records (i.e. anonymous
+unions and structs) will be treated as names in the enclosing scope
+rather than public members of the anonymous record for the purpose
+of name checking.
+```
 
 For example:
 
-.. code-block:: c++
+```c++
+class Foo {
+private:
+  union {
+    int iv_;
+    float fv_;
+  };
+};
+```
 
-    class Foo {
-    private:
-      union {
-        int iv_;
-        float fv_;
-      };
-    };
-
-If :option:`CheckAnonFieldInParent` is `false`, you may get warnings
-that ``iv_`` and ``fv_`` are not coherent to public member names, because
-``iv_`` and ``fv_`` are public members of the anonymous union. When
-:option:`CheckAnonFieldInParent` is `true`, ``iv_`` and ``fv_`` will be
-treated as private data members of ``Foo`` for the purpose of name checking
+If {option}`CheckAnonFieldInParent` is `false`, you may get warnings
+that `iv_` and `fv_` are not coherent to public member names, because
+`iv_` and `fv_` are public members of the anonymous union. When
+{option}`CheckAnonFieldInParent` is `true`, `iv_` and `fv_` will be
+treated as private data members of `Foo` for the purpose of name checking
 and thus no warnings will be emitted.
 
-.. option:: ClassCase
+```{option} ClassCase
+When defined, the check will ensure class names conform to the
+selected casing.
+```
 
-    When defined, the check will ensure class names conform to the
-    selected casing.
+```{option} ClassPrefix
+When defined, the check will ensure class names will add the
+prefix with the given value (regardless of casing).
+```
 
-.. option:: ClassPrefix
+```{option} ClassIgnoredRegexp
+Identifier naming checks won't be enforced for class names matching
+this regular expression.
+```
 
-    When defined, the check will ensure class names will add the
-    prefix with the given value (regardless of casing).
+```{option} ClassSuffix
+When defined, the check will ensure class names will add the
+suffix with the given value (regardless of casing).
+```
 
-.. option:: ClassIgnoredRegexp
-
-    Identifier naming checks won't be enforced for class names matching
-    this regular expression.
-
-.. option:: ClassSuffix
-
-    When defined, the check will ensure class names will add the
-    suffix with the given value (regardless of casing).
-
-.. option:: ClassHungarianPrefix
-
-    When enabled, the check ensures that the declared identifier will
-    have a Hungarian notation prefix based on the declared type.
+```{option} ClassHungarianPrefix
+When enabled, the check ensures that the declared identifier will
+have a Hungarian notation prefix based on the declared type.
+```
 
 For example using values of:
 
-   - ClassCase of ``lower_case``
-   - ClassPrefix of ``pre_``
-   - ClassSuffix of ``_post``
-   - ClassHungarianPrefix of ``On``
+- {option}`ClassCase` of `lower_case`
+- {option}`ClassPrefix` of `pre_`
+- {option}`ClassSuffix` of `_post`
+- {option}`ClassHungarianPrefix` of `On`
 
 Identifies and/or transforms class names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    class FOO {
-    public:
-      FOO();
-      ~FOO();
-    };
+```c++
+class FOO {
+public:
+  FOO();
+  ~FOO();
+};
+```
 
 After:
 
-.. code-block:: c++
+```c++
+class pre_foo_post {
+public:
+  pre_foo_post();
+  ~pre_foo_post();
+};
+```
 
-    class pre_foo_post {
-    public:
-      pre_foo_post();
-      ~pre_foo_post();
-    };
+```{option} ClassConstexprCase
+When defined, the check will ensure class `constexpr` names conform to
+the selected casing.
+```
 
-.. option:: ClassConstexprCase
+```{option} ClassConstexprPrefix
+When defined, the check will ensure class `constexpr` names will add the
+prefix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure class ``constexpr`` names conform to
-    the selected casing.
+```{option} ClassConstexprIgnoredRegexp
+Identifier naming checks won't be enforced for class `constexpr` names
+matching this regular expression.
+```
 
-.. option:: ClassConstexprPrefix
+```{option} ClassConstexprSuffix
+When defined, the check will ensure class `constexpr` names will add the
+suffix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure class ``constexpr`` names will add the
-    prefix with the given value (regardless of casing).
-
-.. option:: ClassConstexprIgnoredRegexp
-
-    Identifier naming checks won't be enforced for class ``constexpr`` names
-    matching this regular expression.
-
-.. option:: ClassConstexprSuffix
-
-    When defined, the check will ensure class ``constexpr`` names will add the
-    suffix with the given value (regardless of casing).
-
-.. option:: ClassConstexprHungarianPrefix
-
-    When enabled, the check ensures that the declared identifier will have a
-    Hungarian notation prefix based on the declared type.
+```{option} ClassConstexprHungarianPrefix
+When enabled, the check ensures that the declared identifier will have a
+Hungarian notation prefix based on the declared type.
+```
 
 For example using values of:
 
-   - ClassConstexprCase of ``lower_case``
-   - ClassConstexprPrefix of ``pre_``
-   - ClassConstexprSuffix of ``_post``
-   - ClassConstexprHungarianPrefix of ``On``
+- {option}`ClassConstexprCase` of `lower_case`
+- {option}`ClassConstexprPrefix` of `pre_`
+- {option}`ClassConstexprSuffix` of `_post`
+- {option}`ClassConstexprHungarianPrefix` of `On`
 
-Identifies and/or transforms class ``constexpr`` variable names as follows:
+Identifies and/or transforms class `constexpr` variable names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    class FOO {
-    public:
-      static constexpr int CLASS_CONSTEXPR;
-    };
+```c++
+class FOO {
+public:
+  static constexpr int CLASS_CONSTEXPR;
+};
+```
 
 After:
 
-.. code-block:: c++
+```c++
+class FOO {
+public:
+  static const int pre_class_constexpr_post;
+};
+```
 
-    class FOO {
-    public:
-      static const int pre_class_constexpr_post;
-    };
+```{option} ClassConstantCase
+When defined, the check will ensure class constant names conform to the
+selected casing.
+```
 
-.. option:: ClassConstantCase
+```{option} ClassConstantPrefix
+When defined, the check will ensure class constant names will add the
+prefix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure class constant names conform to the
-    selected casing.
+```{option} ClassConstantIgnoredRegexp
+Identifier naming checks won't be enforced for class constant names
+matching this regular expression.
+```
 
-.. option:: ClassConstantPrefix
+```{option} ClassConstantSuffix
+When defined, the check will ensure class constant names will add the
+suffix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure class constant names will add the
-    prefix with the given value (regardless of casing).
-
-.. option:: ClassConstantIgnoredRegexp
-
-    Identifier naming checks won't be enforced for class constant names
-    matching this regular expression.
-
-.. option:: ClassConstantSuffix
-
-    When defined, the check will ensure class constant names will add the
-    suffix with the given value (regardless of casing).
-
-.. option:: ClassConstantHungarianPrefix
-
-    When enabled, the check ensures that the declared identifier will
-    have a Hungarian notation prefix based on the declared type.
+```{option} ClassConstantHungarianPrefix
+When enabled, the check ensures that the declared identifier will
+have a Hungarian notation prefix based on the declared type.
+```
 
 For example using values of:
 
-   - ClassConstantCase of ``lower_case``
-   - ClassConstantPrefix of ``pre_``
-   - ClassConstantSuffix of ``_post``
-   - ClassConstantHungarianPrefix of ``On``
+- {option}`ClassConstantCase` of `lower_case`
+- {option}`ClassConstantPrefix` of `pre_`
+- {option}`ClassConstantSuffix` of `_post`
+- {option}`ClassConstantHungarianPrefix` of `On`
 
 Identifies and/or transforms class constant names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    class FOO {
-    public:
-      static const int CLASS_CONSTANT;
-    };
+```c++
+class FOO {
+public:
+  static const int CLASS_CONSTANT;
+};
+```
 
 After:
 
-.. code-block:: c++
+```c++
+class FOO {
+public:
+  static const int pre_class_constant_post;
+};
+```
 
-    class FOO {
-    public:
-      static const int pre_class_constant_post;
-    };
+```{option} ClassMemberCase
+When defined, the check will ensure class member names conform to the
+selected casing.
+```
 
-.. option:: ClassMemberCase
+```{option} ClassMemberPrefix
+When defined, the check will ensure class member names will add the
+prefix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure class member names conform to the
-    selected casing.
+```{option} ClassMemberIgnoredRegexp
+Identifier naming checks won't be enforced for class member names
+matching this regular expression.
+```
 
-.. option:: ClassMemberPrefix
+```{option} ClassMemberSuffix
+When defined, the check will ensure class member names will add the
+suffix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure class member names will add the
-    prefix with the given value (regardless of casing).
-
-.. option:: ClassMemberIgnoredRegexp
-
-    Identifier naming checks won't be enforced for class member names
-    matching this regular expression.
-
-.. option:: ClassMemberSuffix
-
-    When defined, the check will ensure class member names will add the
-    suffix with the given value (regardless of casing).
-
-.. option:: ClassMemberHungarianPrefix
-
-    When enabled, the check ensures that the declared identifier will
-    have a Hungarian notation prefix based on the declared type.
+```{option} ClassMemberHungarianPrefix
+When enabled, the check ensures that the declared identifier will
+have a Hungarian notation prefix based on the declared type.
+```
 
 For example using values of:
 
-   - ClassMemberCase of ``lower_case``
-   - ClassMemberPrefix of ``pre_``
-   - ClassMemberSuffix of ``_post``
-   - ClassMemberHungarianPrefix of ``On``
+- {option}`ClassMemberCase` of `lower_case`
+- {option}`ClassMemberPrefix` of `pre_`
+- {option}`ClassMemberSuffix` of `_post`
+- {option}`ClassMemberHungarianPrefix` of `On`
 
 Identifies and/or transforms class member names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    class FOO {
-    public:
-      static int CLASS_CONSTANT;
-    };
+```c++
+class FOO {
+public:
+  static int CLASS_CONSTANT;
+};
+```
 
 After:
 
-.. code-block:: c++
+```c++
+class FOO {
+public:
+  static int pre_class_constant_post;
+};
+```
 
-    class FOO {
-    public:
-      static int pre_class_constant_post;
-    };
+```{option} ClassMethodCase
+When defined, the check will ensure class method names conform to the
+selected casing.
+```
 
-.. option:: ClassMethodCase
+```{option} ClassMethodPrefix
+When defined, the check will ensure class method names will add the
+prefix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure class method names conform to the
-    selected casing.
+```{option} ClassMethodIgnoredRegexp
+Identifier naming checks won't be enforced for class method names
+matching this regular expression.
+```
 
-.. option:: ClassMethodPrefix
-
-    When defined, the check will ensure class method names will add the
-    prefix with the given value (regardless of casing).
-
-.. option:: ClassMethodIgnoredRegexp
-
-    Identifier naming checks won't be enforced for class method names
-    matching this regular expression.
-
-.. option:: ClassMethodSuffix
-
-    When defined, the check will ensure class method names will add the
-    suffix with the given value (regardless of casing).
+```{option} ClassMethodSuffix
+When defined, the check will ensure class method names will add the
+suffix with the given value (regardless of casing).
+```
 
 For example using values of:
 
-   - ClassMethodCase of ``lower_case``
-   - ClassMethodPrefix of ``pre_``
-   - ClassMethodSuffix of ``_post``
+- {option}`ClassMethodCase` of `lower_case`
+- {option}`ClassMethodPrefix` of `pre_`
+- {option}`ClassMethodSuffix` of `_post`
 
 Identifies and/or transforms class method names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    class FOO {
-    public:
-      int CLASS_MEMBER();
-    };
+```c++
+class FOO {
+public:
+  int CLASS_MEMBER();
+};
+```
 
 After:
 
-.. code-block:: c++
+```c++
+class FOO {
+public:
+  int pre_class_member_post();
+};
+```
 
-    class FOO {
-    public:
-      int pre_class_member_post();
-    };
+```{option} ConceptCase
+When defined, the check will ensure concept names conform to the
+selected casing.
+```
 
-.. option:: ConceptCase
+```{option} ConceptPrefix
+When defined, the check will ensure concept names will add the
+prefix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure concept names conform to the
-    selected casing.
+```{option} ConceptIgnoredRegexp
+Identifier naming checks won't be enforced for concept names
+matching this regular expression.
+```
 
-.. option:: ConceptPrefix
-
-    When defined, the check will ensure concept names will add the
-    prefix with the given value (regardless of casing).
-
-.. option:: ConceptIgnoredRegexp
-
-    Identifier naming checks won't be enforced for concept names
-    matching this regular expression.
-
-.. option:: ConceptSuffix
-
-    When defined, the check will ensure concept names will add the
-    suffix with the given value (regardless of casing).
+```{option} ConceptSuffix
+When defined, the check will ensure concept names will add the
+suffix with the given value (regardless of casing).
+```
 
 For example using values of:
 
-   - ConceptCase of ``CamelCase``
-   - ConceptPrefix of ``Pre``
-   - ConceptSuffix of ``Post``
+- {option}`ConceptCase` of `CamelCase`
+- {option}`ConceptPrefix` of `Pre`
+- {option}`ConceptSuffix` of `Post`
 
 Identifies and/or transforms concept names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    template<typename T> concept my_concept = requires (T t) { {t++}; };
+```c++
+template<typename T> concept my_concept = requires (T t) { {t++}; };
+```
 
 After:
 
-.. code-block:: c++
+```c++
+template<typename T> concept PreMyConceptPost = requires (T t) { {t++}; };
+```
 
-    template<typename T> concept PreMyConceptPost = requires (T t) { {t++}; };
+```{option} ConstantCase
+When defined, the check will ensure constant names conform to the
+selected casing.
+```
 
-.. option:: ConstantCase
+```{option} ConstantPrefix
+When defined, the check will ensure constant names will add the
+prefix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure constant names conform to the
-    selected casing.
+```{option} ConstantIgnoredRegexp
+Identifier naming checks won't be enforced for constant names
+matching this regular expression.
+```
 
-.. option:: ConstantPrefix
+```{option} ConstantSuffix
+When defined, the check will ensure constant names will add the
+suffix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure constant names will add the
-    prefix with the given value (regardless of casing).
-
-.. option:: ConstantIgnoredRegexp
-
-    Identifier naming checks won't be enforced for constant names
-    matching this regular expression.
-
-.. option:: ConstantSuffix
-
-    When defined, the check will ensure constant names will add the
-    suffix with the given value (regardless of casing).
-
-.. option:: ConstantHungarianPrefix
-
-    When enabled, the check ensures that the declared identifier will
-    have a Hungarian notation prefix based on the declared type.
+```{option} ConstantHungarianPrefix
+When enabled, the check ensures that the declared identifier will
+have a Hungarian notation prefix based on the declared type.
+```
 
 For example using values of:
 
-   - ConstantCase of ``lower_case``
-   - ConstantPrefix of ``pre_``
-   - ConstantSuffix of ``_post``
-   - ConstantHungarianPrefix of ``On``
+- {option}`ConstantCase` of `lower_case`
+- {option}`ConstantPrefix` of `pre_`
+- {option}`ConstantSuffix` of `_post`
+- {option}`ConstantHungarianPrefix` of `On`
 
 Identifies and/or transforms constant names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    void function() { unsigned const MyConst_array[] = {1, 2, 3}; }
+```c++
+void function() { unsigned const MyConst_array[] = {1, 2, 3}; }
+```
 
 After:
 
-.. code-block:: c++
+```c++
+void function() { unsigned const pre_myconst_array_post[] = {1, 2, 3}; }
+```
 
-    void function() { unsigned const pre_myconst_array_post[] = {1, 2, 3}; }
+```{option} ConstantMemberCase
+When defined, the check will ensure constant member names conform to the
+selected casing.
+```
 
-.. option:: ConstantMemberCase
+```{option} ConstantMemberPrefix
+When defined, the check will ensure constant member names will add the
+prefix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure constant member names conform to the
-    selected casing.
+```{option} ConstantMemberIgnoredRegexp
+Identifier naming checks won't be enforced for constant member names
+matching this regular expression.
+```
 
-.. option:: ConstantMemberPrefix
+```{option} ConstantMemberSuffix
+When defined, the check will ensure constant member names will add the
+suffix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure constant member names will add the
-    prefix with the given value (regardless of casing).
-
-.. option:: ConstantMemberIgnoredRegexp
-
-    Identifier naming checks won't be enforced for constant member names
-    matching this regular expression.
-
-.. option:: ConstantMemberSuffix
-
-    When defined, the check will ensure constant member names will add the
-    suffix with the given value (regardless of casing).
-
-.. option:: ConstantMemberHungarianPrefix
-
-    When enabled, the check ensures that the declared identifier will
-    have a Hungarian notation prefix based on the declared type.
+```{option} ConstantMemberHungarianPrefix
+When enabled, the check ensures that the declared identifier will
+have a Hungarian notation prefix based on the declared type.
+```
 
 For example using values of:
 
-   - ConstantMemberCase of ``lower_case``
-   - ConstantMemberPrefix of ``pre_``
-   - ConstantMemberSuffix of ``_post``
-   - ConstantMemberHungarianPrefix of ``On``
+- {option}`ConstantMemberCase` of `lower_case`
+- {option}`ConstantMemberPrefix` of `pre_`
+- {option}`ConstantMemberSuffix` of `_post`
+- {option}`ConstantMemberHungarianPrefix` of `On`
 
 Identifies and/or transforms constant member names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    class Foo {
-      char const MY_ConstMember_string[4] = "123";
-    }
+```c++
+class Foo {
+  char const MY_ConstMember_string[4] = "123";
+}
+```
 
 After:
 
-.. code-block:: c++
+```c++
+class Foo {
+  char const pre_my_constmember_string_post[4] = "123";
+}
+```
 
-    class Foo {
-      char const pre_my_constmember_string_post[4] = "123";
-    }
+```{option} ConstantParameterCase
+When defined, the check will ensure constant parameter names conform to the
+selected casing.
+```
 
-.. option:: ConstantParameterCase
+```{option} ConstantParameterPrefix
+When defined, the check will ensure constant parameter names will add the
+prefix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure constant parameter names conform to the
-    selected casing.
+```{option} ConstantParameterIgnoredRegexp
+Identifier naming checks won't be enforced for constant parameter names
+matching this regular expression.
+```
 
-.. option:: ConstantParameterPrefix
+```{option} ConstantParameterSuffix
+When defined, the check will ensure constant parameter names will add the
+suffix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure constant parameter names will add the
-    prefix with the given value (regardless of casing).
-
-.. option:: ConstantParameterIgnoredRegexp
-
-    Identifier naming checks won't be enforced for constant parameter names
-    matching this regular expression.
-
-.. option:: ConstantParameterSuffix
-
-    When defined, the check will ensure constant parameter names will add the
-    suffix with the given value (regardless of casing).
-
-.. option:: ConstantParameterHungarianPrefix
-
-    When enabled, the check ensures that the declared identifier will
-    have a Hungarian notation prefix based on the declared type.
+```{option} ConstantParameterHungarianPrefix
+When enabled, the check ensures that the declared identifier will
+have a Hungarian notation prefix based on the declared type.
+```
 
 For example using values of:
 
-   - ConstantParameterCase of ``lower_case``
-   - ConstantParameterPrefix of ``pre_``
-   - ConstantParameterSuffix of ``_post``
-   - ConstantParameterHungarianPrefix of ``On``
+- {option}`ConstantParameterCase` of `lower_case`
+- {option}`ConstantParameterPrefix` of `pre_`
+- {option}`ConstantParameterSuffix` of `_post`
+- {option}`ConstantParameterHungarianPrefix` of `On`
 
 Identifies and/or transforms constant parameter names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    void GLOBAL_FUNCTION(int PARAMETER_1, int const CONST_parameter);
+```c++
+void GLOBAL_FUNCTION(int PARAMETER_1, int const CONST_parameter);
+```
 
 After:
 
-.. code-block:: c++
+```c++
+void GLOBAL_FUNCTION(int PARAMETER_1, int const pre_const_parameter_post);
+```
 
-    void GLOBAL_FUNCTION(int PARAMETER_1, int const pre_const_parameter_post);
+```{option} ConstantPointerParameterCase
+When defined, the check will ensure constant pointer parameter names conform to the
+selected casing.
+```
 
-.. option:: ConstantPointerParameterCase
+```{option} ConstantPointerParameterPrefix
+When defined, the check will ensure constant pointer parameter names will add the
+prefix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure constant pointer parameter names conform to the
-    selected casing.
+```{option} ConstantPointerParameterIgnoredRegexp
+Identifier naming checks won't be enforced for constant pointer parameter
+names matching this regular expression.
+```
 
-.. option:: ConstantPointerParameterPrefix
+```{option} ConstantPointerParameterSuffix
+When defined, the check will ensure constant pointer parameter names will add the
+suffix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure constant pointer parameter names will add the
-    prefix with the given value (regardless of casing).
-
-.. option:: ConstantPointerParameterIgnoredRegexp
-
-    Identifier naming checks won't be enforced for constant pointer parameter
-    names matching this regular expression.
-
-.. option:: ConstantPointerParameterSuffix
-
-    When defined, the check will ensure constant pointer parameter names will add the
-    suffix with the given value (regardless of casing).
-
-.. option:: ConstantPointerParameterHungarianPrefix
-
-    When enabled, the check ensures that the declared identifier will
-    have a Hungarian notation prefix based on the declared type.
+```{option} ConstantPointerParameterHungarianPrefix
+When enabled, the check ensures that the declared identifier will
+have a Hungarian notation prefix based on the declared type.
+```
 
 For example using values of:
 
-   - ConstantPointerParameterCase of ``lower_case``
-   - ConstantPointerParameterPrefix of ``pre_``
-   - ConstantPointerParameterSuffix of ``_post``
-   - ConstantPointerParameterHungarianPrefix of ``On``
+- {option}`ConstantPointerParameterCase` of `lower_case`
+- {option}`ConstantPointerParameterPrefix` of `pre_`
+- {option}`ConstantPointerParameterSuffix` of `_post`
+- {option}`ConstantPointerParameterHungarianPrefix` of `On`
 
 Identifies and/or transforms constant pointer parameter names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    void GLOBAL_FUNCTION(int const *CONST_parameter);
+```c++
+void GLOBAL_FUNCTION(int const *CONST_parameter);
+```
 
 After:
 
-.. code-block:: c++
+```c++
+void GLOBAL_FUNCTION(int const *pre_const_parameter_post);
+```
 
-    void GLOBAL_FUNCTION(int const *pre_const_parameter_post);
+```{option} ConstexprFunctionCase
+When defined, the check will ensure constexpr function names conform to the
+selected casing.
+```
 
-.. option:: ConstexprFunctionCase
+```{option} ConstexprFunctionPrefix
+When defined, the check will ensure constexpr function names will add the
+prefix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure constexpr function names conform to the
-    selected casing.
+```{option} ConstexprFunctionIgnoredRegexp
+Identifier naming checks won't be enforced for constexpr function names
+matching this regular expression.
+```
 
-.. option:: ConstexprFunctionPrefix
-
-    When defined, the check will ensure constexpr function names will add the
-    prefix with the given value (regardless of casing).
-
-.. option:: ConstexprFunctionIgnoredRegexp
-
-    Identifier naming checks won't be enforced for constexpr function names
-    matching this regular expression.
-
-.. option:: ConstexprFunctionSuffix
-
-    When defined, the check will ensure constexpr function names will add the
-    suffix with the given value (regardless of casing).
+```{option} ConstexprFunctionSuffix
+When defined, the check will ensure constexpr function names will add the
+suffix with the given value (regardless of casing).
+```
 
 For example using values of:
 
-   - ConstexprFunctionCase of ``lower_case``
-   - ConstexprFunctionPrefix of ``pre_``
-   - ConstexprFunctionSuffix of ``_post``
+- {option}`ConstexprFunctionCase` of `lower_case`
+- {option}`ConstexprFunctionPrefix` of `pre_`
+- {option}`ConstexprFunctionSuffix` of `_post`
 
 Identifies and/or transforms constexpr function names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    constexpr int CE_function() { return 3; }
+```c++
+constexpr int CE_function() { return 3; }
+```
 
 After:
 
-.. code-block:: c++
+```c++
+constexpr int pre_ce_function_post() { return 3; }
+```
 
-    constexpr int pre_ce_function_post() { return 3; }
+```{option} ConstexprMethodCase
+When defined, the check will ensure constexpr method names conform to the
+selected casing.
+```
 
-.. option:: ConstexprMethodCase
+```{option} ConstexprMethodPrefix
+When defined, the check will ensure constexpr method names will add the
+prefix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure constexpr method names conform to the
-    selected casing.
+```{option} ConstexprMethodIgnoredRegexp
+Identifier naming checks won't be enforced for constexpr method names
+matching this regular expression.
+```
 
-.. option:: ConstexprMethodPrefix
-
-    When defined, the check will ensure constexpr method names will add the
-    prefix with the given value (regardless of casing).
-
-.. option:: ConstexprMethodIgnoredRegexp
-
-    Identifier naming checks won't be enforced for constexpr method names
-    matching this regular expression.
-
-.. option:: ConstexprMethodSuffix
-
-    When defined, the check will ensure constexpr method names will add the
-    suffix with the given value (regardless of casing).
+```{option} ConstexprMethodSuffix
+When defined, the check will ensure constexpr method names will add the
+suffix with the given value (regardless of casing).
+```
 
 For example using values of:
 
-   - ConstexprMethodCase of ``lower_case``
-   - ConstexprMethodPrefix of ``pre_``
-   - ConstexprMethodSuffix of ``_post``
+- {option}`ConstexprMethodCase` of `lower_case`
+- {option}`ConstexprMethodPrefix` of `pre_`
+- {option}`ConstexprMethodSuffix` of `_post`
 
 Identifies and/or transforms constexpr method names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    class Foo {
-    public:
-      constexpr int CST_expr_Method() { return 2; }
-    }
+```c++
+class Foo {
+public:
+  constexpr int CST_expr_Method() { return 2; }
+}
+```
 
 After:
 
-.. code-block:: c++
+```c++
+class Foo {
+public:
+  constexpr int pre_cst_expr_method_post() { return 2; }
+}
+```
 
-    class Foo {
-    public:
-      constexpr int pre_cst_expr_method_post() { return 2; }
-    }
+```{option} ConstexprVariableCase
+When defined, the check will ensure constexpr variable names conform to the
+selected casing.
+```
 
-.. option:: ConstexprVariableCase
+```{option} ConstexprVariablePrefix
+When defined, the check will ensure constexpr variable names will add the
+prefix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure constexpr variable names conform to the
-    selected casing.
+```{option} ConstexprVariableIgnoredRegexp
+Identifier naming checks won't be enforced for constexpr variable names
+matching this regular expression.
+```
 
-.. option:: ConstexprVariablePrefix
+```{option} ConstexprVariableSuffix
+When defined, the check will ensure constexpr variable names will add the
+suffix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure constexpr variable names will add the
-    prefix with the given value (regardless of casing).
-
-.. option:: ConstexprVariableIgnoredRegexp
-
-    Identifier naming checks won't be enforced for constexpr variable names
-    matching this regular expression.
-
-.. option:: ConstexprVariableSuffix
-
-    When defined, the check will ensure constexpr variable names will add the
-    suffix with the given value (regardless of casing).
-
-.. option:: ConstexprVariableHungarianPrefix
-
-    When enabled, the check ensures that the declared identifier will
-    have a Hungarian notation prefix based on the declared type.
+```{option} ConstexprVariableHungarianPrefix
+When enabled, the check ensures that the declared identifier will
+have a Hungarian notation prefix based on the declared type.
+```
 
 For example using values of:
 
-   - ConstexprVariableCase of ``lower_case``
-   - ConstexprVariablePrefix of ``pre_``
-   - ConstexprVariableSuffix of ``_post``
-   - ConstexprVariableHungarianPrefix of ``On``
+- {option}`ConstexprVariableCase` of `lower_case`
+- {option}`ConstexprVariablePrefix` of `pre_`
+- {option}`ConstexprVariableSuffix` of `_post`
+- {option}`ConstexprVariableHungarianPrefix` of `On`
 
 Identifies and/or transforms constexpr variable names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    constexpr int ConstExpr_variable = MyConstant;
+```c++
+constexpr int ConstExpr_variable = MyConstant;
+```
 
 After:
 
-.. code-block:: c++
+```c++
+constexpr int pre_constexpr_variable_post = MyConstant;
+```
 
-    constexpr int pre_constexpr_variable_post = MyConstant;
+```{option} EnumCase
+When defined, the check will ensure enumeration names conform to the
+selected casing.
+```
 
-.. option:: EnumCase
+```{option} EnumPrefix
+When defined, the check will ensure enumeration names will add the
+prefix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure enumeration names conform to the
-    selected casing.
+```{option} EnumIgnoredRegexp
+Identifier naming checks won't be enforced for enumeration names
+matching this regular expression.
+```
 
-.. option:: EnumPrefix
-
-    When defined, the check will ensure enumeration names will add the
-    prefix with the given value (regardless of casing).
-
-.. option:: EnumIgnoredRegexp
-
-    Identifier naming checks won't be enforced for enumeration names
-    matching this regular expression.
-
-.. option:: EnumSuffix
-
-    When defined, the check will ensure enumeration names will add the
-    suffix with the given value (regardless of casing).
+```{option} EnumSuffix
+When defined, the check will ensure enumeration names will add the
+suffix with the given value (regardless of casing).
+```
 
 For example using values of:
 
-   - EnumCase of ``lower_case``
-   - EnumPrefix of ``pre_``
-   - EnumSuffix of ``_post``
+- {option}`EnumCase` of `lower_case`
+- {option}`EnumPrefix` of `pre_`
+- {option}`EnumSuffix` of `_post`
 
 Identifies and/or transforms enumeration names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    enum FOO { One, Two, Three };
+```c++
+enum FOO { One, Two, Three };
+```
 
 After:
 
-.. code-block:: c++
+```c++
+enum pre_foo_post { One, Two, Three };
+```
 
-    enum pre_foo_post { One, Two, Three };
+```{option} EnumConstantCase
+When defined, the check will ensure enumeration constant names conform to the
+selected casing.
+```
 
-.. option:: EnumConstantCase
+```{option} EnumConstantPrefix
+When defined, the check will ensure enumeration constant names will add the
+prefix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure enumeration constant names conform to the
-    selected casing.
+```{option} EnumConstantIgnoredRegexp
+Identifier naming checks won't be enforced for enumeration constant names
+matching this regular expression.
+```
 
-.. option:: EnumConstantPrefix
+```{option} EnumConstantSuffix
+When defined, the check will ensure enumeration constant names will add the
+suffix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure enumeration constant names will add the
-    prefix with the given value (regardless of casing).
-
-.. option:: EnumConstantIgnoredRegexp
-
-    Identifier naming checks won't be enforced for enumeration constant names
-    matching this regular expression.
-
-.. option:: EnumConstantSuffix
-
-    When defined, the check will ensure enumeration constant names will add the
-    suffix with the given value (regardless of casing).
-
-.. option:: EnumConstantHungarianPrefix
-
-    When enabled, the check ensures that the declared identifier will
-    have a Hungarian notation prefix based on the declared type.
+```{option} EnumConstantHungarianPrefix
+When enabled, the check ensures that the declared identifier will
+have a Hungarian notation prefix based on the declared type.
+```
 
 For example using values of:
 
-   - EnumConstantCase of ``lower_case``
-   - EnumConstantPrefix of ``pre_``
-   - EnumConstantSuffix of ``_post``
-   - EnumConstantHungarianPrefix of ``On``
+- {option}`EnumConstantCase` of `lower_case`
+- {option}`EnumConstantPrefix` of `pre_`
+- {option}`EnumConstantSuffix` of `_post`
+- {option}`EnumConstantHungarianPrefix` of `On`
 
 Identifies and/or transforms enumeration constant names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    enum FOO { One, Two, Three };
+```c++
+enum FOO { One, Two, Three };
+```
 
 After:
 
-.. code-block:: c++
+```c++
+enum FOO { pre_One_post, pre_Two_post, pre_Three_post };
+```
 
-    enum FOO { pre_One_post, pre_Two_post, pre_Three_post };
+```{option} FunctionCase
+When defined, the check will ensure function names conform to the
+selected casing.
+```
 
-.. option:: FunctionCase
+```{option} FunctionPrefix
+When defined, the check will ensure function names will add the
+prefix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure function names conform to the
-    selected casing.
+```{option} FunctionIgnoredRegexp
+Identifier naming checks won't be enforced for function names
+matching this regular expression.
+```
 
-.. option:: FunctionPrefix
-
-    When defined, the check will ensure function names will add the
-    prefix with the given value (regardless of casing).
-
-.. option:: FunctionIgnoredRegexp
-
-    Identifier naming checks won't be enforced for function names
-    matching this regular expression.
-
-.. option:: FunctionSuffix
-
-    When defined, the check will ensure function names will add the
-    suffix with the given value (regardless of casing).
+```{option} FunctionSuffix
+When defined, the check will ensure function names will add the
+suffix with the given value (regardless of casing).
+```
 
 For example using values of:
 
-   - FunctionCase of ``lower_case``
-   - FunctionPrefix of ``pre_``
-   - FunctionSuffix of ``_post``
+- {option}`FunctionCase` of `lower_case`
+- {option}`FunctionPrefix` of `pre_`
+- {option}`FunctionSuffix` of `_post`
 
 Identifies and/or transforms function names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    char MY_Function_string();
+```c++
+char MY_Function_string();
+```
 
 After:
 
-.. code-block:: c++
+```c++
+char pre_my_function_string_post();
+```
 
-    char pre_my_function_string_post();
+```{option} GetConfigPerFile
+When `true`, the check will look for the configuration for where an
+identifier is declared. Useful for when included header files use a
+different style.
+Default is `true`.
+```
 
-.. option:: GetConfigPerFile
+```{option} GlobalConstexprVariableCase
+When defined, the check will ensure global `constexpr` variable names
+conform to the selected casing.
+```
 
-    When `true` the check will look for the configuration for where an
-    identifier is declared. Useful for when included header files use a
-    different style.
-    Default value is `true`.
+```{option} GlobalConstexprVariablePrefix
+When defined, the check will ensure global `constexpr` variable names
+will add the prefixed with the given value (regardless of casing).
+```
 
-.. option:: GlobalConstexprVariableCase
+```{option} GlobalConstexprVariableIgnoredRegexp
+Identifier naming checks won't be enforced for global `constexpr`
+variable names matching this regular expression.
+```
 
-    When defined, the check will ensure global ``constexpr`` variable names
-    conform to the selected casing.
+```{option} GlobalConstexprVariableSuffix
+When defined, the check will ensure global `constexpr` variable names
+will add the suffix with the given value (regardless of casing).
+```
 
-.. option:: GlobalConstexprVariablePrefix
-
-    When defined, the check will ensure global ``constexpr`` variable names
-    will add the prefixed with the given value (regardless of casing).
-
-.. option:: GlobalConstexprVariableIgnoredRegexp
-
-    Identifier naming checks won't be enforced for global ``constexpr``
-    variable names matching this regular expression.
-
-.. option:: GlobalConstexprVariableSuffix
-
-    When defined, the check will ensure global ``constexpr`` variable names
-    will add the suffix with the given value (regardless of casing).
-
-.. option:: GlobalConstexprVariableHungarianPrefix
-
-    When enabled, the check ensures that the declared identifier will have a
-    Hungarian notation prefix based on the declared type.
+```{option} GlobalConstexprVariableHungarianPrefix
+When enabled, the check ensures that the declared identifier will have a
+Hungarian notation prefix based on the declared type.
+```
 
 For example using values of:
 
-   - GlobalConstexprVariableCase of ``lower_case``
-   - GlobalConstexprVariablePrefix of ``pre_``
-   - GlobalConstexprVariableSuffix of ``_post``
-   - GlobalConstexprVariableHungarianPrefix of ``On``
+- {option}`GlobalConstexprVariableCase` of `lower_case`
+- {option}`GlobalConstexprVariablePrefix` of `pre_`
+- {option}`GlobalConstexprVariableSuffix` of `_post`
+- {option}`GlobalConstexprVariableHungarianPrefix` of `On`
 
-Identifies and/or transforms global ``constexpr`` variable names as follows:
+Identifies and/or transforms global `constexpr` variable names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    constexpr unsigned ImportantValue = 69;
+```c++
+constexpr unsigned ImportantValue = 69;
+```
 
 After:
 
-.. code-block:: c++
+```c++
+constexpr unsigned pre_important_value_post = 69;
+```
 
-    constexpr unsigned pre_important_value_post = 69;
+```{option} GlobalConstantCase
+When defined, the check will ensure global constant names conform to the
+selected casing.
+```
 
-.. option:: GlobalConstantCase
+```{option} GlobalConstantPrefix
+When defined, the check will ensure global constant names will add the
+prefix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure global constant names conform to the
-    selected casing.
+```{option} GlobalConstantIgnoredRegexp
+Identifier naming checks won't be enforced for global constant names
+matching this regular expression.
+```
 
-.. option:: GlobalConstantPrefix
+```{option} GlobalConstantSuffix
+When defined, the check will ensure global constant names will add the
+suffix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure global constant names will add the
-    prefix with the given value (regardless of casing).
-
-.. option:: GlobalConstantIgnoredRegexp
-
-    Identifier naming checks won't be enforced for global constant names
-    matching this regular expression.
-
-.. option:: GlobalConstantSuffix
-
-    When defined, the check will ensure global constant names will add the
-    suffix with the given value (regardless of casing).
-
-.. option:: GlobalConstantHungarianPrefix
-
-    When enabled, the check ensures that the declared identifier will
-    have a Hungarian notation prefix based on the declared type.
+```{option} GlobalConstantHungarianPrefix
+When enabled, the check ensures that the declared identifier will
+have a Hungarian notation prefix based on the declared type.
+```
 
 For example using values of:
 
-   - GlobalConstantCase of ``lower_case``
-   - GlobalConstantPrefix of ``pre_``
-   - GlobalConstantSuffix of ``_post``
-   - GlobalConstantHungarianPrefix of ``On``
+- {option}`GlobalConstantCase` of `lower_case`
+- {option}`GlobalConstantPrefix` of `pre_`
+- {option}`GlobalConstantSuffix` of `_post`
+- {option}`GlobalConstantHungarianPrefix` of `On`
 
 Identifies and/or transforms global constant names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    unsigned const MyConstGlobal_array[] = {1, 2, 3};
+```c++
+unsigned const MyConstGlobal_array[] = {1, 2, 3};
+```
 
 After:
 
-.. code-block:: c++
+```c++
+unsigned const pre_myconstglobal_array_post[] = {1, 2, 3};
+```
 
-    unsigned const pre_myconstglobal_array_post[] = {1, 2, 3};
+```{option} GlobalConstantPointerCase
+When defined, the check will ensure global constant pointer names conform to the
+selected casing.
+```
 
-.. option:: GlobalConstantPointerCase
+```{option} GlobalConstantPointerPrefix
+When defined, the check will ensure global constant pointer names will add the
+prefix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure global constant pointer names conform to the
-    selected casing.
+```{option} GlobalConstantPointerIgnoredRegexp
+Identifier naming checks won't be enforced for global constant pointer
+names matching this regular expression.
+```
 
-.. option:: GlobalConstantPointerPrefix
+```{option} GlobalConstantPointerSuffix
+When defined, the check will ensure global constant pointer names will add the
+suffix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure global constant pointer names will add the
-    prefix with the given value (regardless of casing).
-
-.. option:: GlobalConstantPointerIgnoredRegexp
-
-    Identifier naming checks won't be enforced for global constant pointer
-    names matching this regular expression.
-
-.. option:: GlobalConstantPointerSuffix
-
-    When defined, the check will ensure global constant pointer names will add the
-    suffix with the given value (regardless of casing).
-
-.. option:: GlobalConstantPointerHungarianPrefix
-
-    When enabled, the check ensures that the declared identifier will
-    have a Hungarian notation prefix based on the declared type.
+```{option} GlobalConstantPointerHungarianPrefix
+When enabled, the check ensures that the declared identifier will
+have a Hungarian notation prefix based on the declared type.
+```
 
 For example using values of:
 
-   - GlobalConstantPointerCase of ``lower_case``
-   - GlobalConstantPointerPrefix of ``pre_``
-   - GlobalConstantPointerSuffix of ``_post``
-   - GlobalConstantPointerHungarianPrefix of ``On``
+- {option}`GlobalConstantPointerCase` of `lower_case`
+- {option}`GlobalConstantPointerPrefix` of `pre_`
+- {option}`GlobalConstantPointerSuffix` of `_post`
+- {option}`GlobalConstantPointerHungarianPrefix` of `On`
 
 Identifies and/or transforms global constant pointer names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    int *const MyConstantGlobalPointer = nullptr;
+```c++
+int *const MyConstantGlobalPointer = nullptr;
+```
 
 After:
 
-.. code-block:: c++
+```c++
+int *const pre_myconstantglobalpointer_post = nullptr;
+```
 
-    int *const pre_myconstantglobalpointer_post = nullptr;
+```{option} GlobalFunctionCase
+When defined, the check will ensure global function names conform to the
+selected casing.
+```
 
-.. option:: GlobalFunctionCase
+```{option} GlobalFunctionPrefix
+When defined, the check will ensure global function names will add the
+prefix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure global function names conform to the
-    selected casing.
+```{option} GlobalFunctionIgnoredRegexp
+Identifier naming checks won't be enforced for global function names
+matching this regular expression.
+```
 
-.. option:: GlobalFunctionPrefix
-
-    When defined, the check will ensure global function names will add the
-    prefix with the given value (regardless of casing).
-
-.. option:: GlobalFunctionIgnoredRegexp
-
-    Identifier naming checks won't be enforced for global function names
-    matching this regular expression.
-
-.. option:: GlobalFunctionSuffix
-
-    When defined, the check will ensure global function names will add the
-    suffix with the given value (regardless of casing).
+```{option} GlobalFunctionSuffix
+When defined, the check will ensure global function names will add the
+suffix with the given value (regardless of casing).
+```
 
 For example using values of:
 
-   - GlobalFunctionCase of ``lower_case``
-   - GlobalFunctionPrefix of ``pre_``
-   - GlobalFunctionSuffix of ``_post``
+- {option}`GlobalFunctionCase` of `lower_case`
+- {option}`GlobalFunctionPrefix` of `pre_`
+- {option}`GlobalFunctionSuffix` of `_post`
 
 Identifies and/or transforms global function names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    void GLOBAL_FUNCTION(int PARAMETER_1, int const CONST_parameter);
+```c++
+void GLOBAL_FUNCTION(int PARAMETER_1, int const CONST_parameter);
+```
 
 After:
 
-.. code-block:: c++
+```c++
+void pre_global_function_post(int PARAMETER_1, int const CONST_parameter);
+```
 
-    void pre_global_function_post(int PARAMETER_1, int const CONST_parameter);
+```{option} GlobalPointerCase
+When defined, the check will ensure global pointer names conform to the
+selected casing.
+```
 
-.. option:: GlobalPointerCase
+```{option} GlobalPointerPrefix
+When defined, the check will ensure global pointer names will add the
+prefix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure global pointer names conform to the
-    selected casing.
+```{option} GlobalPointerIgnoredRegexp
+Identifier naming checks won't be enforced for global pointer names
+matching this regular expression.
+```
 
-.. option:: GlobalPointerPrefix
+```{option} GlobalPointerSuffix
+When defined, the check will ensure global pointer names will add the
+suffix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure global pointer names will add the
-    prefix with the given value (regardless of casing).
-
-.. option:: GlobalPointerIgnoredRegexp
-
-    Identifier naming checks won't be enforced for global pointer names
-    matching this regular expression.
-
-.. option:: GlobalPointerSuffix
-
-    When defined, the check will ensure global pointer names will add the
-    suffix with the given value (regardless of casing).
-
-.. option:: GlobalPointerHungarianPrefix
-
-    When enabled, the check ensures that the declared identifier will
-    have a Hungarian notation prefix based on the declared type.
+```{option} GlobalPointerHungarianPrefix
+When enabled, the check ensures that the declared identifier will
+have a Hungarian notation prefix based on the declared type.
+```
 
 For example using values of:
 
-   - GlobalPointerCase of ``lower_case``
-   - GlobalPointerPrefix of ``pre_``
-   - GlobalPointerSuffix of ``_post``
-   - GlobalPointerHungarianPrefix of ``On``
+- {option}`GlobalPointerCase` of `lower_case`
+- {option}`GlobalPointerPrefix` of `pre_`
+- {option}`GlobalPointerSuffix` of `_post`
+- {option}`GlobalPointerHungarianPrefix` of `On`
 
 Identifies and/or transforms global pointer names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    int *GLOBAL3;
+```c++
+int *GLOBAL3;
+```
 
 After:
 
-.. code-block:: c++
+```c++
+int *pre_global3_post;
+```
 
-    int *pre_global3_post;
+```{option} GlobalVariableCase
+When defined, the check will ensure global variable names conform to the
+selected casing.
+```
 
-.. option:: GlobalVariableCase
+```{option} GlobalVariablePrefix
+When defined, the check will ensure global variable names will add the
+prefix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure global variable names conform to the
-    selected casing.
+```{option} GlobalVariableIgnoredRegexp
+Identifier naming checks won't be enforced for global variable names
+matching this regular expression.
+```
 
-.. option:: GlobalVariablePrefix
+```{option} GlobalVariableSuffix
+When defined, the check will ensure global variable names will add the
+suffix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure global variable names will add the
-    prefix with the given value (regardless of casing).
-
-.. option:: GlobalVariableIgnoredRegexp
-
-    Identifier naming checks won't be enforced for global variable names
-    matching this regular expression.
-
-.. option:: GlobalVariableSuffix
-
-    When defined, the check will ensure global variable names will add the
-    suffix with the given value (regardless of casing).
-
-.. option:: GlobalVariableHungarianPrefix
-
-    When enabled, the check ensures that the declared identifier will
-    have a Hungarian notation prefix based on the declared type.
+```{option} GlobalVariableHungarianPrefix
+When enabled, the check ensures that the declared identifier will
+have a Hungarian notation prefix based on the declared type.
+```
 
 For example using values of:
 
-   - GlobalVariableCase of ``lower_case``
-   - GlobalVariablePrefix of ``pre_``
-   - GlobalVariableSuffix of ``_post``
-   - GlobalVariableHungarianPrefix of ``On``
+- {option}`GlobalVariableCase` of `lower_case`
+- {option}`GlobalVariablePrefix` of `pre_`
+- {option}`GlobalVariableSuffix` of `_post`
+- {option}`GlobalVariableHungarianPrefix` of `On`
 
 Identifies and/or transforms global variable names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    int GLOBAL3;
+```c++
+int GLOBAL3;
+```
 
 After:
 
-.. code-block:: c++
+```c++
+int pre_global3_post;
+```
 
-    int pre_global3_post;
+```{option} IgnoreMainLikeFunctions
+When `true`, functions that have a similar signature to `main` or
+`wmain` won't enforce checks on the names of their parameters.
+Default is `false`.
+```
 
-.. option:: IgnoreMainLikeFunctions
+```{option} InlineNamespaceCase
+When defined, the check will ensure inline namespaces names conform to the
+selected casing.
+```
 
-    When set to `true` functions that have a similar signature to ``main`` or
-    ``wmain`` won't enforce checks on the names of their parameters.
-    Default value is `false`.
+```{option} InlineNamespacePrefix
+When defined, the check will ensure inline namespaces names will add the
+prefix with the given value (regardless of casing).
+```
 
-.. option:: InlineNamespaceCase
+```{option} InlineNamespaceIgnoredRegexp
+Identifier naming checks won't be enforced for inline namespaces names
+matching this regular expression.
+```
 
-    When defined, the check will ensure inline namespaces names conform to the
-    selected casing.
-
-.. option:: InlineNamespacePrefix
-
-    When defined, the check will ensure inline namespaces names will add the
-    prefix with the given value (regardless of casing).
-
-.. option:: InlineNamespaceIgnoredRegexp
-
-    Identifier naming checks won't be enforced for inline namespaces names
-    matching this regular expression.
-
-.. option:: InlineNamespaceSuffix
-
-    When defined, the check will ensure inline namespaces names will add the
-    suffix with the given value (regardless of casing).
+```{option} InlineNamespaceSuffix
+When defined, the check will ensure inline namespaces names will add the
+suffix with the given value (regardless of casing).
+```
 
 For example using values of:
 
-   - InlineNamespaceCase of ``lower_case``
-   - InlineNamespacePrefix of ``pre_``
-   - InlineNamespaceSuffix of ``_post``
+- {option}`InlineNamespaceCase` of `lower_case`
+- {option}`InlineNamespacePrefix` of `pre_`
+- {option}`InlineNamespaceSuffix` of `_post`
 
 Identifies and/or transforms inline namespaces names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    namespace FOO_NS {
-    inline namespace InlineNamespace {
-    ...
-    }
-    } // namespace FOO_NS
+```c++
+namespace FOO_NS {
+inline namespace InlineNamespace {
+...
+}
+} // namespace FOO_NS
+```
 
 After:
 
-.. code-block:: c++
+```c++
+namespace FOO_NS {
+inline namespace pre_inlinenamespace_post {
+...
+}
+} // namespace FOO_NS
+```
 
-    namespace FOO_NS {
-    inline namespace pre_inlinenamespace_post {
-    ...
-    }
-    } // namespace FOO_NS
+```{option} LambdaCaptureCase
+When defined, the check will ensure lambda init-capture names (e.g.
+`Captured` in `[Captured = Var]`) conform to the selected casing.
+A simple, non-init capture (e.g. `[Var]` or `[&Var]`) refers to the
+same declaration as `Var` itself, so it keeps following whichever
+naming style applies to `Var`'s own declaration instead.
+```
 
-.. option:: LambdaCaptureCase
+```{option} LambdaCapturePrefix
+When defined, the check will ensure lambda init-capture names will add
+the prefix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure lambda init-capture names (e.g.
-    ``Captured`` in ``[Captured = Var]``) conform to the selected casing.
-    A simple, non-init capture (e.g. ``[Var]`` or ``[&Var]``) refers to the
-    same declaration as ``Var`` itself, so it keeps following whichever
-    naming style applies to ``Var``'s own declaration instead.
+```{option} LambdaCaptureIgnoredRegexp
+Identifier naming checks won't be enforced for lambda init-capture names
+matching this regular expression.
+```
 
-.. option:: LambdaCapturePrefix
+```{option} LambdaCaptureSuffix
+When defined, the check will ensure lambda init-capture names will add
+the suffix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure lambda init-capture names will add
-    the prefix with the given value (regardless of casing).
-
-.. option:: LambdaCaptureIgnoredRegexp
-
-    Identifier naming checks won't be enforced for lambda init-capture names
-    matching this regular expression.
-
-.. option:: LambdaCaptureSuffix
-
-    When defined, the check will ensure lambda init-capture names will add
-    the suffix with the given value (regardless of casing).
-
-.. option:: LambdaCaptureHungarianPrefix
-
-    When enabled, the check ensures that the declared identifier will
-    have a Hungarian notation prefix based on the declared type.
+```{option} LambdaCaptureHungarianPrefix
+When enabled, the check ensures that the declared identifier will
+have a Hungarian notation prefix based on the declared type.
+```
 
 For example using values of:
 
-   - LambdaCaptureCase of ``CamelCase``
-   - LambdaCapturePrefix of ``c_``
+- {option}`LambdaCaptureCase` of `CamelCase`
+- {option}`LambdaCapturePrefix` of `c_`
 
 Identifies and/or transforms lambda init-capture names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    void foo() {
-      int local_variable = 0;
-      auto lambda = [captured_value = local_variable]() {
-        return captured_value;
-      };
-    }
+```c++
+void foo() {
+  int local_variable = 0;
+  auto lambda = [captured_value = local_variable]() {
+    return captured_value;
+  };
+}
+```
 
 After:
 
-.. code-block:: c++
+```c++
+void foo() {
+  int local_variable = 0;
+  auto lambda = [c_CapturedValue = local_variable]() {
+    return c_CapturedValue;
+  };
+}
+```
 
-    void foo() {
-      int local_variable = 0;
-      auto lambda = [c_CapturedValue = local_variable]() {
-        return c_CapturedValue;
-      };
-    }
+```{option} LocalConstexprVariableCase
+When defined, the check will ensure local `constexpr` variable names
+conform to the selected casing.
+```
 
-.. option:: LocalConstexprVariableCase
+```{option} LocalConstexprVariablePrefix
+When defined, the check will ensure local `constexpr` variable names will
+add the prefixed with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure local ``constexpr`` variable names
-    conform to the selected casing.
+```{option} LocalConstexprVariableIgnoredRegexp
+Identifier naming checks won't be enforced for local `constexpr` variable
+names matching this regular expression.
+```
 
-.. option:: LocalConstexprVariablePrefix
+```{option} LocalConstexprVariableSuffix
+When defined, the check will ensure local `constexpr` variable names will
+add the suffix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure local ``constexpr`` variable names will
-    add the prefixed with the given value (regardless of casing).
-
-.. option:: LocalConstexprVariableIgnoredRegexp
-
-    Identifier naming checks won't be enforced for local ``constexpr`` variable
-    names matching this regular expression.
-
-.. option:: LocalConstexprVariableSuffix
-
-    When defined, the check will ensure local ``constexpr`` variable names will
-    add the suffix with the given value (regardless of casing).
-
-.. option:: LocalConstexprVariableHungarianPrefix
-
-    When enabled, the check ensures that the declared identifier will have a
-    Hungarian notation prefix based on the declared type.
+```{option} LocalConstexprVariableHungarianPrefix
+When enabled, the check ensures that the declared identifier will have a
+Hungarian notation prefix based on the declared type.
+```
 
 For example using values of:
 
-   - LocalConstexprVariableCase of ``lower_case``
-   - LocalConstexprVariablePrefix of ``pre_``
-   - LocalConstexprVariableSuffix of ``_post``
-   - LocalConstexprVariableHungarianPrefix of ``On``
+- {option}`LocalConstexprVariableCase` of `lower_case`
+- {option}`LocalConstexprVariablePrefix` of `pre_`
+- {option}`LocalConstexprVariableSuffix` of `_post`
+- {option}`LocalConstexprVariableHungarianPrefix` of `On`
 
-Identifies and/or transforms local ``constexpr`` variable names as follows:
+Identifies and/or transforms local `constexpr` variable names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    void foo() { int const local_Constexpr = 420; }
+```c++
+void foo() { int const local_Constexpr = 420; }
+```
 
 After:
 
-.. code-block:: c++
+```c++
+void foo() { int const pre_local_constexpr_post = 420; }
+```
 
-    void foo() { int const pre_local_constexpr_post = 420; }
+```{option} LocalConstantCase
+When defined, the check will ensure local constant names conform to the
+selected casing.
+```
 
-.. option:: LocalConstantCase
+```{option} LocalConstantPrefix
+When defined, the check will ensure local constant names will add the
+prefix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure local constant names conform to the
-    selected casing.
+```{option} LocalConstantIgnoredRegexp
+Identifier naming checks won't be enforced for local constant names
+matching this regular expression.
+```
 
-.. option:: LocalConstantPrefix
+```{option} LocalConstantSuffix
+When defined, the check will ensure local constant names will add the
+suffix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure local constant names will add the
-    prefix with the given value (regardless of casing).
-
-.. option:: LocalConstantIgnoredRegexp
-
-    Identifier naming checks won't be enforced for local constant names
-    matching this regular expression.
-
-.. option:: LocalConstantSuffix
-
-    When defined, the check will ensure local constant names will add the
-    suffix with the given value (regardless of casing).
-
-.. option:: LocalConstantHungarianPrefix
-
-    When enabled, the check ensures that the declared identifier will
-    have a Hungarian notation prefix based on the declared type.
+```{option} LocalConstantHungarianPrefix
+When enabled, the check ensures that the declared identifier will
+have a Hungarian notation prefix based on the declared type.
+```
 
 For example using values of:
 
-   - LocalConstantCase of ``lower_case``
-   - LocalConstantPrefix of ``pre_``
-   - LocalConstantSuffix of ``_post``
-   - LocalConstantHungarianPrefix of ``On``
+- {option}`LocalConstantCase` of `lower_case`
+- {option}`LocalConstantPrefix` of `pre_`
+- {option}`LocalConstantSuffix` of `_post`
+- {option}`LocalConstantHungarianPrefix` of `On`
 
 Identifies and/or transforms local constant names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    void foo() { int const local_Constant = 3; }
+```c++
+void foo() { int const local_Constant = 3; }
+```
 
 After:
 
-.. code-block:: c++
+```c++
+void foo() { int const pre_local_constant_post = 3; }
+```
 
-    void foo() { int const pre_local_constant_post = 3; }
+```{option} LocalConstantPointerCase
+When defined, the check will ensure local constant pointer names conform to the
+selected casing.
+```
 
-.. option:: LocalConstantPointerCase
+```{option} LocalConstantPointerPrefix
+When defined, the check will ensure local constant pointer names will add the
+prefix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure local constant pointer names conform to the
-    selected casing.
+```{option} LocalConstantPointerIgnoredRegexp
+Identifier naming checks won't be enforced for local constant pointer names
+matching this regular expression.
+```
 
-.. option:: LocalConstantPointerPrefix
+```{option} LocalConstantPointerSuffix
+When defined, the check will ensure local constant pointer names will add the
+suffix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure local constant pointer names will add the
-    prefix with the given value (regardless of casing).
-
-.. option:: LocalConstantPointerIgnoredRegexp
-
-    Identifier naming checks won't be enforced for local constant pointer names
-    matching this regular expression.
-
-.. option:: LocalConstantPointerSuffix
-
-    When defined, the check will ensure local constant pointer names will add the
-    suffix with the given value (regardless of casing).
-
-.. option:: LocalConstantPointerHungarianPrefix
-
-    When enabled, the check ensures that the declared identifier will
-    have a Hungarian notation prefix based on the declared type.
+```{option} LocalConstantPointerHungarianPrefix
+When enabled, the check ensures that the declared identifier will
+have a Hungarian notation prefix based on the declared type.
+```
 
 For example using values of:
 
-   - LocalConstantPointerCase of ``lower_case``
-   - LocalConstantPointerPrefix of ``pre_``
-   - LocalConstantPointerSuffix of ``_post``
-   - LocalConstantPointerHungarianPrefix of ``On``
+- {option}`LocalConstantPointerCase` of `lower_case`
+- {option}`LocalConstantPointerPrefix` of `pre_`
+- {option}`LocalConstantPointerSuffix` of `_post`
+- {option}`LocalConstantPointerHungarianPrefix` of `On`
 
 Identifies and/or transforms local constant pointer names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    void foo() { int const *local_Constant = 3; }
+```c++
+void foo() { int const *local_Constant = 3; }
+```
 
 After:
 
-.. code-block:: c++
+```c++
+void foo() { int const *pre_local_constant_post = 3; }
+```
 
-    void foo() { int const *pre_local_constant_post = 3; }
+```{option} LocalPointerCase
+When defined, the check will ensure local pointer names conform to the
+selected casing.
+```
 
-.. option:: LocalPointerCase
+```{option} LocalPointerPrefix
+When defined, the check will ensure local pointer names will add the
+prefix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure local pointer names conform to the
-    selected casing.
+```{option} LocalPointerIgnoredRegexp
+Identifier naming checks won't be enforced for local pointer names
+matching this regular expression.
+```
 
-.. option:: LocalPointerPrefix
+```{option} LocalPointerSuffix
+When defined, the check will ensure local pointer names will add the
+suffix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure local pointer names will add the
-    prefix with the given value (regardless of casing).
-
-.. option:: LocalPointerIgnoredRegexp
-
-    Identifier naming checks won't be enforced for local pointer names
-    matching this regular expression.
-
-.. option:: LocalPointerSuffix
-
-    When defined, the check will ensure local pointer names will add the
-    suffix with the given value (regardless of casing).
-
-.. option:: LocalPointerHungarianPrefix
-
-    When enabled, the check ensures that the declared identifier will
-    have a Hungarian notation prefix based on the declared type.
+```{option} LocalPointerHungarianPrefix
+When enabled, the check ensures that the declared identifier will
+have a Hungarian notation prefix based on the declared type.
+```
 
 For example using values of:
 
-   - LocalPointerCase of ``lower_case``
-   - LocalPointerPrefix of ``pre_``
-   - LocalPointerSuffix of ``_post``
-   - LocalPointerHungarianPrefix of ``On``
+- {option}`LocalPointerCase` of `lower_case`
+- {option}`LocalPointerPrefix` of `pre_`
+- {option}`LocalPointerSuffix` of `_post`
+- {option}`LocalPointerHungarianPrefix` of `On`
 
 Identifies and/or transforms local pointer names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    void foo() { int *local_Constant; }
+```c++
+void foo() { int *local_Constant; }
+```
 
 After:
 
-.. code-block:: c++
+```c++
+void foo() { int *pre_local_constant_post; }
+```
 
-    void foo() { int *pre_local_constant_post; }
+```{option} LocalVariableCase
+When defined, the check will ensure local variable names conform to the
+selected casing.
+```
 
-.. option:: LocalVariableCase
+```{option} LocalVariablePrefix
+When defined, the check will ensure local variable names will add the
+prefix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure local variable names conform to the
-    selected casing.
-
-.. option:: LocalVariablePrefix
-
-    When defined, the check will ensure local variable names will add the
-    prefix with the given value (regardless of casing).
-
-.. option:: LocalVariableIgnoredRegexp
-
-    Identifier naming checks won't be enforced for local variable names
-    matching this regular expression.
+```{option} LocalVariableIgnoredRegexp
+Identifier naming checks won't be enforced for local variable names
+matching this regular expression.
+```
 
 For example using values of:
 
-   - LocalVariableCase of ``CamelCase``
-   - LocalVariableIgnoredRegexp of ``\w{1,2}``
+- {option}`LocalVariableCase` of `CamelCase`
+- {option}`LocalVariableIgnoredRegexp` of `\w{1,2}`
 
 Will exclude variables with a length less than or equal to 2 from the
 camel case check applied to other variables.
 
-.. option:: LocalVariableSuffix
+```{option} LocalVariableSuffix
+When defined, the check will ensure local variable names will add the
+suffix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure local variable names will add the
-    suffix with the given value (regardless of casing).
-
-.. option:: LocalVariableHungarianPrefix
-
-    When enabled, the check ensures that the declared identifier will
-    have a Hungarian notation prefix based on the declared type.
+```{option} LocalVariableHungarianPrefix
+When enabled, the check ensures that the declared identifier will
+have a Hungarian notation prefix based on the declared type.
+```
 
 For example using values of:
 
-   - LocalVariableCase of ``lower_case``
-   - LocalVariablePrefix of ``pre_``
-   - LocalVariableSuffix of ``_post``
-   - LocalVariableHungarianPrefix of ``On``
+- {option}`LocalVariableCase` of `lower_case`
+- {option}`LocalVariablePrefix` of `pre_`
+- {option}`LocalVariableSuffix` of `_post`
+- {option}`LocalVariableHungarianPrefix` of `On`
 
 Identifies and/or transforms local variable names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    void foo() { int local_Constant; }
+```c++
+void foo() { int local_Constant; }
+```
 
 After:
 
-.. code-block:: c++
+```c++
+void foo() { int pre_local_constant_post; }
+```
 
-    void foo() { int pre_local_constant_post; }
+```{option} MacroDefinitionCase
+When defined, the check will ensure macro definitions conform to the
+selected casing.
+```
 
-.. option:: MacroDefinitionCase
+```{option} MacroDefinitionPrefix
+When defined, the check will ensure macro definitions will add the
+prefix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure macro definitions conform to the
-    selected casing.
+```{option} MacroDefinitionIgnoredRegexp
+Identifier naming checks won't be enforced for macro definitions
+matching this regular expression.
+```
 
-.. option:: MacroDefinitionPrefix
-
-    When defined, the check will ensure macro definitions will add the
-    prefix with the given value (regardless of casing).
-
-.. option:: MacroDefinitionIgnoredRegexp
-
-    Identifier naming checks won't be enforced for macro definitions
-    matching this regular expression.
-
-.. option:: MacroDefinitionSuffix
-
-    When defined, the check will ensure macro definitions will add the
-    suffix with the given value (regardless of casing).
+```{option} MacroDefinitionSuffix
+When defined, the check will ensure macro definitions will add the
+suffix with the given value (regardless of casing).
+```
 
 For example using values of:
 
-   - MacroDefinitionCase of ``lower_case``
-   - MacroDefinitionPrefix of ``pre_``
-   - MacroDefinitionSuffix of ``_post``
+- {option}`MacroDefinitionCase` of `lower_case`
+- {option}`MacroDefinitionPrefix` of `pre_`
+- {option}`MacroDefinitionSuffix` of `_post`
 
 Identifies and/or transforms macro definitions as follows:
 
 Before:
 
-.. code-block:: c
-
-    #define MY_MacroDefinition
+```c
+#define MY_MacroDefinition
+```
 
 After:
 
-.. code-block:: c
-
-    #define pre_my_macro_definition_post
+```c
+#define pre_my_macro_definition_post
+```
 
 Note: This will not warn on builtin macros or macros defined on the
-command line using the ``-D`` flag.
+command line using the `-D` flag.
 
-.. option:: MemberCase
+```{option} MemberCase
+When defined, the check will ensure member names conform to the
+selected casing.
+```
 
-    When defined, the check will ensure member names conform to the
-    selected casing.
+```{option} MemberPrefix
+When defined, the check will ensure member names will add the
+prefix with the given value (regardless of casing).
+```
 
-.. option:: MemberPrefix
+```{option} MemberIgnoredRegexp
+Identifier naming checks won't be enforced for member names
+matching this regular expression.
+```
 
-    When defined, the check will ensure member names will add the
-    prefix with the given value (regardless of casing).
+```{option} MemberSuffix
+When defined, the check will ensure member names will add the
+suffix with the given value (regardless of casing).
+```
 
-.. option:: MemberIgnoredRegexp
-
-    Identifier naming checks won't be enforced for member names
-    matching this regular expression.
-
-.. option:: MemberSuffix
-
-    When defined, the check will ensure member names will add the
-    suffix with the given value (regardless of casing).
-
-.. option:: MemberHungarianPrefix
-
-    When enabled, the check ensures that the declared identifier will
-    have a Hungarian notation prefix based on the declared type.
+```{option} MemberHungarianPrefix
+When enabled, the check ensures that the declared identifier will
+have a Hungarian notation prefix based on the declared type.
+```
 
 For example using values of:
 
-   - MemberCase of ``lower_case``
-   - MemberPrefix of ``pre_``
-   - MemberSuffix of ``_post``
-   - MemberHungarianPrefix of ``On``
+- {option}`MemberCase` of `lower_case`
+- {option}`MemberPrefix` of `pre_`
+- {option}`MemberSuffix` of `_post`
+- {option}`MemberHungarianPrefix` of `On`
 
 Identifies and/or transforms member names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    class Foo {
-      char MY_ConstMember_string[4];
-    }
+```c++
+class Foo {
+  char MY_ConstMember_string[4];
+}
+```
 
 After:
 
-.. code-block:: c++
+```c++
+class Foo {
+  char pre_my_constmember_string_post[4];
+}
+```
 
-    class Foo {
-      char pre_my_constmember_string_post[4];
-    }
+```{option} MethodCase
+When defined, the check will ensure method names conform to the
+selected casing.
+```
 
-.. option:: MethodCase
+```{option} MethodPrefix
+When defined, the check will ensure method names will add the
+prefix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure method names conform to the
-    selected casing.
+```{option} MethodIgnoredRegexp
+Identifier naming checks won't be enforced for method names
+matching this regular expression.
+```
 
-.. option:: MethodPrefix
-
-    When defined, the check will ensure method names will add the
-    prefix with the given value (regardless of casing).
-
-.. option:: MethodIgnoredRegexp
-
-    Identifier naming checks won't be enforced for method names
-    matching this regular expression.
-
-.. option:: MethodSuffix
-
-    When defined, the check will ensure method names will add the
-    suffix with the given value (regardless of casing).
+```{option} MethodSuffix
+When defined, the check will ensure method names will add the
+suffix with the given value (regardless of casing).
+```
 
 For example using values of:
 
-   - MethodCase of ``lower_case``
-   - MethodPrefix of ``pre_``
-   - MethodSuffix of ``_post``
+- {option}`MethodCase` of `lower_case`
+- {option}`MethodPrefix` of `pre_`
+- {option}`MethodSuffix` of `_post`
 
 Identifies and/or transforms method names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    class Foo {
-      char MY_Method_string();
-    }
+```c++
+class Foo {
+  char MY_Method_string();
+}
+```
 
 After:
 
-.. code-block:: c++
+```c++
+class Foo {
+  char pre_my_method_string_post();
+}
+```
 
-    class Foo {
-      char pre_my_method_string_post();
-    }
+```{option} NamespaceCase
+When defined, the check will ensure namespace names conform to the
+selected casing.
+```
 
-.. option:: NamespaceCase
+```{option} NamespacePrefix
+When defined, the check will ensure namespace names will add the
+prefix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure namespace names conform to the
-    selected casing.
+```{option} NamespaceIgnoredRegexp
+Identifier naming checks won't be enforced for namespace names
+matching this regular expression.
+```
 
-.. option:: NamespacePrefix
-
-    When defined, the check will ensure namespace names will add the
-    prefix with the given value (regardless of casing).
-
-.. option:: NamespaceIgnoredRegexp
-
-    Identifier naming checks won't be enforced for namespace names
-    matching this regular expression.
-
-.. option:: NamespaceSuffix
-
-    When defined, the check will ensure namespace names will add the
-    suffix with the given value (regardless of casing).
+```{option} NamespaceSuffix
+When defined, the check will ensure namespace names will add the
+suffix with the given value (regardless of casing).
+```
 
 For example using values of:
 
-   - NamespaceCase of ``lower_case``
-   - NamespacePrefix of ``pre_``
-   - NamespaceSuffix of ``_post``
+- {option}`NamespaceCase` of `lower_case`
+- {option}`NamespacePrefix` of `pre_`
+- {option}`NamespaceSuffix` of `_post`
 
 Identifies and/or transforms namespace names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    namespace FOO_NS {
-    ...
-    }
+```c++
+namespace FOO_NS {
+...
+}
+```
 
 After:
 
-.. code-block:: c++
+```c++
+namespace pre_foo_ns_post {
+...
+}
+```
 
-    namespace pre_foo_ns_post {
-    ...
-    }
+```{option} ParameterCase
+When defined, the check will ensure parameter names conform to the
+selected casing.
+```
 
-.. option:: ParameterCase
+```{option} ParameterPrefix
+When defined, the check will ensure parameter names will add the
+prefix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure parameter names conform to the
-    selected casing.
+```{option} ParameterIgnoredRegexp
+Identifier naming checks won't be enforced for parameter names
+matching this regular expression.
+```
 
-.. option:: ParameterPrefix
+```{option} ParameterSuffix
+When defined, the check will ensure parameter names will add the
+suffix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure parameter names will add the
-    prefix with the given value (regardless of casing).
-
-.. option:: ParameterIgnoredRegexp
-
-    Identifier naming checks won't be enforced for parameter names
-    matching this regular expression.
-
-.. option:: ParameterSuffix
-
-    When defined, the check will ensure parameter names will add the
-    suffix with the given value (regardless of casing).
-
-.. option:: ParameterHungarianPrefix
-
-    When enabled, the check ensures that the declared identifier will
-    have a Hungarian notation prefix based on the declared type.
+```{option} ParameterHungarianPrefix
+When enabled, the check ensures that the declared identifier will
+have a Hungarian notation prefix based on the declared type.
+```
 
 For example using values of:
 
-   - ParameterCase of ``lower_case``
-   - ParameterPrefix of ``pre_``
-   - ParameterSuffix of ``_post``
-   - ParameterHungarianPrefix of ``On``
+- {option}`ParameterCase` of `lower_case`
+- {option}`ParameterPrefix` of `pre_`
+- {option}`ParameterSuffix` of `_post`
+- {option}`ParameterHungarianPrefix` of `On`
 
 Identifies and/or transforms parameter names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    void GLOBAL_FUNCTION(int PARAMETER_1, int const CONST_parameter);
+```c++
+void GLOBAL_FUNCTION(int PARAMETER_1, int const CONST_parameter);
+```
 
 After:
 
-.. code-block:: c++
+```c++
+void GLOBAL_FUNCTION(int pre_parameter_post, int const CONST_parameter);
+```
 
-    void GLOBAL_FUNCTION(int pre_parameter_post, int const CONST_parameter);
+```{option} ParameterPackCase
+When defined, the check will ensure parameter pack names conform to the
+selected casing.
+```
 
-.. option:: ParameterPackCase
+```{option} ParameterPackPrefix
+When defined, the check will ensure parameter pack names will add the
+prefix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure parameter pack names conform to the
-    selected casing.
+```{option} ParameterPackIgnoredRegexp
+Identifier naming checks won't be enforced for parameter pack names
+matching this regular expression.
+```
 
-.. option:: ParameterPackPrefix
-
-    When defined, the check will ensure parameter pack names will add the
-    prefix with the given value (regardless of casing).
-
-.. option:: ParameterPackIgnoredRegexp
-
-    Identifier naming checks won't be enforced for parameter pack names
-    matching this regular expression.
-
-.. option:: ParameterPackSuffix
-
-    When defined, the check will ensure parameter pack names will add the
-    suffix with the given value (regardless of casing).
+```{option} ParameterPackSuffix
+When defined, the check will ensure parameter pack names will add the
+suffix with the given value (regardless of casing).
+```
 
 For example using values of:
 
-   - ParameterPackCase of ``lower_case``
-   - ParameterPackPrefix of ``pre_``
-   - ParameterPackSuffix of ``_post``
+- {option}`ParameterPackCase` of `lower_case`
+- {option}`ParameterPackPrefix` of `pre_`
+- {option}`ParameterPackSuffix` of `_post`
 
 Identifies and/or transforms parameter pack names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    template <typename... TYPE_parameters> {
-      void FUNCTION(int... TYPE_parameters);
-    }
+```c++
+template <typename... TYPE_parameters> {
+  void FUNCTION(int... TYPE_parameters);
+}
+```
 
 After:
 
-.. code-block:: c++
+```c++
+template <typename... TYPE_parameters> {
+  void FUNCTION(int... pre_type_parameters_post);
+}
+```
 
-    template <typename... TYPE_parameters> {
-      void FUNCTION(int... pre_type_parameters_post);
-    }
+```{option} PointerParameterCase
+When defined, the check will ensure pointer parameter names conform to the
+selected casing.
+```
 
-.. option:: PointerParameterCase
+```{option} PointerParameterPrefix
+When defined, the check will ensure pointer parameter names will add the
+prefix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure pointer parameter names conform to the
-    selected casing.
+```{option} PointerParameterIgnoredRegexp
+Identifier naming checks won't be enforced for pointer parameter names
+matching this regular expression.
+```
 
-.. option:: PointerParameterPrefix
+```{option} PointerParameterSuffix
+When defined, the check will ensure pointer parameter names will add the
+suffix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure pointer parameter names will add the
-    prefix with the given value (regardless of casing).
-
-.. option:: PointerParameterIgnoredRegexp
-
-    Identifier naming checks won't be enforced for pointer parameter names
-    matching this regular expression.
-
-.. option:: PointerParameterSuffix
-
-    When defined, the check will ensure pointer parameter names will add the
-    suffix with the given value (regardless of casing).
-
-.. option:: PointerParameterHungarianPrefix
-
-    When enabled, the check ensures that the declared identifier will
-    have a Hungarian notation prefix based on the declared type.
+```{option} PointerParameterHungarianPrefix
+When enabled, the check ensures that the declared identifier will
+have a Hungarian notation prefix based on the declared type.
+```
 
 For example using values of:
 
-   - PointerParameterCase of ``lower_case``
-   - PointerParameterPrefix of ``pre_``
-   - PointerParameterSuffix of ``_post``
-   - PointerParameterHungarianPrefix of ``On``
+- {option}`PointerParameterCase` of `lower_case`
+- {option}`PointerParameterPrefix` of `pre_`
+- {option}`PointerParameterSuffix` of `_post`
+- {option}`PointerParameterHungarianPrefix` of `On`
 
 Identifies and/or transforms pointer parameter names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    void FUNCTION(int *PARAMETER);
+```c++
+void FUNCTION(int *PARAMETER);
+```
 
 After:
 
-.. code-block:: c++
+```c++
+void FUNCTION(int *pre_parameter_post);
+```
 
-    void FUNCTION(int *pre_parameter_post);
+```{option} PrivateMemberCase
+When defined, the check will ensure private member names conform to the
+selected casing.
+```
 
-.. option:: PrivateMemberCase
+```{option} PrivateMemberPrefix
+When defined, the check will ensure private member names will add the
+prefix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure private member names conform to the
-    selected casing.
+```{option} PrivateMemberIgnoredRegexp
+Identifier naming checks won't be enforced for private member names
+matching this regular expression.
+```
 
-.. option:: PrivateMemberPrefix
+```{option} PrivateMemberSuffix
+When defined, the check will ensure private member names will add the
+suffix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure private member names will add the
-    prefix with the given value (regardless of casing).
-
-.. option:: PrivateMemberIgnoredRegexp
-
-    Identifier naming checks won't be enforced for private member names
-    matching this regular expression.
-
-.. option:: PrivateMemberSuffix
-
-    When defined, the check will ensure private member names will add the
-    suffix with the given value (regardless of casing).
-
-.. option:: PrivateMemberHungarianPrefix
-
-    When enabled, the check ensures that the declared identifier will
-    have a Hungarian notation prefix based on the declared type.
+```{option} PrivateMemberHungarianPrefix
+When enabled, the check ensures that the declared identifier will
+have a Hungarian notation prefix based on the declared type.
+```
 
 For example using values of:
 
-   - PrivateMemberCase of ``lower_case``
-   - PrivateMemberPrefix of ``pre_``
-   - PrivateMemberSuffix of ``_post``
-   - PrivateMemberHungarianPrefix of ``On``
+- {option}`PrivateMemberCase` of `lower_case`
+- {option}`PrivateMemberPrefix` of `pre_`
+- {option}`PrivateMemberSuffix` of `_post`
+- {option}`PrivateMemberHungarianPrefix` of `On`
 
 Identifies and/or transforms private member names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    class Foo {
-    private:
-      int Member_Variable;
-    }
+```c++
+class Foo {
+private:
+  int Member_Variable;
+}
+```
 
 After:
 
-.. code-block:: c++
+```c++
+class Foo {
+private:
+  int pre_member_variable_post;
+}
+```
 
-    class Foo {
-    private:
-      int pre_member_variable_post;
-    }
+```{option} PrivateMethodCase
+When defined, the check will ensure private method names conform to the
+selected casing.
+```
 
-.. option:: PrivateMethodCase
+```{option} PrivateMethodPrefix
+When defined, the check will ensure private method names will add the
+prefix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure private method names conform to the
-    selected casing.
+```{option} PrivateMethodIgnoredRegexp
+Identifier naming checks won't be enforced for private method names
+matching this regular expression.
+```
 
-.. option:: PrivateMethodPrefix
-
-    When defined, the check will ensure private method names will add the
-    prefix with the given value (regardless of casing).
-
-.. option:: PrivateMethodIgnoredRegexp
-
-    Identifier naming checks won't be enforced for private method names
-    matching this regular expression.
-
-.. option:: PrivateMethodSuffix
-
-    When defined, the check will ensure private method names will add the
-    suffix with the given value (regardless of casing).
+```{option} PrivateMethodSuffix
+When defined, the check will ensure private method names will add the
+suffix with the given value (regardless of casing).
+```
 
 For example using values of:
 
-   - PrivateMethodCase of ``lower_case``
-   - PrivateMethodPrefix of ``pre_``
-   - PrivateMethodSuffix of ``_post``
+- {option}`PrivateMethodCase` of `lower_case`
+- {option}`PrivateMethodPrefix` of `pre_`
+- {option}`PrivateMethodSuffix` of `_post`
 
 Identifies and/or transforms private method names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    class Foo {
-    private:
-      int Member_Method();
-    }
+```c++
+class Foo {
+private:
+  int Member_Method();
+}
+```
 
 After:
 
-.. code-block:: c++
+```c++
+class Foo {
+private:
+  int pre_member_method_post();
+}
+```
 
-    class Foo {
-    private:
-      int pre_member_method_post();
-    }
+```{option} ProtectedMemberCase
+When defined, the check will ensure protected member names conform to the
+selected casing.
+```
 
-.. option:: ProtectedMemberCase
+```{option} ProtectedMemberPrefix
+When defined, the check will ensure protected member names will add the
+prefix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure protected member names conform to the
-    selected casing.
+```{option} ProtectedMemberIgnoredRegexp
+Identifier naming checks won't be enforced for protected member names
+matching this regular expression.
+```
 
-.. option:: ProtectedMemberPrefix
+```{option} ProtectedMemberSuffix
+When defined, the check will ensure protected member names will add the
+suffix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure protected member names will add the
-    prefix with the given value (regardless of casing).
-
-.. option:: ProtectedMemberIgnoredRegexp
-
-    Identifier naming checks won't be enforced for protected member names
-    matching this regular expression.
-
-.. option:: ProtectedMemberSuffix
-
-    When defined, the check will ensure protected member names will add the
-    suffix with the given value (regardless of casing).
-
-.. option:: ProtectedMemberHungarianPrefix
-
-    When enabled, the check ensures that the declared identifier will
-    have a Hungarian notation prefix based on the declared type.
+```{option} ProtectedMemberHungarianPrefix
+When enabled, the check ensures that the declared identifier will
+have a Hungarian notation prefix based on the declared type.
+```
 
 For example using values of:
 
-   - ProtectedMemberCase of ``lower_case``
-   - ProtectedMemberPrefix of ``pre_``
-   - ProtectedMemberSuffix of ``_post``
-   - ProtectedMemberHungarianPrefix of ``On``
+- {option}`ProtectedMemberCase` of `lower_case`
+- {option}`ProtectedMemberPrefix` of `pre_`
+- {option}`ProtectedMemberSuffix` of `_post`
+- {option}`ProtectedMemberHungarianPrefix` of `On`
 
 Identifies and/or transforms protected member names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    class Foo {
-    protected:
-      int Member_Variable;
-    }
+```c++
+class Foo {
+protected:
+  int Member_Variable;
+}
+```
 
 After:
 
-.. code-block:: c++
+```c++
+class Foo {
+protected:
+  int pre_member_variable_post;
+}
+```
 
-    class Foo {
-    protected:
-      int pre_member_variable_post;
-    }
+```{option} ProtectedMethodCase
+When defined, the check will ensure protected method names conform to the
+selected casing.
+```
 
-.. option:: ProtectedMethodCase
+```{option} ProtectedMethodPrefix
+When defined, the check will ensure protected method names will add the
+prefix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure protected method names conform to the
-    selected casing.
+```{option} ProtectedMethodIgnoredRegexp
+Identifier naming checks won't be enforced for protected method names
+matching this regular expression.
+```
 
-.. option:: ProtectedMethodPrefix
-
-    When defined, the check will ensure protected method names will add the
-    prefix with the given value (regardless of casing).
-
-.. option:: ProtectedMethodIgnoredRegexp
-
-    Identifier naming checks won't be enforced for protected method names
-    matching this regular expression.
-
-.. option:: ProtectedMethodSuffix
-
-    When defined, the check will ensure protected method names will add the
-    suffix with the given value (regardless of casing).
+```{option} ProtectedMethodSuffix
+When defined, the check will ensure protected method names will add the
+suffix with the given value (regardless of casing).
+```
 
 For example using values of:
 
-   - ProtectedMethodCase of ``lower_case``
-   - ProtectedMethodPrefix of ``pre_``
-   - ProtectedMethodSuffix of ``_post``
+- {option}`ProtectedMethodCase` of `lower_case`
+- {option}`ProtectedMethodPrefix` of `pre_`
+- {option}`ProtectedMethodSuffix` of `_post`
 
 Identifies and/or transforms protect method names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    class Foo {
-    protected:
-      int Member_Method();
-    }
+```c++
+class Foo {
+protected:
+  int Member_Method();
+}
+```
 
 After:
 
-.. code-block:: c++
+```c++
+class Foo {
+protected:
+  int pre_member_method_post();
+}
+```
 
-    class Foo {
-    protected:
-      int pre_member_method_post();
-    }
+```{option} PublicMemberCase
+When defined, the check will ensure public member names conform to the
+selected casing.
+```
 
-.. option:: PublicMemberCase
+```{option} PublicMemberPrefix
+When defined, the check will ensure public member names will add the
+prefix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure public member names conform to the
-    selected casing.
+```{option} PublicMemberIgnoredRegexp
+Identifier naming checks won't be enforced for public member names
+matching this regular expression.
+```
 
-.. option:: PublicMemberPrefix
+```{option} PublicMemberSuffix
+When defined, the check will ensure public member names will add the
+suffix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure public member names will add the
-    prefix with the given value (regardless of casing).
-
-.. option:: PublicMemberIgnoredRegexp
-
-    Identifier naming checks won't be enforced for public member names
-    matching this regular expression.
-
-.. option:: PublicMemberSuffix
-
-    When defined, the check will ensure public member names will add the
-    suffix with the given value (regardless of casing).
-
-.. option:: PublicMemberHungarianPrefix
-
-    When enabled, the check ensures that the declared identifier will
-    have a Hungarian notation prefix based on the declared type.
+```{option} PublicMemberHungarianPrefix
+When enabled, the check ensures that the declared identifier will
+have a Hungarian notation prefix based on the declared type.
+```
 
 For example using values of:
 
-   - PublicMemberCase of ``lower_case``
-   - PublicMemberPrefix of ``pre_``
-   - PublicMemberSuffix of ``_post``
-   - PublicMemberHungarianPrefix of ``On``
+- {option}`PublicMemberCase` of `lower_case`
+- {option}`PublicMemberPrefix` of `pre_`
+- {option}`PublicMemberSuffix` of `_post`
+- {option}`PublicMemberHungarianPrefix` of `On`
 
 Identifies and/or transforms public member names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    class Foo {
-    public:
-      int Member_Variable;
-    }
+```c++
+class Foo {
+public:
+  int Member_Variable;
+}
+```
 
 After:
 
-.. code-block:: c++
+```c++
+class Foo {
+public:
+  int pre_member_variable_post;
+}
+```
 
-    class Foo {
-    public:
-      int pre_member_variable_post;
-    }
+```{option} PublicMethodCase
+When defined, the check will ensure public method names conform to the
+selected casing.
+```
 
-.. option:: PublicMethodCase
+```{option} PublicMethodPrefix
+When defined, the check will ensure public method names will add the
+prefix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure public method names conform to the
-    selected casing.
+```{option} PublicMethodIgnoredRegexp
+Identifier naming checks won't be enforced for public method names
+matching this regular expression.
+```
 
-.. option:: PublicMethodPrefix
-
-    When defined, the check will ensure public method names will add the
-    prefix with the given value (regardless of casing).
-
-.. option:: PublicMethodIgnoredRegexp
-
-    Identifier naming checks won't be enforced for public method names
-    matching this regular expression.
-
-.. option:: PublicMethodSuffix
-
-    When defined, the check will ensure public method names will add the
-    suffix with the given value (regardless of casing).
+```{option} PublicMethodSuffix
+When defined, the check will ensure public method names will add the
+suffix with the given value (regardless of casing).
+```
 
 For example using values of:
 
-   - PublicMethodCase of ``lower_case``
-   - PublicMethodPrefix of ``pre_``
-   - PublicMethodSuffix of ``_post``
+- {option}`PublicMethodCase` of `lower_case`
+- {option}`PublicMethodPrefix` of `pre_`
+- {option}`PublicMethodSuffix` of `_post`
 
 Identifies and/or transforms public method names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    class Foo {
-    public:
-      int Member_Method();
-    }
+```c++
+class Foo {
+public:
+  int Member_Method();
+}
+```
 
 After:
 
-.. code-block:: c++
+```c++
+class Foo {
+public:
+  int pre_member_method_post();
+}
+```
 
-    class Foo {
-    public:
-      int pre_member_method_post();
-    }
+```{option} ScopedEnumConstantCase
+When defined, the check will ensure scoped enum constant names conform to
+the selected casing.
+```
 
-.. option:: ScopedEnumConstantCase
+```{option} ScopedEnumConstantPrefix
+When defined, the check will ensure scoped enum constant names will add the
+prefix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure scoped enum constant names conform to
-    the selected casing.
+```{option} ScopedEnumConstantIgnoredRegexp
+Identifier naming checks won't be enforced for scoped enum constant names
+matching this regular expression.
+```
 
-.. option:: ScopedEnumConstantPrefix
+```{option} ScopedEnumConstantSuffix
+When defined, the check will ensure scoped enum constant names will add the
+suffix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure scoped enum constant names will add the
-    prefix with the given value (regardless of casing).
-
-.. option:: ScopedEnumConstantIgnoredRegexp
-
-    Identifier naming checks won't be enforced for scoped enum constant names
-    matching this regular expression.
-
-.. option:: ScopedEnumConstantSuffix
-
-    When defined, the check will ensure scoped enum constant names will add the
-    suffix with the given value (regardless of casing).
-
-.. option:: ScopedEnumConstantHungarianPrefix
-
-    When enabled, the check ensures that the declared identifier will
-    have a Hungarian notation prefix based on the declared type.
+```{option} ScopedEnumConstantHungarianPrefix
+When enabled, the check ensures that the declared identifier will
+have a Hungarian notation prefix based on the declared type.
+```
 
 For example using values of:
 
-   - ScopedEnumConstantCase of ``lower_case``
-   - ScopedEnumConstantPrefix of ``pre_``
-   - ScopedEnumConstantSuffix of ``_post``
-   - ScopedEnumConstantHungarianPrefix of ``On``
+- {option}`ScopedEnumConstantCase` of `lower_case`
+- {option}`ScopedEnumConstantPrefix` of `pre_`
+- {option}`ScopedEnumConstantSuffix` of `_post`
+- {option}`ScopedEnumConstantHungarianPrefix` of `On`
 
 Identifies and/or transforms enumeration constant names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    enum class FOO { One, Two, Three };
+```c++
+enum class FOO { One, Two, Three };
+```
 
 After:
 
-.. code-block:: c++
+```c++
+enum class FOO { pre_One_post, pre_Two_post, pre_Three_post };
+```
 
-    enum class FOO { pre_One_post, pre_Two_post, pre_Three_post };
+```{option} StaticConstexprVariableCase
+When defined, the check will ensure static `constexpr` variable names
+conform to the selected casing.
+```
 
-.. option:: StaticConstexprVariableCase
+```{option} StaticConstexprVariablePrefix
+When defined, the check will ensure static `constexpr` variable names
+will add the prefixed with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure static ``constexpr`` variable names
-    conform to the selected casing.
+```{option} StaticConstexprVariableIgnoredRegexp
+Identifier naming checks won't be enforced for static `constexpr`
+variable names matching this regular expression.
+```
 
-.. option:: StaticConstexprVariablePrefix
+```{option} StaticConstexprVariableSuffix
+When defined, the check will ensure static `constexpr` variable names
+will add the suffix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure static ``constexpr`` variable names
-    will add the prefixed with the given value (regardless of casing).
-
-.. option:: StaticConstexprVariableIgnoredRegexp
-
-    Identifier naming checks won't be enforced for static ``constexpr``
-    variable names matching this regular expression.
-
-.. option:: StaticConstexprVariableSuffix
-
-    When defined, the check will ensure static ``constexpr`` variable names
-    will add the suffix with the given value (regardless of casing).
-
-.. option:: StaticConstexprVariableHungarianPrefix
-
-    When enabled, the check ensures that the declared identifier will have a
-    Hungarian notation prefix based on the declared type.
+```{option} StaticConstexprVariableHungarianPrefix
+When enabled, the check ensures that the declared identifier will have a
+Hungarian notation prefix based on the declared type.
+```
 
 For example using values of:
 
-   - StaticConstexprVariableCase of ``lower_case``
-   - StaticConstexprVariablePrefix of ``pre_``
-   - StaticConstexprVariableSuffix of ``_post``
-   - StaticConstexprVariableHungarianPrefix of ``On``
+- {option}`StaticConstexprVariableCase` of `lower_case`
+- {option}`StaticConstexprVariablePrefix` of `pre_`
+- {option}`StaticConstexprVariableSuffix` of `_post`
+- {option}`StaticConstexprVariableHungarianPrefix` of `On`
 
-Identifies and/or transforms static ``constexpr`` variable names as follows:
+Identifies and/or transforms static `constexpr` variable names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    static unsigned constexpr MyConstexprStatic_array[] = {1, 2, 3};
+```c++
+static unsigned constexpr MyConstexprStatic_array[] = {1, 2, 3};
+```
 
 After:
 
-.. code-block:: c++
+```c++
+static unsigned constexpr pre_my_constexpr_static_array_post[] = {1, 2, 3};
+```
 
-    static unsigned constexpr pre_my_constexpr_static_array_post[] = {1, 2, 3};
+```{option} StaticConstantCase
+When defined, the check will ensure static constant names conform to the
+selected casing.
+```
 
-.. option:: StaticConstantCase
+```{option} StaticConstantPrefix
+When defined, the check will ensure static constant names will add the
+prefix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure static constant names conform to the
-    selected casing.
+```{option} StaticConstantIgnoredRegexp
+Identifier naming checks won't be enforced for static constant names
+matching this regular expression.
+```
 
-.. option:: StaticConstantPrefix
+```{option} StaticConstantSuffix
+When defined, the check will ensure static constant names will add the
+suffix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure static constant names will add the
-    prefix with the given value (regardless of casing).
-
-.. option:: StaticConstantIgnoredRegexp
-
-    Identifier naming checks won't be enforced for static constant names
-    matching this regular expression.
-
-.. option:: StaticConstantSuffix
-
-    When defined, the check will ensure static constant names will add the
-    suffix with the given value (regardless of casing).
-
-.. option:: StaticConstantHungarianPrefix
-
-    When enabled, the check ensures that the declared identifier will
-    have a Hungarian notation prefix based on the declared type.
+```{option} StaticConstantHungarianPrefix
+When enabled, the check ensures that the declared identifier will
+have a Hungarian notation prefix based on the declared type.
+```
 
 For example using values of:
 
-   - StaticConstantCase of ``lower_case``
-   - StaticConstantPrefix of ``pre_``
-   - StaticConstantSuffix of ``_post``
-   - StaticConstantHungarianPrefix of ``On``
+- {option}`StaticConstantCase` of `lower_case`
+- {option}`StaticConstantPrefix` of `pre_`
+- {option}`StaticConstantSuffix` of `_post`
+- {option}`StaticConstantHungarianPrefix` of `On`
 
 Identifies and/or transforms static constant names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    static unsigned const MyConstStatic_array[] = {1, 2, 3};
+```c++
+static unsigned const MyConstStatic_array[] = {1, 2, 3};
+```
 
 After:
 
-.. code-block:: c++
+```c++
+static unsigned const pre_myconststatic_array_post[] = {1, 2, 3};
+```
 
-    static unsigned const pre_myconststatic_array_post[] = {1, 2, 3};
+```{option} StaticVariableCase
+When defined, the check will ensure static variable names conform to the
+selected casing.
+```
 
-.. option:: StaticVariableCase
+```{option} StaticVariablePrefix
+When defined, the check will ensure static variable names will add the
+prefix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure static variable names conform to the
-    selected casing.
+```{option} StaticVariableIgnoredRegexp
+Identifier naming checks won't be enforced for static variable names
+matching this regular expression.
+```
 
-.. option:: StaticVariablePrefix
+```{option} StaticVariableSuffix
+When defined, the check will ensure static variable names will add the
+suffix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure static variable names will add the
-    prefix with the given value (regardless of casing).
-
-.. option:: StaticVariableIgnoredRegexp
-
-    Identifier naming checks won't be enforced for static variable names
-    matching this regular expression.
-
-.. option:: StaticVariableSuffix
-
-    When defined, the check will ensure static variable names will add the
-    suffix with the given value (regardless of casing).
-
-.. option:: StaticVariableHungarianPrefix
-
-    When enabled, the check ensures that the declared identifier will
-    have a Hungarian notation prefix based on the declared type.
+```{option} StaticVariableHungarianPrefix
+When enabled, the check ensures that the declared identifier will
+have a Hungarian notation prefix based on the declared type.
+```
 
 For example using values of:
 
-   - StaticVariableCase of ``lower_case``
-   - StaticVariablePrefix of ``pre_``
-   - StaticVariableSuffix of ``_post``
-   - StaticVariableHungarianPrefix of ``On``
+- {option}`StaticVariableCase` of `lower_case`
+- {option}`StaticVariablePrefix` of `pre_`
+- {option}`StaticVariableSuffix` of `_post`
+- {option}`StaticVariableHungarianPrefix` of `On`
 
 Identifies and/or transforms static variable names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    static unsigned MyStatic_array[] = {1, 2, 3};
+```c++
+static unsigned MyStatic_array[] = {1, 2, 3};
+```
 
 After:
 
-.. code-block:: c++
+```c++
+static unsigned pre_mystatic_array_post[] = {1, 2, 3};
+```
 
-    static unsigned pre_mystatic_array_post[] = {1, 2, 3};
+```{option} StructCase
+When defined, the check will ensure struct names conform to the
+selected casing.
+```
 
-.. option:: StructCase
+```{option} StructPrefix
+When defined, the check will ensure struct names will add the
+prefix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure struct names conform to the
-    selected casing.
+```{option} StructIgnoredRegexp
+Identifier naming checks won't be enforced for struct names
+matching this regular expression.
+```
 
-.. option:: StructPrefix
-
-    When defined, the check will ensure struct names will add the
-    prefix with the given value (regardless of casing).
-
-.. option:: StructIgnoredRegexp
-
-    Identifier naming checks won't be enforced for struct names
-    matching this regular expression.
-
-.. option:: StructSuffix
-
-    When defined, the check will ensure struct names will add the
-    suffix with the given value (regardless of casing).
+```{option} StructSuffix
+When defined, the check will ensure struct names will add the
+suffix with the given value (regardless of casing).
+```
 
 For example using values of:
 
-   - StructCase of ``lower_case``
-   - StructPrefix of ``pre_``
-   - StructSuffix of ``_post``
+- {option}`StructCase` of `lower_case`
+- {option}`StructPrefix` of `pre_`
+- {option}`StructSuffix` of `_post`
 
 Identifies and/or transforms struct names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    struct FOO {
-      FOO();
-      ~FOO();
-    };
+```c++
+struct FOO {
+  FOO();
+  ~FOO();
+};
+```
 
 After:
 
-.. code-block:: c++
+```c++
+struct pre_foo_post {
+  pre_foo_post();
+  ~pre_foo_post();
+};
+```
 
-    struct pre_foo_post {
-      pre_foo_post();
-      ~pre_foo_post();
-    };
+```{option} TemplateParameterCase
+When defined, the check will ensure template parameter names conform to the
+selected casing.
+```
 
-.. option:: TemplateParameterCase
+```{option} TemplateParameterPrefix
+When defined, the check will ensure template parameter names will add the
+prefix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure template parameter names conform to the
-    selected casing.
+```{option} TemplateParameterIgnoredRegexp
+Identifier naming checks won't be enforced for template parameter names
+matching this regular expression.
+```
 
-.. option:: TemplateParameterPrefix
-
-    When defined, the check will ensure template parameter names will add the
-    prefix with the given value (regardless of casing).
-
-.. option:: TemplateParameterIgnoredRegexp
-
-    Identifier naming checks won't be enforced for template parameter names
-    matching this regular expression.
-
-.. option:: TemplateParameterSuffix
-
-    When defined, the check will ensure template parameter names will add the
-    suffix with the given value (regardless of casing).
+```{option} TemplateParameterSuffix
+When defined, the check will ensure template parameter names will add the
+suffix with the given value (regardless of casing).
+```
 
 For example using values of:
 
-   - TemplateParameterCase of ``lower_case``
-   - TemplateParameterPrefix of ``pre_``
-   - TemplateParameterSuffix of ``_post``
+- {option}`TemplateParameterCase` of `lower_case`
+- {option}`TemplateParameterPrefix` of `pre_`
+- {option}`TemplateParameterSuffix` of `_post`
 
 Identifies and/or transforms template parameter names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    template <typename T> class Foo {};
+```c++
+template <typename T> class Foo {};
+```
 
 After:
 
-.. code-block:: c++
+```c++
+template <typename pre_t_post> class Foo {};
+```
 
-    template <typename pre_t_post> class Foo {};
+```{option} TemplateTemplateParameterCase
+When defined, the check will ensure template template parameter names conform to the
+selected casing.
+```
 
-.. option:: TemplateTemplateParameterCase
+```{option} TemplateTemplateParameterPrefix
+When defined, the check will ensure template template parameter names will add the
+prefix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure template template parameter names conform to the
-    selected casing.
+```{option} TemplateTemplateParameterIgnoredRegexp
+Identifier naming checks won't be enforced for template template parameter
+names matching this regular expression.
+```
 
-.. option:: TemplateTemplateParameterPrefix
-
-    When defined, the check will ensure template template parameter names will add the
-    prefix with the given value (regardless of casing).
-
-.. option:: TemplateTemplateParameterIgnoredRegexp
-
-    Identifier naming checks won't be enforced for template template parameter
-    names matching this regular expression.
-
-.. option:: TemplateTemplateParameterSuffix
-
-    When defined, the check will ensure template template parameter names will add the
-    suffix with the given value (regardless of casing).
+```{option} TemplateTemplateParameterSuffix
+When defined, the check will ensure template template parameter names will add the
+suffix with the given value (regardless of casing).
+```
 
 For example using values of:
 
-   - TemplateTemplateParameterCase of ``lower_case``
-   - TemplateTemplateParameterPrefix of ``pre_``
-   - TemplateTemplateParameterSuffix of ``_post``
+- {option}`TemplateTemplateParameterCase` of `lower_case`
+- {option}`TemplateTemplateParameterPrefix` of `pre_`
+- {option}`TemplateTemplateParameterSuffix` of `_post`
 
 Identifies and/or transforms template template parameter names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    template <template <typename> class TPL_parameter, int COUNT_params,
-              typename... TYPE_parameters>
+```c++
+template <template <typename> class TPL_parameter, int COUNT_params,
+          typename... TYPE_parameters>
+```
 
 After:
 
-.. code-block:: c++
+```c++
+template <template <typename> class pre_tpl_parameter_post, int COUNT_params,
+          typename... TYPE_parameters>
+```
 
-    template <template <typename> class pre_tpl_parameter_post, int COUNT_params,
-              typename... TYPE_parameters>
+```{option} TypeAliasCase
+When defined, the check will ensure type alias names conform to the
+selected casing.
+```
 
-.. option:: TypeAliasCase
+```{option} TypeAliasPrefix
+When defined, the check will ensure type alias names will add the
+prefix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure type alias names conform to the
-    selected casing.
+```{option} TypeAliasIgnoredRegexp
+Identifier naming checks won't be enforced for type alias names
+matching this regular expression.
+```
 
-.. option:: TypeAliasPrefix
-
-    When defined, the check will ensure type alias names will add the
-    prefix with the given value (regardless of casing).
-
-.. option:: TypeAliasIgnoredRegexp
-
-    Identifier naming checks won't be enforced for type alias names
-    matching this regular expression.
-
-.. option:: TypeAliasSuffix
-
-    When defined, the check will ensure type alias names will add the
-    suffix with the given value (regardless of casing).
+```{option} TypeAliasSuffix
+When defined, the check will ensure type alias names will add the
+suffix with the given value (regardless of casing).
+```
 
 For example using values of:
 
-   - TypeAliasCase of ``lower_case``
-   - TypeAliasPrefix of ``pre_``
-   - TypeAliasSuffix of ``_post``
+- {option}`TypeAliasCase` of `lower_case`
+- {option}`TypeAliasPrefix` of `pre_`
+- {option}`TypeAliasSuffix` of `_post`
 
 Identifies and/or transforms type alias names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    using MY_STRUCT_TYPE = my_structure;
+```c++
+using MY_STRUCT_TYPE = my_structure;
+```
 
 After:
 
-.. code-block:: c++
+```c++
+using pre_my_struct_type_post = my_structure;
+```
 
-    using pre_my_struct_type_post = my_structure;
+```{option} TypedefCase
+When defined, the check will ensure typedef names conform to the
+selected casing.
+```
 
-.. option:: TypedefCase
+```{option} TypedefPrefix
+When defined, the check will ensure typedef names will add the
+prefix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure typedef names conform to the
-    selected casing.
+```{option} TypedefIgnoredRegexp
+Identifier naming checks won't be enforced for typedef names
+matching this regular expression.
+```
 
-.. option:: TypedefPrefix
-
-    When defined, the check will ensure typedef names will add the
-    prefix with the given value (regardless of casing).
-
-.. option:: TypedefIgnoredRegexp
-
-    Identifier naming checks won't be enforced for typedef names
-    matching this regular expression.
-
-.. option:: TypedefSuffix
-
-    When defined, the check will ensure typedef names will add the
-    suffix with the given value (regardless of casing).
+```{option} TypedefSuffix
+When defined, the check will ensure typedef names will add the
+suffix with the given value (regardless of casing).
+```
 
 For example using values of:
 
-   - TypedefCase of ``lower_case``
-   - TypedefPrefix of ``pre_``
-   - TypedefSuffix of ``_post``
+- {option}`TypedefCase` of `lower_case`
+- {option}`TypedefPrefix` of `pre_`
+- {option}`TypedefSuffix` of `_post`
 
 Identifies and/or transforms typedef names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    typedef int MYINT;
+```c++
+typedef int MYINT;
+```
 
 After:
 
-.. code-block:: c++
+```c++
+typedef int pre_myint_post;
+```
 
-    typedef int pre_myint_post;
-
-.. option:: TypedefInheritAnonTagConfig
-
-    When set to `true`, a typedef or type alias that provides the only name of
-    an otherwise unnamed tag, as in ``typedef enum {} MyEnum;``, is checked
-    against the naming style configured for the kind of that tag
-    (``AbstractClass``, ``Class``, ``Enum``, ``Struct`` or ``Union``, i.e.
-    :option:`EnumCase`, :option:`EnumPrefix`, :option:`EnumSuffix` and
-    :option:`EnumIgnoredRegexp` for an enum) rather than against the typedef
-    or type alias style. If that kind configures no case, prefix or suffix,
-    the typedef or type alias style still applies. Typedefs of named tags, of
-    other typedefs and of non-tag types are not affected. Default is `false`.
+```{option} TypedefInheritAnonTagConfig
+When `true`, a typedef or type alias that provides the only name of
+an otherwise unnamed tag, as in `typedef enum {} MyEnum;`, is checked
+against the naming style configured for the kind of that tag
+(`AbstractClass`, `Class`, `Enum`, `Struct` or `Union`, i.e.
+{option}`EnumCase`, {option}`EnumPrefix`, {option}`EnumSuffix` and
+{option}`EnumIgnoredRegexp` for an enum) rather than against the typedef
+or type alias style. If that kind configures no case, prefix or suffix,
+the typedef or type alias style still applies. Typedefs of named tags, of
+other typedefs and of non-tag types are not affected. Default is `false`.
+```
 
 For example using values of:
 
-   - TypedefInheritAnonTagConfig of `true`
-   - EnumCase of ``CamelCase``
-   - TypedefCase of ``lower_case``
+- {option}`TypedefInheritAnonTagConfig` of `true`
+- {option}`EnumCase` of `CamelCase`
+- {option}`TypedefCase` of `lower_case`
 
 Identifies and/or transforms names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    typedef enum { VAL } my_enum;        // The typedef names the enum.
-    typedef enum Kind { VAL2 } my_kind;  // Kind names the enum.
+```c++
+typedef enum { VAL } my_enum;        // The typedef names the enum.
+typedef enum Kind { VAL2 } my_kind;  // Kind names the enum.
+```
 
 After:
 
-.. code-block:: c++
+```c++
+typedef enum { VAL } MyEnum;
+typedef enum Kind { VAL2 } my_kind;
+```
 
-    typedef enum { VAL } MyEnum;
-    typedef enum Kind { VAL2 } my_kind;
+```{option} TypeTemplateParameterCase
+When defined, the check will ensure type template parameter names conform to the
+selected casing.
+```
 
-.. option:: TypeTemplateParameterCase
+```{option} TypeTemplateParameterPrefix
+When defined, the check will ensure type template parameter names will add the
+prefix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure type template parameter names conform to the
-    selected casing.
+```{option} TypeTemplateParameterIgnoredRegexp
+Identifier naming checks won't be enforced for type template names
+matching this regular expression.
+```
 
-.. option:: TypeTemplateParameterPrefix
-
-    When defined, the check will ensure type template parameter names will add the
-    prefix with the given value (regardless of casing).
-
-.. option:: TypeTemplateParameterIgnoredRegexp
-
-    Identifier naming checks won't be enforced for type template names
-    matching this regular expression.
-
-.. option:: TypeTemplateParameterSuffix
-
-    When defined, the check will ensure type template parameter names will add the
-    suffix with the given value (regardless of casing).
+```{option} TypeTemplateParameterSuffix
+When defined, the check will ensure type template parameter names will add the
+suffix with the given value (regardless of casing).
+```
 
 For example using values of:
 
-   - TypeTemplateParameterCase of ``lower_case``
-   - TypeTemplateParameterPrefix of ``pre_``
-   - TypeTemplateParameterSuffix of ``_post``
+- {option}`TypeTemplateParameterCase` of `lower_case`
+- {option}`TypeTemplateParameterPrefix` of `pre_`
+- {option}`TypeTemplateParameterSuffix` of `_post`
 
 Identifies and/or transforms type template parameter names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    template <template <typename> class TPL_parameter, int COUNT_params,
-              typename... TYPE_parameters>
+```c++
+template <template <typename> class TPL_parameter, int COUNT_params,
+          typename... TYPE_parameters>
+```
 
 After:
 
-.. code-block:: c++
+```c++
+template <template <typename> class TPL_parameter, int COUNT_params,
+          typename... pre_type_parameters_post>
+```
 
-    template <template <typename> class TPL_parameter, int COUNT_params,
-              typename... pre_type_parameters_post>
+```{option} UnionCase
+When defined, the check will ensure union names conform to the
+selected casing.
+```
 
-.. option:: UnionCase
+```{option} UnionPrefix
+When defined, the check will ensure union names will add the
+prefix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure union names conform to the
-    selected casing.
+```{option} UnionIgnoredRegexp
+Identifier naming checks won't be enforced for union names
+matching this regular expression.
+```
 
-.. option:: UnionPrefix
-
-    When defined, the check will ensure union names will add the
-    prefix with the given value (regardless of casing).
-
-.. option:: UnionIgnoredRegexp
-
-    Identifier naming checks won't be enforced for union names
-    matching this regular expression.
-
-.. option:: UnionSuffix
-
-    When defined, the check will ensure union names will add the
-    suffix with the given value (regardless of casing).
+```{option} UnionSuffix
+When defined, the check will ensure union names will add the
+suffix with the given value (regardless of casing).
+```
 
 For example using values of:
 
-   - UnionCase of ``lower_case``
-   - UnionPrefix of ``pre_``
-   - UnionSuffix of ``_post``
+- {option}`UnionCase` of `lower_case`
+- {option}`UnionPrefix` of `pre_`
+- {option}`UnionSuffix` of `_post`
 
 Identifies and/or transforms union names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    union FOO {
-      int a;
-      char b;
-    };
+```c++
+union FOO {
+  int a;
+  char b;
+};
+```
 
 After:
 
-.. code-block:: c++
+```c++
+union pre_foo_post {
+  int a;
+  char b;
+};
+```
 
-    union pre_foo_post {
-      int a;
-      char b;
-    };
+```{option} ValueTemplateParameterCase
+When defined, the check will ensure value template parameter names conform to the
+selected casing.
+```
 
-.. option:: ValueTemplateParameterCase
+```{option} ValueTemplateParameterPrefix
+When defined, the check will ensure value template parameter names will add the
+prefix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure value template parameter names conform to the
-    selected casing.
+```{option} ValueTemplateParameterIgnoredRegexp
+Identifier naming checks won't be enforced for value template parameter
+names matching this regular expression.
+```
 
-.. option:: ValueTemplateParameterPrefix
-
-    When defined, the check will ensure value template parameter names will add the
-    prefix with the given value (regardless of casing).
-
-.. option:: ValueTemplateParameterIgnoredRegexp
-
-    Identifier naming checks won't be enforced for value template parameter
-    names matching this regular expression.
-
-.. option:: ValueTemplateParameterSuffix
-
-    When defined, the check will ensure value template parameter names will add the
-    suffix with the given value (regardless of casing).
+```{option} ValueTemplateParameterSuffix
+When defined, the check will ensure value template parameter names will add the
+suffix with the given value (regardless of casing).
+```
 
 For example using values of:
 
-   - ValueTemplateParameterCase of ``lower_case``
-   - ValueTemplateParameterPrefix of ``pre_``
-   - ValueTemplateParameterSuffix of ``_post``
+- {option}`ValueTemplateParameterCase` of `lower_case`
+- {option}`ValueTemplateParameterPrefix` of `pre_`
+- {option}`ValueTemplateParameterSuffix` of `_post`
 
 Identifies and/or transforms value template parameter names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    template <template <typename> class TPL_parameter, int COUNT_params,
-              typename... TYPE_parameters>
+```c++
+template <template <typename> class TPL_parameter, int COUNT_params,
+          typename... TYPE_parameters>
+```
 
 After:
 
-.. code-block:: c++
+```c++
+template <template <typename> class TPL_parameter, int pre_count_params_post,
+          typename... TYPE_parameters>
+```
 
-    template <template <typename> class TPL_parameter, int pre_count_params_post,
-              typename... TYPE_parameters>
+```{option} VariableCase
+When defined, the check will ensure variable names conform to the
+selected casing.
+```
 
-.. option:: VariableCase
+```{option} VariablePrefix
+When defined, the check will ensure variable names will add the
+prefix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure variable names conform to the
-    selected casing.
+```{option} VariableIgnoredRegexp
+Identifier naming checks won't be enforced for variable names
+matching this regular expression.
+```
 
-.. option:: VariablePrefix
+```{option} VariableSuffix
+When defined, the check will ensure variable names will add the
+suffix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure variable names will add the
-    prefix with the given value (regardless of casing).
-
-.. option:: VariableIgnoredRegexp
-
-    Identifier naming checks won't be enforced for variable names
-    matching this regular expression.
-
-.. option:: VariableSuffix
-
-    When defined, the check will ensure variable names will add the
-    suffix with the given value (regardless of casing).
-
-.. option:: VariableHungarianPrefix
-
-    When enabled, the check ensures that the declared identifier will
-    have a Hungarian notation prefix based on the declared type.
+```{option} VariableHungarianPrefix
+When enabled, the check ensures that the declared identifier will
+have a Hungarian notation prefix based on the declared type.
+```
 
 For example using values of:
 
-   - VariableCase of ``lower_case``
-   - VariablePrefix of ``pre_``
-   - VariableSuffix of ``_post``
-   - VariableHungarianPrefix of ``On``
+- {option}`VariableCase` of `lower_case`
+- {option}`VariablePrefix` of `pre_`
+- {option}`VariableSuffix` of `_post`
+- {option}`VariableHungarianPrefix` of `On`
 
 Identifies and/or transforms variable names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    unsigned MyVariable;
+```c++
+unsigned MyVariable;
+```
 
 After:
 
-.. code-block:: c++
+```c++
+unsigned pre_myvariable_post;
+```
 
-    unsigned pre_myvariable_post;
+```{option} VirtualMethodCase
+When defined, the check will ensure virtual method names conform to the
+selected casing.
+```
 
-.. option:: VirtualMethodCase
+```{option} VirtualMethodPrefix
+When defined, the check will ensure virtual method names will add the
+prefix with the given value (regardless of casing).
+```
 
-    When defined, the check will ensure virtual method names conform to the
-    selected casing.
+```{option} VirtualMethodIgnoredRegexp
+Identifier naming checks won't be enforced for virtual method names
+matching this regular expression.
+```
 
-.. option:: VirtualMethodPrefix
-
-    When defined, the check will ensure virtual method names will add the
-    prefix with the given value (regardless of casing).
-
-.. option:: VirtualMethodIgnoredRegexp
-
-    Identifier naming checks won't be enforced for virtual method names
-    matching this regular expression.
-
-.. option:: VirtualMethodSuffix
-
-    When defined, the check will ensure virtual method names will add the
-    suffix with the given value (regardless of casing).
+```{option} VirtualMethodSuffix
+When defined, the check will ensure virtual method names will add the
+suffix with the given value (regardless of casing).
+```
 
 For example using values of:
 
-   - VirtualMethodCase of ``lower_case``
-   - VirtualMethodPrefix of ``pre_``
-   - VirtualMethodSuffix of ``_post``
+- {option}`VirtualMethodCase` of `lower_case`
+- {option}`VirtualMethodPrefix` of `pre_`
+- {option}`VirtualMethodSuffix` of `_post`
 
 Identifies and/or transforms virtual method names as follows:
 
 Before:
 
-.. code-block:: c++
-
-    class Foo {
-    public:
-      virtual int MemberFunction();
-    }
+```c++
+class Foo {
+public:
+  virtual int MemberFunction();
+}
+```
 
 After:
 
-.. code-block:: c++
+```c++
+class Foo {
+public:
+  virtual int pre_member_function_post();
+}
+```
 
-    class Foo {
-    public:
-      virtual int pre_member_function_post();
-    }
-
-
-The default mapping table of Hungarian Notation
------------------------------------------------
+## The default mapping table of Hungarian Notation
 
 In Hungarian notation, a variable name starts with a group of lower-case
 letters which are mnemonics for the type or purpose of that variable, followed
@@ -3090,10 +3084,10 @@ distinguished as the given name. The first character of the given name can be
 capitalized to separate it from the type indicators (see also CamelCase).
 Otherwise the case of this character denotes scope.
 
-The following table is the default mapping table of Hungarian Notation
-which maps Decl to its prefix string. You can also have your own style
-in config file.
+The following table maps type names to their default Hungarian notation
+prefixes. You can define custom mappings in the configuration file.
 
+```{eval-rst}
 ============== ======== ====================== ======== ============== ========
 Primitive Type                                          Microsoft Type
 -------------- -------- ---------------------- -------- -------------- --------
@@ -3129,189 +3123,172 @@ wchar_t        wc                                       UINT64         u64
 short int      si                                       PVOID          p
 short          s
 ============== ======== ====================== ======== ============== ========
+```
 
 **There are more trivial options for Hungarian Notation:**
 
-**HungarianNotation.General.***
-  Options are not belonging to any specific Decl.
+- **HungarianNotation.General.\***: Options not belonging to any specific
+  declaration.
+- **HungarianNotation.CString.\***: Options for null-terminated strings.
+- **HungarianNotation.DerivedType.\***: Options for derived types.
+- **HungarianNotation.PrimitiveType.\***: Options for primitive types.
+- **HungarianNotation.UserDefinedType.\***: Options for user-defined types.
 
-**HungarianNotation.CString.***
-  Options for NULL-terminated string.
+## Options for Hungarian Notation
 
-**HungarianNotation.DerivedType.***
- Options for derived types.
+- {option}`HungarianNotation.General.TreatStructAsClass`
+- {option}`HungarianNotation.DerivedType.Array`
+- {option}`HungarianNotation.DerivedType.Pointer`
+- {option}`HungarianNotation.DerivedType.FunctionPointer`
+- {option}`HungarianNotation.CString.CharPointer`
+- {option}`HungarianNotation.CString.CharArray`
+- {option}`HungarianNotation.CString.WideCharPointer`
+- {option}`HungarianNotation.CString.WideCharArray`
+- {option}`HungarianNotation.PrimitiveType.*`
+- {option}`HungarianNotation.UserDefinedType.*`
 
-**HungarianNotation.PrimitiveType.***
-  Options for primitive types.
+```{option} HungarianNotation.General.TreatStructAsClass
+When defined, the check will treat naming of struct as a class.
+Default is `false`.
+```
 
-**HungarianNotation.UserDefinedType.***
-  Options for user-defined types.
+```{option} HungarianNotation.DerivedType.Array
+When defined, the check will ensure variable name will add the prefix with
+the given string. Default is `a`.
+```
 
+```{option} HungarianNotation.DerivedType.Pointer
+When defined, the check will ensure variable name will add the prefix with
+the given string. Default is `p`.
+```
 
-Options for Hungarian Notation
-------------------------------
-
-- :option:`HungarianNotation.General.TreatStructAsClass`
-
-- :option:`HungarianNotation.DerivedType.Array`
-- :option:`HungarianNotation.DerivedType.Pointer`
-- :option:`HungarianNotation.DerivedType.FunctionPointer`
-
-- :option:`HungarianNotation.CString.CharPointer`
-- :option:`HungarianNotation.CString.CharArray`
-- :option:`HungarianNotation.CString.WideCharPointer`
-- :option:`HungarianNotation.CString.WideCharArray`
-
-- :option:`HungarianNotation.PrimitiveType.*`
-- :option:`HungarianNotation.UserDefinedType.*`
-
-.. option:: HungarianNotation.General.TreatStructAsClass
-
-    When defined, the check will treat naming of struct as a class.
-    The default value is `false`.
-
-.. option:: HungarianNotation.DerivedType.Array
-
-    When defined, the check will ensure variable name will add the prefix with
-    the given string. The default prefix is `a`.
-
-.. option:: HungarianNotation.DerivedType.Pointer
-
-    When defined, the check will ensure variable name will add the prefix with
-    the given string. The default prefix is `p`.
-
-.. option:: HungarianNotation.DerivedType.FunctionPointer
-
-    When defined, the check will ensure variable name will add the prefix with
-    the given string. The default prefix is `fn`.
-
+```{option} HungarianNotation.DerivedType.FunctionPointer
+When defined, the check will ensure variable name will add the prefix with
+the given string. Default is `fn`.
+```
 
 Before:
 
-.. code-block:: c++
+```c++
+// Array
+int DataArray[2] = {0};
 
-    // Array
-    int DataArray[2] = {0};
+// Pointer
+void *DataBuffer = NULL;
 
-    // Pointer
-    void *DataBuffer = NULL;
-
-    // FunctionPointer
-    typedef void (*FUNC_PTR)();
-    FUNC_PTR FuncPtr = NULL;
+// FunctionPointer
+typedef void (*FUNC_PTR)();
+FUNC_PTR FuncPtr = NULL;
+```
 
 After:
 
-.. code-block:: c++
+```c++
+// Array
+int aDataArray[2] = {0};
 
-    // Array
-    int aDataArray[2] = {0};
+// Pointer
+void *pDataBuffer = NULL;
 
-    // Pointer
-    void *pDataBuffer = NULL;
+// FunctionPointer
+typedef void (*FUNC_PTR)();
+FUNC_PTR fnFuncPtr = NULL;
+```
 
-    // FunctionPointer
-    typedef void (*FUNC_PTR)();
-    FUNC_PTR fnFuncPtr = NULL;
+```{option} HungarianNotation.CString.CharPointer
+When defined, the check will ensure variable name will add the prefix with
+the given string. Default is `sz`.
+```
 
+```{option} HungarianNotation.CString.CharArray
+When defined, the check will ensure variable name will add the prefix with
+the given string. Default is `sz`.
+```
 
-.. option:: HungarianNotation.CString.CharPointer
+```{option} HungarianNotation.CString.WideCharPointer
+When defined, the check will ensure variable name will add the prefix with
+the given string. Default is `wsz`.
+```
 
-    When defined, the check will ensure variable name will add the prefix with
-    the given string. The default prefix is `sz`.
-
-.. option:: HungarianNotation.CString.CharArray
-
-    When defined, the check will ensure variable name will add the prefix with
-    the given string. The default prefix is `sz`.
-
-.. option:: HungarianNotation.CString.WideCharPointer
-
-    When defined, the check will ensure variable name will add the prefix with
-    the given string. The default prefix is `wsz`.
-
-.. option:: HungarianNotation.CString.WideCharArray
-
-    When defined, the check will ensure variable name will add the prefix with
-    the given string. The default prefix is `wsz`.
-
+```{option} HungarianNotation.CString.WideCharArray
+When defined, the check will ensure variable name will add the prefix with
+the given string. Default is `wsz`.
+```
 
 Before:
 
-.. code-block:: c++
+```c++
+// CharPointer
+const char *NamePtr = "Name";
 
-    // CharPointer
-    const char *NamePtr = "Name";
+// CharArray
+const char NameArray[] = "Name";
 
-    // CharArray
-    const char NameArray[] = "Name";
+// WideCharPointer
+const wchar_t *WideNamePtr = L"Name";
 
-    // WideCharPointer
-    const wchar_t *WideNamePtr = L"Name";
-
-    // WideCharArray
-    const wchar_t WideNameArray[] = L"Name";
+// WideCharArray
+const wchar_t WideNameArray[] = L"Name";
+```
 
 After:
 
-.. code-block:: c++
+```c++
+// CharPointer
+const char *szNamePtr = "Name";
 
-    // CharPointer
-    const char *szNamePtr = "Name";
+// CharArray
+const char szNameArray[] = "Name";
 
-    // CharArray
-    const char szNameArray[] = "Name";
+// WideCharPointer
+const wchar_t *wszWideNamePtr = L"Name";
 
-    // WideCharPointer
-    const wchar_t *wszWideNamePtr = L"Name";
+// WideCharArray
+const wchar_t wszWideNameArray[] = L"Name";
+```
 
-    // WideCharArray
-    const wchar_t wszWideNameArray[] = L"Name";
+```{option} HungarianNotation.PrimitiveType.*
+When defined, the check will ensure variable name of involved primitive
+types will add the prefix with the given string. The default prefixes are
+defined in the default mapping table.
+```
 
-
-.. option:: HungarianNotation.PrimitiveType.*
-
-    When defined, the check will ensure variable name of involved primitive
-    types will add the prefix with the given string. The default prefixes are
-    defined in the default mapping table.
-
-.. option:: HungarianNotation.UserDefinedType.*
-
-    When defined, the check will ensure variable name of involved primitive
-    types will add the prefix with the given string. The default prefixes are
-    defined in the default mapping table.
-
+```{option} HungarianNotation.UserDefinedType.*
+When defined, the check will ensure variable name of involved user-defined
+types will add the prefix with the given string. The default prefixes are
+defined in the default mapping table.
+```
 
 Before:
 
-.. code-block:: c++
-
-    int8_t   ValueI8      = 0;
-    int16_t  ValueI16     = 0;
-    int32_t  ValueI32     = 0;
-    int64_t  ValueI64     = 0;
-    uint8_t  ValueU8      = 0;
-    uint16_t ValueU16     = 0;
-    uint32_t ValueU32     = 0;
-    uint64_t ValueU64     = 0;
-    float    ValueFloat   = 0.0;
-    double   ValueDouble  = 0.0;
-    ULONG    ValueUlong   = 0;
-    DWORD    ValueDword   = 0;
+```c++
+int8_t   ValueI8      = 0;
+int16_t  ValueI16     = 0;
+int32_t  ValueI32     = 0;
+int64_t  ValueI64     = 0;
+uint8_t  ValueU8      = 0;
+uint16_t ValueU16     = 0;
+uint32_t ValueU32     = 0;
+uint64_t ValueU64     = 0;
+float    ValueFloat   = 0.0;
+double   ValueDouble  = 0.0;
+ULONG    ValueUlong   = 0;
+DWORD    ValueDword   = 0;
+```
 
 After:
 
-.. code-block:: c++
-
-    int8_t   i8ValueI8    = 0;
-    int16_t  i16ValueI16  = 0;
-    int32_t  i32ValueI32  = 0;
-    int64_t  i64ValueI64  = 0;
-    uint8_t  u8ValueU8    = 0;
-    uint16_t u16ValueU16  = 0;
-    uint32_t u32ValueU32  = 0;
-    uint64_t u64ValueU64  = 0;
-    float    fValueFloat  = 0.0;
-    double   dValueDouble = 0.0;
-    ULONG    ulValueUlong = 0;
-    DWORD    dwValueDword = 0;
+```c++
+int8_t   i8ValueI8    = 0;
+int16_t  i16ValueI16  = 0;
+int32_t  i32ValueI32  = 0;
+int64_t  i64ValueI64  = 0;
+uint8_t  u8ValueU8    = 0;
+uint16_t u16ValueU16  = 0;
+uint32_t u32ValueU32  = 0;
+uint64_t u64ValueU64  = 0;
+float    fValueFloat  = 0.0;
+double   dValueDouble = 0.0;
+ULONG    ulValueUlong = 0;
+DWORD    dwValueDword = 0;
+```

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/identifier-naming.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/identifier-naming.md
@@ -46,15 +46,15 @@ settings. The options and their corresponding values are:
 
 The check only enforces style on kinds of identifiers which have been
 configured, so an empty config effectively disables it.
-The {option}`DefaultCase` option can be used to enforce style on all kinds of
+The [`DefaultCase`](#readability-identifier-naming-default-case) option can be used to enforce style on all kinds of
 identifiers, then optionally overriden for specific kinds which are desired
 with a different case.
 
 For example using values of:
 
-- {option}`DefaultCase` of `lower_case`
-- {option}`MacroDefinitionCase` of `UPPER_CASE`
-- {option}`TemplateParameterCase` of `CamelCase`
+- [`DefaultCase`](#readability-identifier-naming-default-case) of `lower_case`
+- [`MacroDefinitionCase`](#readability-identifier-naming-macro-definition-case) of `UPPER_CASE`
+- [`TemplateParameterCase`](#readability-identifier-naming-template-parameter-case) of `CamelCase`
 
 Identifies and transforms names as follows:
 
@@ -80,228 +80,248 @@ The available options are summarized below:
 
 **General options**
 
-- {option}`AggressiveDependentMemberLookup`
-- {option}`AllowTrailingUnderscore`
-- {option}`CheckAnonFieldInParent`
-- {option}`GetConfigPerFile`
-- {option}`IgnoreMainLikeFunctions`
-- {option}`TypedefInheritAnonTagConfig`
+- [`AggressiveDependentMemberLookup`](#readability-identifier-naming-aggressive-dependent-member-lookup)
+- [`AllowTrailingUnderscore`](#readability-identifier-naming-allow-trailing-underscore)
+- [`CheckAnonFieldInParent`](#readability-identifier-naming-check-anon-field-in-parent)
+- [`GetConfigPerFile`](#readability-identifier-naming-get-config-per-file)
+- [`IgnoreMainLikeFunctions`](#readability-identifier-naming-ignore-main-like-functions)
+- [`TypedefInheritAnonTagConfig`](#readability-identifier-naming-typedef-inherit-anon-tag-config)
 
 **Specific options**
 
-- {option}`DefaultCase`, {option}`DefaultPrefix`,
-  {option}`DefaultSuffix`, {option}`DefaultIgnoredRegexp`,
-  {option}`DefaultHungarianPrefix`
-- {option}`AbstractClassCase`, {option}`AbstractClassPrefix`,
-  {option}`AbstractClassSuffix`, {option}`AbstractClassIgnoredRegexp`,
-  {option}`AbstractClassHungarianPrefix`
-- {option}`ClassCase`, {option}`ClassPrefix`, {option}`ClassSuffix`,
-  {option}`ClassIgnoredRegexp`, {option}`ClassHungarianPrefix`
-- {option}`ClassConstexprCase`, {option}`ClassConstexprPrefix`,
-  {option}`ClassConstexprSuffix`, {option}`ClassConstexprIgnoredRegexp`,
-  {option}`ClassConstexprHungarianPrefix`
-- {option}`ClassConstantCase`, {option}`ClassConstantPrefix`,
-  {option}`ClassConstantSuffix`, {option}`ClassConstantIgnoredRegexp`,
-  {option}`ClassConstantHungarianPrefix`
-- {option}`ClassMemberCase`, {option}`ClassMemberPrefix`,
-  {option}`ClassMemberSuffix`, {option}`ClassMemberIgnoredRegexp`,
-  {option}`ClassMemberHungarianPrefix`
-- {option}`ClassMethodCase`, {option}`ClassMethodPrefix`,
-  {option}`ClassMethodSuffix`, {option}`ClassMethodIgnoredRegexp`
-- {option}`ConceptCase`, {option}`ConceptPrefix`, {option}`ConceptSuffix`,
-  {option}`ConceptIgnoredRegexp`
-- {option}`ConstantCase`, {option}`ConstantPrefix`, {option}`ConstantSuffix`,
-  {option}`ConstantIgnoredRegexp`, {option}`ConstantHungarianPrefix`
-- {option}`ConstantMemberCase`, {option}`ConstantMemberPrefix`,
-  {option}`ConstantMemberSuffix`, {option}`ConstantMemberIgnoredRegexp`,
-  {option}`ConstantMemberHungarianPrefix`
-- {option}`ConstantParameterCase`, {option}`ConstantParameterPrefix`,
-  {option}`ConstantParameterSuffix`, {option}`ConstantParameterIgnoredRegexp`,
-  {option}`ConstantParameterHungarianPrefix`
-- {option}`ConstantPointerParameterCase`,
-  {option}`ConstantPointerParameterPrefix`,
-  {option}`ConstantPointerParameterSuffix`,
-  {option}`ConstantPointerParameterIgnoredRegexp`,
-  {option}`ConstantPointerParameterHungarianPrefix`
-- {option}`ConstexprFunctionCase`, {option}`ConstexprFunctionPrefix`,
-  {option}`ConstexprFunctionSuffix`, {option}`ConstexprFunctionIgnoredRegexp`
-- {option}`ConstexprMethodCase`, {option}`ConstexprMethodPrefix`,
-  {option}`ConstexprMethodSuffix`, {option}`ConstexprMethodIgnoredRegexp`
-- {option}`ConstexprVariableCase`, {option}`ConstexprVariablePrefix`,
-  {option}`ConstexprVariableSuffix`, {option}`ConstexprVariableIgnoredRegexp`,
-  {option}`ConstexprVariableHungarianPrefix`
-- {option}`EnumCase`, {option}`EnumPrefix`, {option}`EnumSuffix`,
-  {option}`EnumIgnoredRegexp`
-- {option}`EnumConstantCase`, {option}`EnumConstantPrefix`,
-  {option}`EnumConstantSuffix`, {option}`EnumConstantIgnoredRegexp`,
-  {option}`EnumConstantHungarianPrefix`
-- {option}`FunctionCase`, {option}`FunctionPrefix`, {option}`FunctionSuffix`,
-  {option}`FunctionIgnoredRegexp`
-- {option}`GlobalConstexprVariableCase`,
-  {option}`GlobalConstexprVariablePrefix`,
-  {option}`GlobalConstexprVariableSuffix`,
-  {option}`GlobalConstexprVariableIgnoredRegexp`,
-  {option}`GlobalConstexprVariableHungarianPrefix`
-- {option}`GlobalConstantCase`, {option}`GlobalConstantPrefix`,
-  {option}`GlobalConstantSuffix`, {option}`GlobalConstantIgnoredRegexp`,
-  {option}`GlobalConstantHungarianPrefix`
-- {option}`GlobalConstantPointerCase`,
-  {option}`GlobalConstantPointerPrefix`,
-  {option}`GlobalConstantPointerSuffix`,
-  {option}`GlobalConstantPointerIgnoredRegexp`,
-  {option}`GlobalConstantPointerHungarianPrefix`
-- {option}`GlobalFunctionCase`, {option}`GlobalFunctionPrefix`,
-  {option}`GlobalFunctionSuffix`, {option}`GlobalFunctionIgnoredRegexp`
-- {option}`GlobalPointerCase`, {option}`GlobalPointerPrefix`,
-  {option}`GlobalPointerSuffix`, {option}`GlobalPointerIgnoredRegexp`,
-  {option}`GlobalPointerHungarianPrefix`
-- {option}`GlobalVariableCase`, {option}`GlobalVariablePrefix`,
-  {option}`GlobalVariableSuffix`, {option}`GlobalVariableIgnoredRegexp`,
-  {option}`GlobalVariableHungarianPrefix`
-- {option}`InlineNamespaceCase`, {option}`InlineNamespacePrefix`,
-  {option}`InlineNamespaceSuffix`, {option}`InlineNamespaceIgnoredRegexp`
-- {option}`LambdaCaptureCase`, {option}`LambdaCapturePrefix`,
-  {option}`LambdaCaptureSuffix`, {option}`LambdaCaptureIgnoredRegexp`,
-  {option}`LambdaCaptureHungarianPrefix`
-- {option}`LocalConstexprVariableCase`,
-  {option}`LocalConstexprVariablePrefix`,
-  {option}`LocalConstexprVariableSuffix`,
-  {option}`LocalConstexprVariableIgnoredRegexp`,
-  {option}`LocalConstexprVariableHungarianPrefix`
-- {option}`LocalConstantCase`, {option}`LocalConstantPrefix`,
-  {option}`LocalConstantSuffix`, {option}`LocalConstantIgnoredRegexp`,
-  {option}`LocalConstantHungarianPrefix`
-- {option}`LocalConstantPointerCase`,
-  {option}`LocalConstantPointerPrefix`,
-  {option}`LocalConstantPointerSuffix`,
-  {option}`LocalConstantPointerIgnoredRegexp`,
-  {option}`LocalConstantPointerHungarianPrefix`
-- {option}`LocalPointerCase`, {option}`LocalPointerPrefix`,
-  {option}`LocalPointerSuffix`, {option}`LocalPointerIgnoredRegexp`,
-  {option}`LocalPointerHungarianPrefix`
-- {option}`LocalVariableCase`, {option}`LocalVariablePrefix`,
-  {option}`LocalVariableSuffix`, {option}`LocalVariableIgnoredRegexp`,
-  {option}`LocalVariableHungarianPrefix`
-- {option}`MacroDefinitionCase`, {option}`MacroDefinitionPrefix`,
-  {option}`MacroDefinitionSuffix`, {option}`MacroDefinitionIgnoredRegexp`
-- {option}`MemberCase`, {option}`MemberPrefix`, {option}`MemberSuffix`,
-  {option}`MemberIgnoredRegexp`, {option}`MemberHungarianPrefix`
-- {option}`MethodCase`, {option}`MethodPrefix`, {option}`MethodSuffix`,
-  {option}`MethodIgnoredRegexp`
-- {option}`NamespaceCase`, {option}`NamespacePrefix`,
-  {option}`NamespaceSuffix`, {option}`NamespaceIgnoredRegexp`
-- {option}`ParameterCase`, {option}`ParameterPrefix`,
-  {option}`ParameterSuffix`, {option}`ParameterIgnoredRegexp`,
-  {option}`ParameterHungarianPrefix`
-- {option}`ParameterPackCase`, {option}`ParameterPackPrefix`,
-  {option}`ParameterPackSuffix`, {option}`ParameterPackIgnoredRegexp`
-- {option}`PointerParameterCase`, {option}`PointerParameterPrefix`,
-  {option}`PointerParameterSuffix`, {option}`PointerParameterIgnoredRegexp`,
-  {option}`PointerParameterHungarianPrefix`
-- {option}`PrivateMemberCase`, {option}`PrivateMemberPrefix`,
-  {option}`PrivateMemberSuffix`, {option}`PrivateMemberIgnoredRegexp`,
-  {option}`PrivateMemberHungarianPrefix`
-- {option}`PrivateMethodCase`, {option}`PrivateMethodPrefix`,
-  {option}`PrivateMethodSuffix`, {option}`PrivateMethodIgnoredRegexp`
-- {option}`ProtectedMemberCase`, {option}`ProtectedMemberPrefix`,
-  {option}`ProtectedMemberSuffix`, {option}`ProtectedMemberIgnoredRegexp`,
-  {option}`ProtectedMemberHungarianPrefix`
-- {option}`ProtectedMethodCase`, {option}`ProtectedMethodPrefix`,
-  {option}`ProtectedMethodSuffix`, {option}`ProtectedMethodIgnoredRegexp`
-- {option}`PublicMemberCase`, {option}`PublicMemberPrefix`,
-  {option}`PublicMemberSuffix`, {option}`PublicMemberIgnoredRegexp`,
-  {option}`PublicMemberHungarianPrefix`
-- {option}`PublicMethodCase`, {option}`PublicMethodPrefix`,
-  {option}`PublicMethodSuffix`, {option}`PublicMethodIgnoredRegexp`
-- {option}`ScopedEnumConstantCase`, {option}`ScopedEnumConstantPrefix`,
-  {option}`ScopedEnumConstantSuffix`,
-  {option}`ScopedEnumConstantIgnoredRegexp`
-- {option}`StaticConstexprVariableCase`,
-  {option}`StaticConstexprVariablePrefix`,
-  {option}`StaticConstexprVariableSuffix`,
-  {option}`StaticConstexprVariableIgnoredRegexp`,
-  {option}`StaticConstexprVariableHungarianPrefix`
-- {option}`StaticConstantCase`, {option}`StaticConstantPrefix`,
-  {option}`StaticConstantSuffix`, {option}`StaticConstantIgnoredRegexp`,
-  {option}`StaticConstantHungarianPrefix`
-- {option}`StaticVariableCase`, {option}`StaticVariablePrefix`,
-  {option}`StaticVariableSuffix`, {option}`StaticVariableIgnoredRegexp`,
-  {option}`StaticVariableHungarianPrefix`
-- {option}`StructCase`, {option}`StructPrefix`, {option}`StructSuffix`,
-  {option}`StructIgnoredRegexp`
-- {option}`TemplateParameterCase`, {option}`TemplateParameterPrefix`,
-  {option}`TemplateParameterSuffix`, {option}`TemplateParameterIgnoredRegexp`
-- {option}`TemplateTemplateParameterCase`,
-  {option}`TemplateTemplateParameterPrefix`,
-  {option}`TemplateTemplateParameterSuffix`,
-  {option}`TemplateTemplateParameterIgnoredRegexp`
-- {option}`TypeAliasCase`, {option}`TypeAliasPrefix`,
-  {option}`TypeAliasSuffix`, {option}`TypeAliasIgnoredRegexp`
-- {option}`TypedefCase`, {option}`TypedefPrefix`, {option}`TypedefSuffix`,
-  {option}`TypedefIgnoredRegexp`
-- {option}`TypeTemplateParameterCase`,
-  {option}`TypeTemplateParameterPrefix`,
-  {option}`TypeTemplateParameterSuffix`,
-  {option}`TypeTemplateParameterIgnoredRegexp`
-- {option}`UnionCase`, {option}`UnionPrefix`, {option}`UnionSuffix`,
-  {option}`UnionIgnoredRegexp`
-- {option}`ValueTemplateParameterCase`,
-  {option}`ValueTemplateParameterPrefix`,
-  {option}`ValueTemplateParameterSuffix`,
-  {option}`ValueTemplateParameterIgnoredRegexp`
-- {option}`VariableCase`, {option}`VariablePrefix`, {option}`VariableSuffix`,
-  {option}`VariableIgnoredRegexp`, {option}`VariableHungarianPrefix`
-- {option}`VirtualMethodCase`, {option}`VirtualMethodPrefix`,
-  {option}`VirtualMethodSuffix`, {option}`VirtualMethodIgnoredRegexp`
+- [`DefaultCase`](#readability-identifier-naming-default-case), [`DefaultPrefix`](#readability-identifier-naming-default-prefix),
+  [`DefaultSuffix`](#readability-identifier-naming-default-suffix), [`DefaultIgnoredRegexp`](#readability-identifier-naming-default-ignored-regexp),
+  [`DefaultHungarianPrefix`](#readability-identifier-naming-default-hungarian-prefix)
+- [`AbstractClassCase`](#readability-identifier-naming-abstract-class-case), [`AbstractClassPrefix`](#readability-identifier-naming-abstract-class-prefix),
+  [`AbstractClassSuffix`](#readability-identifier-naming-abstract-class-suffix), [`AbstractClassIgnoredRegexp`](#readability-identifier-naming-abstract-class-ignored-regexp),
+  [`AbstractClassHungarianPrefix`](#readability-identifier-naming-abstract-class-hungarian-prefix)
+- [`ClassCase`](#readability-identifier-naming-class-case), [`ClassPrefix`](#readability-identifier-naming-class-prefix), [`ClassSuffix`](#readability-identifier-naming-class-suffix),
+  [`ClassIgnoredRegexp`](#readability-identifier-naming-class-ignored-regexp), [`ClassHungarianPrefix`](#readability-identifier-naming-class-hungarian-prefix)
+- [`ClassConstexprCase`](#readability-identifier-naming-class-constexpr-case), [`ClassConstexprPrefix`](#readability-identifier-naming-class-constexpr-prefix),
+  [`ClassConstexprSuffix`](#readability-identifier-naming-class-constexpr-suffix), [`ClassConstexprIgnoredRegexp`](#readability-identifier-naming-class-constexpr-ignored-regexp),
+  [`ClassConstexprHungarianPrefix`](#readability-identifier-naming-class-constexpr-hungarian-prefix)
+- [`ClassConstantCase`](#readability-identifier-naming-class-constant-case), [`ClassConstantPrefix`](#readability-identifier-naming-class-constant-prefix),
+  [`ClassConstantSuffix`](#readability-identifier-naming-class-constant-suffix), [`ClassConstantIgnoredRegexp`](#readability-identifier-naming-class-constant-ignored-regexp),
+  [`ClassConstantHungarianPrefix`](#readability-identifier-naming-class-constant-hungarian-prefix)
+- [`ClassMemberCase`](#readability-identifier-naming-class-member-case), [`ClassMemberPrefix`](#readability-identifier-naming-class-member-prefix),
+  [`ClassMemberSuffix`](#readability-identifier-naming-class-member-suffix), [`ClassMemberIgnoredRegexp`](#readability-identifier-naming-class-member-ignored-regexp),
+  [`ClassMemberHungarianPrefix`](#readability-identifier-naming-class-member-hungarian-prefix)
+- [`ClassMethodCase`](#readability-identifier-naming-class-method-case), [`ClassMethodPrefix`](#readability-identifier-naming-class-method-prefix),
+  [`ClassMethodSuffix`](#readability-identifier-naming-class-method-suffix), [`ClassMethodIgnoredRegexp`](#readability-identifier-naming-class-method-ignored-regexp)
+- [`ConceptCase`](#readability-identifier-naming-concept-case), [`ConceptPrefix`](#readability-identifier-naming-concept-prefix), [`ConceptSuffix`](#readability-identifier-naming-concept-suffix),
+  [`ConceptIgnoredRegexp`](#readability-identifier-naming-concept-ignored-regexp)
+- [`ConstantCase`](#readability-identifier-naming-constant-case), [`ConstantPrefix`](#readability-identifier-naming-constant-prefix), [`ConstantSuffix`](#readability-identifier-naming-constant-suffix),
+  [`ConstantIgnoredRegexp`](#readability-identifier-naming-constant-ignored-regexp), [`ConstantHungarianPrefix`](#readability-identifier-naming-constant-hungarian-prefix)
+- [`ConstantMemberCase`](#readability-identifier-naming-constant-member-case), [`ConstantMemberPrefix`](#readability-identifier-naming-constant-member-prefix),
+  [`ConstantMemberSuffix`](#readability-identifier-naming-constant-member-suffix), [`ConstantMemberIgnoredRegexp`](#readability-identifier-naming-constant-member-ignored-regexp),
+  [`ConstantMemberHungarianPrefix`](#readability-identifier-naming-constant-member-hungarian-prefix)
+- [`ConstantParameterCase`](#readability-identifier-naming-constant-parameter-case), [`ConstantParameterPrefix`](#readability-identifier-naming-constant-parameter-prefix),
+  [`ConstantParameterSuffix`](#readability-identifier-naming-constant-parameter-suffix), [`ConstantParameterIgnoredRegexp`](#readability-identifier-naming-constant-parameter-ignored-regexp),
+  [`ConstantParameterHungarianPrefix`](#readability-identifier-naming-constant-parameter-hungarian-prefix)
+- [`ConstantPointerParameterCase`](#readability-identifier-naming-constant-pointer-parameter-case),
+  [`ConstantPointerParameterPrefix`](#readability-identifier-naming-constant-pointer-parameter-prefix),
+  [`ConstantPointerParameterSuffix`](#readability-identifier-naming-constant-pointer-parameter-suffix),
+  [`ConstantPointerParameterIgnoredRegexp`](#readability-identifier-naming-constant-pointer-parameter-ignored-regexp),
+  [`ConstantPointerParameterHungarianPrefix`](#readability-identifier-naming-constant-pointer-parameter-hungarian-prefix)
+- [`ConstexprFunctionCase`](#readability-identifier-naming-constexpr-function-case), [`ConstexprFunctionPrefix`](#readability-identifier-naming-constexpr-function-prefix),
+  [`ConstexprFunctionSuffix`](#readability-identifier-naming-constexpr-function-suffix), [`ConstexprFunctionIgnoredRegexp`](#readability-identifier-naming-constexpr-function-ignored-regexp)
+- [`ConstexprMethodCase`](#readability-identifier-naming-constexpr-method-case), [`ConstexprMethodPrefix`](#readability-identifier-naming-constexpr-method-prefix),
+  [`ConstexprMethodSuffix`](#readability-identifier-naming-constexpr-method-suffix), [`ConstexprMethodIgnoredRegexp`](#readability-identifier-naming-constexpr-method-ignored-regexp)
+- [`ConstexprVariableCase`](#readability-identifier-naming-constexpr-variable-case), [`ConstexprVariablePrefix`](#readability-identifier-naming-constexpr-variable-prefix),
+  [`ConstexprVariableSuffix`](#readability-identifier-naming-constexpr-variable-suffix), [`ConstexprVariableIgnoredRegexp`](#readability-identifier-naming-constexpr-variable-ignored-regexp),
+  [`ConstexprVariableHungarianPrefix`](#readability-identifier-naming-constexpr-variable-hungarian-prefix)
+- [`EnumCase`](#readability-identifier-naming-enum-case), [`EnumPrefix`](#readability-identifier-naming-enum-prefix), [`EnumSuffix`](#readability-identifier-naming-enum-suffix),
+  [`EnumIgnoredRegexp`](#readability-identifier-naming-enum-ignored-regexp)
+- [`EnumConstantCase`](#readability-identifier-naming-enum-constant-case), [`EnumConstantPrefix`](#readability-identifier-naming-enum-constant-prefix),
+  [`EnumConstantSuffix`](#readability-identifier-naming-enum-constant-suffix), [`EnumConstantIgnoredRegexp`](#readability-identifier-naming-enum-constant-ignored-regexp),
+  [`EnumConstantHungarianPrefix`](#readability-identifier-naming-enum-constant-hungarian-prefix)
+- [`FunctionCase`](#readability-identifier-naming-function-case), [`FunctionPrefix`](#readability-identifier-naming-function-prefix), [`FunctionSuffix`](#readability-identifier-naming-function-suffix),
+  [`FunctionIgnoredRegexp`](#readability-identifier-naming-function-ignored-regexp)
+- [`GlobalConstexprVariableCase`](#readability-identifier-naming-global-constexpr-variable-case),
+  [`GlobalConstexprVariablePrefix`](#readability-identifier-naming-global-constexpr-variable-prefix),
+  [`GlobalConstexprVariableSuffix`](#readability-identifier-naming-global-constexpr-variable-suffix),
+  [`GlobalConstexprVariableIgnoredRegexp`](#readability-identifier-naming-global-constexpr-variable-ignored-regexp),
+  [`GlobalConstexprVariableHungarianPrefix`](#readability-identifier-naming-global-constexpr-variable-hungarian-prefix)
+- [`GlobalConstantCase`](#readability-identifier-naming-global-constant-case), [`GlobalConstantPrefix`](#readability-identifier-naming-global-constant-prefix),
+  [`GlobalConstantSuffix`](#readability-identifier-naming-global-constant-suffix), [`GlobalConstantIgnoredRegexp`](#readability-identifier-naming-global-constant-ignored-regexp),
+  [`GlobalConstantHungarianPrefix`](#readability-identifier-naming-global-constant-hungarian-prefix)
+- [`GlobalConstantPointerCase`](#readability-identifier-naming-global-constant-pointer-case),
+  [`GlobalConstantPointerPrefix`](#readability-identifier-naming-global-constant-pointer-prefix),
+  [`GlobalConstantPointerSuffix`](#readability-identifier-naming-global-constant-pointer-suffix),
+  [`GlobalConstantPointerIgnoredRegexp`](#readability-identifier-naming-global-constant-pointer-ignored-regexp),
+  [`GlobalConstantPointerHungarianPrefix`](#readability-identifier-naming-global-constant-pointer-hungarian-prefix)
+- [`GlobalFunctionCase`](#readability-identifier-naming-global-function-case), [`GlobalFunctionPrefix`](#readability-identifier-naming-global-function-prefix),
+  [`GlobalFunctionSuffix`](#readability-identifier-naming-global-function-suffix), [`GlobalFunctionIgnoredRegexp`](#readability-identifier-naming-global-function-ignored-regexp)
+- [`GlobalPointerCase`](#readability-identifier-naming-global-pointer-case), [`GlobalPointerPrefix`](#readability-identifier-naming-global-pointer-prefix),
+  [`GlobalPointerSuffix`](#readability-identifier-naming-global-pointer-suffix), [`GlobalPointerIgnoredRegexp`](#readability-identifier-naming-global-pointer-ignored-regexp),
+  [`GlobalPointerHungarianPrefix`](#readability-identifier-naming-global-pointer-hungarian-prefix)
+- [`GlobalVariableCase`](#readability-identifier-naming-global-variable-case), [`GlobalVariablePrefix`](#readability-identifier-naming-global-variable-prefix),
+  [`GlobalVariableSuffix`](#readability-identifier-naming-global-variable-suffix), [`GlobalVariableIgnoredRegexp`](#readability-identifier-naming-global-variable-ignored-regexp),
+  [`GlobalVariableHungarianPrefix`](#readability-identifier-naming-global-variable-hungarian-prefix)
+- [`InlineNamespaceCase`](#readability-identifier-naming-inline-namespace-case), [`InlineNamespacePrefix`](#readability-identifier-naming-inline-namespace-prefix),
+  [`InlineNamespaceSuffix`](#readability-identifier-naming-inline-namespace-suffix), [`InlineNamespaceIgnoredRegexp`](#readability-identifier-naming-inline-namespace-ignored-regexp)
+- [`LambdaCaptureCase`](#readability-identifier-naming-lambda-capture-case), [`LambdaCapturePrefix`](#readability-identifier-naming-lambda-capture-prefix),
+  [`LambdaCaptureSuffix`](#readability-identifier-naming-lambda-capture-suffix), [`LambdaCaptureIgnoredRegexp`](#readability-identifier-naming-lambda-capture-ignored-regexp),
+  [`LambdaCaptureHungarianPrefix`](#readability-identifier-naming-lambda-capture-hungarian-prefix)
+- [`LocalConstexprVariableCase`](#readability-identifier-naming-local-constexpr-variable-case),
+  [`LocalConstexprVariablePrefix`](#readability-identifier-naming-local-constexpr-variable-prefix),
+  [`LocalConstexprVariableSuffix`](#readability-identifier-naming-local-constexpr-variable-suffix),
+  [`LocalConstexprVariableIgnoredRegexp`](#readability-identifier-naming-local-constexpr-variable-ignored-regexp),
+  [`LocalConstexprVariableHungarianPrefix`](#readability-identifier-naming-local-constexpr-variable-hungarian-prefix)
+- [`LocalConstantCase`](#readability-identifier-naming-local-constant-case), [`LocalConstantPrefix`](#readability-identifier-naming-local-constant-prefix),
+  [`LocalConstantSuffix`](#readability-identifier-naming-local-constant-suffix), [`LocalConstantIgnoredRegexp`](#readability-identifier-naming-local-constant-ignored-regexp),
+  [`LocalConstantHungarianPrefix`](#readability-identifier-naming-local-constant-hungarian-prefix)
+- [`LocalConstantPointerCase`](#readability-identifier-naming-local-constant-pointer-case),
+  [`LocalConstantPointerPrefix`](#readability-identifier-naming-local-constant-pointer-prefix),
+  [`LocalConstantPointerSuffix`](#readability-identifier-naming-local-constant-pointer-suffix),
+  [`LocalConstantPointerIgnoredRegexp`](#readability-identifier-naming-local-constant-pointer-ignored-regexp),
+  [`LocalConstantPointerHungarianPrefix`](#readability-identifier-naming-local-constant-pointer-hungarian-prefix)
+- [`LocalPointerCase`](#readability-identifier-naming-local-pointer-case), [`LocalPointerPrefix`](#readability-identifier-naming-local-pointer-prefix),
+  [`LocalPointerSuffix`](#readability-identifier-naming-local-pointer-suffix), [`LocalPointerIgnoredRegexp`](#readability-identifier-naming-local-pointer-ignored-regexp),
+  [`LocalPointerHungarianPrefix`](#readability-identifier-naming-local-pointer-hungarian-prefix)
+- [`LocalVariableCase`](#readability-identifier-naming-local-variable-case), [`LocalVariablePrefix`](#readability-identifier-naming-local-variable-prefix),
+  [`LocalVariableSuffix`](#readability-identifier-naming-local-variable-suffix), [`LocalVariableIgnoredRegexp`](#readability-identifier-naming-local-variable-ignored-regexp),
+  [`LocalVariableHungarianPrefix`](#readability-identifier-naming-local-variable-hungarian-prefix)
+- [`MacroDefinitionCase`](#readability-identifier-naming-macro-definition-case), [`MacroDefinitionPrefix`](#readability-identifier-naming-macro-definition-prefix),
+  [`MacroDefinitionSuffix`](#readability-identifier-naming-macro-definition-suffix), [`MacroDefinitionIgnoredRegexp`](#readability-identifier-naming-macro-definition-ignored-regexp)
+- [`MemberCase`](#readability-identifier-naming-member-case), [`MemberPrefix`](#readability-identifier-naming-member-prefix), [`MemberSuffix`](#readability-identifier-naming-member-suffix),
+  [`MemberIgnoredRegexp`](#readability-identifier-naming-member-ignored-regexp), [`MemberHungarianPrefix`](#readability-identifier-naming-member-hungarian-prefix)
+- [`MethodCase`](#readability-identifier-naming-method-case), [`MethodPrefix`](#readability-identifier-naming-method-prefix), [`MethodSuffix`](#readability-identifier-naming-method-suffix),
+  [`MethodIgnoredRegexp`](#readability-identifier-naming-method-ignored-regexp)
+- [`NamespaceCase`](#readability-identifier-naming-namespace-case), [`NamespacePrefix`](#readability-identifier-naming-namespace-prefix),
+  [`NamespaceSuffix`](#readability-identifier-naming-namespace-suffix), [`NamespaceIgnoredRegexp`](#readability-identifier-naming-namespace-ignored-regexp)
+- [`ParameterCase`](#readability-identifier-naming-parameter-case), [`ParameterPrefix`](#readability-identifier-naming-parameter-prefix),
+  [`ParameterSuffix`](#readability-identifier-naming-parameter-suffix), [`ParameterIgnoredRegexp`](#readability-identifier-naming-parameter-ignored-regexp),
+  [`ParameterHungarianPrefix`](#readability-identifier-naming-parameter-hungarian-prefix)
+- [`ParameterPackCase`](#readability-identifier-naming-parameter-pack-case), [`ParameterPackPrefix`](#readability-identifier-naming-parameter-pack-prefix),
+  [`ParameterPackSuffix`](#readability-identifier-naming-parameter-pack-suffix), [`ParameterPackIgnoredRegexp`](#readability-identifier-naming-parameter-pack-ignored-regexp)
+- [`PointerParameterCase`](#readability-identifier-naming-pointer-parameter-case), [`PointerParameterPrefix`](#readability-identifier-naming-pointer-parameter-prefix),
+  [`PointerParameterSuffix`](#readability-identifier-naming-pointer-parameter-suffix), [`PointerParameterIgnoredRegexp`](#readability-identifier-naming-pointer-parameter-ignored-regexp),
+  [`PointerParameterHungarianPrefix`](#readability-identifier-naming-pointer-parameter-hungarian-prefix)
+- [`PrivateMemberCase`](#readability-identifier-naming-private-member-case), [`PrivateMemberPrefix`](#readability-identifier-naming-private-member-prefix),
+  [`PrivateMemberSuffix`](#readability-identifier-naming-private-member-suffix), [`PrivateMemberIgnoredRegexp`](#readability-identifier-naming-private-member-ignored-regexp),
+  [`PrivateMemberHungarianPrefix`](#readability-identifier-naming-private-member-hungarian-prefix)
+- [`PrivateMethodCase`](#readability-identifier-naming-private-method-case), [`PrivateMethodPrefix`](#readability-identifier-naming-private-method-prefix),
+  [`PrivateMethodSuffix`](#readability-identifier-naming-private-method-suffix), [`PrivateMethodIgnoredRegexp`](#readability-identifier-naming-private-method-ignored-regexp)
+- [`ProtectedMemberCase`](#readability-identifier-naming-protected-member-case), [`ProtectedMemberPrefix`](#readability-identifier-naming-protected-member-prefix),
+  [`ProtectedMemberSuffix`](#readability-identifier-naming-protected-member-suffix), [`ProtectedMemberIgnoredRegexp`](#readability-identifier-naming-protected-member-ignored-regexp),
+  [`ProtectedMemberHungarianPrefix`](#readability-identifier-naming-protected-member-hungarian-prefix)
+- [`ProtectedMethodCase`](#readability-identifier-naming-protected-method-case), [`ProtectedMethodPrefix`](#readability-identifier-naming-protected-method-prefix),
+  [`ProtectedMethodSuffix`](#readability-identifier-naming-protected-method-suffix), [`ProtectedMethodIgnoredRegexp`](#readability-identifier-naming-protected-method-ignored-regexp)
+- [`PublicMemberCase`](#readability-identifier-naming-public-member-case), [`PublicMemberPrefix`](#readability-identifier-naming-public-member-prefix),
+  [`PublicMemberSuffix`](#readability-identifier-naming-public-member-suffix), [`PublicMemberIgnoredRegexp`](#readability-identifier-naming-public-member-ignored-regexp),
+  [`PublicMemberHungarianPrefix`](#readability-identifier-naming-public-member-hungarian-prefix)
+- [`PublicMethodCase`](#readability-identifier-naming-public-method-case), [`PublicMethodPrefix`](#readability-identifier-naming-public-method-prefix),
+  [`PublicMethodSuffix`](#readability-identifier-naming-public-method-suffix), [`PublicMethodIgnoredRegexp`](#readability-identifier-naming-public-method-ignored-regexp)
+- [`ScopedEnumConstantCase`](#readability-identifier-naming-scoped-enum-constant-case), [`ScopedEnumConstantPrefix`](#readability-identifier-naming-scoped-enum-constant-prefix),
+  [`ScopedEnumConstantSuffix`](#readability-identifier-naming-scoped-enum-constant-suffix),
+  [`ScopedEnumConstantIgnoredRegexp`](#readability-identifier-naming-scoped-enum-constant-ignored-regexp)
+- [`StaticConstexprVariableCase`](#readability-identifier-naming-static-constexpr-variable-case),
+  [`StaticConstexprVariablePrefix`](#readability-identifier-naming-static-constexpr-variable-prefix),
+  [`StaticConstexprVariableSuffix`](#readability-identifier-naming-static-constexpr-variable-suffix),
+  [`StaticConstexprVariableIgnoredRegexp`](#readability-identifier-naming-static-constexpr-variable-ignored-regexp),
+  [`StaticConstexprVariableHungarianPrefix`](#readability-identifier-naming-static-constexpr-variable-hungarian-prefix)
+- [`StaticConstantCase`](#readability-identifier-naming-static-constant-case), [`StaticConstantPrefix`](#readability-identifier-naming-static-constant-prefix),
+  [`StaticConstantSuffix`](#readability-identifier-naming-static-constant-suffix), [`StaticConstantIgnoredRegexp`](#readability-identifier-naming-static-constant-ignored-regexp),
+  [`StaticConstantHungarianPrefix`](#readability-identifier-naming-static-constant-hungarian-prefix)
+- [`StaticVariableCase`](#readability-identifier-naming-static-variable-case), [`StaticVariablePrefix`](#readability-identifier-naming-static-variable-prefix),
+  [`StaticVariableSuffix`](#readability-identifier-naming-static-variable-suffix), [`StaticVariableIgnoredRegexp`](#readability-identifier-naming-static-variable-ignored-regexp),
+  [`StaticVariableHungarianPrefix`](#readability-identifier-naming-static-variable-hungarian-prefix)
+- [`StructCase`](#readability-identifier-naming-struct-case), [`StructPrefix`](#readability-identifier-naming-struct-prefix), [`StructSuffix`](#readability-identifier-naming-struct-suffix),
+  [`StructIgnoredRegexp`](#readability-identifier-naming-struct-ignored-regexp)
+- [`TemplateParameterCase`](#readability-identifier-naming-template-parameter-case), [`TemplateParameterPrefix`](#readability-identifier-naming-template-parameter-prefix),
+  [`TemplateParameterSuffix`](#readability-identifier-naming-template-parameter-suffix), [`TemplateParameterIgnoredRegexp`](#readability-identifier-naming-template-parameter-ignored-regexp)
+- [`TemplateTemplateParameterCase`](#readability-identifier-naming-template-template-parameter-case),
+  [`TemplateTemplateParameterPrefix`](#readability-identifier-naming-template-template-parameter-prefix),
+  [`TemplateTemplateParameterSuffix`](#readability-identifier-naming-template-template-parameter-suffix),
+  [`TemplateTemplateParameterIgnoredRegexp`](#readability-identifier-naming-template-template-parameter-ignored-regexp)
+- [`TypeAliasCase`](#readability-identifier-naming-type-alias-case), [`TypeAliasPrefix`](#readability-identifier-naming-type-alias-prefix),
+  [`TypeAliasSuffix`](#readability-identifier-naming-type-alias-suffix), [`TypeAliasIgnoredRegexp`](#readability-identifier-naming-type-alias-ignored-regexp)
+- [`TypedefCase`](#readability-identifier-naming-typedef-case), [`TypedefPrefix`](#readability-identifier-naming-typedef-prefix), [`TypedefSuffix`](#readability-identifier-naming-typedef-suffix),
+  [`TypedefIgnoredRegexp`](#readability-identifier-naming-typedef-ignored-regexp)
+- [`TypeTemplateParameterCase`](#readability-identifier-naming-type-template-parameter-case),
+  [`TypeTemplateParameterPrefix`](#readability-identifier-naming-type-template-parameter-prefix),
+  [`TypeTemplateParameterSuffix`](#readability-identifier-naming-type-template-parameter-suffix),
+  [`TypeTemplateParameterIgnoredRegexp`](#readability-identifier-naming-type-template-parameter-ignored-regexp)
+- [`UnionCase`](#readability-identifier-naming-union-case), [`UnionPrefix`](#readability-identifier-naming-union-prefix), [`UnionSuffix`](#readability-identifier-naming-union-suffix),
+  [`UnionIgnoredRegexp`](#readability-identifier-naming-union-ignored-regexp)
+- [`ValueTemplateParameterCase`](#readability-identifier-naming-value-template-parameter-case),
+  [`ValueTemplateParameterPrefix`](#readability-identifier-naming-value-template-parameter-prefix),
+  [`ValueTemplateParameterSuffix`](#readability-identifier-naming-value-template-parameter-suffix),
+  [`ValueTemplateParameterIgnoredRegexp`](#readability-identifier-naming-value-template-parameter-ignored-regexp)
+- [`VariableCase`](#readability-identifier-naming-variable-case), [`VariablePrefix`](#readability-identifier-naming-variable-prefix), [`VariableSuffix`](#readability-identifier-naming-variable-suffix),
+  [`VariableIgnoredRegexp`](#readability-identifier-naming-variable-ignored-regexp), [`VariableHungarianPrefix`](#readability-identifier-naming-variable-hungarian-prefix)
+- [`VirtualMethodCase`](#readability-identifier-naming-virtual-method-case), [`VirtualMethodPrefix`](#readability-identifier-naming-virtual-method-prefix),
+  [`VirtualMethodSuffix`](#readability-identifier-naming-virtual-method-suffix), [`VirtualMethodIgnoredRegexp`](#readability-identifier-naming-virtual-method-ignored-regexp)
 
 ## Options description
 
 A detailed description of each option is presented below:
+
+(readability-identifier-naming-default-case)=
 
 ```{option} DefaultCase
 When defined, the check will ensure all names by default conform to the
 selected casing.
 ```
 
+(readability-identifier-naming-default-prefix)=
+
 ```{option} DefaultPrefix
 When defined, the check will ensure all names by default will add the
 prefix with the given value (regardless of casing).
 ```
+
+(readability-identifier-naming-default-ignored-regexp)=
 
 ```{option} DefaultIgnoredRegexp
 Identifier naming checks won't be enforced for all names by default
 matching this regular expression.
 ```
 
+(readability-identifier-naming-default-suffix)=
+
 ```{option} DefaultSuffix
 When defined, the check will ensure all names by default will add the
 suffix with the given value (regardless of casing).
 ```
+
+(readability-identifier-naming-default-hungarian-prefix)=
 
 ```{option} DefaultHungarianPrefix
 When enabled, the check ensures that the declared identifier will
 have a Hungarian notation prefix based on the declared type.
 ```
 
+(readability-identifier-naming-abstract-class-case)=
+
 ```{option} AbstractClassCase
 When defined, the check will ensure abstract class names conform to the
 selected casing.
 ```
+
+(readability-identifier-naming-abstract-class-prefix)=
 
 ```{option} AbstractClassPrefix
 When defined, the check will ensure abstract class names will add the
 prefix with the given value (regardless of casing).
 ```
 
+(readability-identifier-naming-abstract-class-ignored-regexp)=
+
 ```{option} AbstractClassIgnoredRegexp
 Identifier naming checks won't be enforced for abstract class names
 matching this regular expression.
 ```
 
+(readability-identifier-naming-abstract-class-suffix)=
+
 ```{option} AbstractClassSuffix
 When defined, the check will ensure abstract class names will add the
 suffix with the given value (regardless of casing).
 ```
+
+(readability-identifier-naming-abstract-class-hungarian-prefix)=
 
 ```{option} AbstractClassHungarianPrefix
 When enabled, the check ensures that the declared identifier will
@@ -310,10 +330,10 @@ have a Hungarian notation prefix based on the declared type.
 
 For example using values of:
 
-- {option}`AbstractClassCase` of `lower_case`
-- {option}`AbstractClassPrefix` of `pre_`
-- {option}`AbstractClassSuffix` of `_post`
-- {option}`AbstractClassHungarianPrefix` of `On`
+- [`AbstractClassCase`](#readability-identifier-naming-abstract-class-case) of `lower_case`
+- [`AbstractClassPrefix`](#readability-identifier-naming-abstract-class-prefix) of `pre_`
+- [`AbstractClassSuffix`](#readability-identifier-naming-abstract-class-suffix) of `_post`
+- [`AbstractClassHungarianPrefix`](#readability-identifier-naming-abstract-class-hungarian-prefix) of `On`
 
 Identifies and/or transforms abstract class names as follows:
 
@@ -335,6 +355,8 @@ public:
 };
 ```
 
+(readability-identifier-naming-aggressive-dependent-member-lookup)=
+
 ```{option} AggressiveDependentMemberLookup
 When `true`, the check will look in dependent base classes for dependent
 member references that need changing. This can lead to errors with template
@@ -343,7 +365,7 @@ specializations. Default is `false`.
 
 For example using values of:
 
-- {option}`ClassMemberCase` of `lower_case`
+- [`ClassMemberCase`](#readability-identifier-naming-class-member-case) of `lower_case`
 
 Before:
 
@@ -361,7 +383,7 @@ struct Derived : Base<T> {
 };
 ```
 
-After if {option}`AggressiveDependentMemberLookup` is `false`:
+After if [`AggressiveDependentMemberLookup`](#readability-identifier-naming-aggressive-dependent-member-lookup) is `false`:
 
 ```c++
 template <typename T>
@@ -377,7 +399,7 @@ struct Derived : Base<T> {
 };
 ```
 
-After if {option}`AggressiveDependentMemberLookup` is `true`:
+After if [`AggressiveDependentMemberLookup`](#readability-identifier-naming-aggressive-dependent-member-lookup) is `true`:
 
 ```c++
 template <typename T>
@@ -393,6 +415,8 @@ struct Derived : Base<T> {
 };
 ```
 
+(readability-identifier-naming-allow-trailing-underscore)=
+
 ```{option} AllowTrailingUnderscore
 When `true`, a single trailing underscore is allowed on any identifier, in
 addition to whatever casing, prefix and suffix are otherwise configured for
@@ -401,8 +425,10 @@ its kind.
 
 For example using values:
 
-- {option}`AllowTrailingUnderscore` is `true`
-- {option}`LocalVariableCase` is `camelBack`
+- [`AllowTrailingUnderscore`](#readability-identifier-naming-allow-trailing-underscore)
+  is `true`
+- [`LocalVariableCase`](#readability-identifier-naming-local-variable-case) is
+  `camelBack`
 
 Transforms names as follows:
 
@@ -421,6 +447,8 @@ void f(int value) {
   int value_ = value;
 }
 ```
+
+(readability-identifier-naming-check-anon-field-in-parent)=
 
 ```{option} CheckAnonFieldInParent
 When `true`, fields in anonymous records (i.e. anonymous
@@ -441,32 +469,42 @@ private:
 };
 ```
 
-If {option}`CheckAnonFieldInParent` is `false`, you may get warnings
+If [`CheckAnonFieldInParent`](#readability-identifier-naming-check-anon-field-in-parent) is `false`, you may get warnings
 that `iv_` and `fv_` are not coherent to public member names, because
 `iv_` and `fv_` are public members of the anonymous union. When
-{option}`CheckAnonFieldInParent` is `true`, `iv_` and `fv_` will be
+[`CheckAnonFieldInParent`](#readability-identifier-naming-check-anon-field-in-parent) is `true`, `iv_` and `fv_` will be
 treated as private data members of `Foo` for the purpose of name checking
 and thus no warnings will be emitted.
+
+(readability-identifier-naming-class-case)=
 
 ```{option} ClassCase
 When defined, the check will ensure class names conform to the
 selected casing.
 ```
 
+(readability-identifier-naming-class-prefix)=
+
 ```{option} ClassPrefix
 When defined, the check will ensure class names will add the
 prefix with the given value (regardless of casing).
 ```
+
+(readability-identifier-naming-class-ignored-regexp)=
 
 ```{option} ClassIgnoredRegexp
 Identifier naming checks won't be enforced for class names matching
 this regular expression.
 ```
 
+(readability-identifier-naming-class-suffix)=
+
 ```{option} ClassSuffix
 When defined, the check will ensure class names will add the
 suffix with the given value (regardless of casing).
 ```
+
+(readability-identifier-naming-class-hungarian-prefix)=
 
 ```{option} ClassHungarianPrefix
 When enabled, the check ensures that the declared identifier will
@@ -475,10 +513,10 @@ have a Hungarian notation prefix based on the declared type.
 
 For example using values of:
 
-- {option}`ClassCase` of `lower_case`
-- {option}`ClassPrefix` of `pre_`
-- {option}`ClassSuffix` of `_post`
-- {option}`ClassHungarianPrefix` of `On`
+- [`ClassCase`](#readability-identifier-naming-class-case) of `lower_case`
+- [`ClassPrefix`](#readability-identifier-naming-class-prefix) of `pre_`
+- [`ClassSuffix`](#readability-identifier-naming-class-suffix) of `_post`
+- [`ClassHungarianPrefix`](#readability-identifier-naming-class-hungarian-prefix) of `On`
 
 Identifies and/or transforms class names as follows:
 
@@ -502,25 +540,35 @@ public:
 };
 ```
 
+(readability-identifier-naming-class-constexpr-case)=
+
 ```{option} ClassConstexprCase
 When defined, the check will ensure class `constexpr` names conform to
 the selected casing.
 ```
+
+(readability-identifier-naming-class-constexpr-prefix)=
 
 ```{option} ClassConstexprPrefix
 When defined, the check will ensure class `constexpr` names will add the
 prefix with the given value (regardless of casing).
 ```
 
+(readability-identifier-naming-class-constexpr-ignored-regexp)=
+
 ```{option} ClassConstexprIgnoredRegexp
 Identifier naming checks won't be enforced for class `constexpr` names
 matching this regular expression.
 ```
 
+(readability-identifier-naming-class-constexpr-suffix)=
+
 ```{option} ClassConstexprSuffix
 When defined, the check will ensure class `constexpr` names will add the
 suffix with the given value (regardless of casing).
 ```
+
+(readability-identifier-naming-class-constexpr-hungarian-prefix)=
 
 ```{option} ClassConstexprHungarianPrefix
 When enabled, the check ensures that the declared identifier will have a
@@ -529,10 +577,10 @@ Hungarian notation prefix based on the declared type.
 
 For example using values of:
 
-- {option}`ClassConstexprCase` of `lower_case`
-- {option}`ClassConstexprPrefix` of `pre_`
-- {option}`ClassConstexprSuffix` of `_post`
-- {option}`ClassConstexprHungarianPrefix` of `On`
+- [`ClassConstexprCase`](#readability-identifier-naming-class-constexpr-case) of `lower_case`
+- [`ClassConstexprPrefix`](#readability-identifier-naming-class-constexpr-prefix) of `pre_`
+- [`ClassConstexprSuffix`](#readability-identifier-naming-class-constexpr-suffix) of `_post`
+- [`ClassConstexprHungarianPrefix`](#readability-identifier-naming-class-constexpr-hungarian-prefix) of `On`
 
 Identifies and/or transforms class `constexpr` variable names as follows:
 
@@ -554,25 +602,35 @@ public:
 };
 ```
 
+(readability-identifier-naming-class-constant-case)=
+
 ```{option} ClassConstantCase
 When defined, the check will ensure class constant names conform to the
 selected casing.
 ```
+
+(readability-identifier-naming-class-constant-prefix)=
 
 ```{option} ClassConstantPrefix
 When defined, the check will ensure class constant names will add the
 prefix with the given value (regardless of casing).
 ```
 
+(readability-identifier-naming-class-constant-ignored-regexp)=
+
 ```{option} ClassConstantIgnoredRegexp
 Identifier naming checks won't be enforced for class constant names
 matching this regular expression.
 ```
 
+(readability-identifier-naming-class-constant-suffix)=
+
 ```{option} ClassConstantSuffix
 When defined, the check will ensure class constant names will add the
 suffix with the given value (regardless of casing).
 ```
+
+(readability-identifier-naming-class-constant-hungarian-prefix)=
 
 ```{option} ClassConstantHungarianPrefix
 When enabled, the check ensures that the declared identifier will
@@ -581,10 +639,10 @@ have a Hungarian notation prefix based on the declared type.
 
 For example using values of:
 
-- {option}`ClassConstantCase` of `lower_case`
-- {option}`ClassConstantPrefix` of `pre_`
-- {option}`ClassConstantSuffix` of `_post`
-- {option}`ClassConstantHungarianPrefix` of `On`
+- [`ClassConstantCase`](#readability-identifier-naming-class-constant-case) of `lower_case`
+- [`ClassConstantPrefix`](#readability-identifier-naming-class-constant-prefix) of `pre_`
+- [`ClassConstantSuffix`](#readability-identifier-naming-class-constant-suffix) of `_post`
+- [`ClassConstantHungarianPrefix`](#readability-identifier-naming-class-constant-hungarian-prefix) of `On`
 
 Identifies and/or transforms class constant names as follows:
 
@@ -606,25 +664,35 @@ public:
 };
 ```
 
+(readability-identifier-naming-class-member-case)=
+
 ```{option} ClassMemberCase
 When defined, the check will ensure class member names conform to the
 selected casing.
 ```
+
+(readability-identifier-naming-class-member-prefix)=
 
 ```{option} ClassMemberPrefix
 When defined, the check will ensure class member names will add the
 prefix with the given value (regardless of casing).
 ```
 
+(readability-identifier-naming-class-member-ignored-regexp)=
+
 ```{option} ClassMemberIgnoredRegexp
 Identifier naming checks won't be enforced for class member names
 matching this regular expression.
 ```
 
+(readability-identifier-naming-class-member-suffix)=
+
 ```{option} ClassMemberSuffix
 When defined, the check will ensure class member names will add the
 suffix with the given value (regardless of casing).
 ```
+
+(readability-identifier-naming-class-member-hungarian-prefix)=
 
 ```{option} ClassMemberHungarianPrefix
 When enabled, the check ensures that the declared identifier will
@@ -633,10 +701,10 @@ have a Hungarian notation prefix based on the declared type.
 
 For example using values of:
 
-- {option}`ClassMemberCase` of `lower_case`
-- {option}`ClassMemberPrefix` of `pre_`
-- {option}`ClassMemberSuffix` of `_post`
-- {option}`ClassMemberHungarianPrefix` of `On`
+- [`ClassMemberCase`](#readability-identifier-naming-class-member-case) of `lower_case`
+- [`ClassMemberPrefix`](#readability-identifier-naming-class-member-prefix) of `pre_`
+- [`ClassMemberSuffix`](#readability-identifier-naming-class-member-suffix) of `_post`
+- [`ClassMemberHungarianPrefix`](#readability-identifier-naming-class-member-hungarian-prefix) of `On`
 
 Identifies and/or transforms class member names as follows:
 
@@ -658,20 +726,28 @@ public:
 };
 ```
 
+(readability-identifier-naming-class-method-case)=
+
 ```{option} ClassMethodCase
 When defined, the check will ensure class method names conform to the
 selected casing.
 ```
+
+(readability-identifier-naming-class-method-prefix)=
 
 ```{option} ClassMethodPrefix
 When defined, the check will ensure class method names will add the
 prefix with the given value (regardless of casing).
 ```
 
+(readability-identifier-naming-class-method-ignored-regexp)=
+
 ```{option} ClassMethodIgnoredRegexp
 Identifier naming checks won't be enforced for class method names
 matching this regular expression.
 ```
+
+(readability-identifier-naming-class-method-suffix)=
 
 ```{option} ClassMethodSuffix
 When defined, the check will ensure class method names will add the
@@ -680,9 +756,9 @@ suffix with the given value (regardless of casing).
 
 For example using values of:
 
-- {option}`ClassMethodCase` of `lower_case`
-- {option}`ClassMethodPrefix` of `pre_`
-- {option}`ClassMethodSuffix` of `_post`
+- [`ClassMethodCase`](#readability-identifier-naming-class-method-case) of `lower_case`
+- [`ClassMethodPrefix`](#readability-identifier-naming-class-method-prefix) of `pre_`
+- [`ClassMethodSuffix`](#readability-identifier-naming-class-method-suffix) of `_post`
 
 Identifies and/or transforms class method names as follows:
 
@@ -704,20 +780,28 @@ public:
 };
 ```
 
+(readability-identifier-naming-concept-case)=
+
 ```{option} ConceptCase
 When defined, the check will ensure concept names conform to the
 selected casing.
 ```
+
+(readability-identifier-naming-concept-prefix)=
 
 ```{option} ConceptPrefix
 When defined, the check will ensure concept names will add the
 prefix with the given value (regardless of casing).
 ```
 
+(readability-identifier-naming-concept-ignored-regexp)=
+
 ```{option} ConceptIgnoredRegexp
 Identifier naming checks won't be enforced for concept names
 matching this regular expression.
 ```
+
+(readability-identifier-naming-concept-suffix)=
 
 ```{option} ConceptSuffix
 When defined, the check will ensure concept names will add the
@@ -726,9 +810,9 @@ suffix with the given value (regardless of casing).
 
 For example using values of:
 
-- {option}`ConceptCase` of `CamelCase`
-- {option}`ConceptPrefix` of `Pre`
-- {option}`ConceptSuffix` of `Post`
+- [`ConceptCase`](#readability-identifier-naming-concept-case) of `CamelCase`
+- [`ConceptPrefix`](#readability-identifier-naming-concept-prefix) of `Pre`
+- [`ConceptSuffix`](#readability-identifier-naming-concept-suffix) of `Post`
 
 Identifies and/or transforms concept names as follows:
 
@@ -744,25 +828,35 @@ After:
 template<typename T> concept PreMyConceptPost = requires (T t) { {t++}; };
 ```
 
+(readability-identifier-naming-constant-case)=
+
 ```{option} ConstantCase
 When defined, the check will ensure constant names conform to the
 selected casing.
 ```
+
+(readability-identifier-naming-constant-prefix)=
 
 ```{option} ConstantPrefix
 When defined, the check will ensure constant names will add the
 prefix with the given value (regardless of casing).
 ```
 
+(readability-identifier-naming-constant-ignored-regexp)=
+
 ```{option} ConstantIgnoredRegexp
 Identifier naming checks won't be enforced for constant names
 matching this regular expression.
 ```
 
+(readability-identifier-naming-constant-suffix)=
+
 ```{option} ConstantSuffix
 When defined, the check will ensure constant names will add the
 suffix with the given value (regardless of casing).
 ```
+
+(readability-identifier-naming-constant-hungarian-prefix)=
 
 ```{option} ConstantHungarianPrefix
 When enabled, the check ensures that the declared identifier will
@@ -771,10 +865,10 @@ have a Hungarian notation prefix based on the declared type.
 
 For example using values of:
 
-- {option}`ConstantCase` of `lower_case`
-- {option}`ConstantPrefix` of `pre_`
-- {option}`ConstantSuffix` of `_post`
-- {option}`ConstantHungarianPrefix` of `On`
+- [`ConstantCase`](#readability-identifier-naming-constant-case) of `lower_case`
+- [`ConstantPrefix`](#readability-identifier-naming-constant-prefix) of `pre_`
+- [`ConstantSuffix`](#readability-identifier-naming-constant-suffix) of `_post`
+- [`ConstantHungarianPrefix`](#readability-identifier-naming-constant-hungarian-prefix) of `On`
 
 Identifies and/or transforms constant names as follows:
 
@@ -790,25 +884,35 @@ After:
 void function() { unsigned const pre_myconst_array_post[] = {1, 2, 3}; }
 ```
 
+(readability-identifier-naming-constant-member-case)=
+
 ```{option} ConstantMemberCase
 When defined, the check will ensure constant member names conform to the
 selected casing.
 ```
+
+(readability-identifier-naming-constant-member-prefix)=
 
 ```{option} ConstantMemberPrefix
 When defined, the check will ensure constant member names will add the
 prefix with the given value (regardless of casing).
 ```
 
+(readability-identifier-naming-constant-member-ignored-regexp)=
+
 ```{option} ConstantMemberIgnoredRegexp
 Identifier naming checks won't be enforced for constant member names
 matching this regular expression.
 ```
 
+(readability-identifier-naming-constant-member-suffix)=
+
 ```{option} ConstantMemberSuffix
 When defined, the check will ensure constant member names will add the
 suffix with the given value (regardless of casing).
 ```
+
+(readability-identifier-naming-constant-member-hungarian-prefix)=
 
 ```{option} ConstantMemberHungarianPrefix
 When enabled, the check ensures that the declared identifier will
@@ -817,10 +921,10 @@ have a Hungarian notation prefix based on the declared type.
 
 For example using values of:
 
-- {option}`ConstantMemberCase` of `lower_case`
-- {option}`ConstantMemberPrefix` of `pre_`
-- {option}`ConstantMemberSuffix` of `_post`
-- {option}`ConstantMemberHungarianPrefix` of `On`
+- [`ConstantMemberCase`](#readability-identifier-naming-constant-member-case) of `lower_case`
+- [`ConstantMemberPrefix`](#readability-identifier-naming-constant-member-prefix) of `pre_`
+- [`ConstantMemberSuffix`](#readability-identifier-naming-constant-member-suffix) of `_post`
+- [`ConstantMemberHungarianPrefix`](#readability-identifier-naming-constant-member-hungarian-prefix) of `On`
 
 Identifies and/or transforms constant member names as follows:
 
@@ -840,25 +944,35 @@ class Foo {
 }
 ```
 
+(readability-identifier-naming-constant-parameter-case)=
+
 ```{option} ConstantParameterCase
 When defined, the check will ensure constant parameter names conform to the
 selected casing.
 ```
+
+(readability-identifier-naming-constant-parameter-prefix)=
 
 ```{option} ConstantParameterPrefix
 When defined, the check will ensure constant parameter names will add the
 prefix with the given value (regardless of casing).
 ```
 
+(readability-identifier-naming-constant-parameter-ignored-regexp)=
+
 ```{option} ConstantParameterIgnoredRegexp
 Identifier naming checks won't be enforced for constant parameter names
 matching this regular expression.
 ```
 
+(readability-identifier-naming-constant-parameter-suffix)=
+
 ```{option} ConstantParameterSuffix
 When defined, the check will ensure constant parameter names will add the
 suffix with the given value (regardless of casing).
 ```
+
+(readability-identifier-naming-constant-parameter-hungarian-prefix)=
 
 ```{option} ConstantParameterHungarianPrefix
 When enabled, the check ensures that the declared identifier will
@@ -867,10 +981,10 @@ have a Hungarian notation prefix based on the declared type.
 
 For example using values of:
 
-- {option}`ConstantParameterCase` of `lower_case`
-- {option}`ConstantParameterPrefix` of `pre_`
-- {option}`ConstantParameterSuffix` of `_post`
-- {option}`ConstantParameterHungarianPrefix` of `On`
+- [`ConstantParameterCase`](#readability-identifier-naming-constant-parameter-case) of `lower_case`
+- [`ConstantParameterPrefix`](#readability-identifier-naming-constant-parameter-prefix) of `pre_`
+- [`ConstantParameterSuffix`](#readability-identifier-naming-constant-parameter-suffix) of `_post`
+- [`ConstantParameterHungarianPrefix`](#readability-identifier-naming-constant-parameter-hungarian-prefix) of `On`
 
 Identifies and/or transforms constant parameter names as follows:
 
@@ -886,25 +1000,35 @@ After:
 void GLOBAL_FUNCTION(int PARAMETER_1, int const pre_const_parameter_post);
 ```
 
+(readability-identifier-naming-constant-pointer-parameter-case)=
+
 ```{option} ConstantPointerParameterCase
 When defined, the check will ensure constant pointer parameter names conform to the
 selected casing.
 ```
+
+(readability-identifier-naming-constant-pointer-parameter-prefix)=
 
 ```{option} ConstantPointerParameterPrefix
 When defined, the check will ensure constant pointer parameter names will add the
 prefix with the given value (regardless of casing).
 ```
 
+(readability-identifier-naming-constant-pointer-parameter-ignored-regexp)=
+
 ```{option} ConstantPointerParameterIgnoredRegexp
 Identifier naming checks won't be enforced for constant pointer parameter
 names matching this regular expression.
 ```
 
+(readability-identifier-naming-constant-pointer-parameter-suffix)=
+
 ```{option} ConstantPointerParameterSuffix
 When defined, the check will ensure constant pointer parameter names will add the
 suffix with the given value (regardless of casing).
 ```
+
+(readability-identifier-naming-constant-pointer-parameter-hungarian-prefix)=
 
 ```{option} ConstantPointerParameterHungarianPrefix
 When enabled, the check ensures that the declared identifier will
@@ -913,10 +1037,10 @@ have a Hungarian notation prefix based on the declared type.
 
 For example using values of:
 
-- {option}`ConstantPointerParameterCase` of `lower_case`
-- {option}`ConstantPointerParameterPrefix` of `pre_`
-- {option}`ConstantPointerParameterSuffix` of `_post`
-- {option}`ConstantPointerParameterHungarianPrefix` of `On`
+- [`ConstantPointerParameterCase`](#readability-identifier-naming-constant-pointer-parameter-case) of `lower_case`
+- [`ConstantPointerParameterPrefix`](#readability-identifier-naming-constant-pointer-parameter-prefix) of `pre_`
+- [`ConstantPointerParameterSuffix`](#readability-identifier-naming-constant-pointer-parameter-suffix) of `_post`
+- [`ConstantPointerParameterHungarianPrefix`](#readability-identifier-naming-constant-pointer-parameter-hungarian-prefix) of `On`
 
 Identifies and/or transforms constant pointer parameter names as follows:
 
@@ -932,20 +1056,28 @@ After:
 void GLOBAL_FUNCTION(int const *pre_const_parameter_post);
 ```
 
+(readability-identifier-naming-constexpr-function-case)=
+
 ```{option} ConstexprFunctionCase
 When defined, the check will ensure constexpr function names conform to the
 selected casing.
 ```
+
+(readability-identifier-naming-constexpr-function-prefix)=
 
 ```{option} ConstexprFunctionPrefix
 When defined, the check will ensure constexpr function names will add the
 prefix with the given value (regardless of casing).
 ```
 
+(readability-identifier-naming-constexpr-function-ignored-regexp)=
+
 ```{option} ConstexprFunctionIgnoredRegexp
 Identifier naming checks won't be enforced for constexpr function names
 matching this regular expression.
 ```
+
+(readability-identifier-naming-constexpr-function-suffix)=
 
 ```{option} ConstexprFunctionSuffix
 When defined, the check will ensure constexpr function names will add the
@@ -954,9 +1086,9 @@ suffix with the given value (regardless of casing).
 
 For example using values of:
 
-- {option}`ConstexprFunctionCase` of `lower_case`
-- {option}`ConstexprFunctionPrefix` of `pre_`
-- {option}`ConstexprFunctionSuffix` of `_post`
+- [`ConstexprFunctionCase`](#readability-identifier-naming-constexpr-function-case) of `lower_case`
+- [`ConstexprFunctionPrefix`](#readability-identifier-naming-constexpr-function-prefix) of `pre_`
+- [`ConstexprFunctionSuffix`](#readability-identifier-naming-constexpr-function-suffix) of `_post`
 
 Identifies and/or transforms constexpr function names as follows:
 
@@ -972,20 +1104,28 @@ After:
 constexpr int pre_ce_function_post() { return 3; }
 ```
 
+(readability-identifier-naming-constexpr-method-case)=
+
 ```{option} ConstexprMethodCase
 When defined, the check will ensure constexpr method names conform to the
 selected casing.
 ```
+
+(readability-identifier-naming-constexpr-method-prefix)=
 
 ```{option} ConstexprMethodPrefix
 When defined, the check will ensure constexpr method names will add the
 prefix with the given value (regardless of casing).
 ```
 
+(readability-identifier-naming-constexpr-method-ignored-regexp)=
+
 ```{option} ConstexprMethodIgnoredRegexp
 Identifier naming checks won't be enforced for constexpr method names
 matching this regular expression.
 ```
+
+(readability-identifier-naming-constexpr-method-suffix)=
 
 ```{option} ConstexprMethodSuffix
 When defined, the check will ensure constexpr method names will add the
@@ -994,9 +1134,9 @@ suffix with the given value (regardless of casing).
 
 For example using values of:
 
-- {option}`ConstexprMethodCase` of `lower_case`
-- {option}`ConstexprMethodPrefix` of `pre_`
-- {option}`ConstexprMethodSuffix` of `_post`
+- [`ConstexprMethodCase`](#readability-identifier-naming-constexpr-method-case) of `lower_case`
+- [`ConstexprMethodPrefix`](#readability-identifier-naming-constexpr-method-prefix) of `pre_`
+- [`ConstexprMethodSuffix`](#readability-identifier-naming-constexpr-method-suffix) of `_post`
 
 Identifies and/or transforms constexpr method names as follows:
 
@@ -1018,25 +1158,35 @@ public:
 }
 ```
 
+(readability-identifier-naming-constexpr-variable-case)=
+
 ```{option} ConstexprVariableCase
 When defined, the check will ensure constexpr variable names conform to the
 selected casing.
 ```
+
+(readability-identifier-naming-constexpr-variable-prefix)=
 
 ```{option} ConstexprVariablePrefix
 When defined, the check will ensure constexpr variable names will add the
 prefix with the given value (regardless of casing).
 ```
 
+(readability-identifier-naming-constexpr-variable-ignored-regexp)=
+
 ```{option} ConstexprVariableIgnoredRegexp
 Identifier naming checks won't be enforced for constexpr variable names
 matching this regular expression.
 ```
 
+(readability-identifier-naming-constexpr-variable-suffix)=
+
 ```{option} ConstexprVariableSuffix
 When defined, the check will ensure constexpr variable names will add the
 suffix with the given value (regardless of casing).
 ```
+
+(readability-identifier-naming-constexpr-variable-hungarian-prefix)=
 
 ```{option} ConstexprVariableHungarianPrefix
 When enabled, the check ensures that the declared identifier will
@@ -1045,10 +1195,10 @@ have a Hungarian notation prefix based on the declared type.
 
 For example using values of:
 
-- {option}`ConstexprVariableCase` of `lower_case`
-- {option}`ConstexprVariablePrefix` of `pre_`
-- {option}`ConstexprVariableSuffix` of `_post`
-- {option}`ConstexprVariableHungarianPrefix` of `On`
+- [`ConstexprVariableCase`](#readability-identifier-naming-constexpr-variable-case) of `lower_case`
+- [`ConstexprVariablePrefix`](#readability-identifier-naming-constexpr-variable-prefix) of `pre_`
+- [`ConstexprVariableSuffix`](#readability-identifier-naming-constexpr-variable-suffix) of `_post`
+- [`ConstexprVariableHungarianPrefix`](#readability-identifier-naming-constexpr-variable-hungarian-prefix) of `On`
 
 Identifies and/or transforms constexpr variable names as follows:
 
@@ -1064,20 +1214,28 @@ After:
 constexpr int pre_constexpr_variable_post = MyConstant;
 ```
 
+(readability-identifier-naming-enum-case)=
+
 ```{option} EnumCase
 When defined, the check will ensure enumeration names conform to the
 selected casing.
 ```
+
+(readability-identifier-naming-enum-prefix)=
 
 ```{option} EnumPrefix
 When defined, the check will ensure enumeration names will add the
 prefix with the given value (regardless of casing).
 ```
 
+(readability-identifier-naming-enum-ignored-regexp)=
+
 ```{option} EnumIgnoredRegexp
 Identifier naming checks won't be enforced for enumeration names
 matching this regular expression.
 ```
+
+(readability-identifier-naming-enum-suffix)=
 
 ```{option} EnumSuffix
 When defined, the check will ensure enumeration names will add the
@@ -1086,9 +1244,9 @@ suffix with the given value (regardless of casing).
 
 For example using values of:
 
-- {option}`EnumCase` of `lower_case`
-- {option}`EnumPrefix` of `pre_`
-- {option}`EnumSuffix` of `_post`
+- [`EnumCase`](#readability-identifier-naming-enum-case) of `lower_case`
+- [`EnumPrefix`](#readability-identifier-naming-enum-prefix) of `pre_`
+- [`EnumSuffix`](#readability-identifier-naming-enum-suffix) of `_post`
 
 Identifies and/or transforms enumeration names as follows:
 
@@ -1104,25 +1262,35 @@ After:
 enum pre_foo_post { One, Two, Three };
 ```
 
+(readability-identifier-naming-enum-constant-case)=
+
 ```{option} EnumConstantCase
 When defined, the check will ensure enumeration constant names conform to the
 selected casing.
 ```
+
+(readability-identifier-naming-enum-constant-prefix)=
 
 ```{option} EnumConstantPrefix
 When defined, the check will ensure enumeration constant names will add the
 prefix with the given value (regardless of casing).
 ```
 
+(readability-identifier-naming-enum-constant-ignored-regexp)=
+
 ```{option} EnumConstantIgnoredRegexp
 Identifier naming checks won't be enforced for enumeration constant names
 matching this regular expression.
 ```
 
+(readability-identifier-naming-enum-constant-suffix)=
+
 ```{option} EnumConstantSuffix
 When defined, the check will ensure enumeration constant names will add the
 suffix with the given value (regardless of casing).
 ```
+
+(readability-identifier-naming-enum-constant-hungarian-prefix)=
 
 ```{option} EnumConstantHungarianPrefix
 When enabled, the check ensures that the declared identifier will
@@ -1131,10 +1299,10 @@ have a Hungarian notation prefix based on the declared type.
 
 For example using values of:
 
-- {option}`EnumConstantCase` of `lower_case`
-- {option}`EnumConstantPrefix` of `pre_`
-- {option}`EnumConstantSuffix` of `_post`
-- {option}`EnumConstantHungarianPrefix` of `On`
+- [`EnumConstantCase`](#readability-identifier-naming-enum-constant-case) of `lower_case`
+- [`EnumConstantPrefix`](#readability-identifier-naming-enum-constant-prefix) of `pre_`
+- [`EnumConstantSuffix`](#readability-identifier-naming-enum-constant-suffix) of `_post`
+- [`EnumConstantHungarianPrefix`](#readability-identifier-naming-enum-constant-hungarian-prefix) of `On`
 
 Identifies and/or transforms enumeration constant names as follows:
 
@@ -1150,20 +1318,28 @@ After:
 enum FOO { pre_One_post, pre_Two_post, pre_Three_post };
 ```
 
+(readability-identifier-naming-function-case)=
+
 ```{option} FunctionCase
 When defined, the check will ensure function names conform to the
 selected casing.
 ```
+
+(readability-identifier-naming-function-prefix)=
 
 ```{option} FunctionPrefix
 When defined, the check will ensure function names will add the
 prefix with the given value (regardless of casing).
 ```
 
+(readability-identifier-naming-function-ignored-regexp)=
+
 ```{option} FunctionIgnoredRegexp
 Identifier naming checks won't be enforced for function names
 matching this regular expression.
 ```
+
+(readability-identifier-naming-function-suffix)=
 
 ```{option} FunctionSuffix
 When defined, the check will ensure function names will add the
@@ -1172,9 +1348,9 @@ suffix with the given value (regardless of casing).
 
 For example using values of:
 
-- {option}`FunctionCase` of `lower_case`
-- {option}`FunctionPrefix` of `pre_`
-- {option}`FunctionSuffix` of `_post`
+- [`FunctionCase`](#readability-identifier-naming-function-case) of `lower_case`
+- [`FunctionPrefix`](#readability-identifier-naming-function-prefix) of `pre_`
+- [`FunctionSuffix`](#readability-identifier-naming-function-suffix) of `_post`
 
 Identifies and/or transforms function names as follows:
 
@@ -1190,6 +1366,8 @@ After:
 char pre_my_function_string_post();
 ```
 
+(readability-identifier-naming-get-config-per-file)=
+
 ```{option} GetConfigPerFile
 When `true`, the check will look for the configuration for where an
 identifier is declared. Useful for when included header files use a
@@ -1197,25 +1375,35 @@ different style.
 Default is `true`.
 ```
 
+(readability-identifier-naming-global-constexpr-variable-case)=
+
 ```{option} GlobalConstexprVariableCase
 When defined, the check will ensure global `constexpr` variable names
 conform to the selected casing.
 ```
+
+(readability-identifier-naming-global-constexpr-variable-prefix)=
 
 ```{option} GlobalConstexprVariablePrefix
 When defined, the check will ensure global `constexpr` variable names
 will add the prefixed with the given value (regardless of casing).
 ```
 
+(readability-identifier-naming-global-constexpr-variable-ignored-regexp)=
+
 ```{option} GlobalConstexprVariableIgnoredRegexp
 Identifier naming checks won't be enforced for global `constexpr`
 variable names matching this regular expression.
 ```
 
+(readability-identifier-naming-global-constexpr-variable-suffix)=
+
 ```{option} GlobalConstexprVariableSuffix
 When defined, the check will ensure global `constexpr` variable names
 will add the suffix with the given value (regardless of casing).
 ```
+
+(readability-identifier-naming-global-constexpr-variable-hungarian-prefix)=
 
 ```{option} GlobalConstexprVariableHungarianPrefix
 When enabled, the check ensures that the declared identifier will have a
@@ -1224,10 +1412,10 @@ Hungarian notation prefix based on the declared type.
 
 For example using values of:
 
-- {option}`GlobalConstexprVariableCase` of `lower_case`
-- {option}`GlobalConstexprVariablePrefix` of `pre_`
-- {option}`GlobalConstexprVariableSuffix` of `_post`
-- {option}`GlobalConstexprVariableHungarianPrefix` of `On`
+- [`GlobalConstexprVariableCase`](#readability-identifier-naming-global-constexpr-variable-case) of `lower_case`
+- [`GlobalConstexprVariablePrefix`](#readability-identifier-naming-global-constexpr-variable-prefix) of `pre_`
+- [`GlobalConstexprVariableSuffix`](#readability-identifier-naming-global-constexpr-variable-suffix) of `_post`
+- [`GlobalConstexprVariableHungarianPrefix`](#readability-identifier-naming-global-constexpr-variable-hungarian-prefix) of `On`
 
 Identifies and/or transforms global `constexpr` variable names as follows:
 
@@ -1243,25 +1431,35 @@ After:
 constexpr unsigned pre_important_value_post = 69;
 ```
 
+(readability-identifier-naming-global-constant-case)=
+
 ```{option} GlobalConstantCase
 When defined, the check will ensure global constant names conform to the
 selected casing.
 ```
+
+(readability-identifier-naming-global-constant-prefix)=
 
 ```{option} GlobalConstantPrefix
 When defined, the check will ensure global constant names will add the
 prefix with the given value (regardless of casing).
 ```
 
+(readability-identifier-naming-global-constant-ignored-regexp)=
+
 ```{option} GlobalConstantIgnoredRegexp
 Identifier naming checks won't be enforced for global constant names
 matching this regular expression.
 ```
 
+(readability-identifier-naming-global-constant-suffix)=
+
 ```{option} GlobalConstantSuffix
 When defined, the check will ensure global constant names will add the
 suffix with the given value (regardless of casing).
 ```
+
+(readability-identifier-naming-global-constant-hungarian-prefix)=
 
 ```{option} GlobalConstantHungarianPrefix
 When enabled, the check ensures that the declared identifier will
@@ -1270,10 +1468,10 @@ have a Hungarian notation prefix based on the declared type.
 
 For example using values of:
 
-- {option}`GlobalConstantCase` of `lower_case`
-- {option}`GlobalConstantPrefix` of `pre_`
-- {option}`GlobalConstantSuffix` of `_post`
-- {option}`GlobalConstantHungarianPrefix` of `On`
+- [`GlobalConstantCase`](#readability-identifier-naming-global-constant-case) of `lower_case`
+- [`GlobalConstantPrefix`](#readability-identifier-naming-global-constant-prefix) of `pre_`
+- [`GlobalConstantSuffix`](#readability-identifier-naming-global-constant-suffix) of `_post`
+- [`GlobalConstantHungarianPrefix`](#readability-identifier-naming-global-constant-hungarian-prefix) of `On`
 
 Identifies and/or transforms global constant names as follows:
 
@@ -1289,25 +1487,35 @@ After:
 unsigned const pre_myconstglobal_array_post[] = {1, 2, 3};
 ```
 
+(readability-identifier-naming-global-constant-pointer-case)=
+
 ```{option} GlobalConstantPointerCase
 When defined, the check will ensure global constant pointer names conform to the
 selected casing.
 ```
+
+(readability-identifier-naming-global-constant-pointer-prefix)=
 
 ```{option} GlobalConstantPointerPrefix
 When defined, the check will ensure global constant pointer names will add the
 prefix with the given value (regardless of casing).
 ```
 
+(readability-identifier-naming-global-constant-pointer-ignored-regexp)=
+
 ```{option} GlobalConstantPointerIgnoredRegexp
 Identifier naming checks won't be enforced for global constant pointer
 names matching this regular expression.
 ```
 
+(readability-identifier-naming-global-constant-pointer-suffix)=
+
 ```{option} GlobalConstantPointerSuffix
 When defined, the check will ensure global constant pointer names will add the
 suffix with the given value (regardless of casing).
 ```
+
+(readability-identifier-naming-global-constant-pointer-hungarian-prefix)=
 
 ```{option} GlobalConstantPointerHungarianPrefix
 When enabled, the check ensures that the declared identifier will
@@ -1316,10 +1524,10 @@ have a Hungarian notation prefix based on the declared type.
 
 For example using values of:
 
-- {option}`GlobalConstantPointerCase` of `lower_case`
-- {option}`GlobalConstantPointerPrefix` of `pre_`
-- {option}`GlobalConstantPointerSuffix` of `_post`
-- {option}`GlobalConstantPointerHungarianPrefix` of `On`
+- [`GlobalConstantPointerCase`](#readability-identifier-naming-global-constant-pointer-case) of `lower_case`
+- [`GlobalConstantPointerPrefix`](#readability-identifier-naming-global-constant-pointer-prefix) of `pre_`
+- [`GlobalConstantPointerSuffix`](#readability-identifier-naming-global-constant-pointer-suffix) of `_post`
+- [`GlobalConstantPointerHungarianPrefix`](#readability-identifier-naming-global-constant-pointer-hungarian-prefix) of `On`
 
 Identifies and/or transforms global constant pointer names as follows:
 
@@ -1335,20 +1543,28 @@ After:
 int *const pre_myconstantglobalpointer_post = nullptr;
 ```
 
+(readability-identifier-naming-global-function-case)=
+
 ```{option} GlobalFunctionCase
 When defined, the check will ensure global function names conform to the
 selected casing.
 ```
+
+(readability-identifier-naming-global-function-prefix)=
 
 ```{option} GlobalFunctionPrefix
 When defined, the check will ensure global function names will add the
 prefix with the given value (regardless of casing).
 ```
 
+(readability-identifier-naming-global-function-ignored-regexp)=
+
 ```{option} GlobalFunctionIgnoredRegexp
 Identifier naming checks won't be enforced for global function names
 matching this regular expression.
 ```
+
+(readability-identifier-naming-global-function-suffix)=
 
 ```{option} GlobalFunctionSuffix
 When defined, the check will ensure global function names will add the
@@ -1357,9 +1573,9 @@ suffix with the given value (regardless of casing).
 
 For example using values of:
 
-- {option}`GlobalFunctionCase` of `lower_case`
-- {option}`GlobalFunctionPrefix` of `pre_`
-- {option}`GlobalFunctionSuffix` of `_post`
+- [`GlobalFunctionCase`](#readability-identifier-naming-global-function-case) of `lower_case`
+- [`GlobalFunctionPrefix`](#readability-identifier-naming-global-function-prefix) of `pre_`
+- [`GlobalFunctionSuffix`](#readability-identifier-naming-global-function-suffix) of `_post`
 
 Identifies and/or transforms global function names as follows:
 
@@ -1375,25 +1591,35 @@ After:
 void pre_global_function_post(int PARAMETER_1, int const CONST_parameter);
 ```
 
+(readability-identifier-naming-global-pointer-case)=
+
 ```{option} GlobalPointerCase
 When defined, the check will ensure global pointer names conform to the
 selected casing.
 ```
+
+(readability-identifier-naming-global-pointer-prefix)=
 
 ```{option} GlobalPointerPrefix
 When defined, the check will ensure global pointer names will add the
 prefix with the given value (regardless of casing).
 ```
 
+(readability-identifier-naming-global-pointer-ignored-regexp)=
+
 ```{option} GlobalPointerIgnoredRegexp
 Identifier naming checks won't be enforced for global pointer names
 matching this regular expression.
 ```
 
+(readability-identifier-naming-global-pointer-suffix)=
+
 ```{option} GlobalPointerSuffix
 When defined, the check will ensure global pointer names will add the
 suffix with the given value (regardless of casing).
 ```
+
+(readability-identifier-naming-global-pointer-hungarian-prefix)=
 
 ```{option} GlobalPointerHungarianPrefix
 When enabled, the check ensures that the declared identifier will
@@ -1402,10 +1628,10 @@ have a Hungarian notation prefix based on the declared type.
 
 For example using values of:
 
-- {option}`GlobalPointerCase` of `lower_case`
-- {option}`GlobalPointerPrefix` of `pre_`
-- {option}`GlobalPointerSuffix` of `_post`
-- {option}`GlobalPointerHungarianPrefix` of `On`
+- [`GlobalPointerCase`](#readability-identifier-naming-global-pointer-case) of `lower_case`
+- [`GlobalPointerPrefix`](#readability-identifier-naming-global-pointer-prefix) of `pre_`
+- [`GlobalPointerSuffix`](#readability-identifier-naming-global-pointer-suffix) of `_post`
+- [`GlobalPointerHungarianPrefix`](#readability-identifier-naming-global-pointer-hungarian-prefix) of `On`
 
 Identifies and/or transforms global pointer names as follows:
 
@@ -1421,25 +1647,35 @@ After:
 int *pre_global3_post;
 ```
 
+(readability-identifier-naming-global-variable-case)=
+
 ```{option} GlobalVariableCase
 When defined, the check will ensure global variable names conform to the
 selected casing.
 ```
+
+(readability-identifier-naming-global-variable-prefix)=
 
 ```{option} GlobalVariablePrefix
 When defined, the check will ensure global variable names will add the
 prefix with the given value (regardless of casing).
 ```
 
+(readability-identifier-naming-global-variable-ignored-regexp)=
+
 ```{option} GlobalVariableIgnoredRegexp
 Identifier naming checks won't be enforced for global variable names
 matching this regular expression.
 ```
 
+(readability-identifier-naming-global-variable-suffix)=
+
 ```{option} GlobalVariableSuffix
 When defined, the check will ensure global variable names will add the
 suffix with the given value (regardless of casing).
 ```
+
+(readability-identifier-naming-global-variable-hungarian-prefix)=
 
 ```{option} GlobalVariableHungarianPrefix
 When enabled, the check ensures that the declared identifier will
@@ -1448,10 +1684,10 @@ have a Hungarian notation prefix based on the declared type.
 
 For example using values of:
 
-- {option}`GlobalVariableCase` of `lower_case`
-- {option}`GlobalVariablePrefix` of `pre_`
-- {option}`GlobalVariableSuffix` of `_post`
-- {option}`GlobalVariableHungarianPrefix` of `On`
+- [`GlobalVariableCase`](#readability-identifier-naming-global-variable-case) of `lower_case`
+- [`GlobalVariablePrefix`](#readability-identifier-naming-global-variable-prefix) of `pre_`
+- [`GlobalVariableSuffix`](#readability-identifier-naming-global-variable-suffix) of `_post`
+- [`GlobalVariableHungarianPrefix`](#readability-identifier-naming-global-variable-hungarian-prefix) of `On`
 
 Identifies and/or transforms global variable names as follows:
 
@@ -1467,26 +1703,36 @@ After:
 int pre_global3_post;
 ```
 
+(readability-identifier-naming-ignore-main-like-functions)=
+
 ```{option} IgnoreMainLikeFunctions
 When `true`, functions that have a similar signature to `main` or
 `wmain` won't enforce checks on the names of their parameters.
 Default is `false`.
 ```
 
+(readability-identifier-naming-inline-namespace-case)=
+
 ```{option} InlineNamespaceCase
 When defined, the check will ensure inline namespaces names conform to the
 selected casing.
 ```
+
+(readability-identifier-naming-inline-namespace-prefix)=
 
 ```{option} InlineNamespacePrefix
 When defined, the check will ensure inline namespaces names will add the
 prefix with the given value (regardless of casing).
 ```
 
+(readability-identifier-naming-inline-namespace-ignored-regexp)=
+
 ```{option} InlineNamespaceIgnoredRegexp
 Identifier naming checks won't be enforced for inline namespaces names
 matching this regular expression.
 ```
+
+(readability-identifier-naming-inline-namespace-suffix)=
 
 ```{option} InlineNamespaceSuffix
 When defined, the check will ensure inline namespaces names will add the
@@ -1495,9 +1741,9 @@ suffix with the given value (regardless of casing).
 
 For example using values of:
 
-- {option}`InlineNamespaceCase` of `lower_case`
-- {option}`InlineNamespacePrefix` of `pre_`
-- {option}`InlineNamespaceSuffix` of `_post`
+- [`InlineNamespaceCase`](#readability-identifier-naming-inline-namespace-case) of `lower_case`
+- [`InlineNamespacePrefix`](#readability-identifier-naming-inline-namespace-prefix) of `pre_`
+- [`InlineNamespaceSuffix`](#readability-identifier-naming-inline-namespace-suffix) of `_post`
 
 Identifies and/or transforms inline namespaces names as follows:
 
@@ -1521,6 +1767,8 @@ inline namespace pre_inlinenamespace_post {
 } // namespace FOO_NS
 ```
 
+(readability-identifier-naming-lambda-capture-case)=
+
 ```{option} LambdaCaptureCase
 When defined, the check will ensure lambda init-capture names (e.g.
 `Captured` in `[Captured = Var]`) conform to the selected casing.
@@ -1529,20 +1777,28 @@ same declaration as `Var` itself, so it keeps following whichever
 naming style applies to `Var`'s own declaration instead.
 ```
 
+(readability-identifier-naming-lambda-capture-prefix)=
+
 ```{option} LambdaCapturePrefix
 When defined, the check will ensure lambda init-capture names will add
 the prefix with the given value (regardless of casing).
 ```
+
+(readability-identifier-naming-lambda-capture-ignored-regexp)=
 
 ```{option} LambdaCaptureIgnoredRegexp
 Identifier naming checks won't be enforced for lambda init-capture names
 matching this regular expression.
 ```
 
+(readability-identifier-naming-lambda-capture-suffix)=
+
 ```{option} LambdaCaptureSuffix
 When defined, the check will ensure lambda init-capture names will add
 the suffix with the given value (regardless of casing).
 ```
+
+(readability-identifier-naming-lambda-capture-hungarian-prefix)=
 
 ```{option} LambdaCaptureHungarianPrefix
 When enabled, the check ensures that the declared identifier will
@@ -1551,8 +1807,8 @@ have a Hungarian notation prefix based on the declared type.
 
 For example using values of:
 
-- {option}`LambdaCaptureCase` of `CamelCase`
-- {option}`LambdaCapturePrefix` of `c_`
+- [`LambdaCaptureCase`](#readability-identifier-naming-lambda-capture-case) of `CamelCase`
+- [`LambdaCapturePrefix`](#readability-identifier-naming-lambda-capture-prefix) of `c_`
 
 Identifies and/or transforms lambda init-capture names as follows:
 
@@ -1578,25 +1834,35 @@ void foo() {
 }
 ```
 
+(readability-identifier-naming-local-constexpr-variable-case)=
+
 ```{option} LocalConstexprVariableCase
 When defined, the check will ensure local `constexpr` variable names
 conform to the selected casing.
 ```
+
+(readability-identifier-naming-local-constexpr-variable-prefix)=
 
 ```{option} LocalConstexprVariablePrefix
 When defined, the check will ensure local `constexpr` variable names will
 add the prefixed with the given value (regardless of casing).
 ```
 
+(readability-identifier-naming-local-constexpr-variable-ignored-regexp)=
+
 ```{option} LocalConstexprVariableIgnoredRegexp
 Identifier naming checks won't be enforced for local `constexpr` variable
 names matching this regular expression.
 ```
 
+(readability-identifier-naming-local-constexpr-variable-suffix)=
+
 ```{option} LocalConstexprVariableSuffix
 When defined, the check will ensure local `constexpr` variable names will
 add the suffix with the given value (regardless of casing).
 ```
+
+(readability-identifier-naming-local-constexpr-variable-hungarian-prefix)=
 
 ```{option} LocalConstexprVariableHungarianPrefix
 When enabled, the check ensures that the declared identifier will have a
@@ -1605,10 +1871,10 @@ Hungarian notation prefix based on the declared type.
 
 For example using values of:
 
-- {option}`LocalConstexprVariableCase` of `lower_case`
-- {option}`LocalConstexprVariablePrefix` of `pre_`
-- {option}`LocalConstexprVariableSuffix` of `_post`
-- {option}`LocalConstexprVariableHungarianPrefix` of `On`
+- [`LocalConstexprVariableCase`](#readability-identifier-naming-local-constexpr-variable-case) of `lower_case`
+- [`LocalConstexprVariablePrefix`](#readability-identifier-naming-local-constexpr-variable-prefix) of `pre_`
+- [`LocalConstexprVariableSuffix`](#readability-identifier-naming-local-constexpr-variable-suffix) of `_post`
+- [`LocalConstexprVariableHungarianPrefix`](#readability-identifier-naming-local-constexpr-variable-hungarian-prefix) of `On`
 
 Identifies and/or transforms local `constexpr` variable names as follows:
 
@@ -1624,25 +1890,35 @@ After:
 void foo() { int const pre_local_constexpr_post = 420; }
 ```
 
+(readability-identifier-naming-local-constant-case)=
+
 ```{option} LocalConstantCase
 When defined, the check will ensure local constant names conform to the
 selected casing.
 ```
+
+(readability-identifier-naming-local-constant-prefix)=
 
 ```{option} LocalConstantPrefix
 When defined, the check will ensure local constant names will add the
 prefix with the given value (regardless of casing).
 ```
 
+(readability-identifier-naming-local-constant-ignored-regexp)=
+
 ```{option} LocalConstantIgnoredRegexp
 Identifier naming checks won't be enforced for local constant names
 matching this regular expression.
 ```
 
+(readability-identifier-naming-local-constant-suffix)=
+
 ```{option} LocalConstantSuffix
 When defined, the check will ensure local constant names will add the
 suffix with the given value (regardless of casing).
 ```
+
+(readability-identifier-naming-local-constant-hungarian-prefix)=
 
 ```{option} LocalConstantHungarianPrefix
 When enabled, the check ensures that the declared identifier will
@@ -1651,10 +1927,10 @@ have a Hungarian notation prefix based on the declared type.
 
 For example using values of:
 
-- {option}`LocalConstantCase` of `lower_case`
-- {option}`LocalConstantPrefix` of `pre_`
-- {option}`LocalConstantSuffix` of `_post`
-- {option}`LocalConstantHungarianPrefix` of `On`
+- [`LocalConstantCase`](#readability-identifier-naming-local-constant-case) of `lower_case`
+- [`LocalConstantPrefix`](#readability-identifier-naming-local-constant-prefix) of `pre_`
+- [`LocalConstantSuffix`](#readability-identifier-naming-local-constant-suffix) of `_post`
+- [`LocalConstantHungarianPrefix`](#readability-identifier-naming-local-constant-hungarian-prefix) of `On`
 
 Identifies and/or transforms local constant names as follows:
 
@@ -1670,25 +1946,35 @@ After:
 void foo() { int const pre_local_constant_post = 3; }
 ```
 
+(readability-identifier-naming-local-constant-pointer-case)=
+
 ```{option} LocalConstantPointerCase
 When defined, the check will ensure local constant pointer names conform to the
 selected casing.
 ```
+
+(readability-identifier-naming-local-constant-pointer-prefix)=
 
 ```{option} LocalConstantPointerPrefix
 When defined, the check will ensure local constant pointer names will add the
 prefix with the given value (regardless of casing).
 ```
 
+(readability-identifier-naming-local-constant-pointer-ignored-regexp)=
+
 ```{option} LocalConstantPointerIgnoredRegexp
 Identifier naming checks won't be enforced for local constant pointer names
 matching this regular expression.
 ```
 
+(readability-identifier-naming-local-constant-pointer-suffix)=
+
 ```{option} LocalConstantPointerSuffix
 When defined, the check will ensure local constant pointer names will add the
 suffix with the given value (regardless of casing).
 ```
+
+(readability-identifier-naming-local-constant-pointer-hungarian-prefix)=
 
 ```{option} LocalConstantPointerHungarianPrefix
 When enabled, the check ensures that the declared identifier will
@@ -1697,10 +1983,10 @@ have a Hungarian notation prefix based on the declared type.
 
 For example using values of:
 
-- {option}`LocalConstantPointerCase` of `lower_case`
-- {option}`LocalConstantPointerPrefix` of `pre_`
-- {option}`LocalConstantPointerSuffix` of `_post`
-- {option}`LocalConstantPointerHungarianPrefix` of `On`
+- [`LocalConstantPointerCase`](#readability-identifier-naming-local-constant-pointer-case) of `lower_case`
+- [`LocalConstantPointerPrefix`](#readability-identifier-naming-local-constant-pointer-prefix) of `pre_`
+- [`LocalConstantPointerSuffix`](#readability-identifier-naming-local-constant-pointer-suffix) of `_post`
+- [`LocalConstantPointerHungarianPrefix`](#readability-identifier-naming-local-constant-pointer-hungarian-prefix) of `On`
 
 Identifies and/or transforms local constant pointer names as follows:
 
@@ -1716,25 +2002,35 @@ After:
 void foo() { int const *pre_local_constant_post = 3; }
 ```
 
+(readability-identifier-naming-local-pointer-case)=
+
 ```{option} LocalPointerCase
 When defined, the check will ensure local pointer names conform to the
 selected casing.
 ```
+
+(readability-identifier-naming-local-pointer-prefix)=
 
 ```{option} LocalPointerPrefix
 When defined, the check will ensure local pointer names will add the
 prefix with the given value (regardless of casing).
 ```
 
+(readability-identifier-naming-local-pointer-ignored-regexp)=
+
 ```{option} LocalPointerIgnoredRegexp
 Identifier naming checks won't be enforced for local pointer names
 matching this regular expression.
 ```
 
+(readability-identifier-naming-local-pointer-suffix)=
+
 ```{option} LocalPointerSuffix
 When defined, the check will ensure local pointer names will add the
 suffix with the given value (regardless of casing).
 ```
+
+(readability-identifier-naming-local-pointer-hungarian-prefix)=
 
 ```{option} LocalPointerHungarianPrefix
 When enabled, the check ensures that the declared identifier will
@@ -1743,10 +2039,10 @@ have a Hungarian notation prefix based on the declared type.
 
 For example using values of:
 
-- {option}`LocalPointerCase` of `lower_case`
-- {option}`LocalPointerPrefix` of `pre_`
-- {option}`LocalPointerSuffix` of `_post`
-- {option}`LocalPointerHungarianPrefix` of `On`
+- [`LocalPointerCase`](#readability-identifier-naming-local-pointer-case) of `lower_case`
+- [`LocalPointerPrefix`](#readability-identifier-naming-local-pointer-prefix) of `pre_`
+- [`LocalPointerSuffix`](#readability-identifier-naming-local-pointer-suffix) of `_post`
+- [`LocalPointerHungarianPrefix`](#readability-identifier-naming-local-pointer-hungarian-prefix) of `On`
 
 Identifies and/or transforms local pointer names as follows:
 
@@ -1762,15 +2058,21 @@ After:
 void foo() { int *pre_local_constant_post; }
 ```
 
+(readability-identifier-naming-local-variable-case)=
+
 ```{option} LocalVariableCase
 When defined, the check will ensure local variable names conform to the
 selected casing.
 ```
 
+(readability-identifier-naming-local-variable-prefix)=
+
 ```{option} LocalVariablePrefix
 When defined, the check will ensure local variable names will add the
 prefix with the given value (regardless of casing).
 ```
+
+(readability-identifier-naming-local-variable-ignored-regexp)=
 
 ```{option} LocalVariableIgnoredRegexp
 Identifier naming checks won't be enforced for local variable names
@@ -1779,16 +2081,20 @@ matching this regular expression.
 
 For example using values of:
 
-- {option}`LocalVariableCase` of `CamelCase`
-- {option}`LocalVariableIgnoredRegexp` of `\w{1,2}`
+- [`LocalVariableCase`](#readability-identifier-naming-local-variable-case) of `CamelCase`
+- [`LocalVariableIgnoredRegexp`](#readability-identifier-naming-local-variable-ignored-regexp) of `\w{1,2}`
 
 Will exclude variables with a length less than or equal to 2 from the
 camel case check applied to other variables.
+
+(readability-identifier-naming-local-variable-suffix)=
 
 ```{option} LocalVariableSuffix
 When defined, the check will ensure local variable names will add the
 suffix with the given value (regardless of casing).
 ```
+
+(readability-identifier-naming-local-variable-hungarian-prefix)=
 
 ```{option} LocalVariableHungarianPrefix
 When enabled, the check ensures that the declared identifier will
@@ -1797,10 +2103,10 @@ have a Hungarian notation prefix based on the declared type.
 
 For example using values of:
 
-- {option}`LocalVariableCase` of `lower_case`
-- {option}`LocalVariablePrefix` of `pre_`
-- {option}`LocalVariableSuffix` of `_post`
-- {option}`LocalVariableHungarianPrefix` of `On`
+- [`LocalVariableCase`](#readability-identifier-naming-local-variable-case) of `lower_case`
+- [`LocalVariablePrefix`](#readability-identifier-naming-local-variable-prefix) of `pre_`
+- [`LocalVariableSuffix`](#readability-identifier-naming-local-variable-suffix) of `_post`
+- [`LocalVariableHungarianPrefix`](#readability-identifier-naming-local-variable-hungarian-prefix) of `On`
 
 Identifies and/or transforms local variable names as follows:
 
@@ -1816,20 +2122,28 @@ After:
 void foo() { int pre_local_constant_post; }
 ```
 
+(readability-identifier-naming-macro-definition-case)=
+
 ```{option} MacroDefinitionCase
 When defined, the check will ensure macro definitions conform to the
 selected casing.
 ```
+
+(readability-identifier-naming-macro-definition-prefix)=
 
 ```{option} MacroDefinitionPrefix
 When defined, the check will ensure macro definitions will add the
 prefix with the given value (regardless of casing).
 ```
 
+(readability-identifier-naming-macro-definition-ignored-regexp)=
+
 ```{option} MacroDefinitionIgnoredRegexp
 Identifier naming checks won't be enforced for macro definitions
 matching this regular expression.
 ```
+
+(readability-identifier-naming-macro-definition-suffix)=
 
 ```{option} MacroDefinitionSuffix
 When defined, the check will ensure macro definitions will add the
@@ -1838,9 +2152,9 @@ suffix with the given value (regardless of casing).
 
 For example using values of:
 
-- {option}`MacroDefinitionCase` of `lower_case`
-- {option}`MacroDefinitionPrefix` of `pre_`
-- {option}`MacroDefinitionSuffix` of `_post`
+- [`MacroDefinitionCase`](#readability-identifier-naming-macro-definition-case) of `lower_case`
+- [`MacroDefinitionPrefix`](#readability-identifier-naming-macro-definition-prefix) of `pre_`
+- [`MacroDefinitionSuffix`](#readability-identifier-naming-macro-definition-suffix) of `_post`
 
 Identifies and/or transforms macro definitions as follows:
 
@@ -1859,25 +2173,35 @@ After:
 Note: This will not warn on builtin macros or macros defined on the
 command line using the `-D` flag.
 
+(readability-identifier-naming-member-case)=
+
 ```{option} MemberCase
 When defined, the check will ensure member names conform to the
 selected casing.
 ```
+
+(readability-identifier-naming-member-prefix)=
 
 ```{option} MemberPrefix
 When defined, the check will ensure member names will add the
 prefix with the given value (regardless of casing).
 ```
 
+(readability-identifier-naming-member-ignored-regexp)=
+
 ```{option} MemberIgnoredRegexp
 Identifier naming checks won't be enforced for member names
 matching this regular expression.
 ```
 
+(readability-identifier-naming-member-suffix)=
+
 ```{option} MemberSuffix
 When defined, the check will ensure member names will add the
 suffix with the given value (regardless of casing).
 ```
+
+(readability-identifier-naming-member-hungarian-prefix)=
 
 ```{option} MemberHungarianPrefix
 When enabled, the check ensures that the declared identifier will
@@ -1886,10 +2210,10 @@ have a Hungarian notation prefix based on the declared type.
 
 For example using values of:
 
-- {option}`MemberCase` of `lower_case`
-- {option}`MemberPrefix` of `pre_`
-- {option}`MemberSuffix` of `_post`
-- {option}`MemberHungarianPrefix` of `On`
+- [`MemberCase`](#readability-identifier-naming-member-case) of `lower_case`
+- [`MemberPrefix`](#readability-identifier-naming-member-prefix) of `pre_`
+- [`MemberSuffix`](#readability-identifier-naming-member-suffix) of `_post`
+- [`MemberHungarianPrefix`](#readability-identifier-naming-member-hungarian-prefix) of `On`
 
 Identifies and/or transforms member names as follows:
 
@@ -1909,20 +2233,28 @@ class Foo {
 }
 ```
 
+(readability-identifier-naming-method-case)=
+
 ```{option} MethodCase
 When defined, the check will ensure method names conform to the
 selected casing.
 ```
+
+(readability-identifier-naming-method-prefix)=
 
 ```{option} MethodPrefix
 When defined, the check will ensure method names will add the
 prefix with the given value (regardless of casing).
 ```
 
+(readability-identifier-naming-method-ignored-regexp)=
+
 ```{option} MethodIgnoredRegexp
 Identifier naming checks won't be enforced for method names
 matching this regular expression.
 ```
+
+(readability-identifier-naming-method-suffix)=
 
 ```{option} MethodSuffix
 When defined, the check will ensure method names will add the
@@ -1931,9 +2263,9 @@ suffix with the given value (regardless of casing).
 
 For example using values of:
 
-- {option}`MethodCase` of `lower_case`
-- {option}`MethodPrefix` of `pre_`
-- {option}`MethodSuffix` of `_post`
+- [`MethodCase`](#readability-identifier-naming-method-case) of `lower_case`
+- [`MethodPrefix`](#readability-identifier-naming-method-prefix) of `pre_`
+- [`MethodSuffix`](#readability-identifier-naming-method-suffix) of `_post`
 
 Identifies and/or transforms method names as follows:
 
@@ -1953,20 +2285,28 @@ class Foo {
 }
 ```
 
+(readability-identifier-naming-namespace-case)=
+
 ```{option} NamespaceCase
 When defined, the check will ensure namespace names conform to the
 selected casing.
 ```
+
+(readability-identifier-naming-namespace-prefix)=
 
 ```{option} NamespacePrefix
 When defined, the check will ensure namespace names will add the
 prefix with the given value (regardless of casing).
 ```
 
+(readability-identifier-naming-namespace-ignored-regexp)=
+
 ```{option} NamespaceIgnoredRegexp
 Identifier naming checks won't be enforced for namespace names
 matching this regular expression.
 ```
+
+(readability-identifier-naming-namespace-suffix)=
 
 ```{option} NamespaceSuffix
 When defined, the check will ensure namespace names will add the
@@ -1975,9 +2315,9 @@ suffix with the given value (regardless of casing).
 
 For example using values of:
 
-- {option}`NamespaceCase` of `lower_case`
-- {option}`NamespacePrefix` of `pre_`
-- {option}`NamespaceSuffix` of `_post`
+- [`NamespaceCase`](#readability-identifier-naming-namespace-case) of `lower_case`
+- [`NamespacePrefix`](#readability-identifier-naming-namespace-prefix) of `pre_`
+- [`NamespaceSuffix`](#readability-identifier-naming-namespace-suffix) of `_post`
 
 Identifies and/or transforms namespace names as follows:
 
@@ -1997,25 +2337,35 @@ namespace pre_foo_ns_post {
 }
 ```
 
+(readability-identifier-naming-parameter-case)=
+
 ```{option} ParameterCase
 When defined, the check will ensure parameter names conform to the
 selected casing.
 ```
+
+(readability-identifier-naming-parameter-prefix)=
 
 ```{option} ParameterPrefix
 When defined, the check will ensure parameter names will add the
 prefix with the given value (regardless of casing).
 ```
 
+(readability-identifier-naming-parameter-ignored-regexp)=
+
 ```{option} ParameterIgnoredRegexp
 Identifier naming checks won't be enforced for parameter names
 matching this regular expression.
 ```
 
+(readability-identifier-naming-parameter-suffix)=
+
 ```{option} ParameterSuffix
 When defined, the check will ensure parameter names will add the
 suffix with the given value (regardless of casing).
 ```
+
+(readability-identifier-naming-parameter-hungarian-prefix)=
 
 ```{option} ParameterHungarianPrefix
 When enabled, the check ensures that the declared identifier will
@@ -2024,10 +2374,10 @@ have a Hungarian notation prefix based on the declared type.
 
 For example using values of:
 
-- {option}`ParameterCase` of `lower_case`
-- {option}`ParameterPrefix` of `pre_`
-- {option}`ParameterSuffix` of `_post`
-- {option}`ParameterHungarianPrefix` of `On`
+- [`ParameterCase`](#readability-identifier-naming-parameter-case) of `lower_case`
+- [`ParameterPrefix`](#readability-identifier-naming-parameter-prefix) of `pre_`
+- [`ParameterSuffix`](#readability-identifier-naming-parameter-suffix) of `_post`
+- [`ParameterHungarianPrefix`](#readability-identifier-naming-parameter-hungarian-prefix) of `On`
 
 Identifies and/or transforms parameter names as follows:
 
@@ -2043,20 +2393,28 @@ After:
 void GLOBAL_FUNCTION(int pre_parameter_post, int const CONST_parameter);
 ```
 
+(readability-identifier-naming-parameter-pack-case)=
+
 ```{option} ParameterPackCase
 When defined, the check will ensure parameter pack names conform to the
 selected casing.
 ```
+
+(readability-identifier-naming-parameter-pack-prefix)=
 
 ```{option} ParameterPackPrefix
 When defined, the check will ensure parameter pack names will add the
 prefix with the given value (regardless of casing).
 ```
 
+(readability-identifier-naming-parameter-pack-ignored-regexp)=
+
 ```{option} ParameterPackIgnoredRegexp
 Identifier naming checks won't be enforced for parameter pack names
 matching this regular expression.
 ```
+
+(readability-identifier-naming-parameter-pack-suffix)=
 
 ```{option} ParameterPackSuffix
 When defined, the check will ensure parameter pack names will add the
@@ -2065,9 +2423,9 @@ suffix with the given value (regardless of casing).
 
 For example using values of:
 
-- {option}`ParameterPackCase` of `lower_case`
-- {option}`ParameterPackPrefix` of `pre_`
-- {option}`ParameterPackSuffix` of `_post`
+- [`ParameterPackCase`](#readability-identifier-naming-parameter-pack-case) of `lower_case`
+- [`ParameterPackPrefix`](#readability-identifier-naming-parameter-pack-prefix) of `pre_`
+- [`ParameterPackSuffix`](#readability-identifier-naming-parameter-pack-suffix) of `_post`
 
 Identifies and/or transforms parameter pack names as follows:
 
@@ -2087,25 +2445,35 @@ template <typename... TYPE_parameters> {
 }
 ```
 
+(readability-identifier-naming-pointer-parameter-case)=
+
 ```{option} PointerParameterCase
 When defined, the check will ensure pointer parameter names conform to the
 selected casing.
 ```
+
+(readability-identifier-naming-pointer-parameter-prefix)=
 
 ```{option} PointerParameterPrefix
 When defined, the check will ensure pointer parameter names will add the
 prefix with the given value (regardless of casing).
 ```
 
+(readability-identifier-naming-pointer-parameter-ignored-regexp)=
+
 ```{option} PointerParameterIgnoredRegexp
 Identifier naming checks won't be enforced for pointer parameter names
 matching this regular expression.
 ```
 
+(readability-identifier-naming-pointer-parameter-suffix)=
+
 ```{option} PointerParameterSuffix
 When defined, the check will ensure pointer parameter names will add the
 suffix with the given value (regardless of casing).
 ```
+
+(readability-identifier-naming-pointer-parameter-hungarian-prefix)=
 
 ```{option} PointerParameterHungarianPrefix
 When enabled, the check ensures that the declared identifier will
@@ -2114,10 +2482,10 @@ have a Hungarian notation prefix based on the declared type.
 
 For example using values of:
 
-- {option}`PointerParameterCase` of `lower_case`
-- {option}`PointerParameterPrefix` of `pre_`
-- {option}`PointerParameterSuffix` of `_post`
-- {option}`PointerParameterHungarianPrefix` of `On`
+- [`PointerParameterCase`](#readability-identifier-naming-pointer-parameter-case) of `lower_case`
+- [`PointerParameterPrefix`](#readability-identifier-naming-pointer-parameter-prefix) of `pre_`
+- [`PointerParameterSuffix`](#readability-identifier-naming-pointer-parameter-suffix) of `_post`
+- [`PointerParameterHungarianPrefix`](#readability-identifier-naming-pointer-parameter-hungarian-prefix) of `On`
 
 Identifies and/or transforms pointer parameter names as follows:
 
@@ -2133,25 +2501,35 @@ After:
 void FUNCTION(int *pre_parameter_post);
 ```
 
+(readability-identifier-naming-private-member-case)=
+
 ```{option} PrivateMemberCase
 When defined, the check will ensure private member names conform to the
 selected casing.
 ```
+
+(readability-identifier-naming-private-member-prefix)=
 
 ```{option} PrivateMemberPrefix
 When defined, the check will ensure private member names will add the
 prefix with the given value (regardless of casing).
 ```
 
+(readability-identifier-naming-private-member-ignored-regexp)=
+
 ```{option} PrivateMemberIgnoredRegexp
 Identifier naming checks won't be enforced for private member names
 matching this regular expression.
 ```
 
+(readability-identifier-naming-private-member-suffix)=
+
 ```{option} PrivateMemberSuffix
 When defined, the check will ensure private member names will add the
 suffix with the given value (regardless of casing).
 ```
+
+(readability-identifier-naming-private-member-hungarian-prefix)=
 
 ```{option} PrivateMemberHungarianPrefix
 When enabled, the check ensures that the declared identifier will
@@ -2160,10 +2538,10 @@ have a Hungarian notation prefix based on the declared type.
 
 For example using values of:
 
-- {option}`PrivateMemberCase` of `lower_case`
-- {option}`PrivateMemberPrefix` of `pre_`
-- {option}`PrivateMemberSuffix` of `_post`
-- {option}`PrivateMemberHungarianPrefix` of `On`
+- [`PrivateMemberCase`](#readability-identifier-naming-private-member-case) of `lower_case`
+- [`PrivateMemberPrefix`](#readability-identifier-naming-private-member-prefix) of `pre_`
+- [`PrivateMemberSuffix`](#readability-identifier-naming-private-member-suffix) of `_post`
+- [`PrivateMemberHungarianPrefix`](#readability-identifier-naming-private-member-hungarian-prefix) of `On`
 
 Identifies and/or transforms private member names as follows:
 
@@ -2185,20 +2563,28 @@ private:
 }
 ```
 
+(readability-identifier-naming-private-method-case)=
+
 ```{option} PrivateMethodCase
 When defined, the check will ensure private method names conform to the
 selected casing.
 ```
+
+(readability-identifier-naming-private-method-prefix)=
 
 ```{option} PrivateMethodPrefix
 When defined, the check will ensure private method names will add the
 prefix with the given value (regardless of casing).
 ```
 
+(readability-identifier-naming-private-method-ignored-regexp)=
+
 ```{option} PrivateMethodIgnoredRegexp
 Identifier naming checks won't be enforced for private method names
 matching this regular expression.
 ```
+
+(readability-identifier-naming-private-method-suffix)=
 
 ```{option} PrivateMethodSuffix
 When defined, the check will ensure private method names will add the
@@ -2207,9 +2593,9 @@ suffix with the given value (regardless of casing).
 
 For example using values of:
 
-- {option}`PrivateMethodCase` of `lower_case`
-- {option}`PrivateMethodPrefix` of `pre_`
-- {option}`PrivateMethodSuffix` of `_post`
+- [`PrivateMethodCase`](#readability-identifier-naming-private-method-case) of `lower_case`
+- [`PrivateMethodPrefix`](#readability-identifier-naming-private-method-prefix) of `pre_`
+- [`PrivateMethodSuffix`](#readability-identifier-naming-private-method-suffix) of `_post`
 
 Identifies and/or transforms private method names as follows:
 
@@ -2231,25 +2617,35 @@ private:
 }
 ```
 
+(readability-identifier-naming-protected-member-case)=
+
 ```{option} ProtectedMemberCase
 When defined, the check will ensure protected member names conform to the
 selected casing.
 ```
+
+(readability-identifier-naming-protected-member-prefix)=
 
 ```{option} ProtectedMemberPrefix
 When defined, the check will ensure protected member names will add the
 prefix with the given value (regardless of casing).
 ```
 
+(readability-identifier-naming-protected-member-ignored-regexp)=
+
 ```{option} ProtectedMemberIgnoredRegexp
 Identifier naming checks won't be enforced for protected member names
 matching this regular expression.
 ```
 
+(readability-identifier-naming-protected-member-suffix)=
+
 ```{option} ProtectedMemberSuffix
 When defined, the check will ensure protected member names will add the
 suffix with the given value (regardless of casing).
 ```
+
+(readability-identifier-naming-protected-member-hungarian-prefix)=
 
 ```{option} ProtectedMemberHungarianPrefix
 When enabled, the check ensures that the declared identifier will
@@ -2258,10 +2654,10 @@ have a Hungarian notation prefix based on the declared type.
 
 For example using values of:
 
-- {option}`ProtectedMemberCase` of `lower_case`
-- {option}`ProtectedMemberPrefix` of `pre_`
-- {option}`ProtectedMemberSuffix` of `_post`
-- {option}`ProtectedMemberHungarianPrefix` of `On`
+- [`ProtectedMemberCase`](#readability-identifier-naming-protected-member-case) of `lower_case`
+- [`ProtectedMemberPrefix`](#readability-identifier-naming-protected-member-prefix) of `pre_`
+- [`ProtectedMemberSuffix`](#readability-identifier-naming-protected-member-suffix) of `_post`
+- [`ProtectedMemberHungarianPrefix`](#readability-identifier-naming-protected-member-hungarian-prefix) of `On`
 
 Identifies and/or transforms protected member names as follows:
 
@@ -2283,20 +2679,28 @@ protected:
 }
 ```
 
+(readability-identifier-naming-protected-method-case)=
+
 ```{option} ProtectedMethodCase
 When defined, the check will ensure protected method names conform to the
 selected casing.
 ```
+
+(readability-identifier-naming-protected-method-prefix)=
 
 ```{option} ProtectedMethodPrefix
 When defined, the check will ensure protected method names will add the
 prefix with the given value (regardless of casing).
 ```
 
+(readability-identifier-naming-protected-method-ignored-regexp)=
+
 ```{option} ProtectedMethodIgnoredRegexp
 Identifier naming checks won't be enforced for protected method names
 matching this regular expression.
 ```
+
+(readability-identifier-naming-protected-method-suffix)=
 
 ```{option} ProtectedMethodSuffix
 When defined, the check will ensure protected method names will add the
@@ -2305,9 +2709,9 @@ suffix with the given value (regardless of casing).
 
 For example using values of:
 
-- {option}`ProtectedMethodCase` of `lower_case`
-- {option}`ProtectedMethodPrefix` of `pre_`
-- {option}`ProtectedMethodSuffix` of `_post`
+- [`ProtectedMethodCase`](#readability-identifier-naming-protected-method-case) of `lower_case`
+- [`ProtectedMethodPrefix`](#readability-identifier-naming-protected-method-prefix) of `pre_`
+- [`ProtectedMethodSuffix`](#readability-identifier-naming-protected-method-suffix) of `_post`
 
 Identifies and/or transforms protect method names as follows:
 
@@ -2329,25 +2733,35 @@ protected:
 }
 ```
 
+(readability-identifier-naming-public-member-case)=
+
 ```{option} PublicMemberCase
 When defined, the check will ensure public member names conform to the
 selected casing.
 ```
+
+(readability-identifier-naming-public-member-prefix)=
 
 ```{option} PublicMemberPrefix
 When defined, the check will ensure public member names will add the
 prefix with the given value (regardless of casing).
 ```
 
+(readability-identifier-naming-public-member-ignored-regexp)=
+
 ```{option} PublicMemberIgnoredRegexp
 Identifier naming checks won't be enforced for public member names
 matching this regular expression.
 ```
 
+(readability-identifier-naming-public-member-suffix)=
+
 ```{option} PublicMemberSuffix
 When defined, the check will ensure public member names will add the
 suffix with the given value (regardless of casing).
 ```
+
+(readability-identifier-naming-public-member-hungarian-prefix)=
 
 ```{option} PublicMemberHungarianPrefix
 When enabled, the check ensures that the declared identifier will
@@ -2356,10 +2770,10 @@ have a Hungarian notation prefix based on the declared type.
 
 For example using values of:
 
-- {option}`PublicMemberCase` of `lower_case`
-- {option}`PublicMemberPrefix` of `pre_`
-- {option}`PublicMemberSuffix` of `_post`
-- {option}`PublicMemberHungarianPrefix` of `On`
+- [`PublicMemberCase`](#readability-identifier-naming-public-member-case) of `lower_case`
+- [`PublicMemberPrefix`](#readability-identifier-naming-public-member-prefix) of `pre_`
+- [`PublicMemberSuffix`](#readability-identifier-naming-public-member-suffix) of `_post`
+- [`PublicMemberHungarianPrefix`](#readability-identifier-naming-public-member-hungarian-prefix) of `On`
 
 Identifies and/or transforms public member names as follows:
 
@@ -2381,20 +2795,28 @@ public:
 }
 ```
 
+(readability-identifier-naming-public-method-case)=
+
 ```{option} PublicMethodCase
 When defined, the check will ensure public method names conform to the
 selected casing.
 ```
+
+(readability-identifier-naming-public-method-prefix)=
 
 ```{option} PublicMethodPrefix
 When defined, the check will ensure public method names will add the
 prefix with the given value (regardless of casing).
 ```
 
+(readability-identifier-naming-public-method-ignored-regexp)=
+
 ```{option} PublicMethodIgnoredRegexp
 Identifier naming checks won't be enforced for public method names
 matching this regular expression.
 ```
+
+(readability-identifier-naming-public-method-suffix)=
 
 ```{option} PublicMethodSuffix
 When defined, the check will ensure public method names will add the
@@ -2403,9 +2825,9 @@ suffix with the given value (regardless of casing).
 
 For example using values of:
 
-- {option}`PublicMethodCase` of `lower_case`
-- {option}`PublicMethodPrefix` of `pre_`
-- {option}`PublicMethodSuffix` of `_post`
+- [`PublicMethodCase`](#readability-identifier-naming-public-method-case) of `lower_case`
+- [`PublicMethodPrefix`](#readability-identifier-naming-public-method-prefix) of `pre_`
+- [`PublicMethodSuffix`](#readability-identifier-naming-public-method-suffix) of `_post`
 
 Identifies and/or transforms public method names as follows:
 
@@ -2427,25 +2849,35 @@ public:
 }
 ```
 
+(readability-identifier-naming-scoped-enum-constant-case)=
+
 ```{option} ScopedEnumConstantCase
 When defined, the check will ensure scoped enum constant names conform to
 the selected casing.
 ```
+
+(readability-identifier-naming-scoped-enum-constant-prefix)=
 
 ```{option} ScopedEnumConstantPrefix
 When defined, the check will ensure scoped enum constant names will add the
 prefix with the given value (regardless of casing).
 ```
 
+(readability-identifier-naming-scoped-enum-constant-ignored-regexp)=
+
 ```{option} ScopedEnumConstantIgnoredRegexp
 Identifier naming checks won't be enforced for scoped enum constant names
 matching this regular expression.
 ```
 
+(readability-identifier-naming-scoped-enum-constant-suffix)=
+
 ```{option} ScopedEnumConstantSuffix
 When defined, the check will ensure scoped enum constant names will add the
 suffix with the given value (regardless of casing).
 ```
+
+(readability-identifier-naming-scoped-enum-constant-hungarian-prefix)=
 
 ```{option} ScopedEnumConstantHungarianPrefix
 When enabled, the check ensures that the declared identifier will
@@ -2454,10 +2886,10 @@ have a Hungarian notation prefix based on the declared type.
 
 For example using values of:
 
-- {option}`ScopedEnumConstantCase` of `lower_case`
-- {option}`ScopedEnumConstantPrefix` of `pre_`
-- {option}`ScopedEnumConstantSuffix` of `_post`
-- {option}`ScopedEnumConstantHungarianPrefix` of `On`
+- [`ScopedEnumConstantCase`](#readability-identifier-naming-scoped-enum-constant-case) of `lower_case`
+- [`ScopedEnumConstantPrefix`](#readability-identifier-naming-scoped-enum-constant-prefix) of `pre_`
+- [`ScopedEnumConstantSuffix`](#readability-identifier-naming-scoped-enum-constant-suffix) of `_post`
+- [`ScopedEnumConstantHungarianPrefix`](#readability-identifier-naming-scoped-enum-constant-hungarian-prefix) of `On`
 
 Identifies and/or transforms enumeration constant names as follows:
 
@@ -2473,25 +2905,35 @@ After:
 enum class FOO { pre_One_post, pre_Two_post, pre_Three_post };
 ```
 
+(readability-identifier-naming-static-constexpr-variable-case)=
+
 ```{option} StaticConstexprVariableCase
 When defined, the check will ensure static `constexpr` variable names
 conform to the selected casing.
 ```
+
+(readability-identifier-naming-static-constexpr-variable-prefix)=
 
 ```{option} StaticConstexprVariablePrefix
 When defined, the check will ensure static `constexpr` variable names
 will add the prefixed with the given value (regardless of casing).
 ```
 
+(readability-identifier-naming-static-constexpr-variable-ignored-regexp)=
+
 ```{option} StaticConstexprVariableIgnoredRegexp
 Identifier naming checks won't be enforced for static `constexpr`
 variable names matching this regular expression.
 ```
 
+(readability-identifier-naming-static-constexpr-variable-suffix)=
+
 ```{option} StaticConstexprVariableSuffix
 When defined, the check will ensure static `constexpr` variable names
 will add the suffix with the given value (regardless of casing).
 ```
+
+(readability-identifier-naming-static-constexpr-variable-hungarian-prefix)=
 
 ```{option} StaticConstexprVariableHungarianPrefix
 When enabled, the check ensures that the declared identifier will have a
@@ -2500,10 +2942,10 @@ Hungarian notation prefix based on the declared type.
 
 For example using values of:
 
-- {option}`StaticConstexprVariableCase` of `lower_case`
-- {option}`StaticConstexprVariablePrefix` of `pre_`
-- {option}`StaticConstexprVariableSuffix` of `_post`
-- {option}`StaticConstexprVariableHungarianPrefix` of `On`
+- [`StaticConstexprVariableCase`](#readability-identifier-naming-static-constexpr-variable-case) of `lower_case`
+- [`StaticConstexprVariablePrefix`](#readability-identifier-naming-static-constexpr-variable-prefix) of `pre_`
+- [`StaticConstexprVariableSuffix`](#readability-identifier-naming-static-constexpr-variable-suffix) of `_post`
+- [`StaticConstexprVariableHungarianPrefix`](#readability-identifier-naming-static-constexpr-variable-hungarian-prefix) of `On`
 
 Identifies and/or transforms static `constexpr` variable names as follows:
 
@@ -2519,25 +2961,35 @@ After:
 static unsigned constexpr pre_my_constexpr_static_array_post[] = {1, 2, 3};
 ```
 
+(readability-identifier-naming-static-constant-case)=
+
 ```{option} StaticConstantCase
 When defined, the check will ensure static constant names conform to the
 selected casing.
 ```
+
+(readability-identifier-naming-static-constant-prefix)=
 
 ```{option} StaticConstantPrefix
 When defined, the check will ensure static constant names will add the
 prefix with the given value (regardless of casing).
 ```
 
+(readability-identifier-naming-static-constant-ignored-regexp)=
+
 ```{option} StaticConstantIgnoredRegexp
 Identifier naming checks won't be enforced for static constant names
 matching this regular expression.
 ```
 
+(readability-identifier-naming-static-constant-suffix)=
+
 ```{option} StaticConstantSuffix
 When defined, the check will ensure static constant names will add the
 suffix with the given value (regardless of casing).
 ```
+
+(readability-identifier-naming-static-constant-hungarian-prefix)=
 
 ```{option} StaticConstantHungarianPrefix
 When enabled, the check ensures that the declared identifier will
@@ -2546,10 +2998,10 @@ have a Hungarian notation prefix based on the declared type.
 
 For example using values of:
 
-- {option}`StaticConstantCase` of `lower_case`
-- {option}`StaticConstantPrefix` of `pre_`
-- {option}`StaticConstantSuffix` of `_post`
-- {option}`StaticConstantHungarianPrefix` of `On`
+- [`StaticConstantCase`](#readability-identifier-naming-static-constant-case) of `lower_case`
+- [`StaticConstantPrefix`](#readability-identifier-naming-static-constant-prefix) of `pre_`
+- [`StaticConstantSuffix`](#readability-identifier-naming-static-constant-suffix) of `_post`
+- [`StaticConstantHungarianPrefix`](#readability-identifier-naming-static-constant-hungarian-prefix) of `On`
 
 Identifies and/or transforms static constant names as follows:
 
@@ -2565,25 +3017,35 @@ After:
 static unsigned const pre_myconststatic_array_post[] = {1, 2, 3};
 ```
 
+(readability-identifier-naming-static-variable-case)=
+
 ```{option} StaticVariableCase
 When defined, the check will ensure static variable names conform to the
 selected casing.
 ```
+
+(readability-identifier-naming-static-variable-prefix)=
 
 ```{option} StaticVariablePrefix
 When defined, the check will ensure static variable names will add the
 prefix with the given value (regardless of casing).
 ```
 
+(readability-identifier-naming-static-variable-ignored-regexp)=
+
 ```{option} StaticVariableIgnoredRegexp
 Identifier naming checks won't be enforced for static variable names
 matching this regular expression.
 ```
 
+(readability-identifier-naming-static-variable-suffix)=
+
 ```{option} StaticVariableSuffix
 When defined, the check will ensure static variable names will add the
 suffix with the given value (regardless of casing).
 ```
+
+(readability-identifier-naming-static-variable-hungarian-prefix)=
 
 ```{option} StaticVariableHungarianPrefix
 When enabled, the check ensures that the declared identifier will
@@ -2592,10 +3054,10 @@ have a Hungarian notation prefix based on the declared type.
 
 For example using values of:
 
-- {option}`StaticVariableCase` of `lower_case`
-- {option}`StaticVariablePrefix` of `pre_`
-- {option}`StaticVariableSuffix` of `_post`
-- {option}`StaticVariableHungarianPrefix` of `On`
+- [`StaticVariableCase`](#readability-identifier-naming-static-variable-case) of `lower_case`
+- [`StaticVariablePrefix`](#readability-identifier-naming-static-variable-prefix) of `pre_`
+- [`StaticVariableSuffix`](#readability-identifier-naming-static-variable-suffix) of `_post`
+- [`StaticVariableHungarianPrefix`](#readability-identifier-naming-static-variable-hungarian-prefix) of `On`
 
 Identifies and/or transforms static variable names as follows:
 
@@ -2611,20 +3073,28 @@ After:
 static unsigned pre_mystatic_array_post[] = {1, 2, 3};
 ```
 
+(readability-identifier-naming-struct-case)=
+
 ```{option} StructCase
 When defined, the check will ensure struct names conform to the
 selected casing.
 ```
+
+(readability-identifier-naming-struct-prefix)=
 
 ```{option} StructPrefix
 When defined, the check will ensure struct names will add the
 prefix with the given value (regardless of casing).
 ```
 
+(readability-identifier-naming-struct-ignored-regexp)=
+
 ```{option} StructIgnoredRegexp
 Identifier naming checks won't be enforced for struct names
 matching this regular expression.
 ```
+
+(readability-identifier-naming-struct-suffix)=
 
 ```{option} StructSuffix
 When defined, the check will ensure struct names will add the
@@ -2633,9 +3103,9 @@ suffix with the given value (regardless of casing).
 
 For example using values of:
 
-- {option}`StructCase` of `lower_case`
-- {option}`StructPrefix` of `pre_`
-- {option}`StructSuffix` of `_post`
+- [`StructCase`](#readability-identifier-naming-struct-case) of `lower_case`
+- [`StructPrefix`](#readability-identifier-naming-struct-prefix) of `pre_`
+- [`StructSuffix`](#readability-identifier-naming-struct-suffix) of `_post`
 
 Identifies and/or transforms struct names as follows:
 
@@ -2657,20 +3127,28 @@ struct pre_foo_post {
 };
 ```
 
+(readability-identifier-naming-template-parameter-case)=
+
 ```{option} TemplateParameterCase
 When defined, the check will ensure template parameter names conform to the
 selected casing.
 ```
+
+(readability-identifier-naming-template-parameter-prefix)=
 
 ```{option} TemplateParameterPrefix
 When defined, the check will ensure template parameter names will add the
 prefix with the given value (regardless of casing).
 ```
 
+(readability-identifier-naming-template-parameter-ignored-regexp)=
+
 ```{option} TemplateParameterIgnoredRegexp
 Identifier naming checks won't be enforced for template parameter names
 matching this regular expression.
 ```
+
+(readability-identifier-naming-template-parameter-suffix)=
 
 ```{option} TemplateParameterSuffix
 When defined, the check will ensure template parameter names will add the
@@ -2679,9 +3157,9 @@ suffix with the given value (regardless of casing).
 
 For example using values of:
 
-- {option}`TemplateParameterCase` of `lower_case`
-- {option}`TemplateParameterPrefix` of `pre_`
-- {option}`TemplateParameterSuffix` of `_post`
+- [`TemplateParameterCase`](#readability-identifier-naming-template-parameter-case) of `lower_case`
+- [`TemplateParameterPrefix`](#readability-identifier-naming-template-parameter-prefix) of `pre_`
+- [`TemplateParameterSuffix`](#readability-identifier-naming-template-parameter-suffix) of `_post`
 
 Identifies and/or transforms template parameter names as follows:
 
@@ -2697,20 +3175,28 @@ After:
 template <typename pre_t_post> class Foo {};
 ```
 
+(readability-identifier-naming-template-template-parameter-case)=
+
 ```{option} TemplateTemplateParameterCase
 When defined, the check will ensure template template parameter names conform to the
 selected casing.
 ```
+
+(readability-identifier-naming-template-template-parameter-prefix)=
 
 ```{option} TemplateTemplateParameterPrefix
 When defined, the check will ensure template template parameter names will add the
 prefix with the given value (regardless of casing).
 ```
 
+(readability-identifier-naming-template-template-parameter-ignored-regexp)=
+
 ```{option} TemplateTemplateParameterIgnoredRegexp
 Identifier naming checks won't be enforced for template template parameter
 names matching this regular expression.
 ```
+
+(readability-identifier-naming-template-template-parameter-suffix)=
 
 ```{option} TemplateTemplateParameterSuffix
 When defined, the check will ensure template template parameter names will add the
@@ -2719,9 +3205,9 @@ suffix with the given value (regardless of casing).
 
 For example using values of:
 
-- {option}`TemplateTemplateParameterCase` of `lower_case`
-- {option}`TemplateTemplateParameterPrefix` of `pre_`
-- {option}`TemplateTemplateParameterSuffix` of `_post`
+- [`TemplateTemplateParameterCase`](#readability-identifier-naming-template-template-parameter-case) of `lower_case`
+- [`TemplateTemplateParameterPrefix`](#readability-identifier-naming-template-template-parameter-prefix) of `pre_`
+- [`TemplateTemplateParameterSuffix`](#readability-identifier-naming-template-template-parameter-suffix) of `_post`
 
 Identifies and/or transforms template template parameter names as follows:
 
@@ -2739,20 +3225,28 @@ template <template <typename> class pre_tpl_parameter_post, int COUNT_params,
           typename... TYPE_parameters>
 ```
 
+(readability-identifier-naming-type-alias-case)=
+
 ```{option} TypeAliasCase
 When defined, the check will ensure type alias names conform to the
 selected casing.
 ```
+
+(readability-identifier-naming-type-alias-prefix)=
 
 ```{option} TypeAliasPrefix
 When defined, the check will ensure type alias names will add the
 prefix with the given value (regardless of casing).
 ```
 
+(readability-identifier-naming-type-alias-ignored-regexp)=
+
 ```{option} TypeAliasIgnoredRegexp
 Identifier naming checks won't be enforced for type alias names
 matching this regular expression.
 ```
+
+(readability-identifier-naming-type-alias-suffix)=
 
 ```{option} TypeAliasSuffix
 When defined, the check will ensure type alias names will add the
@@ -2761,9 +3255,9 @@ suffix with the given value (regardless of casing).
 
 For example using values of:
 
-- {option}`TypeAliasCase` of `lower_case`
-- {option}`TypeAliasPrefix` of `pre_`
-- {option}`TypeAliasSuffix` of `_post`
+- [`TypeAliasCase`](#readability-identifier-naming-type-alias-case) of `lower_case`
+- [`TypeAliasPrefix`](#readability-identifier-naming-type-alias-prefix) of `pre_`
+- [`TypeAliasSuffix`](#readability-identifier-naming-type-alias-suffix) of `_post`
 
 Identifies and/or transforms type alias names as follows:
 
@@ -2779,20 +3273,28 @@ After:
 using pre_my_struct_type_post = my_structure;
 ```
 
+(readability-identifier-naming-typedef-case)=
+
 ```{option} TypedefCase
 When defined, the check will ensure typedef names conform to the
 selected casing.
 ```
+
+(readability-identifier-naming-typedef-prefix)=
 
 ```{option} TypedefPrefix
 When defined, the check will ensure typedef names will add the
 prefix with the given value (regardless of casing).
 ```
 
+(readability-identifier-naming-typedef-ignored-regexp)=
+
 ```{option} TypedefIgnoredRegexp
 Identifier naming checks won't be enforced for typedef names
 matching this regular expression.
 ```
+
+(readability-identifier-naming-typedef-suffix)=
 
 ```{option} TypedefSuffix
 When defined, the check will ensure typedef names will add the
@@ -2801,9 +3303,9 @@ suffix with the given value (regardless of casing).
 
 For example using values of:
 
-- {option}`TypedefCase` of `lower_case`
-- {option}`TypedefPrefix` of `pre_`
-- {option}`TypedefSuffix` of `_post`
+- [`TypedefCase`](#readability-identifier-naming-typedef-case) of `lower_case`
+- [`TypedefPrefix`](#readability-identifier-naming-typedef-prefix) of `pre_`
+- [`TypedefSuffix`](#readability-identifier-naming-typedef-suffix) of `_post`
 
 Identifies and/or transforms typedef names as follows:
 
@@ -2819,13 +3321,15 @@ After:
 typedef int pre_myint_post;
 ```
 
+(readability-identifier-naming-typedef-inherit-anon-tag-config)=
+
 ```{option} TypedefInheritAnonTagConfig
 When `true`, a typedef or type alias that provides the only name of
 an otherwise unnamed tag, as in `typedef enum {} MyEnum;`, is checked
 against the naming style configured for the kind of that tag
 (`AbstractClass`, `Class`, `Enum`, `Struct` or `Union`, i.e.
-{option}`EnumCase`, {option}`EnumPrefix`, {option}`EnumSuffix` and
-{option}`EnumIgnoredRegexp` for an enum) rather than against the typedef
+[`EnumCase`](#readability-identifier-naming-enum-case), [`EnumPrefix`](#readability-identifier-naming-enum-prefix), [`EnumSuffix`](#readability-identifier-naming-enum-suffix) and
+[`EnumIgnoredRegexp`](#readability-identifier-naming-enum-ignored-regexp) for an enum) rather than against the typedef
 or type alias style. If that kind configures no case, prefix or suffix,
 the typedef or type alias style still applies. Typedefs of named tags, of
 other typedefs and of non-tag types are not affected. Default is `false`.
@@ -2833,9 +3337,9 @@ other typedefs and of non-tag types are not affected. Default is `false`.
 
 For example using values of:
 
-- {option}`TypedefInheritAnonTagConfig` of `true`
-- {option}`EnumCase` of `CamelCase`
-- {option}`TypedefCase` of `lower_case`
+- [`TypedefInheritAnonTagConfig`](#readability-identifier-naming-typedef-inherit-anon-tag-config) of `true`
+- [`EnumCase`](#readability-identifier-naming-enum-case) of `CamelCase`
+- [`TypedefCase`](#readability-identifier-naming-typedef-case) of `lower_case`
 
 Identifies and/or transforms names as follows:
 
@@ -2853,20 +3357,28 @@ typedef enum { VAL } MyEnum;
 typedef enum Kind { VAL2 } my_kind;
 ```
 
+(readability-identifier-naming-type-template-parameter-case)=
+
 ```{option} TypeTemplateParameterCase
 When defined, the check will ensure type template parameter names conform to the
 selected casing.
 ```
+
+(readability-identifier-naming-type-template-parameter-prefix)=
 
 ```{option} TypeTemplateParameterPrefix
 When defined, the check will ensure type template parameter names will add the
 prefix with the given value (regardless of casing).
 ```
 
+(readability-identifier-naming-type-template-parameter-ignored-regexp)=
+
 ```{option} TypeTemplateParameterIgnoredRegexp
 Identifier naming checks won't be enforced for type template names
 matching this regular expression.
 ```
+
+(readability-identifier-naming-type-template-parameter-suffix)=
 
 ```{option} TypeTemplateParameterSuffix
 When defined, the check will ensure type template parameter names will add the
@@ -2875,9 +3387,9 @@ suffix with the given value (regardless of casing).
 
 For example using values of:
 
-- {option}`TypeTemplateParameterCase` of `lower_case`
-- {option}`TypeTemplateParameterPrefix` of `pre_`
-- {option}`TypeTemplateParameterSuffix` of `_post`
+- [`TypeTemplateParameterCase`](#readability-identifier-naming-type-template-parameter-case) of `lower_case`
+- [`TypeTemplateParameterPrefix`](#readability-identifier-naming-type-template-parameter-prefix) of `pre_`
+- [`TypeTemplateParameterSuffix`](#readability-identifier-naming-type-template-parameter-suffix) of `_post`
 
 Identifies and/or transforms type template parameter names as follows:
 
@@ -2895,20 +3407,28 @@ template <template <typename> class TPL_parameter, int COUNT_params,
           typename... pre_type_parameters_post>
 ```
 
+(readability-identifier-naming-union-case)=
+
 ```{option} UnionCase
 When defined, the check will ensure union names conform to the
 selected casing.
 ```
+
+(readability-identifier-naming-union-prefix)=
 
 ```{option} UnionPrefix
 When defined, the check will ensure union names will add the
 prefix with the given value (regardless of casing).
 ```
 
+(readability-identifier-naming-union-ignored-regexp)=
+
 ```{option} UnionIgnoredRegexp
 Identifier naming checks won't be enforced for union names
 matching this regular expression.
 ```
+
+(readability-identifier-naming-union-suffix)=
 
 ```{option} UnionSuffix
 When defined, the check will ensure union names will add the
@@ -2917,9 +3437,9 @@ suffix with the given value (regardless of casing).
 
 For example using values of:
 
-- {option}`UnionCase` of `lower_case`
-- {option}`UnionPrefix` of `pre_`
-- {option}`UnionSuffix` of `_post`
+- [`UnionCase`](#readability-identifier-naming-union-case) of `lower_case`
+- [`UnionPrefix`](#readability-identifier-naming-union-prefix) of `pre_`
+- [`UnionSuffix`](#readability-identifier-naming-union-suffix) of `_post`
 
 Identifies and/or transforms union names as follows:
 
@@ -2941,20 +3461,28 @@ union pre_foo_post {
 };
 ```
 
+(readability-identifier-naming-value-template-parameter-case)=
+
 ```{option} ValueTemplateParameterCase
 When defined, the check will ensure value template parameter names conform to the
 selected casing.
 ```
+
+(readability-identifier-naming-value-template-parameter-prefix)=
 
 ```{option} ValueTemplateParameterPrefix
 When defined, the check will ensure value template parameter names will add the
 prefix with the given value (regardless of casing).
 ```
 
+(readability-identifier-naming-value-template-parameter-ignored-regexp)=
+
 ```{option} ValueTemplateParameterIgnoredRegexp
 Identifier naming checks won't be enforced for value template parameter
 names matching this regular expression.
 ```
+
+(readability-identifier-naming-value-template-parameter-suffix)=
 
 ```{option} ValueTemplateParameterSuffix
 When defined, the check will ensure value template parameter names will add the
@@ -2963,9 +3491,9 @@ suffix with the given value (regardless of casing).
 
 For example using values of:
 
-- {option}`ValueTemplateParameterCase` of `lower_case`
-- {option}`ValueTemplateParameterPrefix` of `pre_`
-- {option}`ValueTemplateParameterSuffix` of `_post`
+- [`ValueTemplateParameterCase`](#readability-identifier-naming-value-template-parameter-case) of `lower_case`
+- [`ValueTemplateParameterPrefix`](#readability-identifier-naming-value-template-parameter-prefix) of `pre_`
+- [`ValueTemplateParameterSuffix`](#readability-identifier-naming-value-template-parameter-suffix) of `_post`
 
 Identifies and/or transforms value template parameter names as follows:
 
@@ -2983,25 +3511,35 @@ template <template <typename> class TPL_parameter, int pre_count_params_post,
           typename... TYPE_parameters>
 ```
 
+(readability-identifier-naming-variable-case)=
+
 ```{option} VariableCase
 When defined, the check will ensure variable names conform to the
 selected casing.
 ```
+
+(readability-identifier-naming-variable-prefix)=
 
 ```{option} VariablePrefix
 When defined, the check will ensure variable names will add the
 prefix with the given value (regardless of casing).
 ```
 
+(readability-identifier-naming-variable-ignored-regexp)=
+
 ```{option} VariableIgnoredRegexp
 Identifier naming checks won't be enforced for variable names
 matching this regular expression.
 ```
 
+(readability-identifier-naming-variable-suffix)=
+
 ```{option} VariableSuffix
 When defined, the check will ensure variable names will add the
 suffix with the given value (regardless of casing).
 ```
+
+(readability-identifier-naming-variable-hungarian-prefix)=
 
 ```{option} VariableHungarianPrefix
 When enabled, the check ensures that the declared identifier will
@@ -3010,10 +3548,10 @@ have a Hungarian notation prefix based on the declared type.
 
 For example using values of:
 
-- {option}`VariableCase` of `lower_case`
-- {option}`VariablePrefix` of `pre_`
-- {option}`VariableSuffix` of `_post`
-- {option}`VariableHungarianPrefix` of `On`
+- [`VariableCase`](#readability-identifier-naming-variable-case) of `lower_case`
+- [`VariablePrefix`](#readability-identifier-naming-variable-prefix) of `pre_`
+- [`VariableSuffix`](#readability-identifier-naming-variable-suffix) of `_post`
+- [`VariableHungarianPrefix`](#readability-identifier-naming-variable-hungarian-prefix) of `On`
 
 Identifies and/or transforms variable names as follows:
 
@@ -3029,20 +3567,28 @@ After:
 unsigned pre_myvariable_post;
 ```
 
+(readability-identifier-naming-virtual-method-case)=
+
 ```{option} VirtualMethodCase
 When defined, the check will ensure virtual method names conform to the
 selected casing.
 ```
+
+(readability-identifier-naming-virtual-method-prefix)=
 
 ```{option} VirtualMethodPrefix
 When defined, the check will ensure virtual method names will add the
 prefix with the given value (regardless of casing).
 ```
 
+(readability-identifier-naming-virtual-method-ignored-regexp)=
+
 ```{option} VirtualMethodIgnoredRegexp
 Identifier naming checks won't be enforced for virtual method names
 matching this regular expression.
 ```
+
+(readability-identifier-naming-virtual-method-suffix)=
 
 ```{option} VirtualMethodSuffix
 When defined, the check will ensure virtual method names will add the
@@ -3051,9 +3597,9 @@ suffix with the given value (regardless of casing).
 
 For example using values of:
 
-- {option}`VirtualMethodCase` of `lower_case`
-- {option}`VirtualMethodPrefix` of `pre_`
-- {option}`VirtualMethodSuffix` of `_post`
+- [`VirtualMethodCase`](#readability-identifier-naming-virtual-method-case) of `lower_case`
+- [`VirtualMethodPrefix`](#readability-identifier-naming-virtual-method-prefix) of `pre_`
+- [`VirtualMethodSuffix`](#readability-identifier-naming-virtual-method-suffix) of `_post`
 
 Identifies and/or transforms virtual method names as follows:
 
@@ -3136,31 +3682,39 @@ short          s
 
 ## Options for Hungarian Notation
 
-- {option}`HungarianNotation.General.TreatStructAsClass`
-- {option}`HungarianNotation.DerivedType.Array`
-- {option}`HungarianNotation.DerivedType.Pointer`
-- {option}`HungarianNotation.DerivedType.FunctionPointer`
-- {option}`HungarianNotation.CString.CharPointer`
-- {option}`HungarianNotation.CString.CharArray`
-- {option}`HungarianNotation.CString.WideCharPointer`
-- {option}`HungarianNotation.CString.WideCharArray`
-- {option}`HungarianNotation.PrimitiveType.*`
-- {option}`HungarianNotation.UserDefinedType.*`
+- [`HungarianNotation.General.TreatStructAsClass`](#readability-identifier-naming-hungarian-notation-general-treat-struct-as-class)
+- [`HungarianNotation.DerivedType.Array`](#readability-identifier-naming-hungarian-notation-derived-type-array)
+- [`HungarianNotation.DerivedType.Pointer`](#readability-identifier-naming-hungarian-notation-derived-type-pointer)
+- [`HungarianNotation.DerivedType.FunctionPointer`](#readability-identifier-naming-hungarian-notation-derived-type-function-pointer)
+- [`HungarianNotation.CString.CharPointer`](#readability-identifier-naming-hungarian-notation-c-string-char-pointer)
+- [`HungarianNotation.CString.CharArray`](#readability-identifier-naming-hungarian-notation-c-string-char-array)
+- [`HungarianNotation.CString.WideCharPointer`](#readability-identifier-naming-hungarian-notation-c-string-wide-char-pointer)
+- [`HungarianNotation.CString.WideCharArray`](#readability-identifier-naming-hungarian-notation-c-string-wide-char-array)
+- [`HungarianNotation.PrimitiveType.*`](#readability-identifier-naming-hungarian-notation-primitive-type)
+- [`HungarianNotation.UserDefinedType.*`](#readability-identifier-naming-hungarian-notation-user-defined-type)
+
+(readability-identifier-naming-hungarian-notation-general-treat-struct-as-class)=
 
 ```{option} HungarianNotation.General.TreatStructAsClass
 When defined, the check will treat naming of struct as a class.
 Default is `false`.
 ```
 
+(readability-identifier-naming-hungarian-notation-derived-type-array)=
+
 ```{option} HungarianNotation.DerivedType.Array
 When defined, the check will ensure variable name will add the prefix with
 the given string. Default is `a`.
 ```
 
+(readability-identifier-naming-hungarian-notation-derived-type-pointer)=
+
 ```{option} HungarianNotation.DerivedType.Pointer
 When defined, the check will ensure variable name will add the prefix with
 the given string. Default is `p`.
 ```
+
+(readability-identifier-naming-hungarian-notation-derived-type-function-pointer)=
 
 ```{option} HungarianNotation.DerivedType.FunctionPointer
 When defined, the check will ensure variable name will add the prefix with
@@ -3195,20 +3749,28 @@ typedef void (*FUNC_PTR)();
 FUNC_PTR fnFuncPtr = NULL;
 ```
 
+(readability-identifier-naming-hungarian-notation-c-string-char-pointer)=
+
 ```{option} HungarianNotation.CString.CharPointer
 When defined, the check will ensure variable name will add the prefix with
 the given string. Default is `sz`.
 ```
+
+(readability-identifier-naming-hungarian-notation-c-string-char-array)=
 
 ```{option} HungarianNotation.CString.CharArray
 When defined, the check will ensure variable name will add the prefix with
 the given string. Default is `sz`.
 ```
 
+(readability-identifier-naming-hungarian-notation-c-string-wide-char-pointer)=
+
 ```{option} HungarianNotation.CString.WideCharPointer
 When defined, the check will ensure variable name will add the prefix with
 the given string. Default is `wsz`.
 ```
+
+(readability-identifier-naming-hungarian-notation-c-string-wide-char-array)=
 
 ```{option} HungarianNotation.CString.WideCharArray
 When defined, the check will ensure variable name will add the prefix with
@@ -3247,11 +3809,15 @@ const wchar_t *wszWideNamePtr = L"Name";
 const wchar_t wszWideNameArray[] = L"Name";
 ```
 
+(readability-identifier-naming-hungarian-notation-primitive-type)=
+
 ```{option} HungarianNotation.PrimitiveType.*
 When defined, the check will ensure variable name of involved primitive
 types will add the prefix with the given string. The default prefixes are
 defined in the default mapping table.
 ```
+
+(readability-identifier-naming-hungarian-notation-user-defined-type)=
 
 ```{option} HungarianNotation.UserDefinedType.*
 When defined, the check will ensure variable name of involved user-defined

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/implicit-bool-conversion.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/implicit-bool-conversion.md
@@ -1,7 +1,7 @@
-.. title:: clang-tidy - readability-implicit-bool-conversion
+```{title} clang-tidy - readability-implicit-bool-conversion
+```
 
-readability-implicit-bool-conversion
-====================================
+# readability-implicit-bool-conversion
 
 This check can be used to find implicit conversions between built-in types and
 booleans. Depending on use case, it may simply help with readability of the
@@ -9,74 +9,70 @@ code, or in some cases, point to potential bugs which remain unnoticed due to
 implicit conversions.
 
 The following is a real-world example of bug which was hiding behind implicit
-``bool`` conversion:
+`bool` conversion:
 
-.. code-block:: c++
+```c++
+class Foo {
+  int m_foo;
 
-  class Foo {
-    int m_foo;
+public:
+  void setFoo(bool foo) { m_foo = foo; } // warning: implicit conversion bool -> int
+  int getFoo() { return m_foo; }
+};
 
-  public:
-    void setFoo(bool foo) { m_foo = foo; } // warning: implicit conversion bool -> int
-    int getFoo() { return m_foo; }
-  };
+void use(Foo& foo) {
+  bool value = foo.getFoo(); // warning: implicit conversion int -> bool
+}
+```
 
-  void use(Foo& foo) {
-    bool value = foo.getFoo(); // warning: implicit conversion int -> bool
-  }
-
-This code is the result of unsuccessful refactoring, where type of ``m_foo``
-changed from ``bool`` to ``int``. The programmer forgot to change all
-occurrences of ``bool``, and the remaining code is no longer correct, yet it
+This code is the result of unsuccessful refactoring, where type of `m_foo`
+changed from `bool` to `int`. The programmer forgot to change all
+occurrences of `bool`, and the remaining code is no longer correct, yet it
 still compiles without any visible warnings.
 
 In addition to issuing warnings, fix-it hints are provided to help solve the
 reported issues. This can be used for improving readability of code, for
 example:
 
-.. code-block:: c++
+```c++
+void conversionsToBool() {
+  float floating;
+  bool boolean = floating;
+  // ^ propose replacement: bool boolean = floating != 0.0f;
 
-  void conversionsToBool() {
-    float floating;
-    bool boolean = floating;
-    // ^ propose replacement: bool boolean = floating != 0.0f;
+  int integer;
+  if (integer) {}
+  // ^ propose replacement: if (integer != 0) {}
 
-    int integer;
-    if (integer) {}
-    // ^ propose replacement: if (integer != 0) {}
+  int* pointer;
+  if (!pointer) {}
+  // ^ propose replacement: if (pointer == nullptr) {}
 
-    int* pointer;
-    if (!pointer) {}
-    // ^ propose replacement: if (pointer == nullptr) {}
+  while (1) {}
+  // ^ propose replacement: while (true) {}
+}
 
-    while (1) {}
-    // ^ propose replacement: while (true) {}
-  }
+void functionTakingInt(int param);
 
-  void functionTakingInt(int param);
+void conversionsFromBool() {
+  bool boolean;
+  functionTakingInt(boolean);
+  // ^ propose replacement: functionTakingInt(static_cast<int>(boolean));
 
-  void conversionsFromBool() {
-    bool boolean;
-    functionTakingInt(boolean);
-    // ^ propose replacement: functionTakingInt(static_cast<int>(boolean));
-
-    functionTakingInt(true);
-    // ^ propose replacement: functionTakingInt(1);
-  }
+  functionTakingInt(true);
+  // ^ propose replacement: functionTakingInt(1);
+}
+```
 
 In general, the following conversion types are checked:
 
 - integer expression/literal to boolean (conversion from a single bit bitfield
   to boolean is explicitly allowed, since there's no ambiguity / information
   loss in this case),
-
 - floating expression/literal to boolean,
-
-- pointer/pointer to member/``nullptr``/``NULL`` to boolean,
-
+- pointer/pointer to member/`nullptr`/`NULL` to boolean,
 - boolean expression/literal to integer (conversion from boolean to a single
   bit bitfield is explicitly allowed),
-
 - boolean expression/literal to floating.
 
 The rules for generating fix-it hints are:
@@ -84,81 +80,75 @@ The rules for generating fix-it hints are:
 - in case of conversions from other built-in type to bool, an explicit
   comparison is proposed to make it clear what exactly is being compared:
 
-  - ``bool boolean = floating;`` is changed to
-    ``bool boolean = floating == 0.0f;``,
-
-  - for other types, appropriate literals are used (``0``, ``0u``, ``0.0f``,
-    ``0.0``, ``nullptr``),
+  - `bool boolean = floating;` is changed to
+    `bool boolean = floating == 0.0f;`,
+  - for other types, appropriate literals are used (`0`, `0u`, `0.0f`,
+    `0.0`, `nullptr`),
 
 - in case of negated expressions conversion to bool, the proposed replacement
   with comparison is simplified:
 
-  - ``if (!pointer)`` is changed to ``if (pointer == nullptr)``,
+  - `if (!pointer)` is changed to `if (pointer == nullptr)`,
 
 - in case of conversions from bool to other built-in types, an explicit
-  ``static_cast`` (or a C-style cast since C23) is proposed to make it clear
+  `static_cast` (or a C-style cast since C23) is proposed to make it clear
   that a conversion is taking place:
 
-  - ``int integer = boolean;`` is changed to
-    ``int integer = static_cast<int>(boolean);``,
+  - `int integer = boolean;` is changed to
+    `int integer = static_cast<int>(boolean);`,
 
 - if the conversion is performed on type literals, an equivalent literal is
   proposed, according to what type is actually expected, for example:
 
-  - ``functionTakingBool(0);`` is changed to ``functionTakingBool(false);``,
-
-  - ``functionTakingInt(true);`` is changed to ``functionTakingInt(1);``,
-
-  - for other types, appropriate literals are used (``false``, ``true``, ``0``,
-    ``1``, ``0u``, ``1u``, ``0.0f``, ``1.0f``, ``0.0``, ``1.0f``).
+  - `functionTakingBool(0);` is changed to `functionTakingBool(false);`,
+  - `functionTakingInt(true);` is changed to `functionTakingInt(1);`,
+  - for other types, appropriate literals are used (`false`, `true`, `0`,
+    `1`, `0u`, `1u`, `0.0f`, `1.0f`, `0.0`, `1.0f`).
 
 Some additional accommodations are made for pre-C++11 dialects:
 
-- ``false`` literal conversion to pointer is detected,
-
-- instead of ``nullptr`` literal, ``0`` is proposed as replacement.
+- `false` literal conversion to pointer is detected,
+- instead of `nullptr` literal, `0` is proposed as replacement.
 
 Some additional accommodations are made for C:
 
-- ``bool`` (or ``_Bool``) operands in logical operators (``&&``, ``||``) are
+- `bool` (or `_Bool`) operands in logical operators (`&&`, `||`) are
   ignored.
-
-- ``bool`` (or ``_Bool``) conditions in conditional operators (``?:``) are
+- `bool` (or `_Bool`) conditions in conditional operators (`?:`) are
   ignored.
 
 Occurrences of implicit conversions inside macros and template instantiations
 are deliberately ignored, as it is not clear how to deal with such cases.
 
-Options
--------
+## Options
 
-.. option::  AllowIntegerConditions
+```{option} AllowIntegerConditions
+When `true`, the check will allow conditional integer conversions.
+Default is `false`.
+```
 
-   When `true`, the check will allow conditional integer conversions. Default
-   is `false`.
+```{option} AllowPointerConditions
+When `true`, the check will allow conditional pointer conversions.
+Default is `false`.
+```
 
-.. option::  AllowPointerConditions
+```{option} AllowLogicalOperatorConversion
+When `true`, the check will suppress warnings for implicit conversions of
+logical operator results (`&&`, `||`, `!`) to `bool`. These
+operators always produce values equal to `0` or `1`, so the conversion
+is safe. Default is `false`.
+```
 
-   When `true`, the check will allow conditional pointer conversions. Default
-   is `false`.
+````{option} UseUpperCaseLiteralSuffix
+When `true`, the replacements will use an uppercase literal suffix in the
+provided fixes. Default is `false`.
 
-.. option::  AllowLogicalOperatorConversion
+Example:
 
-   When `true`, the check will suppress warnings for implicit conversions of
-   logical operator results (``&&``, ``||``, ``!``) to ``bool``. These
-   operators always produce values equal to ``0`` or ``1``, so the conversion
-   is safe. Default is `false`.
-
-.. option::  UseUpperCaseLiteralSuffix
-
-   When `true`, the replacements will use an uppercase literal suffix in the
-   provided fixes. Default is `false`.
-
-    Example
-
-    .. code-block:: c++
-
-      uint32_t foo;
-      if (foo) {}
-      // ^ propose replacement default: if (foo != 0u) {}
-      // ^ propose replacement with option `UseUpperCaseLiteralSuffix`: if (foo != 0U) {}
+```c++
+uint32_t foo;
+if (foo) {}
+// ^ propose replacement default: if (foo != 0u) {}
+// ^ propose replacement with option `UseUpperCaseLiteralSuffix`: if (foo != 0U) {}
+```
+````

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/implicit-bool-conversion.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/implicit-bool-conversion.md
@@ -122,15 +122,21 @@ are deliberately ignored, as it is not clear how to deal with such cases.
 
 ## Options
 
+(readability-implicit-bool-conversion-allow-integer-conditions)=
+
 ```{option} AllowIntegerConditions
 When `true`, the check will allow conditional integer conversions.
 Default is `false`.
 ```
 
+(readability-implicit-bool-conversion-allow-pointer-conditions)=
+
 ```{option} AllowPointerConditions
 When `true`, the check will allow conditional pointer conversions.
 Default is `false`.
 ```
+
+(readability-implicit-bool-conversion-allow-logical-operator-conversion)=
 
 ```{option} AllowLogicalOperatorConversion
 When `true`, the check will suppress warnings for implicit conversions of
@@ -138,6 +144,8 @@ logical operator results (`&&`, `||`, `!`) to `bool`. These
 operators always produce values equal to `0` or `1`, so the conversion
 is safe. Default is `false`.
 ```
+
+(readability-implicit-bool-conversion-use-upper-case-literal-suffix)=
 
 ````{option} UseUpperCaseLiteralSuffix
 When `true`, the replacements will use an uppercase literal suffix in the

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/inconsistent-declaration-parameter-name.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/inconsistent-declaration-parameter-name.md
@@ -54,10 +54,14 @@ the definition or the first declaration seen in a translation unit.
 
 ## Options
 
+(readability-inconsistent-declaration-parameter-name-ignore-macros)=
+
 ```{option} IgnoreMacros
 When `true`, the check will not warn about names declared inside macros.
 Default is `true`.
 ```
+
+(readability-inconsistent-declaration-parameter-name-strict)=
 
 ```{option} Strict
 When `true`, names must match exactly (or be absent). Default is `false`.

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/inconsistent-declaration-parameter-name.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/inconsistent-declaration-parameter-name.md
@@ -1,19 +1,19 @@
-.. title:: clang-tidy - readability-inconsistent-declaration-parameter-name
+```{title} clang-tidy - readability-inconsistent-declaration-parameter-name
+```
 
-readability-inconsistent-declaration-parameter-name
-===================================================
+# readability-inconsistent-declaration-parameter-name
 
 Find function declarations which differ in parameter names.
 
 Example:
 
-.. code-block:: c++
+```c++
+// in foo.hpp:
+void foo(int a, int b, int c);
 
-  // in foo.hpp:
-  void foo(int a, int b, int c);
-
-  // in foo.cpp:
-  void foo(int d, int e, int f); // warning
+// in foo.cpp:
+void foo(int d, int e, int f); // warning
+```
 
 This check should help to enforce consistency in large projects, where it often
 happens that a definition of function is refactored, changing the parameter
@@ -24,43 +24,41 @@ definition always in sync.
 Unnamed parameters are allowed and are not taken into account when comparing
 function declarations, for example:
 
-.. code-block:: c++
-
-  void foo(int a);
-  void foo(int); // no warning
+```c++
+void foo(int a);
+void foo(int); // no warning
+```
 
 One name is also allowed to be a case-insensitive prefix/suffix of the other:
 
-.. code-block:: c++
-
-  void foo(int count);
-  void foo(int count_input) { // no warning
-    int count = adjustCount(count_input);
-  }
+```c++
+void foo(int count);
+void foo(int count_input) { // no warning
+  int count = adjustCount(count_input);
+}
+```
 
 To help with refactoring, in some cases fix-it hints are generated to align
 parameter names to a single naming convention. This works with the assumption
 that the function definition is the most up-to-date version, as it directly
 references parameter names in its body. Example:
 
-.. code-block:: c++
-
-  void foo(int a); // warning and fix-it hint (replace "a" to "b")
-  int foo(int b) { return b + 2; } // definition with use of "b"
+```c++
+void foo(int a); // warning and fix-it hint (replace "a" to "b")
+int foo(int b) { return b + 2; } // definition with use of "b"
+```
 
 In the case of multiple redeclarations or function template specializations,
 a warning is issued for every redeclaration or specialization inconsistent with
 the definition or the first declaration seen in a translation unit.
 
-Options
--------
+## Options
 
-.. option:: IgnoreMacros
+```{option} IgnoreMacros
+When `true`, the check will not warn about names declared inside macros.
+Default is `true`.
+```
 
-   If this option is set to `true` (default is `true`), the check will not warn
-   about names declared inside macros.
-
-.. option:: Strict
-
-   If this option is set to `true` (default is `false`), then names must match
-   exactly (or be absent).
+```{option} Strict
+When `true`, names must match exactly (or be absent). Default is `false`.
+```

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/inconsistent-ifelse-braces.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/inconsistent-ifelse-braces.md
@@ -1,42 +1,42 @@
-.. title:: clang-tidy - readability-inconsistent-ifelse-braces
+```{title} clang-tidy - readability-inconsistent-ifelse-braces
+```
 
-readability-inconsistent-ifelse-braces
-======================================
+# readability-inconsistent-ifelse-braces
 
-Detects ``if``/``else`` statements where one branch uses braces and the other
+Detects `if`/`else` statements where one branch uses braces and the other
 does not.
 
 Before:
 
-.. code-block:: c++
+```c++
+if (condition) {
+  statement;
+} else
+  statement;
 
-  if (condition) {
-    statement;
-  } else
-    statement;
+if (condition)
+  statement;
 
-  if (condition)
-    statement;
-
-  if (condition)
-    statement;
-  else
-    statement;
+if (condition)
+  statement;
+else
+  statement;
+```
 
 After:
 
-.. code-block:: c++
+```c++
+if (condition) {
+  statement;
+} else {
+  statement;
+}
 
-  if (condition) {
-    statement;
-  } else {
-    statement;
-  }
+if (condition)
+  statement;
 
-  if (condition)
-    statement;
-
-  if (condition)
-    statement;
-  else
-    statement;
+if (condition)
+  statement;
+else
+  statement;
+```

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/isolate-declaration.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/isolate-declaration.md
@@ -1,7 +1,7 @@
-.. title:: clang-tidy - readability-isolate-declaration
+```{title} clang-tidy - readability-isolate-declaration
+```
 
-readability-isolate-declaration
-===============================
+# readability-isolate-declaration
 
 Detects local variable declarations declaring more than one variable and
 tries to refactor the code to one statement per declaration.
@@ -10,91 +10,88 @@ The automatic code-transformation will use the same indentation as the original
 for every created statement and add a line break after each statement.
 It keeps the order of the variable declarations consistent, too.
 
-.. code-block:: c++
-
-  void f() {
-    int * pointer = nullptr, value = 42, * const const_ptr = &value;
-    // This declaration will be diagnosed and transformed into:
-    // int * pointer = nullptr;
-    // int value = 42;
-    // int * const const_ptr = &value;
-  }
-
+```c++
+void f() {
+  int * pointer = nullptr, value = 42, * const const_ptr = &value;
+  // This declaration will be diagnosed and transformed into:
+  // int * pointer = nullptr;
+  // int value = 42;
+  // int * const const_ptr = &value;
+}
+```
 
 The check excludes places where it is necessary or common to declare
 multiple variables in one statement and there is no other way supported in the
 language. Please note that structured bindings are not considered.
 
-.. code-block:: c++
+```c++
+// It is not possible to transform this declaration and doing the declaration
+// before the loop will increase the scope of the variable 'Begin' and 'End'
+// which is undesirable.
+for (int Begin = 0, End = 100; Begin < End; ++Begin);
+if (int Begin = 42, Result = some_function(Begin); Begin == Result);
 
-  // It is not possible to transform this declaration and doing the declaration
-  // before the loop will increase the scope of the variable 'Begin' and 'End'
-  // which is undesirable.
-  for (int Begin = 0, End = 100; Begin < End; ++Begin);
-  if (int Begin = 42, Result = some_function(Begin); Begin == Result);
+// It is not possible to transform this declaration because the result is
+// not functionality preserving as 'j' and 'k' would not be part of the
+// 'if' statement anymore.
+if (SomeCondition())
+  int i = 42, j = 43, k = function(i,j);
+```
 
-  // It is not possible to transform this declaration because the result is
-  // not functionality preserving as 'j' and 'k' would not be part of the
-  // 'if' statement anymore.
-  if (SomeCondition())
-    int i = 42, j = 43, k = function(i,j);
-
-
-Limitations
------------
+## Limitations
 
 Global variables and member variables are excluded.
 
 The check currently does not support the automatic transformation of
 member-pointer-types.
 
-.. code-block:: c++
+```c++
+struct S {
+  int a;
+  const int b;
+  void f() {}
+};
 
-  struct S {
-    int a;
-    const int b;
-    void f() {}
-  };
-
-  void f() {
-    // Only a diagnostic message is emitted
-    int S::*p = &S::a, S::*const q = &S::a;
-  }
+void f() {
+  // Only a diagnostic message is emitted
+  int S::*p = &S::a, S::*const q = &S::a;
+}
+```
 
 Furthermore, the transformation is very cautious when it detects various kinds
 of macros or preprocessor directives in the range of the statement. In this
 case the transformation will not happen to avoid unexpected side-effects due to
 macros.
 
-.. code-block:: c++
+```c++
+#define NULL 0
+#define MY_NICE_TYPE int **
+#define VAR_NAME(name) name##__LINE__
+#define A_BUNCH_OF_VARIABLES int m1 = 42, m2 = 43, m3 = 44;
 
-  #define NULL 0
-  #define MY_NICE_TYPE int **
-  #define VAR_NAME(name) name##__LINE__
-  #define A_BUNCH_OF_VARIABLES int m1 = 42, m2 = 43, m3 = 44;
+void macros() {
+  int *p1 = NULL, *p2 = NULL;
+  // Will be transformed to
+  // int *p1 = NULL;
+  // int *p2 = NULL;
 
-  void macros() {
-    int *p1 = NULL, *p2 = NULL;
-    // Will be transformed to
-    // int *p1 = NULL;
-    // int *p2 = NULL;
+  MY_NICE_TYPE p3, v1, v2;
+  // Won't be transformed, but a diagnostic is emitted.
 
-    MY_NICE_TYPE p3, v1, v2;
-    // Won't be transformed, but a diagnostic is emitted.
+  int VAR_NAME(v3),
+      VAR_NAME(v4),
+      VAR_NAME(v5);
+  // Won't be transformed, but a diagnostic is emitted.
 
-    int VAR_NAME(v3),
-        VAR_NAME(v4),
-        VAR_NAME(v5);
-    // Won't be transformed, but a diagnostic is emitted.
+  A_BUNCH_OF_VARIABLES
+  // Won't be transformed, but a diagnostic is emitted.
 
-    A_BUNCH_OF_VARIABLES
-    // Won't be transformed, but a diagnostic is emitted.
-
-    int Unconditional,
-  #if CONFIGURATION
-        IfConfigured = 42,
-  #else
-        IfConfigured = 0;
-  #endif
-    // Won't be transformed, but a diagnostic is emitted.
-  }
+  int Unconditional,
+#if CONFIGURATION
+      IfConfigured = 42,
+#else
+      IfConfigured = 0;
+#endif
+  // Won't be transformed, but a diagnostic is emitted.
+}
+```

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/magic-numbers.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/magic-numbers.md
@@ -1,7 +1,7 @@
-.. title:: clang-tidy - readability-magic-numbers
+```{title} clang-tidy - readability-magic-numbers
+```
 
-readability-magic-numbers
-=========================
+# readability-magic-numbers
 
 Detects magic numbers, integer or floating point literals that are embedded in
 code and not introduced via constants or symbols.
@@ -9,84 +9,83 @@ code and not introduced via constants or symbols.
 Many coding guidelines advise replacing the magic values with symbolic
 constants to improve readability. Here are a few references:
 
-   * `Rule ES.45: Avoid "magic constants"; use symbolic constants in C++ Core Guidelines <https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#res-magic>`_
-   * Item 17 in "C++ Coding Standards: 101 Rules, Guidelines and Best
-     Practices" by Herb Sutter and Andrei Alexandrescu
-   * Chapter 17 in "Clean Code - A handbook of agile software craftsmanship."
-     by Robert C. Martin
-   * Rule 20701 in "TRAIN REAL TIME DATA PROTOCOL Coding Rules" by Armin-Hagen
-     Weiss, Bombardier
-   * http://wiki.c2.com/?MagicNumber
-
+- [Rule ES.45: Avoid "magic constants"; use symbolic constants in C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#res-magic)
+- Item 17 in "C++ Coding Standards: 101 Rules, Guidelines and Best
+  Practices" by Herb Sutter and Andrei Alexandrescu
+- Chapter 17 in "Clean Code - A handbook of agile software craftsmanship."
+  by Robert C. Martin
+- Rule 20701 in "TRAIN REAL TIME DATA PROTOCOL Coding Rules" by Armin-Hagen
+  Weiss, Bombardier
+- <http://wiki.c2.com/?MagicNumber>
 
 Examples of magic values:
 
-.. code-block:: c++
+```c++
+template<typename T, size_t N>
+struct CustomType {
+   T arr[N];
+};
 
-   template<typename T, size_t N>
-   struct CustomType {
-      T arr[N];
-   };
+struct OtherType {
+   CustomType<int, 30> container;
+}
+CustomType<int, 30> values;
 
-   struct OtherType {
-      CustomType<int, 30> container;
-   }
-   CustomType<int, 30> values;
+double circleArea = 3.1415926535 * radius * radius;
 
-   double circleArea = 3.1415926535 * radius * radius;
+double totalCharge = 1.08 * itemPrice;
 
-   double totalCharge = 1.08 * itemPrice;
+int getAnswer() {
+   return -3; // FILENOTFOUND
+}
 
-   int getAnswer() {
-      return -3; // FILENOTFOUND
-   }
-
-   for (int mm = 1; mm <= 12; ++mm) {
-      std::cout << month[mm] << '\n';
-   }
+for (int mm = 1; mm <= 12; ++mm) {
+   std::cout << month[mm] << '\n';
+}
+```
 
 Example with magic values refactored:
 
-.. code-block:: c++
+```c++
+template<typename T, size_t N>
+struct CustomType {
+   T arr[N];
+};
 
-   template<typename T, size_t N>
-   struct CustomType {
-      T arr[N];
-   };
+const size_t NUMBER_OF_ELEMENTS = 30;
+using containerType = CustomType<int, NUMBER_OF_ELEMENTS>;
 
-   const size_t NUMBER_OF_ELEMENTS = 30;
-   using containerType = CustomType<int, NUMBER_OF_ELEMENTS>;
+struct OtherType {
+   containerType container;
+}
+containerType values;
 
-   struct OtherType {
-      containerType container;
-   }
-   containerType values;
+double circleArea = M_PI * radius * radius;
 
-   double circleArea = M_PI * radius * radius;
+const double TAX_RATE = 0.08;  // or make it variable and read from a file
 
-   const double TAX_RATE = 0.08;  // or make it variable and read from a file
+double totalCharge = (1.0 + TAX_RATE) * itemPrice;
 
-   double totalCharge = (1.0 + TAX_RATE) * itemPrice;
+int getAnswer() {
+   return E_FILE_NOT_FOUND;
+}
 
-   int getAnswer() {
-      return E_FILE_NOT_FOUND;
-   }
-
-   for (int mm = 1; mm <= MONTHS_IN_A_YEAR; ++mm) {
-      std::cout << month[mm] << '\n';
-   }
+for (int mm = 1; mm <= MONTHS_IN_A_YEAR; ++mm) {
+   std::cout << month[mm] << '\n';
+}
+```
 
 For integral literals by default only `0` and `1` (and `-1`) integer values
 are accepted without a warning. This can be overridden with the
-:option:`IgnoredIntegerValues` option. Negative values are accepted if their
-absolute value is present in the :option:`IgnoredIntegerValues` list.
+{option}`IgnoredIntegerValues` option. Negative values are accepted if their
+absolute value is present in the {option}`IgnoredIntegerValues` list.
 
 As a special case for integral values, all powers of two can be accepted
-without warning by enabling the :option:`IgnorePowersOf2IntegerValues` option.
+without warning by enabling the {option}`IgnorePowersOf2IntegerValues` option.
 
 For floating point literals by default the `0.0` floating point value is
 accepted without a warning. The set of ignored floating point literals can
-be configured using the :option:`IgnoredFloatingPointValues` option.
+be configured using the {option}`IgnoredFloatingPointValues` option.
 For each value in that set, the given string value is converted to a
 floating-point value representation used by the target architecture. If a
 floating-point literal value compares equal to one of the converted values,
@@ -95,56 +94,55 @@ equality is used to determine whether to diagnose or not, the user needs to
 be aware of the details of floating-point representations for any values that
 cannot be precisely represented for their target architecture.
 
-For each value in the :option:`IgnoredFloatingPointValues` set, both the
+For each value in the {option}`IgnoredFloatingPointValues` set, both the
 single-precision form and double-precision form are accepted (for example, if
 3.14 is in the set, neither 3.14f nor 3.14 will produce a warning).
 
 Scientific notation is supported for both source code input and option.
 Alternatively, the check for the floating point numbers can be disabled for
 all floating point values by enabling the
-:option:`IgnoreAllFloatingPointValues` option.
+{option}`IgnoreAllFloatingPointValues` option.
 
 Since values `0` and `0.0` are so common as the base counter of loops,
 or initialization values for sums, they are always accepted without warning,
 even if not present in the respective ignored values list.
 
-Options
--------
+## Options
 
-.. option:: IgnoredIntegerValues
+```{option} IgnoredIntegerValues
+Semicolon-separated list of magic positive integers that will be accepted
+without a warning. Default values are `{1, 2, 3, 4}`, and `0` is accepted
+unconditionally.
+```
 
-   Semicolon-separated list of magic positive integers that will be accepted
-   without a warning. Default values are `{1, 2, 3, 4}`, and `0` is accepted
-   unconditionally.
+```{option} IgnorePowersOf2IntegerValues
+When `true`, all powers-of-two integer values are accepted without warning.
+Default is `false`.
+```
 
-.. option:: IgnorePowersOf2IntegerValues
+```{option} IgnoredFloatingPointValues
+Semicolon-separated list of magic positive floating point values that will
+be accepted without a warning. Default values are `{1.0, 100.0}` and `0.0`
+is accepted unconditionally.
+```
 
-   Boolean value indicating whether to accept all powers-of-two integer values
-   without warning. Default value is `false`.
+```{option} IgnoreAllFloatingPointValues
+When `true`, all floating point values are accepted without warning.
+Default is `false`.
+```
 
-.. option:: IgnoredFloatingPointValues
+```{option} IgnoreBitFieldsWidths
+When `true`, magic numbers are accepted as bit field widths without warning.
+This is useful for register definitions generated from hardware specifications.
+Default is `true`.
+```
 
-   Semicolon-separated list of magic positive floating point values that will
-   be accepted without a warning. Default values are `{1.0, 100.0}` and `0.0`
-   is accepted unconditionally.
+```{option} IgnoreTypeAliases
+When `true`, magic numbers are accepted in `typedef` or `using` declarations.
+Default is `false`.
+```
 
-.. option:: IgnoreAllFloatingPointValues
-
-   Boolean value indicating whether to accept all floating point values without
-   warning. Default value is `false`.
-
-.. option:: IgnoreBitFieldsWidths
-
-   Boolean value indicating whether to accept magic numbers as bit field widths
-   without warning. This is useful for example for register definitions which
-   are generated from hardware specifications. Default value is `true`.
-
-.. option:: IgnoreTypeAliases
-
-   Boolean value indicating whether to accept magic numbers in ``typedef`` or
-   ``using`` declarations. Default value is `false`.
-
-.. option:: IgnoreUserDefinedLiterals
-
-   Boolean value indicating whether to accept magic numbers in user-defined
-   literals. Default value is `false`.
+```{option} IgnoreUserDefinedLiterals
+When `true`, magic numbers are accepted in user-defined literals.
+Default is `false`.
+```

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/magic-numbers.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/magic-numbers.md
@@ -77,15 +77,15 @@ for (int mm = 1; mm <= MONTHS_IN_A_YEAR; ++mm) {
 
 For integral literals by default only `0` and `1` (and `-1`) integer values
 are accepted without a warning. This can be overridden with the
-{option}`IgnoredIntegerValues`. Negative values are accepted if their
-absolute value is present in the {option}`IgnoredIntegerValues` list.
+[`IgnoredIntegerValues`](#readability-magic-numbers-ignored-integer-values). Negative values are accepted if their
+absolute value is present in the [`IgnoredIntegerValues`](#readability-magic-numbers-ignored-integer-values) list.
 
 As a special case for integral values, all powers of two can be accepted
-without warning by enabling the {option}`IgnorePowersOf2IntegerValues` option.
+without warning by enabling the [`IgnorePowersOf2IntegerValues`](#readability-magic-numbers-ignore-powers-of2-integer-values) option.
 
 For floating point literals by default the `0.0` floating point value is
 accepted without a warning. The set of ignored floating point literals can
-be configured using the {option}`IgnoredFloatingPointValues`.
+be configured using the [`IgnoredFloatingPointValues`](#readability-magic-numbers-ignored-floating-point-values).
 For each value in that set, the given string value is converted to a
 floating-point value representation used by the target architecture. If a
 floating-point literal value compares equal to one of the converted values,
@@ -94,14 +94,14 @@ equality is used to determine whether to diagnose or not, the user needs to
 be aware of the details of floating-point representations for any values that
 cannot be precisely represented for their target architecture.
 
-For each value in the {option}`IgnoredFloatingPointValues` set, both the
+For each value in the [`IgnoredFloatingPointValues`](#readability-magic-numbers-ignored-floating-point-values) set, both the
 single-precision form and double-precision form are accepted (for example, if
 3.14 is in the set, neither 3.14f nor 3.14 will produce a warning).
 
 Scientific notation is supported for both source code input and option.
 Alternatively, the check for the floating point numbers can be disabled for
 all floating point values by enabling the
-{option}`IgnoreAllFloatingPointValues`.
+[`IgnoreAllFloatingPointValues`](#readability-magic-numbers-ignore-all-floating-point-values).
 
 Since values `0` and `0.0` are so common as the base counter of loops,
 or initialization values for sums, they are always accepted without warning,
@@ -109,16 +109,22 @@ even if not present in the respective ignored values list.
 
 ## Options
 
+(readability-magic-numbers-ignored-integer-values)=
+
 ```{option} IgnoredIntegerValues
 Semicolon-separated list of magic positive integers that will be accepted
 without a warning. Default values are `{1, 2, 3, 4}`, and `0` is accepted
 unconditionally.
 ```
 
+(readability-magic-numbers-ignore-powers-of2-integer-values)=
+
 ```{option} IgnorePowersOf2IntegerValues
 When `true`, all powers-of-two integer values are accepted without warning.
 Default is `false`.
 ```
+
+(readability-magic-numbers-ignored-floating-point-values)=
 
 ```{option} IgnoredFloatingPointValues
 Semicolon-separated list of magic positive floating point values that will
@@ -126,10 +132,14 @@ be accepted without a warning. Default values are `{1.0, 100.0}` and `0.0`
 is accepted unconditionally.
 ```
 
+(readability-magic-numbers-ignore-all-floating-point-values)=
+
 ```{option} IgnoreAllFloatingPointValues
 When `true`, all floating point values are accepted without warning.
 Default is `false`.
 ```
+
+(readability-magic-numbers-ignore-bit-fields-widths)=
 
 ```{option} IgnoreBitFieldsWidths
 When `true`, magic numbers are accepted as bit field widths without warning.
@@ -137,10 +147,14 @@ This is useful for register definitions generated from hardware specifications.
 Default is `true`.
 ```
 
+(readability-magic-numbers-ignore-type-aliases)=
+
 ```{option} IgnoreTypeAliases
 When `true`, magic numbers are accepted in `typedef` or `using` declarations.
 Default is `false`.
 ```
+
+(readability-magic-numbers-ignore-user-defined-literals)=
 
 ```{option} IgnoreUserDefinedLiterals
 When `true`, magic numbers are accepted in user-defined literals.

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/magic-numbers.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/magic-numbers.md
@@ -77,7 +77,7 @@ for (int mm = 1; mm <= MONTHS_IN_A_YEAR; ++mm) {
 
 For integral literals by default only `0` and `1` (and `-1`) integer values
 are accepted without a warning. This can be overridden with the
-{option}`IgnoredIntegerValues` option. Negative values are accepted if their
+{option}`IgnoredIntegerValues`. Negative values are accepted if their
 absolute value is present in the {option}`IgnoredIntegerValues` list.
 
 As a special case for integral values, all powers of two can be accepted
@@ -85,7 +85,7 @@ without warning by enabling the {option}`IgnorePowersOf2IntegerValues` option.
 
 For floating point literals by default the `0.0` floating point value is
 accepted without a warning. The set of ignored floating point literals can
-be configured using the {option}`IgnoredFloatingPointValues` option.
+be configured using the {option}`IgnoredFloatingPointValues`.
 For each value in that set, the given string value is converted to a
 floating-point value representation used by the target architecture. If a
 floating-point literal value compares equal to one of the converted values,
@@ -101,7 +101,7 @@ single-precision form and double-precision form are accepted (for example, if
 Scientific notation is supported for both source code input and option.
 Alternatively, the check for the floating point numbers can be disabled for
 all floating point values by enabling the
-{option}`IgnoreAllFloatingPointValues` option.
+{option}`IgnoreAllFloatingPointValues`.
 
 Since values `0` and `0.0` are so common as the base counter of loops,
 or initialization values for sums, they are always accepted without warning,

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/make-member-function-const.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/make-member-function-const.md
@@ -1,30 +1,30 @@
-.. title:: clang-tidy - readability-make-member-function-const
+```{title} clang-tidy - readability-make-member-function-const
+```
 
-readability-make-member-function-const
-======================================
+# readability-make-member-function-const
 
-Finds non-static member functions that can be made ``const``
-because the functions don't use ``this`` in a non-const way.
+Finds non-static member functions that can be made `const`
+because the functions don't use `this` in a non-const way.
 
 This check tries to annotate methods according to
-`logical constness <https://isocpp.org/wiki/faq/const-correctness#logical-vs-physical-state>`_
+[logical constness](https://isocpp.org/wiki/faq/const-correctness#logical-vs-physical-state)
 (not physical constness).
-Therefore, it will suggest to add a ``const`` qualifier to a non-const
+Therefore, it will suggest to add a `const` qualifier to a non-const
 method only if this method does something that is already possible though the
-public interface on a ``const`` pointer to the object:
+public interface on a `const` pointer to the object:
 
-* reading a public member variable
-* calling a public const-qualified member function
-* returning const-qualified ``this``
-* passing const-qualified ``this`` as a parameter.
+- reading a public member variable
+- calling a public const-qualified member function
+- returning const-qualified `this`
+- passing const-qualified `this` as a parameter.
 
-This check will also suggest to add a ``const`` qualifier to a non-const
+This check will also suggest to add a `const` qualifier to a non-const
 method if this method uses private data and functions in a limited number of
 ways where logical constness and physical constness coincide:
 
-* reading a member variable of builtin type
+- reading a member variable of builtin type
 
-Specifically, this check will not suggest to add a ``const`` to a non-const
+Specifically, this check will not suggest to add a `const` to a non-const
 method if the method reads a private member variable of pointer type because
 that allows to modify the pointee which might not preserve logical constness.
 For the same reason, it does not allow to call private member functions
@@ -32,37 +32,37 @@ or member functions on private member variables.
 
 In addition, this check ignores functions that
 
-* are declared ``virtual``
-* contain a ``const_cast``
-* are templated or part of a class template
-* have an empty body
-* do not (implicitly) use ``this`` at all
-  (see :doc:`readability-convert-member-functions-to-static
+- are declared `virtual`
+- contain a `const_cast`
+- are templated or part of a class template
+- have an empty body
+- do not (implicitly) use `this` at all
+  (see {doc}`readability-convert-member-functions-to-static
   <../readability/convert-member-functions-to-static>`).
 
 The following real-world examples will be preserved by the check:
 
-.. code-block:: c++
+```c++
+class E1 {
+  Pimpl &getPimpl() const;
+public:
+  int &get() {
+    // Calling a private member function disables this check.
+    return getPimpl()->i;
+  }
+  ...
+};
 
-  class E1 {
-    Pimpl &getPimpl() const;
-  public:
-    int &get() {
-      // Calling a private member function disables this check.
-      return getPimpl()->i;
-    }
-    ...
-  };
-
-  class E2 {
-  public:
-    const int *get() const;
-    // const_cast disables this check.
-    S *get() {
-      return const_cast<int*>(const_cast<const C*>(this)->get());
-    }
-    ...
-  };
+class E2 {
+public:
+  const int *get() const;
+  // const_cast disables this check.
+  S *get() {
+    return const_cast<int*>(const_cast<const C*>(this)->get());
+  }
+  ...
+};
+```
 
 After applying modifications as suggested by the check, running the check again
-might find more opportunities to mark member functions ``const``.
+might find more opportunities to mark member functions `const`.


### PR DESCRIPTION
Tracking issue: #201242

See the [migration guide] for more information.

[migration guide]:
https://llvm.org/docs/SphinxQuickstartTemplate.html#markdown-migration-guidelines

This is the second part of rewriting check documentations in readability module from reST to MyST Markdown.

AI Usage: This was prepared with rnk's fork of rst2myst and GPT5.6-assisted cleanup.
I manually verified that the documentation renders as expected.

Preview site:
https://broken.life/llvm-staging/readability-markdown-port/index.html