### PR TITLE
[IR] Define empty and malformed !callees semantics

### DIFF
--- a/llvm/docs/LangRef.md
+++ b/llvm/docs/LangRef.md
@@ -7778,8 +7778,7 @@ Example (assuming 64-bit pointers):
 
 #### '`callees`' Metadata
 
-`callees` metadata may be attached to direct and indirect function call sites.
-It does not apply to inline assembly calls; attachments on those calls are ignored.
+`callees` metadata does not apply to inline assembly calls; attachments on those calls are ignored.
 Its operands provide an exhaustive list of possible callees.
 The list may be conservative: a listed function need not be dynamically feasible, but on every defined execution of the call the callee must be one of the listed functions.
 The order and duplication of operands are semantically irrelevant.

--- a/llvm/docs/LangRef.md
+++ b/llvm/docs/LangRef.md
@@ -7778,11 +7778,15 @@ Example (assuming 64-bit pointers):
 
 #### '`callees`' Metadata
 
-`callees` metadata may be attached to indirect call sites.
+`callees` metadata may be attached to call sites.
 Its operands provide an exhaustive list of possible callees.
 The list may be conservative: a listed function need not be dynamically feasible, but on every defined execution of the call the callee must be one of the listed functions.
 The order and duplication of operands are semantically irrelevant.
 The intent of this metadata is to facilitate optimizations such as indirect-call promotion.
+
+The constraint applies whether the called operand is a constant or not.
+Executing a direct call whose target is not in the list has undefined behavior.
+If the direct target is in the list, the attachment is redundant and may be dropped.
 
 An empty node is an exhaustive empty set, so executing the call has undefined behavior.
 If the metadata is absent, no exhaustive callee information is provided.
@@ -7790,7 +7794,6 @@ If the metadata is absent, no exhaustive callee information is provided.
 Each operand must refer to a `Function`.
 If any operand does not, the entire attachment provides no information and must be ignored.
 This includes null operands left behind when a function referenced only through metadata is deleted.
-An attachment on a non-indirect call likewise provides no information.
 
 For example, in the code below, the call instruction may only target the `add` or `sub` functions:
 

--- a/llvm/docs/LangRef.md
+++ b/llvm/docs/LangRef.md
@@ -7778,7 +7778,8 @@ Example (assuming 64-bit pointers):
 
 #### '`callees`' Metadata
 
-`callees` metadata may be attached to call sites.
+`callees` metadata may be attached to direct and indirect function call sites.
+It does not apply to inline assembly calls; attachments on those calls are ignored.
 Its operands provide an exhaustive list of possible callees.
 The list may be conservative: a listed function need not be dynamically feasible, but on every defined execution of the call the callee must be one of the listed functions.
 The order and duplication of operands are semantically irrelevant.

--- a/llvm/docs/LangRef.md
+++ b/llvm/docs/LangRef.md
@@ -7778,12 +7778,21 @@ Example (assuming 64-bit pointers):
 
 #### '`callees`' Metadata
 
