### PR TITLE
[orc-rt] Split unit tests into SupportTests and BedrockTests

### DIFF
--- a/orc-rt/test/unit/BedrockTestUtils.h
+++ b/orc-rt/test/unit/BedrockTestUtils.h
@@ -1,0 +1,40 @@
+//===- BedrockTestUtils.h -------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Test helpers that need Bedrock. These live apart from CommonTestUtils.h so
+// that SupportTests translation units pull in no Bedrock headers at all.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ORC_RT_UNITTEST_BEDROCKTESTUTILS_H
+#define ORC_RT_UNITTEST_BEDROCKTESTUTILS_H
+
+#include "orc-rt/bedrock/ExecutorProcessInfo.h"
+#include "orc-rt/bedrock/Session.h"
+
+#include "gtest/gtest.h"
+
+inline orc_rt::ExecutorProcessInfo mockExecutorProcessInfo() noexcept {
+  return orc_rt::ExecutorProcessInfo("arm64-apple-darwin", 16384,
+                                     "+neon, +fullfp16");
+}
+
+/// DispatchFn for tests that should never dispatch a task. Records a test
+/// failure on invocation, then runs the task inline so that any caller
+/// awaiting a result unblocks (rather than hanging) and the keepalive token
+/// is released, even in -Asserts builds or when the dispatch arrives on a
+/// non-test thread.
+inline void noDispatch(orc_rt::Session::Task T) {
+  ADD_FAILURE() << "unexpected dispatch in a no-dispatch session";
+  T();
+}
+
+/// DispatchFn that runs tasks on the current thread.
+inline void inlineDispatch(orc_rt::Session::Task T) { T(); }
+
+#endif // ORC_RT_UNITTEST_BEDROCKTESTUTILS_H

--- a/orc-rt/test/unit/CMakeLists.txt
+++ b/orc-rt/test/unit/CMakeLists.txt
@@ -7,11 +7,22 @@ if (NOT TARGET llvm_gtest)
   return ()
 endif ()
 
