### PR TITLE
[libFuzzer] Clamp `ConsumeFloatingPointInRange` result to `max`

### DIFF
--- a/compiler-rt/include/fuzzer/FuzzedDataProvider.h
+++ b/compiler-rt/include/fuzzer/FuzzedDataProvider.h
@@ -267,7 +267,7 @@ T FuzzedDataProvider::ConsumeFloatingPointInRange(T min, T max) {
 
   result += range * ConsumeProbability<T>();
 
-  // Rounding can push the resul above |max|, although never below |min|. Clamp
+  // Rounding can push the result above |max|, although never below |min|. Clamp
   // it.
   if (result > max)
     return max;

--- a/compiler-rt/include/fuzzer/FuzzedDataProvider.h
+++ b/compiler-rt/include/fuzzer/FuzzedDataProvider.h
@@ -265,7 +265,12 @@ T FuzzedDataProvider::ConsumeFloatingPointInRange(T min, T max) {
     range = max - min;
   }
 
-  return result + range * ConsumeProbability<T>();
+  result += range * ConsumeProbability<T>();
+
+  // Rounding can push the resul above |max|, although never below |min|. Clamp it.
+  if (result > max)
+    return max;
+  return result;
 }
 
 // Returns a floating point number in the range [0.0, 1.0]. If there's no

--- a/compiler-rt/include/fuzzer/FuzzedDataProvider.h
+++ b/compiler-rt/include/fuzzer/FuzzedDataProvider.h
@@ -267,7 +267,8 @@ T FuzzedDataProvider::ConsumeFloatingPointInRange(T min, T max) {
 
   result += range * ConsumeProbability<T>();
 
-  // Rounding can push the resul above |max|, although never below |min|. Clamp it.
+  // Rounding can push the resul above |max|, although never below |min|. Clamp
+  // it.
   if (result > max)
     return max;
   return result;

--- a/compiler-rt/lib/fuzzer/tests/FuzzedDataProviderUnittest.cpp
+++ b/compiler-rt/lib/fuzzer/tests/FuzzedDataProviderUnittest.cpp
@@ -425,6 +425,33 @@ TEST(FuzzedDataProvider, ConsumeFloatingPoint) {
                                        -13.37, 31.337));
 }
 
+TEST(FuzzedDataProvider, ConsumeFloatingPointInRangeUpperBound) {
+  const std::vector<uint8_t> AllOnes(32, 0xff);
+  FuzzedDataProvider DataProv(AllOnes.data(), AllOnes.size());
+
+  // |max - min| overflows, and min + range + range overflows to infinity.
+  EXPECT_EQ(std::numeric_limits<float>::max(),
+            DataProv.ConsumeFloatingPointInRange<float>(
+                float(-1.3036394e+38), std::numeric_limits<float>::max()));
+  EXPECT_EQ(std::numeric_limits<double>::max(),
+            DataProv.ConsumeFloatingPointInRange<double>(
+                double(-1.3036394035928049e+308),
+                std::numeric_limits<double>::max()));
+
+  // |max - min| overflows, and the result is finite but above |max|.
+  EXPECT_EQ(float(2.2690335e+37),
+            DataProv.ConsumeFloatingPointInRange<float>(float(-3.1759686e+38),
+                                                        float(2.2690335e+37)));
+
+  // |max - min| does not overflow, but rounds to -min, so min + range is 0.
+  EXPECT_EQ(float(-1.0), DataProv.ConsumeFloatingPointInRange<float>(
+                             float(-1e20), float(-1.0)));
+  EXPECT_EQ(double(-1.0), DataProv.ConsumeFloatingPointInRange<double>(
+                              double(-1e30), double(-1.0)));
+
+  EXPECT_EQ(size_t(1), DataProv.remaining_bytes());
+}
+
 TEST(FuzzedDataProvider, ConsumeData) {
   FuzzedDataProvider DataProv(Data, sizeof(Data));
   uint8_t Buffer[10] = {};


### PR DESCRIPTION
Fixes #65312. Floating point rounding could push the result above `max`, or even overflow to infinity, so we clamp it instead.