### PR TITLE
[libc++][pstl] Implementation of parallel std::is_heap() based on std::is_heap_until()

### DIFF
--- a/libcxx/include/__algorithm/pstl.h
+++ b/libcxx/include/__algorithm/pstl.h
@@ -1090,6 +1090,31 @@ template <class _ExecutionPolicy,
           class _RandomAccessIterator,
           class _RawPolicy                                    = __remove_cvref_t<_ExecutionPolicy>,
           enable_if_t<is_execution_policy_v<_RawPolicy>, int> = 0>
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool
+is_heap(_ExecutionPolicy&& __policy, _RandomAccessIterator __first, _RandomAccessIterator __last) {
+  _LIBCPP_REQUIRE_CPP17_RANDOM_ACCESS_ITERATOR(_RandomAccessIterator, "is_heap requires RandomAccessIterators");
+  using _Implementation = __pstl::__dispatch<__pstl::__is_heap, __pstl::__current_configuration, _RawPolicy>;
+  return __pstl::__handle_exception<_Implementation>(
+      std::forward<_ExecutionPolicy>(__policy), std::move(__first), std::move(__last), less{});
+}
+
+template <class _ExecutionPolicy,
+          class _RandomAccessIterator,
+          class _Comp,
+          class _RawPolicy                                    = __remove_cvref_t<_ExecutionPolicy>,
+          enable_if_t<is_execution_policy_v<_RawPolicy>, int> = 0>
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool
+is_heap(_ExecutionPolicy&& __policy, _RandomAccessIterator __first, _RandomAccessIterator __last, _Comp __comp) {
+  _LIBCPP_REQUIRE_CPP17_RANDOM_ACCESS_ITERATOR(_RandomAccessIterator, "is_heap requires RandomAccessIterators");
+  using _Implementation = __pstl::__dispatch<__pstl::__is_heap, __pstl::__current_configuration, _RawPolicy>;
+  return __pstl::__handle_exception<_Implementation>(
+      std::forward<_ExecutionPolicy>(__policy), std::move(__first), std::move(__last), std::move(__comp));
+}
+
+template <class _ExecutionPolicy,
+          class _RandomAccessIterator,
+          class _RawPolicy                                    = __remove_cvref_t<_ExecutionPolicy>,
+          enable_if_t<is_execution_policy_v<_RawPolicy>, int> = 0>
 [[nodiscard]] _LIBCPP_HIDE_FROM_ABI _RandomAccessIterator
 is_heap_until(_ExecutionPolicy&& __policy, _RandomAccessIterator __first, _RandomAccessIterator __last) {
   _LIBCPP_REQUIRE_CPP17_RANDOM_ACCESS_ITERATOR(_RandomAccessIterator, "is_heap_until requires RandomAccessIterators");

--- a/libcxx/include/__pstl/backend_fwd.h
+++ b/libcxx/include/__pstl/backend_fwd.h
@@ -351,9 +351,16 @@ struct __reduce;
 //                       _Tp __init, _BinaryOperation __op) const noexcept;
 
 template <class _Backend, class _ExecutionPolicy>
-struct __is_heap_until;
+struct __is_heap;
 // template <class _Policy, class _RandomAccessIterator, class _Comp>
 // optional<bool>
+// operator()(_Policy&& __policy, _RandomAccessIterator __first, _RandomAccessIterator __last,
+//                                _Comp __comp) const noexcept;
+
+template <class _Backend, class _ExecutionPolicy>
+struct __is_heap_until;
+// template <class _Policy, class _RandomAccessIterator, class _Comp>
+// optional<_RandomAccessIterator>
 // operator()(_Policy&& __policy, _RandomAccessIterator __first, _RandomAccessIterator __last,
 //                                _Comp __comp) const noexcept;
 

--- a/libcxx/include/__pstl/backends/default.h
+++ b/libcxx/include/__pstl/backends/default.h
@@ -66,7 +66,7 @@ namespace __pstl {
 //
 // is_heap_until family
 // --------------
-// No other algorithms based on is_heap_until
+// - is_heap
 //
 // find_if family
 // --------------
@@ -376,6 +376,20 @@ struct __adjacent_find<__default_backend_tag, _ExecutionPolicy> {
       // Currently anything outside bidirectional iterators has to be processed serially
       return std::adjacent_find(std::move(__first), std::move(__last), std::move(__predicate));
     }
+  }
+};
+
+template <class _ExecutionPolicy>
+struct __is_heap<__default_backend_tag, _ExecutionPolicy> {
+  template <class _Policy, class _RandomAccessIterator, class _Comp>
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI optional<bool> operator()(
+      _Policy&& __policy, _RandomAccessIterator __first, _RandomAccessIterator __last, _Comp&& __comp) const noexcept {
+    using _IsHeapUntil = __dispatch<__is_heap_until, __current_configuration, _ExecutionPolicy>;
+    auto __res         = _IsHeapUntil()(__policy, std::move(__first), __last, std::forward<_Comp>(__comp));
+    if (!__res) {
+      return nullopt; // Failed to run the algorithm, propagate the error.
+    }
+    return *__res == __last; // is_heap_until returns the last iterator when no heap violations are found in the range.
   }
 };
 