-function(add_orc_rt_unittest test_dirname)
-  add_unittest(OrcRTUnitTests ${test_dirname} ${ARGN})
+# Adds a unit test suite for one layer. link_lib is the layer's library; the
+# remaining arguments are sources.
+function(add_orc_rt_unittest test_name link_lib)
+  add_unittest(OrcRTUnitTests ${test_name} ${ARGN} DISABLE_LLVM_LINK_LLVM_DYLIB)
+  target_compile_options(${test_name} PRIVATE ${ORC_RT_COMPILE_FLAGS})
+  # Shared test helpers (CommonTestUtils.h, DirectCaller.h, ...) live at the
+  # root of this directory, so tests in the layer subdirectories can include
+  # them by bare name.
+  target_include_directories(${test_name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+  target_link_libraries(${test_name} PRIVATE ${link_lib})
 endfunction()
 
-add_orc_rt_unittest(CoreTests
+# SupportTests links the Support objects and nothing else, so a new
+# support-to-bedrock dependency shows up here as a link error rather than
+# going unnoticed.
+add_orc_rt_unittest(SupportTests orc-rt-support
   support/AllocActionTest.cpp
   support/BitmaskEnumTest.cpp
   support/CAPICompileTest.c
@@ -49,6 +60,10 @@ add_orc_rt_unittest(CoreTests
 
   support/sys/ErrnoTest.cpp
 
+  tools/OptionParserTest.cpp
+  )
+
+add_orc_rt_unittest(BedrockTests orc-rt-bedrock
   bedrock/BootstrapInfoTest.cpp
   bedrock/ExecutorProcessInfoTest.cpp
   bedrock/InProcessControllerAccessTest.cpp
@@ -69,18 +84,6 @@ add_orc_rt_unittest(CoreTests
 
   bedrock/sys/CPUFeaturesTest.cpp
   bedrock/sys/TargetTripleTest.cpp
-
-  tools/OptionParserTest.cpp
-
-  DISABLE_LLVM_LINK_LLVM_DYLIB
-  )
-target_compile_options(CoreTests PRIVATE ${ORC_RT_COMPILE_FLAGS})
-# Cross-layer test helpers (CommonTestUtils.h, DirectCaller.h, ...) live at the
-# root of this directory, so tests in the layer subdirectories can include them
-# by bare name.
-target_include_directories(CoreTests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(CoreTests PRIVATE
-  orc-rt-bedrock
   )
 
 # Build a shared library for NativeDylibManager tests.
@@ -88,6 +91,6 @@ add_library(NativeDylibManagerTestLib SHARED
   Inputs/NativeDylibManagerTestLib.cpp)
 set_target_properties(NativeDylibManagerTestLib PROPERTIES
   PREFIX "")
-target_compile_definitions(CoreTests PRIVATE
+target_compile_definitions(BedrockTests PRIVATE
   "NDM_TEST_LIB_PATH=\"$<TARGET_FILE:NativeDylibManagerTestLib>\"")
-add_dependencies(CoreTests NativeDylibManagerTestLib)
+add_dependencies(BedrockTests NativeDylibManagerTestLib)

--- a/orc-rt/test/unit/CommonTestUtils.h
+++ b/orc-rt/test/unit/CommonTestUtils.h
@@ -9,8 +9,10 @@
 #ifndef ORC_RT_UNITTEST_COMMONTESTUTILS_H
 #define ORC_RT_UNITTEST_COMMONTESTUTILS_H
 
-#include "orc-rt/bedrock/ExecutorProcessInfo.h"
-#include "orc-rt/bedrock/Session.h"
+// Helpers here must not depend on Bedrock: this header is included by
+// SupportTests translation units, which link Support alone. Bedrock-dependent
+// helpers belong in BedrockTestUtils.h.
+
 #include "orc-rt/support/Error.h"
 #include "orc-rt/support/WrapperFunction.h"
 #include "orc-rt/support/move_only_function.h"
@@ -42,24 +44,6 @@ public:
 private:
   std::vector<std::string> &ErrMsgs;
 };
-
-inline orc_rt::ExecutorProcessInfo mockExecutorProcessInfo() noexcept {
-  return orc_rt::ExecutorProcessInfo("arm64-apple-darwin", 16384,
-                                     "+neon, +fullfp16");
-}
-
-/// DispatchFn for tests that should never dispatch a task. Records a test
-/// failure on invocation, then runs the task inline so that any caller
-/// awaiting a result unblocks (rather than hanging) and the keepalive token
-/// is released, even in -Asserts builds or when the dispatch arrives on a
-/// non-test thread.
-inline void noDispatch(orc_rt::Session::Task T) {
-  ADD_FAILURE() << "unexpected dispatch in a no-dispatch session";
-  T();
-}
-
-/// DispatchFn that runs tasks on the current thread.
-inline void inlineDispatch(orc_rt::Session::Task T) { T(); }
 
 template <size_t Idx = 0> class OpCounter {
 public:

--- a/orc-rt/test/unit/bedrock/BootstrapInfoTest.cpp
+++ b/orc-rt/test/unit/bedrock/BootstrapInfoTest.cpp
@@ -15,6 +15,7 @@
 #include "orc-rt/support/move_only_function.h"
 #include "gtest/gtest.h"
 
+#include "BedrockTestUtils.h"
 #include "CommonTestUtils.h"
 
 using namespace orc_rt;

--- a/orc-rt/test/unit/bedrock/InProcessControllerAccessTest.cpp
+++ b/orc-rt/test/unit/bedrock/InProcessControllerAccessTest.cpp
@@ -15,6 +15,7 @@
 
 #include "gtest/gtest.h"
 
+#include "BedrockTestUtils.h"
 #include "CommonTestUtils.h"
 
 #include <deque>

--- a/orc-rt/test/unit/bedrock/NativeDylibManagerTest.cpp
+++ b/orc-rt/test/unit/bedrock/NativeDylibManagerTest.cpp
@@ -15,6 +15,7 @@
 
 #include "gtest/gtest.h"
 
+#include "BedrockTestUtils.h"
 #include "CommonTestUtils.h"
 
 #include <optional>

--- a/orc-rt/test/unit/bedrock/SessionTest.cpp
+++ b/orc-rt/test/unit/bedrock/SessionTest.cpp
@@ -19,6 +19,7 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+#include "BedrockTestUtils.h"
 #include "CommonTestUtils.h"
 
 #include <chrono>

--- a/orc-rt/test/unit/bedrock/SimpleNativeMemoryMapTest.cpp
+++ b/orc-rt/test/unit/bedrock/SimpleNativeMemoryMapTest.cpp
@@ -15,6 +15,7 @@
 #include "orc-rt/support/sps/SPSAllocAction.h"
 
 #include "AllocActionTestUtils.h"
+#include "BedrockTestUtils.h"
 #include "CommonTestUtils.h"
 #include "gtest/gtest.h"
 

--- a/orc-rt/test/unit/bedrock/sps/NativeDylibManagerSPSCITest.cpp
+++ b/orc-rt/test/unit/bedrock/sps/NativeDylibManagerSPSCITest.cpp
@@ -15,6 +15,7 @@
 #include "orc-rt/bedrock/Session.h"
 #include "orc-rt/support/sps/SPSWrapperFunction.h"
 
+#include "BedrockTestUtils.h"
 #include "CommonTestUtils.h"
 #include "DirectCaller.h"
 #include "gtest/gtest.h"

--- a/orc-rt/test/unit/bedrock/sps/SimpleNativeMemoryMapSPSCITest.cpp
+++ b/orc-rt/test/unit/bedrock/sps/SimpleNativeMemoryMapSPSCITest.cpp
@@ -18,6 +18,7 @@
 #include "orc-rt/support/sps/SPSWrapperFunction.h"
 
 #include "AllocActionTestUtils.h"
+#include "BedrockTestUtils.h"
 #include "CommonTestUtils.h"
 #include "DirectCaller.h"
 #include "gtest/gtest.h"

--- a/orc-rt/test/unit/bedrock/sps/SimpleRemoteCATest.cpp
+++ b/orc-rt/test/unit/bedrock/sps/SimpleRemoteCATest.cpp
@@ -18,6 +18,7 @@
 
 #include "gtest/gtest.h"
 
+#include "BedrockTestUtils.h"
 #include "CommonTestUtils.h"
 
 #include "orc-rt/support/sps/SimplePackedSerialization.h"

--- a/orc-rt/test/unit/support/ProxyTest.cpp
+++ b/orc-rt/test/unit/support/ProxyTest.cpp
@@ -12,14 +12,18 @@
 
 #include "orc-rt/support/Proxy.h"
 
-#include "CommonTestUtils.h"
-
 #include "gtest/gtest.h"
 
 #include <optional>
 #include <utility>
 
 using namespace orc_rt;
+
+// Proxy.h only forward-declares Session and never touches it. We mock it below
+// so that we don't need to link against bedrock.
+namespace orc_rt {
+class Session {};
+} // namespace orc_rt
 
 namespace {
 
@@ -53,7 +57,7 @@ TEST(ProxyTest, DefaultConstructedProxyIsNull) {
 }
 
 TEST(ProxyTest, DispatchReportsVoidResult) {
-  Session S(mockExecutorProcessInfo(), noDispatch, noErrors);
+  Session S;
 
   int Tag = 0;
   Proxy<void()> P(voidDispatch, &Tag);
@@ -70,7 +74,7 @@ TEST(ProxyTest, DispatchReportsVoidResult) {
 }
 
 TEST(ProxyTest, DispatchForwardsArgsAndResult) {
-  Session S(mockExecutorProcessInfo(), noDispatch, noErrors);
+  Session S;
 
   int Tag = 0;
   Proxy<int(int)> P(addOneDispatch, &Tag);
@@ -82,7 +86,7 @@ TEST(ProxyTest, DispatchForwardsArgsAndResult) {
 }
 
 TEST(ProxyTest, DispatchForwardsCalleeTag) {
-  Session S(mockExecutorProcessInfo(), noDispatch, noErrors);
+  Session S;
 
   int Tag = 0;
   Proxy<const void *()> P(returnTagDispatch, &Tag);


### PR DESCRIPTION
Replace CoreTests with one test binary per layer. SupportTests links the Support object library and nothing else, so a new support-to-bedrock dependency fails to link rather than going unnoticed.

Making that work required splitting CommonTestUtils.h: its Bedrock-dependent helpers move to a new BedrockTestUtils.h, so that no SupportTests translation unit includes a Bedrock header. That in turn lets ProxyTest join SupportTests -- Proxy.h only forward-declares Session, so the test can define its own instead of constructing a real one.