### PR TITLE
[VPlan] Don't recompute getPlan in simplifyRecipes. NFC

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
@@ -1150,11 +1150,9 @@ static void removeRedundantExpandSCEVRecipes(VPlan &Plan) {
 }
 
 /// Try to simplify logical and bitwise recipes in \p Def.
-static VPValue *simplifyLogicalRecipe(VPSingleDefRecipe *Def,
+static VPValue *simplifyLogicalRecipe(VPlan &Plan, VPSingleDefRecipe *Def,
                                       VPBuilder &Builder,
                                       bool CanCreateNewRecipe) {
-  VPlan *Plan = Def->getParent()->getPlan();
-
   // Simplify (X && Y) | (X && !Y) -> X.
   // TODO: Split up into simpler, modular combines: (X && Y) | (X && Z) into X
   // && (Y | Z) and (X | !X) into true. This requires queuing newly created
@@ -1167,7 +1165,7 @@ static VPValue *simplifyLogicalRecipe(VPSingleDefRecipe *Def,
 
   // x | AllOnes -> AllOnes
   if (match(Def, m_c_BinaryOr(m_VPValue(X), m_AllOnes())))
-    return Plan->getAllOnesValue(Def->getScalarType());
+    return Plan.getAllOnesValue(Def->getScalarType());
 
   // x | 0 -> x
   if (match(Def, m_c_BinaryOr(m_VPValue(X), m_ZeroInt())))
@@ -1175,11 +1173,11 @@ static VPValue *simplifyLogicalRecipe(VPSingleDefRecipe *Def,
 
   // x | !x -> AllOnes
   if (match(Def, m_c_BinaryOr(m_VPValue(X), m_Not(m_Deferred(X)))))
-    return Plan->getAllOnesValue(Def->getScalarType());
+    return Plan.getAllOnesValue(Def->getScalarType());
 
   // x & 0 -> 0
   if (match(Def, m_c_BinaryAnd(m_VPValue(X), m_ZeroInt())))
-    return Plan->getZero(Def->getScalarType());
+    return Plan.getZero(Def->getScalarType());
 
   // x & AllOnes -> x
   if (match(Def, m_c_BinaryAnd(m_VPValue(X), m_AllOnes())))
@@ -1187,7 +1185,7 @@ static VPValue *simplifyLogicalRecipe(VPSingleDefRecipe *Def,
 
   // x && false -> false
   if (match(Def, m_c_LogicalAnd(m_VPValue(X), m_False())))
-    return Plan->getFalse();
+    return Plan.getFalse();
 
   // x && true -> x
   if (match(Def, m_c_LogicalAnd(m_VPValue(X), m_True())))
@@ -1215,7 +1213,7 @@ static VPValue *simplifyLogicalRecipe(VPSingleDefRecipe *Def,
 
   // x && !x -> 0
   if (match(Def, m_LogicalAnd(m_VPValue(X), m_Not(m_Deferred(X)))))
-    return Plan->getFalse();
+    return Plan.getFalse();
 
   if (match(Def, m_Select(m_VPValue(), m_VPValue(X), m_Deferred(X))))
     return X;
@@ -1266,12 +1264,10 @@ static VPValue *simplifyLogicalRecipe(VPSingleDefRecipe *Def,
 /// Try to simplify VPSingleDefRecipe \p Def. Returns a new recipe if it should
 /// be replaced, or the existing recipe if it was modified. Returns nullptr if
 /// nothing was simplified.
-static VPValue *simplifyRecipe(VPSingleDefRecipe *Def) {
-  VPlan *Plan = Def->getParent()->getPlan();
-
+static VPValue *simplifyRecipe(VPlan &Plan, VPSingleDefRecipe *Def) {
   // Simplification of live-in IR values for SingleDef recipes using
   // InstSimplifyFolder.
-  const DataLayout &DL = Plan->getDataLayout();
+  const DataLayout &DL = Plan.getDataLayout();
   if (VPValue *V = vputils::tryToFoldLiveIns(*Def, Def->operands(), DL))
     return V;
 
@@ -1345,7 +1341,8 @@ static VPValue *simplifyRecipe(VPSingleDefRecipe *Def) {
     }
   }
 
-  if (VPValue *V = simplifyLogicalRecipe(Def, Builder, CanCreateNewRecipe))
+  if (VPValue *V =
+          simplifyLogicalRecipe(Plan, Def, Builder, CanCreateNewRecipe))
     return V;
 
   VPValue *X, *Y;
@@ -1356,13 +1353,13 @@ static VPValue *simplifyRecipe(VPSingleDefRecipe *Def) {
     return A;
 
   if (match(Def, m_c_Mul(m_VPValue(A), m_ZeroInt())))
-    return Plan->getZero(Def->getScalarType());
+    return Plan.getZero(Def->getScalarType());
 
   if (CanCreateNewRecipe && match(Def, m_c_Mul(m_VPValue(A), m_AllOnes()))) {
     // Preserve nsw from the Mul on the new Sub.
     VPIRFlags::WrapFlagsTy NW = {
         false, cast<VPRecipeWithIRFlags>(Def)->hasNoSignedWrap()};
-    return Builder.createSub(Plan->getZero(A->getScalarType()), A,
+    return Builder.createSub(Plan.getZero(A->getScalarType()), A,
                              Def->getDebugLoc(), "", NW);
   }
 
@@ -1380,7 +1377,7 @@ static VPValue *simplifyRecipe(VPSingleDefRecipe *Def) {
   const APInt *APC;
   if (CanCreateNewRecipe && match(Def, m_URem(m_VPValue(X), m_APInt(APC))) &&
       APC->isPowerOf2())
-    return Builder.createAnd(X, Plan->getConstantInt(*APC - 1),
+    return Builder.createAnd(X, Plan.getConstantInt(*APC - 1),
                              Def->getDebugLoc());
 
   if (CanCreateNewRecipe && match(Def, m_c_Mul(m_VPValue(A), m_APInt(APC))) &&
@@ -1392,7 +1389,7 @@ static VPValue *simplifyRecipe(VPSingleDefRecipe *Def) {
                                   ShiftAmt != APC->getBitWidth() - 1);
     return Builder.createNaryOp(
         Instruction::Shl,
-        {A, Plan->getConstantInt(APC->getBitWidth(), ShiftAmt)}, NW,
+        {A, Plan.getConstantInt(APC->getBitWidth(), ShiftAmt)}, NW,
         Def->getDebugLoc());
   }
 
@@ -1400,7 +1397,7 @@ static VPValue *simplifyRecipe(VPSingleDefRecipe *Def) {
       APC->isPowerOf2())
     return Builder.createNaryOp(
         Instruction::LShr,
-        {A, Plan->getConstantInt(APC->getBitWidth(), APC->exactLogBase2())},
+        {A, Plan.getConstantInt(APC->getBitWidth(), APC->exactLogBase2())},
         *cast<VPRecipeWithIRFlags>(Def), Def->getDebugLoc());
 
   if (match(Def, m_Not(m_VPValue(A)))) {
@@ -1501,7 +1498,7 @@ static VPValue *simplifyRecipe(VPSingleDefRecipe *Def) {
                                                   m_VPValue(X), m_VPValue())) &&
       match(A, m_c_BinaryOr(m_Specific(X), m_VPValue(Y))) &&
       Def->getScalarType()->isIntegerTy(1)) {
-    Def->setOperand(1, Plan->getTrue());
+    Def->setOperand(1, Plan.getTrue());
     Def->setOperand(0, Y);
     return Def;
   }
@@ -1524,7 +1521,7 @@ static VPValue *simplifyRecipe(VPSingleDefRecipe *Def) {
     if (isa<VPInstruction, VPReplicateRecipe>(A) && vputils::isSingleScalar(A))
       return A;
 
-    if (Plan->hasScalarVFOnly())
+    if (Plan.hasScalarVFOnly())
       return A;
   }
 
@@ -1586,7 +1583,7 @@ static VPValue *simplifyRecipe(VPSingleDefRecipe *Def) {
 
   // Some simplifications can only be applied after unrolling. Perform them
   // below.
-  if (!Plan->isUnrolled())
+  if (!Plan.isUnrolled())
     return nullptr;
 
   // After unrolling, extract-lane may be used to extract values from multiple
@@ -1658,7 +1655,7 @@ static VPValue *simplifyRecipe(VPSingleDefRecipe *Def) {
     return Def;
   }
 
-  if (Plan->getConcreteUF() == 1 && match(Def, m_ExtractLastPart(m_VPValue(A))))
+  if (Plan.getConcreteUF() == 1 && match(Def, m_ExtractLastPart(m_VPValue(A))))
     return A;
 
   return nullptr;
@@ -1670,7 +1667,7 @@ void VPlanTransforms::simplifyRecipes(VPlan &Plan) {
   for (VPBasicBlock *VPBB : VPBlockUtils::blocksOnly<VPBasicBlock>(RPOT)) {
     for (VPRecipeBase &R : make_early_inc_range(*VPBB))
       if (auto *Def = dyn_cast<VPSingleDefRecipe>(&R))
-        if (VPValue *New = simplifyRecipe(Def)) {
+        if (VPValue *New = simplifyRecipe(Plan, Def)) {
           if (New != Def) {
             // Replace the recipe with a new one.
             Def->replaceAllUsesWith(New);


### PR DESCRIPTION
getPlan involves a traversal, so avoid doing it on every recipe simplified.

Improves compile time: https://llvm-compile-time-tracker.com/compare.php?from=8f7d3ba08f14c3d54b8b407d1758dbd1da01bb38&to=aaeebfa47f57bbf1bc9f26ce9a4e777939f46352&stat=instructions:u
