### PR TITLE
VE: Use splitAt in expandExtendStackPseudo

### DIFF
--- a/llvm/lib/Target/VE/VEInstrInfo.cpp
+++ b/llvm/lib/Target/VE/VEInstrInfo.cpp
@@ -1019,21 +1019,19 @@ bool VEInstrInfo::expandExtendStackPseudo(MachineInstr &MI) const {
   // Create new MBB
   MachineBasicBlock *BB = &MBB;
   const BasicBlock *LLVM_BB = BB->getBasicBlock();
+
+  // EXTEND_STACK and its guard pseudo (the instruction after MI) stay in BB;
+  // everything past them moves to sinkMBB.
+  MachineInstr &GuardMI = *std::next(MachineBasicBlock::iterator(MI));
+  MachineBasicBlock *sinkMBB = BB->splitAt(GuardMI, /*UpdateLiveIns=*/true);
+
+  // Insert the syscall block between BB and sinkMBB so it falls through.
   MachineBasicBlock *syscallMBB = MF.CreateMachineBasicBlock(LLVM_BB);
-  MachineBasicBlock *sinkMBB = MF.CreateMachineBasicBlock(LLVM_BB);
-  MachineFunction::iterator It = ++(BB->getIterator());
-  MF.insert(It, syscallMBB);
-  MF.insert(It, sinkMBB);
+  MF.insert(++BB->getIterator(), syscallMBB);
 
-  // Transfer the remainder of BB and its successor edges to sinkMBB.
-  sinkMBB->splice(sinkMBB->begin(), BB,
-                  std::next(std::next(MachineBasicBlock::iterator(MI))),
-                  BB->end());
-  sinkMBB->transferSuccessorsAndUpdatePHIs(BB);
-
-  // Next, add the true and fallthrough blocks as its successors.
+  // BB branches to sinkMBB when the stack is already large enough, and
+  // otherwise falls through to syscallMBB.
   BB->addSuccessor(syscallMBB);
-  BB->addSuccessor(sinkMBB);
   BuildMI(BB, dl, TII.get(VE::BRCFLrr_t))
       .addImm(VECC::CC_IGE)
       .addReg(VE::SX11) // %sp
@@ -1077,7 +1075,6 @@ bool VEInstrInfo::expandExtendStackPseudo(MachineInstr &MI) const {
   MI.eraseFromParent(); // The pseudo instruction is gone now.
 
   LivePhysRegs LiveRegs;
-  computeAndAddLiveIns(LiveRegs, *sinkMBB);
   computeAndAddLiveIns(LiveRegs, *syscallMBB);
   return true;
 }

--- a/llvm/test/CodeGen/VE/Scalar/alloca.ll
+++ b/llvm/test/CodeGen/VE/Scalar/alloca.ll
@@ -5,7 +5,7 @@ declare void @bar(ptr, i64)
 ; Function Attrs: nounwind
 define void @test(i64 %n) {
 ; CHECK-LABEL: test:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    or %s1, 0, %s0
 ; CHECK-NEXT:    lea %s0, 15(, %s0)
 ; CHECK-NEXT:    and %s0, -16, %s0

--- a/llvm/test/CodeGen/VE/Scalar/alloca_aligned.ll
+++ b/llvm/test/CodeGen/VE/Scalar/alloca_aligned.ll
@@ -5,7 +5,7 @@ declare void @bar(ptr, i64)
 ; Function Attrs: nounwind
 define void @test(i64 %n) {
 ; CHECK-LABEL: test:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    or %s2, 0, %s0
 ; CHECK-NEXT:    lea %s0, 15(, %s0)
 ; CHECK-NEXT:    and %s0, -16, %s0

--- a/llvm/test/CodeGen/VE/Scalar/atomic_cmp_swap.ll
+++ b/llvm/test/CodeGen/VE/Scalar/atomic_cmp_swap.ll
@@ -431,8 +431,8 @@ define i128 @_Z28atomic_cmp_swap_relaxed_i128RNSt3__16atomicInEERnn(ptr nonnull 
 ; CHECK-NEXT:    st %s10, 8(, %s11)
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    lea %s11, -256(, %s11)
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB9_2
-; CHECK-NEXT:  # %bb.1: # %bb
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB9_1
+; CHECK-NEXT:  # %bb.2: # %bb
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -441,7 +441,7 @@ define i128 @_Z28atomic_cmp_swap_relaxed_i128RNSt3__16atomicInEERnn(ptr nonnull 
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB9_2: # %bb
+; CHECK-NEXT:  .LBB9_1: # %bb
 ; CHECK-NEXT:    or %s6, 0, %s1
 ; CHECK-NEXT:    or %s1, 0, %s0
 ; CHECK-NEXT:    st %s3, 248(, %s11)
@@ -478,8 +478,8 @@ define i128 @_Z28atomic_cmp_swap_relaxed_u128RNSt3__16atomicIoEERoo(ptr nonnull 
 ; CHECK-NEXT:    st %s10, 8(, %s11)
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    lea %s11, -256(, %s11)
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB10_2
-; CHECK-NEXT:  # %bb.1: # %bb
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB10_1
+; CHECK-NEXT:  # %bb.2: # %bb
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -488,7 +488,7 @@ define i128 @_Z28atomic_cmp_swap_relaxed_u128RNSt3__16atomicIoEERoo(ptr nonnull 
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB10_2: # %bb
+; CHECK-NEXT:  .LBB10_1: # %bb
 ; CHECK-NEXT:    or %s6, 0, %s1
 ; CHECK-NEXT:    or %s1, 0, %s0
 ; CHECK-NEXT:    st %s3, 248(, %s11)
@@ -880,8 +880,8 @@ define i128 @_Z28atomic_cmp_swap_acquire_i128RNSt3__16atomicInEERnn(ptr nonnull 
 ; CHECK-NEXT:    st %s10, 8(, %s11)
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    lea %s11, -256(, %s11)
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB20_2
-; CHECK-NEXT:  # %bb.1: # %bb
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB20_1
+; CHECK-NEXT:  # %bb.2: # %bb
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -890,7 +890,7 @@ define i128 @_Z28atomic_cmp_swap_acquire_i128RNSt3__16atomicInEERnn(ptr nonnull 
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB20_2: # %bb
+; CHECK-NEXT:  .LBB20_1: # %bb
 ; CHECK-NEXT:    or %s6, 0, %s1
 ; CHECK-NEXT:    or %s1, 0, %s0
 ; CHECK-NEXT:    st %s3, 248(, %s11)
@@ -927,8 +927,8 @@ define i128 @_Z28atomic_cmp_swap_acquire_u128RNSt3__16atomicIoEERoo(ptr nonnull 
 ; CHECK-NEXT:    st %s10, 8(, %s11)
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    lea %s11, -256(, %s11)
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB21_2
-; CHECK-NEXT:  # %bb.1: # %bb
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB21_1
+; CHECK-NEXT:  # %bb.2: # %bb
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -937,7 +937,7 @@ define i128 @_Z28atomic_cmp_swap_acquire_u128RNSt3__16atomicIoEERoo(ptr nonnull 
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB21_2: # %bb
+; CHECK-NEXT:  .LBB21_1: # %bb
 ; CHECK-NEXT:    or %s6, 0, %s1
 ; CHECK-NEXT:    or %s1, 0, %s0
 ; CHECK-NEXT:    st %s3, 248(, %s11)
@@ -1338,8 +1338,8 @@ define i128 @_Z28atomic_cmp_swap_seq_cst_i128RNSt3__16atomicInEERnn(ptr nonnull 
 ; CHECK-NEXT:    st %s10, 8(, %s11)
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    lea %s11, -256(, %s11)
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB31_2
-; CHECK-NEXT:  # %bb.1: # %bb
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB31_1
+; CHECK-NEXT:  # %bb.2: # %bb
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -1348,7 +1348,7 @@ define i128 @_Z28atomic_cmp_swap_seq_cst_i128RNSt3__16atomicInEERnn(ptr nonnull 
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB31_2: # %bb
+; CHECK-NEXT:  .LBB31_1: # %bb
 ; CHECK-NEXT:    or %s6, 0, %s1
 ; CHECK-NEXT:    or %s1, 0, %s0
 ; CHECK-NEXT:    st %s3, 248(, %s11)
@@ -1385,8 +1385,8 @@ define i128 @_Z28atomic_cmp_swap_seq_cst_u128RNSt3__16atomicIoEERoo(ptr nonnull 
 ; CHECK-NEXT:    st %s10, 8(, %s11)
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    lea %s11, -256(, %s11)
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB32_2
-; CHECK-NEXT:  # %bb.1: # %bb
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB32_1
+; CHECK-NEXT:  # %bb.2: # %bb
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -1395,7 +1395,7 @@ define i128 @_Z28atomic_cmp_swap_seq_cst_u128RNSt3__16atomicIoEERoo(ptr nonnull 
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB32_2: # %bb
+; CHECK-NEXT:  .LBB32_1: # %bb
 ; CHECK-NEXT:    or %s6, 0, %s1
 ; CHECK-NEXT:    or %s1, 0, %s0
 ; CHECK-NEXT:    st %s3, 248(, %s11)
@@ -1429,8 +1429,8 @@ define zeroext i1 @_Z30atomic_cmp_swap_relaxed_stk_i1Rbb(ptr nocapture nonnull a
 ; CHECK-LABEL: _Z30atomic_cmp_swap_relaxed_stk_i1Rbb:
 ; CHECK:       # %bb.0: # %bb
 ; CHECK-NEXT:    adds.l %s11, -16, %s11
-; CHECK-NEXT:    brge.l %s11, %s8, .LBB33_4
-; CHECK-NEXT:  # %bb.3: # %bb
+; CHECK-NEXT:    brge.l %s11, %s8, .LBB33_3
+; CHECK-NEXT:  # %bb.4: # %bb
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -1439,7 +1439,7 @@ define zeroext i1 @_Z30atomic_cmp_swap_relaxed_stk_i1Rbb(ptr nocapture nonnull a
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB33_4: # %bb
+; CHECK-NEXT:  .LBB33_3: # %bb
 ; CHECK-NEXT:    ld1b.zx %s2, (, %s0)
 ; CHECK-NEXT:    ldl.zx %s3, 8(, %s11)
 ; CHECK-NEXT:    and %s1, %s1, (32)0
@@ -1490,8 +1490,8 @@ define signext i8 @_Z30atomic_cmp_swap_relaxed_stk_i8Rcc(ptr nocapture nonnull a
 ; CHECK-LABEL: _Z30atomic_cmp_swap_relaxed_stk_i8Rcc:
 ; CHECK:       # %bb.0: # %bb
 ; CHECK-NEXT:    adds.l %s11, -16, %s11
-; CHECK-NEXT:    brge.l %s11, %s8, .LBB34_4
-; CHECK-NEXT:  # %bb.3: # %bb
+; CHECK-NEXT:    brge.l %s11, %s8, .LBB34_3
+; CHECK-NEXT:  # %bb.4: # %bb
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -1500,7 +1500,7 @@ define signext i8 @_Z30atomic_cmp_swap_relaxed_stk_i8Rcc(ptr nocapture nonnull a
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB34_4: # %bb
+; CHECK-NEXT:  .LBB34_3: # %bb
 ; CHECK-NEXT:    ld1b.zx %s2, (, %s0)
 ; CHECK-NEXT:    and %s1, %s1, (56)0
 ; CHECK-NEXT:    ldl.zx %s3, 8(, %s11)
@@ -1546,8 +1546,8 @@ define zeroext i8 @_Z30atomic_cmp_swap_relaxed_stk_u8Rhh(ptr nocapture nonnull a
 ; CHECK-LABEL: _Z30atomic_cmp_swap_relaxed_stk_u8Rhh:
 ; CHECK:       # %bb.0: # %bb
 ; CHECK-NEXT:    adds.l %s11, -16, %s11
-; CHECK-NEXT:    brge.l %s11, %s8, .LBB35_4
-; CHECK-NEXT:  # %bb.3: # %bb
+; CHECK-NEXT:    brge.l %s11, %s8, .LBB35_3
+; CHECK-NEXT:  # %bb.4: # %bb
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -1556,7 +1556,7 @@ define zeroext i8 @_Z30atomic_cmp_swap_relaxed_stk_u8Rhh(ptr nocapture nonnull a
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB35_4: # %bb
+; CHECK-NEXT:  .LBB35_3: # %bb
 ; CHECK-NEXT:    ld1b.zx %s2, (, %s0)
 ; CHECK-NEXT:    ldl.zx %s3, 8(, %s11)
 ; CHECK-NEXT:    and %s1, %s1, (32)0
@@ -1601,8 +1601,8 @@ define signext i16 @_Z31atomic_cmp_swap_relaxed_stk_i16Rss(ptr nocapture nonnull
 ; CHECK-LABEL: _Z31atomic_cmp_swap_relaxed_stk_i16Rss:
 ; CHECK:       # %bb.0: # %bb
 ; CHECK-NEXT:    adds.l %s11, -16, %s11
-; CHECK-NEXT:    brge.l %s11, %s8, .LBB36_4
-; CHECK-NEXT:  # %bb.3: # %bb
+; CHECK-NEXT:    brge.l %s11, %s8, .LBB36_3
+; CHECK-NEXT:  # %bb.4: # %bb
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -1611,7 +1611,7 @@ define signext i16 @_Z31atomic_cmp_swap_relaxed_stk_i16Rss(ptr nocapture nonnull
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB36_4: # %bb
+; CHECK-NEXT:  .LBB36_3: # %bb
 ; CHECK-NEXT:    ld2b.zx %s2, (, %s0)
 ; CHECK-NEXT:    and %s1, %s1, (48)0
 ; CHECK-NEXT:    ldl.zx %s3, 8(, %s11)
@@ -1657,8 +1657,8 @@ define zeroext i16 @_Z31atomic_cmp_swap_relaxed_stk_u16Rtt(ptr nocapture nonnull
 ; CHECK-LABEL: _Z31atomic_cmp_swap_relaxed_stk_u16Rtt:
 ; CHECK:       # %bb.0: # %bb
 ; CHECK-NEXT:    adds.l %s11, -16, %s11
-; CHECK-NEXT:    brge.l %s11, %s8, .LBB37_4
-; CHECK-NEXT:  # %bb.3: # %bb
+; CHECK-NEXT:    brge.l %s11, %s8, .LBB37_3
+; CHECK-NEXT:  # %bb.4: # %bb
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -1667,7 +1667,7 @@ define zeroext i16 @_Z31atomic_cmp_swap_relaxed_stk_u16Rtt(ptr nocapture nonnull
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB37_4: # %bb
+; CHECK-NEXT:  .LBB37_3: # %bb
 ; CHECK-NEXT:    ld2b.zx %s2, (, %s0)
 ; CHECK-NEXT:    ldl.zx %s3, 8(, %s11)
 ; CHECK-NEXT:    and %s1, %s1, (32)0
@@ -1712,8 +1712,8 @@ define signext i32 @_Z31atomic_cmp_swap_relaxed_stk_i32Rii(ptr nocapture nonnull
 ; CHECK-LABEL: _Z31atomic_cmp_swap_relaxed_stk_i32Rii:
 ; CHECK:       # %bb.0: # %bb
 ; CHECK-NEXT:    adds.l %s11, -16, %s11
-; CHECK-NEXT:    brge.l %s11, %s8, .LBB38_4
-; CHECK-NEXT:  # %bb.3: # %bb
+; CHECK-NEXT:    brge.l %s11, %s8, .LBB38_3
+; CHECK-NEXT:  # %bb.4: # %bb
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -1722,7 +1722,7 @@ define signext i32 @_Z31atomic_cmp_swap_relaxed_stk_i32Rii(ptr nocapture nonnull
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB38_4: # %bb
+; CHECK-NEXT:  .LBB38_3: # %bb
 ; CHECK-NEXT:    ldl.sx %s3, (, %s0)
 ; CHECK-NEXT:    cas.w %s1, 8(%s11), %s3
 ; CHECK-NEXT:    cmps.w.sx %s4, %s1, %s3
@@ -1759,8 +1759,8 @@ define zeroext i32 @_Z31atomic_cmp_swap_relaxed_stk_u32Rjj(ptr nocapture nonnull
 ; CHECK-LABEL: _Z31atomic_cmp_swap_relaxed_stk_u32Rjj:
 ; CHECK:       # %bb.0: # %bb
 ; CHECK-NEXT:    adds.l %s11, -16, %s11
-; CHECK-NEXT:    brge.l %s11, %s8, .LBB39_4
-; CHECK-NEXT:  # %bb.3: # %bb
+; CHECK-NEXT:    brge.l %s11, %s8, .LBB39_3
+; CHECK-NEXT:  # %bb.4: # %bb
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -1769,7 +1769,7 @@ define zeroext i32 @_Z31atomic_cmp_swap_relaxed_stk_u32Rjj(ptr nocapture nonnull
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB39_4: # %bb
+; CHECK-NEXT:  .LBB39_3: # %bb
 ; CHECK-NEXT:    ldl.sx %s3, (, %s0)
 ; CHECK-NEXT:    cas.w %s1, 8(%s11), %s3
 ; CHECK-NEXT:    cmps.w.sx %s4, %s1, %s3
@@ -1806,8 +1806,8 @@ define i64 @_Z31atomic_cmp_swap_relaxed_stk_i64Rll(ptr nocapture nonnull align 8
 ; CHECK-LABEL: _Z31atomic_cmp_swap_relaxed_stk_i64Rll:
 ; CHECK:       # %bb.0: # %bb
 ; CHECK-NEXT:    adds.l %s11, -16, %s11
-; CHECK-NEXT:    brge.l %s11, %s8, .LBB40_4
-; CHECK-NEXT:  # %bb.3: # %bb
+; CHECK-NEXT:    brge.l %s11, %s8, .LBB40_3
+; CHECK-NEXT:  # %bb.4: # %bb
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -1816,7 +1816,7 @@ define i64 @_Z31atomic_cmp_swap_relaxed_stk_i64Rll(ptr nocapture nonnull align 8
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB40_4: # %bb
+; CHECK-NEXT:  .LBB40_3: # %bb
 ; CHECK-NEXT:    ld %s3, (, %s0)
 ; CHECK-NEXT:    cas.l %s1, 8(%s11), %s3
 ; CHECK-NEXT:    cmps.l %s4, %s1, %s3
@@ -1853,8 +1853,8 @@ define i64 @_Z31atomic_cmp_swap_relaxed_stk_u64Rmm(ptr nocapture nonnull align 8
 ; CHECK-LABEL: _Z31atomic_cmp_swap_relaxed_stk_u64Rmm:
 ; CHECK:       # %bb.0: # %bb
 ; CHECK-NEXT:    adds.l %s11, -16, %s11
-; CHECK-NEXT:    brge.l %s11, %s8, .LBB41_4
-; CHECK-NEXT:  # %bb.3: # %bb
+; CHECK-NEXT:    brge.l %s11, %s8, .LBB41_3
+; CHECK-NEXT:  # %bb.4: # %bb
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -1863,7 +1863,7 @@ define i64 @_Z31atomic_cmp_swap_relaxed_stk_u64Rmm(ptr nocapture nonnull align 8
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB41_4: # %bb
+; CHECK-NEXT:  .LBB41_3: # %bb
 ; CHECK-NEXT:    ld %s3, (, %s0)
 ; CHECK-NEXT:    cas.l %s1, 8(%s11), %s3
 ; CHECK-NEXT:    cmps.l %s4, %s1, %s3
@@ -1903,8 +1903,8 @@ define i128 @_Z32atomic_cmp_swap_relaxed_stk_i128Rnn(ptr nonnull align 16 derefe
 ; CHECK-NEXT:    st %s10, 8(, %s11)
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    lea %s11, -272(, %s11)
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB42_2
-; CHECK-NEXT:  # %bb.1: # %bb
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB42_1
+; CHECK-NEXT:  # %bb.2: # %bb
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -1913,7 +1913,7 @@ define i128 @_Z32atomic_cmp_swap_relaxed_stk_i128Rnn(ptr nonnull align 16 derefe
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB42_2: # %bb
+; CHECK-NEXT:  .LBB42_1: # %bb
 ; CHECK-NEXT:    or %s6, 0, %s0
 ; CHECK-NEXT:    st %s2, 264(, %s11)
 ; CHECK-NEXT:    st %s1, 256(, %s11)
@@ -1953,8 +1953,8 @@ define i128 @_Z32atomic_cmp_swap_relaxed_stk_u128Roo(ptr nonnull align 16 derefe
 ; CHECK-NEXT:    st %s10, 8(, %s11)
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    lea %s11, -272(, %s11)
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB43_2
-; CHECK-NEXT:  # %bb.1: # %bb
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB43_1
+; CHECK-NEXT:  # %bb.2: # %bb
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -1963,7 +1963,7 @@ define i128 @_Z32atomic_cmp_swap_relaxed_stk_u128Roo(ptr nonnull align 16 derefe
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB43_2: # %bb
+; CHECK-NEXT:  .LBB43_1: # %bb
 ; CHECK-NEXT:    or %s6, 0, %s0
 ; CHECK-NEXT:    st %s2, 264(, %s11)
 ; CHECK-NEXT:    st %s1, 256(, %s11)
@@ -2351,8 +2351,8 @@ define i128 @_Z31atomic_cmp_swap_relaxed_gv_i128Rnn(ptr nonnull align 16 derefer
 ; CHECK-NEXT:    st %s10, 8(, %s11)
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    lea %s11, -256(, %s11)
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB53_2
-; CHECK-NEXT:  # %bb.1: # %bb
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB53_1
+; CHECK-NEXT:  # %bb.2: # %bb
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -2361,7 +2361,7 @@ define i128 @_Z31atomic_cmp_swap_relaxed_gv_i128Rnn(ptr nonnull align 16 derefer
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB53_2: # %bb
+; CHECK-NEXT:  .LBB53_1: # %bb
 ; CHECK-NEXT:    or %s6, 0, %s0
 ; CHECK-NEXT:    st %s2, 248(, %s11)
 ; CHECK-NEXT:    st %s1, 240(, %s11)
@@ -2400,8 +2400,8 @@ define i128 @_Z31atomic_cmp_swap_relaxed_gv_u128Roo(ptr nonnull align 16 derefer
 ; CHECK-NEXT:    st %s10, 8(, %s11)
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    lea %s11, -256(, %s11)
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB54_2
-; CHECK-NEXT:  # %bb.1: # %bb
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB54_1
+; CHECK-NEXT:  # %bb.2: # %bb
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -2410,7 +2410,7 @@ define i128 @_Z31atomic_cmp_swap_relaxed_gv_u128Roo(ptr nonnull align 16 derefer
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB54_2: # %bb
+; CHECK-NEXT:  .LBB54_1: # %bb
 ; CHECK-NEXT:    or %s6, 0, %s0
 ; CHECK-NEXT:    st %s2, 248(, %s11)
 ; CHECK-NEXT:    st %s1, 240(, %s11)

--- a/llvm/test/CodeGen/VE/Scalar/atomic_load.ll
+++ b/llvm/test/CodeGen/VE/Scalar/atomic_load.ll
@@ -170,7 +170,7 @@ define i64 @_Z23atomic_load_relaxed_u64RNSt3__16atomicImEE(ptr nocapture nonnull
 ; Function Attrs: nofree nounwind mustprogress
 define i128 @_Z24atomic_load_relaxed_i128RNSt3__16atomicInEE(ptr nonnull align 16 dereferenceable(16) %0) {
 ; CHECK-LABEL: _Z24atomic_load_relaxed_i128RNSt3__16atomicInEE:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    or %s1, 0, %s0
 ; CHECK-NEXT:    lea %s0, __atomic_load@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0
@@ -193,7 +193,7 @@ define i128 @_Z24atomic_load_relaxed_i128RNSt3__16atomicInEE(ptr nonnull align 1
 ; Function Attrs: nofree nounwind mustprogress
 define i128 @_Z24atomic_load_relaxed_u128RNSt3__16atomicIoEE(ptr nonnull align 16 dereferenceable(16) %0) {
 ; CHECK-LABEL: _Z24atomic_load_relaxed_u128RNSt3__16atomicIoEE:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    or %s1, 0, %s0
 ; CHECK-NEXT:    lea %s0, __atomic_load@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0
@@ -318,7 +318,7 @@ define i64 @_Z23atomic_load_acquire_u64RNSt3__16atomicImEE(ptr nocapture nonnull
 ; Function Attrs: nofree nounwind mustprogress
 define i128 @_Z24atomic_load_acquire_i128RNSt3__16atomicInEE(ptr nonnull align 16 dereferenceable(16) %0) {
 ; CHECK-LABEL: _Z24atomic_load_acquire_i128RNSt3__16atomicInEE:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    or %s1, 0, %s0
 ; CHECK-NEXT:    lea %s0, __atomic_load@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0
@@ -341,7 +341,7 @@ define i128 @_Z24atomic_load_acquire_i128RNSt3__16atomicInEE(ptr nonnull align 1
 ; Function Attrs: nofree nounwind mustprogress
 define i128 @_Z24atomic_load_acquire_u128RNSt3__16atomicIoEE(ptr nonnull align 16 dereferenceable(16) %0) {
 ; CHECK-LABEL: _Z24atomic_load_acquire_u128RNSt3__16atomicIoEE:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    or %s1, 0, %s0
 ; CHECK-NEXT:    lea %s0, __atomic_load@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0
@@ -466,7 +466,7 @@ define i64 @_Z23atomic_load_seq_cst_u64RNSt3__16atomicImEE(ptr nocapture nonnull
 ; Function Attrs: nofree nounwind mustprogress
 define i128 @_Z24atomic_load_seq_cst_i128RNSt3__16atomicInEE(ptr nonnull align 16 dereferenceable(16) %0) {
 ; CHECK-LABEL: _Z24atomic_load_seq_cst_i128RNSt3__16atomicInEE:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    or %s1, 0, %s0
 ; CHECK-NEXT:    lea %s0, __atomic_load@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0
@@ -489,7 +489,7 @@ define i128 @_Z24atomic_load_seq_cst_i128RNSt3__16atomicInEE(ptr nonnull align 1
 ; Function Attrs: nofree nounwind mustprogress
 define i128 @_Z24atomic_load_seq_cst_u128RNSt3__16atomicIoEE(ptr nonnull align 16 dereferenceable(16) %0) {
 ; CHECK-LABEL: _Z24atomic_load_seq_cst_u128RNSt3__16atomicIoEE:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    or %s1, 0, %s0
 ; CHECK-NEXT:    lea %s0, __atomic_load@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0
@@ -512,7 +512,7 @@ define i128 @_Z24atomic_load_seq_cst_u128RNSt3__16atomicIoEE(ptr nonnull align 1
 ; Function Attrs: mustprogress
 define zeroext i1 @_Z26atomic_load_relaxed_stk_i1v() {
 ; CHECK-LABEL: _Z26atomic_load_relaxed_stk_i1v:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s0, _Z6fun_i1RNSt3__16atomicIbEE@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0
 ; CHECK-NEXT:    lea.sl %s12, _Z6fun_i1RNSt3__16atomicIbEE@hi(, %s0)
@@ -542,7 +542,7 @@ declare void @llvm.lifetime.end.p0(i64 immarg, ptr nocapture)
 ; Function Attrs: mustprogress
 define signext i8 @_Z26atomic_load_relaxed_stk_i8v() {
 ; CHECK-LABEL: _Z26atomic_load_relaxed_stk_i8v:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s0, _Z6fun_i8RNSt3__16atomicIcEE@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0
 ; CHECK-NEXT:    lea.sl %s12, _Z6fun_i8RNSt3__16atomicIcEE@hi(, %s0)
@@ -563,7 +563,7 @@ declare void @_Z6fun_i8RNSt3__16atomicIcEE(ptr nonnull align 1 dereferenceable(1
 ; Function Attrs: mustprogress
 define zeroext i8 @_Z26atomic_load_relaxed_stk_u8v() {
 ; CHECK-LABEL: _Z26atomic_load_relaxed_stk_u8v:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s0, _Z6fun_u8RNSt3__16atomicIhEE@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0
 ; CHECK-NEXT:    lea.sl %s12, _Z6fun_u8RNSt3__16atomicIhEE@hi(, %s0)
@@ -584,7 +584,7 @@ declare void @_Z6fun_u8RNSt3__16atomicIhEE(ptr nonnull align 1 dereferenceable(1
 ; Function Attrs: mustprogress
 define signext i16 @_Z27atomic_load_relaxed_stk_i16v() {
 ; CHECK-LABEL: _Z27atomic_load_relaxed_stk_i16v:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s0, _Z7fun_i16RNSt3__16atomicIsEE@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0
 ; CHECK-NEXT:    lea.sl %s12, _Z7fun_i16RNSt3__16atomicIsEE@hi(, %s0)
@@ -605,7 +605,7 @@ declare void @_Z7fun_i16RNSt3__16atomicIsEE(ptr nonnull align 2 dereferenceable(
 ; Function Attrs: mustprogress
 define zeroext i16 @_Z27atomic_load_relaxed_stk_u16v() {
 ; CHECK-LABEL: _Z27atomic_load_relaxed_stk_u16v:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s0, _Z7fun_u16RNSt3__16atomicItEE@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0
 ; CHECK-NEXT:    lea.sl %s12, _Z7fun_u16RNSt3__16atomicItEE@hi(, %s0)
@@ -626,7 +626,7 @@ declare void @_Z7fun_u16RNSt3__16atomicItEE(ptr nonnull align 2 dereferenceable(
 ; Function Attrs: mustprogress
 define signext i32 @_Z27atomic_load_relaxed_stk_i32v() {
 ; CHECK-LABEL: _Z27atomic_load_relaxed_stk_i32v:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s0, _Z7fun_i32RNSt3__16atomicIiEE@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0
 ; CHECK-NEXT:    lea.sl %s12, _Z7fun_i32RNSt3__16atomicIiEE@hi(, %s0)
@@ -647,7 +647,7 @@ declare void @_Z7fun_i32RNSt3__16atomicIiEE(ptr nonnull align 4 dereferenceable(
 ; Function Attrs: mustprogress
 define zeroext i32 @_Z27atomic_load_relaxed_stk_u32v() {
 ; CHECK-LABEL: _Z27atomic_load_relaxed_stk_u32v:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s0, _Z7fun_u32RNSt3__16atomicIjEE@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0
 ; CHECK-NEXT:    lea.sl %s12, _Z7fun_u32RNSt3__16atomicIjEE@hi(, %s0)
@@ -668,7 +668,7 @@ declare void @_Z7fun_u32RNSt3__16atomicIjEE(ptr nonnull align 4 dereferenceable(
 ; Function Attrs: mustprogress
 define i64 @_Z27atomic_load_relaxed_stk_i64v() {
 ; CHECK-LABEL: _Z27atomic_load_relaxed_stk_i64v:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s0, _Z7fun_i64RNSt3__16atomicIlEE@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0
 ; CHECK-NEXT:    lea.sl %s12, _Z7fun_i64RNSt3__16atomicIlEE@hi(, %s0)
@@ -689,7 +689,7 @@ declare void @_Z7fun_i64RNSt3__16atomicIlEE(ptr nonnull align 8 dereferenceable(
 ; Function Attrs: mustprogress
 define i64 @_Z27atomic_load_relaxed_stk_u64v() {
 ; CHECK-LABEL: _Z27atomic_load_relaxed_stk_u64v:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s0, _Z7fun_u64RNSt3__16atomicImEE@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0
 ; CHECK-NEXT:    lea.sl %s12, _Z7fun_u64RNSt3__16atomicImEE@hi(, %s0)
@@ -710,7 +710,7 @@ declare void @_Z7fun_u64RNSt3__16atomicImEE(ptr nonnull align 8 dereferenceable(
 ; Function Attrs: mustprogress
 define i128 @_Z28atomic_load_relaxed_stk_i128v() {
 ; CHECK-LABEL: _Z28atomic_load_relaxed_stk_i128v:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s0, _Z8fun_i128RNSt3__16atomicInEE@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0
 ; CHECK-NEXT:    lea.sl %s12, _Z8fun_i128RNSt3__16atomicInEE@hi(, %s0)
@@ -744,7 +744,7 @@ declare void @_Z8fun_i128RNSt3__16atomicInEE(ptr nonnull align 16 dereferenceabl
 ; Function Attrs: mustprogress
 define i128 @_Z28atomic_load_relaxed_stk_u128v() {
 ; CHECK-LABEL: _Z28atomic_load_relaxed_stk_u128v:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s0, _Z8fun_u128RNSt3__16atomicIoEE@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0
 ; CHECK-NEXT:    lea.sl %s12, _Z8fun_u128RNSt3__16atomicIoEE@hi(, %s0)
@@ -898,7 +898,7 @@ define i64 @_Z26atomic_load_relaxed_gv_u64v() {
 ; Function Attrs: nofree nounwind mustprogress
 define i128 @_Z27atomic_load_relaxed_gv_i128v() {
 ; CHECK-LABEL: _Z27atomic_load_relaxed_gv_i128v:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s0, __atomic_load@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0
 ; CHECK-NEXT:    lea.sl %s12, __atomic_load@hi(, %s0)
@@ -923,7 +923,7 @@ define i128 @_Z27atomic_load_relaxed_gv_i128v() {
 ; Function Attrs: nofree nounwind mustprogress
 define i128 @_Z27atomic_load_relaxed_gv_u128v() {
 ; CHECK-LABEL: _Z27atomic_load_relaxed_gv_u128v:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s0, __atomic_load@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0
 ; CHECK-NEXT:    lea.sl %s12, __atomic_load@hi(, %s0)

--- a/llvm/test/CodeGen/VE/Scalar/atomic_store.ll
+++ b/llvm/test/CodeGen/VE/Scalar/atomic_store.ll
@@ -168,7 +168,7 @@ define void @_Z24atomic_store_relaxed_u64RNSt3__16atomicImEEm(ptr nocapture nonn
 ; Function Attrs: nofree nounwind mustprogress
 define void @_Z25atomic_store_relaxed_i128RNSt3__16atomicInEEn(ptr nonnull align 16 dereferenceable(16) %0, i128 %1) {
 ; CHECK-LABEL: _Z25atomic_store_relaxed_i128RNSt3__16atomicInEEn:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    or %s4, 0, %s0
 ; CHECK-NEXT:    st %s2, 248(, %s11)
 ; CHECK-NEXT:    st %s1, 240(, %s11)
@@ -192,7 +192,7 @@ define void @_Z25atomic_store_relaxed_i128RNSt3__16atomicInEEn(ptr nonnull align
 ; Function Attrs: nofree nounwind mustprogress
 define void @_Z25atomic_store_relaxed_u128RNSt3__16atomicIoEEo(ptr nonnull align 16 dereferenceable(16) %0, i128 %1) {
 ; CHECK-LABEL: _Z25atomic_store_relaxed_u128RNSt3__16atomicIoEEo:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    or %s4, 0, %s0
 ; CHECK-NEXT:    st %s2, 248(, %s11)
 ; CHECK-NEXT:    st %s1, 240(, %s11)
@@ -316,7 +316,7 @@ define void @_Z24atomic_store_release_u64RNSt3__16atomicImEEm(ptr nocapture nonn
 ; Function Attrs: nofree nounwind mustprogress
 define void @_Z25atomic_store_release_i128RNSt3__16atomicInEEn(ptr nonnull align 16 dereferenceable(16) %0, i128 %1) {
 ; CHECK-LABEL: _Z25atomic_store_release_i128RNSt3__16atomicInEEn:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    or %s4, 0, %s0
 ; CHECK-NEXT:    st %s2, 248(, %s11)
 ; CHECK-NEXT:    st %s1, 240(, %s11)
@@ -340,7 +340,7 @@ define void @_Z25atomic_store_release_i128RNSt3__16atomicInEEn(ptr nonnull align
 ; Function Attrs: nofree nounwind mustprogress
 define void @_Z25atomic_store_release_u128RNSt3__16atomicIoEEo(ptr nonnull align 16 dereferenceable(16) %0, i128 %1) {
 ; CHECK-LABEL: _Z25atomic_store_release_u128RNSt3__16atomicIoEEo:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    or %s4, 0, %s0
 ; CHECK-NEXT:    st %s2, 248(, %s11)
 ; CHECK-NEXT:    st %s1, 240(, %s11)
@@ -473,7 +473,7 @@ define void @_Z24atomic_store_seq_cst_u64RNSt3__16atomicImEEm(ptr nocapture nonn
 ; Function Attrs: nofree nounwind mustprogress
 define void @_Z25atomic_store_seq_cst_i128RNSt3__16atomicInEEn(ptr nonnull align 16 dereferenceable(16) %0, i128 %1) {
 ; CHECK-LABEL: _Z25atomic_store_seq_cst_i128RNSt3__16atomicInEEn:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    or %s4, 0, %s0
 ; CHECK-NEXT:    st %s2, 248(, %s11)
 ; CHECK-NEXT:    st %s1, 240(, %s11)
@@ -497,7 +497,7 @@ define void @_Z25atomic_store_seq_cst_i128RNSt3__16atomicInEEn(ptr nonnull align
 ; Function Attrs: nofree nounwind mustprogress
 define void @_Z25atomic_store_seq_cst_u128RNSt3__16atomicIoEEo(ptr nonnull align 16 dereferenceable(16) %0, i128 %1) {
 ; CHECK-LABEL: _Z25atomic_store_seq_cst_u128RNSt3__16atomicIoEEo:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    or %s4, 0, %s0
 ; CHECK-NEXT:    st %s2, 248(, %s11)
 ; CHECK-NEXT:    st %s1, 240(, %s11)
@@ -521,7 +521,7 @@ define void @_Z25atomic_store_seq_cst_u128RNSt3__16atomicIoEEo(ptr nonnull align
 ; Function Attrs: nofree nounwind mustprogress
 define void @_Z26atomic_load_relaxed_stk_i1b(i1 zeroext %0) {
 ; CHECK-LABEL: _Z26atomic_load_relaxed_stk_i1b:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    st1b %s0, 15(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -542,7 +542,7 @@ declare void @llvm.lifetime.end.p0(i64 immarg, ptr nocapture)
 ; Function Attrs: nofree nounwind mustprogress
 define void @_Z26atomic_load_relaxed_stk_i8c(i8 signext %0) {
 ; CHECK-LABEL: _Z26atomic_load_relaxed_stk_i8c:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    st1b %s0, 15(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -556,7 +556,7 @@ define void @_Z26atomic_load_relaxed_stk_i8c(i8 signext %0) {
 ; Function Attrs: nofree nounwind mustprogress
 define void @_Z26atomic_load_relaxed_stk_u8h(i8 zeroext %0) {
 ; CHECK-LABEL: _Z26atomic_load_relaxed_stk_u8h:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    st1b %s0, 15(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -570,7 +570,7 @@ define void @_Z26atomic_load_relaxed_stk_u8h(i8 zeroext %0) {
 ; Function Attrs: nofree nounwind mustprogress
 define void @_Z27atomic_load_relaxed_stk_i16s(i16 signext %0) {
 ; CHECK-LABEL: _Z27atomic_load_relaxed_stk_i16s:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    st2b %s0, 14(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -584,7 +584,7 @@ define void @_Z27atomic_load_relaxed_stk_i16s(i16 signext %0) {
 ; Function Attrs: nofree nounwind mustprogress
 define void @_Z27atomic_load_relaxed_stk_u16t(i16 zeroext %0) {
 ; CHECK-LABEL: _Z27atomic_load_relaxed_stk_u16t:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    st2b %s0, 14(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -598,7 +598,7 @@ define void @_Z27atomic_load_relaxed_stk_u16t(i16 zeroext %0) {
 ; Function Attrs: nofree nounwind mustprogress
 define void @_Z27atomic_load_relaxed_stk_i32i(i32 signext %0) {
 ; CHECK-LABEL: _Z27atomic_load_relaxed_stk_i32i:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    stl %s0, 12(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -612,7 +612,7 @@ define void @_Z27atomic_load_relaxed_stk_i32i(i32 signext %0) {
 ; Function Attrs: nofree nounwind mustprogress
 define void @_Z27atomic_load_relaxed_stk_u32j(i32 zeroext %0) {
 ; CHECK-LABEL: _Z27atomic_load_relaxed_stk_u32j:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    stl %s0, 12(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -626,7 +626,7 @@ define void @_Z27atomic_load_relaxed_stk_u32j(i32 zeroext %0) {
 ; Function Attrs: nofree nounwind mustprogress
 define void @_Z27atomic_load_relaxed_stk_i64l(i64 %0) {
 ; CHECK-LABEL: _Z27atomic_load_relaxed_stk_i64l:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    st %s0, 8(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -640,7 +640,7 @@ define void @_Z27atomic_load_relaxed_stk_i64l(i64 %0) {
 ; Function Attrs: nofree nounwind mustprogress
 define void @_Z27atomic_load_relaxed_stk_u64m(i64 %0) {
 ; CHECK-LABEL: _Z27atomic_load_relaxed_stk_u64m:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    st %s0, 8(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -654,7 +654,7 @@ define void @_Z27atomic_load_relaxed_stk_u64m(i64 %0) {
 ; Function Attrs: nofree nounwind mustprogress
 define void @_Z28atomic_load_relaxed_stk_i128n(i128 %0) {
 ; CHECK-LABEL: _Z28atomic_load_relaxed_stk_i128n:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    st %s1, 264(, %s11)
 ; CHECK-NEXT:    st %s0, 256(, %s11)
 ; CHECK-NEXT:    lea %s0, __atomic_store@lo
@@ -680,7 +680,7 @@ define void @_Z28atomic_load_relaxed_stk_i128n(i128 %0) {
 ; Function Attrs: nofree nounwind mustprogress
 define void @_Z28atomic_load_relaxed_stk_u128o(i128 %0) {
 ; CHECK-LABEL: _Z28atomic_load_relaxed_stk_u128o:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    st %s1, 264(, %s11)
 ; CHECK-NEXT:    st %s0, 256(, %s11)
 ; CHECK-NEXT:    lea %s0, __atomic_store@lo
@@ -824,7 +824,7 @@ define void @_Z26atomic_load_relaxed_gv_u64m(i64 %0) {
 ; Function Attrs: nofree nounwind mustprogress
 define void @_Z27atomic_load_relaxed_gv_i128n(i128 %0) {
 ; CHECK-LABEL: _Z27atomic_load_relaxed_gv_i128n:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    st %s1, 248(, %s11)
 ; CHECK-NEXT:    st %s0, 240(, %s11)
 ; CHECK-NEXT:    lea %s0, __atomic_store@lo
@@ -849,7 +849,7 @@ define void @_Z27atomic_load_relaxed_gv_i128n(i128 %0) {
 ; Function Attrs: nofree nounwind mustprogress
 define void @_Z27atomic_load_relaxed_gv_u128o(i128 %0) {
 ; CHECK-LABEL: _Z27atomic_load_relaxed_gv_u128o:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    st %s1, 248(, %s11)
 ; CHECK-NEXT:    st %s0, 240(, %s11)
 ; CHECK-NEXT:    lea %s0, __atomic_store@lo

--- a/llvm/test/CodeGen/VE/Scalar/atomic_swap.ll
+++ b/llvm/test/CodeGen/VE/Scalar/atomic_swap.ll
@@ -226,8 +226,8 @@ define i128 @_Z24atomic_swap_relaxed_i128RNSt3__16atomicInEEn(ptr nonnull align 
 ; CHECK-NEXT:    st %s10, 8(, %s11)
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    lea %s11, -272(, %s11)
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB9_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB9_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -236,7 +236,7 @@ define i128 @_Z24atomic_swap_relaxed_i128RNSt3__16atomicInEEn(ptr nonnull align 
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB9_2:
+; CHECK-NEXT:  .LBB9_1:
 ; CHECK-NEXT:    or %s5, 0, %s0
 ; CHECK-NEXT:    st %s2, 264(, %s11)
 ; CHECK-NEXT:    st %s1, 256(, %s11)
@@ -275,8 +275,8 @@ define i128 @_Z24atomic_swap_relaxed_u128RNSt3__16atomicIoEEo(ptr nonnull align 
 ; CHECK-NEXT:    st %s10, 8(, %s11)
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    lea %s11, -272(, %s11)
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB10_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB10_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -285,7 +285,7 @@ define i128 @_Z24atomic_swap_relaxed_u128RNSt3__16atomicIoEEo(ptr nonnull align 
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB10_2:
+; CHECK-NEXT:  .LBB10_1:
 ; CHECK-NEXT:    or %s5, 0, %s0
 ; CHECK-NEXT:    st %s2, 264(, %s11)
 ; CHECK-NEXT:    st %s1, 256(, %s11)
@@ -474,8 +474,8 @@ define i128 @_Z24atomic_swap_acquire_i128RNSt3__16atomicInEEn(ptr nonnull align 
 ; CHECK-NEXT:    st %s10, 8(, %s11)
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    lea %s11, -272(, %s11)
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB20_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB20_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -484,7 +484,7 @@ define i128 @_Z24atomic_swap_acquire_i128RNSt3__16atomicInEEn(ptr nonnull align 
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB20_2:
+; CHECK-NEXT:  .LBB20_1:
 ; CHECK-NEXT:    or %s5, 0, %s0
 ; CHECK-NEXT:    st %s2, 264(, %s11)
 ; CHECK-NEXT:    st %s1, 256(, %s11)
@@ -523,8 +523,8 @@ define i128 @_Z24atomic_swap_acquire_u128RNSt3__16atomicIoEEo(ptr nonnull align 
 ; CHECK-NEXT:    st %s10, 8(, %s11)
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    lea %s11, -272(, %s11)
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB21_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB21_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -533,7 +533,7 @@ define i128 @_Z24atomic_swap_acquire_u128RNSt3__16atomicIoEEo(ptr nonnull align 
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB21_2:
+; CHECK-NEXT:  .LBB21_1:
 ; CHECK-NEXT:    or %s5, 0, %s0
 ; CHECK-NEXT:    st %s2, 264(, %s11)
 ; CHECK-NEXT:    st %s1, 256(, %s11)
@@ -731,8 +731,8 @@ define i128 @_Z24atomic_swap_seq_cst_i128RNSt3__16atomicInEEn(ptr nonnull align 
 ; CHECK-NEXT:    st %s10, 8(, %s11)
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    lea %s11, -272(, %s11)
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB31_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB31_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -741,7 +741,7 @@ define i128 @_Z24atomic_swap_seq_cst_i128RNSt3__16atomicInEEn(ptr nonnull align 
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB31_2:
+; CHECK-NEXT:  .LBB31_1:
 ; CHECK-NEXT:    or %s5, 0, %s0
 ; CHECK-NEXT:    st %s2, 264(, %s11)
 ; CHECK-NEXT:    st %s1, 256(, %s11)
@@ -780,8 +780,8 @@ define i128 @_Z24atomic_swap_seq_cst_u128RNSt3__16atomicIoEEo(ptr nonnull align 
 ; CHECK-NEXT:    st %s10, 8(, %s11)
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    lea %s11, -272(, %s11)
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB32_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB32_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -790,7 +790,7 @@ define i128 @_Z24atomic_swap_seq_cst_u128RNSt3__16atomicIoEEo(ptr nonnull align 
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB32_2:
+; CHECK-NEXT:  .LBB32_1:
 ; CHECK-NEXT:    or %s5, 0, %s0
 ; CHECK-NEXT:    st %s2, 264(, %s11)
 ; CHECK-NEXT:    st %s1, 256(, %s11)
@@ -826,8 +826,8 @@ define zeroext i1 @_Z26atomic_swap_relaxed_stk_i1b(i1 zeroext %0) {
 ; CHECK-LABEL: _Z26atomic_swap_relaxed_stk_i1b:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    adds.l %s11, -16, %s11
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB33_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB33_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -836,7 +836,7 @@ define zeroext i1 @_Z26atomic_swap_relaxed_stk_i1b(i1 zeroext %0) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB33_2:
+; CHECK-NEXT:  .LBB33_1:
 ; CHECK-NEXT:    and %s0, %s0, (32)0
 ; CHECK-NEXT:    or %s1, 1, (0)1
 ; CHECK-NEXT:    lea %s2, 8(, %s11)
@@ -865,8 +865,8 @@ define signext i8 @_Z26atomic_swap_relaxed_stk_i8c(i8 signext %0) {
 ; CHECK-LABEL: _Z26atomic_swap_relaxed_stk_i8c:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    adds.l %s11, -16, %s11
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB34_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB34_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -875,7 +875,7 @@ define signext i8 @_Z26atomic_swap_relaxed_stk_i8c(i8 signext %0) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB34_2:
+; CHECK-NEXT:  .LBB34_1:
 ; CHECK-NEXT:    and %s0, %s0, (32)0
 ; CHECK-NEXT:    or %s1, 1, (0)1
 ; CHECK-NEXT:    lea %s2, 8(, %s11)
@@ -896,8 +896,8 @@ define zeroext i8 @_Z26atomic_swap_relaxed_stk_u8h(i8 zeroext %0) {
 ; CHECK-LABEL: _Z26atomic_swap_relaxed_stk_u8h:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    adds.l %s11, -16, %s11
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB35_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB35_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -906,7 +906,7 @@ define zeroext i8 @_Z26atomic_swap_relaxed_stk_u8h(i8 zeroext %0) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB35_2:
+; CHECK-NEXT:  .LBB35_1:
 ; CHECK-NEXT:    and %s0, %s0, (32)0
 ; CHECK-NEXT:    or %s1, 1, (0)1
 ; CHECK-NEXT:    lea %s2, 8(, %s11)
@@ -926,8 +926,8 @@ define signext i16 @_Z27atomic_swap_relaxed_stk_i16s(i16 signext %0) {
 ; CHECK-LABEL: _Z27atomic_swap_relaxed_stk_i16s:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    adds.l %s11, -16, %s11
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB36_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB36_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -936,7 +936,7 @@ define signext i16 @_Z27atomic_swap_relaxed_stk_i16s(i16 signext %0) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB36_2:
+; CHECK-NEXT:  .LBB36_1:
 ; CHECK-NEXT:    and %s0, %s0, (32)0
 ; CHECK-NEXT:    or %s1, 3, (0)1
 ; CHECK-NEXT:    lea %s2, 8(, %s11)
@@ -957,8 +957,8 @@ define zeroext i16 @_Z27atomic_swap_relaxed_stk_u16t(i16 zeroext %0) {
 ; CHECK-LABEL: _Z27atomic_swap_relaxed_stk_u16t:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    adds.l %s11, -16, %s11
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB37_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB37_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -967,7 +967,7 @@ define zeroext i16 @_Z27atomic_swap_relaxed_stk_u16t(i16 zeroext %0) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB37_2:
+; CHECK-NEXT:  .LBB37_1:
 ; CHECK-NEXT:    and %s0, %s0, (32)0
 ; CHECK-NEXT:    or %s1, 3, (0)1
 ; CHECK-NEXT:    lea %s2, 8(, %s11)
@@ -987,8 +987,8 @@ define signext i32 @_Z27atomic_swap_relaxed_stk_i32i(i32 signext %0) {
 ; CHECK-LABEL: _Z27atomic_swap_relaxed_stk_i32i:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    adds.l %s11, -16, %s11
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB38_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB38_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -997,7 +997,7 @@ define signext i32 @_Z27atomic_swap_relaxed_stk_i32i(i32 signext %0) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB38_2:
+; CHECK-NEXT:  .LBB38_1:
 ; CHECK-NEXT:    ts1am.w %s0, 8(%s11), 15
 ; CHECK-NEXT:    adds.w.sx %s0, %s0, (0)1
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
@@ -1014,8 +1014,8 @@ define zeroext i32 @_Z27atomic_swap_relaxed_stk_u32j(i32 zeroext %0) {
 ; CHECK-LABEL: _Z27atomic_swap_relaxed_stk_u32j:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    adds.l %s11, -16, %s11
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB39_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB39_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -1024,7 +1024,7 @@ define zeroext i32 @_Z27atomic_swap_relaxed_stk_u32j(i32 zeroext %0) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB39_2:
+; CHECK-NEXT:  .LBB39_1:
 ; CHECK-NEXT:    ts1am.w %s0, 8(%s11), 15
 ; CHECK-NEXT:    adds.w.zx %s0, %s0, (0)1
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
@@ -1041,8 +1041,8 @@ define i64 @_Z27atomic_swap_relaxed_stk_i64l(i64 %0) {
 ; CHECK-LABEL: _Z27atomic_swap_relaxed_stk_i64l:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    adds.l %s11, -16, %s11
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB40_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB40_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -1051,7 +1051,7 @@ define i64 @_Z27atomic_swap_relaxed_stk_i64l(i64 %0) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB40_2:
+; CHECK-NEXT:  .LBB40_1:
 ; CHECK-NEXT:    lea %s1, 255
 ; CHECK-NEXT:    ts1am.l %s0, 8(%s11), %s1
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
@@ -1068,8 +1068,8 @@ define i64 @_Z27atomic_swap_relaxed_stk_u64m(i64 %0) {
 ; CHECK-LABEL: _Z27atomic_swap_relaxed_stk_u64m:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    adds.l %s11, -16, %s11
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB41_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB41_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -1078,7 +1078,7 @@ define i64 @_Z27atomic_swap_relaxed_stk_u64m(i64 %0) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB41_2:
+; CHECK-NEXT:  .LBB41_1:
 ; CHECK-NEXT:    lea %s1, 255
 ; CHECK-NEXT:    ts1am.l %s0, 8(%s11), %s1
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
@@ -1098,8 +1098,8 @@ define i128 @_Z28atomic_swap_relaxed_stk_i128n(i128 %0) {
 ; CHECK-NEXT:    st %s10, 8(, %s11)
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    lea %s11, -288(, %s11)
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB42_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB42_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -1108,7 +1108,7 @@ define i128 @_Z28atomic_swap_relaxed_stk_i128n(i128 %0) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB42_2:
+; CHECK-NEXT:  .LBB42_1:
 ; CHECK-NEXT:    st %s1, 280(, %s11)
 ; CHECK-NEXT:    st %s0, 272(, %s11)
 ; CHECK-NEXT:    lea %s0, __atomic_exchange@lo
@@ -1149,8 +1149,8 @@ define i128 @_Z28atomic_swap_relaxed_stk_u128o(i128 %0) {
 ; CHECK-NEXT:    st %s10, 8(, %s11)
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    lea %s11, -288(, %s11)
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB43_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB43_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -1159,7 +1159,7 @@ define i128 @_Z28atomic_swap_relaxed_stk_u128o(i128 %0) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB43_2:
+; CHECK-NEXT:  .LBB43_1:
 ; CHECK-NEXT:    st %s1, 280(, %s11)
 ; CHECK-NEXT:    st %s0, 272(, %s11)
 ; CHECK-NEXT:    lea %s0, __atomic_exchange@lo
@@ -1366,8 +1366,8 @@ define i128 @_Z27atomic_swap_relaxed_gv_i128n(i128 %0) {
 ; CHECK-NEXT:    st %s10, 8(, %s11)
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    lea %s11, -272(, %s11)
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB53_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB53_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -1376,7 +1376,7 @@ define i128 @_Z27atomic_swap_relaxed_gv_i128n(i128 %0) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB53_2:
+; CHECK-NEXT:  .LBB53_1:
 ; CHECK-NEXT:    st %s1, 264(, %s11)
 ; CHECK-NEXT:    st %s0, 256(, %s11)
 ; CHECK-NEXT:    lea %s0, __atomic_exchange@lo
@@ -1416,8 +1416,8 @@ define i128 @_Z27atomic_swap_relaxed_gv_u128o(i128 %0) {
 ; CHECK-NEXT:    st %s10, 8(, %s11)
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    lea %s11, -272(, %s11)
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB54_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB54_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -1426,7 +1426,7 @@ define i128 @_Z27atomic_swap_relaxed_gv_u128o(i128 %0) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB54_2:
+; CHECK-NEXT:  .LBB54_1:
 ; CHECK-NEXT:    st %s1, 264(, %s11)
 ; CHECK-NEXT:    st %s0, 256(, %s11)
 ; CHECK-NEXT:    lea %s0, __atomic_exchange@lo

--- a/llvm/test/CodeGen/VE/Scalar/br_analyze.ll
+++ b/llvm/test/CodeGen/VE/Scalar/br_analyze.ll
@@ -13,8 +13,8 @@ define i32 @f1(i32 %a, ptr %bptr) {
 ; CHECK-NEXT:    st %s10, 8(, %s11)
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    lea %s11, -240(, %s11)
-; CHECK-NEXT:    brge.l %s11, %s8, .LBB0_4
-; CHECK-NEXT:  # %bb.3: # %entry
+; CHECK-NEXT:    brge.l %s11, %s8, .LBB0_3
+; CHECK-NEXT:  # %bb.4: # %entry
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -23,7 +23,7 @@ define i32 @f1(i32 %a, ptr %bptr) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB0_4: # %entry
+; CHECK-NEXT:  .LBB0_3: # %entry
 ; CHECK-NEXT:    ldl.sx %s1, (, %s1)
 ; CHECK-NEXT:    cmpu.w %s0, %s1, %s0
 ; CHECK-NEXT:    brlt.w 0, %s0, .LBB0_2
@@ -60,8 +60,8 @@ define i32 @f2(i32 %a) {
 ; CHECK-NEXT:    st %s10, 8(, %s11)
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    lea %s11, -240(, %s11)
-; CHECK-NEXT:    brge.l %s11, %s8, .LBB1_4
-; CHECK-NEXT:  # %bb.3: # %entry
+; CHECK-NEXT:    brge.l %s11, %s8, .LBB1_3
+; CHECK-NEXT:  # %bb.4: # %entry
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -70,7 +70,7 @@ define i32 @f2(i32 %a) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB1_4: # %entry
+; CHECK-NEXT:  .LBB1_3: # %entry
 ; CHECK-NEXT:    breq.w 0, %s0, .LBB1_2
 ; CHECK-NEXT:  # %bb.1: # %return
 ; CHECK-NEXT:    or %s0, 1, (0)1

--- a/llvm/test/CodeGen/VE/Scalar/builtin_sjlj.ll
+++ b/llvm/test/CodeGen/VE/Scalar/builtin_sjlj.ll
@@ -9,7 +9,7 @@
 ; Function Attrs: noinline nounwind optnone
 define signext i32 @t_setjmp() {
 ; CHECK-LABEL: t_setjmp:
-; CHECK:       .LBB{{[0-9]+}}_5:
+; CHECK:       .LBB{{[0-9]+}}_4:
 ; CHECK-NEXT:    st %s18, 48(, %s9) # 8-byte Folded Spill
 ; CHECK-NEXT:    st %s19, 56(, %s9) # 8-byte Folded Spill
 ; CHECK-NEXT:    st %s20, 64(, %s9) # 8-byte Folded Spill
@@ -69,8 +69,8 @@ define signext i32 @t_setjmp() {
 ; PIC-NEXT:    st %s16, 32(, %s11)
 ; PIC-NEXT:    or %s9, 0, %s11
 ; PIC-NEXT:    lea %s11, -176(, %s11)
-; PIC-NEXT:    brge.l %s11, %s8, .LBB0_5
-; PIC-NEXT:  # %bb.4:
+; PIC-NEXT:    brge.l %s11, %s8, .LBB0_4
+; PIC-NEXT:  # %bb.5:
 ; PIC-NEXT:    ld %s61, 24(, %s14)
 ; PIC-NEXT:    or %s62, 0, %s0
 ; PIC-NEXT:    lea %s63, 315
@@ -79,7 +79,7 @@ define signext i32 @t_setjmp() {
 ; PIC-NEXT:    shm.l %s11, 16(%s61)
 ; PIC-NEXT:    monc
 ; PIC-NEXT:    or %s0, 0, %s62
-; PIC-NEXT:  .LBB0_5:
+; PIC-NEXT:  .LBB0_4:
 ; PIC-NEXT:    st %s18, 48(, %s9) # 8-byte Folded Spill
 ; PIC-NEXT:    st %s19, 56(, %s9) # 8-byte Folded Spill
 ; PIC-NEXT:    st %s20, 64(, %s9) # 8-byte Folded Spill
@@ -160,7 +160,7 @@ declare i32 @llvm.eh.sjlj.setjmp(ptr)
 ; Function Attrs: noinline nounwind optnone
 define void @t_longjmp() {
 ; CHECK-LABEL: t_longjmp:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s0, buf@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0
 ; CHECK-NEXT:    lea.sl %s0, buf@hi(, %s0)
@@ -178,8 +178,8 @@ define void @t_longjmp() {
 ; PIC-NEXT:    st %s16, 32(, %s11)
 ; PIC-NEXT:    or %s9, 0, %s11
 ; PIC-NEXT:    lea %s11, -176(, %s11)
-; PIC-NEXT:    brge.l.t %s11, %s8, .LBB1_2
-; PIC-NEXT:  # %bb.1:
+; PIC-NEXT:    brge.l.t %s11, %s8, .LBB1_1
+; PIC-NEXT:  # %bb.2:
 ; PIC-NEXT:    ld %s61, 24(, %s14)
 ; PIC-NEXT:    or %s62, 0, %s0
 ; PIC-NEXT:    lea %s63, 315
@@ -188,7 +188,7 @@ define void @t_longjmp() {
 ; PIC-NEXT:    shm.l %s11, 16(%s61)
 ; PIC-NEXT:    monc
 ; PIC-NEXT:    or %s0, 0, %s62
-; PIC-NEXT:  .LBB1_2:
+; PIC-NEXT:  .LBB1_1:
 ; PIC-NEXT:    lea %s15, _GLOBAL_OFFSET_TABLE_@pc_lo(-24)
 ; PIC-NEXT:    and %s15, %s15, (32)0
 ; PIC-NEXT:    sic %s16

--- a/llvm/test/CodeGen/VE/Scalar/builtin_sjlj_bp.ll
+++ b/llvm/test/CodeGen/VE/Scalar/builtin_sjlj_bp.ll
@@ -7,7 +7,7 @@ declare i32 @llvm.eh.sjlj.setjmp(ptr) nounwind
 ; Function Attrs: noinline nounwind optnone
 define i32 @t_setjmp(i64 %n, ptr byval(%Foo) nocapture readnone align 8 %f) {
 ; CHECK-LABEL: t_setjmp:
-; CHECK:       .LBB{{[0-9]+}}_5:
+; CHECK:       .LBB{{[0-9]+}}_4:
 ; CHECK-NEXT:    st %s18, 48(, %s9) # 8-byte Folded Spill
 ; CHECK-NEXT:    st %s19, 56(, %s9) # 8-byte Folded Spill
 ; CHECK-NEXT:    st %s20, 64(, %s9) # 8-byte Folded Spill

--- a/llvm/test/CodeGen/VE/Scalar/builtin_sjlj_callsite.ll
+++ b/llvm/test/CodeGen/VE/Scalar/builtin_sjlj_callsite.ll
@@ -11,8 +11,8 @@ define void @test_callsite() personality ptr @__gxx_personality_sj0 {
 ; CHECK-NEXT:    st %s10, 8(, %s11)
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    lea %s11, -432(, %s11)
-; CHECK-NEXT:    brge.l %s11, %s8, .LBB0_7
-; CHECK-NEXT:  # %bb.6:
+; CHECK-NEXT:    brge.l %s11, %s8, .LBB0_6
+; CHECK-NEXT:  # %bb.7:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -21,7 +21,7 @@ define void @test_callsite() personality ptr @__gxx_personality_sj0 {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB0_7:
+; CHECK-NEXT:  .LBB0_6:
 ; CHECK-NEXT:    st %s18, 48(, %s9) # 8-byte Folded Spill
 ; CHECK-NEXT:    st %s19, 56(, %s9) # 8-byte Folded Spill
 ; CHECK-NEXT:    st %s20, 64(, %s9) # 8-byte Folded Spill
@@ -126,8 +126,8 @@ define void @test_callsite() personality ptr @__gxx_personality_sj0 {
 ; PIC-NEXT:    st %s16, 32(, %s11)
 ; PIC-NEXT:    or %s9, 0, %s11
 ; PIC-NEXT:    lea %s11, -432(, %s11)
-; PIC-NEXT:    brge.l %s11, %s8, .LBB0_7
-; PIC-NEXT:  # %bb.6:
+; PIC-NEXT:    brge.l %s11, %s8, .LBB0_6
+; PIC-NEXT:  # %bb.7:
 ; PIC-NEXT:    ld %s61, 24(, %s14)
 ; PIC-NEXT:    or %s62, 0, %s0
 ; PIC-NEXT:    lea %s63, 315
@@ -136,7 +136,7 @@ define void @test_callsite() personality ptr @__gxx_personality_sj0 {
 ; PIC-NEXT:    shm.l %s11, 16(%s61)
 ; PIC-NEXT:    monc
 ; PIC-NEXT:    or %s0, 0, %s62
-; PIC-NEXT:  .LBB0_7:
+; PIC-NEXT:  .LBB0_6:
 ; PIC-NEXT:    st %s18, 48(, %s9) # 8-byte Folded Spill
 ; PIC-NEXT:    st %s19, 56(, %s9) # 8-byte Folded Spill
 ; PIC-NEXT:    st %s20, 64(, %s9) # 8-byte Folded Spill

--- a/llvm/test/CodeGen/VE/Scalar/builtin_sjlj_landingpad.ll
+++ b/llvm/test/CodeGen/VE/Scalar/builtin_sjlj_landingpad.ll
@@ -12,8 +12,8 @@ define dso_local i32 @foo(i32 %arg) local_unnamed_addr personality ptr @__gxx_pe
 ; CHECK-NEXT:    st %s10, 8(, %s11)
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    lea %s11, -352(, %s11)
-; CHECK-NEXT:    brge.l %s11, %s8, .LBB0_8
-; CHECK-NEXT:  # %bb.7: # %entry
+; CHECK-NEXT:    brge.l %s11, %s8, .LBB0_7
+; CHECK-NEXT:  # %bb.8: # %entry
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -22,7 +22,7 @@ define dso_local i32 @foo(i32 %arg) local_unnamed_addr personality ptr @__gxx_pe
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB0_8: # %entry
+; CHECK-NEXT:  .LBB0_7: # %entry
 ; CHECK-NEXT:    st %s18, 48(, %s9) # 8-byte Folded Spill
 ; CHECK-NEXT:    st %s19, 56(, %s9) # 8-byte Folded Spill
 ; CHECK-NEXT:    st %s20, 64(, %s9) # 8-byte Folded Spill
@@ -129,8 +129,8 @@ define dso_local i32 @foo(i32 %arg) local_unnamed_addr personality ptr @__gxx_pe
 ; PIC-NEXT:    st %s16, 32(, %s11)
 ; PIC-NEXT:    or %s9, 0, %s11
 ; PIC-NEXT:    lea %s11, -352(, %s11)
-; PIC-NEXT:    brge.l %s11, %s8, .LBB0_8
-; PIC-NEXT:  # %bb.7: # %entry
+; PIC-NEXT:    brge.l %s11, %s8, .LBB0_7
+; PIC-NEXT:  # %bb.8: # %entry
 ; PIC-NEXT:    ld %s61, 24(, %s14)
 ; PIC-NEXT:    or %s62, 0, %s0
 ; PIC-NEXT:    lea %s63, 315
@@ -139,7 +139,7 @@ define dso_local i32 @foo(i32 %arg) local_unnamed_addr personality ptr @__gxx_pe
 ; PIC-NEXT:    shm.l %s11, 16(%s61)
 ; PIC-NEXT:    monc
 ; PIC-NEXT:    or %s0, 0, %s62
-; PIC-NEXT:  .LBB0_8: # %entry
+; PIC-NEXT:  .LBB0_7: # %entry
 ; PIC-NEXT:    st %s18, 48(, %s9) # 8-byte Folded Spill
 ; PIC-NEXT:    st %s19, 56(, %s9) # 8-byte Folded Spill
 ; PIC-NEXT:    st %s20, 64(, %s9) # 8-byte Folded Spill

--- a/llvm/test/CodeGen/VE/Scalar/call.ll
+++ b/llvm/test/CodeGen/VE/Scalar/call.ll
@@ -8,7 +8,7 @@ declare void @test(i64)
 
 define i32 @sample_call() {
 ; CHECK-LABEL: sample_call:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s0, sample_add@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0
 ; CHECK-NEXT:    lea.sl %s12, sample_add@hi(, %s0)
@@ -22,7 +22,7 @@ define i32 @sample_call() {
 
 define i32 @stack_call_int() {
 ; CHECK-LABEL: stack_call_int:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    or %s0, 10, (0)1
 ; CHECK-NEXT:    st %s0, 248(, %s11)
 ; CHECK-NEXT:    or %s34, 9, (0)1
@@ -46,7 +46,7 @@ define i32 @stack_call_int() {
 
 define i32 @stack_call_int_szext() {
 ; CHECK-LABEL: stack_call_int_szext:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    or %s0, -1, (0)1
 ; CHECK-NEXT:    st %s0, 248(, %s11)
 ; CHECK-NEXT:    lea %s34, 65535
@@ -70,7 +70,7 @@ define i32 @stack_call_int_szext() {
 
 define float @stack_call_float() {
 ; CHECK-LABEL: stack_call_float:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea.sl %s0, 1092616192
 ; CHECK-NEXT:    st %s0, 248(, %s11)
 ; CHECK-NEXT:    lea.sl %s34, 1091567616
@@ -94,7 +94,7 @@ define float @stack_call_float() {
 
 define float @stack_call_float2(float %p0) {
 ; CHECK-LABEL: stack_call_float2:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    st %s0, 248(, %s11)
 ; CHECK-NEXT:    lea %s1, stack_callee_float@lo
 ; CHECK-NEXT:    and %s1, %s1, (32)0

--- a/llvm/test/CodeGen/VE/Scalar/callstruct.ll
+++ b/llvm/test/CodeGen/VE/Scalar/callstruct.ll
@@ -20,7 +20,7 @@ define void @fun(ptr noalias nocapture sret(%struct.a) %a, i32 %p1, i32 %p2) {
 ; Function Attrs: nounwind
 define void @caller() {
 ; CHECK-LABEL: caller:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s0, callee@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0
 ; CHECK-NEXT:    lea.sl %s12, callee@hi(, %s0)

--- a/llvm/test/CodeGen/VE/Scalar/cast.ll
+++ b/llvm/test/CodeGen/VE/Scalar/cast.ll
@@ -582,8 +582,8 @@ define float @ull2f_strict(i32 %x) {
 ; CHECK-LABEL: ull2f_strict:
 ; CHECK:     # %bb.0:
 ; CHECK-NEXT:	adds.l %s11, -16, %s11
-; CHECK-NEXT:		brge.l.t %s11, %s8, .LBB58_2
-; CHECK-NEXT:	# %bb.1:
+; CHECK-NEXT:		brge.l.t %s11, %s8, .LBB58_1
+; CHECK-NEXT:	# %bb.2:
 ; CHECK-NEXT:		ld %s61, 24(, %s14)
 ; CHECK-NEXT:		or %s62, 0, %s0
 ; CHECK-NEXT:		lea %s63, 315
@@ -592,7 +592,7 @@ define float @ull2f_strict(i32 %x) {
 ; CHECK-NEXT:		shm.l %s11, 16(%s61)
 ; CHECK-NEXT:		monc
 ; CHECK-NEXT:		or %s0, 0, %s62
-; CHECK-NEXT:	.LBB58_2:
+; CHECK-NEXT:	.LBB58_1:
 ; CHECK-NEXT:		lea %s1, 1127219200
 ; CHECK-NEXT:		stl %s1, 12(, %s11)
 ; CHECK-NEXT:		stl %s0, 8(, %s11)
@@ -1411,7 +1411,7 @@ define i128 @ui1282i128(i128 returned %0) {
 ; Function Attrs: norecurse nounwind readnone
 define float @i1282f(i128) {
 ; CHECK-LABEL: i1282f:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s2, __floattisf@lo
 ; CHECK-NEXT:    and %s2, %s2, (32)0
 ; CHECK-NEXT:    lea.sl %s12, __floattisf@hi(, %s2)
@@ -1424,7 +1424,7 @@ define float @i1282f(i128) {
 ; Function Attrs: norecurse nounwind readnone
 define float @ui1282f(i128) {
 ; CHECK-LABEL: ui1282f:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s2, __floatuntisf@lo
 ; CHECK-NEXT:    and %s2, %s2, (32)0
 ; CHECK-NEXT:    lea.sl %s12, __floatuntisf@hi(, %s2)
@@ -1437,7 +1437,7 @@ define float @ui1282f(i128) {
 ; Function Attrs: norecurse nounwind readnone
 define double @i1282d(i128) {
 ; CHECK-LABEL: i1282d:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s2, __floattidf@lo
 ; CHECK-NEXT:    and %s2, %s2, (32)0
 ; CHECK-NEXT:    lea.sl %s12, __floattidf@hi(, %s2)
@@ -1450,7 +1450,7 @@ define double @i1282d(i128) {
 ; Function Attrs: norecurse nounwind readnone
 define double @ui1282d(i128) {
 ; CHECK-LABEL: ui1282d:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s2, __floatuntidf@lo
 ; CHECK-NEXT:    and %s2, %s2, (32)0
 ; CHECK-NEXT:    lea.sl %s12, __floatuntidf@hi(, %s2)
@@ -1463,7 +1463,7 @@ define double @ui1282d(i128) {
 ; Function Attrs: norecurse nounwind readnone
 define i128 @d2i128(double) {
 ; CHECK-LABEL: d2i128:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s1, __fixdfti@lo
 ; CHECK-NEXT:    and %s1, %s1, (32)0
 ; CHECK-NEXT:    lea.sl %s12, __fixdfti@hi(, %s1)
@@ -1476,7 +1476,7 @@ define i128 @d2i128(double) {
 ; Function Attrs: norecurse nounwind readnone
 define i128 @d2ui128(double) {
 ; CHECK-LABEL: d2ui128:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s1, __fixunsdfti@lo
 ; CHECK-NEXT:    and %s1, %s1, (32)0
 ; CHECK-NEXT:    lea.sl %s12, __fixunsdfti@hi(, %s1)
@@ -1489,7 +1489,7 @@ define i128 @d2ui128(double) {
 ; Function Attrs: norecurse nounwind readnone
 define i128 @f2i128(float) {
 ; CHECK-LABEL: f2i128:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s1, __fixsfti@lo
 ; CHECK-NEXT:    and %s1, %s1, (32)0
 ; CHECK-NEXT:    lea.sl %s12, __fixsfti@hi(, %s1)
@@ -1502,7 +1502,7 @@ define i128 @f2i128(float) {
 ; Function Attrs: norecurse nounwind readnone
 define i128 @f2ui128(float) {
 ; CHECK-LABEL: f2ui128:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s1, __fixunssfti@lo
 ; CHECK-NEXT:    and %s1, %s1, (32)0
 ; CHECK-NEXT:    lea.sl %s12, __fixunssfti@hi(, %s1)

--- a/llvm/test/CodeGen/VE/Scalar/div.ll
+++ b/llvm/test/CodeGen/VE/Scalar/div.ll
@@ -3,7 +3,7 @@
 ; Function Attrs: norecurse nounwind readnone
 define i128 @divi128(i128, i128) {
 ; CHECK-LABEL: divi128:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s4, __divti3@lo
 ; CHECK-NEXT:    and %s4, %s4, (32)0
 ; CHECK-NEXT:    lea.sl %s12, __divti3@hi(, %s4)
@@ -37,7 +37,7 @@ define signext i32 @divi32(i32 signext %a, i32 signext %b) {
 ; Function Attrs: norecurse nounwind readnone
 define i128 @divu128(i128, i128) {
 ; CHECK-LABEL: divu128:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s4, __udivti3@lo
 ; CHECK-NEXT:    and %s4, %s4, (32)0
 ; CHECK-NEXT:    lea.sl %s12, __udivti3@hi(, %s4)
@@ -123,7 +123,7 @@ define zeroext i8 @divu8(i8 zeroext %a, i8 zeroext %b) {
 ; Function Attrs: norecurse nounwind readnone
 define i128 @divi128ri(i128) {
 ; CHECK-LABEL: divi128ri:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s2, __divti3@lo
 ; CHECK-NEXT:    and %s2, %s2, (32)0
 ; CHECK-NEXT:    lea.sl %s12, __divti3@hi(, %s2)
@@ -163,7 +163,7 @@ define signext i32 @divi32ri(i32 signext %a, i32 signext %b) {
 ; Function Attrs: norecurse nounwind readnone
 define i128 @divu128ri(i128) {
 ; CHECK-LABEL: divu128ri:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s2, __udivti3@lo
 ; CHECK-NEXT:    and %s2, %s2, (32)0
 ; CHECK-NEXT:    lea.sl %s12, __udivti3@hi(, %s2)
@@ -201,7 +201,7 @@ define zeroext i32 @divu32ri(i32 zeroext %a, i32 zeroext %b) {
 ; Function Attrs: norecurse nounwind readnone
 define i128 @divi128li(i128) {
 ; CHECK-LABEL: divi128li:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    or %s3, 0, %s1
 ; CHECK-NEXT:    or %s2, 0, %s0
 ; CHECK-NEXT:    lea %s0, __divti3@lo
@@ -239,7 +239,7 @@ define signext i32 @divi32li(i32 signext %a, i32 signext %b) {
 ; Function Attrs: norecurse nounwind readnone
 define i128 @divu128li(i128) {
 ; CHECK-LABEL: divu128li:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    or %s3, 0, %s1
 ; CHECK-NEXT:    or %s2, 0, %s0
 ; CHECK-NEXT:    lea %s0, __udivti3@lo

--- a/llvm/test/CodeGen/VE/Scalar/fabs.ll
+++ b/llvm/test/CodeGen/VE/Scalar/fabs.ll
@@ -58,7 +58,7 @@ declare double @llvm.fabs.f64(double)
 ; Function Attrs: nounwind readnone
 define fp128 @fabs_quad_var(fp128 %0) {
 ; CHECK-LABEL: fabs_quad_var:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    st %s1, (, %s11)
 ; CHECK-NEXT:    st %s0, 8(, %s11)
 ; CHECK-NEXT:    ld1b.zx %s0, 15(, %s11)

--- a/llvm/test/CodeGen/VE/Scalar/fcopysign.ll
+++ b/llvm/test/CodeGen/VE/Scalar/fcopysign.ll
@@ -66,7 +66,7 @@ declare double @llvm.copysign.f64(double, double)
 ; Function Attrs: nounwind readnone
 define fp128 @copysign_quad_var(fp128 %0, fp128 %1) {
 ; CHECK-LABEL: copysign_quad_var:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    st %s3, 16(, %s11)
 ; CHECK-NEXT:    st %s2, 24(, %s11)
 ; CHECK-NEXT:    st %s1, (, %s11)
@@ -116,7 +116,7 @@ define double @copysign_double_zero(double %0) {
 ; Function Attrs: nounwind readnone
 define fp128 @copysign_quad_zero(fp128 %0) {
 ; CHECK-LABEL: copysign_quad_zero:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s2, .LCPI{{[0-9]+}}_0@lo
 ; CHECK-NEXT:    and %s2, %s2, (32)0
 ; CHECK-NEXT:    lea.sl %s2, .LCPI{{[0-9]+}}_0@hi(, %s2)
@@ -172,7 +172,7 @@ define double @copysign_double_const(double %0) {
 ; Function Attrs: nounwind readnone
 define fp128 @copysign_quad_const(fp128 %0) {
 ; CHECK-LABEL: copysign_quad_const:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s2, .LCPI{{[0-9]+}}_0@lo
 ; CHECK-NEXT:    and %s2, %s2, (32)0
 ; CHECK-NEXT:    lea.sl %s2, .LCPI{{[0-9]+}}_0@hi(, %s2)

--- a/llvm/test/CodeGen/VE/Scalar/fcos.ll
+++ b/llvm/test/CodeGen/VE/Scalar/fcos.ll
@@ -32,7 +32,7 @@
 ; Function Attrs: nounwind readnone
 define float @fcos_float_var(float %0) {
 ; CHECK-LABEL: fcos_float_var:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s1, cosf@lo
 ; CHECK-NEXT:    and %s1, %s1, (32)0
 ; CHECK-NEXT:    lea.sl %s12, cosf@hi(, %s1)
@@ -48,7 +48,7 @@ declare float @llvm.cos.f32(float)
 ; Function Attrs: nounwind readnone
 define double @fcos_double_var(double %0) {
 ; CHECK-LABEL: fcos_double_var:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s1, cos@lo
 ; CHECK-NEXT:    and %s1, %s1, (32)0
 ; CHECK-NEXT:    lea.sl %s12, cos@hi(, %s1)
@@ -64,7 +64,7 @@ declare double @llvm.cos.f64(double)
 ; Function Attrs: nounwind readnone
 define fp128 @fcos_quad_var(fp128 %0) {
 ; CHECK-LABEL: fcos_quad_var:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s2, cosl@lo
 ; CHECK-NEXT:    and %s2, %s2, (32)0
 ; CHECK-NEXT:    lea.sl %s12, cosl@hi(, %s2)
@@ -98,7 +98,7 @@ define double @fcos_double_zero() {
 ; Function Attrs: nounwind readnone
 define fp128 @fcos_quad_zero() {
 ; CHECK-LABEL: fcos_quad_zero:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s0, .LCPI{{[0-9]+}}_0@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0
 ; CHECK-NEXT:    lea.sl %s2, .LCPI{{[0-9]+}}_0@hi(, %s0)
@@ -135,7 +135,7 @@ define double @fcos_double_const() {
 ; Function Attrs: nounwind readnone
 define fp128 @fcos_quad_const() {
 ; CHECK-LABEL: fcos_quad_const:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s0, .LCPI{{[0-9]+}}_0@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0
 ; CHECK-NEXT:    lea.sl %s2, .LCPI{{[0-9]+}}_0@hi(, %s0)

--- a/llvm/test/CodeGen/VE/Scalar/fma.ll
+++ b/llvm/test/CodeGen/VE/Scalar/fma.ll
@@ -34,7 +34,7 @@
 ; Function Attrs: mustprogress nofree nosync nounwind readnone willreturn
 define float @fma_float_var(float noundef %0, float noundef %1, float noundef %2) {
 ; CHECK-LABEL: fma_float_var:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s3, fmaf@lo
 ; CHECK-NEXT:    and %s3, %s3, (32)0
 ; CHECK-NEXT:    lea.sl %s12, fmaf@hi(, %s3)
@@ -50,7 +50,7 @@ declare float @llvm.fma.f32(float, float, float)
 ; Function Attrs: mustprogress nofree nosync nounwind readnone willreturn
 define double @fma_double_var(double noundef %0, double noundef %1, double noundef %2) {
 ; CHECK-LABEL: fma_double_var:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s3, fma@lo
 ; CHECK-NEXT:    and %s3, %s3, (32)0
 ; CHECK-NEXT:    lea.sl %s12, fma@hi(, %s3)
@@ -66,7 +66,7 @@ declare double @llvm.fma.f64(double, double, double)
 ; Function Attrs: mustprogress nofree nosync nounwind readnone willreturn
 define fp128 @fma_quad_var(fp128 noundef %0, fp128 noundef %1, fp128 noundef %2) {
 ; CHECK-LABEL: fma_quad_var:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s6, fmal@lo
 ; CHECK-NEXT:    and %s6, %s6, (32)0
 ; CHECK-NEXT:    lea.sl %s12, fmal@hi(, %s6)
@@ -138,7 +138,7 @@ define fp128 @fma_quad_back_zero(fp128 noundef %0, fp128 noundef returned %1) {
 ; Function Attrs: mustprogress nofree nosync nounwind readnone willreturn
 define float @fma_float_fore_const(float noundef %0, float noundef %1) {
 ; CHECK-LABEL: fma_float_fore_const:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    or %s2, 0, %s1
 ; CHECK-NEXT:    lea %s1, fmaf@lo
 ; CHECK-NEXT:    and %s1, %s1, (32)0
@@ -153,7 +153,7 @@ define float @fma_float_fore_const(float noundef %0, float noundef %1) {
 ; Function Attrs: mustprogress nofree nosync nounwind readnone willreturn
 define double @fma_double_fore_const(double noundef %0, double noundef %1) {
 ; CHECK-LABEL: fma_double_fore_const:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    or %s2, 0, %s1
 ; CHECK-NEXT:    lea %s1, fma@lo
 ; CHECK-NEXT:    and %s1, %s1, (32)0
@@ -168,7 +168,7 @@ define double @fma_double_fore_const(double noundef %0, double noundef %1) {
 ; Function Attrs: mustprogress nofree nosync nounwind readnone willreturn
 define fp128 @fma_quad_fore_const(fp128 noundef %0, fp128 noundef %1) {
 ; CHECK-LABEL: fma_quad_fore_const:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    or %s4, 0, %s2
 ; CHECK-NEXT:    or %s5, 0, %s3
 ; CHECK-NEXT:    lea %s2, .LCPI{{[0-9]+}}_0@lo
@@ -188,7 +188,7 @@ define fp128 @fma_quad_fore_const(fp128 noundef %0, fp128 noundef %1) {
 ; Function Attrs: mustprogress nofree nosync nounwind readnone willreturn
 define float @fma_float_back_const(float noundef %0, float noundef %1) {
 ; CHECK-LABEL: fma_float_back_const:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    or %s2, 0, %s1
 ; CHECK-NEXT:    lea %s1, fmaf@lo
 ; CHECK-NEXT:    and %s1, %s1, (32)0
@@ -203,7 +203,7 @@ define float @fma_float_back_const(float noundef %0, float noundef %1) {
 ; Function Attrs: mustprogress nofree nosync nounwind readnone willreturn
 define double @fma_double_back_const(double noundef %0, double noundef %1) {
 ; CHECK-LABEL: fma_double_back_const:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    or %s2, 0, %s1
 ; CHECK-NEXT:    lea %s1, fma@lo
 ; CHECK-NEXT:    and %s1, %s1, (32)0
@@ -218,7 +218,7 @@ define double @fma_double_back_const(double noundef %0, double noundef %1) {
 ; Function Attrs: mustprogress nofree nosync nounwind readnone willreturn
 define fp128 @fma_quad_back_const(fp128 noundef %0, fp128 noundef %1) {
 ; CHECK-LABEL: fma_quad_back_const:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    or %s4, 0, %s2
 ; CHECK-NEXT:    or %s5, 0, %s3
 ; CHECK-NEXT:    lea %s2, .LCPI{{[0-9]+}}_0@lo

--- a/llvm/test/CodeGen/VE/Scalar/fp_div.ll
+++ b/llvm/test/CodeGen/VE/Scalar/fp_div.ll
@@ -20,7 +20,7 @@ define double @func2(double %a, double %b) {
 
 define fp128 @func3(fp128 %a, fp128 %b) {
 ; CHECK-LABEL: func3:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s4, __divtf3@lo
 ; CHECK-NEXT:    and %s4, %s4, (32)0
 ; CHECK-NEXT:    lea.sl %s12, __divtf3@hi(, %s4)
@@ -52,7 +52,7 @@ define double @func5(double %a) {
 
 define fp128 @func6(fp128 %a) {
 ; CHECK-LABEL: func6:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s2, .LCPI{{[0-9]+}}_0@lo
 ; CHECK-NEXT:    and %s2, %s2, (32)0
 ; CHECK-NEXT:    lea.sl %s4, .LCPI{{[0-9]+}}_0@hi(, %s2)
@@ -92,7 +92,7 @@ define double @func8(double %a) {
 ; Function Attrs: norecurse nounwind readnone
 define fp128 @func9(fp128 %a) {
 ; CHECK-LABEL: func9:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s2, .LCPI{{[0-9]+}}_0@lo
 ; CHECK-NEXT:    and %s2, %s2, (32)0
 ; CHECK-NEXT:    lea.sl %s4, .LCPI{{[0-9]+}}_0@hi(, %s2)

--- a/llvm/test/CodeGen/VE/Scalar/fp_extload_truncstore.ll
+++ b/llvm/test/CodeGen/VE/Scalar/fp_extload_truncstore.ll
@@ -8,8 +8,8 @@ define float @func_fp16fp32(ptr %a) {
 ; CHECK-NEXT:    st %s10, 8(, %s11)
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    lea %s11, -240(, %s11)
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB0_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB0_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -18,7 +18,7 @@ define float @func_fp16fp32(ptr %a) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB0_2:
+; CHECK-NEXT:  .LBB0_1:
 ; CHECK-NEXT:    ld2b.zx %s0, (, %s0)
 ; CHECK-NEXT:    lea %s1, __extendhfsf2@lo
 ; CHECK-NEXT:    and %s1, %s1, (32)0
@@ -40,8 +40,8 @@ define double @func_fp16fp64(ptr %a) {
 ; CHECK-NEXT:    st %s10, 8(, %s11)
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    lea %s11, -240(, %s11)
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB1_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB1_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -50,7 +50,7 @@ define double @func_fp16fp64(ptr %a) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB1_2:
+; CHECK-NEXT:  .LBB1_1:
 ; CHECK-NEXT:    ld2b.zx %s0, (, %s0)
 ; CHECK-NEXT:    lea %s1, __extendhfsf2@lo
 ; CHECK-NEXT:    and %s1, %s1, (32)0
@@ -73,8 +73,8 @@ define half @func_fp32fp16(ptr %fl.ptr, float %a) {
 ; CHECK-NEXT:    st %s10, 8(, %s11)
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    lea %s11, -240(, %s11)
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB2_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB2_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -83,7 +83,7 @@ define half @func_fp32fp16(ptr %fl.ptr, float %a) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB2_2:
+; CHECK-NEXT:  .LBB2_1:
 ; CHECK-NEXT:    st %s18, 288(, %s11) # 8-byte Folded Spill
 ; CHECK-NEXT:    or %s18, 0, %s0
 ; CHECK-NEXT:    lea %s0, __truncsfhf2@lo
@@ -121,8 +121,8 @@ define void @func_fp64fp16(ptr %fl.ptr, double %val) {
 ; CHECK-NEXT:    st %s10, 8(, %s11)
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    lea %s11, -240(, %s11)
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB4_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB4_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -131,7 +131,7 @@ define void @func_fp64fp16(ptr %fl.ptr, double %val) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB4_2:
+; CHECK-NEXT:  .LBB4_1:
 ; CHECK-NEXT:    st %s18, 288(, %s11) # 8-byte Folded Spill
 ; CHECK-NEXT:    or %s18, 0, %s0
 ; CHECK-NEXT:    lea %s0, __truncdfhf2@lo

--- a/llvm/test/CodeGen/VE/Scalar/fp_fneg.ll
+++ b/llvm/test/CodeGen/VE/Scalar/fp_fneg.ll
@@ -52,7 +52,7 @@ define double @fneg_double(double %0) {
 ; Function Attrs: norecurse nounwind readnone
 define fp128 @fneg_quad(fp128 %0) {
 ; CHECK-LABEL: fneg_quad:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    st %s1, (, %s11)
 ; CHECK-NEXT:    st %s0, 8(, %s11)
 ; CHECK-NEXT:    ld1b.zx %s0, 15(, %s11)

--- a/llvm/test/CodeGen/VE/Scalar/fp_frem.ll
+++ b/llvm/test/CodeGen/VE/Scalar/fp_frem.ll
@@ -34,7 +34,7 @@
 ; Function Attrs: norecurse nounwind readnone
 define float @frem_float_var(float %0, float %1) {
 ; CHECK-LABEL: frem_float_var:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s2, fmodf@lo
 ; CHECK-NEXT:    and %s2, %s2, (32)0
 ; CHECK-NEXT:    lea.sl %s12, fmodf@hi(, %s2)
@@ -47,7 +47,7 @@ define float @frem_float_var(float %0, float %1) {
 ; Function Attrs: norecurse nounwind readnone
 define double @frem_double_var(double %0, double %1) {
 ; CHECK-LABEL: frem_double_var:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s2, fmod@lo
 ; CHECK-NEXT:    and %s2, %s2, (32)0
 ; CHECK-NEXT:    lea.sl %s12, fmod@hi(, %s2)
@@ -60,7 +60,7 @@ define double @frem_double_var(double %0, double %1) {
 ; Function Attrs: norecurse nounwind readnone
 define fp128 @frem_quad_var(fp128 %0, fp128 %1) {
 ; CHECK-LABEL: frem_quad_var:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s4, fmodl@lo
 ; CHECK-NEXT:    and %s4, %s4, (32)0
 ; CHECK-NEXT:    lea.sl %s12, fmodl@hi(, %s4)
@@ -73,7 +73,7 @@ define fp128 @frem_quad_var(fp128 %0, fp128 %1) {
 ; Function Attrs: norecurse nounwind readnone
 define float @frem_float_zero(float %0) {
 ; CHECK-LABEL: frem_float_zero:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    or %s1, 0, %s0
 ; CHECK-NEXT:    lea %s0, fmodf@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0
@@ -88,7 +88,7 @@ define float @frem_float_zero(float %0) {
 ; Function Attrs: norecurse nounwind readnone
 define double @frem_double_zero(double %0) {
 ; CHECK-LABEL: frem_double_zero:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    or %s1, 0, %s0
 ; CHECK-NEXT:    lea %s0, fmod@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0
@@ -103,7 +103,7 @@ define double @frem_double_zero(double %0) {
 ; Function Attrs: norecurse nounwind readnone
 define fp128 @frem_quad_zero(fp128 %0) {
 ; CHECK-LABEL: frem_quad_zero:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    or %s2, 0, %s0
 ; CHECK-NEXT:    or %s3, 0, %s1
 ; CHECK-NEXT:    lea %s0, .LCPI{{[0-9]+}}_0@lo
@@ -123,7 +123,7 @@ define fp128 @frem_quad_zero(fp128 %0) {
 ; Function Attrs: norecurse nounwind readnone
 define float @frem_float_cont(float %0) {
 ; CHECK-LABEL: frem_float_cont:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    or %s1, 0, %s0
 ; CHECK-NEXT:    lea %s0, fmodf@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0
@@ -138,7 +138,7 @@ define float @frem_float_cont(float %0) {
 ; Function Attrs: norecurse nounwind readnone
 define double @frem_double_cont(double %0) {
 ; CHECK-LABEL: frem_double_cont:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    or %s1, 0, %s0
 ; CHECK-NEXT:    lea %s0, fmod@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0
@@ -153,7 +153,7 @@ define double @frem_double_cont(double %0) {
 ; Function Attrs: norecurse nounwind readnone
 define fp128 @frem_quad_cont(fp128 %0) {
 ; CHECK-LABEL: frem_quad_cont:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    or %s2, 0, %s0
 ; CHECK-NEXT:    or %s3, 0, %s1
 ; CHECK-NEXT:    lea %s0, .LCPI{{[0-9]+}}_0@lo

--- a/llvm/test/CodeGen/VE/Scalar/frameaddr.ll
+++ b/llvm/test/CodeGen/VE/Scalar/frameaddr.ll
@@ -2,7 +2,7 @@
 
 define ptr @test1() nounwind {
 ; CHECK-LABEL: test1:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    or %s0, 0, %s9
 ; CHECK-NEXT:    or %s11, 0, %s9
 entry:
@@ -12,7 +12,7 @@ entry:
 
 define ptr @test2() nounwind {
 ; CHECK-LABEL: test2:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ld %s0, (, %s9)
 ; CHECK-NEXT:    ld %s0, (, %s0)
 ; CHECK-NEXT:    or %s11, 0, %s9

--- a/llvm/test/CodeGen/VE/Scalar/fsin.ll
+++ b/llvm/test/CodeGen/VE/Scalar/fsin.ll
@@ -32,7 +32,7 @@
 ; Function Attrs: nounwind readnone
 define float @fsin_float_var(float %0) {
 ; CHECK-LABEL: fsin_float_var:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s1, sinf@lo
 ; CHECK-NEXT:    and %s1, %s1, (32)0
 ; CHECK-NEXT:    lea.sl %s12, sinf@hi(, %s1)
@@ -48,7 +48,7 @@ declare float @llvm.sin.f32(float)
 ; Function Attrs: nounwind readnone
 define double @fsin_double_var(double %0) {
 ; CHECK-LABEL: fsin_double_var:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s1, sin@lo
 ; CHECK-NEXT:    and %s1, %s1, (32)0
 ; CHECK-NEXT:    lea.sl %s12, sin@hi(, %s1)
@@ -64,7 +64,7 @@ declare double @llvm.sin.f64(double)
 ; Function Attrs: nounwind readnone
 define fp128 @fsin_quad_var(fp128 %0) {
 ; CHECK-LABEL: fsin_quad_var:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s2, sinl@lo
 ; CHECK-NEXT:    and %s2, %s2, (32)0
 ; CHECK-NEXT:    lea.sl %s12, sinl@hi(, %s2)
@@ -98,7 +98,7 @@ define double @fsin_double_zero() {
 ; Function Attrs: nounwind readnone
 define fp128 @fsin_quad_zero() {
 ; CHECK-LABEL: fsin_quad_zero:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s0, .LCPI{{[0-9]+}}_0@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0
 ; CHECK-NEXT:    lea.sl %s2, .LCPI{{[0-9]+}}_0@hi(, %s0)
@@ -136,7 +136,7 @@ define double @fsin_double_const() {
 ; Function Attrs: nounwind readnone
 define fp128 @fsin_quad_const() {
 ; CHECK-LABEL: fsin_quad_const:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s0, .LCPI{{[0-9]+}}_0@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0
 ; CHECK-NEXT:    lea.sl %s2, .LCPI{{[0-9]+}}_0@hi(, %s0)

--- a/llvm/test/CodeGen/VE/Scalar/fsqrt.ll
+++ b/llvm/test/CodeGen/VE/Scalar/fsqrt.ll
@@ -33,7 +33,7 @@
 ; Function Attrs: nounwind readnone
 define float @fsqrt_float_var(float %0) {
 ; CHECK-LABEL: fsqrt_float_var:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s1, sqrtf@lo
 ; CHECK-NEXT:    and %s1, %s1, (32)0
 ; CHECK-NEXT:    lea.sl %s12, sqrtf@hi(, %s1)
@@ -49,7 +49,7 @@ declare float @llvm.sqrt.f32(float)
 ; Function Attrs: nounwind readnone
 define double @fsqrt_double_var(double %0) {
 ; CHECK-LABEL: fsqrt_double_var:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s1, sqrt@lo
 ; CHECK-NEXT:    and %s1, %s1, (32)0
 ; CHECK-NEXT:    lea.sl %s12, sqrt@hi(, %s1)
@@ -65,7 +65,7 @@ declare double @llvm.sqrt.f64(double)
 ; Function Attrs: nounwind readnone
 define fp128 @fsqrt_quad_var(fp128 %0) {
 ; CHECK-LABEL: fsqrt_quad_var:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s2, sqrtl@lo
 ; CHECK-NEXT:    and %s2, %s2, (32)0
 ; CHECK-NEXT:    lea.sl %s12, sqrtl@hi(, %s2)
@@ -99,7 +99,7 @@ define double @fsqrt_double_zero() {
 ; Function Attrs: nounwind readnone
 define fp128 @fsqrt_quad_zero() {
 ; CHECK-LABEL: fsqrt_quad_zero:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s0, .LCPI{{[0-9]+}}_0@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0
 ; CHECK-NEXT:    lea.sl %s2, .LCPI{{[0-9]+}}_0@hi(, %s0)
@@ -135,7 +135,7 @@ define double @fsqrt_double_const() {
 ; Function Attrs: nounwind readnone
 define fp128 @fsqrt_quad_const() {
 ; CHECK-LABEL: fsqrt_quad_const:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s0, .LCPI{{[0-9]+}}_0@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0
 ; CHECK-NEXT:    lea.sl %s2, .LCPI{{[0-9]+}}_0@hi(, %s0)

--- a/llvm/test/CodeGen/VE/Scalar/function_prologue_epilogue.ll
+++ b/llvm/test/CodeGen/VE/Scalar/function_prologue_epilogue.ll
@@ -51,8 +51,8 @@ define i32 @func_alloca(i32 signext %0) {
 ; CHECK-LABEL: func_alloca:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    adds.l %s11, -16, %s11
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB2_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB2_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -61,7 +61,7 @@ define i32 @func_alloca(i32 signext %0) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB2_2:
+; CHECK-NEXT:  .LBB2_1:
 ; CHECK-NEXT:    stl %s0, 12(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -69,8 +69,8 @@ define i32 @func_alloca(i32 signext %0) {
 ; PIC-LABEL: func_alloca:
 ; PIC:       # %bb.0:
 ; PIC-NEXT:    adds.l %s11, -16, %s11
-; PIC-NEXT:    brge.l.t %s11, %s8, .LBB2_2
-; PIC-NEXT:  # %bb.1:
+; PIC-NEXT:    brge.l.t %s11, %s8, .LBB2_1
+; PIC-NEXT:  # %bb.2:
 ; PIC-NEXT:    ld %s61, 24(, %s14)
 ; PIC-NEXT:    or %s62, 0, %s0
 ; PIC-NEXT:    lea %s63, 315
@@ -79,7 +79,7 @@ define i32 @func_alloca(i32 signext %0) {
 ; PIC-NEXT:    shm.l %s11, 16(%s61)
 ; PIC-NEXT:    monc
 ; PIC-NEXT:    or %s0, 0, %s62
-; PIC-NEXT:  .LBB2_2:
+; PIC-NEXT:  .LBB2_1:
 ; PIC-NEXT:    stl %s0, 12(, %s11)
 ; PIC-NEXT:    adds.l %s11, 16, %s11
 ; PIC-NEXT:    b.l.t (, %s10)

--- a/llvm/test/CodeGen/VE/Scalar/inlineasm-mem-lo.ll
+++ b/llvm/test/CodeGen/VE/Scalar/inlineasm-mem-lo.ll
@@ -2,7 +2,7 @@
 
 define i64 @leam(i64 %x) nounwind {
 ; CHECK-LABEL: leam:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    #APP
 ; CHECK-NEXT:    lea %s0, 8(%s11)
 ; CHECK-NEXT:    #NO_APP

--- a/llvm/test/CodeGen/VE/Scalar/load-align1.ll
+++ b/llvm/test/CodeGen/VE/Scalar/load-align1.ll
@@ -10,7 +10,7 @@
 ; Function Attrs: norecurse nounwind readonly
 define double @loadf64stk() {
 ; CHECK-LABEL: loadf64stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ld %s0, 8(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -22,7 +22,7 @@ define double @loadf64stk() {
 ; Function Attrs: norecurse nounwind readonly
 define float @loadf32stk() {
 ; CHECK-LABEL: loadf32stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ldu %s0, 12(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -34,7 +34,7 @@ define float @loadf32stk() {
 ; Function Attrs: norecurse nounwind readonly
 define i64 @loadi64stk() {
 ; CHECK-LABEL: loadi64stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ld %s0, 8(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -46,7 +46,7 @@ define i64 @loadi64stk() {
 ; Function Attrs: norecurse nounwind readonly
 define i32 @loadi32stk() {
 ; CHECK-LABEL: loadi32stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ldl.sx %s0, 12(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -58,7 +58,7 @@ define i32 @loadi32stk() {
 ; Function Attrs: norecurse nounwind readonly
 define i16 @loadi16stk() {
 ; CHECK-LABEL: loadi16stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ld2b.zx %s0, 14(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -70,7 +70,7 @@ define i16 @loadi16stk() {
 ; Function Attrs: norecurse nounwind readonly
 define i8 @loadi8stk() {
 ; CHECK-LABEL: loadi8stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ld1b.zx %s0, 15(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)

--- a/llvm/test/CodeGen/VE/Scalar/load-align2.ll
+++ b/llvm/test/CodeGen/VE/Scalar/load-align2.ll
@@ -10,7 +10,7 @@
 ; Function Attrs: norecurse nounwind readonly
 define double @loadf64stk() {
 ; CHECK-LABEL: loadf64stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ld %s0, 8(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -22,7 +22,7 @@ define double @loadf64stk() {
 ; Function Attrs: norecurse nounwind readonly
 define float @loadf32stk() {
 ; CHECK-LABEL: loadf32stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ldu %s0, 12(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -34,7 +34,7 @@ define float @loadf32stk() {
 ; Function Attrs: norecurse nounwind readonly
 define i64 @loadi64stk() {
 ; CHECK-LABEL: loadi64stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ld %s0, 8(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -46,7 +46,7 @@ define i64 @loadi64stk() {
 ; Function Attrs: norecurse nounwind readonly
 define i32 @loadi32stk() {
 ; CHECK-LABEL: loadi32stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ldl.sx %s0, 12(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -58,7 +58,7 @@ define i32 @loadi32stk() {
 ; Function Attrs: norecurse nounwind readonly
 define i16 @loadi16stk() {
 ; CHECK-LABEL: loadi16stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ld2b.zx %s0, 14(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -70,7 +70,7 @@ define i16 @loadi16stk() {
 ; Function Attrs: norecurse nounwind readonly
 define i8 @loadi8stk() {
 ; CHECK-LABEL: loadi8stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ld1b.zx %s0, 14(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)

--- a/llvm/test/CodeGen/VE/Scalar/load-align4.ll
+++ b/llvm/test/CodeGen/VE/Scalar/load-align4.ll
@@ -10,7 +10,7 @@
 ; Function Attrs: norecurse nounwind readonly
 define double @loadf64stk() {
 ; CHECK-LABEL: loadf64stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ld %s0, 8(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -22,7 +22,7 @@ define double @loadf64stk() {
 ; Function Attrs: norecurse nounwind readonly
 define float @loadf32stk() {
 ; CHECK-LABEL: loadf32stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ldu %s0, 12(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -34,7 +34,7 @@ define float @loadf32stk() {
 ; Function Attrs: norecurse nounwind readonly
 define i64 @loadi64stk() {
 ; CHECK-LABEL: loadi64stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ld %s0, 8(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -46,7 +46,7 @@ define i64 @loadi64stk() {
 ; Function Attrs: norecurse nounwind readonly
 define i32 @loadi32stk() {
 ; CHECK-LABEL: loadi32stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ldl.sx %s0, 12(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -58,7 +58,7 @@ define i32 @loadi32stk() {
 ; Function Attrs: norecurse nounwind readonly
 define i16 @loadi16stk() {
 ; CHECK-LABEL: loadi16stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ld2b.zx %s0, 12(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -70,7 +70,7 @@ define i16 @loadi16stk() {
 ; Function Attrs: norecurse nounwind readonly
 define i8 @loadi8stk() {
 ; CHECK-LABEL: loadi8stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ld1b.zx %s0, 12(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)

--- a/llvm/test/CodeGen/VE/Scalar/load-align8.ll
+++ b/llvm/test/CodeGen/VE/Scalar/load-align8.ll
@@ -10,7 +10,7 @@
 ; Function Attrs: norecurse nounwind readonly
 define double @loadf64stk() {
 ; CHECK-LABEL: loadf64stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ld %s0, 8(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -22,7 +22,7 @@ define double @loadf64stk() {
 ; Function Attrs: norecurse nounwind readonly
 define float @loadf32stk() {
 ; CHECK-LABEL: loadf32stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ldu %s0, 8(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -34,7 +34,7 @@ define float @loadf32stk() {
 ; Function Attrs: norecurse nounwind readonly
 define i64 @loadi64stk() {
 ; CHECK-LABEL: loadi64stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ld %s0, 8(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -46,7 +46,7 @@ define i64 @loadi64stk() {
 ; Function Attrs: norecurse nounwind readonly
 define i32 @loadi32stk() {
 ; CHECK-LABEL: loadi32stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ldl.sx %s0, 8(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -58,7 +58,7 @@ define i32 @loadi32stk() {
 ; Function Attrs: norecurse nounwind readonly
 define i16 @loadi16stk() {
 ; CHECK-LABEL: loadi16stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ld2b.zx %s0, 8(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -70,7 +70,7 @@ define i16 @loadi16stk() {
 ; Function Attrs: norecurse nounwind readonly
 define i8 @loadi8stk() {
 ; CHECK-LABEL: loadi8stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ld1b.zx %s0, 8(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)

--- a/llvm/test/CodeGen/VE/Scalar/load.ll
+++ b/llvm/test/CodeGen/VE/Scalar/load.ll
@@ -154,7 +154,7 @@ define i64 @loadi8zext(ptr nocapture readonly %0) {
 ; Function Attrs: norecurse nounwind readonly
 define fp128 @loadf128stk() {
 ; CHECK-LABEL: loadf128stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ld %s1, (, %s11)
 ; CHECK-NEXT:    ld %s0, 8(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
@@ -167,7 +167,7 @@ define fp128 @loadf128stk() {
 ; Function Attrs: norecurse nounwind readonly
 define double @loadf64stk() {
 ; CHECK-LABEL: loadf64stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ld %s0, (, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -179,7 +179,7 @@ define double @loadf64stk() {
 ; Function Attrs: norecurse nounwind readonly
 define float @loadf32stk() {
 ; CHECK-LABEL: loadf32stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ldu %s0, (, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -191,7 +191,7 @@ define float @loadf32stk() {
 ; Function Attrs: norecurse nounwind readonly
 define i128 @loadi128stk() {
 ; CHECK-LABEL: loadi128stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ld %s0, (, %s11)
 ; CHECK-NEXT:    ld %s1, 8(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
@@ -204,7 +204,7 @@ define i128 @loadi128stk() {
 ; Function Attrs: norecurse nounwind readonly
 define i64 @loadi64stk() {
 ; CHECK-LABEL: loadi64stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ld %s0, (, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -216,7 +216,7 @@ define i64 @loadi64stk() {
 ; Function Attrs: norecurse nounwind readonly
 define i32 @loadi32stk() {
 ; CHECK-LABEL: loadi32stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ldl.sx %s0, (, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -228,7 +228,7 @@ define i32 @loadi32stk() {
 ; Function Attrs: norecurse nounwind readonly
 define i16 @loadi16stk() {
 ; CHECK-LABEL: loadi16stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ld2b.zx %s0, (, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -240,7 +240,7 @@ define i16 @loadi16stk() {
 ; Function Attrs: norecurse nounwind readonly
 define i8 @loadi8stk() {
 ; CHECK-LABEL: loadi8stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ld1b.zx %s0, (, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)

--- a/llvm/test/CodeGen/VE/Scalar/load_stk.ll
+++ b/llvm/test/CodeGen/VE/Scalar/load_stk.ll
@@ -97,8 +97,8 @@ define x86_fastcallcc i64 @loadi64_stk() {
 ; CHECK-LABEL: loadi64_stk:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    adds.l %s11, -16, %s11
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB0_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB0_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -107,7 +107,7 @@ define x86_fastcallcc i64 @loadi64_stk() {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB0_2:
+; CHECK-NEXT:  .LBB0_1:
 ; CHECK-NEXT:    ld %s0, 8(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -129,8 +129,8 @@ define x86_fastcallcc i64 @loadi64_stk_big() {
 ; CHECK-LABEL: loadi64_stk_big:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    lea %s11, -2147483648(, %s11)
-; CHECK-NEXT:    brge.l %s11, %s8, .LBB1_4
-; CHECK-NEXT:  # %bb.3:
+; CHECK-NEXT:    brge.l %s11, %s8, .LBB1_3
+; CHECK-NEXT:  # %bb.4:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -139,7 +139,7 @@ define x86_fastcallcc i64 @loadi64_stk_big() {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB1_4:
+; CHECK-NEXT:  .LBB1_3:
 ; CHECK-NEXT:    ld %s0, 2147483640(, %s11)
 ; CHECK-NEXT:    or %s1, 0, (0)1
 ; CHECK-NEXT:    lea %s2, 2147483640
@@ -180,8 +180,8 @@ define x86_fastcallcc i64 @loadi64_stk_big2() {
 ; CHECK-NEXT:    lea %s13, 2147483632
 ; CHECK-NEXT:    and %s13, %s13, (32)0
 ; CHECK-NEXT:    lea.sl %s11, -1(%s13, %s11)
-; CHECK-NEXT:    brge.l %s11, %s8, .LBB2_4
-; CHECK-NEXT:  # %bb.3:
+; CHECK-NEXT:    brge.l %s11, %s8, .LBB2_3
+; CHECK-NEXT:  # %bb.4:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -190,7 +190,7 @@ define x86_fastcallcc i64 @loadi64_stk_big2() {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB2_4:
+; CHECK-NEXT:  .LBB2_3:
 ; CHECK-NEXT:    lea %s13, -2147483640
 ; CHECK-NEXT:    and %s13, %s13, (32)0
 ; CHECK-NEXT:    lea.sl %s13, (%s11, %s13)
@@ -236,8 +236,8 @@ define x86_fastcallcc i64 @loadi64_stk_dyn(i64 noundef %0) {
 ; CHECK-NEXT:    st %s10, 8(, %s11)
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    lea %s11, -256(, %s11)
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB3_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB3_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -246,7 +246,7 @@ define x86_fastcallcc i64 @loadi64_stk_dyn(i64 noundef %0) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB3_2:
+; CHECK-NEXT:  .LBB3_1:
 ; CHECK-NEXT:    lea %s0, 15(, %s0)
 ; CHECK-NEXT:    and %s0, -16, %s0
 ; CHECK-NEXT:    lea %s1, __ve_grow_stack@lo
@@ -280,8 +280,8 @@ define x86_fastcallcc i64 @loadi64_stk_dyn_align(i64 noundef %0) {
 ; CHECK-NEXT:    lea %s11, -288(, %s11)
 ; CHECK-NEXT:    and %s11, %s11, (59)1
 ; CHECK-NEXT:    or %s17, 0, %s11
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB4_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB4_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -290,7 +290,7 @@ define x86_fastcallcc i64 @loadi64_stk_dyn_align(i64 noundef %0) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB4_2:
+; CHECK-NEXT:  .LBB4_1:
 ; CHECK-NEXT:    lea %s0, 15(, %s0)
 ; CHECK-NEXT:    and %s0, -16, %s0
 ; CHECK-NEXT:    lea %s1, __ve_grow_stack@lo
@@ -325,8 +325,8 @@ define x86_fastcallcc i64 @loadi64_stk_dyn_align2(i64 noundef %0) {
 ; CHECK-NEXT:    lea %s11, -320(, %s11)
 ; CHECK-NEXT:    and %s11, %s11, (58)1
 ; CHECK-NEXT:    or %s17, 0, %s11
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB5_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB5_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -335,7 +335,7 @@ define x86_fastcallcc i64 @loadi64_stk_dyn_align2(i64 noundef %0) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB5_2:
+; CHECK-NEXT:  .LBB5_1:
 ; CHECK-NEXT:    lea %s0, 15(, %s0)
 ; CHECK-NEXT:    and %s0, -16, %s0
 ; CHECK-NEXT:    lea %s1, __ve_grow_stack@lo
@@ -375,8 +375,8 @@ define x86_fastcallcc i64 @loadi64_stk_dyn_align_spill(i64 noundef %0) {
 ; CHECK-NEXT:    lea %s11, -288(, %s11)
 ; CHECK-NEXT:    and %s11, %s11, (59)1
 ; CHECK-NEXT:    or %s17, 0, %s11
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB6_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB6_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -385,7 +385,7 @@ define x86_fastcallcc i64 @loadi64_stk_dyn_align_spill(i64 noundef %0) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB6_2:
+; CHECK-NEXT:  .LBB6_1:
 ; CHECK-NEXT:    st %s18, 48(, %s9) # 8-byte Folded Spill
 ; CHECK-NEXT:    st %s19, 56(, %s9) # 8-byte Folded Spill
 ; CHECK-NEXT:    or %s18, 0, %s0
@@ -435,8 +435,8 @@ define x86_fastcallcc fp128 @loadquad_stk() {
 ; CHECK-LABEL: loadquad_stk:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    adds.l %s11, -16, %s11
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB7_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB7_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -445,7 +445,7 @@ define x86_fastcallcc fp128 @loadquad_stk() {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB7_2:
+; CHECK-NEXT:  .LBB7_1:
 ; CHECK-NEXT:    ld %s1, (, %s11)
 ; CHECK-NEXT:    ld %s0, 8(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
@@ -464,8 +464,8 @@ define x86_fastcallcc fp128 @loadquad_stk_big() {
 ; CHECK-NEXT:    lea %s13, 2147483632
 ; CHECK-NEXT:    and %s13, %s13, (32)0
 ; CHECK-NEXT:    lea.sl %s11, -1(%s13, %s11)
-; CHECK-NEXT:    brge.l %s11, %s8, .LBB8_4
-; CHECK-NEXT:  # %bb.3:
+; CHECK-NEXT:    brge.l %s11, %s8, .LBB8_3
+; CHECK-NEXT:  # %bb.4:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -474,7 +474,7 @@ define x86_fastcallcc fp128 @loadquad_stk_big() {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB8_4:
+; CHECK-NEXT:  .LBB8_3:
 ; CHECK-NEXT:    lea %s13, -2147483648
 ; CHECK-NEXT:    and %s13, %s13, (32)0
 ; CHECK-NEXT:    lea.sl %s13, (%s11, %s13)
@@ -519,8 +519,8 @@ define x86_fastcallcc fp128 @loadquad_stk_big2() {
 ; CHECK-NEXT:    lea %s13, 2147483632
 ; CHECK-NEXT:    and %s13, %s13, (32)0
 ; CHECK-NEXT:    lea.sl %s11, -1(%s13, %s11)
-; CHECK-NEXT:    brge.l %s11, %s8, .LBB9_4
-; CHECK-NEXT:  # %bb.3:
+; CHECK-NEXT:    brge.l %s11, %s8, .LBB9_3
+; CHECK-NEXT:  # %bb.4:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -529,7 +529,7 @@ define x86_fastcallcc fp128 @loadquad_stk_big2() {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB9_4:
+; CHECK-NEXT:  .LBB9_3:
 ; CHECK-NEXT:    lea %s13, -2147483648
 ; CHECK-NEXT:    and %s13, %s13, (32)0
 ; CHECK-NEXT:    lea.sl %s13, (%s11, %s13)
@@ -576,8 +576,8 @@ define x86_fastcallcc fp128 @loadquad_stk_dyn(i64 noundef %0) {
 ; CHECK-NEXT:    st %s10, 8(, %s11)
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    lea %s11, -256(, %s11)
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB10_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB10_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -586,7 +586,7 @@ define x86_fastcallcc fp128 @loadquad_stk_dyn(i64 noundef %0) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB10_2:
+; CHECK-NEXT:  .LBB10_1:
 ; CHECK-NEXT:    lea %s0, 15(, %s0)
 ; CHECK-NEXT:    and %s0, -16, %s0
 ; CHECK-NEXT:    lea %s1, __ve_grow_stack@lo
@@ -622,8 +622,8 @@ define x86_fastcallcc fp128 @loadquad_stk_dyn_align(i64 noundef %0) {
 ; CHECK-NEXT:    lea %s11, -288(, %s11)
 ; CHECK-NEXT:    and %s11, %s11, (59)1
 ; CHECK-NEXT:    or %s17, 0, %s11
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB11_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB11_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -632,7 +632,7 @@ define x86_fastcallcc fp128 @loadquad_stk_dyn_align(i64 noundef %0) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB11_2:
+; CHECK-NEXT:  .LBB11_1:
 ; CHECK-NEXT:    lea %s0, 15(, %s0)
 ; CHECK-NEXT:    and %s0, -16, %s0
 ; CHECK-NEXT:    lea %s1, __ve_grow_stack@lo
@@ -669,8 +669,8 @@ define x86_fastcallcc fp128 @loadquad_stk_dyn_align2(i64 noundef %0) {
 ; CHECK-NEXT:    lea %s11, -320(, %s11)
 ; CHECK-NEXT:    and %s11, %s11, (58)1
 ; CHECK-NEXT:    or %s17, 0, %s11
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB12_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB12_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -679,7 +679,7 @@ define x86_fastcallcc fp128 @loadquad_stk_dyn_align2(i64 noundef %0) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB12_2:
+; CHECK-NEXT:  .LBB12_1:
 ; CHECK-NEXT:    lea %s0, 15(, %s0)
 ; CHECK-NEXT:    and %s0, -16, %s0
 ; CHECK-NEXT:    lea %s1, __ve_grow_stack@lo
@@ -722,8 +722,8 @@ define x86_fastcallcc fp128 @loadquad_stk_dyn_align_spill(i64 noundef %0) {
 ; CHECK-NEXT:    lea %s11, -288(, %s11)
 ; CHECK-NEXT:    and %s11, %s11, (59)1
 ; CHECK-NEXT:    or %s17, 0, %s11
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB13_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB13_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -732,7 +732,7 @@ define x86_fastcallcc fp128 @loadquad_stk_dyn_align_spill(i64 noundef %0) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB13_2:
+; CHECK-NEXT:  .LBB13_1:
 ; CHECK-NEXT:    st %s18, 48(, %s9) # 8-byte Folded Spill
 ; CHECK-NEXT:    st %s20, 64(, %s9) # 8-byte Folded Spill
 ; CHECK-NEXT:    st %s21, 72(, %s9) # 8-byte Folded Spill

--- a/llvm/test/CodeGen/VE/Scalar/loadrri.ll
+++ b/llvm/test/CodeGen/VE/Scalar/loadrri.ll
@@ -25,7 +25,7 @@ define signext i8 @func_rr(ptr nocapture readonly %0, i32 signext %1) {
 ; Function Attrs: nounwind
 define signext i8 @func_fr(ptr readonly %0, i32 signext %1) {
 ; CHECK-LABEL: func_fr:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    sll %s1, %s1, 2
 ; CHECK-NEXT:    ldl.sx %s0, (%s1, %s0)
 ; CHECK-NEXT:    stl %s0, 8(%s1, %s11)
@@ -52,7 +52,7 @@ declare void @llvm.lifetime.end.p0(i64 immarg, ptr nocapture)
 
 define signext i8 @func_rf(ptr readonly %0, i64 %1, i32 signext %2) {
 ; CHECK-LABEL: func_rf:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ld1b.sx %s0, 8(%s1, %s11)
 ; CHECK-NEXT:    adds.l %s11, 32, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)

--- a/llvm/test/CodeGen/VE/Scalar/multiply.ll
+++ b/llvm/test/CodeGen/VE/Scalar/multiply.ll
@@ -43,7 +43,7 @@ define i64 @func64(i64 %a, i64 %b) {
 
 define i128 @func128(i128 %a, i128 %b) {
 ; CHECK-LABEL: func128:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    or %s4, 0, %s1
 ; CHECK-NEXT:    or %s5, 0, %s0
 ; CHECK-NEXT:    lea %s0, __multi3@lo
@@ -100,7 +100,7 @@ define i64 @func64z(i64 %a, i64 %b) {
 
 define i128 @func128z(i128 %a, i128 %b) {
 ; CHECK-LABEL: func128z:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    or %s4, 0, %s1
 ; CHECK-NEXT:    or %s5, 0, %s0
 ; CHECK-NEXT:    lea %s0, __multi3@lo
@@ -159,7 +159,7 @@ define i64 @funci64(i64 %a) {
 
 define i128 @funci128(i128 %a) {
 ; CHECK-LABEL: funci128:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s2, __multi3@lo
 ; CHECK-NEXT:    and %s2, %s2, (32)0
 ; CHECK-NEXT:    lea.sl %s12, __multi3@hi(, %s2)
@@ -212,7 +212,7 @@ define i64 @funci64z(i64 %a) {
 
 define i128 @funci128z(i128 %a) {
 ; CHECK-LABEL: funci128z:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s2, __multi3@lo
 ; CHECK-NEXT:    and %s2, %s2, (32)0
 ; CHECK-NEXT:    lea.sl %s12, __multi3@hi(, %s2)

--- a/llvm/test/CodeGen/VE/Scalar/pic_access_static_data.ll
+++ b/llvm/test/CodeGen/VE/Scalar/pic_access_static_data.ll
@@ -36,7 +36,7 @@ define void @func() {
 ; Function Attrs: nounwind
 define i32 @main() {
 ; CHECK-LABEL: main:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s15, _GLOBAL_OFFSET_TABLE_@pc_lo(-24)
 ; CHECK-NEXT:    and %s15, %s15, (32)0
 ; CHECK-NEXT:    sic %s16

--- a/llvm/test/CodeGen/VE/Scalar/pic_func_call.ll
+++ b/llvm/test/CodeGen/VE/Scalar/pic_func_call.ll
@@ -2,7 +2,7 @@
 
 define void @func() {
 ; CHECK-LABEL: func:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s15, _GLOBAL_OFFSET_TABLE_@pc_lo(-24)
 ; CHECK-NEXT:    and %s15, %s15, (32)0
 ; CHECK-NEXT:    sic %s16

--- a/llvm/test/CodeGen/VE/Scalar/pic_indirect_func_call.ll
+++ b/llvm/test/CodeGen/VE/Scalar/pic_indirect_func_call.ll
@@ -4,7 +4,7 @@
 
 define void @func() {
 ; CHECK-LABEL: func:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s15, _GLOBAL_OFFSET_TABLE_@pc_lo(-24)
 ; CHECK-NEXT:    and %s15, %s15, (32)0
 ; CHECK-NEXT:    sic %s16

--- a/llvm/test/CodeGen/VE/Scalar/pow.ll
+++ b/llvm/test/CodeGen/VE/Scalar/pow.ll
@@ -27,7 +27,7 @@
 ; Function Attrs: mustprogress nofree nosync nounwind readnone willreturn
 define float @func_fp_pow_var_float(float noundef %0, float noundef %1) {
 ; CHECK-LABEL: func_fp_pow_var_float:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s2, powf@lo
 ; CHECK-NEXT:    and %s2, %s2, (32)0
 ; CHECK-NEXT:    lea.sl %s12, powf@hi(, %s2)
@@ -43,7 +43,7 @@ declare float @llvm.pow.f32(float, float)
 ; Function Attrs: mustprogress nofree nosync nounwind readnone willreturn
 define double @func_fp_pow_var_double(double noundef %0, double noundef %1) {
 ; CHECK-LABEL: func_fp_pow_var_double:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s2, pow@lo
 ; CHECK-NEXT:    and %s2, %s2, (32)0
 ; CHECK-NEXT:    lea.sl %s12, pow@hi(, %s2)
@@ -59,7 +59,7 @@ declare double @llvm.pow.f64(double, double)
 ; Function Attrs: mustprogress nofree nosync nounwind readnone willreturn
 define fp128 @func_fp_pow_var_quad(fp128 noundef %0, fp128 noundef %1) {
 ; CHECK-LABEL: func_fp_pow_var_quad:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s4, powl@lo
 ; CHECK-NEXT:    and %s4, %s4, (32)0
 ; CHECK-NEXT:    lea.sl %s12, powl@hi(, %s4)
@@ -106,7 +106,7 @@ define fp128 @func_fp_pow_zero_back_quad(fp128 noundef %0) {
 ; Function Attrs: mustprogress nofree nosync nounwind readnone willreturn
 define float @func_fp_pow_zero_fore_float(float noundef %0) {
 ; CHECK-LABEL: func_fp_pow_zero_fore_float:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    or %s1, 0, %s0
 ; CHECK-NEXT:    lea %s0, powf@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0
@@ -121,7 +121,7 @@ define float @func_fp_pow_zero_fore_float(float noundef %0) {
 ; Function Attrs: mustprogress nofree nosync nounwind readnone willreturn
 define double @func_fp_pow_zero_fore_double(double noundef %0) {
 ; CHECK-LABEL: func_fp_pow_zero_fore_double:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    or %s1, 0, %s0
 ; CHECK-NEXT:    lea %s0, pow@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0
@@ -136,7 +136,7 @@ define double @func_fp_pow_zero_fore_double(double noundef %0) {
 ; Function Attrs: mustprogress nofree nosync nounwind readnone willreturn
 define fp128 @func_fp_pow_zero_fore_quad(fp128 noundef %0) {
 ; CHECK-LABEL: func_fp_pow_zero_fore_quad:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    or %s2, 0, %s0
 ; CHECK-NEXT:    or %s3, 0, %s1
 ; CHECK-NEXT:    lea %s0, .LCPI{{[0-9]+}}_0@lo
@@ -180,7 +180,7 @@ define double @func_fp_pow_const_back_double(double noundef %0) {
 ; Function Attrs: mustprogress nofree nosync nounwind readnone willreturn
 define fp128 @func_fp_pow_const_back_quad(fp128 noundef %0) {
 ; CHECK-LABEL: func_fp_pow_const_back_quad:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    fmul.q %s2, %s0, %s0
 ; CHECK-NEXT:    lea %s0, .LCPI{{[0-9]+}}_0@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0
@@ -199,7 +199,7 @@ define fp128 @func_fp_pow_const_back_quad(fp128 noundef %0) {
 ; Function Attrs: mustprogress nofree nosync nounwind readnone willreturn
 define float @func_fp_pow_const_fore_float(float noundef %0) {
 ; CHECK-LABEL: func_fp_pow_const_fore_float:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    or %s1, 0, %s0
 ; CHECK-NEXT:    lea %s0, powf@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0
@@ -214,7 +214,7 @@ define float @func_fp_pow_const_fore_float(float noundef %0) {
 ; Function Attrs: mustprogress nofree nosync nounwind readnone willreturn
 define double @func_fp_pow_const_fore_double(double noundef %0) {
 ; CHECK-LABEL: func_fp_pow_const_fore_double:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    or %s1, 0, %s0
 ; CHECK-NEXT:    lea %s0, pow@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0
@@ -229,7 +229,7 @@ define double @func_fp_pow_const_fore_double(double noundef %0) {
 ; Function Attrs: mustprogress nofree nosync nounwind readnone willreturn
 define fp128 @func_fp_pow_const_fore_quad(fp128 noundef %0) {
 ; CHECK-LABEL: func_fp_pow_const_fore_quad:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    or %s2, 0, %s0
 ; CHECK-NEXT:    or %s3, 0, %s1
 ; CHECK-NEXT:    lea %s0, .LCPI{{[0-9]+}}_0@lo

--- a/llvm/test/CodeGen/VE/Scalar/rem.ll
+++ b/llvm/test/CodeGen/VE/Scalar/rem.ll
@@ -3,7 +3,7 @@
 ; Function Attrs: norecurse nounwind readnone
 define i128 @remi128(i128 %a, i128 %b) {
 ; CHECK-LABEL: remi128:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s4, __modti3@lo
 ; CHECK-NEXT:    and %s4, %s4, (32)0
 ; CHECK-NEXT:    lea.sl %s12, __modti3@hi(, %s4)
@@ -41,7 +41,7 @@ define signext i32 @remi32(i32 signext %a, i32 signext %b) {
 ; Function Attrs: norecurse nounwind readnone
 define i128 @remu128(i128 %a, i128 %b) {
 ; CHECK-LABEL: remu128:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s4, __umodti3@lo
 ; CHECK-NEXT:    and %s4, %s4, (32)0
 ; CHECK-NEXT:    lea.sl %s12, __umodti3@hi(, %s4)
@@ -137,7 +137,7 @@ define zeroext i8 @remu8(i8 zeroext %a, i8 zeroext %b) {
 ; Function Attrs: norecurse nounwind readnone
 define i128 @remi128ri(i128 %a) {
 ; CHECK-LABEL: remi128ri:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s2, __modti3@lo
 ; CHECK-NEXT:    and %s2, %s2, (32)0
 ; CHECK-NEXT:    lea.sl %s12, __modti3@hi(, %s2)
@@ -181,7 +181,7 @@ define signext i32 @remi32ri(i32 signext %a) {
 ; Function Attrs: norecurse nounwind readnone
 define i128 @remu128ri(i128 %a) {
 ; CHECK-LABEL: remu128ri:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s2, __umodti3@lo
 ; CHECK-NEXT:    and %s2, %s2, (32)0
 ; CHECK-NEXT:    lea.sl %s12, __umodti3@hi(, %s2)
@@ -224,7 +224,7 @@ define zeroext i32 @remu32ri(i32 zeroext %a) {
 ; Function Attrs: norecurse nounwind readnone
 define i128 @remi128li(i128 %a) {
 ; CHECK-LABEL: remi128li:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    or %s3, 0, %s1
 ; CHECK-NEXT:    or %s2, 0, %s0
 ; CHECK-NEXT:    lea %s0, __modti3@lo
@@ -266,7 +266,7 @@ define signext i32 @remi32li(i32 signext %a, i32 signext %b) {
 ; Function Attrs: norecurse nounwind readnone
 define i128 @remu128li(i128) {
 ; CHECK-LABEL: remu128li:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    or %s3, 0, %s1
 ; CHECK-NEXT:    or %s2, 0, %s0
 ; CHECK-NEXT:    lea %s0, __umodti3@lo

--- a/llvm/test/CodeGen/VE/Scalar/returnaddr.ll
+++ b/llvm/test/CodeGen/VE/Scalar/returnaddr.ll
@@ -8,8 +8,8 @@ define ptr @h() nounwind readnone optsize {
 ; CHECK-NEXT:    st %s10, 8(, %s11)
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    lea %s11, -176(, %s11)
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB0_2
-; CHECK-NEXT:  # %bb.1: # %entry
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB0_1
+; CHECK-NEXT:  # %bb.2: # %entry
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -18,7 +18,7 @@ define ptr @h() nounwind readnone optsize {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB0_2: # %entry
+; CHECK-NEXT:  .LBB0_1: # %entry
 ; CHECK-NEXT:    ld %s0, (, %s9)
 ; CHECK-NEXT:    ld %s0, (, %s0)
 ; CHECK-NEXT:    ld %s0, 8(, %s0)
@@ -40,8 +40,8 @@ define ptr @g() nounwind readnone optsize {
 ; CHECK-NEXT:    st %s10, 8(, %s11)
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    lea %s11, -176(, %s11)
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB1_2
-; CHECK-NEXT:  # %bb.1: # %entry
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB1_1
+; CHECK-NEXT:  # %bb.2: # %entry
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -50,7 +50,7 @@ define ptr @g() nounwind readnone optsize {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB1_2: # %entry
+; CHECK-NEXT:  .LBB1_1: # %entry
 ; CHECK-NEXT:    ld %s0, (, %s9)
 ; CHECK-NEXT:    ld %s0, 8(, %s0)
 ; CHECK-NEXT:    or %s11, 0, %s9
@@ -69,8 +69,8 @@ define ptr @f() nounwind readnone optsize {
 ; CHECK-NEXT:    st %s10, 8(, %s11)
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    lea %s11, -176(, %s11)
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB2_2
-; CHECK-NEXT:  # %bb.1: # %entry
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB2_1
+; CHECK-NEXT:  # %bb.2: # %entry
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -79,7 +79,7 @@ define ptr @f() nounwind readnone optsize {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB2_2: # %entry
+; CHECK-NEXT:  .LBB2_1: # %entry
 ; CHECK-NEXT:    ld %s0, 8(, %s9)
 ; CHECK-NEXT:    or %s11, 0, %s9
 ; CHECK-NEXT:    ld %s10, 8(, %s11)

--- a/llvm/test/CodeGen/VE/Scalar/sext_zext_load.ll
+++ b/llvm/test/CodeGen/VE/Scalar/sext_zext_load.ll
@@ -2,7 +2,7 @@
 
 define signext i16 @func1() {
 ; CHECK-LABEL: func1:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ld1b.sx %s0, 15(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -14,7 +14,7 @@ define signext i16 @func1() {
 
 define i32 @func2() {
 ; CHECK-LABEL: func2:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ld1b.sx %s0, 15(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -26,7 +26,7 @@ define i32 @func2() {
 
 define i64 @func3() {
 ; CHECK-LABEL: func3:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ld1b.sx %s0, 15(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -38,7 +38,7 @@ define i64 @func3() {
 
 define zeroext i16 @func5() {
 ; CHECK-LABEL: func5:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ld1b.sx %s0, 15(, %s11)
 ; CHECK-NEXT:    and %s0, %s0, (48)0
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
@@ -51,7 +51,7 @@ define zeroext i16 @func5() {
 
 define i32 @func6() {
 ; CHECK-LABEL: func6:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ld1b.sx %s0, 15(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -63,7 +63,7 @@ define i32 @func6() {
 
 define i64 @func7() {
 ; CHECK-LABEL: func7:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ld1b.sx %s0, 15(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -75,7 +75,7 @@ define i64 @func7() {
 
 define signext i16 @func9() {
 ; CHECK-LABEL: func9:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ld1b.zx %s0, 15(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -87,7 +87,7 @@ define signext i16 @func9() {
 
 define i32 @func10() {
 ; CHECK-LABEL: func10:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ld1b.zx %s0, 15(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -99,7 +99,7 @@ define i32 @func10() {
 
 define i64 @func11() {
 ; CHECK-LABEL: func11:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ld1b.zx %s0, 15(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -111,7 +111,7 @@ define i64 @func11() {
 
 define zeroext i16 @func13() {
 ; CHECK-LABEL: func13:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ld1b.zx %s0, 15(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -123,7 +123,7 @@ define zeroext i16 @func13() {
 
 define zeroext i16 @func14() {
 ; CHECK-LABEL: func14:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ld1b.zx %s0, 15(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -135,7 +135,7 @@ define zeroext i16 @func14() {
 
 define i64 @func15() {
 ; CHECK-LABEL: func15:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ld1b.zx %s0, 15(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -147,7 +147,7 @@ define i64 @func15() {
 
 define i32 @func17() {
 ; CHECK-LABEL: func17:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ld2b.sx %s0, 14(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -159,7 +159,7 @@ define i32 @func17() {
 
 define i64 @func18() {
 ; CHECK-LABEL: func18:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ld2b.sx %s0, 14(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -171,7 +171,7 @@ define i64 @func18() {
 
 define zeroext i16 @func20() {
 ; CHECK-LABEL: func20:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ld2b.zx %s0, 14(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -182,7 +182,7 @@ define zeroext i16 @func20() {
 
 define i64 @func21() {
 ; CHECK-LABEL: func21:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ld2b.sx %s0, 14(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -194,7 +194,7 @@ define i64 @func21() {
 
 define i32 @func23() {
 ; CHECK-LABEL: func23:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ld2b.zx %s0, 14(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -206,7 +206,7 @@ define i32 @func23() {
 
 define i64 @func24() {
 ; CHECK-LABEL: func24:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ld2b.zx %s0, 14(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -218,7 +218,7 @@ define i64 @func24() {
 
 define zeroext i16 @func26() {
 ; CHECK-LABEL: func26:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ld2b.zx %s0, 14(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -229,7 +229,7 @@ define zeroext i16 @func26() {
 
 define i64 @func27() {
 ; CHECK-LABEL: func27:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ld2b.zx %s0, 14(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -241,7 +241,7 @@ define i64 @func27() {
 
 define i64 @func29() {
 ; CHECK-LABEL: func29:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ldl.sx %s0, 12(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -253,7 +253,7 @@ define i64 @func29() {
 
 define i64 @func31() {
 ; CHECK-LABEL: func31:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ldl.sx %s0, 12(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -265,7 +265,7 @@ define i64 @func31() {
 
 define i64 @func33() {
 ; CHECK-LABEL: func33:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ldl.zx %s0, 12(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -277,7 +277,7 @@ define i64 @func33() {
 
 define i64 @func35() {
 ; CHECK-LABEL: func35:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ldl.zx %s0, 12(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -289,7 +289,7 @@ define i64 @func35() {
 
 define signext i8 @func37() {
 ; CHECK-LABEL: func37:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ld1b.zx %s0, 15(, %s11)
 ; CHECK-NEXT:    sll %s0, %s0, 63
 ; CHECK-NEXT:    sra.l %s0, %s0, 63
@@ -303,7 +303,7 @@ define signext i8 @func37() {
 
 define signext i16 @func38() {
 ; CHECK-LABEL: func38:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ld1b.zx %s0, 15(, %s11)
 ; CHECK-NEXT:    sll %s0, %s0, 63
 ; CHECK-NEXT:    sra.l %s0, %s0, 63
@@ -317,7 +317,7 @@ define signext i16 @func38() {
 
 define signext i32 @func39() {
 ; CHECK-LABEL: func39:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ld1b.zx %s0, 15(, %s11)
 ; CHECK-NEXT:    sll %s0, %s0, 63
 ; CHECK-NEXT:    sra.l %s0, %s0, 63
@@ -331,7 +331,7 @@ define signext i32 @func39() {
 
 define signext i64 @func40() {
 ; CHECK-LABEL: func40:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ld1b.zx %s0, 15(, %s11)
 ; CHECK-NEXT:    sll %s0, %s0, 63
 ; CHECK-NEXT:    sra.l %s0, %s0, 63
@@ -345,7 +345,7 @@ define signext i64 @func40() {
 
 define signext i8 @func42() {
 ; CHECK-LABEL: func42:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ld1b.zx %s0, 15(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -357,7 +357,7 @@ define signext i8 @func42() {
 
 define signext i16 @func43() {
 ; CHECK-LABEL: func43:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ld1b.zx %s0, 15(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -369,7 +369,7 @@ define signext i16 @func43() {
 
 define signext i32 @func44() {
 ; CHECK-LABEL: func44:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ld1b.zx %s0, 15(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -381,7 +381,7 @@ define signext i32 @func44() {
 
 define signext i64 @func45() {
 ; CHECK-LABEL: func45:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    ld1b.zx %s0, 15(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)

--- a/llvm/test/CodeGen/VE/Scalar/shl.ll
+++ b/llvm/test/CodeGen/VE/Scalar/shl.ll
@@ -144,7 +144,7 @@ define i64 @shl_u64_var(i64 %0, i64 %1) {
 ; Function Attrs: norecurse nounwind readnone
 define i128 @shl_i128_var(i128 %0, i128 %1) {
 ; CHECK-LABEL: shl_i128_var:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    and %s2, %s2, (32)0
 ; CHECK-NEXT:    lea %s3, __ashlti3@lo
 ; CHECK-NEXT:    and %s3, %s3, (32)0
@@ -158,7 +158,7 @@ define i128 @shl_i128_var(i128 %0, i128 %1) {
 ; Function Attrs: norecurse nounwind readnone
 define i128 @shl_u128_var(i128 %0, i128 %1) {
 ; CHECK-LABEL: shl_u128_var:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    and %s2, %s2, (32)0
 ; CHECK-NEXT:    lea %s3, __ashlti3@lo
 ; CHECK-NEXT:    and %s3, %s3, (32)0
@@ -272,7 +272,7 @@ define i64 @shl_const_u64(i64 %0) {
 ; Function Attrs: norecurse nounwind readnone
 define i128 @shl_const_i128(i128 %0) {
 ; CHECK-LABEL: shl_const_i128:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    and %s2, %s0, (32)0
 ; CHECK-NEXT:    lea %s0, __ashlti3@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0
@@ -288,7 +288,7 @@ define i128 @shl_const_i128(i128 %0) {
 ; Function Attrs: norecurse nounwind readnone
 define i128 @shl_const_u128(i128 %0) {
 ; CHECK-LABEL: shl_const_u128:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    and %s2, %s0, (32)0
 ; CHECK-NEXT:    lea %s0, __ashlti3@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0

--- a/llvm/test/CodeGen/VE/Scalar/shr.ll
+++ b/llvm/test/CodeGen/VE/Scalar/shr.ll
@@ -179,7 +179,7 @@ define i64 @shl_u64_var(i64 %0, i64 %1) {
 ; Function Attrs: norecurse nounwind readnone
 define i128 @shl_i128_var(i128 %0, i128 %1) {
 ; CHECK-LABEL: shl_i128_var:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    adds.w.sx %s2, %s2, (0)1
 ; CHECK-NEXT:    lea %s3, __ashrti3@lo
 ; CHECK-NEXT:    and %s3, %s3, (32)0
@@ -193,7 +193,7 @@ define i128 @shl_i128_var(i128 %0, i128 %1) {
 ; Function Attrs: norecurse nounwind readnone
 define i128 @shl_u128_var(i128 %0, i128 %1) {
 ; CHECK-LABEL: shl_u128_var:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    and %s2, %s2, (32)0
 ; CHECK-NEXT:    lea %s3, __lshrti3@lo
 ; CHECK-NEXT:    and %s3, %s3, (32)0
@@ -303,7 +303,7 @@ define i64 @shl_const_u64(i64 %0) {
 ; Function Attrs: norecurse nounwind readnone
 define i128 @shl_const_i128(i128 %0) {
 ; CHECK-LABEL: shl_const_i128:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    adds.w.sx %s2, %s0, (0)1
 ; CHECK-NEXT:    lea %s0, __ashrti3@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0
@@ -319,7 +319,7 @@ define i128 @shl_const_i128(i128 %0) {
 ; Function Attrs: norecurse nounwind readnone
 define i128 @shl_const_u128(i128 %0) {
 ; CHECK-LABEL: shl_const_u128:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    adds.w.sx %s2, %s0, (0)1
 ; CHECK-NEXT:    lea %s0, __ashrti3@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0

--- a/llvm/test/CodeGen/VE/Scalar/stackframe_align.ll
+++ b/llvm/test/CodeGen/VE/Scalar/stackframe_align.ll
@@ -13,8 +13,8 @@ define ptr @test_frame7(ptr %0) {
 ; CHECK-LABEL: test_frame7:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    adds.l %s11, -16, %s11
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB0_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB0_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -23,7 +23,7 @@ define ptr @test_frame7(ptr %0) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB0_2:
+; CHECK-NEXT:  .LBB0_1:
 ; CHECK-NEXT:    ld1b.zx %s1, (, %s0)
 ; CHECK-NEXT:    lea %s0, 9(, %s11)
 ; CHECK-NEXT:    st1b %s1, 9(, %s11)
@@ -36,8 +36,8 @@ define ptr @test_frame7(ptr %0) {
 ; CHECKFP-NEXT:    st %s10, 8(, %s11)
 ; CHECKFP-NEXT:    or %s9, 0, %s11
 ; CHECKFP-NEXT:    lea %s11, -192(, %s11)
-; CHECKFP-NEXT:    brge.l.t %s11, %s8, .LBB0_2
-; CHECKFP-NEXT:  # %bb.1:
+; CHECKFP-NEXT:    brge.l.t %s11, %s8, .LBB0_1
+; CHECKFP-NEXT:  # %bb.2:
 ; CHECKFP-NEXT:    ld %s61, 24(, %s14)
 ; CHECKFP-NEXT:    or %s62, 0, %s0
 ; CHECKFP-NEXT:    lea %s63, 315
@@ -46,7 +46,7 @@ define ptr @test_frame7(ptr %0) {
 ; CHECKFP-NEXT:    shm.l %s11, 16(%s61)
 ; CHECKFP-NEXT:    monc
 ; CHECKFP-NEXT:    or %s0, 0, %s62
-; CHECKFP-NEXT:  .LBB0_2:
+; CHECKFP-NEXT:  .LBB0_1:
 ; CHECKFP-NEXT:    ld1b.zx %s1, (, %s0)
 ; CHECKFP-NEXT:    lea %s0, -7(, %s9)
 ; CHECKFP-NEXT:    st1b %s1, -7(, %s9)
@@ -68,8 +68,8 @@ define ptr @test_frame7_align8(ptr %0) {
 ; CHECK-LABEL: test_frame7_align8:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    adds.l %s11, -16, %s11
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB1_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB1_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -78,7 +78,7 @@ define ptr @test_frame7_align8(ptr %0) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB1_2:
+; CHECK-NEXT:  .LBB1_1:
 ; CHECK-NEXT:    ld1b.zx %s1, (, %s0)
 ; CHECK-NEXT:    lea %s0, 8(, %s11)
 ; CHECK-NEXT:    st1b %s1, 8(, %s11)
@@ -91,8 +91,8 @@ define ptr @test_frame7_align8(ptr %0) {
 ; CHECKFP-NEXT:    st %s10, 8(, %s11)
 ; CHECKFP-NEXT:    or %s9, 0, %s11
 ; CHECKFP-NEXT:    lea %s11, -192(, %s11)
-; CHECKFP-NEXT:    brge.l.t %s11, %s8, .LBB1_2
-; CHECKFP-NEXT:  # %bb.1:
+; CHECKFP-NEXT:    brge.l.t %s11, %s8, .LBB1_1
+; CHECKFP-NEXT:  # %bb.2:
 ; CHECKFP-NEXT:    ld %s61, 24(, %s14)
 ; CHECKFP-NEXT:    or %s62, 0, %s0
 ; CHECKFP-NEXT:    lea %s63, 315
@@ -101,7 +101,7 @@ define ptr @test_frame7_align8(ptr %0) {
 ; CHECKFP-NEXT:    shm.l %s11, 16(%s61)
 ; CHECKFP-NEXT:    monc
 ; CHECKFP-NEXT:    or %s0, 0, %s62
-; CHECKFP-NEXT:  .LBB1_2:
+; CHECKFP-NEXT:  .LBB1_1:
 ; CHECKFP-NEXT:    ld1b.zx %s1, (, %s0)
 ; CHECKFP-NEXT:    lea %s0, -8(, %s9)
 ; CHECKFP-NEXT:    st1b %s1, -8(, %s9)
@@ -123,8 +123,8 @@ define ptr @test_frame16_align16(ptr %0) {
 ; CHECK-LABEL: test_frame16_align16:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    adds.l %s11, -16, %s11
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB2_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB2_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -133,7 +133,7 @@ define ptr @test_frame16_align16(ptr %0) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB2_2:
+; CHECK-NEXT:  .LBB2_1:
 ; CHECK-NEXT:    ld1b.zx %s1, (, %s0)
 ; CHECK-NEXT:    lea %s0, (, %s11)
 ; CHECK-NEXT:    st1b %s1, (, %s11)
@@ -146,8 +146,8 @@ define ptr @test_frame16_align16(ptr %0) {
 ; CHECKFP-NEXT:    st %s10, 8(, %s11)
 ; CHECKFP-NEXT:    or %s9, 0, %s11
 ; CHECKFP-NEXT:    lea %s11, -192(, %s11)
-; CHECKFP-NEXT:    brge.l.t %s11, %s8, .LBB2_2
-; CHECKFP-NEXT:  # %bb.1:
+; CHECKFP-NEXT:    brge.l.t %s11, %s8, .LBB2_1
+; CHECKFP-NEXT:  # %bb.2:
 ; CHECKFP-NEXT:    ld %s61, 24(, %s14)
 ; CHECKFP-NEXT:    or %s62, 0, %s0
 ; CHECKFP-NEXT:    lea %s63, 315
@@ -156,7 +156,7 @@ define ptr @test_frame16_align16(ptr %0) {
 ; CHECKFP-NEXT:    shm.l %s11, 16(%s61)
 ; CHECKFP-NEXT:    monc
 ; CHECKFP-NEXT:    or %s0, 0, %s62
-; CHECKFP-NEXT:  .LBB2_2:
+; CHECKFP-NEXT:  .LBB2_1:
 ; CHECKFP-NEXT:    ld1b.zx %s1, (, %s0)
 ; CHECKFP-NEXT:    lea %s0, -16(, %s9)
 ; CHECKFP-NEXT:    st1b %s1, -16(, %s9)
@@ -183,8 +183,8 @@ define ptr @test_frame16_align32(ptr %0) {
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    lea %s11, -224(, %s11)
 ; CHECK-NEXT:    and %s11, %s11, (59)1
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB3_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB3_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -193,7 +193,7 @@ define ptr @test_frame16_align32(ptr %0) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB3_2:
+; CHECK-NEXT:  .LBB3_1:
 ; CHECK-NEXT:    ld1b.zx %s1, (, %s0)
 ; CHECK-NEXT:    lea %s0, 192(, %s11)
 ; CHECK-NEXT:    st1b %s1, 192(, %s11)
@@ -209,8 +209,8 @@ define ptr @test_frame16_align32(ptr %0) {
 ; CHECKFP-NEXT:    or %s9, 0, %s11
 ; CHECKFP-NEXT:    lea %s11, -224(, %s11)
 ; CHECKFP-NEXT:    and %s11, %s11, (59)1
-; CHECKFP-NEXT:    brge.l.t %s11, %s8, .LBB3_2
-; CHECKFP-NEXT:  # %bb.1:
+; CHECKFP-NEXT:    brge.l.t %s11, %s8, .LBB3_1
+; CHECKFP-NEXT:  # %bb.2:
 ; CHECKFP-NEXT:    ld %s61, 24(, %s14)
 ; CHECKFP-NEXT:    or %s62, 0, %s0
 ; CHECKFP-NEXT:    lea %s63, 315
@@ -219,7 +219,7 @@ define ptr @test_frame16_align32(ptr %0) {
 ; CHECKFP-NEXT:    shm.l %s11, 16(%s61)
 ; CHECKFP-NEXT:    monc
 ; CHECKFP-NEXT:    or %s0, 0, %s62
-; CHECKFP-NEXT:  .LBB3_2:
+; CHECKFP-NEXT:  .LBB3_1:
 ; CHECKFP-NEXT:    ld1b.zx %s1, (, %s0)
 ; CHECKFP-NEXT:    lea %s0, 192(, %s11)
 ; CHECKFP-NEXT:    st1b %s1, 192(, %s11)
@@ -246,8 +246,8 @@ define ptr @test_frame32_align32(ptr %0) {
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    lea %s11, -224(, %s11)
 ; CHECK-NEXT:    and %s11, %s11, (59)1
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB4_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB4_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -256,7 +256,7 @@ define ptr @test_frame32_align32(ptr %0) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB4_2:
+; CHECK-NEXT:  .LBB4_1:
 ; CHECK-NEXT:    ld1b.zx %s1, (, %s0)
 ; CHECK-NEXT:    lea %s0, 192(, %s11)
 ; CHECK-NEXT:    st1b %s1, 192(, %s11)
@@ -272,8 +272,8 @@ define ptr @test_frame32_align32(ptr %0) {
 ; CHECKFP-NEXT:    or %s9, 0, %s11
 ; CHECKFP-NEXT:    lea %s11, -224(, %s11)
 ; CHECKFP-NEXT:    and %s11, %s11, (59)1
-; CHECKFP-NEXT:    brge.l.t %s11, %s8, .LBB4_2
-; CHECKFP-NEXT:  # %bb.1:
+; CHECKFP-NEXT:    brge.l.t %s11, %s8, .LBB4_1
+; CHECKFP-NEXT:  # %bb.2:
 ; CHECKFP-NEXT:    ld %s61, 24(, %s14)
 ; CHECKFP-NEXT:    or %s62, 0, %s0
 ; CHECKFP-NEXT:    lea %s63, 315
@@ -282,7 +282,7 @@ define ptr @test_frame32_align32(ptr %0) {
 ; CHECKFP-NEXT:    shm.l %s11, 16(%s61)
 ; CHECKFP-NEXT:    monc
 ; CHECKFP-NEXT:    or %s0, 0, %s62
-; CHECKFP-NEXT:  .LBB4_2:
+; CHECKFP-NEXT:  .LBB4_1:
 ; CHECKFP-NEXT:    ld1b.zx %s1, (, %s0)
 ; CHECKFP-NEXT:    lea %s0, 192(, %s11)
 ; CHECKFP-NEXT:    st1b %s1, 192(, %s11)
@@ -312,8 +312,8 @@ define ptr @test_frame_dynalign16(ptr %0, i64 %1) {
 ; CHECK-NEXT:    st %s10, 8(, %s11)
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    lea %s11, -240(, %s11)
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB5_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB5_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -322,7 +322,7 @@ define ptr @test_frame_dynalign16(ptr %0, i64 %1) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB5_2:
+; CHECK-NEXT:  .LBB5_1:
 ; CHECK-NEXT:    or %s2, 0, %s0
 ; CHECK-NEXT:    lea %s0, 15(, %s1)
 ; CHECK-NEXT:    and %s0, -16, %s0
@@ -344,8 +344,8 @@ define ptr @test_frame_dynalign16(ptr %0, i64 %1) {
 ; CHECKFP-NEXT:    st %s10, 8(, %s11)
 ; CHECKFP-NEXT:    or %s9, 0, %s11
 ; CHECKFP-NEXT:    lea %s11, -240(, %s11)
-; CHECKFP-NEXT:    brge.l.t %s11, %s8, .LBB5_2
-; CHECKFP-NEXT:  # %bb.1:
+; CHECKFP-NEXT:    brge.l.t %s11, %s8, .LBB5_1
+; CHECKFP-NEXT:  # %bb.2:
 ; CHECKFP-NEXT:    ld %s61, 24(, %s14)
 ; CHECKFP-NEXT:    or %s62, 0, %s0
 ; CHECKFP-NEXT:    lea %s63, 315
@@ -354,7 +354,7 @@ define ptr @test_frame_dynalign16(ptr %0, i64 %1) {
 ; CHECKFP-NEXT:    shm.l %s11, 16(%s61)
 ; CHECKFP-NEXT:    monc
 ; CHECKFP-NEXT:    or %s0, 0, %s62
-; CHECKFP-NEXT:  .LBB5_2:
+; CHECKFP-NEXT:  .LBB5_1:
 ; CHECKFP-NEXT:    or %s2, 0, %s0
 ; CHECKFP-NEXT:    lea %s0, 15(, %s1)
 ; CHECKFP-NEXT:    and %s0, -16, %s0
@@ -396,8 +396,8 @@ define ptr @test_frame16_align16_dynalign32(ptr %0, i64 %n) {
 ; CHECK-NEXT:    lea %s11, -288(, %s11)
 ; CHECK-NEXT:    and %s11, %s11, (59)1
 ; CHECK-NEXT:    or %s17, 0, %s11
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB6_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB6_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -406,7 +406,7 @@ define ptr @test_frame16_align16_dynalign32(ptr %0, i64 %n) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB6_2:
+; CHECK-NEXT:  .LBB6_1:
 ; CHECK-NEXT:    ld1b.zx %s0, (, %s0)
 ; CHECK-NEXT:    st1b %s0, 272(, %s17)
 ; CHECK-NEXT:    lea %s0, 15(, %s1)
@@ -436,8 +436,8 @@ define ptr @test_frame16_align16_dynalign32(ptr %0, i64 %n) {
 ; CHECKFP-NEXT:    lea %s11, -288(, %s11)
 ; CHECKFP-NEXT:    and %s11, %s11, (59)1
 ; CHECKFP-NEXT:    or %s17, 0, %s11
-; CHECKFP-NEXT:    brge.l.t %s11, %s8, .LBB6_2
-; CHECKFP-NEXT:  # %bb.1:
+; CHECKFP-NEXT:    brge.l.t %s11, %s8, .LBB6_1
+; CHECKFP-NEXT:  # %bb.2:
 ; CHECKFP-NEXT:    ld %s61, 24(, %s14)
 ; CHECKFP-NEXT:    or %s62, 0, %s0
 ; CHECKFP-NEXT:    lea %s63, 315
@@ -446,7 +446,7 @@ define ptr @test_frame16_align16_dynalign32(ptr %0, i64 %n) {
 ; CHECKFP-NEXT:    shm.l %s11, 16(%s61)
 ; CHECKFP-NEXT:    monc
 ; CHECKFP-NEXT:    or %s0, 0, %s62
-; CHECKFP-NEXT:  .LBB6_2:
+; CHECKFP-NEXT:  .LBB6_1:
 ; CHECKFP-NEXT:    ld1b.zx %s0, (, %s0)
 ; CHECKFP-NEXT:    st1b %s0, 272(, %s17)
 ; CHECKFP-NEXT:    lea %s0, 15(, %s1)

--- a/llvm/test/CodeGen/VE/Scalar/stackframe_call.ll
+++ b/llvm/test/CodeGen/VE/Scalar/stackframe_call.ll
@@ -19,8 +19,8 @@ define ptr @test_frame0(ptr %0, ptr %1) {
 ; CHECK-NEXT:    st %s10, 8(, %s11)
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    lea %s11, -240(, %s11)
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB0_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB0_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -29,7 +29,7 @@ define ptr @test_frame0(ptr %0, ptr %1) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB0_2:
+; CHECK-NEXT:  .LBB0_1:
 ; CHECK-NEXT:    lea %s2, fun@lo
 ; CHECK-NEXT:    and %s2, %s2, (32)0
 ; CHECK-NEXT:    lea.sl %s12, fun@hi(, %s2)
@@ -47,8 +47,8 @@ define ptr @test_frame0(ptr %0, ptr %1) {
 ; PIC-NEXT:    st %s16, 32(, %s11)
 ; PIC-NEXT:    or %s9, 0, %s11
 ; PIC-NEXT:    lea %s11, -240(, %s11)
-; PIC-NEXT:    brge.l.t %s11, %s8, .LBB0_2
-; PIC-NEXT:  # %bb.1:
+; PIC-NEXT:    brge.l.t %s11, %s8, .LBB0_1
+; PIC-NEXT:  # %bb.2:
 ; PIC-NEXT:    ld %s61, 24(, %s14)
 ; PIC-NEXT:    or %s62, 0, %s0
 ; PIC-NEXT:    lea %s63, 315
@@ -57,7 +57,7 @@ define ptr @test_frame0(ptr %0, ptr %1) {
 ; PIC-NEXT:    shm.l %s11, 16(%s61)
 ; PIC-NEXT:    monc
 ; PIC-NEXT:    or %s0, 0, %s62
-; PIC-NEXT:  .LBB0_2:
+; PIC-NEXT:  .LBB0_1:
 ; PIC-NEXT:    lea %s15, _GLOBAL_OFFSET_TABLE_@pc_lo(-24)
 ; PIC-NEXT:    and %s15, %s15, (32)0
 ; PIC-NEXT:    sic %s16
@@ -87,8 +87,8 @@ define ptr @test_frame32(ptr %0) {
 ; CHECK-NEXT:    st %s10, 8(, %s11)
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    lea %s11, -272(, %s11)
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB1_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB1_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -97,7 +97,7 @@ define ptr @test_frame32(ptr %0) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB1_2:
+; CHECK-NEXT:  .LBB1_1:
 ; CHECK-NEXT:    or %s1, 0, %s0
 ; CHECK-NEXT:    lea %s0, fun@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0
@@ -117,8 +117,8 @@ define ptr @test_frame32(ptr %0) {
 ; PIC-NEXT:    st %s16, 32(, %s11)
 ; PIC-NEXT:    or %s9, 0, %s11
 ; PIC-NEXT:    lea %s11, -272(, %s11)
-; PIC-NEXT:    brge.l.t %s11, %s8, .LBB1_2
-; PIC-NEXT:  # %bb.1:
+; PIC-NEXT:    brge.l.t %s11, %s8, .LBB1_1
+; PIC-NEXT:  # %bb.2:
 ; PIC-NEXT:    ld %s61, 24(, %s14)
 ; PIC-NEXT:    or %s62, 0, %s0
 ; PIC-NEXT:    lea %s63, 315
@@ -127,7 +127,7 @@ define ptr @test_frame32(ptr %0) {
 ; PIC-NEXT:    shm.l %s11, 16(%s61)
 ; PIC-NEXT:    monc
 ; PIC-NEXT:    or %s0, 0, %s62
-; PIC-NEXT:  .LBB1_2:
+; PIC-NEXT:  .LBB1_1:
 ; PIC-NEXT:    or %s1, 0, %s0
 ; PIC-NEXT:    lea %s15, _GLOBAL_OFFSET_TABLE_@pc_lo(-24)
 ; PIC-NEXT:    and %s15, %s15, (32)0
@@ -169,8 +169,8 @@ define ptr @test_align32(i32 signext %0, ptr nocapture readnone %1) {
 ; CHECK-NEXT:    lea %s11, -288(, %s11)
 ; CHECK-NEXT:    and %s11, %s11, (59)1
 ; CHECK-NEXT:    or %s17, 0, %s11
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB2_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB2_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -179,7 +179,7 @@ define ptr @test_align32(i32 signext %0, ptr nocapture readnone %1) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB2_2:
+; CHECK-NEXT:  .LBB2_1:
 ; CHECK-NEXT:    lea %s0, 15(, %s0)
 ; CHECK-NEXT:    and %s0, -16, %s0
 ; CHECK-NEXT:    lea %s1, __ve_grow_stack_align@lo
@@ -212,8 +212,8 @@ define ptr @test_align32(i32 signext %0, ptr nocapture readnone %1) {
 ; PIC-NEXT:    lea %s11, -288(, %s11)
 ; PIC-NEXT:    and %s11, %s11, (59)1
 ; PIC-NEXT:    or %s17, 0, %s11
-; PIC-NEXT:    brge.l.t %s11, %s8, .LBB2_2
-; PIC-NEXT:  # %bb.1:
+; PIC-NEXT:    brge.l.t %s11, %s8, .LBB2_1
+; PIC-NEXT:  # %bb.2:
 ; PIC-NEXT:    ld %s61, 24(, %s14)
 ; PIC-NEXT:    or %s62, 0, %s0
 ; PIC-NEXT:    lea %s63, 315
@@ -222,7 +222,7 @@ define ptr @test_align32(i32 signext %0, ptr nocapture readnone %1) {
 ; PIC-NEXT:    shm.l %s11, 16(%s61)
 ; PIC-NEXT:    monc
 ; PIC-NEXT:    or %s0, 0, %s62
-; PIC-NEXT:  .LBB2_2:
+; PIC-NEXT:  .LBB2_1:
 ; PIC-NEXT:    lea %s15, _GLOBAL_OFFSET_TABLE_@pc_lo(-24)
 ; PIC-NEXT:    and %s15, %s15, (32)0
 ; PIC-NEXT:    sic %s16
@@ -268,8 +268,8 @@ define ptr @test_frame0_var(ptr %0, ptr %1) {
 ; CHECK-NEXT:    st %s10, 8(, %s11)
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    lea %s11, -240(, %s11)
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB3_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB3_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -278,7 +278,7 @@ define ptr @test_frame0_var(ptr %0, ptr %1) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB3_2:
+; CHECK-NEXT:  .LBB3_1:
 ; CHECK-NEXT:    lea %s2, data@lo
 ; CHECK-NEXT:    and %s2, %s2, (32)0
 ; CHECK-NEXT:    lea.sl %s2, data@hi(, %s2)
@@ -301,8 +301,8 @@ define ptr @test_frame0_var(ptr %0, ptr %1) {
 ; PIC-NEXT:    st %s16, 32(, %s11)
 ; PIC-NEXT:    or %s9, 0, %s11
 ; PIC-NEXT:    lea %s11, -240(, %s11)
-; PIC-NEXT:    brge.l.t %s11, %s8, .LBB3_2
-; PIC-NEXT:  # %bb.1:
+; PIC-NEXT:    brge.l.t %s11, %s8, .LBB3_1
+; PIC-NEXT:  # %bb.2:
 ; PIC-NEXT:    ld %s61, 24(, %s14)
 ; PIC-NEXT:    or %s62, 0, %s0
 ; PIC-NEXT:    lea %s63, 315
@@ -311,7 +311,7 @@ define ptr @test_frame0_var(ptr %0, ptr %1) {
 ; PIC-NEXT:    shm.l %s11, 16(%s61)
 ; PIC-NEXT:    monc
 ; PIC-NEXT:    or %s0, 0, %s62
-; PIC-NEXT:  .LBB3_2:
+; PIC-NEXT:  .LBB3_1:
 ; PIC-NEXT:    lea %s15, _GLOBAL_OFFSET_TABLE_@pc_lo(-24)
 ; PIC-NEXT:    and %s15, %s15, (32)0
 ; PIC-NEXT:    sic %s16
@@ -347,8 +347,8 @@ define ptr @test_frame32_var(ptr %0) {
 ; CHECK-NEXT:    st %s10, 8(, %s11)
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    lea %s11, -272(, %s11)
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB4_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB4_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -357,7 +357,7 @@ define ptr @test_frame32_var(ptr %0) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB4_2:
+; CHECK-NEXT:  .LBB4_1:
 ; CHECK-NEXT:    lea %s1, data@lo
 ; CHECK-NEXT:    and %s1, %s1, (32)0
 ; CHECK-NEXT:    lea.sl %s1, data@hi(, %s1)
@@ -382,8 +382,8 @@ define ptr @test_frame32_var(ptr %0) {
 ; PIC-NEXT:    st %s16, 32(, %s11)
 ; PIC-NEXT:    or %s9, 0, %s11
 ; PIC-NEXT:    lea %s11, -272(, %s11)
-; PIC-NEXT:    brge.l.t %s11, %s8, .LBB4_2
-; PIC-NEXT:  # %bb.1:
+; PIC-NEXT:    brge.l.t %s11, %s8, .LBB4_1
+; PIC-NEXT:  # %bb.2:
 ; PIC-NEXT:    ld %s61, 24(, %s14)
 ; PIC-NEXT:    or %s62, 0, %s0
 ; PIC-NEXT:    lea %s63, 315
@@ -392,7 +392,7 @@ define ptr @test_frame32_var(ptr %0) {
 ; PIC-NEXT:    shm.l %s11, 16(%s61)
 ; PIC-NEXT:    monc
 ; PIC-NEXT:    or %s0, 0, %s62
-; PIC-NEXT:  .LBB4_2:
+; PIC-NEXT:  .LBB4_1:
 ; PIC-NEXT:    lea %s15, _GLOBAL_OFFSET_TABLE_@pc_lo(-24)
 ; PIC-NEXT:    and %s15, %s15, (32)0
 ; PIC-NEXT:    sic %s16
@@ -436,8 +436,8 @@ define ptr @test_align32_var(i32 signext %0, ptr nocapture readnone %1) {
 ; CHECK-NEXT:    lea %s11, -288(, %s11)
 ; CHECK-NEXT:    and %s11, %s11, (59)1
 ; CHECK-NEXT:    or %s17, 0, %s11
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB5_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB5_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -446,7 +446,7 @@ define ptr @test_align32_var(i32 signext %0, ptr nocapture readnone %1) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB5_2:
+; CHECK-NEXT:  .LBB5_1:
 ; CHECK-NEXT:    lea %s0, 15(, %s0)
 ; CHECK-NEXT:    and %s0, -16, %s0
 ; CHECK-NEXT:    lea %s1, __ve_grow_stack_align@lo
@@ -484,8 +484,8 @@ define ptr @test_align32_var(i32 signext %0, ptr nocapture readnone %1) {
 ; PIC-NEXT:    lea %s11, -288(, %s11)
 ; PIC-NEXT:    and %s11, %s11, (59)1
 ; PIC-NEXT:    or %s17, 0, %s11
-; PIC-NEXT:    brge.l.t %s11, %s8, .LBB5_2
-; PIC-NEXT:  # %bb.1:
+; PIC-NEXT:    brge.l.t %s11, %s8, .LBB5_1
+; PIC-NEXT:  # %bb.2:
 ; PIC-NEXT:    ld %s61, 24(, %s14)
 ; PIC-NEXT:    or %s62, 0, %s0
 ; PIC-NEXT:    lea %s63, 315
@@ -494,7 +494,7 @@ define ptr @test_align32_var(i32 signext %0, ptr nocapture readnone %1) {
 ; PIC-NEXT:    shm.l %s11, 16(%s61)
 ; PIC-NEXT:    monc
 ; PIC-NEXT:    or %s0, 0, %s62
-; PIC-NEXT:  .LBB5_2:
+; PIC-NEXT:  .LBB5_1:
 ; PIC-NEXT:    lea %s15, _GLOBAL_OFFSET_TABLE_@pc_lo(-24)
 ; PIC-NEXT:    and %s15, %s15, (32)0
 ; PIC-NEXT:    sic %s16

--- a/llvm/test/CodeGen/VE/Scalar/stackframe_nocall.ll
+++ b/llvm/test/CodeGen/VE/Scalar/stackframe_nocall.ll
@@ -30,8 +30,8 @@ define nonnull ptr @test_frame32(ptr nocapture readonly %0) {
 ; CHECK-LABEL: test_frame32:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    adds.l %s11, -32, %s11
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB1_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB1_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -40,7 +40,7 @@ define nonnull ptr @test_frame32(ptr nocapture readonly %0) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB1_2:
+; CHECK-NEXT:  .LBB1_1:
 ; CHECK-NEXT:    ld1b.zx %s1, (, %s0)
 ; CHECK-NEXT:    lea %s0, (, %s11)
 ; CHECK-NEXT:    st1b %s1, (, %s11)
@@ -50,8 +50,8 @@ define nonnull ptr @test_frame32(ptr nocapture readonly %0) {
 ; PIC-LABEL: test_frame32:
 ; PIC:       # %bb.0:
 ; PIC-NEXT:    adds.l %s11, -32, %s11
-; PIC-NEXT:    brge.l.t %s11, %s8, .LBB1_2
-; PIC-NEXT:  # %bb.1:
+; PIC-NEXT:    brge.l.t %s11, %s8, .LBB1_1
+; PIC-NEXT:  # %bb.2:
 ; PIC-NEXT:    ld %s61, 24(, %s14)
 ; PIC-NEXT:    or %s62, 0, %s0
 ; PIC-NEXT:    lea %s63, 315
@@ -60,7 +60,7 @@ define nonnull ptr @test_frame32(ptr nocapture readonly %0) {
 ; PIC-NEXT:    shm.l %s11, 16(%s61)
 ; PIC-NEXT:    monc
 ; PIC-NEXT:    or %s0, 0, %s62
-; PIC-NEXT:  .LBB1_2:
+; PIC-NEXT:  .LBB1_1:
 ; PIC-NEXT:    ld1b.zx %s1, (, %s0)
 ; PIC-NEXT:    lea %s0, (, %s11)
 ; PIC-NEXT:    st1b %s1, (, %s11)
@@ -91,8 +91,8 @@ define noalias nonnull ptr @test_align32(i32 signext %0, ptr nocapture readonly 
 ; CHECK-NEXT:    lea %s11, -288(, %s11)
 ; CHECK-NEXT:    and %s11, %s11, (59)1
 ; CHECK-NEXT:    or %s17, 0, %s11
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB2_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB2_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -101,7 +101,7 @@ define noalias nonnull ptr @test_align32(i32 signext %0, ptr nocapture readonly 
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB2_2:
+; CHECK-NEXT:  .LBB2_1:
 ; CHECK-NEXT:    or %s2, 0, %s1
 ; CHECK-NEXT:    lea %s0, 15(, %s0)
 ; CHECK-NEXT:    and %s0, -16, %s0
@@ -133,8 +133,8 @@ define noalias nonnull ptr @test_align32(i32 signext %0, ptr nocapture readonly 
 ; PIC-NEXT:    lea %s11, -288(, %s11)
 ; PIC-NEXT:    and %s11, %s11, (59)1
 ; PIC-NEXT:    or %s17, 0, %s11
-; PIC-NEXT:    brge.l.t %s11, %s8, .LBB2_2
-; PIC-NEXT:  # %bb.1:
+; PIC-NEXT:    brge.l.t %s11, %s8, .LBB2_1
+; PIC-NEXT:  # %bb.2:
 ; PIC-NEXT:    ld %s61, 24(, %s14)
 ; PIC-NEXT:    or %s62, 0, %s0
 ; PIC-NEXT:    lea %s63, 315
@@ -143,7 +143,7 @@ define noalias nonnull ptr @test_align32(i32 signext %0, ptr nocapture readonly 
 ; PIC-NEXT:    shm.l %s11, 16(%s61)
 ; PIC-NEXT:    monc
 ; PIC-NEXT:    or %s0, 0, %s62
-; PIC-NEXT:  .LBB2_2:
+; PIC-NEXT:  .LBB2_1:
 ; PIC-NEXT:    or %s2, 0, %s1
 ; PIC-NEXT:    lea %s15, _GLOBAL_OFFSET_TABLE_@pc_lo(-24)
 ; PIC-NEXT:    and %s15, %s15, (32)0
@@ -218,8 +218,8 @@ define nonnull ptr @test_frame32_var(ptr nocapture readnone %0) {
 ; CHECK-LABEL: test_frame32_var:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    adds.l %s11, -32, %s11
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB4_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB4_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -228,7 +228,7 @@ define nonnull ptr @test_frame32_var(ptr nocapture readnone %0) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB4_2:
+; CHECK-NEXT:  .LBB4_1:
 ; CHECK-NEXT:    lea %s0, data@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0
 ; CHECK-NEXT:    lea.sl %s0, data@hi(, %s0)
@@ -243,8 +243,8 @@ define nonnull ptr @test_frame32_var(ptr nocapture readnone %0) {
 ; PIC-NEXT:    st %s15, 24(, %s11)
 ; PIC-NEXT:    st %s16, 32(, %s11)
 ; PIC-NEXT:    adds.l %s11, -32, %s11
-; PIC-NEXT:    brge.l.t %s11, %s8, .LBB4_2
-; PIC-NEXT:  # %bb.1:
+; PIC-NEXT:    brge.l.t %s11, %s8, .LBB4_1
+; PIC-NEXT:  # %bb.2:
 ; PIC-NEXT:    ld %s61, 24(, %s14)
 ; PIC-NEXT:    or %s62, 0, %s0
 ; PIC-NEXT:    lea %s63, 315
@@ -253,7 +253,7 @@ define nonnull ptr @test_frame32_var(ptr nocapture readnone %0) {
 ; PIC-NEXT:    shm.l %s11, 16(%s61)
 ; PIC-NEXT:    monc
 ; PIC-NEXT:    or %s0, 0, %s62
-; PIC-NEXT:  .LBB4_2:
+; PIC-NEXT:  .LBB4_1:
 ; PIC-NEXT:    lea %s15, _GLOBAL_OFFSET_TABLE_@pc_lo(-24)
 ; PIC-NEXT:    and %s15, %s15, (32)0
 ; PIC-NEXT:    sic %s16
@@ -288,8 +288,8 @@ define noalias nonnull ptr @test_align32_var(i32 signext %0, ptr nocapture reado
 ; CHECK-NEXT:    lea %s11, -288(, %s11)
 ; CHECK-NEXT:    and %s11, %s11, (59)1
 ; CHECK-NEXT:    or %s17, 0, %s11
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB5_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB5_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -298,7 +298,7 @@ define noalias nonnull ptr @test_align32_var(i32 signext %0, ptr nocapture reado
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB5_2:
+; CHECK-NEXT:  .LBB5_1:
 ; CHECK-NEXT:    or %s2, 0, %s1
 ; CHECK-NEXT:    lea %s0, 15(, %s0)
 ; CHECK-NEXT:    and %s0, -16, %s0
@@ -330,8 +330,8 @@ define noalias nonnull ptr @test_align32_var(i32 signext %0, ptr nocapture reado
 ; PIC-NEXT:    lea %s11, -288(, %s11)
 ; PIC-NEXT:    and %s11, %s11, (59)1
 ; PIC-NEXT:    or %s17, 0, %s11
-; PIC-NEXT:    brge.l.t %s11, %s8, .LBB5_2
-; PIC-NEXT:  # %bb.1:
+; PIC-NEXT:    brge.l.t %s11, %s8, .LBB5_1
+; PIC-NEXT:  # %bb.2:
 ; PIC-NEXT:    ld %s61, 24(, %s14)
 ; PIC-NEXT:    or %s62, 0, %s0
 ; PIC-NEXT:    lea %s63, 315
@@ -340,7 +340,7 @@ define noalias nonnull ptr @test_align32_var(i32 signext %0, ptr nocapture reado
 ; PIC-NEXT:    shm.l %s11, 16(%s61)
 ; PIC-NEXT:    monc
 ; PIC-NEXT:    or %s0, 0, %s62
-; PIC-NEXT:  .LBB5_2:
+; PIC-NEXT:  .LBB5_1:
 ; PIC-NEXT:    or %s2, 0, %s1
 ; PIC-NEXT:    lea %s15, _GLOBAL_OFFSET_TABLE_@pc_lo(-24)
 ; PIC-NEXT:    and %s15, %s15, (32)0

--- a/llvm/test/CodeGen/VE/Scalar/stackframe_size.ll
+++ b/llvm/test/CodeGen/VE/Scalar/stackframe_size.ll
@@ -20,8 +20,8 @@ define ptr @test_frame8(ptr %0) {
 ; CHECK-LABEL: test_frame8:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    adds.l %s11, -16, %s11
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB1_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB1_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -30,7 +30,7 @@ define ptr @test_frame8(ptr %0) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB1_2:
+; CHECK-NEXT:  .LBB1_1:
 ; CHECK-NEXT:    ld1b.zx %s1, (, %s0)
 ; CHECK-NEXT:    lea %s0, 8(, %s11)
 ; CHECK-NEXT:    st1b %s1, 8(, %s11)
@@ -47,8 +47,8 @@ define ptr @test_frame16(ptr %0) {
 ; CHECK-LABEL: test_frame16:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    adds.l %s11, -16, %s11
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB2_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB2_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -57,7 +57,7 @@ define ptr @test_frame16(ptr %0) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB2_2:
+; CHECK-NEXT:  .LBB2_1:
 ; CHECK-NEXT:    ld1b.zx %s1, (, %s0)
 ; CHECK-NEXT:    lea %s0, (, %s11)
 ; CHECK-NEXT:    st1b %s1, (, %s11)
@@ -74,8 +74,8 @@ define ptr @test_frame32(ptr %0) {
 ; CHECK-LABEL: test_frame32:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    adds.l %s11, -32, %s11
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB3_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB3_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -84,7 +84,7 @@ define ptr @test_frame32(ptr %0) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB3_2:
+; CHECK-NEXT:  .LBB3_1:
 ; CHECK-NEXT:    ld1b.zx %s1, (, %s0)
 ; CHECK-NEXT:    lea %s0, (, %s11)
 ; CHECK-NEXT:    st1b %s1, (, %s11)
@@ -101,8 +101,8 @@ define ptr @test_frame64(ptr %0) {
 ; CHECK-LABEL: test_frame64:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    adds.l %s11, -64, %s11
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB4_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB4_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -111,7 +111,7 @@ define ptr @test_frame64(ptr %0) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB4_2:
+; CHECK-NEXT:  .LBB4_1:
 ; CHECK-NEXT:    ld1b.zx %s1, (, %s0)
 ; CHECK-NEXT:    lea %s0, (, %s11)
 ; CHECK-NEXT:    st1b %s1, (, %s11)
@@ -128,8 +128,8 @@ define ptr @test_frame128(ptr %0) {
 ; CHECK-LABEL: test_frame128:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    lea %s11, -128(, %s11)
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB5_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB5_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -138,7 +138,7 @@ define ptr @test_frame128(ptr %0) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB5_2:
+; CHECK-NEXT:  .LBB5_1:
 ; CHECK-NEXT:    ld1b.zx %s1, (, %s0)
 ; CHECK-NEXT:    lea %s0, (, %s11)
 ; CHECK-NEXT:    st1b %s1, (, %s11)
@@ -155,8 +155,8 @@ define ptr @test_frame65536(ptr %0) {
 ; CHECK-LABEL: test_frame65536:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    lea %s11, -65536(, %s11)
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB6_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB6_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -165,7 +165,7 @@ define ptr @test_frame65536(ptr %0) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB6_2:
+; CHECK-NEXT:  .LBB6_1:
 ; CHECK-NEXT:    ld1b.zx %s1, (, %s0)
 ; CHECK-NEXT:    lea %s0, (, %s11)
 ; CHECK-NEXT:    st1b %s1, (, %s11)
@@ -184,8 +184,8 @@ define ptr @test_frame4294967296(ptr %0) {
 ; CHECK-NEXT:    lea %s13, 0
 ; CHECK-NEXT:    and %s13, %s13, (32)0
 ; CHECK-NEXT:    lea.sl %s11, -1(%s13, %s11)
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB7_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB7_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -194,7 +194,7 @@ define ptr @test_frame4294967296(ptr %0) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB7_2:
+; CHECK-NEXT:  .LBB7_1:
 ; CHECK-NEXT:    ld1b.zx %s1, (, %s0)
 ; CHECK-NEXT:    lea %s0, (, %s11)
 ; CHECK-NEXT:    st1b %s1, (, %s11)

--- a/llvm/test/CodeGen/VE/Scalar/stacksave.ll
+++ b/llvm/test/CodeGen/VE/Scalar/stacksave.ll
@@ -3,7 +3,7 @@
 ; Function Attrs: noinline nounwind optnone
 define ptr @stacksave() {
 ; CHECK-LABEL: stacksave:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    or %s0, 0, %s11
 ; CHECK-NEXT:    or %s11, 0, %s9
   %ret = call ptr @llvm.stacksave()
@@ -13,7 +13,7 @@ define ptr @stacksave() {
 ; Function Attrs: noinline nounwind optnone
 define void @stackrestore(ptr %ptr) {
 ; CHECK-LABEL: stackrestore:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    or %s11, 0, %s0
 ; CHECK-NEXT:    or %s11, 0, %s9
   call void @llvm.stackrestore(ptr %ptr)

--- a/llvm/test/CodeGen/VE/Scalar/store-align1.ll
+++ b/llvm/test/CodeGen/VE/Scalar/store-align1.ll
@@ -10,7 +10,7 @@
 ; Function Attrs: norecurse nounwind readonly
 define void @storef64stk(double %0) {
 ; CHECK-LABEL: storef64stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    st %s0, 8(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -22,7 +22,7 @@ define void @storef64stk(double %0) {
 ; Function Attrs: norecurse nounwind readonly
 define void @storef32stk(float %0) {
 ; CHECK-LABEL: storef32stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    stu %s0, 12(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -34,7 +34,7 @@ define void @storef32stk(float %0) {
 ; Function Attrs: norecurse nounwind readonly
 define void @storei64stk(i64 %0) {
 ; CHECK-LABEL: storei64stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    st %s0, 8(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -46,7 +46,7 @@ define void @storei64stk(i64 %0) {
 ; Function Attrs: norecurse nounwind readonly
 define void @storei32stk(i32 %0) {
 ; CHECK-LABEL: storei32stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    stl %s0, 12(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -58,7 +58,7 @@ define void @storei32stk(i32 %0) {
 ; Function Attrs: norecurse nounwind readonly
 define void @storei16stk(i16 %0) {
 ; CHECK-LABEL: storei16stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    st2b %s0, 14(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -70,7 +70,7 @@ define void @storei16stk(i16 %0) {
 ; Function Attrs: norecurse nounwind readonly
 define void @storei8stk(i8 %0) {
 ; CHECK-LABEL: storei8stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    st1b %s0, 15(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)

--- a/llvm/test/CodeGen/VE/Scalar/store-align2.ll
+++ b/llvm/test/CodeGen/VE/Scalar/store-align2.ll
@@ -10,7 +10,7 @@
 ; Function Attrs: norecurse nounwind readonly
 define void @storef64stk(double %0) {
 ; CHECK-LABEL: storef64stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    st %s0, 8(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -22,7 +22,7 @@ define void @storef64stk(double %0) {
 ; Function Attrs: norecurse nounwind readonly
 define void @storef32stk(float %0) {
 ; CHECK-LABEL: storef32stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    stu %s0, 12(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -34,7 +34,7 @@ define void @storef32stk(float %0) {
 ; Function Attrs: norecurse nounwind readonly
 define void @storei64stk(i64 %0) {
 ; CHECK-LABEL: storei64stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    st %s0, 8(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -46,7 +46,7 @@ define void @storei64stk(i64 %0) {
 ; Function Attrs: norecurse nounwind readonly
 define void @storei32stk(i32 %0) {
 ; CHECK-LABEL: storei32stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    stl %s0, 12(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -58,7 +58,7 @@ define void @storei32stk(i32 %0) {
 ; Function Attrs: norecurse nounwind readonly
 define void @storei16stk(i16 %0) {
 ; CHECK-LABEL: storei16stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    st2b %s0, 14(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -70,7 +70,7 @@ define void @storei16stk(i16 %0) {
 ; Function Attrs: norecurse nounwind readonly
 define void @storei8stk(i8 %0) {
 ; CHECK-LABEL: storei8stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    st1b %s0, 14(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)

--- a/llvm/test/CodeGen/VE/Scalar/store-align4.ll
+++ b/llvm/test/CodeGen/VE/Scalar/store-align4.ll
@@ -10,7 +10,7 @@
 ; Function Attrs: norecurse nounwind readonly
 define void @storef64stk(double %0) {
 ; CHECK-LABEL: storef64stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    st %s0, 8(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -22,7 +22,7 @@ define void @storef64stk(double %0) {
 ; Function Attrs: norecurse nounwind readonly
 define void @storef32stk(float %0) {
 ; CHECK-LABEL: storef32stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    stu %s0, 12(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -34,7 +34,7 @@ define void @storef32stk(float %0) {
 ; Function Attrs: norecurse nounwind readonly
 define void @storei64stk(i64 %0) {
 ; CHECK-LABEL: storei64stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    st %s0, 8(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -46,7 +46,7 @@ define void @storei64stk(i64 %0) {
 ; Function Attrs: norecurse nounwind readonly
 define void @storei32stk(i32 %0) {
 ; CHECK-LABEL: storei32stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    stl %s0, 12(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -58,7 +58,7 @@ define void @storei32stk(i32 %0) {
 ; Function Attrs: norecurse nounwind readonly
 define void @storei16stk(i16 %0) {
 ; CHECK-LABEL: storei16stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    st2b %s0, 12(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -70,7 +70,7 @@ define void @storei16stk(i16 %0) {
 ; Function Attrs: norecurse nounwind readonly
 define void @storei8stk(i8 %0) {
 ; CHECK-LABEL: storei8stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    st1b %s0, 12(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)

--- a/llvm/test/CodeGen/VE/Scalar/store-align8.ll
+++ b/llvm/test/CodeGen/VE/Scalar/store-align8.ll
@@ -10,7 +10,7 @@
 ; Function Attrs: norecurse nounwind readonly
 define void @storef64stk(double %0) {
 ; CHECK-LABEL: storef64stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    st %s0, 8(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -22,7 +22,7 @@ define void @storef64stk(double %0) {
 ; Function Attrs: norecurse nounwind readonly
 define void @storef32stk(float %0) {
 ; CHECK-LABEL: storef32stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    stu %s0, 8(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -34,7 +34,7 @@ define void @storef32stk(float %0) {
 ; Function Attrs: norecurse nounwind readonly
 define void @storei64stk(i64 %0) {
 ; CHECK-LABEL: storei64stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    st %s0, 8(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -46,7 +46,7 @@ define void @storei64stk(i64 %0) {
 ; Function Attrs: norecurse nounwind readonly
 define void @storei32stk(i32 %0) {
 ; CHECK-LABEL: storei32stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    stl %s0, 8(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -58,7 +58,7 @@ define void @storei32stk(i32 %0) {
 ; Function Attrs: norecurse nounwind readonly
 define void @storei16stk(i16 %0) {
 ; CHECK-LABEL: storei16stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    st2b %s0, 8(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -70,7 +70,7 @@ define void @storei16stk(i16 %0) {
 ; Function Attrs: norecurse nounwind readonly
 define void @storei8stk(i8 %0) {
 ; CHECK-LABEL: storei8stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    st1b %s0, 8(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)

--- a/llvm/test/CodeGen/VE/Scalar/store.ll
+++ b/llvm/test/CodeGen/VE/Scalar/store.ll
@@ -118,7 +118,7 @@ define void @storei8tr(ptr nocapture %0, i64 %1) {
 ; Function Attrs: norecurse nounwind readonly
 define void @storef128stk(fp128 %0) {
 ; CHECK-LABEL: storef128stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    st %s1, (, %s11)
 ; CHECK-NEXT:    st %s0, 8(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
@@ -131,7 +131,7 @@ define void @storef128stk(fp128 %0) {
 ; Function Attrs: norecurse nounwind readonly
 define void @storef64stk(double %0) {
 ; CHECK-LABEL: storef64stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    st %s0, (, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -143,7 +143,7 @@ define void @storef64stk(double %0) {
 ; Function Attrs: norecurse nounwind readonly
 define void @storef32stk(float %0) {
 ; CHECK-LABEL: storef32stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    stu %s0, (, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -155,7 +155,7 @@ define void @storef32stk(float %0) {
 ; Function Attrs: norecurse nounwind readonly
 define void @storei128stk(i128 %0) {
 ; CHECK-LABEL: storei128stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    st %s1, 8(, %s11)
 ; CHECK-NEXT:    st %s0, (, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
@@ -168,7 +168,7 @@ define void @storei128stk(i128 %0) {
 ; Function Attrs: norecurse nounwind readonly
 define void @storei64stk(i64 %0) {
 ; CHECK-LABEL: storei64stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    st %s0, (, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -180,7 +180,7 @@ define void @storei64stk(i64 %0) {
 ; Function Attrs: norecurse nounwind readonly
 define void @storei32stk(i32 %0) {
 ; CHECK-LABEL: storei32stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    stl %s0, (, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -192,7 +192,7 @@ define void @storei32stk(i32 %0) {
 ; Function Attrs: norecurse nounwind readonly
 define void @storei16stk(i16 %0) {
 ; CHECK-LABEL: storei16stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    st2b %s0, (, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -204,7 +204,7 @@ define void @storei16stk(i16 %0) {
 ; Function Attrs: norecurse nounwind readonly
 define void @storei8stk(i8 %0) {
 ; CHECK-LABEL: storei8stk:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    st1b %s0, (, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)

--- a/llvm/test/CodeGen/VE/Scalar/store_stk.ll
+++ b/llvm/test/CodeGen/VE/Scalar/store_stk.ll
@@ -97,8 +97,8 @@ define x86_fastcallcc void @storei64_stk(i64 noundef %0) {
 ; CHECK-LABEL: storei64_stk:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    adds.l %s11, -16, %s11
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB0_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB0_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -107,7 +107,7 @@ define x86_fastcallcc void @storei64_stk(i64 noundef %0) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB0_2:
+; CHECK-NEXT:  .LBB0_1:
 ; CHECK-NEXT:    st %s0, 8(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
 ; CHECK-NEXT:    b.l.t (, %s10)
@@ -129,8 +129,8 @@ define x86_fastcallcc void @storei64_stk_big(i64 noundef %0, i64 noundef %1) {
 ; CHECK-LABEL: storei64_stk_big:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    lea %s11, -2147483648(, %s11)
-; CHECK-NEXT:    brge.l %s11, %s8, .LBB1_4
-; CHECK-NEXT:  # %bb.3:
+; CHECK-NEXT:    brge.l %s11, %s8, .LBB1_3
+; CHECK-NEXT:  # %bb.4:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -139,7 +139,7 @@ define x86_fastcallcc void @storei64_stk_big(i64 noundef %0, i64 noundef %1) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB1_4:
+; CHECK-NEXT:  .LBB1_3:
 ; CHECK-NEXT:    st %s0, 2147483640(, %s11)
 ; CHECK-NEXT:    or %s0, 0, (0)1
 ; CHECK-NEXT:    lea %s2, 2147483640
@@ -180,8 +180,8 @@ define x86_fastcallcc void @storei64_stk_big2(i64 noundef %0, i64 noundef %1) {
 ; CHECK-NEXT:    lea %s13, 2147483632
 ; CHECK-NEXT:    and %s13, %s13, (32)0
 ; CHECK-NEXT:    lea.sl %s11, -1(%s13, %s11)
-; CHECK-NEXT:    brge.l %s11, %s8, .LBB2_4
-; CHECK-NEXT:  # %bb.3:
+; CHECK-NEXT:    brge.l %s11, %s8, .LBB2_3
+; CHECK-NEXT:  # %bb.4:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -190,7 +190,7 @@ define x86_fastcallcc void @storei64_stk_big2(i64 noundef %0, i64 noundef %1) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB2_4:
+; CHECK-NEXT:  .LBB2_3:
 ; CHECK-NEXT:    lea %s13, -2147483640
 ; CHECK-NEXT:    and %s13, %s13, (32)0
 ; CHECK-NEXT:    lea.sl %s13, (%s11, %s13)
@@ -236,8 +236,8 @@ define x86_fastcallcc void @storei64_stk_dyn(i64 noundef %0, i64 noundef %1) {
 ; CHECK-NEXT:    st %s10, 8(, %s11)
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    lea %s11, -256(, %s11)
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB3_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB3_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -246,7 +246,7 @@ define x86_fastcallcc void @storei64_stk_dyn(i64 noundef %0, i64 noundef %1) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB3_2:
+; CHECK-NEXT:  .LBB3_1:
 ; CHECK-NEXT:    or %s2, 0, %s0
 ; CHECK-NEXT:    lea %s0, 15(, %s1)
 ; CHECK-NEXT:    and %s0, -16, %s0
@@ -281,8 +281,8 @@ define x86_fastcallcc void @storei64_stk_dyn_align(i64 noundef %0, i64 noundef %
 ; CHECK-NEXT:    lea %s11, -288(, %s11)
 ; CHECK-NEXT:    and %s11, %s11, (59)1
 ; CHECK-NEXT:    or %s17, 0, %s11
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB4_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB4_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -291,7 +291,7 @@ define x86_fastcallcc void @storei64_stk_dyn_align(i64 noundef %0, i64 noundef %
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB4_2:
+; CHECK-NEXT:  .LBB4_1:
 ; CHECK-NEXT:    or %s2, 0, %s0
 ; CHECK-NEXT:    lea %s0, 15(, %s1)
 ; CHECK-NEXT:    and %s0, -16, %s0
@@ -327,8 +327,8 @@ define x86_fastcallcc void @storei64_stk_dyn_align2(i64 noundef %0, i64 noundef 
 ; CHECK-NEXT:    lea %s11, -320(, %s11)
 ; CHECK-NEXT:    and %s11, %s11, (58)1
 ; CHECK-NEXT:    or %s17, 0, %s11
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB5_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB5_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -337,7 +337,7 @@ define x86_fastcallcc void @storei64_stk_dyn_align2(i64 noundef %0, i64 noundef 
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB5_2:
+; CHECK-NEXT:  .LBB5_1:
 ; CHECK-NEXT:    or %s2, 0, %s0
 ; CHECK-NEXT:    lea %s0, 15(, %s1)
 ; CHECK-NEXT:    and %s0, -16, %s0
@@ -378,8 +378,8 @@ define x86_fastcallcc void @storei64_stk_dyn_align_spill(i64 noundef %0, i64 nou
 ; CHECK-NEXT:    lea %s11, -288(, %s11)
 ; CHECK-NEXT:    and %s11, %s11, (59)1
 ; CHECK-NEXT:    or %s17, 0, %s11
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB6_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB6_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -388,7 +388,7 @@ define x86_fastcallcc void @storei64_stk_dyn_align_spill(i64 noundef %0, i64 nou
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB6_2:
+; CHECK-NEXT:  .LBB6_1:
 ; CHECK-NEXT:    st %s18, 48(, %s9) # 8-byte Folded Spill
 ; CHECK-NEXT:    st %s19, 56(, %s9) # 8-byte Folded Spill
 ; CHECK-NEXT:    st %s20, 64(, %s9) # 8-byte Folded Spill
@@ -440,8 +440,8 @@ define x86_fastcallcc void @storequad_stk(fp128 noundef %0) {
 ; CHECK-LABEL: storequad_stk:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    adds.l %s11, -16, %s11
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB7_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB7_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -450,7 +450,7 @@ define x86_fastcallcc void @storequad_stk(fp128 noundef %0) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB7_2:
+; CHECK-NEXT:  .LBB7_1:
 ; CHECK-NEXT:    st %s1, (, %s11)
 ; CHECK-NEXT:    st %s0, 8(, %s11)
 ; CHECK-NEXT:    adds.l %s11, 16, %s11
@@ -469,8 +469,8 @@ define x86_fastcallcc void @storequad_stk_big(fp128 noundef %0, i64 noundef %1) 
 ; CHECK-NEXT:    lea %s13, 2147483632
 ; CHECK-NEXT:    and %s13, %s13, (32)0
 ; CHECK-NEXT:    lea.sl %s11, -1(%s13, %s11)
-; CHECK-NEXT:    brge.l %s11, %s8, .LBB8_4
-; CHECK-NEXT:  # %bb.3:
+; CHECK-NEXT:    brge.l %s11, %s8, .LBB8_3
+; CHECK-NEXT:  # %bb.4:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -479,7 +479,7 @@ define x86_fastcallcc void @storequad_stk_big(fp128 noundef %0, i64 noundef %1) 
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB8_4:
+; CHECK-NEXT:  .LBB8_3:
 ; CHECK-NEXT:    lea %s13, -2147483648
 ; CHECK-NEXT:    and %s13, %s13, (32)0
 ; CHECK-NEXT:    lea.sl %s13, (%s11, %s13)
@@ -524,8 +524,8 @@ define x86_fastcallcc void @storequad_stk_big2(fp128 noundef %0, i64 noundef %1)
 ; CHECK-NEXT:    lea %s13, 2147483632
 ; CHECK-NEXT:    and %s13, %s13, (32)0
 ; CHECK-NEXT:    lea.sl %s11, -1(%s13, %s11)
-; CHECK-NEXT:    brge.l %s11, %s8, .LBB9_4
-; CHECK-NEXT:  # %bb.3:
+; CHECK-NEXT:    brge.l %s11, %s8, .LBB9_3
+; CHECK-NEXT:  # %bb.4:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -534,7 +534,7 @@ define x86_fastcallcc void @storequad_stk_big2(fp128 noundef %0, i64 noundef %1)
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB9_4:
+; CHECK-NEXT:  .LBB9_3:
 ; CHECK-NEXT:    lea %s13, -2147483648
 ; CHECK-NEXT:    and %s13, %s13, (32)0
 ; CHECK-NEXT:    lea.sl %s13, (%s11, %s13)
@@ -581,8 +581,8 @@ define x86_fastcallcc void @storequad_stk_dyn(fp128 noundef %0, i64 noundef %1) 
 ; CHECK-NEXT:    st %s10, 8(, %s11)
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    lea %s11, -256(, %s11)
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB10_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB10_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -591,7 +591,7 @@ define x86_fastcallcc void @storequad_stk_dyn(fp128 noundef %0, i64 noundef %1) 
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB10_2:
+; CHECK-NEXT:  .LBB10_1:
 ; CHECK-NEXT:    or %s4, 0, %s0
 ; CHECK-NEXT:    or %s5, 0, %s1
 ; CHECK-NEXT:    lea %s0, 15(, %s2)
@@ -629,8 +629,8 @@ define x86_fastcallcc void @storequad_stk_dyn_align(fp128 noundef %0, i64 nounde
 ; CHECK-NEXT:    lea %s11, -288(, %s11)
 ; CHECK-NEXT:    and %s11, %s11, (59)1
 ; CHECK-NEXT:    or %s17, 0, %s11
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB11_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB11_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -639,7 +639,7 @@ define x86_fastcallcc void @storequad_stk_dyn_align(fp128 noundef %0, i64 nounde
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB11_2:
+; CHECK-NEXT:  .LBB11_1:
 ; CHECK-NEXT:    or %s4, 0, %s0
 ; CHECK-NEXT:    or %s5, 0, %s1
 ; CHECK-NEXT:    lea %s0, 15(, %s2)
@@ -678,8 +678,8 @@ define x86_fastcallcc void @storequad_stk_dyn_align2(fp128 noundef %0, i64 nound
 ; CHECK-NEXT:    lea %s11, -320(, %s11)
 ; CHECK-NEXT:    and %s11, %s11, (58)1
 ; CHECK-NEXT:    or %s17, 0, %s11
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB12_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB12_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -688,7 +688,7 @@ define x86_fastcallcc void @storequad_stk_dyn_align2(fp128 noundef %0, i64 nound
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB12_2:
+; CHECK-NEXT:  .LBB12_1:
 ; CHECK-NEXT:    or %s4, 0, %s0
 ; CHECK-NEXT:    or %s5, 0, %s1
 ; CHECK-NEXT:    lea %s0, 15(, %s2)
@@ -733,8 +733,8 @@ define x86_fastcallcc void @storequad_stk_dyn_align_spill(fp128 noundef %0, i64 
 ; CHECK-NEXT:    lea %s11, -288(, %s11)
 ; CHECK-NEXT:    and %s11, %s11, (59)1
 ; CHECK-NEXT:    or %s17, 0, %s11
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB13_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB13_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -743,7 +743,7 @@ define x86_fastcallcc void @storequad_stk_dyn_align_spill(fp128 noundef %0, i64 
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB13_2:
+; CHECK-NEXT:  .LBB13_1:
 ; CHECK-NEXT:    st %s18, 48(, %s9) # 8-byte Folded Spill
 ; CHECK-NEXT:    st %s19, 56(, %s9) # 8-byte Folded Spill
 ; CHECK-NEXT:    st %s20, 64(, %s9) # 8-byte Folded Spill

--- a/llvm/test/CodeGen/VE/Scalar/tls.ll
+++ b/llvm/test/CodeGen/VE/Scalar/tls.ll
@@ -11,7 +11,7 @@
 ; Function Attrs: norecurse nounwind readnone
 define nonnull ptr @get_global() {
 ; GENDYN-LABEL: get_global:
-; GENDYN:       .LBB{{[0-9]+}}_2:
+; GENDYN:       .LBB{{[0-9]+}}_1:
 ; GENDYN-NEXT:    lea %s0, x@tls_gd_lo(-24)
 ; GENDYN-NEXT:    and %s0, %s0, (32)0
 ; GENDYN-NEXT:    sic %s10
@@ -23,7 +23,7 @@ define nonnull ptr @get_global() {
 ; GENDYN-NEXT:    or %s11, 0, %s9
 ;
 ; GENDYNPIC-LABEL: get_global:
-; GENDYNPIC:       .LBB{{[0-9]+}}_2:
+; GENDYNPIC:       .LBB{{[0-9]+}}_1:
 ; GENDYNPIC-NEXT:    lea %s15, _GLOBAL_OFFSET_TABLE_@pc_lo(-24)
 ; GENDYNPIC-NEXT:    and %s15, %s15, (32)0
 ; GENDYNPIC-NEXT:    sic %s16
@@ -39,7 +39,7 @@ define nonnull ptr @get_global() {
 ; GENDYNPIC-NEXT:    or %s11, 0, %s9
 ;
 ; LOCAL-LABEL: get_global:
-; LOCAL:       .LBB{{[0-9]+}}_2:
+; LOCAL:       .LBB{{[0-9]+}}_1:
 ; LOCAL-NEXT:  lea %s34, x@tpoff_lo
 ; LOCAL-NEXT:  and %s34, %s34, (32)0
 ; LOCAL-NEXT:  lea.sl %s34, x@tpoff_hi(%s34)
@@ -52,7 +52,7 @@ entry:
 ; Function Attrs: norecurse nounwind readnone
 define nonnull ptr @get_local() {
 ; GENDYN-LABEL: get_local:
-; GENDYN:       .LBB{{[0-9]+}}_2:
+; GENDYN:       .LBB{{[0-9]+}}_1:
 ; GENDYN-NEXT:    lea %s0, y@tls_gd_lo(-24)
 ; GENDYN-NEXT:    and %s0, %s0, (32)0
 ; GENDYN-NEXT:    sic %s10
@@ -64,7 +64,7 @@ define nonnull ptr @get_local() {
 ; GENDYN-NEXT:    or %s11, 0, %s9
 ;
 ; GENDYNPIC-LABEL: get_local:
-; GENDYNPIC:       .LBB{{[0-9]+}}_2:
+; GENDYNPIC:       .LBB{{[0-9]+}}_1:
 ; GENDYNPIC-NEXT:    lea %s15, _GLOBAL_OFFSET_TABLE_@pc_lo(-24)
 ; GENDYNPIC-NEXT:    and %s15, %s15, (32)0
 ; GENDYNPIC-NEXT:    sic %s16
@@ -80,7 +80,7 @@ define nonnull ptr @get_local() {
 ; GENDYNPIC-NEXT:    or %s11, 0, %s9
 ;
 ; LOCAL-LABEL: get_local:
-; LOCAL:       .LBB{{[0-9]+}}_2:
+; LOCAL:       .LBB{{[0-9]+}}_1:
 ; LOCAL-NEXT:  lea %s34, y@tpoff_lo
 ; LOCAL-NEXT:  and %s34, %s34, (32)0
 ; LOCAL-NEXT:  lea.sl %s34, y@tpoff_hi(%s34)
@@ -93,7 +93,7 @@ entry:
 ; Function Attrs: norecurse nounwind
 define void @set_global(i32 %v) {
 ; GENDYN-LABEL: set_global:
-; GENDYN:       .LBB{{[0-9]+}}_2:
+; GENDYN:       .LBB{{[0-9]+}}_1:
 ; GENDYN-NEXT:    st %s18, 288(, %s11) # 8-byte Folded Spill
 ; GENDYN-NEXT:    or %s18, 0, %s0
 ; GENDYN-NEXT:    lea %s0, x@tls_gd_lo(-24)
@@ -109,7 +109,7 @@ define void @set_global(i32 %v) {
 ; GENDYN-NEXT:    or %s11, 0, %s9
 ;
 ; GENDYNPIC-LABEL: set_global:
-; GENDYNPIC:       .LBB{{[0-9]+}}_2:
+; GENDYNPIC:       .LBB{{[0-9]+}}_1:
 ; GENDYNPIC-NEXT:    st %s18, 288(, %s11) # 8-byte Folded Spill
 ; GENDYNPIC-NEXT:    or %s18, 0, %s0
 ; GENDYNPIC-NEXT:    lea %s15, _GLOBAL_OFFSET_TABLE_@pc_lo(-24)
@@ -129,7 +129,7 @@ define void @set_global(i32 %v) {
 ; GENDYNPIC-NEXT:    or %s11, 0, %s9
 ;
 ; LOCAL-LABEL: set_global:
-; LOCAL:       .LBB{{[0-9]+}}_2:
+; LOCAL:       .LBB{{[0-9]+}}_1:
 ; LOCAL-NEXT:  lea %s34, x@tpoff_lo
 ; LOCAL-NEXT:  and %s34, %s34, (32)0
 ; LOCAL-NEXT:  lea.sl %s34, x@tpoff_hi(%s34)
@@ -144,7 +144,7 @@ entry:
 ; Function Attrs: norecurse nounwind
 define void @set_local(i32 %v) {
 ; GENDYN-LABEL: set_local:
-; GENDYN:       .LBB{{[0-9]+}}_2:
+; GENDYN:       .LBB{{[0-9]+}}_1:
 ; GENDYN-NEXT:    st %s18, 288(, %s11) # 8-byte Folded Spill
 ; GENDYN-NEXT:    or %s18, 0, %s0
 ; GENDYN-NEXT:    lea %s0, y@tls_gd_lo(-24)
@@ -160,7 +160,7 @@ define void @set_local(i32 %v) {
 ; GENDYN-NEXT:    or %s11, 0, %s9
 ;
 ; GENDYNPIC-LABEL: set_local:
-; GENDYNPIC:       .LBB{{[0-9]+}}_2:
+; GENDYNPIC:       .LBB{{[0-9]+}}_1:
 ; GENDYNPIC-NEXT:    st %s18, 288(, %s11) # 8-byte Folded Spill
 ; GENDYNPIC-NEXT:    or %s18, 0, %s0
 ; GENDYNPIC-NEXT:    lea %s15, _GLOBAL_OFFSET_TABLE_@pc_lo(-24)
@@ -180,7 +180,7 @@ define void @set_local(i32 %v) {
 ; GENDYNPIC-NEXT:    or %s11, 0, %s9
 ;
 ; LOCAL-LABEL: set_local:
-; LOCAL:       .LBB{{[0-9]+}}_2:
+; LOCAL:       .LBB{{[0-9]+}}_1:
 ; LOCAL-NEXT:  lea %s34, y@tpoff_lo
 ; LOCAL-NEXT:  and %s34, %s34, (32)0
 ; LOCAL-NEXT:  lea.sl %s34, y@tpoff_hi(%s34)

--- a/llvm/test/CodeGen/VE/Scalar/va_caller.ll
+++ b/llvm/test/CodeGen/VE/Scalar/va_caller.ll
@@ -4,7 +4,7 @@ declare i32 @func(i32, ...)
 
 define i32 @caller() {
 ; CHECK-LABEL: caller:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    or %s0, 0, (0)1
 ; CHECK-NEXT:    st %s0, 264(, %s11)
 ; CHECK-NEXT:    or %s1, 10, (0)1

--- a/llvm/test/CodeGen/VE/VELIntrinsics/lvlgen.ll
+++ b/llvm/test/CodeGen/VE/VELIntrinsics/lvlgen.ll
@@ -69,7 +69,7 @@ define void @stable_vl(i32 %evl, ptr %P, ptr %Q) {
 ; Function Attrs: nounwind
 define void @call_invl(i32 %evl, ptr %P, ptr %Q) {
 ; CHECK-LABEL: call_invl:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    st %s18, 288(, %s11) # 8-byte Folded Spill
 ; CHECK-NEXT:    st %s19, 296(, %s11) # 8-byte Folded Spill
 ; CHECK-NEXT:    st %s20, 304(, %s11) # 8-byte Folded Spill

--- a/llvm/test/CodeGen/VE/Vector/fastcc_caller.ll
+++ b/llvm/test/CodeGen/VE/Vector/fastcc_caller.ll
@@ -11,7 +11,7 @@ declare void @test(i64)
 
 define fastcc i32 @sample_call() {
 ; CHECK-LABEL: sample_call:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s0, sample_add@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0
 ; CHECK-NEXT:    lea.sl %s12, sample_add@hi(, %s0)
@@ -25,7 +25,7 @@ define fastcc i32 @sample_call() {
 
 define fastcc i32 @stack_call_int() {
 ; CHECK-LABEL: stack_call_int:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    or %s0, 10, (0)1
 ; CHECK-NEXT:    st %s0, 248(, %s11)
 ; CHECK-NEXT:    or %s34, 9, (0)1
@@ -49,7 +49,7 @@ define fastcc i32 @stack_call_int() {
 
 define fastcc i32 @stack_call_int_szext() {
 ; CHECK-LABEL: stack_call_int_szext:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    or %s0, -1, (0)1
 ; CHECK-NEXT:    st %s0, 248(, %s11)
 ; CHECK-NEXT:    lea %s34, 65535
@@ -73,7 +73,7 @@ define fastcc i32 @stack_call_int_szext() {
 
 define fastcc float @stack_call_float() {
 ; CHECK-LABEL: stack_call_float:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea.sl %s0, 1092616192
 ; CHECK-NEXT:    st %s0, 248(, %s11)
 ; CHECK-NEXT:    lea.sl %s34, 1091567616
@@ -97,7 +97,7 @@ define fastcc float @stack_call_float() {
 
 define fastcc float @stack_call_float2(float %p0) {
 ; CHECK-LABEL: stack_call_float2:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    st %s0, 248(, %s11)
 ; CHECK-NEXT:    lea %s1, stack_callee_float@lo
 ; CHECK-NEXT:    and %s1, %s1, (32)0
@@ -124,7 +124,7 @@ declare fastcc void @vsample_iv(i32, <256 x i32>)
 
 define void @caller_vret() {
 ; CHECK:       caller_vret:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s0, get_v256i32@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0
 ; CHECK-NEXT:    lea.sl %s12, get_v256i32@hi(, %s0)
@@ -136,7 +136,7 @@ define void @caller_vret() {
 
 define void @caller_vret_pass_p0() {
 ; CHECK-LABEL: caller_vret_pass_p0:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK:         lea %s0, get_v256i32@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0
 ; CHECK-NEXT:    lea.sl %s12, get_v256i32@hi(, %s0)
@@ -153,7 +153,7 @@ define void @caller_vret_pass_p0() {
 
 define void @caller_vret_pass_p1(i32 %s) {
 ; CHECK-LABEL: caller_vret_pass_p1:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK:         or %s18, 0, %s0
 ; CHECK-NEXT:    lea %s0, get_v256i32@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0
@@ -174,7 +174,7 @@ declare fastcc void @vsample_vvv(<256 x i32>, <256 x i32>, <256 x i32>)
 
 define void @caller_vret_pass_p01() {
 ; CHECK-LABEL: caller_vret_pass_p01:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s0, get_v256i32@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0
 ; CHECK-NEXT:    lea.sl %s12, get_v256i32@hi(, %s0)
@@ -194,7 +194,7 @@ define void @caller_vret_pass_p01() {
 
 define void @caller_vret_pass_p012() {
 ; CHECK-LABEL: caller_vret_pass_p012:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s0, get_v256i32@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0
 ; CHECK-NEXT:    lea.sl %s12, get_v256i32@hi(, %s0)
@@ -221,7 +221,7 @@ declare fastcc void @vsample_vvvvvvv(<256 x i32>, <256 x i32>, <256 x i32>, <256
 ; TODO improve vreg copy (redundant lea+lvl emitted)
 define fastcc void @roundtrip_caller_callee(<256 x i32> %p0, <256 x i32> %p1, <256 x i32> %p2, <256 x i32> %p3, <256 x i32> %p4, <256 x i32> %p5, <256 x i32> %p6) {
 ; CHECK-LABEL: roundtrip_caller_callee:
-; CHECK:       .LBB{{[0-9]+}}_2:
+; CHECK:       .LBB{{[0-9]+}}_1:
 ; CHECK-NEXT:    lea %s16, 256
 ; CHECK-NEXT:    lvl %s16
 ; CHECK-NEXT:    vor %v7, (0)1, %v0

--- a/llvm/test/CodeGen/VE/Vector/load_stk_ldvm.ll
+++ b/llvm/test/CodeGen/VE/Vector/load_stk_ldvm.ll
@@ -101,8 +101,8 @@ define fastcc <256 x i1> @load__vm256_stk() {
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    lea %s11, -224(, %s11)
 ; CHECK-NEXT:    and %s11, %s11, (59)1
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB0_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB0_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -111,7 +111,7 @@ define fastcc <256 x i1> @load__vm256_stk() {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB0_2:
+; CHECK-NEXT:  .LBB0_1:
 ; CHECK-NEXT:    ld %s16, 192(, %s11)
 ; CHECK-NEXT:    lvm %vm1, 0, %s16
 ; CHECK-NEXT:    ld %s16, 200(, %s11)
@@ -146,8 +146,8 @@ define fastcc <256 x i1> @load__vm256_stk_big_fit() {
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    lea %s11, -2147483648(, %s11)
 ; CHECK-NEXT:    and %s11, %s11, (59)1
-; CHECK-NEXT:    brge.l %s11, %s8, .LBB1_4
-; CHECK-NEXT:  # %bb.3:
+; CHECK-NEXT:    brge.l %s11, %s8, .LBB1_3
+; CHECK-NEXT:  # %bb.4:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -156,7 +156,7 @@ define fastcc <256 x i1> @load__vm256_stk_big_fit() {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB1_4:
+; CHECK-NEXT:  .LBB1_3:
 ; CHECK-NEXT:    ld %s16, 2147483616(, %s11)
 ; CHECK-NEXT:    lvm %vm1, 0, %s16
 ; CHECK-NEXT:    ld %s16, 2147483624(, %s11)
@@ -208,8 +208,8 @@ define fastcc <256 x i1> @load__vm256_stk_big() {
 ; CHECK-NEXT:    and %s13, %s13, (32)0
 ; CHECK-NEXT:    lea.sl %s11, -1(%s13, %s11)
 ; CHECK-NEXT:    and %s11, %s11, (59)1
-; CHECK-NEXT:    brge.l %s11, %s8, .LBB2_4
-; CHECK-NEXT:  # %bb.3:
+; CHECK-NEXT:    brge.l %s11, %s8, .LBB2_3
+; CHECK-NEXT:  # %bb.4:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -218,7 +218,7 @@ define fastcc <256 x i1> @load__vm256_stk_big() {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB2_4:
+; CHECK-NEXT:  .LBB2_3:
 ; CHECK-NEXT:    lea %s13, -2147483648
 ; CHECK-NEXT:    and %s13, %s13, (32)0
 ; CHECK-NEXT:    lea.sl %s13, (%s11, %s13)
@@ -273,8 +273,8 @@ define fastcc <256 x i1> @load__vm256_stk_big2() {
 ; CHECK-NEXT:    and %s13, %s13, (32)0
 ; CHECK-NEXT:    lea.sl %s11, -1(%s13, %s11)
 ; CHECK-NEXT:    and %s11, %s11, (59)1
-; CHECK-NEXT:    brge.l %s11, %s8, .LBB3_4
-; CHECK-NEXT:  # %bb.3:
+; CHECK-NEXT:    brge.l %s11, %s8, .LBB3_3
+; CHECK-NEXT:  # %bb.4:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -283,7 +283,7 @@ define fastcc <256 x i1> @load__vm256_stk_big2() {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB3_4:
+; CHECK-NEXT:  .LBB3_3:
 ; CHECK-NEXT:    lea %s13, -2147483456
 ; CHECK-NEXT:    and %s13, %s13, (32)0
 ; CHECK-NEXT:    lea.sl %s13, (%s11, %s13)
@@ -336,8 +336,8 @@ define fastcc <256 x i1> @load__vm256_stk_dyn(i64 noundef %0) {
 ; CHECK-NEXT:    st %s10, 8(, %s11)
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    lea %s11, -272(, %s11)
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB4_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB4_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -346,7 +346,7 @@ define fastcc <256 x i1> @load__vm256_stk_dyn(i64 noundef %0) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB4_2:
+; CHECK-NEXT:  .LBB4_1:
 ; CHECK-NEXT:    sll %s0, %s0, 5
 ; CHECK-NEXT:    lea %s1, __ve_grow_stack@lo
 ; CHECK-NEXT:    and %s1, %s1, (32)0
@@ -389,8 +389,8 @@ define fastcc <256 x i1> @load__vm256_stk_dyn_align(i64 noundef %0) {
 ; CHECK-NEXT:    lea %s11, -288(, %s11)
 ; CHECK-NEXT:    and %s11, %s11, (59)1
 ; CHECK-NEXT:    or %s17, 0, %s11
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB5_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB5_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -399,7 +399,7 @@ define fastcc <256 x i1> @load__vm256_stk_dyn_align(i64 noundef %0) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB5_2:
+; CHECK-NEXT:  .LBB5_1:
 ; CHECK-NEXT:    sll %s0, %s0, 5
 ; CHECK-NEXT:    lea %s1, __ve_grow_stack@lo
 ; CHECK-NEXT:    and %s1, %s1, (32)0
@@ -443,8 +443,8 @@ define fastcc <256 x i1> @load__vm256_stk_dyn_align2(i64 noundef %0) {
 ; CHECK-NEXT:    lea %s11, -320(, %s11)
 ; CHECK-NEXT:    and %s11, %s11, (58)1
 ; CHECK-NEXT:    or %s17, 0, %s11
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB6_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB6_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -453,7 +453,7 @@ define fastcc <256 x i1> @load__vm256_stk_dyn_align2(i64 noundef %0) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB6_2:
+; CHECK-NEXT:  .LBB6_1:
 ; CHECK-NEXT:    sll %s0, %s0, 5
 ; CHECK-NEXT:    lea %s1, __ve_grow_stack@lo
 ; CHECK-NEXT:    and %s1, %s1, (32)0
@@ -509,8 +509,8 @@ define fastcc <256 x i1> @load__vm256_stk_dyn_align_spill(i64 noundef %0) {
 ; CHECK-NEXT:    lea %s11, -320(, %s11)
 ; CHECK-NEXT:    and %s11, %s11, (59)1
 ; CHECK-NEXT:    or %s17, 0, %s11
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB7_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB7_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -519,7 +519,7 @@ define fastcc <256 x i1> @load__vm256_stk_dyn_align_spill(i64 noundef %0) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB7_2:
+; CHECK-NEXT:  .LBB7_1:
 ; CHECK-NEXT:    st %s18, 48(, %s9) # 8-byte Folded Spill
 ; CHECK-NEXT:    or %s18, 0, %s0
 ; CHECK-NEXT:    lea %s0, 15(, %s0)
@@ -596,8 +596,8 @@ define fastcc <512 x i1> @load__vm512_stk() {
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    lea %s11, -256(, %s11)
 ; CHECK-NEXT:    and %s11, %s11, (58)1
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB8_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB8_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -606,7 +606,7 @@ define fastcc <512 x i1> @load__vm512_stk() {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB8_2:
+; CHECK-NEXT:  .LBB8_1:
 ; CHECK-NEXT:    # implicit-def: $vmp1
 ; CHECK-NEXT:    ld %s16, 192(, %s11)
 ; CHECK-NEXT:    lvm %vm3, 0, %s16
@@ -644,8 +644,8 @@ define fastcc <512 x i1> @load__vm512_stk_big_fit() {
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    lea %s11, -2147483648(, %s11)
 ; CHECK-NEXT:    and %s11, %s11, (58)1
-; CHECK-NEXT:    brge.l %s11, %s8, .LBB9_4
-; CHECK-NEXT:  # %bb.3:
+; CHECK-NEXT:    brge.l %s11, %s8, .LBB9_3
+; CHECK-NEXT:  # %bb.4:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -654,7 +654,7 @@ define fastcc <512 x i1> @load__vm512_stk_big_fit() {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB9_4:
+; CHECK-NEXT:  .LBB9_3:
 ; CHECK-NEXT:    # implicit-def: $vmp1
 ; CHECK-NEXT:    ld %s16, 2147483584(, %s11)
 ; CHECK-NEXT:    lvm %vm3, 0, %s16
@@ -715,8 +715,8 @@ define fastcc <512 x i1> @load__vm512_stk_big() {
 ; CHECK-NEXT:    and %s13, %s13, (32)0
 ; CHECK-NEXT:    lea.sl %s11, -1(%s13, %s11)
 ; CHECK-NEXT:    and %s11, %s11, (58)1
-; CHECK-NEXT:    brge.l %s11, %s8, .LBB10_4
-; CHECK-NEXT:  # %bb.3:
+; CHECK-NEXT:    brge.l %s11, %s8, .LBB10_3
+; CHECK-NEXT:  # %bb.4:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -725,7 +725,7 @@ define fastcc <512 x i1> @load__vm512_stk_big() {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB10_4:
+; CHECK-NEXT:  .LBB10_3:
 ; CHECK-NEXT:    lea %s13, -2147483648
 ; CHECK-NEXT:    and %s13, %s13, (32)0
 ; CHECK-NEXT:    lea.sl %s13, (%s11, %s13)
@@ -789,8 +789,8 @@ define fastcc <512 x i1> @load__vm512_stk_big2() {
 ; CHECK-NEXT:    and %s13, %s13, (32)0
 ; CHECK-NEXT:    lea.sl %s11, -1(%s13, %s11)
 ; CHECK-NEXT:    and %s11, %s11, (58)1
-; CHECK-NEXT:    brge.l %s11, %s8, .LBB11_4
-; CHECK-NEXT:  # %bb.3:
+; CHECK-NEXT:    brge.l %s11, %s8, .LBB11_3
+; CHECK-NEXT:  # %bb.4:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -799,7 +799,7 @@ define fastcc <512 x i1> @load__vm512_stk_big2() {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB11_4:
+; CHECK-NEXT:  .LBB11_3:
 ; CHECK-NEXT:    lea %s13, -2147483456
 ; CHECK-NEXT:    and %s13, %s13, (32)0
 ; CHECK-NEXT:    lea.sl %s13, (%s11, %s13)
@@ -864,8 +864,8 @@ define fastcc <512 x i1> @load__vm512_stk_dyn(i64 noundef %0) {
 ; CHECK-NEXT:    lea %s11, -320(, %s11)
 ; CHECK-NEXT:    and %s11, %s11, (58)1
 ; CHECK-NEXT:    or %s17, 0, %s11
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB12_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB12_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -874,7 +874,7 @@ define fastcc <512 x i1> @load__vm512_stk_dyn(i64 noundef %0) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB12_2:
+; CHECK-NEXT:  .LBB12_1:
 ; CHECK-NEXT:    sll %s0, %s0, 6
 ; CHECK-NEXT:    lea %s1, __ve_grow_stack@lo
 ; CHECK-NEXT:    and %s1, %s1, (32)0
@@ -931,8 +931,8 @@ define fastcc <512 x i1> @load__vm512_stk_dyn_align(i64 noundef %0) {
 ; CHECK-NEXT:    lea %s11, -320(, %s11)
 ; CHECK-NEXT:    and %s11, %s11, (59)1
 ; CHECK-NEXT:    or %s17, 0, %s11
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB13_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB13_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -941,7 +941,7 @@ define fastcc <512 x i1> @load__vm512_stk_dyn_align(i64 noundef %0) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB13_2:
+; CHECK-NEXT:  .LBB13_1:
 ; CHECK-NEXT:    sll %s0, %s0, 6
 ; CHECK-NEXT:    lea %s1, __ve_grow_stack@lo
 ; CHECK-NEXT:    and %s1, %s1, (32)0
@@ -998,8 +998,8 @@ define fastcc <512 x i1> @load__vm512_stk_dyn_align2(i64 noundef %0) {
 ; CHECK-NEXT:    lea %s11, -384(, %s11)
 ; CHECK-NEXT:    and %s11, %s11, (58)1
 ; CHECK-NEXT:    or %s17, 0, %s11
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB14_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB14_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -1008,7 +1008,7 @@ define fastcc <512 x i1> @load__vm512_stk_dyn_align2(i64 noundef %0) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB14_2:
+; CHECK-NEXT:  .LBB14_1:
 ; CHECK-NEXT:    sll %s0, %s0, 6
 ; CHECK-NEXT:    lea %s1, __ve_grow_stack@lo
 ; CHECK-NEXT:    and %s1, %s1, (32)0
@@ -1086,8 +1086,8 @@ define fastcc <512 x i1> @load__vm512_stk_dyn_align_spill(i64 noundef %0) {
 ; CHECK-NEXT:    lea %s11, -384(, %s11)
 ; CHECK-NEXT:    and %s11, %s11, (59)1
 ; CHECK-NEXT:    or %s17, 0, %s11
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB15_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB15_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -1096,7 +1096,7 @@ define fastcc <512 x i1> @load__vm512_stk_dyn_align_spill(i64 noundef %0) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB15_2:
+; CHECK-NEXT:  .LBB15_1:
 ; CHECK-NEXT:    st %s18, 48(, %s9) # 8-byte Folded Spill
 ; CHECK-NEXT:    or %s18, 0, %s0
 ; CHECK-NEXT:    sll %s0, %s0, 6

--- a/llvm/test/CodeGen/VE/Vector/loadvr.ll
+++ b/llvm/test/CodeGen/VE/Vector/loadvr.ll
@@ -56,8 +56,8 @@ define fastcc <256 x i64> @loadv256i64stk() {
 ; CHECK-LABEL: loadv256i64stk:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    lea %s11, -2048(, %s11)
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB4_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB4_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -66,7 +66,7 @@ define fastcc <256 x i64> @loadv256i64stk() {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB4_2:
+; CHECK-NEXT:  .LBB4_1:
 ; CHECK-NEXT:    lea %s0, 256
 ; CHECK-NEXT:    lea %s1, (, %s11)
 ; CHECK-NEXT:    lvl %s0

--- a/llvm/test/CodeGen/VE/Vector/store_stk_stvm.ll
+++ b/llvm/test/CodeGen/VE/Vector/store_stk_stvm.ll
@@ -101,8 +101,8 @@ define fastcc void @store__vm256_stk(<256 x i1> noundef %0) {
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    lea %s11, -224(, %s11)
 ; CHECK-NEXT:    and %s11, %s11, (59)1
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB0_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB0_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -111,7 +111,7 @@ define fastcc void @store__vm256_stk(<256 x i1> noundef %0) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB0_2:
+; CHECK-NEXT:  .LBB0_1:
 ; CHECK-NEXT:    svm %s16, %vm1, 0
 ; CHECK-NEXT:    st %s16, 192(, %s11)
 ; CHECK-NEXT:    svm %s16, %vm1, 1
@@ -146,8 +146,8 @@ define fastcc void @store__vm256_stk_big_fit(<256 x i1> noundef %0, i64 noundef 
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    lea %s11, -2147483648(, %s11)
 ; CHECK-NEXT:    and %s11, %s11, (59)1
-; CHECK-NEXT:    brge.l %s11, %s8, .LBB1_4
-; CHECK-NEXT:  # %bb.3:
+; CHECK-NEXT:    brge.l %s11, %s8, .LBB1_3
+; CHECK-NEXT:  # %bb.4:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -156,7 +156,7 @@ define fastcc void @store__vm256_stk_big_fit(<256 x i1> noundef %0, i64 noundef 
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB1_4:
+; CHECK-NEXT:  .LBB1_3:
 ; CHECK-NEXT:    svm %s16, %vm1, 0
 ; CHECK-NEXT:    st %s16, 2147483616(, %s11)
 ; CHECK-NEXT:    svm %s16, %vm1, 1
@@ -208,8 +208,8 @@ define fastcc void @store__vm256_stk_big(<256 x i1> noundef %0, i64 noundef %1) 
 ; CHECK-NEXT:    and %s13, %s13, (32)0
 ; CHECK-NEXT:    lea.sl %s11, -1(%s13, %s11)
 ; CHECK-NEXT:    and %s11, %s11, (59)1
-; CHECK-NEXT:    brge.l %s11, %s8, .LBB2_4
-; CHECK-NEXT:  # %bb.3:
+; CHECK-NEXT:    brge.l %s11, %s8, .LBB2_3
+; CHECK-NEXT:  # %bb.4:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -218,7 +218,7 @@ define fastcc void @store__vm256_stk_big(<256 x i1> noundef %0, i64 noundef %1) 
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB2_4:
+; CHECK-NEXT:  .LBB2_3:
 ; CHECK-NEXT:    lea %s13, -2147483648
 ; CHECK-NEXT:    and %s13, %s13, (32)0
 ; CHECK-NEXT:    lea.sl %s13, (%s11, %s13)
@@ -273,8 +273,8 @@ define fastcc void @store__vm256_stk_big2(<256 x i1> noundef %0, i64 noundef %1)
 ; CHECK-NEXT:    and %s13, %s13, (32)0
 ; CHECK-NEXT:    lea.sl %s11, -1(%s13, %s11)
 ; CHECK-NEXT:    and %s11, %s11, (59)1
-; CHECK-NEXT:    brge.l %s11, %s8, .LBB3_4
-; CHECK-NEXT:  # %bb.3:
+; CHECK-NEXT:    brge.l %s11, %s8, .LBB3_3
+; CHECK-NEXT:  # %bb.4:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -283,7 +283,7 @@ define fastcc void @store__vm256_stk_big2(<256 x i1> noundef %0, i64 noundef %1)
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB3_4:
+; CHECK-NEXT:  .LBB3_3:
 ; CHECK-NEXT:    lea %s13, -2147483456
 ; CHECK-NEXT:    and %s13, %s13, (32)0
 ; CHECK-NEXT:    lea.sl %s13, (%s11, %s13)
@@ -336,8 +336,8 @@ define fastcc void @store__vm256_stk_dyn(<256 x i1> noundef %0, i64 noundef %1) 
 ; CHECK-NEXT:    st %s10, 8(, %s11)
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    lea %s11, -272(, %s11)
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB4_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB4_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -346,7 +346,7 @@ define fastcc void @store__vm256_stk_dyn(<256 x i1> noundef %0, i64 noundef %1) 
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB4_2:
+; CHECK-NEXT:  .LBB4_1:
 ; CHECK-NEXT:    sll %s0, %s0, 5
 ; CHECK-NEXT:    lea %s1, __ve_grow_stack@lo
 ; CHECK-NEXT:    and %s1, %s1, (32)0
@@ -393,8 +393,8 @@ define fastcc void @store__vm256_stk_dyn_align(<256 x i1> noundef %0, i64 nounde
 ; CHECK-NEXT:    lea %s11, -288(, %s11)
 ; CHECK-NEXT:    and %s11, %s11, (59)1
 ; CHECK-NEXT:    or %s17, 0, %s11
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB5_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB5_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -403,7 +403,7 @@ define fastcc void @store__vm256_stk_dyn_align(<256 x i1> noundef %0, i64 nounde
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB5_2:
+; CHECK-NEXT:  .LBB5_1:
 ; CHECK-NEXT:    sll %s0, %s0, 5
 ; CHECK-NEXT:    lea %s1, __ve_grow_stack@lo
 ; CHECK-NEXT:    and %s1, %s1, (32)0
@@ -451,8 +451,8 @@ define fastcc void @store__vm256_stk_dyn_align2(<256 x i1> noundef %0, i64 nound
 ; CHECK-NEXT:    lea %s11, -320(, %s11)
 ; CHECK-NEXT:    and %s11, %s11, (58)1
 ; CHECK-NEXT:    or %s17, 0, %s11
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB6_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB6_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -461,7 +461,7 @@ define fastcc void @store__vm256_stk_dyn_align2(<256 x i1> noundef %0, i64 nound
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB6_2:
+; CHECK-NEXT:  .LBB6_1:
 ; CHECK-NEXT:    sll %s0, %s0, 5
 ; CHECK-NEXT:    lea %s1, __ve_grow_stack@lo
 ; CHECK-NEXT:    and %s1, %s1, (32)0
@@ -521,8 +521,8 @@ define fastcc void @store__vm256_stk_dyn_align_spill(<256 x i1> noundef %0, i64 
 ; CHECK-NEXT:    lea %s11, -320(, %s11)
 ; CHECK-NEXT:    and %s11, %s11, (59)1
 ; CHECK-NEXT:    or %s17, 0, %s11
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB7_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB7_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -531,7 +531,7 @@ define fastcc void @store__vm256_stk_dyn_align_spill(<256 x i1> noundef %0, i64 
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB7_2:
+; CHECK-NEXT:  .LBB7_1:
 ; CHECK-NEXT:    st %s18, 48(, %s9) # 8-byte Folded Spill
 ; CHECK-NEXT:    st %s19, 56(, %s9) # 8-byte Folded Spill
 ; CHECK-NEXT:    or %s18, 0, %s0
@@ -613,8 +613,8 @@ define fastcc void @store__vm512_stk(<512 x i1> noundef %0) {
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    lea %s11, -256(, %s11)
 ; CHECK-NEXT:    and %s11, %s11, (58)1
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB8_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB8_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -623,7 +623,7 @@ define fastcc void @store__vm512_stk(<512 x i1> noundef %0) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB8_2:
+; CHECK-NEXT:  .LBB8_1:
 ; CHECK-NEXT:    svm %s16, %vm3, 0
 ; CHECK-NEXT:    st %s16, 192(, %s11)
 ; CHECK-NEXT:    svm %s16, %vm3, 1
@@ -660,8 +660,8 @@ define fastcc void @store__vm512_stk_bc(<512 x i1> noundef %0) {
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    lea %s11, -320(, %s11)
 ; CHECK-NEXT:    and %s11, %s11, (58)1
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB9_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB9_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -670,7 +670,7 @@ define fastcc void @store__vm512_stk_bc(<512 x i1> noundef %0) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB9_2:
+; CHECK-NEXT:  .LBB9_1:
 ; CHECK-NEXT:    svm %s16, %vm3, 0
 ; CHECK-NEXT:    st %s16, 192(, %s11)
 ; CHECK-NEXT:    svm %s16, %vm3, 1
@@ -726,8 +726,8 @@ define fastcc void @store__vm512_stk_big(<512 x i1> noundef %0, i64 noundef %1) 
 ; CHECK-NEXT:    and %s13, %s13, (32)0
 ; CHECK-NEXT:    lea.sl %s11, -1(%s13, %s11)
 ; CHECK-NEXT:    and %s11, %s11, (58)1
-; CHECK-NEXT:    brge.l %s11, %s8, .LBB10_4
-; CHECK-NEXT:  # %bb.3:
+; CHECK-NEXT:    brge.l %s11, %s8, .LBB10_3
+; CHECK-NEXT:  # %bb.4:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -736,7 +736,7 @@ define fastcc void @store__vm512_stk_big(<512 x i1> noundef %0, i64 noundef %1) 
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB10_4:
+; CHECK-NEXT:  .LBB10_3:
 ; CHECK-NEXT:    lea %s13, -2147483456
 ; CHECK-NEXT:    and %s13, %s13, (32)0
 ; CHECK-NEXT:    lea.sl %s13, (%s11, %s13)
@@ -799,8 +799,8 @@ define fastcc void @store__vm512_stk_big2(<512 x i1> noundef %0, i64 noundef %1)
 ; CHECK-NEXT:    and %s13, %s13, (32)0
 ; CHECK-NEXT:    lea.sl %s11, -1(%s13, %s11)
 ; CHECK-NEXT:    and %s11, %s11, (58)1
-; CHECK-NEXT:    brge.l %s11, %s8, .LBB11_4
-; CHECK-NEXT:  # %bb.3:
+; CHECK-NEXT:    brge.l %s11, %s8, .LBB11_3
+; CHECK-NEXT:  # %bb.4:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -809,7 +809,7 @@ define fastcc void @store__vm512_stk_big2(<512 x i1> noundef %0, i64 noundef %1)
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB11_4:
+; CHECK-NEXT:  .LBB11_3:
 ; CHECK-NEXT:    lea %s13, -2147483456
 ; CHECK-NEXT:    and %s13, %s13, (32)0
 ; CHECK-NEXT:    lea.sl %s13, (%s11, %s13)
@@ -873,8 +873,8 @@ define fastcc void @store__vm512_stk_dyn(<512 x i1> noundef %0, i64 noundef %1) 
 ; CHECK-NEXT:    lea %s11, -320(, %s11)
 ; CHECK-NEXT:    and %s11, %s11, (58)1
 ; CHECK-NEXT:    or %s17, 0, %s11
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB12_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB12_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -883,7 +883,7 @@ define fastcc void @store__vm512_stk_dyn(<512 x i1> noundef %0, i64 noundef %1) 
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB12_2:
+; CHECK-NEXT:  .LBB12_1:
 ; CHECK-NEXT:    sll %s0, %s0, 6
 ; CHECK-NEXT:    lea %s1, __ve_grow_stack@lo
 ; CHECK-NEXT:    and %s1, %s1, (32)0
@@ -947,8 +947,8 @@ define fastcc void @store__vm512_stk_dyn_align(<512 x i1> noundef %0, i64 nounde
 ; CHECK-NEXT:    lea %s11, -320(, %s11)
 ; CHECK-NEXT:    and %s11, %s11, (59)1
 ; CHECK-NEXT:    or %s17, 0, %s11
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB13_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB13_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -957,7 +957,7 @@ define fastcc void @store__vm512_stk_dyn_align(<512 x i1> noundef %0, i64 nounde
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB13_2:
+; CHECK-NEXT:  .LBB13_1:
 ; CHECK-NEXT:    sll %s0, %s0, 6
 ; CHECK-NEXT:    lea %s1, __ve_grow_stack@lo
 ; CHECK-NEXT:    and %s1, %s1, (32)0
@@ -1021,8 +1021,8 @@ define fastcc void @store__vm512_stk_dyn_align2(<512 x i1> noundef %0, i64 nound
 ; CHECK-NEXT:    lea %s11, -384(, %s11)
 ; CHECK-NEXT:    and %s11, %s11, (58)1
 ; CHECK-NEXT:    or %s17, 0, %s11
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB14_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB14_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -1031,7 +1031,7 @@ define fastcc void @store__vm512_stk_dyn_align2(<512 x i1> noundef %0, i64 nound
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB14_2:
+; CHECK-NEXT:  .LBB14_1:
 ; CHECK-NEXT:    lea %s0, 15(, %s0)
 ; CHECK-NEXT:    and %s0, -16, %s0
 ; CHECK-NEXT:    lea %s1, __ve_grow_stack@lo
@@ -1116,8 +1116,8 @@ define fastcc void @store__vm512_stk_dyn_align_spill(<512 x i1> noundef %0, i64 
 ; CHECK-NEXT:    lea %s11, -384(, %s11)
 ; CHECK-NEXT:    and %s11, %s11, (59)1
 ; CHECK-NEXT:    or %s17, 0, %s11
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB15_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB15_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -1126,7 +1126,7 @@ define fastcc void @store__vm512_stk_dyn_align_spill(<512 x i1> noundef %0, i64 
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB15_2:
+; CHECK-NEXT:  .LBB15_1:
 ; CHECK-NEXT:    st %s18, 48(, %s9) # 8-byte Folded Spill
 ; CHECK-NEXT:    st %s19, 56(, %s9) # 8-byte Folded Spill
 ; CHECK-NEXT:    or %s18, 0, %s0

--- a/llvm/test/CodeGen/VE/Vector/storevr.ll
+++ b/llvm/test/CodeGen/VE/Vector/storevr.ll
@@ -20,8 +20,8 @@ define fastcc void @storev256i64stk(<256 x i64>) {
 ; CHECK-LABEL: storev256i64stk:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    lea %s11, -2048(, %s11)
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB1_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB1_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -30,7 +30,7 @@ define fastcc void @storev256i64stk(<256 x i64>) {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB1_2:
+; CHECK-NEXT:  .LBB1_1:
 ; CHECK-NEXT:    lea %s0, 256
 ; CHECK-NEXT:    lea %s1, (, %s11)
 ; CHECK-NEXT:    lvl %s0

--- a/llvm/test/CodeGen/VE/naked-fn-with-frame-pointer.ll
+++ b/llvm/test/CodeGen/VE/naked-fn-with-frame-pointer.ll
@@ -21,8 +21,8 @@ define dso_local void @normal() "frame-pointer"="all" {
 ; CHECK-NEXT:    st %s10, 8(, %s11)
 ; CHECK-NEXT:    or %s9, 0, %s11
 ; CHECK-NEXT:    lea %s11, -240(, %s11)
-; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB1_2
-; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    brge.l.t %s11, %s8, .LBB1_1
+; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    ld %s61, 24(, %s14)
 ; CHECK-NEXT:    or %s62, 0, %s0
 ; CHECK-NEXT:    lea %s63, 315
@@ -31,7 +31,7 @@ define dso_local void @normal() "frame-pointer"="all" {
 ; CHECK-NEXT:    shm.l %s11, 16(%s61)
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
-; CHECK-NEXT:  .LBB1_2:
+; CHECK-NEXT:  .LBB1_1:
 ; CHECK-NEXT:    lea %s0, main@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0
 ; CHECK-NEXT:    lea.sl %s12, main@hi(, %s0)


### PR DESCRIPTION
Replace the manual block-splitting in expandExtendStackPseudo with
MachineBasicBlock::splitAt. Reduces boilerplate, but there's some
block renumbering churn in the output.

Co-authored-by: Claude (Claude-Opus-4.8)