### PR TITLE
VE: Compute live-ins after splitting for EXTEND_STACK expansion

### DIFF
--- a/llvm/lib/Target/VE/VEInstrInfo.cpp
+++ b/llvm/lib/Target/VE/VEInstrInfo.cpp
@@ -16,6 +16,7 @@
 #include "VESubtarget.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/CodeGen/LivePhysRegs.h"
 #include "llvm/CodeGen/MachineFrameInfo.h"
 #include "llvm/CodeGen/MachineInstrBuilder.h"
 #include "llvm/CodeGen/MachineMemOperand.h"
@@ -1074,6 +1075,10 @@ bool VEInstrInfo::expandExtendStackPseudo(MachineInstr &MI) const {
       .addImm(0);
 
   MI.eraseFromParent(); // The pseudo instruction is gone now.
+
+  LivePhysRegs LiveRegs;
+  computeAndAddLiveIns(LiveRegs, *sinkMBB);
+  computeAndAddLiveIns(LiveRegs, *syscallMBB);
   return true;
 }
 

--- a/llvm/test/CodeGen/VE/Scalar/builtin_sjlj.ll
+++ b/llvm/test/CodeGen/VE/Scalar/builtin_sjlj.ll
@@ -1,5 +1,5 @@
-; RUN: llc < %s -mtriple=ve | FileCheck %s
-; RUN: llc < %s -mtriple=ve -relocation-model=pic | \
+; RUN: llc < %s -mtriple=ve -verify-machineinstrs | FileCheck %s
+; RUN: llc < %s -mtriple=ve -relocation-model=pic -verify-machineinstrs | \
 ; RUN:     FileCheck %s -check-prefix=PIC
 
 %struct.__jmp_buf_tag = type { [25 x i64], i64, [16 x i64] }


### PR DESCRIPTION
expandExtendStackPseudo splits its block but left the new blocks without
live-in lists, so their uses of registers live across the split are
rejected by -verify-machineinstrs.

Co-authored-by: Claude (Claude-Opus-4.8)