### PR TITLE
[libc] Modify Exponent decomposition functions to work with emulated Float128

### DIFF
--- a/libc/config/baremetal/aarch64/entrypoints.txt
+++ b/libc/config/baremetal/aarch64/entrypoints.txt
@@ -468,6 +468,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fmull
     libc.src.math.frexp
     libc.src.math.frexpf
+    libc.src.math.frexpf128
     libc.src.math.frexpl
     libc.src.math.fromfp
     libc.src.math.fromfpf
@@ -486,6 +487,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.hypotf
     libc.src.math.ilogb
     libc.src.math.ilogbf
+    libc.src.math.ilogbf128
     libc.src.math.ilogbl
     libc.src.math.iscanonical
     libc.src.math.iscanonicalf
@@ -505,6 +507,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.lgammaf
     libc.src.math.llogb
     libc.src.math.llogbf
+    libc.src.math.llogbf128
     libc.src.math.llogbl
     libc.src.math.llrint
     libc.src.math.llrintf
@@ -523,6 +526,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.log2f
     libc.src.math.logb
     libc.src.math.logbf
+    libc.src.math.logbf128
     libc.src.math.logbl
     libc.src.math.logf
     libc.src.math.lrint
@@ -772,16 +776,12 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.ffmaf128
     libc.src.math.fmodf128
     libc.src.math.fmulf128
-    libc.src.math.frexpf128
     libc.src.math.fromfpf128
     libc.src.math.fromfpxf128
     libc.src.math.fsqrtf128
     libc.src.math.fsubf128
     libc.src.math.getpayloadf128
-    libc.src.math.ilogbf128
     libc.src.math.ldexpf128
-    libc.src.math.llogbf128
-    libc.src.math.logbf128
     libc.src.math.modff128
     libc.src.math.nanf128
     libc.src.math.nextafterf128

--- a/libc/config/baremetal/arm/entrypoints.txt
+++ b/libc/config/baremetal/arm/entrypoints.txt
@@ -480,6 +480,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fmull
     libc.src.math.frexp
     libc.src.math.frexpf
+    libc.src.math.frexpf128
     libc.src.math.frexpl
     libc.src.math.fromfp
     libc.src.math.fromfpf
@@ -498,6 +499,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.hypotf
     libc.src.math.ilogb
     libc.src.math.ilogbf
+    libc.src.math.ilogbf128
     libc.src.math.ilogbl
     libc.src.math.iscanonical
     libc.src.math.iscanonicalf
@@ -517,6 +519,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.lgammaf
     libc.src.math.llogb
     libc.src.math.llogbf
+    libc.src.math.llogbf128
     libc.src.math.llogbl
     libc.src.math.llrint
     libc.src.math.llrintf
@@ -535,6 +538,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.log2f
     libc.src.math.logb
     libc.src.math.logbf
+    libc.src.math.logbf128
     libc.src.math.logbl
     libc.src.math.logf
     libc.src.math.lrint
@@ -783,16 +787,12 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.ffmaf128
     libc.src.math.fmodf128
     libc.src.math.fmulf128
-    libc.src.math.frexpf128
     libc.src.math.fromfpf128
     libc.src.math.fromfpxf128
     libc.src.math.fsqrtf128
     libc.src.math.fsubf128
     libc.src.math.getpayloadf128
-    libc.src.math.ilogbf128
     libc.src.math.ldexpf128
-    libc.src.math.llogbf128
-    libc.src.math.logbf128
     libc.src.math.modff128
     libc.src.math.nanf128
     libc.src.math.nextafterf128

--- a/libc/config/baremetal/riscv/entrypoints.txt
+++ b/libc/config/baremetal/riscv/entrypoints.txt
@@ -476,6 +476,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fmull
     libc.src.math.frexp
     libc.src.math.frexpf
+    libc.src.math.frexpf128
     libc.src.math.frexpl
     libc.src.math.fromfp
     libc.src.math.fromfpf
@@ -494,6 +495,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.hypotf
     libc.src.math.ilogb
     libc.src.math.ilogbf
+    libc.src.math.ilogbf128
     libc.src.math.ilogbl
     libc.src.math.iscanonical
     libc.src.math.iscanonicalf
@@ -513,6 +515,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.lgammaf
     libc.src.math.llogb
     libc.src.math.llogbf
+    libc.src.math.llogbf128
     libc.src.math.llogbl
     libc.src.math.llrint
     libc.src.math.llrintf
@@ -531,6 +534,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.log2f
     libc.src.math.logb
     libc.src.math.logbf
+    libc.src.math.logbf128
     libc.src.math.logbl
     libc.src.math.logf
     libc.src.math.lrint
@@ -780,16 +784,12 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.ffmaf128
     # libc.src.math.fmodf128
     libc.src.math.fmulf128
-    libc.src.math.frexpf128
     libc.src.math.fromfpf128
     libc.src.math.fromfpxf128
     libc.src.math.fsqrtf128
     libc.src.math.fsubf128
     libc.src.math.getpayloadf128
-    libc.src.math.ilogbf128
     libc.src.math.ldexpf128
-    libc.src.math.llogbf128
-    libc.src.math.logbf128
     libc.src.math.modff128
     libc.src.math.nanf128
     libc.src.math.nextafterf128

--- a/libc/config/darwin/aarch64/entrypoints.txt
+++ b/libc/config/darwin/aarch64/entrypoints.txt
@@ -287,6 +287,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fmull
     libc.src.math.frexp
     libc.src.math.frexpf
+    libc.src.math.frexpf128
     libc.src.math.frexpl
     libc.src.math.fromfp
     libc.src.math.fromfpf
@@ -305,6 +306,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.hypotf
     libc.src.math.ilogb
     libc.src.math.ilogbf
+    libc.src.math.ilogbf128
     libc.src.math.ilogbl
     libc.src.math.iscanonical
     libc.src.math.iscanonicalf
@@ -324,6 +326,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.lgammaf
     libc.src.math.llogb
     libc.src.math.llogbf
+    libc.src.math.llogbf128
     libc.src.math.llogbl
     libc.src.math.llrint
     libc.src.math.llrintf
@@ -342,6 +345,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.log2f
     libc.src.math.logb
     libc.src.math.logbf
+    libc.src.math.logbf128
     libc.src.math.logbl
     libc.src.math.logf
     libc.src.math.lrint
@@ -592,16 +596,12 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.ffmaf128
     libc.src.math.fmodf128
     libc.src.math.fmulf128
-    libc.src.math.frexpf128
     libc.src.math.fromfpf128
     libc.src.math.fromfpxf128
     libc.src.math.fsqrtf128
     libc.src.math.fsubf128
     libc.src.math.getpayloadf128
-    libc.src.math.ilogbf128
     libc.src.math.ldexpf128
-    libc.src.math.llogbf128
-    libc.src.math.logbf128
     libc.src.math.modff128
     libc.src.math.nanf128
     libc.src.math.nextafterf128

--- a/libc/config/darwin/x86_64/entrypoints.txt
+++ b/libc/config/darwin/x86_64/entrypoints.txt
@@ -184,6 +184,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     #libc.src.math.hypotf
     #libc.src.math.ilogb
     #libc.src.math.ilogbf
+    #libc.src.math.ilogbf128b
     #libc.src.math.ilogbl
     #libc.src.math.iscanonicalf128
     #libc.src.math.isnanf128
@@ -213,6 +214,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     #libc.src.math.logf
     #libc.src.math.logb
     #libc.src.math.logbf
+    #libc.src.math.logbf128
     #libc.src.math.logbl
     #libc.src.math.modf
     #libc.src.math.modff

--- a/libc/config/darwin/x86_64/entrypoints.txt
+++ b/libc/config/darwin/x86_64/entrypoints.txt
@@ -184,7 +184,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     #libc.src.math.hypotf
     #libc.src.math.ilogb
     #libc.src.math.ilogbf
-    #libc.src.math.ilogbf128b
+    #libc.src.math.ilogbf128
     #libc.src.math.ilogbl
     #libc.src.math.iscanonicalf128
     #libc.src.math.isnanf128
