### PR TITLE
[NFC][AMDGPU] Inline `getEffectiveWavesPerEU`

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUSubtarget.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUSubtarget.cpp
@@ -177,32 +177,6 @@ std::pair<unsigned, unsigned> AMDGPUSubtarget::getFlatWorkGroupSizes(
   return Requested;
 }
 
-std::pair<unsigned, unsigned> AMDGPUSubtarget::getEffectiveWavesPerEU(
-    std::pair<unsigned, unsigned> RequestedWavesPerEU,
-    std::pair<unsigned, unsigned> FlatWorkGroupSizes, unsigned LDSBytes) const {
-  // Default minimum/maximum number of waves per EU. The range of flat workgroup
-  // sizes limits the achievable maximum, and we aim to support enough waves per
-  // EU so that we can concurrently execute all waves of a single workgroup of
-  // maximum size on a CU.
-  std::pair<unsigned, unsigned> Default = {
-      getWavesPerEUForWorkGroup(FlatWorkGroupSizes.second),
-      getOccupancyWithWorkGroupSizes(LDSBytes, FlatWorkGroupSizes).second};
-  Default.first = std::min(Default.first, Default.second);
-
-  // Make sure requested minimum is within the default range and lower than the
-  // requested maximum. The latter must not violate target specification.
-  if (RequestedWavesPerEU.first < Default.first ||
-      RequestedWavesPerEU.first > Default.second ||
-      RequestedWavesPerEU.first > RequestedWavesPerEU.second ||
-      RequestedWavesPerEU.second > getMaxWavesPerEU())
-    return Default;
-
-  // We cannot exceed maximum occupancy implied by flat workgroup size and LDS.
-  RequestedWavesPerEU.second =
-      std::min(RequestedWavesPerEU.second, Default.second);
-  return RequestedWavesPerEU;
-}
-
 std::pair<unsigned, unsigned>
 AMDGPUSubtarget::getWavesPerEU(const Function &F) const {
   // Default/requested minimum/maximum flat work group sizes.
@@ -218,13 +192,30 @@ AMDGPUSubtarget::getWavesPerEU(const Function &F) const {
 std::pair<unsigned, unsigned>
 AMDGPUSubtarget::getWavesPerEU(std::pair<unsigned, unsigned> FlatWorkGroupSizes,
                                unsigned LDSBytes, const Function &F) const {
-  // Default minimum/maximum number of waves per execution unit.
-  std::pair<unsigned, unsigned> Default(1, getMaxWavesPerEU());
+  // Default minimum/maximum number of waves per EU. The range of flat workgroup
+  // sizes limits the achievable maximum, and we aim to support enough waves per
+  // EU so that we can concurrently execute all waves of a single workgroup of
+  // maximum size on a CU.
+  std::pair<unsigned, unsigned> Default = {
+      getWavesPerEUForWorkGroup(FlatWorkGroupSizes.second),
+      getOccupancyWithWorkGroupSizes(LDSBytes, FlatWorkGroupSizes).second};
+  Default.first = std::min(Default.first, Default.second);
 
   // Requested minimum/maximum number of waves per execution unit.
-  std::pair<unsigned, unsigned> Requested =
-      AMDGPU::getIntegerPairAttribute(F, "amdgpu-waves-per-eu", Default, true);
-  return getEffectiveWavesPerEU(Requested, FlatWorkGroupSizes, LDSBytes);
+  std::pair<unsigned, unsigned> Requested = AMDGPU::getIntegerPairAttribute(
+      F, "amdgpu-waves-per-eu", {1, getMaxWavesPerEU()},
+      /*OnlyFirstRequired=*/true);
+
+  // Make sure requested minimum is within the default range and lower than the
+  // requested maximum. The latter must not violate target specification.
+  if (Requested.first < Default.first || Requested.first > Default.second ||
+      Requested.first > Requested.second ||
+      Requested.second > getMaxWavesPerEU())
+    return Default;
+
+  // We cannot exceed maximum occupancy implied by flat workgroup size and LDS.
+  Requested.second = std::min(Requested.second, Default.second);
+  return Requested;
 }
 
 std::optional<unsigned>

--- a/llvm/lib/Target/AMDGPU/AMDGPUSubtarget.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUSubtarget.h
@@ -121,15 +121,6 @@ public:
   getWavesPerEU(std::pair<unsigned, unsigned> FlatWorkGroupSizes,
                 unsigned LDSBytes, const Function &F) const;
 
-  /// Returns the target minimum/maximum number of waves per EU. This is based
-  /// on the minimum/maximum number of \p RequestedWavesPerEU and further
-  /// limited by the maximum achievable occupancy derived from the range of \p
-  /// FlatWorkGroupSizes and number of \p LDSBytes per workgroup.
-  std::pair<unsigned, unsigned>
-  getEffectiveWavesPerEU(std::pair<unsigned, unsigned> RequestedWavesPerEU,
-                         std::pair<unsigned, unsigned> FlatWorkGroupSizes,
-                         unsigned LDSBytes) const;
-
   /// Return the amount of LDS that can be used that will not restrict the
   /// occupancy lower than WaveCount.
   unsigned getMaxLocalMemSizeWithWaveCount(unsigned WaveCount,


### PR DESCRIPTION
This function only has one use. No need to keep it.