--- a/libcxx/test/libcxx/algorithms/pstl.iterator-requirements.verify.cpp
+++ b/libcxx/test/libcxx/algorithms/pstl.iterator-requirements.verify.cpp
@@ -158,6 +158,11 @@ void f(non_forward_iterator non_fwd,
   }
 
   {
+    (void)std::is_heap(pol, non_random, non_random);       // expected-error@*:* {{static assertion failed: is_heap}}
+    (void)std::is_heap(pol, non_random, non_random, pred); // expected-error@*:* {{static assertion failed: is_heap}}
+  }
+
+  {
     (void)std::is_heap_until(
         pol, non_random, non_random); // expected-error@*:* {{static assertion failed: is_heap_until}}
     (void)std::is_heap_until(

--- a/libcxx/test/libcxx/algorithms/pstl.nodiscard.verify.cpp
+++ b/libcxx/test/libcxx/algorithms/pstl.nodiscard.verify.cpp
@@ -56,6 +56,10 @@ void test() {
   // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
   std::find_first_of(std::execution::par, std::begin(a), std::end(a), std::begin(b), std::end(b), pred2);
   // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::is_heap(std::execution::par, std::begin(a), std::end(a));
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::is_heap(std::execution::par, std::begin(a), std::end(a), pred2);
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
   std::is_heap_until(std::execution::par, std::begin(a), std::end(a));
   // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
   std::is_heap_until(std::execution::par, std::begin(a), std::end(a), pred2);

--- a/libcxx/test/std/algorithms/alg.sorting/alg.heap.operations/is.heap/pstl.is_heap.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.sorting/alg.heap.operations/is.heap/pstl.is_heap.pass.cpp
@@ -1,0 +1,1064 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// REQUIRES: std-at-least-c++17
+
+// UNSUPPORTED: libcpp-has-no-incomplete-pstl
+
+// <algorithm>
+
+// template<class ExecutionPolicy, class RandomAccessIterator>
+//   bool
+//   is_heap(ExecutionPolicy&& exec,
+//           RandomAccessIterator first, RandomAccessIterator last);
+
+#include <cstddef>
+#include <algorithm>
+#include <cassert>
+#include <iterator>
+#include <numeric>
+
+#include "test_execution_policies.h"
+#include "test_iterators.h"
+#include "test_macros.h"
+#include "type_algorithms.h"
+#include "runway_sample.h"
+
+EXECUTION_POLICY_SFINAE_TEST(is_heap);
+
+static_assert(sfinae_test_is_heap<int, int*, int*>);
+static_assert(!sfinae_test_is_heap<std::execution::parallel_policy, int*, int*>);
+
+template <class Iter>
+struct Test {
+  template <class ExecutionPolicy>
+  void operator()(ExecutionPolicy&& policy) {
+    { // Check the return type
+      int a[]  = {0};
+      auto res = std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)));
+      static_assert(std::is_same_v<decltype(res), bool>);
+    }
+    { // Empty
+      int a[] = {0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::begin(a))));
+    }
+    { // Single
+      int a[] = {0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=2, heap
+      int a[] = {0, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=2, not heap
+      int a[] = {0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=2, heap
+      int a[] = {1, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=3, heap
+      int a[] = {0, 0, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=3, not heap
+      int a[] = {0, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=3, not heap
+      int a[] = {0, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=3, not heap
+      int a[] = {0, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=3, heap
+      int a[] = {1, 0, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=3, heap
+      int a[] = {1, 0, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=3, heap
+      int a[] = {1, 1, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=4, heap
+      int a[] = {0, 0, 0, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=4, not heap
+      int a[] = {0, 0, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=4, not heap
+      int a[] = {0, 0, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=4, not heap
+      int a[] = {0, 0, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=4, not heap
+      int a[] = {0, 1, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=4, not heap
+      int a[] = {0, 1, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=4, not heap
+      int a[] = {0, 1, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=4, not heap
+      int a[] = {0, 1, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=4, heap
+      int a[] = {1, 0, 0, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=4, not heap
+      int a[] = {1, 0, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=4, heap
+      int a[] = {1, 0, 1, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=4, not heap
+      int a[] = {1, 0, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=4, heap
+      int a[] = {1, 1, 0, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=4, heap
+      int a[] = {1, 1, 0, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=4, heap
+      int a[] = {1, 1, 1, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=5, heap
+      int a[] = {0, 0, 0, 0, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=5, not heap
+      int a[] = {0, 0, 0, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=5, not heap
+      int a[] = {0, 0, 0, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=5, not heap
+      int a[] = {0, 0, 0, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=5, not heap
+      int a[] = {0, 0, 1, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=5, not heap
+      int a[] = {0, 0, 1, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=5, not heap
+      int a[] = {0, 0, 1, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=5, not heap
+      int a[] = {0, 0, 1, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=5, not heap
+      int a[] = {0, 1, 0, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=5, not heap
+      int a[] = {0, 1, 0, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=5, not heap
+      int a[] = {0, 1, 0, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=5, not heap
+      int a[] = {0, 1, 0, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=5, not heap
+      int a[] = {0, 1, 1, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=5, not heap
+      int a[] = {0, 1, 1, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=5, not heap
+      int a[] = {0, 1, 1, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=5, not heap
+      int a[] = {0, 1, 1, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=5, heap
+      int a[] = {1, 0, 0, 0, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=5, not heap
+      int a[] = {1, 0, 0, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=5, not heap
+      int a[] = {1, 0, 0, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=5, not heap
+      int a[] = {1, 0, 0, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=5, heap
+      int a[] = {1, 0, 1, 0, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=5, not heap
+      int a[] = {1, 0, 1, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=5, not heap
+      int a[] = {1, 0, 1, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=5, not heap
+      int a[] = {1, 0, 1, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=5, heap
+      int a[] = {1, 1, 0, 0, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=5, heap
+      int a[] = {1, 1, 0, 0, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=5, heap
+      int a[] = {1, 1, 0, 1, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=5, heap
+      int a[] = {1, 1, 0, 1, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=5, heap
+      int a[] = {1, 1, 1, 0, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=5, heap
+      int a[] = {1, 1, 1, 0, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=5, heap
+      int a[] = {1, 1, 1, 1, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, heap
+      int a[] = {0, 0, 0, 0, 0, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, not heap
+      int a[] = {0, 0, 0, 0, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, not heap
+      int a[] = {0, 0, 0, 0, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, not heap
+      int a[] = {0, 0, 0, 0, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, not heap
+      int a[] = {0, 0, 0, 1, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, not heap
+      int a[] = {0, 0, 0, 1, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, not heap
+      int a[] = {0, 0, 0, 1, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, not heap
+      int a[] = {0, 0, 0, 1, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, not heap
+      int a[] = {0, 0, 1, 0, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, not heap
+      int a[] = {0, 0, 1, 0, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, not heap
+      int a[] = {0, 0, 1, 0, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, not heap
+      int a[] = {0, 0, 1, 0, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, not heap
+      int a[] = {0, 0, 1, 1, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, not heap
+      int a[] = {0, 0, 1, 1, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, not heap
+      int a[] = {0, 0, 1, 1, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, not heap
+      int a[] = {0, 0, 1, 1, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, not heap
+      int a[] = {0, 1, 0, 0, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, not heap
+      int a[] = {0, 1, 0, 0, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, not heap
+      int a[] = {0, 1, 0, 0, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, not heap
+      int a[] = {0, 1, 0, 0, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, not heap
+      int a[] = {0, 1, 0, 1, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, not heap
+      int a[] = {0, 1, 0, 1, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, not heap
+      int a[] = {0, 1, 0, 1, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, not heap
+      int a[] = {0, 1, 0, 1, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, not heap
+      int a[] = {0, 1, 1, 0, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, not heap
+      int a[] = {0, 1, 1, 0, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, not heap
+      int a[] = {0, 1, 1, 0, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, not heap
+      int a[] = {0, 1, 1, 0, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, not heap
+      int a[] = {0, 1, 1, 1, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, not heap
+      int a[] = {0, 1, 1, 1, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, not heap
+      int a[] = {0, 1, 1, 1, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, not heap
+      int a[] = {0, 1, 1, 1, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, heap
+      int a[] = {1, 0, 0, 0, 0, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, not heap
+      int a[] = {1, 0, 0, 0, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, not heap
+      int a[] = {1, 0, 0, 0, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, not heap
+      int a[] = {1, 0, 0, 0, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, not heap
+      int a[] = {1, 0, 0, 1, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, not heap
+      int a[] = {1, 0, 0, 1, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, not heap
+      int a[] = {1, 0, 0, 1, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, not heap
+      int a[] = {1, 0, 0, 1, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, heap
+      int a[] = {1, 0, 1, 0, 0, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, heap
+      int a[] = {1, 0, 1, 0, 0, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, not heap
+      int a[] = {1, 0, 1, 0, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, not heap
+      int a[] = {1, 0, 1, 0, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, not heap
+      int a[] = {1, 0, 1, 1, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, not heap
+      int a[] = {1, 0, 1, 1, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, not heap
+      int a[] = {1, 0, 1, 1, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, not heap
+      int a[] = {1, 0, 1, 1, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, heap
+      int a[] = {1, 1, 0, 0, 0, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, not heap
+      int a[] = {1, 1, 0, 0, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, heap
+      int a[] = {1, 1, 0, 0, 1, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, not heap
+      int a[] = {1, 1, 0, 0, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, heap
+      int a[] = {1, 1, 0, 1, 0, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, not heap
+      int a[] = {1, 1, 0, 1, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, heap
+      int a[] = {1, 1, 0, 1, 1, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, not heap
+      int a[] = {1, 1, 0, 1, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, heap
+      int a[] = {1, 1, 1, 0, 0, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, heap
+      int a[] = {1, 1, 1, 0, 0, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, heap
+      int a[] = {1, 1, 1, 0, 1, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, heap
+      int a[] = {1, 1, 1, 0, 1, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, heap
+      int a[] = {1, 1, 1, 1, 0, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, heap
+      int a[] = {1, 1, 1, 1, 0, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=6, heap
+      int a[] = {1, 1, 1, 1, 1, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, heap
+      int a[] = {0, 0, 0, 0, 0, 0, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 0, 0, 0, 0, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 0, 0, 0, 0, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 0, 0, 0, 0, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 0, 0, 0, 1, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 0, 0, 0, 1, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 0, 0, 0, 1, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 0, 0, 0, 1, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 0, 0, 1, 0, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 0, 0, 1, 0, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 0, 0, 1, 0, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 0, 0, 1, 0, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 0, 0, 1, 1, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 0, 0, 1, 1, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 0, 0, 1, 1, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 0, 0, 1, 1, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 0, 1, 0, 0, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 0, 1, 0, 0, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 0, 1, 0, 0, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 0, 1, 0, 0, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 0, 1, 0, 1, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 0, 1, 0, 1, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 0, 1, 0, 1, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 0, 1, 0, 1, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 0, 1, 1, 0, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 0, 1, 1, 0, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 0, 1, 1, 0, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 0, 1, 1, 0, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 0, 1, 1, 1, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 0, 1, 1, 1, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 0, 1, 1, 1, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 0, 1, 1, 1, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 0, 0, 0, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 0, 0, 0, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 0, 0, 0, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 0, 0, 0, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 0, 0, 1, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 0, 0, 1, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 0, 0, 1, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 0, 0, 1, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 0, 1, 0, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 0, 1, 0, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 0, 1, 0, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 0, 1, 0, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 0, 1, 1, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 0, 1, 1, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 0, 1, 1, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 0, 1, 1, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 1, 0, 0, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 1, 0, 0, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 1, 0, 0, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 1, 0, 0, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 1, 0, 1, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 1, 0, 1, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 1, 0, 1, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 1, 0, 1, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 1, 1, 0, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 1, 1, 0, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 1, 1, 0, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 1, 1, 0, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 1, 1, 1, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 1, 1, 1, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 1, 1, 1, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 1, 1, 1, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, heap
+      int a[] = {1, 0, 0, 0, 0, 0, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 0, 0, 0, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 0, 0, 0, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 0, 0, 0, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 0, 0, 1, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 0, 0, 1, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 0, 0, 1, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 0, 0, 1, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 0, 1, 0, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 0, 1, 0, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 0, 1, 0, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 0, 1, 0, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 0, 1, 1, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 0, 1, 1, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 0, 1, 1, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 0, 1, 1, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, heap
+      int a[] = {1, 0, 1, 0, 0, 0, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, heap
+      int a[] = {1, 0, 1, 0, 0, 0, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, heap
+      int a[] = {1, 0, 1, 0, 0, 1, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, heap
+      int a[] = {1, 0, 1, 0, 0, 1, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 1, 0, 1, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 1, 0, 1, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 1, 0, 1, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 1, 0, 1, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 1, 1, 0, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 1, 1, 0, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 1, 1, 0, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 1, 1, 0, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 1, 1, 1, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 1, 1, 1, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 1, 1, 1, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 1, 1, 1, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, heap
+      int a[] = {1, 1, 0, 0, 0, 0, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 1, 0, 0, 0, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 1, 0, 0, 0, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 1, 0, 0, 0, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, heap
+      int a[] = {1, 1, 0, 0, 1, 0, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 1, 0, 0, 1, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 1, 0, 0, 1, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 1, 0, 0, 1, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, heap
+      int a[] = {1, 1, 0, 1, 0, 0, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 1, 0, 1, 0, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 1, 0, 1, 0, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 1, 0, 1, 0, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, heap
+      int a[] = {1, 1, 0, 1, 1, 0, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 1, 0, 1, 1, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 1, 0, 1, 1, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 1, 0, 1, 1, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, heap
+      int a[] = {1, 1, 1, 0, 0, 0, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, heap
+      int a[] = {1, 1, 1, 0, 0, 0, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, heap
+      int a[] = {1, 1, 1, 0, 0, 1, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, heap
+      int a[] = {1, 1, 1, 0, 0, 1, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, heap
+      int a[] = {1, 1, 1, 0, 1, 0, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, heap
+      int a[] = {1, 1, 1, 0, 1, 0, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, heap
+      int a[] = {1, 1, 1, 0, 1, 1, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, heap
+      int a[] = {1, 1, 1, 0, 1, 1, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, heap
+      int a[] = {1, 1, 1, 1, 0, 0, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, heap
+      int a[] = {1, 1, 1, 1, 0, 0, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, heap
+      int a[] = {1, 1, 1, 1, 0, 1, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, heap
+      int a[] = {1, 1, 1, 1, 0, 1, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, heap
+      int a[] = {1, 1, 1, 1, 1, 0, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, heap
+      int a[] = {1, 1, 1, 1, 1, 0, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Size=7, heap
+      int a[] = {1, 1, 1, 1, 1, 1, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+    }
+    { // Break a heap at sampled locations
+      int a[1073];
+      std::iota(std::begin(a), std::end(a), 0);
+      std::make_heap(std::begin(a), std::end(a));
+      runway_sample(std::size(a), [&](size_t i) {
+        if (i == 0)
+          return;
+        int old = std::exchange(a[i], 10000);
+        assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a))));
+        a[i] = old;
+      });
+    }
+    { // Check valid sub-heaps at sampled locations (to force different partitions)
+      int a[1073];
+      std::iota(std::begin(a), std::end(a), 0);
+      std::make_heap(std::begin(a), std::end(a));
+      runway_sample(std::size(a), [&](size_t i) {
+        assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::begin(a) + i)));
+      });
+    }
+  }
+};
+
+int main(int, char**) {
+  types::for_each(types::random_access_iterator_list<const int*>{}, TestIteratorWithPolicies<Test>{});
+  return 0;
+}

--- a/libcxx/test/std/algorithms/alg.sorting/alg.heap.operations/is.heap/pstl.is_heap_comp.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.sorting/alg.heap.operations/is.heap/pstl.is_heap_comp.pass.cpp
@@ -1,0 +1,1067 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// REQUIRES: std-at-least-c++17
+
+// UNSUPPORTED: libcpp-has-no-incomplete-pstl
+
+// <algorithm>
+
+// template<class ExecutionPolicy, class RandomAccessIterator, class Compare>
+//   bool
+//   is_heap(ExecutionPolicy&& exec,
+//           RandomAccessIterator first, RandomAccessIterator last,
+//           Compare comp);
+
+#include <cstddef>
+#include <algorithm>
+#include <cassert>
+#include <functional>
+#include <iterator>
+#include <numeric>
+
+#include "test_execution_policies.h"
+#include "test_iterators.h"
+#include "test_macros.h"
+#include "type_algorithms.h"
+#include "runway_sample.h"
+
+EXECUTION_POLICY_SFINAE_TEST(is_heap);
+
+static_assert(sfinae_test_is_heap<int, int*, int*, bool (*)(int, int)>);
+static_assert(!sfinae_test_is_heap<std::execution::parallel_policy, int*, int*, bool (*)(int, int)>);
+
+template <class Iter>
+struct Test {
+  template <class ExecutionPolicy>
+  void operator()(ExecutionPolicy&& policy) {
+    std::greater<int> comp;
+    { // Check the return type
+      int a[]  = {0};
+      auto res = std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp);
+      static_assert(std::is_same_v<decltype(res), bool>);
+    }
+    { // Empty
+      int a[] = {0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::begin(a)), comp));
+    }
+    { // Single
+      int a[] = {0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=2, heap
+      int a[] = {0, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=2, heap
+      int a[] = {0, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=2, not heap
+      int a[] = {1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=3, heap
+      int a[] = {0, 0, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=3, heap
+      int a[] = {0, 0, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=3, heap
+      int a[] = {0, 1, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=3, heap
+      int a[] = {0, 1, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=3, not heap
+      int a[] = {1, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=3, not heap
+      int a[] = {1, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=3, not heap
+      int a[] = {1, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=4, heap
+      int a[] = {0, 0, 0, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=4, heap
+      int a[] = {0, 0, 0, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=4, heap
+      int a[] = {0, 0, 1, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=4, heap
+      int a[] = {0, 0, 1, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=4, not heap
+      int a[] = {0, 1, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=4, heap
+      int a[] = {0, 1, 0, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=4, not heap
+      int a[] = {0, 1, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=4, heap
+      int a[] = {0, 1, 1, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=4, not heap
+      int a[] = {1, 0, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=4, not heap
+      int a[] = {1, 0, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=4, not heap
+      int a[] = {1, 0, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=4, not heap
+      int a[] = {1, 0, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=4, not heap
+      int a[] = {1, 1, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=4, not heap
+      int a[] = {1, 1, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=4, not heap
+      int a[] = {1, 1, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=5, heap
+      int a[] = {0, 0, 0, 0, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=5, heap
+      int a[] = {0, 0, 0, 0, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=5, heap
+      int a[] = {0, 0, 0, 1, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=5, heap
+      int a[] = {0, 0, 0, 1, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=5, heap
+      int a[] = {0, 0, 1, 0, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=5, heap
+      int a[] = {0, 0, 1, 0, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=5, heap
+      int a[] = {0, 0, 1, 1, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=5, heap
+      int a[] = {0, 0, 1, 1, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=5, not heap
+      int a[] = {0, 1, 0, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=5, not heap
+      int a[] = {0, 1, 0, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=5, not heap
+      int a[] = {0, 1, 0, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=5, heap
+      int a[] = {0, 1, 0, 1, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=5, not heap
+      int a[] = {0, 1, 1, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=5, not heap
+      int a[] = {0, 1, 1, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=5, not heap
+      int a[] = {0, 1, 1, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=5, heap
+      int a[] = {0, 1, 1, 1, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=5, not heap
+      int a[] = {1, 0, 0, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=5, not heap
+      int a[] = {1, 0, 0, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=5, not heap
+      int a[] = {1, 0, 0, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=5, not heap
+      int a[] = {1, 0, 0, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=5, not heap
+      int a[] = {1, 0, 1, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=5, not heap
+      int a[] = {1, 0, 1, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=5, not heap
+      int a[] = {1, 0, 1, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=5, not heap
+      int a[] = {1, 0, 1, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=5, not heap
+      int a[] = {1, 1, 0, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=5, not heap
+      int a[] = {1, 1, 0, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=5, not heap
+      int a[] = {1, 1, 0, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=5, not heap
+      int a[] = {1, 1, 0, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=5, not heap
+      int a[] = {1, 1, 1, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=5, not heap
+      int a[] = {1, 1, 1, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=5, not heap
+      int a[] = {1, 1, 1, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, heap
+      int a[] = {0, 0, 0, 0, 0, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, heap
+      int a[] = {0, 0, 0, 0, 0, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, heap
+      int a[] = {0, 0, 0, 0, 1, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, heap
+      int a[] = {0, 0, 0, 0, 1, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, heap
+      int a[] = {0, 0, 0, 1, 0, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, heap
+      int a[] = {0, 0, 0, 1, 0, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, heap
+      int a[] = {0, 0, 0, 1, 1, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, heap
+      int a[] = {0, 0, 0, 1, 1, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, not heap
+      int a[] = {0, 0, 1, 0, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, heap
+      int a[] = {0, 0, 1, 0, 0, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, not heap
+      int a[] = {0, 0, 1, 0, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, heap
+      int a[] = {0, 0, 1, 0, 1, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, not heap
+      int a[] = {0, 0, 1, 1, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, heap
+      int a[] = {0, 0, 1, 1, 0, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, not heap
+      int a[] = {0, 0, 1, 1, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, heap
+      int a[] = {0, 0, 1, 1, 1, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, not heap
+      int a[] = {0, 1, 0, 0, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, not heap
+      int a[] = {0, 1, 0, 0, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, not heap
+      int a[] = {0, 1, 0, 0, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, not heap
+      int a[] = {0, 1, 0, 0, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, not heap
+      int a[] = {0, 1, 0, 1, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, not heap
+      int a[] = {0, 1, 0, 1, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, heap
+      int a[] = {0, 1, 0, 1, 1, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, heap
+      int a[] = {0, 1, 0, 1, 1, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, not heap
+      int a[] = {0, 1, 1, 0, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, not heap
+      int a[] = {0, 1, 1, 0, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, not heap
+      int a[] = {0, 1, 1, 0, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, not heap
+      int a[] = {0, 1, 1, 0, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, not heap
+      int a[] = {0, 1, 1, 1, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, not heap
+      int a[] = {0, 1, 1, 1, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, not heap
+      int a[] = {0, 1, 1, 1, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, heap
+      int a[] = {0, 1, 1, 1, 1, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, not heap
+      int a[] = {1, 0, 0, 0, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, not heap
+      int a[] = {1, 0, 0, 0, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, not heap
+      int a[] = {1, 0, 0, 0, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, not heap
+      int a[] = {1, 0, 0, 0, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, not heap
+      int a[] = {1, 0, 0, 1, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, not heap
+      int a[] = {1, 0, 0, 1, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, not heap
+      int a[] = {1, 0, 0, 1, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, not heap
+      int a[] = {1, 0, 0, 1, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, not heap
+      int a[] = {1, 0, 1, 0, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, not heap
+      int a[] = {1, 0, 1, 0, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, not heap
+      int a[] = {1, 0, 1, 0, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, not heap
+      int a[] = {1, 0, 1, 0, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, not heap
+      int a[] = {1, 0, 1, 1, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, not heap
+      int a[] = {1, 0, 1, 1, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, not heap
+      int a[] = {1, 0, 1, 1, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, not heap
+      int a[] = {1, 0, 1, 1, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, not heap
+      int a[] = {1, 1, 0, 0, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, not heap
+      int a[] = {1, 1, 0, 0, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, not heap
+      int a[] = {1, 1, 0, 0, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, not heap
+      int a[] = {1, 1, 0, 0, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, not heap
+      int a[] = {1, 1, 0, 1, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, not heap
+      int a[] = {1, 1, 0, 1, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, not heap
+      int a[] = {1, 1, 0, 1, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, not heap
+      int a[] = {1, 1, 0, 1, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, not heap
+      int a[] = {1, 1, 1, 0, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, not heap
+      int a[] = {1, 1, 1, 0, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, not heap
+      int a[] = {1, 1, 1, 0, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, not heap
+      int a[] = {1, 1, 1, 0, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, not heap
+      int a[] = {1, 1, 1, 1, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, not heap
+      int a[] = {1, 1, 1, 1, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=6, not heap
+      int a[] = {1, 1, 1, 1, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, heap
+      int a[] = {0, 0, 0, 0, 0, 0, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, heap
+      int a[] = {0, 0, 0, 0, 0, 0, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, heap
+      int a[] = {0, 0, 0, 0, 0, 1, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, heap
+      int a[] = {0, 0, 0, 0, 0, 1, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, heap
+      int a[] = {0, 0, 0, 0, 1, 0, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, heap
+      int a[] = {0, 0, 0, 0, 1, 0, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, heap
+      int a[] = {0, 0, 0, 0, 1, 1, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, heap
+      int a[] = {0, 0, 0, 0, 1, 1, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, heap
+      int a[] = {0, 0, 0, 1, 0, 0, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, heap
+      int a[] = {0, 0, 0, 1, 0, 0, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, heap
+      int a[] = {0, 0, 0, 1, 0, 1, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, heap
+      int a[] = {0, 0, 0, 1, 0, 1, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, heap
+      int a[] = {0, 0, 0, 1, 1, 0, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, heap
+      int a[] = {0, 0, 0, 1, 1, 0, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, heap
+      int a[] = {0, 0, 0, 1, 1, 1, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, heap
+      int a[] = {0, 0, 0, 1, 1, 1, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 0, 1, 0, 0, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 0, 1, 0, 0, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 0, 1, 0, 0, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, heap
+      int a[] = {0, 0, 1, 0, 0, 1, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 0, 1, 0, 1, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 0, 1, 0, 1, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 0, 1, 0, 1, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, heap
+      int a[] = {0, 0, 1, 0, 1, 1, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 0, 1, 1, 0, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 0, 1, 1, 0, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 0, 1, 1, 0, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, heap
+      int a[] = {0, 0, 1, 1, 0, 1, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 0, 1, 1, 1, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 0, 1, 1, 1, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 0, 1, 1, 1, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, heap
+      int a[] = {0, 0, 1, 1, 1, 1, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 0, 0, 0, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 0, 0, 0, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 0, 0, 0, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 0, 0, 0, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 0, 0, 1, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 0, 0, 1, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 0, 0, 1, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 0, 0, 1, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 0, 1, 0, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 0, 1, 0, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 0, 1, 0, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 0, 1, 0, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, heap
+      int a[] = {0, 1, 0, 1, 1, 0, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, heap
+      int a[] = {0, 1, 0, 1, 1, 0, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, heap
+      int a[] = {0, 1, 0, 1, 1, 1, 0};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, heap
+      int a[] = {0, 1, 0, 1, 1, 1, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 1, 0, 0, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 1, 0, 0, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 1, 0, 0, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 1, 0, 0, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 1, 0, 1, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 1, 0, 1, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 1, 0, 1, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 1, 0, 1, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 1, 1, 0, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 1, 1, 0, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 1, 1, 0, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 1, 1, 0, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 1, 1, 1, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 1, 1, 1, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {0, 1, 1, 1, 1, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, heap
+      int a[] = {0, 1, 1, 1, 1, 1, 1};
+      assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 0, 0, 0, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 0, 0, 0, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 0, 0, 0, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 0, 0, 0, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 0, 0, 1, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 0, 0, 1, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 0, 0, 1, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 0, 0, 1, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 0, 1, 0, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 0, 1, 0, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 0, 1, 0, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 0, 1, 0, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 0, 1, 1, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 0, 1, 1, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 0, 1, 1, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 0, 1, 1, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 1, 0, 0, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 1, 0, 0, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 1, 0, 0, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 1, 0, 0, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 1, 0, 1, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 1, 0, 1, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 1, 0, 1, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 1, 0, 1, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 1, 1, 0, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 1, 1, 0, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 1, 1, 0, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 1, 1, 0, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 1, 1, 1, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 1, 1, 1, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 1, 1, 1, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 0, 1, 1, 1, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 1, 0, 0, 0, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 1, 0, 0, 0, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 1, 0, 0, 0, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 1, 0, 0, 0, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 1, 0, 0, 1, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 1, 0, 0, 1, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 1, 0, 0, 1, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 1, 0, 0, 1, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 1, 0, 1, 0, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 1, 0, 1, 0, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 1, 0, 1, 0, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 1, 0, 1, 0, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 1, 0, 1, 1, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 1, 0, 1, 1, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 1, 0, 1, 1, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 1, 0, 1, 1, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 1, 1, 0, 0, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 1, 1, 0, 0, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 1, 1, 0, 0, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 1, 1, 0, 0, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 1, 1, 0, 1, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 1, 1, 0, 1, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 1, 1, 0, 1, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 1, 1, 0, 1, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 1, 1, 1, 0, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 1, 1, 1, 0, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 1, 1, 1, 0, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 1, 1, 1, 0, 1, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 1, 1, 1, 1, 0, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 1, 1, 1, 1, 0, 1};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Size=7, not heap
+      int a[] = {1, 1, 1, 1, 1, 1, 0};
+      assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+    }
+    { // Break a heap at sampled locations
+      int a[1073];
+      std::iota(std::begin(a), std::end(a), 0);
+      std::make_heap(std::begin(a), std::end(a), comp);
+      runway_sample(std::size(a), [&](size_t i) {
+        if (i == 0)
+          return;
+        int old = std::exchange(a[i], -10000);
+        assert(!std::is_heap(policy, Iter(std::begin(a)), Iter(std::end(a)), comp));
+        a[i] = old;
+      });
+    }
+    { // Check valid sub-heaps at sampled locations (to force different partitions)
+      int a[1073];
+      std::iota(std::begin(a), std::end(a), 0);
+      std::make_heap(std::begin(a), std::end(a), comp);
+      runway_sample(std::size(a), [&](size_t i) {
+        assert(std::is_heap(policy, Iter(std::begin(a)), Iter(std::begin(a) + i), comp));
+      });
+    }
+  }
+};
+
+int main(int, char**) {
+  types::for_each(types::random_access_iterator_list<const int*>{}, TestIteratorWithPolicies<Test>{});
+  return 0;
+}

--- a/libcxx/test/std/algorithms/alg.sorting/alg.heap.operations/is.heap/pstl.is_heap_until_comp.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.sorting/alg.heap.operations/is.heap/pstl.is_heap_until_comp.pass.cpp
@@ -158,7 +158,7 @@ struct Test {
       int a[] = {0, 0, 0, 0, 0};
       assert(std::is_heap_until(policy, Iter(std::begin(a)), Iter(std::end(a)), comp) == Iter(std::end(a)));
     }
-    { // Size=5, not heap
+    { // Size=5, heap
       int a[] = {0, 0, 0, 0, 1};
       assert(std::is_heap_until(policy, Iter(std::begin(a)), Iter(std::end(a)), comp) == Iter(std::end(a)));
     }
@@ -370,7 +370,7 @@ struct Test {
       int a[] = {0, 1, 0, 1, 1, 0};
       assert(std::is_heap_until(policy, Iter(std::begin(a)), Iter(std::end(a)), comp) == Iter(std::end(a)));
     }
-    { // Size=6, not heap
+    { // Size=6, heap
       int a[] = {0, 1, 0, 1, 1, 1};
       assert(std::is_heap_until(policy, Iter(std::begin(a)), Iter(std::end(a)), comp) == Iter(std::end(a)));
     }

--- a/libcxx/test/std/algorithms/pstl.exception_handling.pass.cpp
+++ b/libcxx/test/std/algorithms/pstl.exception_handling.pass.cpp
@@ -264,6 +264,12 @@ int main(int, char**) {
       {
         auto comp = maybe_throw(tokens[5], [](int x, int y) -> bool { return x < y; });
 
+        // is_heap(first, last)
+        assert_non_throwing([=, &policy] { (void)std::is_heap(policy, std::move(first1), std::move(last1)); });
+
+        // is_heap(first, last, comp)
+        assert_non_throwing([=, &policy] { (void)std::is_heap(policy, std::move(first1), std::move(last1), comp); });
+
         // is_heap_until(first, last)
         assert_non_throwing([=, &policy] { (void)std::is_heap_until(policy, std::move(first1), std::move(last1)); });
 


### PR DESCRIPTION
This PR adds a "one-liner" implementation of a parallel `std::is_heap()` based on `std::is_heap_until()`.

The implementation is effectively a call to `std::is_heap_until()` and a comparison with the last iterator:
```c++
auto res = IsHeapUntil()(policy, first, last, comp);
if (!res) {
    return nullopt;
}
return *res == last;
```

Included tests check that:
- Semantics of the iterator-only function is correct.
- Semantics of the predicated function is correct.
- The functions correctly SFINAE out when the first argument is not an execution policy.
- The `nodiscard` policy is followed.
- The `noexcept` policy is followed.
- `static_assert` verifies iterators' categories.

Part of #99938.