### PR TITLE
[VPlan] Make m_False and m_True matchers stateless. NFC

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanPatternMatch.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanPatternMatch.h
@@ -113,14 +113,6 @@ inline specific_intval<0> m_SpecificSInt(int64_t V) {
       is_specific_int(APInt(64, V, /*isSigned=*/true), /*IsSigned=*/true));
 }
 
-inline specific_intval<1> m_False() {
-  return specific_intval<1>(is_specific_int(APInt(64, 0)));
-}
-
-inline specific_intval<1> m_True() {
-  return specific_intval<1>(is_specific_int(APInt(64, 1)));
-}
-
 struct is_all_ones {
   bool isValue(const APInt &C) const { return C.isAllOnes(); }
 };
@@ -148,6 +140,10 @@ inline int_pred_ty<is_zero_int> m_ZeroInt() {
 /// Match an integer 1 or a vector with all elements equal to 1.
 /// For vectors, this includes constants with undefined elements.
 inline int_pred_ty<is_one> m_One() { return int_pred_ty<is_one>(); }
+
+inline int_pred_ty<is_zero_int, 1> m_False() { return {}; }
+
+inline int_pred_ty<is_one, 1> m_True() { return {}; }
 
 struct bind_apint {
   const APInt *&Res;


### PR DESCRIPTION
is_zero_int and is_one avoid storage unlike is_specific_int, and allow the match function to be an inlined isZero/isOne call instead of APInt::isSameValue.

Improves compile time: https://llvm-compile-time-tracker.com/compare.php?from=8f7d3ba08f14c3d54b8b407d1758dbd1da01bb38&to=c766163e82ec7a377efc7a26ef1e6db38e0dec1d&stat=instructions:u