@@ -313,6 +313,7 @@ list(APPEND TARGET_LIBM_ENTRYPOINTS
   libc.src.math.issignalingbf16
   libc.src.math.ldexpbf16
   libc.src.math.llogbbf16
+  libc.src.math.llogbf128
   libc.src.math.llrintbf16
   libc.src.math.llroundbf16
   libc.src.math.log_bf16

--- a/libc/config/darwin/x86_64/entrypoints.txt
+++ b/libc/config/darwin/x86_64/entrypoints.txt
@@ -176,6 +176,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     #libc.src.math.fmodf
     #libc.src.math.frexp
     #libc.src.math.frexpf
+    #libc.src.math.frexpf128
     #libc.src.math.frexpl
     #libc.src.math.fsub
     #libc.src.math.fsubl

--- a/libc/config/freebsd/x86_64/entrypoints.txt
+++ b/libc/config/freebsd/x86_64/entrypoints.txt
@@ -220,6 +220,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fmodl
     libc.src.math.frexp
     libc.src.math.frexpf
+    libc.src.math.frexpf128
     libc.src.math.frexpl
     libc.src.math.fsub
     libc.src.math.fsubl
@@ -227,6 +228,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.hypotf
     libc.src.math.ilogb
     libc.src.math.ilogbf
+    libc.src.math.ilogbf128
     libc.src.math.ilogbl
     libc.src.math.iscanonicalf128
     libc.src.math.isnanf128
@@ -253,6 +255,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.logf
     libc.src.math.logb
     libc.src.math.logbf
+    libc.src.math.logbf128
     libc.src.math.logbl
     libc.src.math.lrint
     libc.src.math.lrintf
@@ -359,6 +362,7 @@ list(APPEND TARGET_LIBM_ENTRYPOINTS
     libc.src.math.issignalingl
     libc.src.math.llogb
     libc.src.math.llogbf
+    libc.src.math.llogbf128
     libc.src.math.llogbl
     libc.src.math.nextdown
     libc.src.math.nextdownf
@@ -532,16 +536,12 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.ffmaf128
     libc.src.math.fmodf128
     libc.src.math.fmulf128
-    libc.src.math.frexpf128
     libc.src.math.fromfpf128
     libc.src.math.fromfpxf128
     libc.src.math.fsqrtf128
     libc.src.math.fsubf128
     libc.src.math.getpayloadf128
-    libc.src.math.ilogbf128
     libc.src.math.ldexpf128
-    libc.src.math.llogbf128
-    libc.src.math.logbf128
     libc.src.math.modff128
     libc.src.math.nanf128
     libc.src.math.nextafterf128

--- a/libc/config/gpu/amdgpu/entrypoints.txt
+++ b/libc/config/gpu/amdgpu/entrypoints.txt
@@ -415,6 +415,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fmull
     libc.src.math.frexp
     libc.src.math.frexpf
+    libc.src.math.frexpf128
     libc.src.math.frexpl
     libc.src.math.fromfp
     libc.src.math.fromfpf

--- a/libc/config/gpu/amdgpu/entrypoints.txt
+++ b/libc/config/gpu/amdgpu/entrypoints.txt
@@ -434,6 +434,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.hypotf
     libc.src.math.ilogb
     libc.src.math.ilogbf
+    libc.src.math.ilogbf128
     libc.src.math.ilogbl
     libc.src.math.iscanonicalf128
     libc.src.math.isnan
@@ -449,6 +450,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.lgammaf
     libc.src.math.llogb
     libc.src.math.llogbf
+    libc.src.math.llogbf128
     libc.src.math.llogbl
     libc.src.math.llrint
     libc.src.math.llrintf
@@ -467,6 +469,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.log2f
     libc.src.math.logb
     libc.src.math.logbf
+    libc.src.math.logbf128
     libc.src.math.logbl
     libc.src.math.logf
     libc.src.math.lrint

--- a/libc/config/gpu/nvptx/entrypoints.txt
+++ b/libc/config/gpu/nvptx/entrypoints.txt
@@ -411,6 +411,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fmull
     libc.src.math.frexp
     libc.src.math.frexpf
+    libc.src.math.frexpf128
     libc.src.math.frexpl
     # FIXME: Broken.
     # libc.src.math.fromfp

--- a/libc/config/gpu/nvptx/entrypoints.txt
+++ b/libc/config/gpu/nvptx/entrypoints.txt
@@ -431,6 +431,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.hypotf
     libc.src.math.ilogb
     libc.src.math.ilogbf
+    libc.src.math.ilogbf128
     libc.src.math.ilogbl
     libc.src.math.iscanonicalf128
     libc.src.math.isnan
@@ -446,6 +447,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.lgammaf
     libc.src.math.llogb
     libc.src.math.llogbf
+    libc.src.math.llogbf128
     libc.src.math.llogbl
     libc.src.math.llrint
     libc.src.math.llrintf
@@ -464,6 +466,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.log2f
     libc.src.math.logb
     libc.src.math.logbf
+    libc.src.math.logbf128
     libc.src.math.logbl
     libc.src.math.logf
     libc.src.math.lrint

--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -653,6 +653,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fmull
     libc.src.math.frexp
     libc.src.math.frexpf
+    libc.src.math.frexpf128
     libc.src.math.frexpl
     libc.src.math.fromfp
     libc.src.math.fromfpf
@@ -671,6 +672,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.hypotf
     libc.src.math.ilogb
     libc.src.math.ilogbf
+    libc.src.math.ilogbf128
     libc.src.math.ilogbl
     libc.src.math.iscanonical
     libc.src.math.iscanonicalf
@@ -690,6 +692,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.lgammaf
     libc.src.math.llogb
     libc.src.math.llogbf
+    libc.src.math.llogbf128
     libc.src.math.llogbl
     libc.src.math.llrint
     libc.src.math.llrintf
@@ -708,6 +711,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.log2f
     libc.src.math.logb
     libc.src.math.logbf
+    libc.src.math.logbf128
     libc.src.math.logbl
     libc.src.math.logf
     libc.src.math.lrint
@@ -951,16 +955,12 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.ffmaf128
     libc.src.math.fmodf128
     libc.src.math.fmulf128
-    libc.src.math.frexpf128
     libc.src.math.fromfpf128
     libc.src.math.fromfpxf128
     libc.src.math.fsqrtf128
     libc.src.math.fsubf128
     libc.src.math.getpayloadf128
-    libc.src.math.ilogbf128
     libc.src.math.ldexpf128
-    libc.src.math.llogbf128
-    libc.src.math.logbf128
     libc.src.math.modff128
     libc.src.math.nanf128
     libc.src.math.nextafterf128

--- a/libc/config/linux/arm/entrypoints.txt
+++ b/libc/config/linux/arm/entrypoints.txt
@@ -492,6 +492,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.hypotf
     libc.src.math.ilogb
     libc.src.math.ilogbf
+    libc.src.math.ilogbf128
     libc.src.math.ilogbl
     libc.src.math.iscanonicalf128
     libc.src.math.isnanf128
@@ -502,6 +503,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.lgammaf
     libc.src.math.llogb
     libc.src.math.llogbf
+    libc.src.math.llogbf128
     libc.src.math.llogbl
     libc.src.math.llrint
     libc.src.math.llrintf
@@ -520,6 +522,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.log2f
     libc.src.math.logb
     libc.src.math.logbf
+    libc.src.math.logbf128
     libc.src.math.logbl
     libc.src.math.logf
     libc.src.math.lrint

--- a/libc/config/linux/arm/entrypoints.txt
+++ b/libc/config/linux/arm/entrypoints.txt
@@ -475,6 +475,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fmul
     libc.src.math.frexp
     libc.src.math.frexpf
+    libc.src.math.frexpf128
     libc.src.math.frexpl
     libc.src.math.fromfp
     libc.src.math.fromfpf

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -722,6 +722,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fmull
     libc.src.math.frexp
     libc.src.math.frexpf
+    libc.src.math.frexpf128
     libc.src.math.frexpl
     libc.src.math.fromfp
     libc.src.math.fromfpf
@@ -740,6 +741,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.hypotf
     libc.src.math.ilogb
     libc.src.math.ilogbf
+    libc.src.math.ilogbf128
     libc.src.math.ilogbl
     libc.src.math.iscanonical
     libc.src.math.iscanonicalf
@@ -759,6 +761,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.lgammaf
     libc.src.math.llogb
     libc.src.math.llogbf
+    libc.src.math.llogbf128
     libc.src.math.llogbl
     libc.src.math.llrint
     libc.src.math.llrintf
@@ -777,6 +780,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.log2f
     libc.src.math.logb
     libc.src.math.logbf
+    libc.src.math.logbf128
     libc.src.math.logbl
     libc.src.math.logf
     libc.src.math.lrint
@@ -1037,16 +1041,12 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.ffmaf128
     libc.src.math.fmodf128
     libc.src.math.fmulf128
-    libc.src.math.frexpf128
     libc.src.math.fromfpf128
     libc.src.math.fromfpxf128
     libc.src.math.fsqrtf128
     libc.src.math.fsubf128
     libc.src.math.getpayloadf128
-    libc.src.math.ilogbf128
     libc.src.math.ldexpf128
-    libc.src.math.llogbf128
-    libc.src.math.logbf128
     libc.src.math.modff128
     libc.src.math.nanf128
     libc.src.math.nextafterf128

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -731,6 +731,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fmull
     libc.src.math.frexp
     libc.src.math.frexpf
+    libc.src.math.frexpf128
     libc.src.math.frexpl
     libc.src.math.fromfp
     libc.src.math.fromfpf
@@ -749,6 +750,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.hypotf
     libc.src.math.ilogb
     libc.src.math.ilogbf
+    libc.src.math.ilogbf128
     libc.src.math.ilogbl
     libc.src.math.iscanonical
     libc.src.math.iscanonicalf
@@ -768,6 +770,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.lgammaf
     libc.src.math.llogb
     libc.src.math.llogbf
+    libc.src.math.llogbf128
     libc.src.math.llogbl
     libc.src.math.llrint
     libc.src.math.llrintf
@@ -786,6 +789,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.log2f
     libc.src.math.logb
     libc.src.math.logbf
+    libc.src.math.logbf128
     libc.src.math.logbl
     libc.src.math.logf
     libc.src.math.lrint
@@ -1046,16 +1050,12 @@ if(LIBC_TYPES_HAS_NATIVE_FLOAT128)
     libc.src.math.ffmaf128
     libc.src.math.fmodf128
     libc.src.math.fmulf128
-    libc.src.math.frexpf128
     libc.src.math.fromfpf128
     libc.src.math.fromfpxf128
     libc.src.math.fsqrtf128
     libc.src.math.fsubf128
     libc.src.math.getpayloadf128
-    libc.src.math.ilogbf128
     libc.src.math.ldexpf128
-    libc.src.math.llogbf128
-    libc.src.math.logbf128
     libc.src.math.modff128
     libc.src.math.nanf128
     libc.src.math.nextafterf128

--- a/libc/config/windows/entrypoints.txt
+++ b/libc/config/windows/entrypoints.txt
@@ -404,6 +404,7 @@ list(APPEND TARGET_LIBM_ENTRYPOINTS
   libc.src.math.issignalingbf16
   libc.src.math.ldexpbf16
   libc.src.math.llogbbf16
+  libc.src.math.llogbf128
   libc.src.math.llrintbf16
   libc.src.math.llroundbf16
   libc.src.math.log_bf16

--- a/libc/config/windows/entrypoints.txt
+++ b/libc/config/windows/entrypoints.txt
@@ -253,6 +253,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.fmodl
     libc.src.math.frexp
     libc.src.math.frexpf
+    libc.src.math.frexpf128
     libc.src.math.frexpl
     libc.src.math.fsub
     libc.src.math.fsubl

--- a/libc/config/windows/entrypoints.txt
+++ b/libc/config/windows/entrypoints.txt
@@ -261,6 +261,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.hypotf
     libc.src.math.ilogb
     libc.src.math.ilogbf
+    libc.src.math.ilogbf128
     libc.src.math.ilogbl
     libc.src.math.iscanonicalf128
     libc.src.math.isnanf128
@@ -287,6 +288,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.logf
     libc.src.math.logb
     libc.src.math.logbf
+    libc.src.math.logbf128
     libc.src.math.logbl
     libc.src.math.lrint
     libc.src.math.lrintf

--- a/libc/shared/math/frexpf128.h
+++ b/libc/shared/math/frexpf128.h
@@ -5,6 +5,12 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file re-exports frexpf128 through the shared::math namespace so that
+/// other LLVM components can use it without depending on libc internals.
+///
+//===----------------------------------------------------------------------===//
 
 #ifndef LLVM_LIBC_SHARED_MATH_FREXPF128_H
 #define LLVM_LIBC_SHARED_MATH_FREXPF128_H

--- a/libc/shared/math/frexpf128.h
+++ b/libc/shared/math/frexpf128.h
@@ -7,8 +7,7 @@
 //===----------------------------------------------------------------------===//
 ///
 /// \file
-/// This file re-exports frexpf128 through the shared::math namespace so that
-/// other LLVM components can use it without depending on libc internals.
+/// Shared declaration of the float128 frexp function.
 ///
 //===----------------------------------------------------------------------===//
 

--- a/libc/shared/math/frexpf128.h
+++ b/libc/shared/math/frexpf128.h
@@ -9,10 +9,6 @@
 #ifndef LLVM_LIBC_SHARED_MATH_FREXPF128_H
 #define LLVM_LIBC_SHARED_MATH_FREXPF128_H
 
-#include "include/llvm-libc-types/float128.h"
-
-#ifdef LIBC_TYPES_HAS_NATIVE_FLOAT128
-
 #include "shared/libc_common.h"
 #include "src/__support/math/frexpf128.h"
 
@@ -23,7 +19,5 @@ using math::frexpf128;
 
 } // namespace shared
 } // namespace LIBC_NAMESPACE_DECL
-
-#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 #endif // LLVM_LIBC_SHARED_MATH_FREXPF128_H

--- a/libc/shared/math/ilogbf128.h
+++ b/libc/shared/math/ilogbf128.h
@@ -9,10 +9,6 @@
 #ifndef LLVM_LIBC_SHARED_MATH_ILOGBF128_H
 #define LLVM_LIBC_SHARED_MATH_ILOGBF128_H
 
-#include "include/llvm-libc-types/float128.h"
-
-#ifdef LIBC_TYPES_HAS_NATIVE_FLOAT128
-
 #include "shared/libc_common.h"
 #include "src/__support/math/ilogbf128.h"
 
@@ -23,7 +19,5 @@ using math::ilogbf128;
 
 } // namespace shared
 } // namespace LIBC_NAMESPACE_DECL
