### PR TITLE
MC: Move DisableIntegratedAS from TargetOptions to MCTargetOptions

### DIFF
--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -407,7 +407,7 @@ static bool initTargetOptions(const CompilerInstance &CI,
   Options.MCOptions.BinutilsVersion =
       llvm::MCTargetOptions::parseBinutilsVersion(CodeGenOpts.BinutilsVersion);
   Options.UseInitArray = CodeGenOpts.UseInitArray;
-  Options.DisableIntegratedAS = CodeGenOpts.DisableIntegratedAS;
+  Options.MCOptions.DisableIntegratedAS = CodeGenOpts.DisableIntegratedAS;
 
   // Set EABI version.
   Options.EABIVersion = TargetOpts.EABIVersion;

--- a/flang/lib/Frontend/CompilerInstance.cpp
+++ b/flang/lib/Frontend/CompilerInstance.cpp
@@ -383,7 +383,7 @@ bool CompilerInstance::setUpTargetMachine() {
   tOpts.EnableAIXExtendedAltivecABI = targetOpts.EnableAIXExtendedAltivecABI;
   tOpts.EnableMachineFunctionSplitter = targetOpts.SplitMachineFunctions;
   tOpts.VecLib = convertDriverVectorLibraryToVectorLibrary(CGOpts.getVecLib());
-  tOpts.DisableIntegratedAS = CGOpts.DisableIntegratedAS;
+  tOpts.MCOptions.DisableIntegratedAS = CGOpts.DisableIntegratedAS;
   tOpts.FunctionSections = CGOpts.FunctionSections;
   tOpts.DataSections = CGOpts.DataSections;
 

--- a/llvm/include/llvm/CodeGen/CommandFlags.h
+++ b/llvm/include/llvm/CodeGen/CommandFlags.h
@@ -87,8 +87,6 @@ LLVM_ABI std::string getTrapFuncName();
 
 LLVM_ABI bool getUseCtors();
 
-LLVM_ABI bool getDisableIntegratedAS();
-
 LLVM_ABI bool getDataSections();
 LLVM_ABI std::optional<bool> getExplicitDataSections();
 

--- a/llvm/include/llvm/MC/MCTargetOptions.h
+++ b/llvm/include/llvm/MC/MCTargetOptions.h
@@ -72,6 +72,9 @@ public:
 
   bool X86Sse2Avx = false;
 
+  // Disable the integrated assembler.
+  bool DisableIntegratedAS = false;
+
   // For ELF relocations, controls section symbol conversion.
   RelocSectionSymType RelocSectionSym = RelocSectionSymType::All;
 

--- a/llvm/include/llvm/MC/MCTargetOptionsCommandFlags.h
+++ b/llvm/include/llvm/MC/MCTargetOptionsCommandFlags.h
@@ -64,6 +64,8 @@ LLVM_ABI bool getX86RelaxRelocations();
 
 LLVM_ABI bool getX86Sse2Avx();
 
+LLVM_ABI bool getDisableIntegratedAS();
+
 LLVM_ABI RelocSectionSymType getRelocSectionSym();
 
 LLVM_ABI bool getLargeEHEncoding();

--- a/llvm/include/llvm/Target/TargetOptions.h
+++ b/llvm/include/llvm/Target/TargetOptions.h
@@ -123,14 +123,13 @@ public:
         HonorSignDependentRoundingFPMathOption(false), NoZerosInBSS(false),
         GuaranteedTailCallOpt(false), StackSymbolOrdering(true),
         EnableFastISel(false), EnableGlobalISel(false), UseInitArray(false),
-        DisableIntegratedAS(false), FunctionSections(false),
-        DataSections(false), IgnoreXCOFFVisibility(false),
-        XCOFFTracebackTable(true), UniqueSectionNames(true),
-        UniqueBasicBlockSectionNames(false), SeparateNamedSections(false),
-        TrapUnreachable(false), NoTrapAfterNoreturn(false), TLSSize(0),
-        EmulatedTLS(false), EnableTLSDESC(false), EnableIPRA(false),
-        EmitStackSizeSection(false), EnableMachineOutliner(false),
-        EnableMachineFunctionSplitter(false),
+        FunctionSections(false), DataSections(false),
+        IgnoreXCOFFVisibility(false), XCOFFTracebackTable(true),
+        UniqueSectionNames(true), UniqueBasicBlockSectionNames(false),
+        SeparateNamedSections(false), TrapUnreachable(false),
+        NoTrapAfterNoreturn(false), TLSSize(0), EmulatedTLS(false),
+        EnableTLSDESC(false), EnableIPRA(false), EmitStackSizeSection(false),
+        EnableMachineOutliner(false), EnableMachineFunctionSplitter(false),
         EnableStaticDataPartitioning(false), SupportsDefaultOutlining(false),
         EnableDefaultMachineVerifier(true), EmitAddrsig(false),
         BBAddrMap(false), EmitCallGraphSection(false), EmitCallSiteInfo(false),
@@ -196,9 +195,6 @@ public:
   /// UseInitArray - Use .init_array instead of .ctors for static
   /// constructors.
   unsigned UseInitArray : 1;
-
-  /// Disable the integrated assembler.
-  unsigned DisableIntegratedAS : 1;
 
   /// Emit functions into separate sections.
   unsigned FunctionSections : 1;

--- a/llvm/lib/CodeGen/CodeGenTargetMachineImpl.cpp
+++ b/llvm/lib/CodeGen/CodeGenTargetMachineImpl.cpp
@@ -69,7 +69,7 @@ void CodeGenTargetMachineImpl::initAsmInfo() {
                        "Make sure you include the correct TargetSelect.h"
                        "and that InitializeAllTargetMCs() is being invoked!");
 
-  if (Options.DisableIntegratedAS) {
+  if (Options.MCOptions.DisableIntegratedAS) {
     TmpAsmInfo->setUseIntegratedAssembler(false);
     // If there is explict option disable integratedAS, we can't use it for
     // inlineasm either.

--- a/llvm/lib/CodeGen/CommandFlags.cpp
+++ b/llvm/lib/CodeGen/CommandFlags.cpp
@@ -90,7 +90,6 @@ CGOPT(bool, StackSymbolOrdering)
 CGOPT(bool, StackRealign)
 CGOPT(std::string, TrapFuncName)
 CGOPT(bool, UseCtors)
-CGOPT(bool, DisableIntegratedAS)
 CGOPT_EXP(bool, DataSections)
 CGOPT_EXP(bool, FunctionSections)
 CGOPT(bool, IgnoreXCOFFVisibility)
@@ -519,11 +518,6 @@ codegen::RegisterCodeGenFlags::RegisterCodeGenFlags() {
       cl::init(false));
   CGBINDOPT(XCOFFReadOnlyPointers);
 
-  static cl::opt<bool> DisableIntegratedAS(
-      "no-integrated-as", cl::desc("Disable integrated assembler"),
-      cl::init(false));
-  CGBINDOPT(DisableIntegratedAS);
-
   mc::RegisterMCTargetOptionsFlags();
 }
 
@@ -585,7 +579,6 @@ codegen::InitTargetOptionsFromCodeGenFlags(const Triple &TheTriple) {
   Options.GuaranteedTailCallOpt = getEnableGuaranteedTailCallOpt();
   Options.StackSymbolOrdering = getStackSymbolOrdering();
   Options.UseInitArray = !getUseCtors();
-  Options.DisableIntegratedAS = getDisableIntegratedAS();
   Options.DataSections =
       getExplicitDataSections().value_or(TheTriple.hasDefaultDataSections());
   Options.FunctionSections = getFunctionSections();

--- a/llvm/lib/LTO/LTOCodeGenerator.cpp
+++ b/llvm/lib/LTO/LTOCodeGenerator.cpp
@@ -232,7 +232,7 @@ bool LTOCodeGenerator::writeMergedModules(StringRef Path) {
 
 bool LTOCodeGenerator::useAIXSystemAssembler() {
   const auto &Triple = TargetMach->getTargetTriple();
-  return Triple.isOSAIX() && Config.Options.DisableIntegratedAS;
+  return Triple.isOSAIX() && Config.Options.MCOptions.DisableIntegratedAS;
 }
 
 bool LTOCodeGenerator::runAIXSystemAssembler(SmallString<128> &AssemblyFile) {

--- a/llvm/lib/MC/MCTargetOptionsCommandFlags.cpp
+++ b/llvm/lib/MC/MCTargetOptionsCommandFlags.cpp
@@ -59,6 +59,7 @@ MCOPT(bool, Crel)
 MCOPT(bool, ImplicitMapSyms)
 MCOPT(bool, X86RelaxRelocations)
 MCOPT(bool, X86Sse2Avx)
+MCOPT(bool, DisableIntegratedAS)
 MCOPT(RelocSectionSymType, RelocSectionSym)
 MCOPT(bool, LargeEHEncoding)
 MCSTROPT(ABIName)
@@ -172,6 +173,11 @@ llvm::mc::RegisterMCTargetOptionsFlags::RegisterMCTargetOptionsFlags() {
                               "instructions with VEX prefix"));
   MCBINDOPT(X86Sse2Avx);
 
+  static cl::opt<bool> DisableIntegratedAS(
+      "no-integrated-as", cl::desc("Disable integrated assembler"),
+      cl::init(false));
+  MCBINDOPT(DisableIntegratedAS);
+
   static cl::opt<RelocSectionSymType> RelocSectionSym(
       "reloc-section-sym",
       cl::desc("Control section symbol conversion for relocations"),
@@ -224,6 +230,7 @@ MCTargetOptions llvm::mc::InitMCTargetOptionsFromFlags() {
   Options.ImplicitMapSyms = getImplicitMapSyms();
   Options.X86RelaxRelocations = getX86RelaxRelocations();
   Options.X86Sse2Avx = getX86Sse2Avx();
+  Options.DisableIntegratedAS = getDisableIntegratedAS();
   Options.RelocSectionSym = getRelocSectionSym();
   Options.LargeEHEncoding = getLargeEHEncoding();
   Options.EmitDwarfUnwind = getEmitDwarfUnwind();


### PR DESCRIPTION
The integrated assembler is only meaningful in MC, so this field belongs
in MCTargetOptions alongside the other assembler options rather than in
the codegen-level TargetOptions.

Co-authored-by: Claude (Claude-Opus-4.8)