### PR TITLE
[Clang] Skip invalid fields when synthesizing defaulted comparisons

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -652,6 +652,10 @@ features cannot lower the translation-unit ABI level;
 - Fixed a crash when a coroutine keyword appeared inside a mem-initializer on a
   function that is not a constructor. (#GH194298)
 
+- Fixed an assertion when a defaulted comparison operator was synthesized for a
+  class with an invalid non-static data member, such as one qualified with an
+  address space. (#GH194605)
+
 #### Bug Fixes to AST Handling
 
 - Fixed a non-deterministic ordering of unused local typedefs that made

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -8203,6 +8203,9 @@ protected:
       //   Unnamed bit-fields are not members ...
       if (Field->isUnnamedBitField())
         continue;
+      // Skip invalid fields; they have already been diagnosed.
+      if (Field->isInvalidDecl())
+        continue;
       // Recursively expand anonymous structs.
       if (Field->isAnonymousStructOrUnion()) {
         if (visitSubobjects(Results, Field->getType()->getAsCXXRecordDecl(),

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -8203,7 +8203,6 @@ protected:
       //   Unnamed bit-fields are not members ...
       if (Field->isUnnamedBitField())
         continue;
-      // Skip invalid fields; they have already been diagnosed.
       if (Field->isInvalidDecl())
         continue;
       // Recursively expand anonymous structs.

--- a/clang/test/SemaCXX/cxx20-default-compare.cpp
+++ b/clang/test/SemaCXX/cxx20-default-compare.cpp
@@ -95,5 +95,5 @@ struct S {
   bool operator==(const S &) const = default;
 };
 
-bool f(const S &a, const S &b) { return a == b; }
+static_assert(S{} == S{});
 }

--- a/clang/test/SemaCXX/cxx20-default-compare.cpp
+++ b/clang/test/SemaCXX/cxx20-default-compare.cpp
@@ -95,7 +95,5 @@ struct S {
   bool operator==(const S &) const = default;
 };
 
-static_assert(!__is_trivially_equality_comparable(S));
-
 bool f(const S &a, const S &b) { return a == b; }
 }

--- a/clang/test/SemaCXX/cxx20-default-compare.cpp
+++ b/clang/test/SemaCXX/cxx20-default-compare.cpp
@@ -88,3 +88,14 @@ union A {
 A a;
 bool b = a == a;
 }
+
+namespace GH194605 {
+struct S {
+  int [[clang::address_space(1)]] i; // expected-error {{field may not be qualified with an address space}}
+  bool operator==(const S &) const = default;
+};
+
+static_assert(!__is_trivially_equality_comparable(S));
+
+bool f(const S &a, const S &b) { return a == b; }
+}


### PR DESCRIPTION
Fixes #194605

`CheckFieldDecl` already rejects `int [[clang::address_space(1)]] i;` and marks the field invalid, but `DefaultedComparisonVisitor` still visited it when synthesizing the defaulted `operator==`. `BuildFieldReferenceExpr` then tripped the `!MemberQuals.hasAddressSpace()` assertion. Both `__is_trivially_equality_comparable(S)` and a plain `a == b` reach that path.

`visitSubobjects` now skips invalid fields, the same way `SpecialMemberVisitor` and the copy-assignment synthesis already do. That covers the analyzer and the synthesizer together, and the assertion stays in place since it still holds for valid code.