-
-#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 #endif // LLVM_LIBC_SHARED_MATH_ILOGBF128_H

--- a/libc/shared/math/ilogbf128.h
+++ b/libc/shared/math/ilogbf128.h
@@ -5,6 +5,12 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file re-exports ilogbf128 through the shared::math namespace so that
+/// other LLVM components can use it without depending on libc internals.
+///
+//===----------------------------------------------------------------------===//
 
 #ifndef LLVM_LIBC_SHARED_MATH_ILOGBF128_H
 #define LLVM_LIBC_SHARED_MATH_ILOGBF128_H

--- a/libc/shared/math/ilogbf128.h
+++ b/libc/shared/math/ilogbf128.h
@@ -7,8 +7,7 @@
 //===----------------------------------------------------------------------===//
 ///
 /// \file
-/// This file re-exports ilogbf128 through the shared::math namespace so that
-/// other LLVM components can use it without depending on libc internals.
+/// Shared declaration of the float128 ilogb function.
 ///
 //===----------------------------------------------------------------------===//
 

--- a/libc/shared/math/llogbf128.h
+++ b/libc/shared/math/llogbf128.h
@@ -9,10 +9,6 @@
 #ifndef LLVM_LIBC_SHARED_MATH_LLOGBF128_H
 #define LLVM_LIBC_SHARED_MATH_LLOGBF128_H
 
-#include "include/llvm-libc-types/float128.h"
-
-#ifdef LIBC_TYPES_HAS_NATIVE_FLOAT128
-
 #include "shared/libc_common.h"
 #include "src/__support/math/llogbf128.h"
 
@@ -23,7 +19,5 @@ using math::llogbf128;
 
 } // namespace shared
 } // namespace LIBC_NAMESPACE_DECL
-
-#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 #endif // LLVM_LIBC_SHARED_MATH_LLOGBF128_H

--- a/libc/shared/math/llogbf128.h
+++ b/libc/shared/math/llogbf128.h
@@ -7,8 +7,7 @@
 //===----------------------------------------------------------------------===//
 ///
 /// \file
-/// This file re-exports llogbf128 through the shared::math namespace so that
-/// other LLVM components can use it without depending on libc internals.
+/// Shared declaration of the float128 llogb function.
 ///
 //===----------------------------------------------------------------------===//
 

--- a/libc/shared/math/llogbf128.h
+++ b/libc/shared/math/llogbf128.h
@@ -5,6 +5,12 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file re-exports llogbf128 through the shared::math namespace so that
+/// other LLVM components can use it without depending on libc internals.
+///
+//===----------------------------------------------------------------------===//
 
 #ifndef LLVM_LIBC_SHARED_MATH_LLOGBF128_H
 #define LLVM_LIBC_SHARED_MATH_LLOGBF128_H

--- a/libc/shared/math/logbf128.h
+++ b/libc/shared/math/logbf128.h
@@ -5,6 +5,12 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file re-exports logbf128 through the shared::math namespace so that
+/// other LLVM components can use it without depending on libc internals.
+///
+//===----------------------------------------------------------------------===//
 
 #ifndef LLVM_LIBC_SHARED_MATH_LOGBF128_H
 #define LLVM_LIBC_SHARED_MATH_LOGBF128_H

--- a/libc/shared/math/logbf128.h
+++ b/libc/shared/math/logbf128.h
@@ -7,8 +7,7 @@
 //===----------------------------------------------------------------------===//
 ///
 /// \file
-/// This file re-exports logbf128 through the shared::math namespace so that
-/// other LLVM components can use it without depending on libc internals.
+/// Shared declaration of the float128 logb function.
 ///
 //===----------------------------------------------------------------------===//
 

--- a/libc/shared/math/logbf128.h
+++ b/libc/shared/math/logbf128.h
@@ -9,10 +9,6 @@
 #ifndef LLVM_LIBC_SHARED_MATH_LOGBF128_H
 #define LLVM_LIBC_SHARED_MATH_LOGBF128_H
 
-#include "include/llvm-libc-types/float128.h"
-
-#ifdef LIBC_TYPES_HAS_NATIVE_FLOAT128
-
 #include "shared/libc_common.h"
 #include "src/__support/math/logbf128.h"
 
@@ -23,7 +19,5 @@ using math::logbf128;
 
 } // namespace shared
 } // namespace LIBC_NAMESPACE_DECL