-`callees` metadata may be attached to indirect call sites. If `callees`
-metadata is attached to a call site, and any callee is not among the set of
-functions provided by the metadata, the behavior is undefined. The intent of
-this metadata is to facilitate optimizations such as indirect-call promotion.
-For example, in the code below, the call instruction may only target the
-`add` or `sub` functions:
+`callees` metadata may be attached to indirect call sites.
+Its operands provide an exhaustive list of possible callees.
+The list may be conservative: a listed function need not be dynamically feasible, but on every defined execution of the call the callee must be one of the listed functions.
+The order and duplication of operands are semantically irrelevant.
+The intent of this metadata is to facilitate optimizations such as indirect-call promotion.
+
+An empty node is an exhaustive empty set, so executing the call has undefined behavior.
+If the metadata is absent, no exhaustive callee information is provided.
+
+Each operand must refer to a `Function`.
+If any operand does not, the entire attachment provides no information and must be ignored.
+This includes null operands left behind when a function referenced only through metadata is deleted.
+An attachment on a non-indirect call likewise provides no information.
+
+For example, in the code below, the call instruction may only target the `add` or `sub` functions:
 
 ```llvm
 %result = call i64 %binop(i64 %x, i64 %y), !callees !0

--- a/llvm/include/llvm/IR/InstrTypes.h
+++ b/llvm/include/llvm/IR/InstrTypes.h
@@ -1426,12 +1426,13 @@ public:
 
   /// Decode the exhaustive list of possible callees from !callees metadata.
   ///
-  /// Return true for a well-formed attachment, including an empty attachment.
-  /// Return false if the attachment is absent or contains an operand that is
-  /// not a Function. The result does not depend on the called operand and does
-  /// not check whether that operand satisfies the callee constraint.
-  /// \p Callees is cleared on failure. On success, duplicate functions are
-  /// omitted while preserving the order of their first occurrence.
+  /// Return true for a well-formed attachment on a function call, including an
+  /// empty attachment. Direct and indirect function calls are supported.
+  /// Return false for inline assembly calls, or if the attachment is absent or
+  /// contains an operand that is not a Function. This does not check whether
+  /// the called operand satisfies the callee constraint. \p Callees is cleared
+  /// on failure. On success, duplicate functions are omitted while preserving
+  /// the order of their first occurrence.
   LLVM_ABI bool getCalleesMetadata(SmallVectorImpl<Function *> &Callees) const;
 
   /// Determine whether the passed iterator points to the callee operand's Use.

--- a/llvm/include/llvm/IR/InstrTypes.h
+++ b/llvm/include/llvm/IR/InstrTypes.h
@@ -1424,6 +1424,15 @@ public:
   /// Return true if the callsite is an indirect call.
   LLVM_ABI bool isIndirectCall() const;
 
+  /// Decode the exhaustive list of possible callees from !callees metadata.
+  ///
+  /// Return true for a well-formed attachment on an indirect call, including
+  /// an empty attachment. Return false if the attachment is absent, is on a
+  /// non-indirect call, or contains an operand that is not a Function.
+  /// \p Callees is cleared on failure. On success, duplicate functions are
+  /// omitted while preserving the order of their first occurrence.
+  LLVM_ABI bool getCalleesMetadata(SmallVectorImpl<Function *> &Callees) const;
+
   /// Determine whether the passed iterator points to the callee operand's Use.
   bool isCallee(Value::const_user_iterator UI) const {
     return isCallee(&UI.getUse());

--- a/llvm/include/llvm/IR/InstrTypes.h
+++ b/llvm/include/llvm/IR/InstrTypes.h
@@ -1426,9 +1426,10 @@ public:
 
   /// Decode the exhaustive list of possible callees from !callees metadata.
   ///
-  /// Return true for a well-formed attachment on an indirect call, including
-  /// an empty attachment. Return false if the attachment is absent, is on a
-  /// non-indirect call, or contains an operand that is not a Function.
+  /// Return true for a well-formed attachment, including an empty attachment.
+  /// Return false if the attachment is absent or contains an operand that is
+  /// not a Function. The result does not depend on the called operand and does
+  /// not check whether that operand satisfies the callee constraint.
   /// \p Callees is cleared on failure. On success, duplicate functions are
   /// omitted while preserving the order of their first occurrence.
   LLVM_ABI bool getCalleesMetadata(SmallVectorImpl<Function *> &Callees) const;

--- a/llvm/include/llvm/IR/MDBuilder.h
+++ b/llvm/include/llvm/IR/MDBuilder.h
@@ -132,7 +132,7 @@ public:
   //===------------------------------------------------------------------===//
 
   /// Return metadata indicating the exhaustive list of possible callees of
-  /// calls.
+  /// function calls.
   LLVM_ABI MDNode *createCallees(ArrayRef<Function *> Callees);
 
   //===------------------------------------------------------------------===//

--- a/llvm/include/llvm/IR/MDBuilder.h
+++ b/llvm/include/llvm/IR/MDBuilder.h
@@ -131,8 +131,8 @@ public:
   // Callees metadata.
   //===------------------------------------------------------------------===//
 
-  /// Return metadata indicating the possible callees of indirect
-  /// calls.
+  /// Return metadata indicating the exhaustive list of possible callees of
+  /// indirect calls.
   LLVM_ABI MDNode *createCallees(ArrayRef<Function *> Callees);
 
   //===------------------------------------------------------------------===//

--- a/llvm/include/llvm/IR/MDBuilder.h
+++ b/llvm/include/llvm/IR/MDBuilder.h
@@ -132,7 +132,7 @@ public:
   //===------------------------------------------------------------------===//
 
   /// Return metadata indicating the exhaustive list of possible callees of
-  /// indirect calls.
+  /// calls.
   LLVM_ABI MDNode *createCallees(ArrayRef<Function *> Callees);
 
   //===------------------------------------------------------------------===//

--- a/llvm/lib/Analysis/ModuleSummaryAnalysis.cpp
+++ b/llvm/lib/Analysis/ModuleSummaryAnalysis.cpp
@@ -512,17 +512,14 @@ static void computeFunctionSummary(
         if (!CalledValue || isa<Constant>(CalledValue))
           continue;
 
-        // Check if the instruction has a callees metadata. If so, add callees
-        // to CallGraphEdges to reflect the references from the metadata, and
-        // to enable importing for subsequent indirect call promotion and
+        // If the instruction has valid callees metadata, add its callees to
+        // CallGraphEdges to reflect the references from the metadata, and to
+        // enable importing for subsequent indirect call promotion and
         // inlining.
-        if (auto *MD = I.getMetadata(LLVMContext::MD_callees)) {
-          for (const auto &Op : MD->operands()) {
-            Function *Callee = mdconst::extract_or_null<Function>(Op);
-            if (Callee)
-              CallGraphEdges[Index.getOrInsertValueInfo(Callee)];
-          }
-        }
+        SmallVector<Function *, 4> Callees;
+        if (CB->getCalleesMetadata(Callees))
+          for (Function *Callee : Callees)
+            CallGraphEdges[Index.getOrInsertValueInfo(Callee)];
 
         CandidateProfileData =
             ICallAnalysis.getPromotionCandidatesForInstruction(

--- a/llvm/lib/IR/Instructions.cpp
+++ b/llvm/lib/IR/Instructions.cpp
@@ -14,6 +14,7 @@
 #include "llvm/IR/Instructions.h"
 #include "LLVMContextImpl.h"
 #include "llvm/ADT/SmallBitVector.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/IR/Attributes.h"
@@ -339,6 +340,28 @@ bool CallBase::isIndirectCall() const {
   if (isa<Function>(V) || isa<Constant>(V))
     return false;
   return !isInlineAsm();
+}
+
+bool CallBase::getCalleesMetadata(SmallVectorImpl<Function *> &Callees) const {
+  Callees.clear();
+  if (!isIndirectCall())
+    return false;
+
+  const MDNode *MD = getMetadata(LLVMContext::MD_callees);
+  if (!MD)
+    return false;
+
+  SmallPtrSet<Function *, 4> Seen;
+  for (const MDOperand &Op : MD->operands()) {
+    Function *Callee = mdconst::dyn_extract_or_null<Function>(Op);
+    if (!Callee) {
+      Callees.clear();
+      return false;
+    }
+    if (Seen.insert(Callee).second)
+      Callees.push_back(Callee);
+  }
+  return true;
 }
 
 /// Tests if this call site must be tail call optimized. Only a CallInst can

--- a/llvm/lib/IR/Instructions.cpp
+++ b/llvm/lib/IR/Instructions.cpp
@@ -344,9 +344,6 @@ bool CallBase::isIndirectCall() const {
 
 bool CallBase::getCalleesMetadata(SmallVectorImpl<Function *> &Callees) const {
   Callees.clear();
-  if (!isIndirectCall())
-    return false;
-
   const MDNode *MD = getMetadata(LLVMContext::MD_callees);
   if (!MD)
     return false;

--- a/llvm/lib/IR/Instructions.cpp
+++ b/llvm/lib/IR/Instructions.cpp
@@ -344,6 +344,8 @@ bool CallBase::isIndirectCall() const {
 
 bool CallBase::getCalleesMetadata(SmallVectorImpl<Function *> &Callees) const {
   Callees.clear();
+  if (isInlineAsm())
+    return false;
   const MDNode *MD = getMetadata(LLVMContext::MD_callees);
   if (!MD)
     return false;

--- a/llvm/lib/Target/AMDGPU/AMDGPUSplitModule.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUSplitModule.cpp
@@ -475,29 +475,6 @@ void SplitGraph::Node::visitAllDependencies(
   }
 }
 
-/// Checks if \p I has MD_callees and if it does, parse it and put the function
-/// in \p Callees.
-///
-/// \returns true if there was metadata and it was parsed correctly. false if
-/// there was no MD or if it contained unknown entries and parsing failed.
-/// If this returns false, \p Callees will contain incomplete information
-/// and must not be used.
-static bool handleCalleesMD(const Instruction &I,
-                            SetVector<Function *> &Callees) {
-  auto *MD = I.getMetadata(LLVMContext::MD_callees);
-  if (!MD)
-    return false;
-
-  for (const auto &Op : MD->operands()) {
-    Function *Callee = mdconst::extract_or_null<Function>(Op);
-    if (!Callee)
-      return false;
-    Callees.insert(Callee);
-  }
-
-  return true;
-}
-
 void SplitGraph::buildGraph(CallGraph &CG) {
   SplitModuleTimer SMT("buildGraph", "graph construction");
   LLVM_DEBUG(
@@ -550,8 +527,11 @@ void SplitGraph::buildGraph(CallGraph &CG) {
           continue;
         }
 
-        if (handleCalleesMD(Inst, KnownCallees))
+        SmallVector<Function *, 4> CallCallees;
+        if (CB->getCalleesMetadata(CallCallees)) {
+          KnownCallees.insert_range(CallCallees);
           continue;
+        }
         // If we failed to parse any !callees MD, or some was missing,
         // the entire KnownCallees list is now unreliable.
         KnownCallees.clear();

--- a/llvm/lib/Transforms/IPO/AttributorAttributes.cpp
+++ b/llvm/lib/Transforms/IPO/AttributorAttributes.cpp
@@ -12372,14 +12372,13 @@ struct AAIndirectCallInfoCallSite : public AAIndirectCallInfo {
 
   /// See AbstractAttribute::initialize(...).
   void initialize(Attributor &A) override {
-    auto *MD = getCtxI()->getMetadata(LLVMContext::MD_callees);
-    if (!MD && !A.isClosedWorldModule())
+    SmallVector<Function *, 4> Callees;
+    HasCalleesMetadata = cast<CallBase>(getCtxI())->getCalleesMetadata(Callees);
+    if (!HasCalleesMetadata && !A.isClosedWorldModule())
       return;
 
-    if (MD) {
-      for (const auto &Op : MD->operands())
-        if (Function *Callee = mdconst::dyn_extract_or_null<Function>(Op))
-          PotentialCallees.insert(Callee);
+    if (HasCalleesMetadata) {
+      PotentialCallees.insert_range(Callees);
     } else if (A.isClosedWorldModule()) {
       ArrayRef<Function *> IndirectlyCallableFunctions =
           A.getInfoCache().getIndirectlyCallableFunctions(A);
@@ -12400,6 +12399,11 @@ struct AAIndirectCallInfoCallSite : public AAIndirectCallInfo {
 
     auto CheckPotentialCalleeUse = [&](Function &PotentialCallee,
                                        bool &UsedAssumedInformation) {
+      // A semantic !callees list can describe pointer flow through code
+      // outside this IR module. Do not remove a listed target merely because
+      // AAGlobalValueInfo cannot find an in-module path to the call operand.
+      if (HasCalleesMetadata)
+        return true;
       const auto *GIAA = A.getAAFor<AAGlobalValueInfo>(
           *this, IRPosition::value(PotentialCallee), DepClassTy::OPTIONAL);
       if (!GIAA || GIAA->isPotentialUse(CalleeUse))
@@ -12674,9 +12678,13 @@ private:
   /// Map to remember filter results.
   DenseMap<Function *, std::optional<bool>> FilterResults;
 
-  /// If the !callee metadata was present, this set will contain all potential
+  /// If !callees metadata was present, this set will contain all potential
   /// callees (superset).
   SmallSetVector<Function *, 4> PotentialCallees;
+
+  /// Whether PotentialCallees came from semantic !callees metadata rather than
+  /// the Attributor's closed-world candidate inventory.
+  bool HasCalleesMetadata = false;
 
   /// This set contains all currently assumed calllees, which might grow over
   /// time.

--- a/llvm/test/ThinLTO/X86/Inputs/callees-metadata-malformed.ll
+++ b/llvm/test/ThinLTO/X86/Inputs/callees-metadata-malformed.ll
@@ -1,0 +1,13 @@
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+define void @callee(ptr %target) {
+  call void %target(), !callees !0
+  ret void
+}
+
+define internal void @metadata_only_target() {
+  ret void
+}
+
+!0 = !{ptr @metadata_only_target, ptr null}

--- a/llvm/test/ThinLTO/X86/callees-metadata-malformed.ll
+++ b/llvm/test/ThinLTO/X86/callees-metadata-malformed.ll
@@ -1,0 +1,23 @@
+; RUN: opt -module-summary %s -o %t1.bc
+; RUN: opt -module-summary %p/Inputs/callees-metadata-malformed.ll -o %t2.bc
+; RUN: llvm-lto2 run %t1.bc %t2.bc -o %t.o -save-temps \
+; RUN:     -r=%t1.bc,caller,plx \
+; RUN:     -r=%t1.bc,callee,l \
+; RUN:     -r=%t2.bc,callee,pl
+; RUN: llvm-dis %t.o.1.3.import.bc -o - | FileCheck %s
+
+; A mixed malformed !callees node must not add an edge for its valid-looking
+; operand to the module summary.
+
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+; CHECK: define available_externally void @callee
+; CHECK-NOT: define {{.*}} @metadata_only_target
+
+define void @caller(ptr %target) {
+  call void @callee(ptr %target)
+  ret void
+}
+
+declare void @callee(ptr)

--- a/llvm/test/Transforms/Attributor/callees-metadata-external-roundtrip.ll
+++ b/llvm/test/Transforms/Attributor/callees-metadata-external-roundtrip.ll
@@ -1,0 +1,25 @@
+; RUN: opt -passes=attributor -S %s | FileCheck %s
+
+target triple = "amdgcn-amd-amdhsa"
+
+; The host may read @h and later pass or store that pointer for @k. Semantic
+; !callees is the authority for this external round trip; the absence of an
+; in-module use path from @f to %p cannot erase the call and its volatile side
+; effect.
+@h = protected constant ptr @f
+@sink = protected global i32 0
+@llvm.used = appending global [1 x ptr] [ptr @h], section "llvm.metadata"
+
+define hidden void @f() noinline {
+  store volatile i32 1, ptr @sink
+  ret void
+}
+
+define amdgpu_kernel void @k(ptr %p) {
+; CHECK-LABEL: define amdgpu_kernel void @k(
+; CHECK: call void @f()
+  call void %p(), !callees !0
+  ret void
+}
+
+!0 = !{ptr @f}

--- a/llvm/test/Transforms/Attributor/callees-metadata-malformed.ll
+++ b/llvm/test/Transforms/Attributor/callees-metadata-malformed.ll
@@ -1,0 +1,33 @@
+; RUN: opt -passes='globaldce,attributor' -S %s | FileCheck %s
+
+; A function referenced only by metadata can be deleted, leaving a raw null
+; operand behind. The resulting malformed !callees attachment must be ignored
+; rather than interpreted as an exhaustive empty set.
+
+define void @caller(ptr %callee) {
+; CHECK-LABEL: define void @caller(
+; CHECK:         call void %callee(), !callees ![[CALLEES:[0-9]+]]
+; CHECK-NEXT:    ret void
+  call void %callee(), !callees !0
+  ret void
+}
+
+define internal void @metadata_only_target() {
+  ret void
+}
+
+; CHECK-NOT: define internal void @metadata_only_target
+
+; A well-formed empty attachment is an exhaustive empty set. Reaching the call
+; is therefore undefined, and Attributor may make the call site unreachable.
+define void @empty_callees(ptr %callee) {
+; CHECK-LABEL: define void @empty_callees(
+; CHECK-NEXT:    unreachable
+  call void %callee(), !callees !1
+  ret void
+}
+
+; CHECK: ![[CALLEES]] = distinct !{null}
+
+!0 = !{ptr @metadata_only_target}
+!1 = !{}

--- a/llvm/test/tools/llvm-split/AMDGPU/kernels-dependency-indirect-callee-md.ll
+++ b/llvm/test/tools/llvm-split/AMDGPU/kernels-dependency-indirect-callee-md.ll
@@ -8,6 +8,17 @@
 ; RUN: llvm-dis -o - %t-nomd1 | FileCheck --check-prefix=CHECK-NOMD1 --implicit-check-not=define %s
 ; RUN: llvm-dis -o - %t-nomd2 | FileCheck --check-prefix=CHECK-NOMD2 --implicit-check-not=define %s
 
+; A malformed attachment must behave like an absent attachment. In particular,
+; do not retain the valid-looking prefix of a mixed node.
+; RUN: sed 's/_MD_/, !callees !{ptr @CallCandidate0, ptr null}/g' %s | \
+; RUN:   llvm-split -o %t-malformed -j 3 -mtriple amdgpu-amd-amdhsa
+; RUN: llvm-dis -o - %t-malformed0 | \
+; RUN:   FileCheck --check-prefix=CHECK-NOMD0 --implicit-check-not=define %s
+; RUN: llvm-dis -o - %t-malformed1 | \
+; RUN:   FileCheck --check-prefix=CHECK-NOMD1 --implicit-check-not=define %s
+; RUN: llvm-dis -o - %t-malformed2 | \
+; RUN:   FileCheck --check-prefix=CHECK-NOMD2 --implicit-check-not=define %s
+
 ; CHECK0: define internal void @HelperC
 ; CHECK0: define amdgpu_kernel void @C
 

--- a/llvm/unittests/IR/InstructionsTest.cpp
+++ b/llvm/unittests/IR/InstructionsTest.cpp
@@ -174,13 +174,16 @@ TEST(InstructionsTest, CalleesMetadataDecoding) {
   MDNode *Valid = MDB.createCallees({Target0});
   Direct->setMetadata(LLVMContext::MD_callees, Valid);
   Callees.push_back(Target1);
-  EXPECT_FALSE(Direct->getCalleesMetadata(Callees));
-  EXPECT_TRUE(Callees.empty());
+  ASSERT_TRUE(Direct->getCalleesMetadata(Callees));
+  ASSERT_EQ(Callees.size(), 1u);
+  EXPECT_EQ(Callees[0], Target0);
 
+  // Decoding validates the attachment, not the identity of the called operand.
   InlineAsmCall->setMetadata(LLVMContext::MD_callees, Valid);
   Callees.push_back(Target1);
-  EXPECT_FALSE(InlineAsmCall->getCalleesMetadata(Callees));
-  EXPECT_TRUE(Callees.empty());
+  ASSERT_TRUE(InlineAsmCall->getCalleesMetadata(Callees));
+  ASSERT_EQ(Callees.size(), 1u);
+  EXPECT_EQ(Callees[0], Target0);
 
   Function *Invoker =
       Function::Create(CallerTy, GlobalValue::ExternalLinkage, "invoker", M);
@@ -197,6 +200,59 @@ TEST(InstructionsTest, CalleesMetadataDecoding) {
   ASSERT_EQ(Callees.size(), 2u);
   EXPECT_EQ(Callees[0], Target1);
   EXPECT_EQ(Callees[1], Target0);
+}
+
+TEST(InstructionsTest, CalleesMetadataSurvivesCalleeSimplification) {
+  LLVMContext C;
+  Module M("test", C);
+  FunctionType *CalleeTy = FunctionType::get(Type::getVoidTy(C), false);
+  Function *Allowed =
+      Function::Create(CalleeTy, GlobalValue::ExternalLinkage, "allowed", M);
+  Function *Excluded =
+      Function::Create(CalleeTy, GlobalValue::ExternalLinkage, "excluded", M);
+  FunctionType *CallerTy =
+      FunctionType::get(Type::getVoidTy(C), PointerType::getUnqual(C), false);
+  Function *Caller =
+      Function::Create(CallerTy, GlobalValue::ExternalLinkage, "caller", M);
+  BasicBlock *Entry = BasicBlock::Create(C, "entry", Caller);
+  CallInst *Call = CallInst::Create(CalleeTy, Caller->getArg(0), {}, "", Entry);
+  ReturnInst::Create(C, Entry);
+
+  MDBuilder MDB(C);
+  MDNode *MD = MDB.createCallees({Allowed});
+  Call->setMetadata(LLVMContext::MD_callees, MD);
+  SmallVector<Function *, 4> Callees;
+  auto CheckList = [&] {
+    ASSERT_TRUE(Call->getCalleesMetadata(Callees));
+    ASSERT_EQ(Callees.size(), 1u);
+    EXPECT_EQ(Callees[0], Allowed);
+    EXPECT_EQ(Call->getMetadata(LLVMContext::MD_callees), MD);
+  };
+  ASSERT_TRUE(Call->isIndirectCall());
+  CheckList();
+
+  // A proven direct target in the list satisfies the unchanged constraint.
+  Call->setCalledOperand(Allowed);
+  ASSERT_FALSE(Call->isIndirectCall());
+  CheckList();
+
+  // Executing this call would be UB, but the attachment is still well-formed.
+  // The decoder must not discard it when simplification exposes the mismatch.
+  Call->setCalledOperand(Excluded);
+  CheckList();
+
+  // Other constant operands must not erase the constraint either.
+  Call->setCalledOperand(ConstantPointerNull::get(PointerType::getUnqual(C)));
+  CheckList();
+
+  // Empty is still distinct from absence after a call becomes direct.
+  Call->setCalledOperand(Allowed);
+  Call->setMetadata(LLVMContext::MD_callees, MDNode::get(C, {}));
+  EXPECT_TRUE(Call->getCalleesMetadata(Callees));
+  EXPECT_TRUE(Callees.empty());
+  Call->setMetadata(LLVMContext::MD_callees, nullptr);
+  EXPECT_FALSE(Call->getCalleesMetadata(Callees));
+  EXPECT_TRUE(Callees.empty());
 }
 
 TEST(InstructionsTest, CalleesMetadataRejectsMalformedOperands) {

--- a/llvm/unittests/IR/InstructionsTest.cpp
+++ b/llvm/unittests/IR/InstructionsTest.cpp
@@ -20,7 +20,11 @@
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/FPEnv.h"
 #include "llvm/IR/Function.h"
+#include "llvm/IR/GlobalAlias.h"
+#include "llvm/IR/GlobalIFunc.h"
+#include "llvm/IR/GlobalVariable.h"
 #include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/InlineAsm.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/MDBuilder.h"
 #include "llvm/IR/Module.h"
@@ -128,6 +132,136 @@ TEST_F(ModuleWithFunctionTest, InvokeInst) {
     EXPECT_EQ(Invoke->getArgOperand(Idx)->getType(), Arg->getType());
     Idx++;
   }
+}
+
+TEST(InstructionsTest, CalleesMetadataDecoding) {
+  LLVMContext C;
+  Module M("test", C);
+  FunctionType *CalleeTy = FunctionType::get(Type::getVoidTy(C), false);
+  Function *Target0 =
+      Function::Create(CalleeTy, GlobalValue::ExternalLinkage, "target0", M);
+  Function *Target1 =
+      Function::Create(CalleeTy, GlobalValue::ExternalLinkage, "target1", M);
+
+  FunctionType *CallerTy =
+      FunctionType::get(Type::getVoidTy(C), PointerType::getUnqual(C), false);
+  Function *Caller =
+      Function::Create(CallerTy, GlobalValue::ExternalLinkage, "caller", M);
+  BasicBlock *Entry = BasicBlock::Create(C, "entry", Caller);
+  CallInst *Indirect =
+      CallInst::Create(CalleeTy, Caller->getArg(0), {}, "", Entry);
+  CallInst *Direct = CallInst::Create(Target0, {}, "", Entry);
+  InlineAsm *Asm = InlineAsm::get(CalleeTy, "", "", true);
+  CallInst *InlineAsmCall = CallInst::Create(CalleeTy, Asm, {}, "", Entry);
+  ReturnInst::Create(C, Entry);
+
+  SmallVector<Function *, 4> Callees = {Target0};
+  EXPECT_FALSE(Indirect->getCalleesMetadata(Callees));
+  EXPECT_TRUE(Callees.empty());
+
+  Indirect->setMetadata(LLVMContext::MD_callees, MDNode::get(C, {}));
+  EXPECT_TRUE(Indirect->getCalleesMetadata(Callees));
+  EXPECT_TRUE(Callees.empty());
+
+  MDBuilder MDB(C);
+  Indirect->setMetadata(LLVMContext::MD_callees,
+                        MDB.createCallees({Target0, Target1, Target0}));
+  ASSERT_TRUE(Indirect->getCalleesMetadata(Callees));
+  ASSERT_EQ(Callees.size(), 2u);
+  EXPECT_EQ(Callees[0], Target0);
+  EXPECT_EQ(Callees[1], Target1);
+
+  MDNode *Valid = MDB.createCallees({Target0});
+  Direct->setMetadata(LLVMContext::MD_callees, Valid);
+  Callees.push_back(Target1);
+  EXPECT_FALSE(Direct->getCalleesMetadata(Callees));
+  EXPECT_TRUE(Callees.empty());
+
+  InlineAsmCall->setMetadata(LLVMContext::MD_callees, Valid);
+  Callees.push_back(Target1);
+  EXPECT_FALSE(InlineAsmCall->getCalleesMetadata(Callees));
+  EXPECT_TRUE(Callees.empty());
+
+  Function *Invoker =
+      Function::Create(CallerTy, GlobalValue::ExternalLinkage, "invoker", M);
+  BasicBlock *InvokeEntry = BasicBlock::Create(C, "entry", Invoker);
+  BasicBlock *Normal = BasicBlock::Create(C, "normal", Invoker);
+  BasicBlock *Unwind = BasicBlock::Create(C, "unwind", Invoker);
+  InvokeInst *Invoke = InvokeInst::Create(CalleeTy, Invoker->getArg(0), Normal,
+                                          Unwind, {}, "", InvokeEntry);
+  ReturnInst::Create(C, Normal);
+  new UnreachableInst(C, Unwind);
+  Invoke->setMetadata(LLVMContext::MD_callees,
+                      MDB.createCallees({Target1, Target0}));
+  ASSERT_TRUE(Invoke->getCalleesMetadata(Callees));
+  ASSERT_EQ(Callees.size(), 2u);
+  EXPECT_EQ(Callees[0], Target1);
+  EXPECT_EQ(Callees[1], Target0);
+}
+
+TEST(InstructionsTest, CalleesMetadataRejectsMalformedOperands) {
+  LLVMContext C;
+  Module M("test", C);
+  FunctionType *CalleeTy = FunctionType::get(Type::getVoidTy(C), false);
+  Function *Target =
+      Function::Create(CalleeTy, GlobalValue::ExternalLinkage, "target", M);
+  FunctionType *CallerTy =
+      FunctionType::get(Type::getVoidTy(C), PointerType::getUnqual(C), false);
+  Function *Caller =
+      Function::Create(CallerTy, GlobalValue::ExternalLinkage, "caller", M);
+  BasicBlock *Entry = BasicBlock::Create(C, "entry", Caller);
+  CallInst *Indirect =
+      CallInst::Create(CalleeTy, Caller->getArg(0), {}, "", Entry);
+  ReturnInst::Create(C, Entry);
+
+  auto *Global =
+      new GlobalVariable(M, Type::getInt8Ty(C), false,
+                         GlobalValue::ExternalLinkage, nullptr, "global");
+  GlobalAlias *Alias = GlobalAlias::create(
+      Target->getType(), 0, GlobalValue::ExternalLinkage, "alias", Target, &M);
+  GlobalIFunc *IFunc = GlobalIFunc::create(
+      Target->getType(), 0, GlobalValue::ExternalLinkage, "ifunc", Target, &M);
+
+  SmallVector<Function *, 4> Callees;
+  auto CheckMalformed = [&](StringRef Name, Metadata *BadOperand) {
+    SCOPED_TRACE(Name);
+    Metadata *Operands[] = {ConstantAsMetadata::get(Target), BadOperand};
+    Indirect->setMetadata(LLVMContext::MD_callees, MDNode::get(C, Operands));
+    Callees.push_back(Target);
+    EXPECT_FALSE(Indirect->getCalleesMetadata(Callees));
+    EXPECT_TRUE(Callees.empty());
+  };
+
+  CheckMalformed("raw null", nullptr);
+  CheckMalformed("typed null", ConstantAsMetadata::get(ConstantPointerNull::get(
+                                   PointerType::getUnqual(C))));
+  CheckMalformed("undef", ConstantAsMetadata::get(
+                              UndefValue::get(PointerType::getUnqual(C))));
+  CheckMalformed("poison", ConstantAsMetadata::get(
+                               PoisonValue::get(PointerType::getUnqual(C))));
+  CheckMalformed("global", ConstantAsMetadata::get(Global));
+  CheckMalformed("alias", ConstantAsMetadata::get(Alias));
+  CheckMalformed("ifunc", ConstantAsMetadata::get(IFunc));
+  CheckMalformed("constant expression",
+                 ConstantAsMetadata::get(
+                     ConstantExpr::getPtrToInt(Target, Type::getInt64Ty(C))));
+  CheckMalformed("integer", ConstantAsMetadata::get(
+                                ConstantInt::get(Type::getInt32Ty(C), 0)));
+  CheckMalformed("string", MDString::get(C, "not a function"));
+  CheckMalformed("nested node", MDNode::get(C, {}));
+  CheckMalformed("local value", ValueAsMetadata::get(Caller->getArg(0)));
+
+  Function *DeletedTarget =
+      Function::Create(CalleeTy, GlobalValue::ExternalLinkage, "deleted", M);
+  Indirect->setMetadata(
+      LLVMContext::MD_callees,
+      MDNode::getDistinct(C, ConstantAsMetadata::get(DeletedTarget)));
+  DeletedTarget->eraseFromParent();
+  ASSERT_EQ(Indirect->getMetadata(LLVMContext::MD_callees)->getOperand(0).get(),
+            nullptr);
+  Callees.push_back(Target);
+  EXPECT_FALSE(Indirect->getCalleesMetadata(Callees));
+  EXPECT_TRUE(Callees.empty());
 }
 
 TEST(InstructionsTest, UncondBrInst) {

--- a/llvm/unittests/IR/InstructionsTest.cpp
+++ b/llvm/unittests/IR/InstructionsTest.cpp
@@ -178,12 +178,15 @@ TEST(InstructionsTest, CalleesMetadataDecoding) {
   ASSERT_EQ(Callees.size(), 1u);
   EXPECT_EQ(Callees[0], Target0);
 
-  // Decoding validates the attachment, not the identity of the called operand.
   InlineAsmCall->setMetadata(LLVMContext::MD_callees, Valid);
   Callees.push_back(Target1);
-  ASSERT_TRUE(InlineAsmCall->getCalleesMetadata(Callees));
-  ASSERT_EQ(Callees.size(), 1u);
-  EXPECT_EQ(Callees[0], Target0);
+  EXPECT_FALSE(InlineAsmCall->getCalleesMetadata(Callees));
+  EXPECT_TRUE(Callees.empty());
+
+  InlineAsmCall->setMetadata(LLVMContext::MD_callees, MDNode::get(C, {}));
+  Callees.push_back(Target1);
+  EXPECT_FALSE(InlineAsmCall->getCalleesMetadata(Callees));
+  EXPECT_TRUE(Callees.empty());
 
   Function *Invoker =
       Function::Create(CallerTy, GlobalValue::ExternalLinkage, "invoker", M);


### PR DESCRIPTION
`!callees` constrains the possible targets of a call, but the LangRef does not
define the empty case or say how a malformed attachment must be handled.
Existing consumers consequently decode the metadata differently: some skip a
non-function operand and consume the rest of the list as if it were still
exhaustive, and the `mdconst::extract_or_null` users assert on any constant
operand that is not a `Function`.

This patch defines the following behavior:

* The operands form an exhaustive set of possible callees. The set may be
  conservative, and operand order and duplication are not significant.
* Whether the called operand is a constant does not matter. A direct call to a
  function outside the set is undefined; if the direct target is in the set,
  the attachment is redundant and may be dropped.
* An empty node is an empty set, so executing the call is undefined.
* Absent metadata provides no information.
* If any operand does not refer to a `Function`, the whole attachment provides
  no information and must be ignored. Dropping only the bad operand is unsound:
  `!{ptr @a, ptr @b}` becomes `!{ptr @a, null}` when GlobalDCE removes a
  declaration referenced only through metadata, and the remaining list is no
  longer exhaustive.
* Attachments on inline assembly calls are ignored.

`CallBase::getCalleesMetadata` is the common fail-closed decoder. It
distinguishes an empty set from absence, removes duplicates while preserving
first-occurrence order, clears its result on failure, and does not check
whether the called operand satisfies the constraint.

Module summary analysis, Attributor, and AMDGPU module splitting now use the
decoder. Their behavior changes only for malformed attachments, which are now
treated as absent instead of being partially consumed or asserting.

Tests cover absent, empty, duplicate, malformed, deleted-function,
direct-call, inline-assembly, call, and invoke decoding; the constraint
surviving replacement of the called operand by a constant; Attributor handling
of an empty set and of deleted targets, including a mixed list where GlobalDCE
removes a declaration while another target remains live; ThinLTO summary
construction; and AMDGPU module splitting. The mixed-list regression checks
that Attributor preserves the indirect call instead of treating the surviving
target as exhaustive.

This is part 1 of a planned six-patch series enabling finite resource bounds
for eligible AMDGPU indirect calls using exhaustive `!callees` information.
This patch defines the generic IR contract and fixes existing consumers
independently. Follow-ups cover IR preservation, a generic machine-level
carrier, SelectionDAG/GlobalISel transport, and AMDGPU resource analysis. The
independent resource-cycle prerequisite is #221625.