### PR TITLE
[mlir][emitc] Fix arith.{div,rem}ui index support

### DIFF
--- a/mlir/lib/Conversion/ArithToEmitC/ArithToEmitC.cpp
+++ b/mlir/lib/Conversion/ArithToEmitC/ArithToEmitC.cpp
@@ -460,7 +460,7 @@ public:
       return rewriter.notifyMatchFailure(uiBinOp,
                                          "converting result type failed");
     if (!isa<IntegerType, emitc::SizeTType>(newRetTy)) {
-      return rewriter.notifyMatchFailure(uiBinOp, "expected integer type");
+      return rewriter.notifyMatchFailure(uiBinOp, "unsupported result type");
     }
     Type unsignedType =
         adaptIntegralTypeSignedness(newRetTy, /*needsUnsigned=*/true);

--- a/mlir/lib/Conversion/ArithToEmitC/ArithToEmitC.cpp
+++ b/mlir/lib/Conversion/ArithToEmitC/ArithToEmitC.cpp
@@ -459,7 +459,7 @@ public:
     if (!newRetTy)
       return rewriter.notifyMatchFailure(uiBinOp,
                                          "converting result type failed");
-    if (!isa<IntegerType>(newRetTy)) {
+    if (!isa<IntegerType, emitc::SizeTType>(newRetTy)) {
       return rewriter.notifyMatchFailure(uiBinOp, "expected integer type");
     }
     Type unsignedType =
@@ -467,8 +467,8 @@ public:
     if (!unsignedType)
       return rewriter.notifyMatchFailure(uiBinOp,
                                          "converting result type failed");
-    Value lhsAdapted = adaptValueType(uiBinOp.getLhs(), rewriter, unsignedType);
-    Value rhsAdapted = adaptValueType(uiBinOp.getRhs(), rewriter, unsignedType);
+    Value lhsAdapted = adaptValueType(adaptor.getLhs(), rewriter, unsignedType);
+    Value rhsAdapted = adaptValueType(adaptor.getRhs(), rewriter, unsignedType);
 
     auto newDivOp = EmitCOp::create(rewriter, uiBinOp.getLoc(), unsignedType,
                                     ArrayRef<Value>{lhsAdapted, rhsAdapted});

--- a/mlir/test/Conversion/ArithToEmitC/arith-to-emitc.mlir
+++ b/mlir/test/Conversion/ArithToEmitC/arith-to-emitc.mlir
@@ -89,6 +89,10 @@ func.func @arith_index(%arg0: i32, %arg1: i32) {
   %1 = arith.subi %cst0, %cst1 : index
   // CHECK: emitc.mul %[[CST0]], %[[CST1]] : (!emitc.size_t, !emitc.size_t) -> !emitc.size_t
   %2 = arith.muli %cst0, %cst1 : index
+  // CHECK: emitc.div %[[CST0]], %[[CST1]] : (!emitc.size_t, !emitc.size_t) -> !emitc.size_t
+  %3 = arith.divui %cst0, %cst1 : index
+  // CHECK: emitc.rem %[[CST0]], %[[CST1]] : (!emitc.size_t, !emitc.size_t) -> !emitc.size_t
+  %4 = arith.remui %cst0, %cst1 : index
 
   return
 }

--- a/mlir/test/Target/Cpp/arithmetic_operators.mlir
+++ b/mlir/test/Target/Cpp/arithmetic_operators.mlir
@@ -21,6 +21,13 @@ func.func @div_int(%arg0: i32, %arg1: i32) {
 // CHECK-LABEL: void div_int
 // CHECK-NEXT:  int32_t [[V2:[^ ]*]] = [[V0:[^ ]*]] / [[V1:[^ ]*]]
 
+func.func @div_size_t(%arg0: !emitc.size_t, %arg1: !emitc.size_t) {
+  %1 = "emitc.div" (%arg0, %arg1) : (!emitc.size_t, !emitc.size_t) -> !emitc.size_t
+  return
+}
+// CHECK-LABEL: void div_size_t
+// CHECK-NEXT:  size_t [[V2:[^ ]*]] = [[V0:[^ ]*]] / [[V1:[^ ]*]]
+
 func.func @mul_int(%arg0: i32, %arg1: i32) {
   %1 = "emitc.mul" (%arg0, %arg1) : (i32, i32) -> i32
   return
@@ -34,6 +41,13 @@ func.func @rem(%arg0: i32, %arg1: i32) {
 }
 // CHECK-LABEL: void rem
 // CHECK-NEXT:  int32_t [[V2:[^ ]*]] = [[V0:[^ ]*]] % [[V1:[^ ]*]]
+
+func.func @rem_size_t(%arg0: !emitc.size_t, %arg1: !emitc.size_t) {
+  %1 = "emitc.rem" (%arg0, %arg1) : (!emitc.size_t, !emitc.size_t) -> !emitc.size_t
+  return
+}
+// CHECK-LABEL: void rem_size_t
+// CHECK-NEXT:  size_t [[V2:[^ ]*]] = [[V0:[^ ]*]] % [[V1:[^ ]*]]
 
 func.func @sub_int(%arg0: i32, %arg1: i32) {
   %1 = "emitc.sub" (%arg0, %arg1) : (i32, i32) -> i32


### PR DESCRIPTION
These ops were failing to lower to emitc.{div,rem} when applied to index operands since the code was:
- only checking for IntegerType, rejecting the !emitc.size_t into which IndexType is converted.
- using the original operands instead of the converted ops, creating unrealized_conversion_cast ops.