-
-#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 #endif // LLVM_LIBC_SHARED_MATH_LOGBF128_H

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -5182,6 +5182,7 @@ add_header_library(
   HDRS
     logbf128.h
   DEPENDS
+    libc.src.__support.FPUtil.float128
     libc.src.__support.FPUtil.manipulation_functions
     libc.src.__support.macros.properties.types
 )

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -3788,9 +3788,9 @@ add_header_library(
   HDRS
     frexpf128.h
   DEPENDS
-    libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.float128
     libc.src.__support.FPUtil.manipulation_functions
+    libc.src.__support.macros.properties.types
 )
 
 add_header_library(
@@ -3974,9 +3974,9 @@ add_header_library(
   HDRS
     ilogbf128.h
   DEPENDS
-    libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.float128
     libc.src.__support.FPUtil.manipulation_functions
+    libc.src.__support.macros.properties.types
 )
 
 add_header_library(
@@ -4053,9 +4053,9 @@ add_header_library(
   HDRS
     llogbf128.h
   DEPENDS
-    libc.src.__support.macros.config
     libc.src.__support.FPUtil.float128
     libc.src.__support.FPUtil.manipulation_functions
+    libc.src.__support.macros.config
 )
 
 add_header_library(

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -3975,8 +3975,8 @@ add_header_library(
     ilogbf128.h
   DEPENDS
     libc.src.__support.macros.properties.types
+    libc.src.__support.FPUtil.float128
     libc.src.__support.FPUtil.manipulation_functions
-    libc.include.llvm-libc-types.float128
 )
 
 add_header_library(
@@ -4054,8 +4054,8 @@ add_header_library(
     llogbf128.h
   DEPENDS
     libc.src.__support.macros.config
+    libc.src.__support.FPUtil.float128
     libc.src.__support.FPUtil.manipulation_functions
-    libc.include.llvm-libc-types.float128
 )
 
 add_header_library(

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -3789,6 +3789,7 @@ add_header_library(
     frexpf128.h
   DEPENDS
     libc.src.__support.macros.properties.types
+    libc.src.__support.FPUtil.float128
     libc.src.__support.FPUtil.manipulation_functions
 )
 

--- a/libc/src/__support/math/frexpf128.h
+++ b/libc/src/__support/math/frexpf128.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_SRC___SUPPORT_MATH_FREXPF128_H
 #define LLVM_LIBC_SRC___SUPPORT_MATH_FREXPF128_H
 
-#include "src/__support/FPUtil/float128.h"
 #include "src/__support/FPUtil/ManipulationFunctions.h"
+#include "src/__support/FPUtil/float128.h"
 #include "src/__support/common.h"
 #include "src/__support/macros/config.h"
 

--- a/libc/src/__support/math/frexpf128.h
+++ b/libc/src/__support/math/frexpf128.h
@@ -9,10 +9,7 @@
 #ifndef LLVM_LIBC_SRC___SUPPORT_MATH_FREXPF128_H
 #define LLVM_LIBC_SRC___SUPPORT_MATH_FREXPF128_H
 
-#include "include/llvm-libc-types/float128.h"
-
-#ifdef LIBC_TYPES_HAS_NATIVE_FLOAT128
-
+#include "src/__support/FPUtil/float128.h"
 #include "src/__support/FPUtil/ManipulationFunctions.h"
 #include "src/__support/common.h"
 #include "src/__support/macros/config.h"
@@ -21,14 +18,14 @@ namespace LIBC_NAMESPACE_DECL {
 
 namespace math {
 
-LIBC_INLINE constexpr float128 frexpf128(float128 x, int *exp) {
+using LIBC_NAMESPACE::fputil::Float128;
+
+LIBC_INLINE constexpr Float128 frexpf128(Float128 x, int *exp) {
   return fputil::frexp(x, *exp);
 }
 
 } // namespace math
 
 } // namespace LIBC_NAMESPACE_DECL
-
-#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 #endif // LLVM_LIBC_SRC___SUPPORT_MATH_FREXPF128_H

--- a/libc/src/__support/math/frexpf128.h
+++ b/libc/src/__support/math/frexpf128.h
@@ -1,9 +1,15 @@
-//===-- Implementation header for expf --------------------------*- C++ -*-===//
+//===-- Implementation header for frexpf128 ---------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains the implementation of frexpf128, the float128 variant of
+/// frexp.
+///
 //===----------------------------------------------------------------------===//
 
 #ifndef LLVM_LIBC_SRC___SUPPORT_MATH_FREXPF128_H

--- a/libc/src/__support/math/frexpf128.h
+++ b/libc/src/__support/math/frexpf128.h
@@ -7,8 +7,7 @@
 //===----------------------------------------------------------------------===//
 ///
 /// \file
-/// This file contains the implementation of frexpf128, the float128 variant of
-/// frexp.
+/// Implementation of the float128 frexp function.
 ///
 //===----------------------------------------------------------------------===//
 

--- a/libc/src/__support/math/ilogbf128.h
+++ b/libc/src/__support/math/ilogbf128.h
@@ -7,8 +7,7 @@
 //===----------------------------------------------------------------------===//
 ///
 /// \file
-/// This file contains the implementation of ilogbf128, the float128 variant of
-/// ilogb.
+/// Implementation of the float128 ilogb function.
 ///
 //===----------------------------------------------------------------------===//
 

--- a/libc/src/__support/math/ilogbf128.h
+++ b/libc/src/__support/math/ilogbf128.h
@@ -9,10 +9,7 @@
 #ifndef LLVM_LIBC_SRC___SUPPORT_MATH_ILOGBF128_H
 #define LLVM_LIBC_SRC___SUPPORT_MATH_ILOGBF128_H
 
-#include "include/llvm-libc-types/float128.h"
-
-#ifdef LIBC_TYPES_HAS_NATIVE_FLOAT128
-
+#include "src/__support/FPUtil/float128.h"
 #include "src/__support/FPUtil/ManipulationFunctions.h"
 #include "src/__support/common.h"
 #include "src/__support/macros/config.h"
@@ -21,14 +18,14 @@ namespace LIBC_NAMESPACE_DECL {
 
 namespace math {
 
-LIBC_INLINE constexpr int ilogbf128(float128 x) {
+using LIBC_NAMESPACE::fputil::Float128;
+
+LIBC_INLINE constexpr int ilogbf128(Float128 x) {
   return fputil::intlogb<int>(x);
 }
 
 } // namespace math
 
 } // namespace LIBC_NAMESPACE_DECL
-
-#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 #endif // LLVM_LIBC_SRC___SUPPORT_MATH_ILOGBF128_H

--- a/libc/src/__support/math/ilogbf128.h
+++ b/libc/src/__support/math/ilogbf128.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_SRC___SUPPORT_MATH_ILOGBF128_H
 #define LLVM_LIBC_SRC___SUPPORT_MATH_ILOGBF128_H
 
-#include "src/__support/FPUtil/float128.h"
 #include "src/__support/FPUtil/ManipulationFunctions.h"
+#include "src/__support/FPUtil/float128.h"
 #include "src/__support/common.h"
 #include "src/__support/macros/config.h"
 

--- a/libc/src/__support/math/ilogbf128.h
+++ b/libc/src/__support/math/ilogbf128.h
@@ -5,6 +5,12 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains the implementation of ilogbf128, the float128 variant of
+/// ilogb.
+///
+//===----------------------------------------------------------------------===//
 
 #ifndef LLVM_LIBC_SRC___SUPPORT_MATH_ILOGBF128_H
 #define LLVM_LIBC_SRC___SUPPORT_MATH_ILOGBF128_H

--- a/libc/src/__support/math/llogbf128.h
+++ b/libc/src/__support/math/llogbf128.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_SRC___SUPPORT_MATH_LLOGBF128_H
 #define LLVM_LIBC_SRC___SUPPORT_MATH_LLOGBF128_H
 
-#include "src/__support/FPUtil/float128.h"
 #include "src/__support/FPUtil/ManipulationFunctions.h"
+#include "src/__support/FPUtil/float128.h"
 #include "src/__support/common.h"
 #include "src/__support/macros/config.h"
 

--- a/libc/src/__support/math/llogbf128.h
+++ b/libc/src/__support/math/llogbf128.h
@@ -9,10 +9,7 @@
 #ifndef LLVM_LIBC_SRC___SUPPORT_MATH_LLOGBF128_H
 #define LLVM_LIBC_SRC___SUPPORT_MATH_LLOGBF128_H
 
-#include "include/llvm-libc-types/float128.h"
-
-#ifdef LIBC_TYPES_HAS_NATIVE_FLOAT128
-
+#include "src/__support/FPUtil/float128.h"
 #include "src/__support/FPUtil/ManipulationFunctions.h"
 #include "src/__support/common.h"
 #include "src/__support/macros/config.h"
@@ -21,14 +18,14 @@ namespace LIBC_NAMESPACE_DECL {
 
 namespace math {
 
-LIBC_INLINE constexpr long llogbf128(float128 x) {
+using LIBC_NAMESPACE::fputil::Float128;
+
+LIBC_INLINE constexpr long llogbf128(Float128 x) {
   return fputil::intlogb<long>(x);
 }
 
 } // namespace math
 
 } // namespace LIBC_NAMESPACE_DECL
-
-#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 #endif // LLVM_LIBC_SRC___SUPPORT_MATH_LLOGBF128_H

--- a/libc/src/__support/math/llogbf128.h
+++ b/libc/src/__support/math/llogbf128.h
@@ -5,6 +5,12 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains the implementation of llogbf128, the float128 variant of
+/// llogb.
+///
+//===----------------------------------------------------------------------===//
 
 #ifndef LLVM_LIBC_SRC___SUPPORT_MATH_LLOGBF128_H
 #define LLVM_LIBC_SRC___SUPPORT_MATH_LLOGBF128_H

--- a/libc/src/__support/math/llogbf128.h
+++ b/libc/src/__support/math/llogbf128.h
@@ -7,8 +7,7 @@
 //===----------------------------------------------------------------------===//
 ///
 /// \file
-/// This file contains the implementation of llogbf128, the float128 variant of
-/// llogb.
+/// Implementation of the float128 llogb function.
 ///
 //===----------------------------------------------------------------------===//
 

--- a/libc/src/__support/math/logbf128.h
+++ b/libc/src/__support/math/logbf128.h
@@ -9,10 +9,7 @@
 #ifndef LLVM_LIBC_SRC___SUPPORT_MATH_LOGBF128_H
 #define LLVM_LIBC_SRC___SUPPORT_MATH_LOGBF128_H
 
-#include "include/llvm-libc-types/float128.h"
-
-#ifdef LIBC_TYPES_HAS_NATIVE_FLOAT128
-
+#include "src/__support/FPUtil/float128.h"
 #include "src/__support/FPUtil/ManipulationFunctions.h"
 #include "src/__support/common.h"
 #include "src/__support/macros/config.h"
@@ -21,12 +18,14 @@ namespace LIBC_NAMESPACE_DECL {
 
 namespace math {
 
-LIBC_INLINE constexpr float128 logbf128(float128 x) { return fputil::logb(x); }
+using LIBC_NAMESPACE::fputil::Float128;
+
+LIBC_INLINE constexpr Float128 logbf128(Float128 x) { 
+    return fputil::logb(x); 
+}
 
 } // namespace math
 
 } // namespace LIBC_NAMESPACE_DECL
-
-#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 #endif // LLVM_LIBC_SRC___SUPPORT_MATH_LOGBF128_H

--- a/libc/src/__support/math/logbf128.h
+++ b/libc/src/__support/math/logbf128.h
@@ -7,8 +7,7 @@
 //===----------------------------------------------------------------------===//
 ///
 /// \file
-/// This file contains the implementation of logbf128, the float128 variant of
-/// logb.
+/// Implementation of the float128 logb function.
 ///
 //===----------------------------------------------------------------------===//
 

--- a/libc/src/__support/math/logbf128.h
+++ b/libc/src/__support/math/logbf128.h
@@ -5,6 +5,12 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains the implementation of logbf128, the float128 variant of
+/// logb.
+///
+//===----------------------------------------------------------------------===//
 
 #ifndef LLVM_LIBC_SRC___SUPPORT_MATH_LOGBF128_H
 #define LLVM_LIBC_SRC___SUPPORT_MATH_LOGBF128_H

--- a/libc/src/__support/math/logbf128.h
+++ b/libc/src/__support/math/logbf128.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_SRC___SUPPORT_MATH_LOGBF128_H
 #define LLVM_LIBC_SRC___SUPPORT_MATH_LOGBF128_H
 
-#include "src/__support/FPUtil/float128.h"
 #include "src/__support/FPUtil/ManipulationFunctions.h"
+#include "src/__support/FPUtil/float128.h"
 #include "src/__support/common.h"
 #include "src/__support/macros/config.h"
 
@@ -20,9 +20,7 @@ namespace math {
 
 using LIBC_NAMESPACE::fputil::Float128;
 
-LIBC_INLINE constexpr Float128 logbf128(Float128 x) { 
-    return fputil::logb(x); 
-}
+LIBC_INLINE constexpr Float128 logbf128(Float128 x) { return fputil::logb(x); }
 
 } // namespace math
 

--- a/libc/src/math/frexpf128.h
+++ b/libc/src/math/frexpf128.h
@@ -5,6 +5,12 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains the declaration of the frexpf128 entrypoint, the
+/// float128 variant of the C standard frexp function.
+///
+//===----------------------------------------------------------------------===//
 
 #ifndef LLVM_LIBC_SRC_MATH_FREXPF128_H
 #define LLVM_LIBC_SRC_MATH_FREXPF128_H

--- a/libc/src/math/frexpf128.h
+++ b/libc/src/math/frexpf128.h
@@ -9,10 +9,15 @@
 #ifndef LLVM_LIBC_SRC_MATH_FREXPF128_H
 #define LLVM_LIBC_SRC_MATH_FREXPF128_H
 
+#include "src/__support/FPUtil/float128.h"
 #include "src/__support/macros/config.h"
 #include "src/__support/macros/properties/types.h"
 
 namespace LIBC_NAMESPACE_DECL {
+
+#ifndef LIBC_TYPES_HAS_NATIVE_FLOAT128
+using float128 = LIBC_NAMESPACE::fputil::Float128;
+#endif
 
 float128 frexpf128(float128 x, int *exp);
 

--- a/libc/src/math/frexpf128.h
+++ b/libc/src/math/frexpf128.h
@@ -7,8 +7,7 @@
 //===----------------------------------------------------------------------===//
 ///
 /// \file
-/// This file contains the declaration of the frexpf128 entrypoint, the
-/// float128 variant of the C standard frexp function.
+/// Declaration of the float128 frexp function.
 ///
 //===----------------------------------------------------------------------===//
 

--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -1589,6 +1589,7 @@ add_entrypoint_object(
   HDRS
     ../ilogbf128.h
   DEPENDS
+    libc.src.__support.CPP.bit
     libc.src.__support.math.ilogbf128
 )
 
@@ -1676,6 +1677,7 @@ add_entrypoint_object(
   HDRS
     ../llogbf128.h
   DEPENDS
+    libc.src.__support.CPP.bit
     libc.src.__support.math.llogbf128
 )
 

--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -1943,6 +1943,7 @@ add_entrypoint_object(
   HDRS
     ../logbf128.h
   DEPENDS
+    libc.src.__support.CPP.bit
     libc.src.__support.math.logbf128
     libc.src.errno.errno
 )

--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -1527,6 +1527,7 @@ add_entrypoint_object(
   HDRS
     ../frexpf128.h
   DEPENDS
+    libc.src.__support.CPP.bit
     libc.src.__support.math.frexpf128
 )
 

--- a/libc/src/math/generic/frexpf128.cpp
+++ b/libc/src/math/generic/frexpf128.cpp
@@ -7,13 +7,16 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/math/frexpf128.h"
-
+#include "src/__support/CPP/bit.h"
 #include "src/__support/math/frexpf128.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
+using LIBC_NAMESPACE::fputil::Float128;
+
 LLVM_LIBC_FUNCTION(float128, frexpf128, (float128 x, int *exp)) {
-  return math::frexpf128(x, exp);
+  return cpp::bit_cast<float128>(
+    math::frexpf128(cpp::bit_cast<Float128>(x), exp));
 }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/math/generic/frexpf128.cpp
+++ b/libc/src/math/generic/frexpf128.cpp
@@ -5,6 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implementation of the float128 frexp function.
+///
+//===----------------------------------------------------------------------===//
 
 #include "src/math/frexpf128.h"
 #include "src/__support/CPP/bit.h"

--- a/libc/src/math/generic/frexpf128.cpp
+++ b/libc/src/math/generic/frexpf128.cpp
@@ -16,7 +16,7 @@ using LIBC_NAMESPACE::fputil::Float128;
 
 LLVM_LIBC_FUNCTION(float128, frexpf128, (float128 x, int *exp)) {
   return cpp::bit_cast<float128>(
-    math::frexpf128(cpp::bit_cast<Float128>(x), exp));
+      math::frexpf128(cpp::bit_cast<Float128>(x), exp));
 }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/math/generic/ilogbf128.cpp
+++ b/libc/src/math/generic/ilogbf128.cpp
@@ -7,10 +7,16 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/math/ilogbf128.h"
+#include "src/__support/CPP/bit.h"
 #include "src/__support/math/ilogbf128.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
-LLVM_LIBC_FUNCTION(int, ilogbf128, (float128 x)) { return math::ilogbf128(x); }
+using LIBC_NAMESPACE::fputil::Float128;
+
+LLVM_LIBC_FUNCTION(int, ilogbf128, (float128 x)) {
+    return math::ilogbf128(
+        cpp::bit_cast<Float128>(x));
+}
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/math/generic/ilogbf128.cpp
+++ b/libc/src/math/generic/ilogbf128.cpp
@@ -5,6 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implementation of the float128 ilogb function.
+///
+//===----------------------------------------------------------------------===//
 
 #include "src/math/ilogbf128.h"
 #include "src/__support/CPP/bit.h"

--- a/libc/src/math/generic/ilogbf128.cpp
+++ b/libc/src/math/generic/ilogbf128.cpp
@@ -15,8 +15,7 @@ namespace LIBC_NAMESPACE_DECL {
 using LIBC_NAMESPACE::fputil::Float128;
 
 LLVM_LIBC_FUNCTION(int, ilogbf128, (float128 x)) {
-    return math::ilogbf128(
-        cpp::bit_cast<Float128>(x));
+  return math::ilogbf128(cpp::bit_cast<Float128>(x));
 }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/math/generic/llogbf128.cpp
+++ b/libc/src/math/generic/llogbf128.cpp
@@ -7,10 +7,16 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/math/llogbf128.h"
+#include "src/__support/CPP/bit.h"
 #include "src/__support/math/llogbf128.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
-LLVM_LIBC_FUNCTION(long, llogbf128, (float128 x)) { return math::llogbf128(x); }
+using LIBC_NAMESPACE::fputil::Float128;
+
+LLVM_LIBC_FUNCTION(long, llogbf128, (float128 x)) {
+    return math::llogbf128(
+        cpp::bit_cast<Float128>(x));
+}
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/math/generic/llogbf128.cpp
+++ b/libc/src/math/generic/llogbf128.cpp
@@ -5,6 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implementation of the float128 llogb function.
+///
+//===----------------------------------------------------------------------===//
 
 #include "src/math/llogbf128.h"
 #include "src/__support/CPP/bit.h"

--- a/libc/src/math/generic/llogbf128.cpp
+++ b/libc/src/math/generic/llogbf128.cpp
@@ -15,8 +15,7 @@ namespace LIBC_NAMESPACE_DECL {
 using LIBC_NAMESPACE::fputil::Float128;
 
 LLVM_LIBC_FUNCTION(long, llogbf128, (float128 x)) {
-    return math::llogbf128(
-        cpp::bit_cast<Float128>(x));
+  return math::llogbf128(cpp::bit_cast<Float128>(x));
 }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/math/generic/logbf128.cpp
+++ b/libc/src/math/generic/logbf128.cpp
@@ -5,6 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implementation of the float128 logb function.
+///
+//===----------------------------------------------------------------------===//
 
 #include "src/math/logbf128.h"
 #include "src/__support/CPP/bit.h"

--- a/libc/src/math/generic/logbf128.cpp
+++ b/libc/src/math/generic/logbf128.cpp
@@ -7,12 +7,16 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/math/logbf128.h"
+#include "src/__support/CPP/bit.h"
 #include "src/__support/math/logbf128.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
+using LIBC_NAMESPACE::fputil::Float128;
+
 LLVM_LIBC_FUNCTION(float128, logbf128, (float128 x)) {
-  return math::logbf128(x);
+  return cpp::bit_cast<Float128>(
+      math::logbf128(cpp::bit_cast<Float128>(x)));
 }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/math/generic/logbf128.cpp
+++ b/libc/src/math/generic/logbf128.cpp
@@ -15,8 +15,7 @@ namespace LIBC_NAMESPACE_DECL {
 using LIBC_NAMESPACE::fputil::Float128;
 
 LLVM_LIBC_FUNCTION(float128, logbf128, (float128 x)) {
-  return cpp::bit_cast<Float128>(
-      math::logbf128(cpp::bit_cast<Float128>(x)));
+  return cpp::bit_cast<float128>(math::logbf128(cpp::bit_cast<Float128>(x)));
 }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/math/ilogbf128.h
+++ b/libc/src/math/ilogbf128.h
@@ -9,10 +9,15 @@
 #ifndef LLVM_LIBC_SRC_MATH_ILOGBF128_H
 #define LLVM_LIBC_SRC_MATH_ILOGBF128_H
 
+#include "src/__support/FPUtil/float128.h"
 #include "src/__support/macros/config.h"
 #include "src/__support/macros/properties/types.h"
 
 namespace LIBC_NAMESPACE_DECL {
+
+#ifndef LIBC_TYPES_HAS_NATIVE_FLOAT128
+using float128 = LIBC_NAMESPACE::fputil::Float128;
+#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 int ilogbf128(float128 x);
 

--- a/libc/src/math/ilogbf128.h
+++ b/libc/src/math/ilogbf128.h
@@ -5,6 +5,12 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains the declaration of the ilogbf128 entrypoint, the
+/// float128 variant of the C standard ilogb function.
+///
+//===----------------------------------------------------------------------===//
 
 #ifndef LLVM_LIBC_SRC_MATH_ILOGBF128_H
 #define LLVM_LIBC_SRC_MATH_ILOGBF128_H

--- a/libc/src/math/ilogbf128.h
+++ b/libc/src/math/ilogbf128.h
@@ -7,8 +7,7 @@
 //===----------------------------------------------------------------------===//
 ///
 /// \file
-/// This file contains the declaration of the ilogbf128 entrypoint, the
-/// float128 variant of the C standard ilogb function.
+/// Declaration of the float128 ilogb function.
 ///
 //===----------------------------------------------------------------------===//
 

--- a/libc/src/math/llogbf128.h
+++ b/libc/src/math/llogbf128.h
@@ -5,6 +5,12 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains the declaration of the llogbf128 entrypoint, the
+/// float128 variant of the C standard llogb function.
+///
+//===----------------------------------------------------------------------===//
 
 #ifndef LLVM_LIBC_SRC_MATH_LLOGBF128_H
 #define LLVM_LIBC_SRC_MATH_LLOGBF128_H

--- a/libc/src/math/llogbf128.h
+++ b/libc/src/math/llogbf128.h
@@ -7,8 +7,7 @@
 //===----------------------------------------------------------------------===//
 ///
 /// \file
-/// This file contains the declaration of the llogbf128 entrypoint, the
-/// float128 variant of the C standard llogb function.
+/// Declaration of the float128 llogb function.
 ///
 //===----------------------------------------------------------------------===//
 

--- a/libc/src/math/llogbf128.h
+++ b/libc/src/math/llogbf128.h
@@ -9,10 +9,15 @@
 #ifndef LLVM_LIBC_SRC_MATH_LLOGBF128_H
 #define LLVM_LIBC_SRC_MATH_LLOGBF128_H
 
+#include "src/__support/FPUtil/float128.h"
 #include "src/__support/macros/config.h"
 #include "src/__support/macros/properties/types.h"
 
 namespace LIBC_NAMESPACE_DECL {
+
+#ifndef LIBC_TYPES_HAS_NATIVE_FLOAT128
+using float128 = LIBC_NAMESPACE::fputil::Float128;
+#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 long llogbf128(float128 x);
 

--- a/libc/src/math/logbf128.h
+++ b/libc/src/math/logbf128.h
@@ -9,10 +9,15 @@
 #ifndef LLVM_LIBC_SRC_MATH_LOGBF128_H
 #define LLVM_LIBC_SRC_MATH_LOGBF128_H
 
+#include "src/__support/FPUtil/float128.h"
 #include "src/__support/macros/config.h"
 #include "src/__support/macros/properties/types.h"
 
 namespace LIBC_NAMESPACE_DECL {
+
+#ifndef LIBC_TYPES_HAS_NATIVE_FLOAT128
+using float128 = LIBC_NAMESPACE::fputil::Float128;
+#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 float128 logbf128(float128 x);
 

--- a/libc/src/math/logbf128.h
+++ b/libc/src/math/logbf128.h
@@ -5,6 +5,12 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains the declaration of the logbf128 entrypoint, the
+/// float128 variant of the C standard logb function.
+///
+//===----------------------------------------------------------------------===//
 
 #ifndef LLVM_LIBC_SRC_MATH_LOGBF128_H
 #define LLVM_LIBC_SRC_MATH_LOGBF128_H

--- a/libc/src/math/logbf128.h
+++ b/libc/src/math/logbf128.h
@@ -7,8 +7,7 @@
 //===----------------------------------------------------------------------===//
 ///
 /// \file
-/// This file contains the declaration of the logbf128 entrypoint, the
-/// float128 variant of the C standard logb function.
+/// Declaration of the float128 logb function.
 ///
 //===----------------------------------------------------------------------===//
 

--- a/libc/test/shared/shared_math_constexpr_test.cpp
+++ b/libc/test/shared/shared_math_constexpr_test.cpp
@@ -428,6 +428,7 @@ static_assert(0 == LIBC_NAMESPACE::shared::isnanf128(Float128(0.0)));
 static_assert(0.0 == LIBC_NAMESPACE::shared::issignalingf128(Float128(0.0)));
 static_assert(0LL == LIBC_NAMESPACE::shared::llrintf128(Float128(0.0)));
 static_assert(0LL == LIBC_NAMESPACE::shared::llroundf128(Float128(0.0)));
+static_assert(Float128(0.0) == LIBC_NAMESPACE::shared::logbf128(Float128(1.0)));
 static_assert(0L == LIBC_NAMESPACE::shared::lrintf128(Float128(0.0)));
 static_assert(0L == LIBC_NAMESPACE::shared::lroundf128(Float128(0.0)));
 static_assert(Float128(0.0) ==

--- a/libc/test/shared/shared_math_constexpr_test.cpp
+++ b/libc/test/shared/shared_math_constexpr_test.cpp
@@ -419,6 +419,10 @@ static_assert(Float128(0.0) ==
 static_assert(Float128(0.0) ==
               LIBC_NAMESPACE::shared::fminimum_numf128(Float128(0.0),
                                                        Float128(0.0)));
+static_assert(Float128(0.0) == [] {
+  int exp{};
+  return LIBC_NAMESPACE::shared::frexpf128(Float128(0.0), &exp);
+}());
 static_assert(1 == LIBC_NAMESPACE::shared::iscanonicalf128(Float128(0.0)));
 static_assert(0 == LIBC_NAMESPACE::shared::isnanf128(Float128(0.0)));
 static_assert(0.0 == LIBC_NAMESPACE::shared::issignalingf128(Float128(0.0)));

--- a/libc/test/shared/shared_math_constexpr_test.cpp
+++ b/libc/test/shared/shared_math_constexpr_test.cpp
@@ -427,7 +427,7 @@ static_assert(0 == LIBC_NAMESPACE::shared::ilogbf128(Float128(1.0)));
 static_assert(1 == LIBC_NAMESPACE::shared::iscanonicalf128(Float128(0.0)));
 static_assert(0 == LIBC_NAMESPACE::shared::isnanf128(Float128(0.0)));
 static_assert(0.0 == LIBC_NAMESPACE::shared::issignalingf128(Float128(0.0)));
-static_assert(0LL == LIBC_NAMESPACE::shared::llogbf128(Float128(1.0)));
+static_assert(0L == LIBC_NAMESPACE::shared::llogbf128(Float128(1.0)));
 static_assert(0LL == LIBC_NAMESPACE::shared::llrintf128(Float128(0.0)));
 static_assert(0LL == LIBC_NAMESPACE::shared::llroundf128(Float128(0.0)));
 static_assert(Float128(0.0) == LIBC_NAMESPACE::shared::logbf128(Float128(1.0)));

--- a/libc/test/shared/shared_math_constexpr_test.cpp
+++ b/libc/test/shared/shared_math_constexpr_test.cpp
@@ -423,9 +423,11 @@ static_assert(Float128(0.0) == [] {
   int exp{};
   return LIBC_NAMESPACE::shared::frexpf128(Float128(0.0), &exp);
 }());
+static_assert(0 == LIBC_NAMESPACE::shared::ilogbf128(Float128(1.0)));
 static_assert(1 == LIBC_NAMESPACE::shared::iscanonicalf128(Float128(0.0)));
 static_assert(0 == LIBC_NAMESPACE::shared::isnanf128(Float128(0.0)));
 static_assert(0.0 == LIBC_NAMESPACE::shared::issignalingf128(Float128(0.0)));
+static_assert(0LL == LIBC_NAMESPACE::shared::llogbf128(Float128(1.0)));
 static_assert(0LL == LIBC_NAMESPACE::shared::llrintf128(Float128(0.0)));
 static_assert(0LL == LIBC_NAMESPACE::shared::llroundf128(Float128(0.0)));
 static_assert(Float128(0.0) == LIBC_NAMESPACE::shared::logbf128(Float128(1.0)));

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -581,6 +581,8 @@ TEST(LlvmLibcSharedMathTest, AllLongDouble) {
 
 // Emulated float128 tests
 TEST(LlvmLibcSharedMathTest, AllEmuFloat128) {
+  int exponent;
+
   EXPECT_FP_EQ(Float128(0.0),
                LIBC_NAMESPACE::shared::atan2f128(Float128(0.0), Float128(0.0)));
   EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::ceilf128(Float128(0.0)));
@@ -610,10 +612,9 @@ TEST(LlvmLibcSharedMathTest, AllEmuFloat128) {
                                   Float128(0.0), Float128(0.0)));
   EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::fminimum_numf128(
                                   Float128(0.0), Float128(0.0)));
-  int frexpf128_exp = 0;
-  EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::frexpf128(
-                                  Float128(0.0), &frexpf128_exp));
-  EXPECT_EQ(0, frexpf128_exp);
+  EXPECT_FP_EQ_ALL_ROUNDING(Float128(0.75), LIBC_NAMESPACE::shared::frexpf128(
+                                                Float128(24), &exponent));
+  EXPECT_EQ(exponent, 5);
   EXPECT_EQ(0, LIBC_NAMESPACE::shared::ilogbf128(Float128(1.0)));
   EXPECT_EQ(1, LIBC_NAMESPACE::shared::iscanonicalf128(Float128(0.0)));
   EXPECT_EQ(0, LIBC_NAMESPACE::shared::isnanf128(Float128(0.0)));

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -614,9 +614,11 @@ TEST(LlvmLibcSharedMathTest, AllEmuFloat128) {
   EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::frexpf128(
                                   Float128(0.0), &frexpf128_exp));
   EXPECT_EQ(0, frexpf128_exp);
+  EXPECT_EQ(0, LIBC_NAMESPACE::shared::ilogbf128(Float128(1.0)));
   EXPECT_EQ(1, LIBC_NAMESPACE::shared::iscanonicalf128(Float128(0.0)));
   EXPECT_EQ(0, LIBC_NAMESPACE::shared::isnanf128(Float128(0.0)));
   EXPECT_EQ(0, LIBC_NAMESPACE::shared::issignalingf128(Float128(0.0)));
+  EXPECT_EQ(0LL, LIBC_NAMESPACE::shared::llogbf128(Float128(1.0)));
   EXPECT_EQ(0LL, LIBC_NAMESPACE::shared::llrintf128(Float128(0.0)));
   EXPECT_EQ(0LL, LIBC_NAMESPACE::shared::llroundf128(Float128(0.0)));
   EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::logbf128(Float128(1.0)));
@@ -641,7 +643,6 @@ TEST(LlvmLibcSharedMathTest, AllFloat128) {
                          float128(0.0), float128(0.0), float128(0.0)));
   EXPECT_FP_EQ(1.0f, LIBC_NAMESPACE::shared::fsqrtf128(float128(1.0f)));
 
-  EXPECT_EQ(3, LIBC_NAMESPACE::shared::ilogbf128(float128(8.0)));
   ASSERT_FP_EQ(float128(8 << 5),
                LIBC_NAMESPACE::shared::ldexpf128(float128(8), 5));
   ASSERT_FP_EQ(float128(-1 * (8 << 5)),
@@ -649,8 +650,6 @@ TEST(LlvmLibcSharedMathTest, AllFloat128) {
   EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::shared::dfmaf128(
                         float128(0.0), float128(0.0), float128(0.0)));
   EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::shared::dsqrtf128(float128(0.0)));
-
-  EXPECT_EQ(0L, LIBC_NAMESPACE::shared::llogbf128(float128(1.0)));
 
   EXPECT_FP_EQ(bfloat16(5.0), LIBC_NAMESPACE::shared::bf16addf128(
                                   float128(2.0), float128(3.0)));

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -610,6 +610,10 @@ TEST(LlvmLibcSharedMathTest, AllEmuFloat128) {
                                   Float128(0.0), Float128(0.0)));
   EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::fminimum_numf128(
                                   Float128(0.0), Float128(0.0)));
+  int frexpf128_exp = 0;
+  EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::frexpf128(
+                                  Float128(0.0), &frexpf128_exp));
+  EXPECT_EQ(0, frexpf128_exp);
   EXPECT_EQ(1, LIBC_NAMESPACE::shared::iscanonicalf128(Float128(0.0)));
   EXPECT_EQ(0, LIBC_NAMESPACE::shared::isnanf128(Float128(0.0)));
   EXPECT_EQ(0, LIBC_NAMESPACE::shared::issignalingf128(Float128(0.0)));
@@ -631,14 +635,10 @@ TEST(LlvmLibcSharedMathTest, AllEmuFloat128) {
 
 TEST(LlvmLibcSharedMathTest, AllFloat128) {
   using FPBits = LIBC_NAMESPACE::fputil::FPBits<float128>;
-  int exponent;
 
   EXPECT_FP_EQ(0.0f, LIBC_NAMESPACE::shared::ffmaf128(
                          float128(0.0), float128(0.0), float128(0.0)));
   EXPECT_FP_EQ(1.0f, LIBC_NAMESPACE::shared::fsqrtf128(float128(1.0f)));
-  EXPECT_FP_EQ_ALL_ROUNDING(float128(0.75), LIBC_NAMESPACE::shared::frexpf128(
-                                                float128(24), &exponent));
-  EXPECT_EQ(exponent, 5);
 
   EXPECT_EQ(3, LIBC_NAMESPACE::shared::ilogbf128(float128(8.0)));
   ASSERT_FP_EQ(float128(8 << 5),

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -619,6 +619,7 @@ TEST(LlvmLibcSharedMathTest, AllEmuFloat128) {
   EXPECT_EQ(0, LIBC_NAMESPACE::shared::issignalingf128(Float128(0.0)));
   EXPECT_EQ(0LL, LIBC_NAMESPACE::shared::llrintf128(Float128(0.0)));
   EXPECT_EQ(0LL, LIBC_NAMESPACE::shared::llroundf128(Float128(0.0)));
+  EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::logbf128(Float128(1.0)));
   EXPECT_EQ(0L, LIBC_NAMESPACE::shared::lrintf128(Float128(0.0)));
   EXPECT_EQ(0L, LIBC_NAMESPACE::shared::lroundf128(Float128(0.0)));
   EXPECT_FP_EQ(Float128(0.0),
@@ -645,7 +646,6 @@ TEST(LlvmLibcSharedMathTest, AllFloat128) {
                LIBC_NAMESPACE::shared::ldexpf128(float128(8), 5));
   ASSERT_FP_EQ(float128(-1 * (8 << 5)),
                LIBC_NAMESPACE::shared::ldexpf128(float128(-8), 5));
-  EXPECT_FP_EQ(float128(0.0), LIBC_NAMESPACE::shared::logbf128(float128(1.0)));
   EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::shared::dfmaf128(
                         float128(0.0), float128(0.0), float128(0.0)));
   EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::shared::dsqrtf128(float128(0.0)));

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -618,7 +618,7 @@ TEST(LlvmLibcSharedMathTest, AllEmuFloat128) {
   EXPECT_EQ(1, LIBC_NAMESPACE::shared::iscanonicalf128(Float128(0.0)));
   EXPECT_EQ(0, LIBC_NAMESPACE::shared::isnanf128(Float128(0.0)));
   EXPECT_EQ(0, LIBC_NAMESPACE::shared::issignalingf128(Float128(0.0)));
-  EXPECT_EQ(0LL, LIBC_NAMESPACE::shared::llogbf128(Float128(1.0)));
+  EXPECT_EQ(0L, LIBC_NAMESPACE::shared::llogbf128(Float128(1.0)));
   EXPECT_EQ(0LL, LIBC_NAMESPACE::shared::llrintf128(Float128(0.0)));
   EXPECT_EQ(0LL, LIBC_NAMESPACE::shared::llroundf128(Float128(0.0)));
   EXPECT_FP_EQ(Float128(0.0), LIBC_NAMESPACE::shared::logbf128(Float128(1.0)));

--- a/libc/test/src/math/CMakeLists.txt
+++ b/libc/test/src/math/CMakeLists.txt
@@ -1743,6 +1743,21 @@ add_fp_unittest(
 )
 
 add_fp_unittest(
+  logbf128_test
+  NEED_MPFR_F128
+  SUITE
+    libc-math-unittests
+  SRCS
+    logbf128_test.cpp
+  HDRS
+    LogbTest.h
+  DEPENDS
+    libc.src.math.logbf128
+    libc.src.__support.FPUtil.float128
+    libc.src.__support.FPUtil.manipulation_functions
+)
+
+add_fp_unittest(
   logbl_test
   SUITE
     libc-math-unittests

--- a/libc/test/src/math/logbf128_test.cpp
+++ b/libc/test/src/math/logbf128_test.cpp
@@ -1,0 +1,18 @@
+//===-- Unittests for logbf128 --------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "LogbTest.h"
+
+#include "src/__support/FPUtil/float128.h"
+#include "src/math/logbf128.h"
+
+#ifndef LIBC_TYPES_HAS_NATIVE_FLOAT128
+using float128 = LIBC_NAMESPACE::fputil::Float128;
+#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
+
+LIST_LOGB_TESTS(float128, LIBC_NAMESPACE::logbf128)

--- a/libc/test/src/math/smoke/CMakeLists.txt
+++ b/libc/test/src/math/smoke/CMakeLists.txt
@@ -2126,6 +2126,7 @@ add_fp_unittest(
   DEPENDS
     libc.src.math.ilogbf128
     libc.src.__support.CPP.algorithm
+    libc.src.__support.FPUtil.float128
     libc.src.__support.FPUtil.fp_bits
     libc.src.__support.FPUtil.manipulation_functions
 )
@@ -2303,6 +2304,7 @@ add_fp_unittest(
   DEPENDS
     libc.src.math.llogbf128
     libc.src.__support.CPP.algorithm
+    libc.src.__support.FPUtil.float128
     libc.src.__support.FPUtil.fp_bits
     libc.src.__support.FPUtil.manipulation_functions
 )

--- a/libc/test/src/math/smoke/CMakeLists.txt
+++ b/libc/test/src/math/smoke/CMakeLists.txt
@@ -1746,6 +1746,7 @@ add_fp_unittest(
     FrexpTest.h
   DEPENDS
     libc.src.math.frexpf128
+    libc.src.__support.FPUtil.float128
 )
 
 add_fp_unittest(

--- a/libc/test/src/math/smoke/CMakeLists.txt
+++ b/libc/test/src/math/smoke/CMakeLists.txt
@@ -2487,6 +2487,7 @@ add_fp_unittest(
   DEPENDS
     libc.src.math.logbf128
     libc.src.__support.CPP.algorithm
+    libc.src.__support.FPUtil.float128
     libc.src.__support.FPUtil.manipulation_functions
 )
 

--- a/libc/test/src/math/smoke/frexpf128_test.cpp
+++ b/libc/test/src/math/smoke/frexpf128_test.cpp
@@ -8,6 +8,11 @@
 
 #include "FrexpTest.h"
 
+#include "src/__support/FPUtil/float128.h"
 #include "src/math/frexpf128.h"
+
+#ifndef LIBC_TYPES_HAS_NATIVE_FLOAT128
+using float128 = LIBC_NAMESPACE::fputil::Float128;
+#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 LIST_FREXP_TESTS(float128, LIBC_NAMESPACE::frexpf128);

--- a/libc/test/src/math/smoke/ilogbf128_test.cpp
+++ b/libc/test/src/math/smoke/ilogbf128_test.cpp
@@ -8,6 +8,11 @@
 
 #include "ILogbTest.h"
 
+#include "src/__support/FPUtil/float128.h"
 #include "src/math/ilogbf128.h"
+
+#ifndef LIBC_TYPES_HAS_NATIVE_FLOAT128
+using float128 = LIBC_NAMESPACE::fputil::Float128;
+#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 LIST_INTLOGB_TESTS(int, float128, LIBC_NAMESPACE::ilogbf128);

--- a/libc/test/src/math/smoke/llogbf128_test.cpp
+++ b/libc/test/src/math/smoke/llogbf128_test.cpp
@@ -8,6 +8,11 @@
 
 #include "ILogbTest.h"
 
+#include "src/__support/FPUtil/float128.h"
 #include "src/math/llogbf128.h"
+
+#ifndef LIBC_TYPES_HAS_NATIVE_FLOAT128
+using float128 = LIBC_NAMESPACE::fputil::Float128;
+#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 LIST_INTLOGB_TESTS(long, float128, LIBC_NAMESPACE::llogbf128);

--- a/libc/test/src/math/smoke/logbf128_test.cpp
+++ b/libc/test/src/math/smoke/logbf128_test.cpp
@@ -8,6 +8,11 @@
 
 #include "LogbTest.h"
 
+#include "src/__support/FPUtil/float128.h"
 #include "src/math/logbf128.h"
+
+#ifndef LIBC_TYPES_HAS_NATIVE_FLOAT128
+using float128 = LIBC_NAMESPACE::fputil::Float128;
+#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 LIST_LOGB_TESTS(float128, LIBC_NAMESPACE::logbf128)

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -9087,9 +9087,9 @@ libc_support_library(
     hdrs = ["src/__support/math/logbf128.h"],
     deps = [
         ":__support_common",
+        ":__support_fputil_float128",
         ":__support_fputil_manipulation_functions",
         ":__support_macros_config",
-        ":llvm_libc_types_float128",
     ],
 )
 
@@ -12858,6 +12858,8 @@ libc_math_function(
 libc_math_function(
     name = "logbf128",
     additional_deps = [
+        ":__support_cpp_bit",
+        ":__support_fputil_float128",
         ":__support_math_logbf128",
     ],
 )

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -8309,10 +8309,10 @@ libc_support_library(
     hdrs = ["src/__support/math/ilogbf128.h"],
     deps = [
         ":__support_common",
+        ":__support_fputil_float128",
         ":__support_fputil_manipulation_functions",
         ":__support_macros_config",
         ":__support_macros_properties_types",
-        ":llvm_libc_types_float128",
     ],
 )
 
@@ -8711,9 +8711,9 @@ libc_support_library(
     hdrs = ["src/__support/math/llogbf128.h"],
     deps = [
         ":__support_common",
+        ":__support_fputil_float128",
         ":__support_fputil_manipulation_functions",
         ":__support_macros_config",
-        ":llvm_libc_types_float128",
     ],
 )
 
@@ -12559,6 +12559,8 @@ libc_math_function(
 libc_math_function(
     name = "ilogbf128",
     additional_deps = [
+        ":__support_cpp_bit",
+        ":__support_fputil_float128",
         ":__support_math_ilogbf128",
     ],
 )
@@ -12651,6 +12653,8 @@ libc_math_function(
 libc_math_function(
     name = "llogbf128",
     additional_deps = [
+        ":__support_cpp_bit",
+        ":__support_fputil_float128",
         ":__support_math_llogbf128",
     ],
 )

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -8299,8 +8299,8 @@ libc_support_library(
     deps = [
         ":__support_common",
         ":__support_fputil_manipulation_functions",
+        ":__support_fputil_float128",
         ":__support_macros_config",
-        ":llvm_libc_types_float128",
     ],
 )
 
@@ -12355,6 +12355,8 @@ libc_math_function(
 libc_math_function(
     name = "frexpf128",
     additional_deps = [
+        ":__support_cpp_bit",
+        ":__support_fputil_float128",
         ":__support_math_frexpf128",
     ],
 )

--- a/utils/bazel/llvm-project-overlay/libc/test/src/math/smoke/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/math/smoke/BUILD.bazel
@@ -1012,6 +1012,9 @@ math_test(
 math_test(
     name = "ilogbf128",
     hdrs = ["ILogbTest.h"],
+    deps = [
+        "//libc:__support_fputil_float128",
+    ],
 )
 
 math_test(
@@ -1057,6 +1060,9 @@ math_test(
 math_test(
     name = "llogbf128",
     hdrs = ["ILogbTest.h"],
+    deps = [
+        "//libc:__support_fputil_float128",
+    ],
 )
 
 math_test(

--- a/utils/bazel/llvm-project-overlay/libc/test/src/math/smoke/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/math/smoke/BUILD.bazel
@@ -879,6 +879,9 @@ math_test(
 math_test(
     name = "frexpf128",
     hdrs = ["FrexpTest.h"],
+    deps = [
+        "//libc:__support_fputil_float128",
+    ],
 )
 
 math_test(

--- a/utils/bazel/llvm-project-overlay/libc/test/src/math/smoke/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/math/smoke/BUILD.bazel
@@ -1177,6 +1177,9 @@ math_test(
 math_test(
     name = "logbf128",
     hdrs = ["LogbTest.h"],
+    deps = [
+        "//libc:__support_fputil_float128",
+    ],
 )
 
 math_test(


### PR DESCRIPTION
Closes #219757
Modifies:
- `frexpf128`
- `logbf128`
- `ilogbf128`
- `llogbf128`

AI Usage: No code was written by AI.

@Sukumarsawant Please review the PR.