### PR TITLE
[X86] Prefer carry to overflow flag when using multiplication

### DIFF
--- a/llvm/lib/Target/X86/X86FastISel.cpp
+++ b/llvm/lib/Target/X86/X86FastISel.cpp
@@ -249,9 +249,9 @@ bool X86FastISel::foldX86XALUIntrinsic(X86::CondCode &CC, const Instruction *I,
   switch (II->getIntrinsicID()) {
   default: return false;
   case Intrinsic::sadd_with_overflow:
-  case Intrinsic::ssub_with_overflow:
+  case Intrinsic::ssub_with_overflow: TmpCC = X86::COND_O; break;
   case Intrinsic::smul_with_overflow:
-  case Intrinsic::umul_with_overflow: TmpCC = X86::COND_O; break;
+  case Intrinsic::umul_with_overflow:
   case Intrinsic::uadd_with_overflow:
   case Intrinsic::usub_with_overflow: TmpCC = X86::COND_B; break;
   }
@@ -2861,9 +2861,9 @@ bool X86FastISel::fastLowerIntrinsicCall(const IntrinsicInst *II) {
     case Intrinsic::usub_with_overflow:
       BaseOpc = ISD::SUB; CondCode = X86::COND_B; break;
     case Intrinsic::smul_with_overflow:
-      BaseOpc = X86ISD::SMUL; CondCode = X86::COND_O; break;
+      BaseOpc = X86ISD::SMUL; CondCode = X86::COND_B; break;
     case Intrinsic::umul_with_overflow:
-      BaseOpc = X86ISD::UMUL; CondCode = X86::COND_O; break;
+      BaseOpc = X86ISD::UMUL; CondCode = X86::COND_B; break;
     }
 
     Register LHSReg = getRegForValue(LHS);

--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -25384,11 +25384,11 @@ getX86XALUOOp(X86::CondCode &Cond, SDValue Op, SelectionDAG &DAG) {
     break;
   case ISD::SMULO:
     BaseOp = X86ISD::SMUL;
-    Cond = X86::COND_O;
+    Cond = X86::COND_B;
     break;
   case ISD::UMULO:
     BaseOp = X86ISD::UMUL;
-    Cond = X86::COND_O;
+    Cond = X86::COND_B;
     break;
   }
 

--- a/llvm/test/CodeGen/X86/apx/adc.ll
+++ b/llvm/test/CodeGen/X86/apx/adc.ll
@@ -595,3 +595,22 @@ define void @adc64mi_legacy(ptr %ptr, i64 %x, i64 %y) nounwind {
   store i64 %r, ptr %ptr
   ret void
 }
+
+define i32 @mul_overflow_apx(i32 %a, i8 %b, i8 %c) {
+; CHECK-LABEL: mul_overflow_apx:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    movl %esi, %eax # encoding: [0x89,0xf0]
+; CHECK-NEXT:    xorl %ecx, %ecx # encoding: [0x31,0xc9]
+; CHECK-NEXT:    # kill: def $al killed $al killed $eax
+; CHECK-NEXT:    mulb %dl # encoding: [0xf6,0xe2]
+; CHECK-NEXT:    seto %cl # encoding: [0x0f,0x90,0xc1]
+; CHECK-NEXT:    leal (%rdi,%rcx), %eax # encoding: [0x8d,0x04,0x0f]
+; CHECK-NEXT:    retq # encoding: [0xc3]
+  %umul = tail call { i8, i1 } @llvm.umul.with.overflow.i8(i8 %b, i8 %c)
+  %umul.overflow = extractvalue { i8, i1 } %umul, 1
+  %conv2 = zext i1 %umul.overflow to i32
+  %add = add i32 %a, %conv2
+  ret i32 %add
+}
+
+declare { i8, i1 } @llvm.umul.with.overflow.i8(i8, i8)

--- a/llvm/test/CodeGen/X86/apx/adc.ll
+++ b/llvm/test/CodeGen/X86/apx/adc.ll
@@ -600,11 +600,9 @@ define i32 @mul_overflow_apx(i32 %a, i8 %b, i8 %c) {
 ; CHECK-LABEL: mul_overflow_apx:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    movl %esi, %eax # encoding: [0x89,0xf0]
-; CHECK-NEXT:    xorl %ecx, %ecx # encoding: [0x31,0xc9]
 ; CHECK-NEXT:    # kill: def $al killed $al killed $eax
 ; CHECK-NEXT:    mulb %dl # encoding: [0xf6,0xe2]
-; CHECK-NEXT:    seto %cl # encoding: [0x0f,0x90,0xc1]
-; CHECK-NEXT:    leal (%rdi,%rcx), %eax # encoding: [0x8d,0x04,0x0f]
+; CHECK-NEXT:    adcl $0, %edi, %eax # encoding: [0x62,0xf4,0x7c,0x18,0x83,0xd7,0x00]
 ; CHECK-NEXT:    retq # encoding: [0xc3]
   %umul = tail call { i8, i1 } @llvm.umul.with.overflow.i8(i8 %b, i8 %c)
   %umul.overflow = extractvalue { i8, i1 } %umul, 1
@@ -612,5 +610,3 @@ define i32 @mul_overflow_apx(i32 %a, i8 %b, i8 %c) {
   %add = add i32 %a, %conv2
   ret i32 %add
 }
-
-declare { i8, i1 } @llvm.umul.with.overflow.i8(i8, i8)

--- a/llvm/test/CodeGen/X86/apx/flags-copy-lowering.ll
+++ b/llvm/test/CodeGen/X86/apx/flags-copy-lowering.ll
@@ -10,7 +10,7 @@ define i32 @flag_copy_1(i32 %x, i32 %y, ptr %pz) nounwind {
 ; CHECK-NEXT:    mull %esi
 ; CHECK-NEXT:    movl (%rcx), %ecx
 ; CHECK-NEXT:    {nf} addl %eax, %ecx
-; CHECK-NEXT:    cmovol %ecx, %eax
+; CHECK-NEXT:    cmovbl %ecx, %eax
 ; CHECK-NEXT:    retq
   %o = tail call { i32, i1 } @llvm.umul.with.overflow.i32(i32 %x, i32 %y)
   %v1 = extractvalue { i32, i1 } %o, 1

--- a/llvm/test/CodeGen/X86/overflow-intrinsic-setcc-fold.ll
+++ b/llvm/test/CodeGen/X86/overflow-intrinsic-setcc-fold.ll
@@ -109,7 +109,7 @@ define i1 @smulo_not_i32(i32 %v1, i32 %v2) {
 ; CHECK-LABEL: smulo_not_i32:
 ; CHECK:       ## %bb.0: ## %entry
 ; CHECK-NEXT:    imull %esi, %edi
-; CHECK-NEXT:    setno %al
+; CHECK-NEXT:    setae %al
 ; CHECK-NEXT:    retq
 entry:
   %t = call {i32, i1} @llvm.smul.with.overflow.i32(i32 %v1, i32 %v2)
@@ -122,7 +122,7 @@ define i1 @smulo_not_i64(i64 %v1, i64 %v2) {
 ; CHECK-LABEL: smulo_not_i64:
 ; CHECK:       ## %bb.0: ## %entry
 ; CHECK-NEXT:    imulq %rsi, %rdi
-; CHECK-NEXT:    setno %al
+; CHECK-NEXT:    setae %al
 ; CHECK-NEXT:    retq
 entry:
   %t = call {i64, i1} @llvm.smul.with.overflow.i64(i64 %v1, i64 %v2)
@@ -136,7 +136,7 @@ define i1 @umulo_not_i32(i32 %v1, i32 %v2) {
 ; CHECK:       ## %bb.0: ## %entry
 ; CHECK-NEXT:    movl %edi, %eax
 ; CHECK-NEXT:    mull %esi
-; CHECK-NEXT:    setno %al
+; CHECK-NEXT:    setae %al
 ; CHECK-NEXT:    retq
 entry:
   %t = call {i32, i1} @llvm.umul.with.overflow.i32(i32 %v1, i32 %v2)
@@ -150,7 +150,7 @@ define i1 @umulo_not_i64(i64 %v1, i64 %v2) {
 ; CHECK:       ## %bb.0: ## %entry
 ; CHECK-NEXT:    movq %rdi, %rax
 ; CHECK-NEXT:    mulq %rsi
-; CHECK-NEXT:    setno %al
+; CHECK-NEXT:    setae %al
 ; CHECK-NEXT:    retq
 entry:
   %t = call {i64, i1} @llvm.umul.with.overflow.i64(i64 %v1, i64 %v2)

--- a/llvm/test/CodeGen/X86/select-lea.ll
+++ b/llvm/test/CodeGen/X86/select-lea.ll
@@ -333,7 +333,7 @@ define i32 @smul_add_imm(i32 %x, i32 %y) {
 ; X64-NEXT:    # kill: def $edi killed $edi def $rdi
 ; X64-NEXT:    imull %esi, %edi
 ; X64-NEXT:    leal 100(%rdi), %eax
-; X64-NEXT:    cmovnol %edi, %eax
+; X64-NEXT:    cmovael %edi, %eax
 ; X64-NEXT:    retq
 ;
 ; CMOV-LABEL: smul_add_imm:
@@ -341,14 +341,14 @@ define i32 @smul_add_imm(i32 %x, i32 %y) {
 ; CMOV-NEXT:    movl {{[0-9]+}}(%esp), %ecx
 ; CMOV-NEXT:    imull {{[0-9]+}}(%esp), %ecx
 ; CMOV-NEXT:    leal 100(%ecx), %eax
-; CMOV-NEXT:    cmovnol %ecx, %eax
+; CMOV-NEXT:    cmovael %ecx, %eax
 ; CMOV-NEXT:    retl
 ;
 ; NOCMOV-LABEL: smul_add_imm:
 ; NOCMOV:       # %bb.0:
 ; NOCMOV-NEXT:    movl {{[0-9]+}}(%esp), %eax
 ; NOCMOV-NEXT:    imull {{[0-9]+}}(%esp), %eax
-; NOCMOV-NEXT:    jno .LBB8_2
+; NOCMOV-NEXT:    jae .LBB8_2
 ; NOCMOV-NEXT:  # %bb.1:
 ; NOCMOV-NEXT:    addl $100, %eax
 ; NOCMOV-NEXT:  .LBB8_2:
@@ -368,7 +368,7 @@ define i32 @smul_add_load(i32 %x, i32 %y, ptr %pz) nounwind {
 ; X64-NEXT:    imull %esi, %eax
 ; X64-NEXT:    addl (%rdx), %eax
 ; X64-NEXT:    imull %esi, %edi
-; X64-NEXT:    cmovnol %edi, %eax
+; X64-NEXT:    cmovael %edi, %eax
 ; X64-NEXT:    retq
 ;
 ; CMOV-LABEL: smul_add_load:
@@ -381,7 +381,7 @@ define i32 @smul_add_load(i32 %x, i32 %y, ptr %pz) nounwind {
 ; CMOV-NEXT:    imull %edx, %esi
 ; CMOV-NEXT:    addl (%ecx), %esi
 ; CMOV-NEXT:    imull %edx, %eax
-; CMOV-NEXT:    cmovol %esi, %eax
+; CMOV-NEXT:    cmovbl %esi, %eax
 ; CMOV-NEXT:    popl %esi
 ; CMOV-NEXT:    retl
 ;
@@ -392,7 +392,7 @@ define i32 @smul_add_load(i32 %x, i32 %y, ptr %pz) nounwind {
 ; NOCMOV-NEXT:    movl %eax, %ecx
 ; NOCMOV-NEXT:    imull %edx, %ecx
 ; NOCMOV-NEXT:    imull %edx, %eax
-; NOCMOV-NEXT:    jno .LBB9_2
+; NOCMOV-NEXT:    jae .LBB9_2
 ; NOCMOV-NEXT:  # %bb.1:
 ; NOCMOV-NEXT:    movl {{[0-9]+}}(%esp), %eax
 ; NOCMOV-NEXT:    addl (%eax), %ecx
@@ -415,7 +415,7 @@ define i32 @umul_add_imm(i32 %x, i32 %y) {
 ; X64-NEXT:    mull %esi
 ; X64-NEXT:    # kill: def $eax killed $eax def $rax
 ; X64-NEXT:    leal 100(%rax), %ecx
-; X64-NEXT:    cmovol %ecx, %eax
+; X64-NEXT:    cmovbl %ecx, %eax
 ; X64-NEXT:    # kill: def $eax killed $eax killed $rax
 ; X64-NEXT:    retq
 ;
@@ -424,14 +424,14 @@ define i32 @umul_add_imm(i32 %x, i32 %y) {
 ; CMOV-NEXT:    movl {{[0-9]+}}(%esp), %eax
 ; CMOV-NEXT:    mull {{[0-9]+}}(%esp)
 ; CMOV-NEXT:    leal 100(%eax), %ecx
-; CMOV-NEXT:    cmovol %ecx, %eax
+; CMOV-NEXT:    cmovbl %ecx, %eax
 ; CMOV-NEXT:    retl
 ;
 ; NOCMOV-LABEL: umul_add_imm:
 ; NOCMOV:       # %bb.0:
 ; NOCMOV-NEXT:    movl {{[0-9]+}}(%esp), %eax
 ; NOCMOV-NEXT:    mull {{[0-9]+}}(%esp)
-; NOCMOV-NEXT:    jno .LBB10_2
+; NOCMOV-NEXT:    jae .LBB10_2
 ; NOCMOV-NEXT:  # %bb.1:
 ; NOCMOV-NEXT:    addl $100, %eax
 ; NOCMOV-NEXT:  .LBB10_2:
@@ -450,7 +450,7 @@ define i32 @umul_add_load(i32 %x, i32 %y, ptr %pz) nounwind {
 ; X64-NEXT:    movq %rdx, %rcx
 ; X64-NEXT:    movl %edi, %eax
 ; X64-NEXT:    mull %esi
-; X64-NEXT:    seto %dl
+; X64-NEXT:    setb %dl
 ; X64-NEXT:    movl (%rcx), %ecx
 ; X64-NEXT:    addl %eax, %ecx
 ; X64-NEXT:    testb %dl, %dl
@@ -462,7 +462,7 @@ define i32 @umul_add_load(i32 %x, i32 %y, ptr %pz) nounwind {
 ; CMOV-NEXT:    movl {{[0-9]+}}(%esp), %ecx
 ; CMOV-NEXT:    movl {{[0-9]+}}(%esp), %eax
 ; CMOV-NEXT:    mull {{[0-9]+}}(%esp)
-; CMOV-NEXT:    seto %dl
+; CMOV-NEXT:    setb %dl
 ; CMOV-NEXT:    movl (%ecx), %ecx
 ; CMOV-NEXT:    addl %eax, %ecx
 ; CMOV-NEXT:    testb %dl, %dl
@@ -473,7 +473,7 @@ define i32 @umul_add_load(i32 %x, i32 %y, ptr %pz) nounwind {
 ; NOCMOV:       # %bb.0:
 ; NOCMOV-NEXT:    movl {{[0-9]+}}(%esp), %eax
 ; NOCMOV-NEXT:    mull {{[0-9]+}}(%esp)
-; NOCMOV-NEXT:    jno .LBB11_2
+; NOCMOV-NEXT:    jae .LBB11_2
 ; NOCMOV-NEXT:  # %bb.1:
 ; NOCMOV-NEXT:    movl {{[0-9]+}}(%esp), %ecx
 ; NOCMOV-NEXT:    addl (%ecx), %eax

--- a/llvm/test/CodeGen/X86/smul-with-overflow.ll
+++ b/llvm/test/CodeGen/X86/smul-with-overflow.ll
@@ -11,7 +11,7 @@ define i1 @test1(i32 %v1, i32 %v2) nounwind {
 ; X86-NEXT:    subl $12, %esp
 ; X86-NEXT:    movl {{[0-9]+}}(%esp), %eax
 ; X86-NEXT:    imull {{[0-9]+}}(%esp), %eax
-; X86-NEXT:    jno .LBB0_1
+; X86-NEXT:    jae .LBB0_1
 ; X86-NEXT:  # %bb.2: # %overflow
 ; X86-NEXT:    movl $no, (%esp)
 ; X86-NEXT:    calll printf@PLT
@@ -31,7 +31,7 @@ define i1 @test1(i32 %v1, i32 %v2) nounwind {
 ; X64-NEXT:    pushq %rax
 ; X64-NEXT:    movl %edi, %eax
 ; X64-NEXT:    imull %esi, %eax
-; X64-NEXT:    jno .LBB0_1
+; X64-NEXT:    jae .LBB0_1
 ; X64-NEXT:  # %bb.2: # %overflow
 ; X64-NEXT:    movl $no, %edi
 ; X64-NEXT:    xorl %eax, %eax
@@ -68,7 +68,7 @@ define i1 @test2(i32 %v1, i32 %v2) nounwind {
 ; X86-NEXT:    subl $12, %esp
 ; X86-NEXT:    movl {{[0-9]+}}(%esp), %eax
 ; X86-NEXT:    imull {{[0-9]+}}(%esp), %eax
-; X86-NEXT:    jno .LBB1_2
+; X86-NEXT:    jae .LBB1_2
 ; X86-NEXT:  # %bb.1: # %overflow
 ; X86-NEXT:    movl $no, (%esp)
 ; X86-NEXT:    calll printf@PLT
@@ -88,7 +88,7 @@ define i1 @test2(i32 %v1, i32 %v2) nounwind {
 ; X64-NEXT:    pushq %rax
 ; X64-NEXT:    movl %edi, %eax
 ; X64-NEXT:    imull %esi, %eax
-; X64-NEXT:    jno .LBB1_2
+; X64-NEXT:    jae .LBB1_2
 ; X64-NEXT:  # %bb.1: # %overflow
 ; X64-NEXT:    movl $no, %edi
 ; X64-NEXT:    xorl %eax, %eax

--- a/llvm/test/CodeGen/X86/smul_fix_sat.ll
+++ b/llvm/test/CodeGen/X86/smul_fix_sat.ll
@@ -294,7 +294,7 @@ define i32 @func4(i32 %x, i32 %y) nounwind {
 ; X64-NEXT:    sets %al
 ; X64-NEXT:    addl $2147483647, %eax # imm = 0x7FFFFFFF
 ; X64-NEXT:    imull %esi, %edi
-; X64-NEXT:    cmovnol %edi, %eax
+; X64-NEXT:    cmovael %edi, %eax
 ; X64-NEXT:    retq
 ;
 ; X86-LABEL: func4:
@@ -308,7 +308,7 @@ define i32 @func4(i32 %x, i32 %y) nounwind {
 ; X86-NEXT:    sets %cl
 ; X86-NEXT:    addl $2147483647, %ecx # imm = 0x7FFFFFFF
 ; X86-NEXT:    imull %edx, %eax
-; X86-NEXT:    cmovol %ecx, %eax
+; X86-NEXT:    cmovbl %ecx, %eax
 ; X86-NEXT:    popl %esi
 ; X86-NEXT:    retl
   %tmp = call i32 @llvm.smul.fix.sat.i32(i32 %x, i32 %y, i32 0)
@@ -325,7 +325,7 @@ define i64 @func5(i64 %x, i64 %y) {
 ; X64-NEXT:    movabsq $9223372036854775807, %rax # imm = 0x7FFFFFFFFFFFFFFF
 ; X64-NEXT:    addq %rcx, %rax
 ; X64-NEXT:    imulq %rsi, %rdi
-; X64-NEXT:    cmovnoq %rdi, %rax
+; X64-NEXT:    cmovaeq %rdi, %rax
 ; X64-NEXT:    retq
 ;
 ; X86-LABEL: func5:
@@ -424,7 +424,7 @@ define i4 @func6(i4 %x, i4 %y) nounwind {
 ; X64-NEXT:    # kill: def $al killed $al killed $eax
 ; X64-NEXT:    imulb %sil
 ; X64-NEXT:    movzbl %al, %eax
-; X64-NEXT:    cmovol %ecx, %eax
+; X64-NEXT:    cmovbl %ecx, %eax
 ; X64-NEXT:    sarb $4, %al
 ; X64-NEXT:    # kill: def $al killed $al killed $eax
 ; X64-NEXT:    retq
@@ -443,7 +443,7 @@ define i4 @func6(i4 %x, i4 %y) nounwind {
 ; X86-NEXT:    addl $127, %edx
 ; X86-NEXT:    imulb %cl
 ; X86-NEXT:    movzbl %al, %eax
-; X86-NEXT:    cmovol %edx, %eax
+; X86-NEXT:    cmovbl %edx, %eax
 ; X86-NEXT:    sarb $4, %al
 ; X86-NEXT:    # kill: def $al killed $al killed $eax
 ; X86-NEXT:    retl
@@ -503,7 +503,7 @@ define <4 x i32> @vec2(<4 x i32> %x, <4 x i32> %y) nounwind {
 ; X86-NEXT:    sets %al
 ; X86-NEXT:    addl $2147483647, %eax # imm = 0x7FFFFFFF
 ; X86-NEXT:    imull %edi, %ecx
-; X86-NEXT:    cmovol %eax, %ecx
+; X86-NEXT:    cmovbl %eax, %ecx
 ; X86-NEXT:    xorl %eax, %eax
 ; X86-NEXT:    movl %edx, %edi
 ; X86-NEXT:    xorl %ebx, %edi
@@ -511,7 +511,7 @@ define <4 x i32> @vec2(<4 x i32> %x, <4 x i32> %y) nounwind {
 ; X86-NEXT:    sets %al
 ; X86-NEXT:    addl $2147483647, %eax # imm = 0x7FFFFFFF
 ; X86-NEXT:    imull %ebx, %edx
-; X86-NEXT:    cmovol %eax, %edx
+; X86-NEXT:    cmovbl %eax, %edx
 ; X86-NEXT:    xorl %eax, %eax
 ; X86-NEXT:    movl %edi, %ebx
 ; X86-NEXT:    xorl %esi, %ebx
@@ -519,14 +519,14 @@ define <4 x i32> @vec2(<4 x i32> %x, <4 x i32> %y) nounwind {
 ; X86-NEXT:    sets %al
 ; X86-NEXT:    addl $2147483647, %eax # imm = 0x7FFFFFFF
 ; X86-NEXT:    imull %esi, %edi
-; X86-NEXT:    cmovol %eax, %edi
+; X86-NEXT:    cmovbl %eax, %edi
 ; X86-NEXT:    xorl %eax, %eax
 ; X86-NEXT:    movl %ebx, %esi
 ; X86-NEXT:    xorl %ebp, %esi
 ; X86-NEXT:    sets %al
 ; X86-NEXT:    addl $2147483647, %eax # imm = 0x7FFFFFFF
 ; X86-NEXT:    imull %ebp, %ebx
-; X86-NEXT:    cmovol %eax, %ebx
+; X86-NEXT:    cmovbl %eax, %ebx
 ; X86-NEXT:    movl {{[0-9]+}}(%esp), %eax
 ; X86-NEXT:    movl %ebx, 12(%eax)
 ; X86-NEXT:    movl %edi, 8(%eax)

--- a/llvm/test/CodeGen/X86/smul_fix_sat_constants.ll
+++ b/llvm/test/CodeGen/X86/smul_fix_sat_constants.ll
@@ -32,7 +32,7 @@ define i64 @func2() nounwind {
 ; X64-NEXT:    movl $3, %eax
 ; X64-NEXT:    imulq $2, %rax, %rcx
 ; X64-NEXT:    movabsq $9223372036854775807, %rax # imm = 0x7FFFFFFFFFFFFFFF
-; X64-NEXT:    cmovnoq %rcx, %rax
+; X64-NEXT:    cmovaeq %rcx, %rax
 ; X64-NEXT:    retq
   %tmp = call i64 @llvm.smul.fix.sat.i64(i64 3, i64 2, i32 0)
   ret i64 %tmp

--- a/llvm/test/CodeGen/X86/umul-with-carry.ll
+++ b/llvm/test/CodeGen/X86/umul-with-carry.ll
@@ -11,7 +11,7 @@ define i1 @func(i32 %v1, i32 %v2) nounwind {
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    movl {{[0-9]+}}(%esp), %eax
 ; CHECK-NEXT:    mull {{[0-9]+}}(%esp)
-; CHECK-NEXT:    jno .LBB0_1
+; CHECK-NEXT:    jae .LBB0_1
 ; CHECK-NEXT:  # %bb.2: # %carry
 ; CHECK-NEXT:    pushl $no
 ; CHECK-NEXT:    calll printf@PLT

--- a/llvm/test/CodeGen/X86/umul-with-overflow.ll
+++ b/llvm/test/CodeGen/X86/umul-with-overflow.ll
@@ -9,7 +9,7 @@ define zeroext i1 @a(i32 %x)  nounwind {
 ; X86:       # %bb.0:
 ; X86-NEXT:    movl $3, %eax
 ; X86-NEXT:    mull {{[0-9]+}}(%esp)
-; X86-NEXT:    seto %al
+; X86-NEXT:    setb %al
 ; X86-NEXT:    retl
 ;
 ; X64-LABEL: a:
@@ -17,7 +17,7 @@ define zeroext i1 @a(i32 %x)  nounwind {
 ; X64-NEXT:    movl %edi, %eax
 ; X64-NEXT:    movl $3, %ecx
 ; X64-NEXT:    mull %ecx
-; X64-NEXT:    seto %al
+; X64-NEXT:    setb %al
 ; X64-NEXT:    retq
   %res = call {i32, i1} @llvm.umul.with.overflow.i32(i32 %x, i32 3)
   %obil = extractvalue {i32, i1} %res, 1

--- a/llvm/test/CodeGen/X86/umul_fix_sat.ll
+++ b/llvm/test/CodeGen/X86/umul_fix_sat.ll
@@ -211,7 +211,7 @@ define i32 @func4(i32 %x, i32 %y) nounwind {
 ; X64-NEXT:    movl %edi, %eax
 ; X64-NEXT:    mull %esi
 ; X64-NEXT:    movl $-1, %ecx
-; X64-NEXT:    cmovol %ecx, %eax
+; X64-NEXT:    cmovbl %ecx, %eax
 ; X64-NEXT:    retq
 ;
 ; X86-LABEL: func4:
@@ -219,7 +219,7 @@ define i32 @func4(i32 %x, i32 %y) nounwind {
 ; X86-NEXT:    movl {{[0-9]+}}(%esp), %eax
 ; X86-NEXT:    mull {{[0-9]+}}(%esp)
 ; X86-NEXT:    movl $-1, %ecx
-; X86-NEXT:    cmovol %ecx, %eax
+; X86-NEXT:    cmovbl %ecx, %eax
 ; X86-NEXT:    retl
   %tmp = call i32 @llvm.umul.fix.sat.i32(i32 %x, i32 %y, i32 0)
   ret i32 %tmp
@@ -231,7 +231,7 @@ define i64 @func5(i64 %x, i64 %y) {
 ; X64-NEXT:    movq %rdi, %rax
 ; X64-NEXT:    mulq %rsi
 ; X64-NEXT:    movq $-1, %rcx
-; X64-NEXT:    cmovoq %rcx, %rax
+; X64-NEXT:    cmovbq %rcx, %rax
 ; X64-NEXT:    retq
 ;
 ; X86-LABEL: func5:
@@ -258,10 +258,10 @@ define i64 @func5(i64 %x, i64 %y) {
 ; X86-NEXT:    andb %dl, %cl
 ; X86-NEXT:    mull {{[0-9]+}}(%esp)
 ; X86-NEXT:    movl %eax, %edi
-; X86-NEXT:    seto %bl
+; X86-NEXT:    setb %bl
 ; X86-NEXT:    movl %esi, %eax
 ; X86-NEXT:    mull %ebp
-; X86-NEXT:    seto %ch
+; X86-NEXT:    setb %ch
 ; X86-NEXT:    orb %bl, %ch
 ; X86-NEXT:    orb %cl, %ch
 ; X86-NEXT:    leal (%edi,%eax), %esi
@@ -296,7 +296,7 @@ define i4 @func6(i4 %x, i4 %y) nounwind {
 ; X64-NEXT:    mulb %sil
 ; X64-NEXT:    movzbl %al, %ecx
 ; X64-NEXT:    movl $255, %eax
-; X64-NEXT:    cmovnol %ecx, %eax
+; X64-NEXT:    cmovael %ecx, %eax
 ; X64-NEXT:    shrb $4, %al
 ; X64-NEXT:    # kill: def $al killed $al killed $eax
 ; X64-NEXT:    retq
@@ -310,7 +310,7 @@ define i4 @func6(i4 %x, i4 %y) nounwind {
 ; X86-NEXT:    mulb %cl
 ; X86-NEXT:    movzbl %al, %ecx
 ; X86-NEXT:    movl $255, %eax
-; X86-NEXT:    cmovnol %ecx, %eax
+; X86-NEXT:    cmovael %ecx, %eax
 ; X86-NEXT:    shrb $4, %al
 ; X86-NEXT:    # kill: def $al killed $al killed $eax
 ; X86-NEXT:    retl
@@ -337,18 +337,18 @@ define <4 x i32> @vec2(<4 x i32> %x, <4 x i32> %y) nounwind {
 ; X86-NEXT:    mull {{[0-9]+}}(%esp)
 ; X86-NEXT:    movl %eax, %esi
 ; X86-NEXT:    movl $-1, %edi
-; X86-NEXT:    cmovol %edi, %esi
+; X86-NEXT:    cmovbl %edi, %esi
 ; X86-NEXT:    movl %ebx, %eax
 ; X86-NEXT:    mull {{[0-9]+}}(%esp)
 ; X86-NEXT:    movl %eax, %ebx
-; X86-NEXT:    cmovol %edi, %ebx
+; X86-NEXT:    cmovbl %edi, %ebx
 ; X86-NEXT:    movl %ebp, %eax
 ; X86-NEXT:    mull {{[0-9]+}}(%esp)
 ; X86-NEXT:    movl %eax, %ebp
-; X86-NEXT:    cmovol %edi, %ebp
+; X86-NEXT:    cmovbl %edi, %ebp
 ; X86-NEXT:    movl {{[0-9]+}}(%esp), %eax
 ; X86-NEXT:    mull {{[0-9]+}}(%esp)
-; X86-NEXT:    cmovol %edi, %eax
+; X86-NEXT:    cmovbl %edi, %eax
 ; X86-NEXT:    movl %eax, 12(%ecx)
 ; X86-NEXT:    movl %ebp, 8(%ecx)
 ; X86-NEXT:    movl %ebx, 4(%ecx)

--- a/llvm/test/CodeGen/X86/umulo-128-legalisation-lowering.ll
+++ b/llvm/test/CodeGen/X86/umulo-128-legalisation-lowering.ll
@@ -14,10 +14,10 @@ define { i128, i8 } @muloti_test(i128 %l, i128 %r) unnamed_addr #0 {
 ; X64-NEXT:    andb %dl, %r9b
 ; X64-NEXT:    mulq %r8
 ; X64-NEXT:    movq %rax, %rsi
-; X64-NEXT:    seto %r10b
+; X64-NEXT:    setb %r10b
 ; X64-NEXT:    movq %rcx, %rax
 ; X64-NEXT:    mulq %rdi
-; X64-NEXT:    seto %r11b
+; X64-NEXT:    setb %r11b
 ; X64-NEXT:    orb %r10b, %r11b
 ; X64-NEXT:    orb %r9b, %r11b
 ; X64-NEXT:    leaq (%rsi,%rax), %rcx
@@ -51,11 +51,11 @@ define { i128, i8 } @muloti_test(i128 %l, i128 %r) unnamed_addr #0 {
 ; X86-NEXT:    movl {{[0-9]+}}(%esp), %esi
 ; X86-NEXT:    mull %ebx
 ; X86-NEXT:    movl %eax, %ecx
-; X86-NEXT:    seto {{[-0-9]+}}(%e{{[sb]}}p) # 1-byte Folded Spill
+; X86-NEXT:    setb {{[-0-9]+}}(%e{{[sb]}}p) # 1-byte Folded Spill
 ; X86-NEXT:    movl %esi, %eax
 ; X86-NEXT:    mull %edi
 ; X86-NEXT:    leal (%ecx,%eax), %esi
-; X86-NEXT:    seto {{[-0-9]+}}(%e{{[sb]}}p) # 1-byte Folded Spill
+; X86-NEXT:    setb {{[-0-9]+}}(%e{{[sb]}}p) # 1-byte Folded Spill
 ; X86-NEXT:    movl %edi, %eax
 ; X86-NEXT:    mull %ebx
 ; X86-NEXT:    movl %eax, {{[-0-9]+}}(%e{{[sb]}}p) # 4-byte Spill
@@ -66,13 +66,13 @@ define { i128, i8 } @muloti_test(i128 %l, i128 %r) unnamed_addr #0 {
 ; X86-NEXT:    movl {{[0-9]+}}(%esp), %edi
 ; X86-NEXT:    mull %edi
 ; X86-NEXT:    movl %eax, %esi
-; X86-NEXT:    seto {{[-0-9]+}}(%e{{[sb]}}p) # 1-byte Folded Spill
+; X86-NEXT:    setb {{[-0-9]+}}(%e{{[sb]}}p) # 1-byte Folded Spill
 ; X86-NEXT:    movl {{[0-9]+}}(%esp), %ebx
 ; X86-NEXT:    movl %ebx, {{[-0-9]+}}(%e{{[sb]}}p) # 4-byte Spill
 ; X86-NEXT:    movl {{[0-9]+}}(%esp), %eax
 ; X86-NEXT:    mull %ebx
 ; X86-NEXT:    leal (%esi,%eax), %esi
-; X86-NEXT:    seto {{[-0-9]+}}(%e{{[sb]}}p) # 1-byte Folded Spill
+; X86-NEXT:    setb {{[-0-9]+}}(%e{{[sb]}}p) # 1-byte Folded Spill
 ; X86-NEXT:    movl %ebx, %eax
 ; X86-NEXT:    mull %edi
 ; X86-NEXT:    movl %eax, %ebp

--- a/llvm/test/CodeGen/X86/umulo-64-legalisation-lowering.ll
+++ b/llvm/test/CodeGen/X86/umulo-64-legalisation-lowering.ll
@@ -26,10 +26,10 @@ define { i64, i8 } @mulodi_test(i64 %l, i64 %r) unnamed_addr #0 {
 ; X86-NEXT:    andb %dl, %cl
 ; X86-NEXT:    mull {{[0-9]+}}(%esp)
 ; X86-NEXT:    movl %eax, %edi
-; X86-NEXT:    seto %bl
+; X86-NEXT:    setb %bl
 ; X86-NEXT:    movl %esi, %eax
 ; X86-NEXT:    mull %ebp
-; X86-NEXT:    seto %ch
+; X86-NEXT:    setb %ch
 ; X86-NEXT:    orb %bl, %ch
 ; X86-NEXT:    orb %cl, %ch
 ; X86-NEXT:    leal (%edi,%eax), %esi

--- a/llvm/test/CodeGen/X86/vec_smulo.ll
+++ b/llvm/test/CodeGen/X86/vec_smulo.ll
@@ -32,8 +32,7 @@ define <1 x i32> @smulo_v1i32(<1 x i32> %a0, <1 x i32> %a1, ptr %p2) nounwind {
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    xorl %eax, %eax
 ; CHECK-NEXT:    imull %esi, %edi
-; CHECK-NEXT:    seto %al
-; CHECK-NEXT:    negl %eax
+; CHECK-NEXT:    sbbl %eax, %eax
 ; CHECK-NEXT:    movl %edi, (%rdx)
 ; CHECK-NEXT:    retq
   %t = call {<1 x i32>, <1 x i1>} @llvm.smul.with.overflow.v1i32(<1 x i32> %a0, <1 x i32> %a1)
@@ -2804,13 +2803,13 @@ define <2 x i32> @smulo_v2i64(<2 x i64> %a0, <2 x i64> %a1, ptr %p2) nounwind {
 ; SSE2-NEXT:    imulq %rdx, %rsi
 ; SSE2-NEXT:    movq $-1, %rdx
 ; SSE2-NEXT:    movl $0, %r9d
-; SSE2-NEXT:    cmovoq %rdx, %r9
+; SSE2-NEXT:    cmovbq %rdx, %r9
 ; SSE2-NEXT:    movq %rsi, %xmm1
 ; SSE2-NEXT:    imulq %rax, %rcx
 ; SSE2-NEXT:    movq %rcx, %xmm0
 ; SSE2-NEXT:    punpcklqdq {{.*#+}} xmm1 = xmm1[0],xmm0[0]
 ; SSE2-NEXT:    movq %r9, %xmm0
-; SSE2-NEXT:    cmovoq %rdx, %r8
+; SSE2-NEXT:    cmovbq %rdx, %r8
 ; SSE2-NEXT:    movq %r8, %xmm2
 ; SSE2-NEXT:    punpcklqdq {{.*#+}} xmm0 = xmm0[0],xmm2[0]
 ; SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm0[0,2,2,3]
@@ -2829,13 +2828,13 @@ define <2 x i32> @smulo_v2i64(<2 x i64> %a0, <2 x i64> %a1, ptr %p2) nounwind {
 ; SSSE3-NEXT:    imulq %rdx, %rsi
 ; SSSE3-NEXT:    movq $-1, %rdx
 ; SSSE3-NEXT:    movl $0, %r9d
-; SSSE3-NEXT:    cmovoq %rdx, %r9
+; SSSE3-NEXT:    cmovbq %rdx, %r9
 ; SSSE3-NEXT:    movq %rsi, %xmm1
 ; SSSE3-NEXT:    imulq %rax, %rcx
 ; SSSE3-NEXT:    movq %rcx, %xmm0
 ; SSSE3-NEXT:    punpcklqdq {{.*#+}} xmm1 = xmm1[0],xmm0[0]
 ; SSSE3-NEXT:    movq %r9, %xmm0
-; SSSE3-NEXT:    cmovoq %rdx, %r8
+; SSSE3-NEXT:    cmovbq %rdx, %r8
 ; SSSE3-NEXT:    movq %r8, %xmm2
 ; SSSE3-NEXT:    punpcklqdq {{.*#+}} xmm0 = xmm0[0],xmm2[0]
 ; SSSE3-NEXT:    pshufd {{.*#+}} xmm0 = xmm0[0,2,2,3]
@@ -2852,13 +2851,13 @@ define <2 x i32> @smulo_v2i64(<2 x i64> %a0, <2 x i64> %a1, ptr %p2) nounwind {
 ; SSE41-NEXT:    imulq %rdx, %rsi
 ; SSE41-NEXT:    movq $-1, %rdx
 ; SSE41-NEXT:    movl $0, %r9d
-; SSE41-NEXT:    cmovoq %rdx, %r9
+; SSE41-NEXT:    cmovbq %rdx, %r9
 ; SSE41-NEXT:    movq %rsi, %xmm0
 ; SSE41-NEXT:    imulq %rax, %rcx
 ; SSE41-NEXT:    movq %rcx, %xmm1
 ; SSE41-NEXT:    punpcklqdq {{.*#+}} xmm1 = xmm1[0],xmm0[0]
 ; SSE41-NEXT:    movq %r9, %xmm0
-; SSE41-NEXT:    cmovoq %rdx, %r8
+; SSE41-NEXT:    cmovbq %rdx, %r8
 ; SSE41-NEXT:    movq %r8, %xmm2
 ; SSE41-NEXT:    punpcklqdq {{.*#+}} xmm2 = xmm2[0],xmm0[0]
 ; SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm2[0,2,2,3]
@@ -2875,13 +2874,13 @@ define <2 x i32> @smulo_v2i64(<2 x i64> %a0, <2 x i64> %a1, ptr %p2) nounwind {
 ; AVX-NEXT:    imulq %rdx, %rsi
 ; AVX-NEXT:    movq $-1, %rdx
 ; AVX-NEXT:    movl $0, %r9d
-; AVX-NEXT:    cmovoq %rdx, %r9
+; AVX-NEXT:    cmovbq %rdx, %r9
 ; AVX-NEXT:    vmovq %rsi, %xmm0
 ; AVX-NEXT:    imulq %rax, %rcx
 ; AVX-NEXT:    vmovq %rcx, %xmm1
 ; AVX-NEXT:    vpunpcklqdq {{.*#+}} xmm1 = xmm1[0],xmm0[0]
 ; AVX-NEXT:    vmovq %r9, %xmm0
-; AVX-NEXT:    cmovoq %rdx, %r8
+; AVX-NEXT:    cmovbq %rdx, %r8
 ; AVX-NEXT:    vmovq %r8, %xmm2
 ; AVX-NEXT:    vpunpcklqdq {{.*#+}} xmm0 = xmm2[0],xmm0[0]
 ; AVX-NEXT:    vpshufd {{.*#+}} xmm0 = xmm0[0,2,2,3]
@@ -2895,12 +2894,12 @@ define <2 x i32> @smulo_v2i64(<2 x i64> %a0, <2 x i64> %a1, ptr %p2) nounwind {
 ; AVX512-NEXT:    vmovq %xmm1, %rdx
 ; AVX512-NEXT:    vmovq %xmm0, %rsi
 ; AVX512-NEXT:    imulq %rdx, %rsi
-; AVX512-NEXT:    seto %dl
+; AVX512-NEXT:    setb %dl
 ; AVX512-NEXT:    imulq %rax, %rcx
 ; AVX512-NEXT:    vmovq %rcx, %xmm0
 ; AVX512-NEXT:    vmovq %rsi, %xmm1
 ; AVX512-NEXT:    vpunpcklqdq {{.*#+}} xmm1 = xmm1[0],xmm0[0]
-; AVX512-NEXT:    seto %al
+; AVX512-NEXT:    setb %al
 ; AVX512-NEXT:    vmovd %edx, %xmm0
 ; AVX512-NEXT:    vpinsrb $1, %eax, %xmm0, %xmm0
 ; AVX512-NEXT:    vpmovzxbd {{.*#+}} xmm0 = xmm0[0],zero,zero,zero,xmm0[1],zero,zero,zero,xmm0[2],zero,zero,zero,xmm0[3],zero,zero,zero

--- a/llvm/test/CodeGen/X86/vec_umulo.ll
+++ b/llvm/test/CodeGen/X86/vec_umulo.ll
@@ -34,8 +34,7 @@ define <1 x i32> @umulo_v1i32(<1 x i32> %a0, <1 x i32> %a1, ptr %p2) nounwind {
 ; CHECK-NEXT:    movl %edi, %eax
 ; CHECK-NEXT:    xorl %edi, %edi
 ; CHECK-NEXT:    mull %esi
-; CHECK-NEXT:    seto %dil
-; CHECK-NEXT:    negl %edi
+; CHECK-NEXT:    sbbl %edi, %edi
 ; CHECK-NEXT:    movl %eax, (%rcx)
 ; CHECK-NEXT:    movl %edi, %eax
 ; CHECK-NEXT:    retq
@@ -2474,14 +2473,14 @@ define <2 x i32> @umulo_v2i64(<2 x i64> %a0, <2 x i64> %a1, ptr %p2) nounwind {
 ; SSE2-NEXT:    mulq %rdx
 ; SSE2-NEXT:    movq $-1, %r9
 ; SSE2-NEXT:    movl $0, %r10d
-; SSE2-NEXT:    cmovoq %r9, %r10
+; SSE2-NEXT:    cmovbq %r9, %r10
 ; SSE2-NEXT:    movq %rax, %xmm1
 ; SSE2-NEXT:    movq %rcx, %rax
 ; SSE2-NEXT:    mulq %rsi
 ; SSE2-NEXT:    movq %rax, %xmm0
 ; SSE2-NEXT:    punpcklqdq {{.*#+}} xmm1 = xmm1[0],xmm0[0]
 ; SSE2-NEXT:    movq %r10, %xmm0
-; SSE2-NEXT:    cmovoq %r9, %r8
+; SSE2-NEXT:    cmovbq %r9, %r8
 ; SSE2-NEXT:    movq %r8, %xmm2
 ; SSE2-NEXT:    punpcklqdq {{.*#+}} xmm0 = xmm0[0],xmm2[0]
 ; SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm0[0,2,2,3]
@@ -2500,14 +2499,14 @@ define <2 x i32> @umulo_v2i64(<2 x i64> %a0, <2 x i64> %a1, ptr %p2) nounwind {
 ; SSSE3-NEXT:    mulq %rdx
 ; SSSE3-NEXT:    movq $-1, %r9
 ; SSSE3-NEXT:    movl $0, %r10d
-; SSSE3-NEXT:    cmovoq %r9, %r10
+; SSSE3-NEXT:    cmovbq %r9, %r10
 ; SSSE3-NEXT:    movq %rax, %xmm1
 ; SSSE3-NEXT:    movq %rcx, %rax
 ; SSSE3-NEXT:    mulq %rsi
 ; SSSE3-NEXT:    movq %rax, %xmm0
 ; SSSE3-NEXT:    punpcklqdq {{.*#+}} xmm1 = xmm1[0],xmm0[0]
 ; SSSE3-NEXT:    movq %r10, %xmm0
-; SSSE3-NEXT:    cmovoq %r9, %r8
+; SSSE3-NEXT:    cmovbq %r9, %r8
 ; SSSE3-NEXT:    movq %r8, %xmm2
 ; SSSE3-NEXT:    punpcklqdq {{.*#+}} xmm0 = xmm0[0],xmm2[0]
 ; SSSE3-NEXT:    pshufd {{.*#+}} xmm0 = xmm0[0,2,2,3]
@@ -2524,14 +2523,14 @@ define <2 x i32> @umulo_v2i64(<2 x i64> %a0, <2 x i64> %a1, ptr %p2) nounwind {
 ; SSE41-NEXT:    mulq %rdx
 ; SSE41-NEXT:    movq $-1, %r9
 ; SSE41-NEXT:    movl $0, %r10d
-; SSE41-NEXT:    cmovoq %r9, %r10
+; SSE41-NEXT:    cmovbq %r9, %r10
 ; SSE41-NEXT:    movq %rax, %xmm0
 ; SSE41-NEXT:    movq %rcx, %rax
 ; SSE41-NEXT:    mulq %rsi
 ; SSE41-NEXT:    movq %rax, %xmm1
 ; SSE41-NEXT:    punpcklqdq {{.*#+}} xmm1 = xmm1[0],xmm0[0]
 ; SSE41-NEXT:    movq %r10, %xmm0
-; SSE41-NEXT:    cmovoq %r9, %r8
+; SSE41-NEXT:    cmovbq %r9, %r8
 ; SSE41-NEXT:    movq %r8, %xmm2
 ; SSE41-NEXT:    punpcklqdq {{.*#+}} xmm2 = xmm2[0],xmm0[0]
 ; SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm2[0,2,2,3]
@@ -2548,14 +2547,14 @@ define <2 x i32> @umulo_v2i64(<2 x i64> %a0, <2 x i64> %a1, ptr %p2) nounwind {
 ; AVX-NEXT:    mulq %rdx
 ; AVX-NEXT:    movq $-1, %r9
 ; AVX-NEXT:    movl $0, %r10d
-; AVX-NEXT:    cmovoq %r9, %r10
+; AVX-NEXT:    cmovbq %r9, %r10
 ; AVX-NEXT:    vmovq %rax, %xmm0
 ; AVX-NEXT:    movq %rcx, %rax
 ; AVX-NEXT:    mulq %rsi
 ; AVX-NEXT:    vmovq %rax, %xmm1
 ; AVX-NEXT:    vpunpcklqdq {{.*#+}} xmm1 = xmm1[0],xmm0[0]
 ; AVX-NEXT:    vmovq %r10, %xmm0
-; AVX-NEXT:    cmovoq %r9, %r8
+; AVX-NEXT:    cmovbq %r9, %r8
 ; AVX-NEXT:    vmovq %r8, %xmm2
 ; AVX-NEXT:    vpunpcklqdq {{.*#+}} xmm0 = xmm2[0],xmm0[0]
 ; AVX-NEXT:    vpshufd {{.*#+}} xmm0 = xmm0[0,2,2,3]
@@ -2570,13 +2569,13 @@ define <2 x i32> @umulo_v2i64(<2 x i64> %a0, <2 x i64> %a1, ptr %p2) nounwind {
 ; AVX512-NEXT:    vmovq %xmm1, %rdx
 ; AVX512-NEXT:    mulq %rdx
 ; AVX512-NEXT:    movq %rax, %rsi
-; AVX512-NEXT:    seto %r9b
+; AVX512-NEXT:    setb %r9b
 ; AVX512-NEXT:    movq %rcx, %rax
 ; AVX512-NEXT:    mulq %r8
 ; AVX512-NEXT:    vmovq %rax, %xmm0
 ; AVX512-NEXT:    vmovq %rsi, %xmm1
 ; AVX512-NEXT:    vpunpcklqdq {{.*#+}} xmm1 = xmm1[0],xmm0[0]
-; AVX512-NEXT:    seto %al
+; AVX512-NEXT:    setb %al
 ; AVX512-NEXT:    vmovd %r9d, %xmm0
 ; AVX512-NEXT:    vpinsrb $1, %eax, %xmm0, %xmm0
 ; AVX512-NEXT:    vpmovzxbd {{.*#+}} xmm0 = xmm0[0],zero,zero,zero,xmm0[1],zero,zero,zero,xmm0[2],zero,zero,zero,xmm0[3],zero,zero,zero
@@ -2903,10 +2902,10 @@ define <2 x i32> @umulo_v2i128(<2 x i128> %a0, <2 x i128> %a1, ptr %p2) nounwind
 ; SSE2-NEXT:    andb %dl, %bpl
 ; SSE2-NEXT:    mulq %r8
 ; SSE2-NEXT:    movq %rax, %rsi
-; SSE2-NEXT:    seto %r15b
+; SSE2-NEXT:    setb %r15b
 ; SSE2-NEXT:    movq %r11, %rax
 ; SSE2-NEXT:    mulq %rdi
-; SSE2-NEXT:    seto %r12b
+; SSE2-NEXT:    setb %r12b
 ; SSE2-NEXT:    orb %r15b, %r12b
 ; SSE2-NEXT:    orb %bpl, %r12b
 ; SSE2-NEXT:    leaq (%rsi,%rax), %r11
@@ -2925,10 +2924,10 @@ define <2 x i32> @umulo_v2i128(<2 x i128> %a0, <2 x i128> %a1, ptr %p2) nounwind
 ; SSE2-NEXT:    movq %r10, %rax
 ; SSE2-NEXT:    mulq %r14
 ; SSE2-NEXT:    movq %rax, %r8
-; SSE2-NEXT:    seto %r10b
+; SSE2-NEXT:    setb %r10b
 ; SSE2-NEXT:    movq %r9, %rax
 ; SSE2-NEXT:    mulq %rcx
-; SSE2-NEXT:    seto %r9b
+; SSE2-NEXT:    setb %r9b
 ; SSE2-NEXT:    orb %r10b, %r9b
 ; SSE2-NEXT:    orb %bpl, %r9b
 ; SSE2-NEXT:    addq %rax, %r8
@@ -2976,10 +2975,10 @@ define <2 x i32> @umulo_v2i128(<2 x i128> %a0, <2 x i128> %a1, ptr %p2) nounwind
 ; SSSE3-NEXT:    andb %dl, %bpl
 ; SSSE3-NEXT:    mulq %r8
 ; SSSE3-NEXT:    movq %rax, %rsi
-; SSSE3-NEXT:    seto %r15b
+; SSSE3-NEXT:    setb %r15b
 ; SSSE3-NEXT:    movq %r11, %rax
 ; SSSE3-NEXT:    mulq %rdi
-; SSSE3-NEXT:    seto %r12b
+; SSSE3-NEXT:    setb %r12b
 ; SSSE3-NEXT:    orb %r15b, %r12b
 ; SSSE3-NEXT:    orb %bpl, %r12b
 ; SSSE3-NEXT:    leaq (%rsi,%rax), %r11
@@ -2998,10 +2997,10 @@ define <2 x i32> @umulo_v2i128(<2 x i128> %a0, <2 x i128> %a1, ptr %p2) nounwind
 ; SSSE3-NEXT:    movq %r10, %rax
 ; SSSE3-NEXT:    mulq %r14
 ; SSSE3-NEXT:    movq %rax, %r8
-; SSSE3-NEXT:    seto %r10b
+; SSSE3-NEXT:    setb %r10b
 ; SSSE3-NEXT:    movq %r9, %rax
 ; SSSE3-NEXT:    mulq %rcx
-; SSSE3-NEXT:    seto %r9b
+; SSSE3-NEXT:    setb %r9b
 ; SSSE3-NEXT:    orb %r10b, %r9b
 ; SSSE3-NEXT:    orb %bpl, %r9b
 ; SSSE3-NEXT:    addq %rax, %r8
@@ -3049,10 +3048,10 @@ define <2 x i32> @umulo_v2i128(<2 x i128> %a0, <2 x i128> %a1, ptr %p2) nounwind
 ; SSE41-NEXT:    andb %dl, %bpl
 ; SSE41-NEXT:    mulq %r8
 ; SSE41-NEXT:    movq %rax, %rsi
-; SSE41-NEXT:    seto %r15b
+; SSE41-NEXT:    setb %r15b
 ; SSE41-NEXT:    movq %r11, %rax
 ; SSE41-NEXT:    mulq %rdi
-; SSE41-NEXT:    seto %r12b
+; SSE41-NEXT:    setb %r12b
 ; SSE41-NEXT:    orb %r15b, %r12b
 ; SSE41-NEXT:    orb %bpl, %r12b
 ; SSE41-NEXT:    leaq (%rsi,%rax), %r11
@@ -3071,10 +3070,10 @@ define <2 x i32> @umulo_v2i128(<2 x i128> %a0, <2 x i128> %a1, ptr %p2) nounwind
 ; SSE41-NEXT:    movq %r10, %rax
 ; SSE41-NEXT:    mulq %r14
 ; SSE41-NEXT:    movq %rax, %r8
-; SSE41-NEXT:    seto %r10b
+; SSE41-NEXT:    setb %r10b
 ; SSE41-NEXT:    movq %r9, %rax
 ; SSE41-NEXT:    mulq %rcx
-; SSE41-NEXT:    seto %r9b
+; SSE41-NEXT:    setb %r9b
 ; SSE41-NEXT:    orb %r10b, %r9b
 ; SSE41-NEXT:    orb %bpl, %r9b
 ; SSE41-NEXT:    addq %rax, %r8
@@ -3121,10 +3120,10 @@ define <2 x i32> @umulo_v2i128(<2 x i128> %a0, <2 x i128> %a1, ptr %p2) nounwind
 ; AVX-NEXT:    andb %dl, %bpl
 ; AVX-NEXT:    mulq %r8
 ; AVX-NEXT:    movq %rax, %rsi
-; AVX-NEXT:    seto %r15b
+; AVX-NEXT:    setb %r15b
 ; AVX-NEXT:    movq %r11, %rax
 ; AVX-NEXT:    mulq %rdi
-; AVX-NEXT:    seto %r12b
+; AVX-NEXT:    setb %r12b
 ; AVX-NEXT:    orb %r15b, %r12b
 ; AVX-NEXT:    orb %bpl, %r12b
 ; AVX-NEXT:    leaq (%rsi,%rax), %r11
@@ -3143,10 +3142,10 @@ define <2 x i32> @umulo_v2i128(<2 x i128> %a0, <2 x i128> %a1, ptr %p2) nounwind
 ; AVX-NEXT:    movq %r10, %rax
 ; AVX-NEXT:    mulq %r14
 ; AVX-NEXT:    movq %rax, %r8
-; AVX-NEXT:    seto %r10b
+; AVX-NEXT:    setb %r10b
 ; AVX-NEXT:    movq %r9, %rax
 ; AVX-NEXT:    mulq %rcx
-; AVX-NEXT:    seto %r9b
+; AVX-NEXT:    setb %r9b
 ; AVX-NEXT:    orb %r10b, %r9b
 ; AVX-NEXT:    orb %bpl, %r9b
 ; AVX-NEXT:    addq %rax, %r8
@@ -3192,10 +3191,10 @@ define <2 x i32> @umulo_v2i128(<2 x i128> %a0, <2 x i128> %a1, ptr %p2) nounwind
 ; AVX512F-NEXT:    andb %dl, %bpl
 ; AVX512F-NEXT:    mulq %r14
 ; AVX512F-NEXT:    movq %rax, %r11
-; AVX512F-NEXT:    seto %r15b
+; AVX512F-NEXT:    setb %r15b
 ; AVX512F-NEXT:    movq %rsi, %rax
 ; AVX512F-NEXT:    mulq %rcx
-; AVX512F-NEXT:    seto %r12b
+; AVX512F-NEXT:    setb %r12b
 ; AVX512F-NEXT:    orb %r15b, %r12b
 ; AVX512F-NEXT:    orb %bpl, %r12b
 ; AVX512F-NEXT:    addq %rax, %r11
@@ -3215,10 +3214,10 @@ define <2 x i32> @umulo_v2i128(<2 x i128> %a0, <2 x i128> %a1, ptr %p2) nounwind
 ; AVX512F-NEXT:    movq %r10, %rax
 ; AVX512F-NEXT:    mulq %r8
 ; AVX512F-NEXT:    movq %rax, %r10
-; AVX512F-NEXT:    seto %bpl
+; AVX512F-NEXT:    setb %bpl
 ; AVX512F-NEXT:    movq %r9, %rax
 ; AVX512F-NEXT:    mulq %rdi
-; AVX512F-NEXT:    seto %r9b
+; AVX512F-NEXT:    setb %r9b
 ; AVX512F-NEXT:    orb %bpl, %r9b
 ; AVX512F-NEXT:    orb %r11b, %r9b
 ; AVX512F-NEXT:    addq %rax, %r10
@@ -3264,10 +3263,10 @@ define <2 x i32> @umulo_v2i128(<2 x i128> %a0, <2 x i128> %a1, ptr %p2) nounwind
 ; AVX512BW-NEXT:    andb %dl, %bpl
 ; AVX512BW-NEXT:    mulq %r14
 ; AVX512BW-NEXT:    movq %rax, %r11
-; AVX512BW-NEXT:    seto %r15b
+; AVX512BW-NEXT:    setb %r15b
 ; AVX512BW-NEXT:    movq %rsi, %rax
 ; AVX512BW-NEXT:    mulq %rcx
-; AVX512BW-NEXT:    seto %r12b
+; AVX512BW-NEXT:    setb %r12b
 ; AVX512BW-NEXT:    orb %r15b, %r12b
 ; AVX512BW-NEXT:    orb %bpl, %r12b
 ; AVX512BW-NEXT:    addq %rax, %r11
@@ -3287,10 +3286,10 @@ define <2 x i32> @umulo_v2i128(<2 x i128> %a0, <2 x i128> %a1, ptr %p2) nounwind
 ; AVX512BW-NEXT:    movq %r10, %rax
 ; AVX512BW-NEXT:    mulq %r8
 ; AVX512BW-NEXT:    movq %rax, %r10
-; AVX512BW-NEXT:    seto %bpl
+; AVX512BW-NEXT:    setb %bpl
 ; AVX512BW-NEXT:    movq %r9, %rax
 ; AVX512BW-NEXT:    mulq %rdi
-; AVX512BW-NEXT:    seto %r9b
+; AVX512BW-NEXT:    setb %r9b
 ; AVX512BW-NEXT:    orb %bpl, %r9b
 ; AVX512BW-NEXT:    orb %r11b, %r9b
 ; AVX512BW-NEXT:    addq %rax, %r10

--- a/llvm/test/CodeGen/X86/xmulo.ll
+++ b/llvm/test/CodeGen/X86/xmulo.ll
@@ -63,7 +63,7 @@ define zeroext i1 @smuloi8(i8 %v1, i8 %v2, ptr %res) {
 ; SDAG-NEXT:    movl %edi, %eax
 ; SDAG-NEXT:    # kill: def $al killed $al killed $eax
 ; SDAG-NEXT:    imulb %sil
-; SDAG-NEXT:    seto %cl
+; SDAG-NEXT:    setb %cl
 ; SDAG-NEXT:    movb %al, (%rdx)
 ; SDAG-NEXT:    movl %ecx, %eax
 ; SDAG-NEXT:    retq
@@ -73,7 +73,7 @@ define zeroext i1 @smuloi8(i8 %v1, i8 %v2, ptr %res) {
 ; FAST-NEXT:    movl %edi, %eax
 ; FAST-NEXT:    # kill: def $al killed $al killed $eax
 ; FAST-NEXT:    imulb %sil
-; FAST-NEXT:    seto %cl
+; FAST-NEXT:    setb %cl
 ; FAST-NEXT:    movb %al, (%rdx)
 ; FAST-NEXT:    andb $1, %cl
 ; FAST-NEXT:    movl %ecx, %eax
@@ -83,7 +83,7 @@ define zeroext i1 @smuloi8(i8 %v1, i8 %v2, ptr %res) {
 ; WIN64:       # %bb.0:
 ; WIN64-NEXT:    movl %ecx, %eax
 ; WIN64-NEXT:    imulb %dl
-; WIN64-NEXT:    seto %cl
+; WIN64-NEXT:    setb %cl
 ; WIN64-NEXT:    movb %al, (%r8)
 ; WIN64-NEXT:    movl %ecx, %eax
 ; WIN64-NEXT:    retq
@@ -93,7 +93,7 @@ define zeroext i1 @smuloi8(i8 %v1, i8 %v2, ptr %res) {
 ; WIN32-NEXT:    movl {{[0-9]+}}(%esp), %edx
 ; WIN32-NEXT:    movzbl {{[0-9]+}}(%esp), %eax
 ; WIN32-NEXT:    imulb {{[0-9]+}}(%esp)
-; WIN32-NEXT:    seto %cl
+; WIN32-NEXT:    setb %cl
 ; WIN32-NEXT:    movb %al, (%edx)
 ; WIN32-NEXT:    movl %ecx, %eax
 ; WIN32-NEXT:    retl
@@ -108,14 +108,14 @@ define zeroext i1 @smuloi16(i16 %v1, i16 %v2, ptr %res) {
 ; SDAG-LABEL: smuloi16:
 ; SDAG:       # %bb.0:
 ; SDAG-NEXT:    imulw %si, %di
-; SDAG-NEXT:    seto %al
+; SDAG-NEXT:    setb %al
 ; SDAG-NEXT:    movw %di, (%rdx)
 ; SDAG-NEXT:    retq
 ;
 ; FAST-LABEL: smuloi16:
 ; FAST:       # %bb.0:
 ; FAST-NEXT:    imulw %si, %di
-; FAST-NEXT:    seto %al
+; FAST-NEXT:    setb %al
 ; FAST-NEXT:    movw %di, (%rdx)
 ; FAST-NEXT:    andb $1, %al
 ; FAST-NEXT:    retq
@@ -123,7 +123,7 @@ define zeroext i1 @smuloi16(i16 %v1, i16 %v2, ptr %res) {
 ; WIN64-LABEL: smuloi16:
 ; WIN64:       # %bb.0:
 ; WIN64-NEXT:    imulw %dx, %cx
-; WIN64-NEXT:    seto %al
+; WIN64-NEXT:    setb %al
 ; WIN64-NEXT:    movw %cx, (%r8)
 ; WIN64-NEXT:    retq
 ;
@@ -132,7 +132,7 @@ define zeroext i1 @smuloi16(i16 %v1, i16 %v2, ptr %res) {
 ; WIN32-NEXT:    movl {{[0-9]+}}(%esp), %ecx
 ; WIN32-NEXT:    movzwl {{[0-9]+}}(%esp), %edx
 ; WIN32-NEXT:    imulw {{[0-9]+}}(%esp), %dx
-; WIN32-NEXT:    seto %al
+; WIN32-NEXT:    setb %al
 ; WIN32-NEXT:    movw %dx, (%ecx)
 ; WIN32-NEXT:    retl
   %t = call {i16, i1} @llvm.smul.with.overflow.i16(i16 %v1, i16 %v2)
@@ -146,14 +146,14 @@ define zeroext i1 @smuloi32(i32 %v1, i32 %v2, ptr %res) {
 ; SDAG-LABEL: smuloi32:
 ; SDAG:       # %bb.0:
 ; SDAG-NEXT:    imull %esi, %edi
-; SDAG-NEXT:    seto %al
+; SDAG-NEXT:    setb %al
 ; SDAG-NEXT:    movl %edi, (%rdx)
 ; SDAG-NEXT:    retq
 ;
 ; FAST-LABEL: smuloi32:
 ; FAST:       # %bb.0:
 ; FAST-NEXT:    imull %esi, %edi
-; FAST-NEXT:    seto %al
+; FAST-NEXT:    setb %al
 ; FAST-NEXT:    movl %edi, (%rdx)
 ; FAST-NEXT:    andb $1, %al
 ; FAST-NEXT:    retq
@@ -161,7 +161,7 @@ define zeroext i1 @smuloi32(i32 %v1, i32 %v2, ptr %res) {
 ; WIN64-LABEL: smuloi32:
 ; WIN64:       # %bb.0:
 ; WIN64-NEXT:    imull %edx, %ecx
-; WIN64-NEXT:    seto %al
+; WIN64-NEXT:    setb %al
 ; WIN64-NEXT:    movl %ecx, (%r8)
 ; WIN64-NEXT:    retq
 ;
@@ -170,7 +170,7 @@ define zeroext i1 @smuloi32(i32 %v1, i32 %v2, ptr %res) {
 ; WIN32-NEXT:    movl {{[0-9]+}}(%esp), %ecx
 ; WIN32-NEXT:    movl {{[0-9]+}}(%esp), %edx
 ; WIN32-NEXT:    imull {{[0-9]+}}(%esp), %edx
-; WIN32-NEXT:    seto %al
+; WIN32-NEXT:    setb %al
 ; WIN32-NEXT:    movl %edx, (%ecx)
 ; WIN32-NEXT:    retl
   %t = call {i32, i1} @llvm.smul.with.overflow.i32(i32 %v1, i32 %v2)
@@ -184,14 +184,14 @@ define zeroext i1 @smuloi64(i64 %v1, i64 %v2, ptr %res) {
 ; SDAG-LABEL: smuloi64:
 ; SDAG:       # %bb.0:
 ; SDAG-NEXT:    imulq %rsi, %rdi
-; SDAG-NEXT:    seto %al
+; SDAG-NEXT:    setb %al
 ; SDAG-NEXT:    movq %rdi, (%rdx)
 ; SDAG-NEXT:    retq
 ;
 ; FAST-LABEL: smuloi64:
 ; FAST:       # %bb.0:
 ; FAST-NEXT:    imulq %rsi, %rdi
-; FAST-NEXT:    seto %al
+; FAST-NEXT:    setb %al
 ; FAST-NEXT:    movq %rdi, (%rdx)
 ; FAST-NEXT:    andb $1, %al
 ; FAST-NEXT:    retq
@@ -199,7 +199,7 @@ define zeroext i1 @smuloi64(i64 %v1, i64 %v2, ptr %res) {
 ; WIN64-LABEL: smuloi64:
 ; WIN64:       # %bb.0:
 ; WIN64-NEXT:    imulq %rdx, %rcx
-; WIN64-NEXT:    seto %al
+; WIN64-NEXT:    setb %al
 ; WIN64-NEXT:    movq %rcx, (%r8)
 ; WIN64-NEXT:    retq
 ;
@@ -276,7 +276,7 @@ define zeroext i1 @umuloi8(i8 %v1, i8 %v2, ptr %res) {
 ; SDAG-NEXT:    movl %edi, %eax
 ; SDAG-NEXT:    # kill: def $al killed $al killed $eax
 ; SDAG-NEXT:    mulb %sil
-; SDAG-NEXT:    seto %cl
+; SDAG-NEXT:    setb %cl
 ; SDAG-NEXT:    movb %al, (%rdx)
 ; SDAG-NEXT:    movl %ecx, %eax
 ; SDAG-NEXT:    retq
@@ -286,7 +286,7 @@ define zeroext i1 @umuloi8(i8 %v1, i8 %v2, ptr %res) {
 ; FAST-NEXT:    movl %edi, %eax
 ; FAST-NEXT:    # kill: def $al killed $al killed $eax
 ; FAST-NEXT:    mulb %sil
-; FAST-NEXT:    seto %cl
+; FAST-NEXT:    setb %cl
 ; FAST-NEXT:    movb %al, (%rdx)
 ; FAST-NEXT:    andb $1, %cl
 ; FAST-NEXT:    movl %ecx, %eax
@@ -296,7 +296,7 @@ define zeroext i1 @umuloi8(i8 %v1, i8 %v2, ptr %res) {
 ; WIN64:       # %bb.0:
 ; WIN64-NEXT:    movl %ecx, %eax
 ; WIN64-NEXT:    mulb %dl
-; WIN64-NEXT:    seto %cl
+; WIN64-NEXT:    setb %cl
 ; WIN64-NEXT:    movb %al, (%r8)
 ; WIN64-NEXT:    movl %ecx, %eax
 ; WIN64-NEXT:    retq
@@ -306,7 +306,7 @@ define zeroext i1 @umuloi8(i8 %v1, i8 %v2, ptr %res) {
 ; WIN32-NEXT:    movl {{[0-9]+}}(%esp), %edx
 ; WIN32-NEXT:    movzbl {{[0-9]+}}(%esp), %eax
 ; WIN32-NEXT:    mulb {{[0-9]+}}(%esp)
-; WIN32-NEXT:    seto %cl
+; WIN32-NEXT:    setb %cl
 ; WIN32-NEXT:    movb %al, (%edx)
 ; WIN32-NEXT:    movl %ecx, %eax
 ; WIN32-NEXT:    retl
@@ -324,7 +324,7 @@ define zeroext i1 @umuloi16(i16 %v1, i16 %v2, ptr %res) {
 ; SDAG-NEXT:    movl %edi, %eax
 ; SDAG-NEXT:    # kill: def $ax killed $ax killed $eax
 ; SDAG-NEXT:    mulw %si
-; SDAG-NEXT:    seto %dl
+; SDAG-NEXT:    setb %dl
 ; SDAG-NEXT:    movw %ax, (%rcx)
 ; SDAG-NEXT:    movl %edx, %eax
 ; SDAG-NEXT:    retq
@@ -335,7 +335,7 @@ define zeroext i1 @umuloi16(i16 %v1, i16 %v2, ptr %res) {
 ; FAST-NEXT:    movl %edi, %eax
 ; FAST-NEXT:    # kill: def $ax killed $ax killed $eax
 ; FAST-NEXT:    mulw %si
-; FAST-NEXT:    seto %dl
+; FAST-NEXT:    setb %dl
 ; FAST-NEXT:    movw %ax, (%rcx)
 ; FAST-NEXT:    andb $1, %dl
 ; FAST-NEXT:    movl %edx, %eax
@@ -345,7 +345,7 @@ define zeroext i1 @umuloi16(i16 %v1, i16 %v2, ptr %res) {
 ; WIN64:       # %bb.0:
 ; WIN64-NEXT:    movl %ecx, %eax
 ; WIN64-NEXT:    mulw %dx
-; WIN64-NEXT:    seto %cl
+; WIN64-NEXT:    setb %cl
 ; WIN64-NEXT:    movw %ax, (%r8)
 ; WIN64-NEXT:    movl %ecx, %eax
 ; WIN64-NEXT:    retq
@@ -356,7 +356,7 @@ define zeroext i1 @umuloi16(i16 %v1, i16 %v2, ptr %res) {
 ; WIN32-NEXT:    movl {{[0-9]+}}(%esp), %esi
 ; WIN32-NEXT:    movzwl {{[0-9]+}}(%esp), %eax
 ; WIN32-NEXT:    mulw {{[0-9]+}}(%esp)
-; WIN32-NEXT:    seto %cl
+; WIN32-NEXT:    setb %cl
 ; WIN32-NEXT:    movw %ax, (%esi)
 ; WIN32-NEXT:    movl %ecx, %eax
 ; WIN32-NEXT:    popl %esi
@@ -374,7 +374,7 @@ define zeroext i1 @umuloi32(i32 %v1, i32 %v2, ptr %res) {
 ; SDAG-NEXT:    movq %rdx, %rcx
 ; SDAG-NEXT:    movl %edi, %eax
 ; SDAG-NEXT:    mull %esi
-; SDAG-NEXT:    seto %dl
+; SDAG-NEXT:    setb %dl
 ; SDAG-NEXT:    movl %eax, (%rcx)
 ; SDAG-NEXT:    movl %edx, %eax
 ; SDAG-NEXT:    retq
@@ -384,7 +384,7 @@ define zeroext i1 @umuloi32(i32 %v1, i32 %v2, ptr %res) {
 ; FAST-NEXT:    movq %rdx, %rcx
 ; FAST-NEXT:    movl %edi, %eax
 ; FAST-NEXT:    mull %esi
-; FAST-NEXT:    seto %dl
+; FAST-NEXT:    setb %dl
 ; FAST-NEXT:    movl %eax, (%rcx)
 ; FAST-NEXT:    andb $1, %dl
 ; FAST-NEXT:    movl %edx, %eax
@@ -394,7 +394,7 @@ define zeroext i1 @umuloi32(i32 %v1, i32 %v2, ptr %res) {
 ; WIN64:       # %bb.0:
 ; WIN64-NEXT:    movl %ecx, %eax
 ; WIN64-NEXT:    mull %edx
-; WIN64-NEXT:    seto %cl
+; WIN64-NEXT:    setb %cl
 ; WIN64-NEXT:    movl %eax, (%r8)
 ; WIN64-NEXT:    movl %ecx, %eax
 ; WIN64-NEXT:    retq
@@ -405,7 +405,7 @@ define zeroext i1 @umuloi32(i32 %v1, i32 %v2, ptr %res) {
 ; WIN32-NEXT:    movl {{[0-9]+}}(%esp), %esi
 ; WIN32-NEXT:    movl {{[0-9]+}}(%esp), %eax
 ; WIN32-NEXT:    mull {{[0-9]+}}(%esp)
-; WIN32-NEXT:    seto %cl
+; WIN32-NEXT:    setb %cl
 ; WIN32-NEXT:    movl %eax, (%esi)
 ; WIN32-NEXT:    movl %ecx, %eax
 ; WIN32-NEXT:    popl %esi
@@ -423,7 +423,7 @@ define zeroext i1 @umuloi64(i64 %v1, i64 %v2, ptr %res) {
 ; SDAG-NEXT:    movq %rdx, %rcx
 ; SDAG-NEXT:    movq %rdi, %rax
 ; SDAG-NEXT:    mulq %rsi
-; SDAG-NEXT:    seto %dl
+; SDAG-NEXT:    setb %dl
 ; SDAG-NEXT:    movq %rax, (%rcx)
 ; SDAG-NEXT:    movl %edx, %eax
 ; SDAG-NEXT:    retq
@@ -433,7 +433,7 @@ define zeroext i1 @umuloi64(i64 %v1, i64 %v2, ptr %res) {
 ; FAST-NEXT:    movq %rdx, %rcx
 ; FAST-NEXT:    movq %rdi, %rax
 ; FAST-NEXT:    mulq %rsi
-; FAST-NEXT:    seto %dl
+; FAST-NEXT:    setb %dl
 ; FAST-NEXT:    movq %rax, (%rcx)
 ; FAST-NEXT:    andb $1, %dl
 ; FAST-NEXT:    movl %edx, %eax
@@ -443,7 +443,7 @@ define zeroext i1 @umuloi64(i64 %v1, i64 %v2, ptr %res) {
 ; WIN64:       # %bb.0:
 ; WIN64-NEXT:    movq %rcx, %rax
 ; WIN64-NEXT:    mulq %rdx
-; WIN64-NEXT:    seto %cl
+; WIN64-NEXT:    setb %cl
 ; WIN64-NEXT:    movq %rax, (%r8)
 ; WIN64-NEXT:    movl %ecx, %eax
 ; WIN64-NEXT:    retq
@@ -464,10 +464,10 @@ define zeroext i1 @umuloi64(i64 %v1, i64 %v2, ptr %res) {
 ; WIN32-NEXT:    andb %dl, %cl
 ; WIN32-NEXT:    mull {{[0-9]+}}(%esp)
 ; WIN32-NEXT:    movl %eax, %edi
-; WIN32-NEXT:    seto %bl
+; WIN32-NEXT:    setb %bl
 ; WIN32-NEXT:    movl %esi, %eax
 ; WIN32-NEXT:    mull %ebp
-; WIN32-NEXT:    seto %ch
+; WIN32-NEXT:    setb %ch
 ; WIN32-NEXT:    orb %bl, %ch
 ; WIN32-NEXT:    orb %cl, %ch
 ; WIN32-NEXT:    leal (%edi,%eax), %esi
@@ -501,7 +501,7 @@ define i32 @smuloselecti32(i32 %v1, i32 %v2) {
 ; LINUX-NEXT:    movl %esi, %eax
 ; LINUX-NEXT:    movl %edi, %ecx
 ; LINUX-NEXT:    imull %esi, %ecx
-; LINUX-NEXT:    cmovol %edi, %eax
+; LINUX-NEXT:    cmovbl %edi, %eax
 ; LINUX-NEXT:    retq
 ;
 ; WIN64-LABEL: smuloselecti32:
@@ -509,7 +509,7 @@ define i32 @smuloselecti32(i32 %v1, i32 %v2) {
 ; WIN64-NEXT:    movl %edx, %eax
 ; WIN64-NEXT:    movl %ecx, %edx
 ; WIN64-NEXT:    imull %eax, %edx
-; WIN64-NEXT:    cmovol %ecx, %eax
+; WIN64-NEXT:    cmovbl %ecx, %eax
 ; WIN64-NEXT:    retq
 ;
 ; WIN32-LABEL: smuloselecti32:
@@ -518,7 +518,7 @@ define i32 @smuloselecti32(i32 %v1, i32 %v2) {
 ; WIN32-NEXT:    movl {{[0-9]+}}(%esp), %eax
 ; WIN32-NEXT:    movl %eax, %edx
 ; WIN32-NEXT:    imull %ecx, %edx
-; WIN32-NEXT:    jo LBB11_2
+; WIN32-NEXT:    jb LBB11_2
 ; WIN32-NEXT:  # %bb.1:
 ; WIN32-NEXT:    movl %ecx, %eax
 ; WIN32-NEXT:  LBB11_2:
@@ -535,7 +535,7 @@ define i64 @smuloselecti64(i64 %v1, i64 %v2) {
 ; LINUX-NEXT:    movq %rsi, %rax
 ; LINUX-NEXT:    movq %rdi, %rcx
 ; LINUX-NEXT:    imulq %rsi, %rcx
-; LINUX-NEXT:    cmovoq %rdi, %rax
+; LINUX-NEXT:    cmovbq %rdi, %rax
 ; LINUX-NEXT:    retq
 ;
 ; WIN64-LABEL: smuloselecti64:
@@ -543,7 +543,7 @@ define i64 @smuloselecti64(i64 %v1, i64 %v2) {
 ; WIN64-NEXT:    movq %rdx, %rax
 ; WIN64-NEXT:    movq %rcx, %rdx
 ; WIN64-NEXT:    imulq %rax, %rdx
-; WIN64-NEXT:    cmovoq %rcx, %rax
+; WIN64-NEXT:    cmovbq %rcx, %rax
 ; WIN64-NEXT:    retq
 ;
 ; WIN32-LABEL: smuloselecti64:
@@ -618,7 +618,7 @@ define i32 @umuloselecti32(i32 %v1, i32 %v2) {
 ; LINUX:       # %bb.0:
 ; LINUX-NEXT:    movl %edi, %eax
 ; LINUX-NEXT:    mull %esi
-; LINUX-NEXT:    cmovol %edi, %esi
+; LINUX-NEXT:    cmovbl %edi, %esi
 ; LINUX-NEXT:    movl %esi, %eax
 ; LINUX-NEXT:    retq
 ;
@@ -627,7 +627,7 @@ define i32 @umuloselecti32(i32 %v1, i32 %v2) {
 ; WIN64-NEXT:    movl %edx, %r8d
 ; WIN64-NEXT:    movl %ecx, %eax
 ; WIN64-NEXT:    mull %edx
-; WIN64-NEXT:    cmovol %ecx, %r8d
+; WIN64-NEXT:    cmovbl %ecx, %r8d
 ; WIN64-NEXT:    movl %r8d, %eax
 ; WIN64-NEXT:    retq
 ;
@@ -638,7 +638,7 @@ define i32 @umuloselecti32(i32 %v1, i32 %v2) {
 ; WIN32-NEXT:    movl {{[0-9]+}}(%esp), %esi
 ; WIN32-NEXT:    movl %ecx, %eax
 ; WIN32-NEXT:    mull %esi
-; WIN32-NEXT:    jo LBB13_2
+; WIN32-NEXT:    jb LBB13_2
 ; WIN32-NEXT:  # %bb.1:
 ; WIN32-NEXT:    movl %esi, %ecx
 ; WIN32-NEXT:  LBB13_2:
@@ -656,7 +656,7 @@ define i64 @umuloselecti64(i64 %v1, i64 %v2) {
 ; LINUX:       # %bb.0:
 ; LINUX-NEXT:    movq %rdi, %rax
 ; LINUX-NEXT:    mulq %rsi
-; LINUX-NEXT:    cmovoq %rdi, %rsi
+; LINUX-NEXT:    cmovbq %rdi, %rsi
 ; LINUX-NEXT:    movq %rsi, %rax
 ; LINUX-NEXT:    retq
 ;
@@ -665,7 +665,7 @@ define i64 @umuloselecti64(i64 %v1, i64 %v2) {
 ; WIN64-NEXT:    movq %rdx, %r8
 ; WIN64-NEXT:    movq %rcx, %rax
 ; WIN64-NEXT:    mulq %rdx
-; WIN64-NEXT:    cmovoq %rcx, %r8
+; WIN64-NEXT:    cmovbq %rcx, %r8
 ; WIN64-NEXT:    movq %r8, %rax
 ; WIN64-NEXT:    retq
 ;
@@ -689,11 +689,11 @@ define i64 @umuloselecti64(i64 %v1, i64 %v2) {
 ; WIN32-NEXT:    mull %edi
 ; WIN32-NEXT:    movl %edi, %edx
 ; WIN32-NEXT:    movl %eax, %edi
-; WIN32-NEXT:    seto {{[-0-9]+}}(%e{{[sb]}}p) # 1-byte Folded Spill
+; WIN32-NEXT:    setb {{[-0-9]+}}(%e{{[sb]}}p) # 1-byte Folded Spill
 ; WIN32-NEXT:    movl %ebp, %eax
 ; WIN32-NEXT:    movl %edx, %ebp
 ; WIN32-NEXT:    mull %ecx
-; WIN32-NEXT:    seto %bh
+; WIN32-NEXT:    setb %bh
 ; WIN32-NEXT:    orb {{[-0-9]+}}(%e{{[sb]}}p), %bh # 1-byte Folded Reload
 ; WIN32-NEXT:    orb %bl, %bh
 ; WIN32-NEXT:    addl %eax, %edi
@@ -731,7 +731,7 @@ define zeroext i1 @smulobri8(i8 %v1, i8 %v2) {
 ; SDAG-NEXT:    movl %edi, %eax
 ; SDAG-NEXT:    # kill: def $al killed $al killed $eax
 ; SDAG-NEXT:    imulb %sil
-; SDAG-NEXT:    jo .LBB15_1
+; SDAG-NEXT:    jb .LBB15_1
 ; SDAG-NEXT:  # %bb.2: # %continue
 ; SDAG-NEXT:    movb $1, %al
 ; SDAG-NEXT:    retq
@@ -744,7 +744,7 @@ define zeroext i1 @smulobri8(i8 %v1, i8 %v2) {
 ; FAST-NEXT:    movl %edi, %eax
 ; FAST-NEXT:    # kill: def $al killed $al killed $eax
 ; FAST-NEXT:    imulb %sil
-; FAST-NEXT:    seto %al
+; FAST-NEXT:    setb %al
 ; FAST-NEXT:    testb $1, %al
 ; FAST-NEXT:    jne .LBB15_1
 ; FAST-NEXT:  # %bb.2: # %continue
@@ -761,7 +761,7 @@ define zeroext i1 @smulobri8(i8 %v1, i8 %v2) {
 ; WIN64:       # %bb.0:
 ; WIN64-NEXT:    movl %ecx, %eax
 ; WIN64-NEXT:    imulb %dl
-; WIN64-NEXT:    jo .LBB15_1
+; WIN64-NEXT:    jb .LBB15_1
 ; WIN64-NEXT:  # %bb.2: # %continue
 ; WIN64-NEXT:    movb $1, %al
 ; WIN64-NEXT:    retq
@@ -773,7 +773,7 @@ define zeroext i1 @smulobri8(i8 %v1, i8 %v2) {
 ; WIN32:       # %bb.0:
 ; WIN32-NEXT:    movzbl {{[0-9]+}}(%esp), %eax
 ; WIN32-NEXT:    imulb {{[0-9]+}}(%esp)
-; WIN32-NEXT:    jo LBB15_1
+; WIN32-NEXT:    jb LBB15_1
 ; WIN32-NEXT:  # %bb.2: # %continue
 ; WIN32-NEXT:    movb $1, %al
 ; WIN32-NEXT:    retl
@@ -796,7 +796,7 @@ define zeroext i1 @smulobri16(i16 %v1, i16 %v2) {
 ; SDAG-LABEL: smulobri16:
 ; SDAG:       # %bb.0:
 ; SDAG-NEXT:    imulw %si, %di
-; SDAG-NEXT:    jo .LBB16_1
+; SDAG-NEXT:    jb .LBB16_1
 ; SDAG-NEXT:  # %bb.2: # %continue
 ; SDAG-NEXT:    movb $1, %al
 ; SDAG-NEXT:    retq
@@ -807,7 +807,7 @@ define zeroext i1 @smulobri16(i16 %v1, i16 %v2) {
 ; FAST-LABEL: smulobri16:
 ; FAST:       # %bb.0:
 ; FAST-NEXT:    imulw %si, %di
-; FAST-NEXT:    seto %al
+; FAST-NEXT:    setb %al
 ; FAST-NEXT:    testb $1, %al
 ; FAST-NEXT:    jne .LBB16_1
 ; FAST-NEXT:  # %bb.2: # %continue
@@ -823,7 +823,7 @@ define zeroext i1 @smulobri16(i16 %v1, i16 %v2) {
 ; WIN64-LABEL: smulobri16:
 ; WIN64:       # %bb.0:
 ; WIN64-NEXT:    imulw %dx, %cx
-; WIN64-NEXT:    jo .LBB16_1
+; WIN64-NEXT:    jb .LBB16_1
 ; WIN64-NEXT:  # %bb.2: # %continue
 ; WIN64-NEXT:    movb $1, %al
 ; WIN64-NEXT:    retq
@@ -835,7 +835,7 @@ define zeroext i1 @smulobri16(i16 %v1, i16 %v2) {
 ; WIN32:       # %bb.0:
 ; WIN32-NEXT:    movzwl {{[0-9]+}}(%esp), %eax
 ; WIN32-NEXT:    imulw {{[0-9]+}}(%esp), %ax
-; WIN32-NEXT:    jo LBB16_1
+; WIN32-NEXT:    jb LBB16_1
 ; WIN32-NEXT:  # %bb.2: # %continue
 ; WIN32-NEXT:    movb $1, %al
 ; WIN32-NEXT:    retl
@@ -858,7 +858,7 @@ define zeroext i1 @smulobri32(i32 %v1, i32 %v2) {
 ; SDAG-LABEL: smulobri32:
 ; SDAG:       # %bb.0:
 ; SDAG-NEXT:    imull %esi, %edi
-; SDAG-NEXT:    jo .LBB17_1
+; SDAG-NEXT:    jb .LBB17_1
 ; SDAG-NEXT:  # %bb.2: # %continue
 ; SDAG-NEXT:    movb $1, %al
 ; SDAG-NEXT:    retq
@@ -869,7 +869,7 @@ define zeroext i1 @smulobri32(i32 %v1, i32 %v2) {
 ; FAST-LABEL: smulobri32:
 ; FAST:       # %bb.0:
 ; FAST-NEXT:    imull %esi, %edi
-; FAST-NEXT:    jo .LBB17_1
+; FAST-NEXT:    jb .LBB17_1
 ; FAST-NEXT:  # %bb.2: # %continue
 ; FAST-NEXT:    movb $1, %al
 ; FAST-NEXT:    andb $1, %al
@@ -883,7 +883,7 @@ define zeroext i1 @smulobri32(i32 %v1, i32 %v2) {
 ; WIN64-LABEL: smulobri32:
 ; WIN64:       # %bb.0:
 ; WIN64-NEXT:    imull %edx, %ecx
-; WIN64-NEXT:    jo .LBB17_1
+; WIN64-NEXT:    jb .LBB17_1
 ; WIN64-NEXT:  # %bb.2: # %continue
 ; WIN64-NEXT:    movb $1, %al
 ; WIN64-NEXT:    retq
@@ -895,7 +895,7 @@ define zeroext i1 @smulobri32(i32 %v1, i32 %v2) {
 ; WIN32:       # %bb.0:
 ; WIN32-NEXT:    movl {{[0-9]+}}(%esp), %eax
 ; WIN32-NEXT:    imull {{[0-9]+}}(%esp), %eax
-; WIN32-NEXT:    jo LBB17_1
+; WIN32-NEXT:    jb LBB17_1
 ; WIN32-NEXT:  # %bb.2: # %continue
 ; WIN32-NEXT:    movb $1, %al
 ; WIN32-NEXT:    retl
@@ -918,7 +918,7 @@ define zeroext i1 @smulobri64(i64 %v1, i64 %v2) {
 ; SDAG-LABEL: smulobri64:
 ; SDAG:       # %bb.0:
 ; SDAG-NEXT:    imulq %rsi, %rdi
-; SDAG-NEXT:    jo .LBB18_1
+; SDAG-NEXT:    jb .LBB18_1
 ; SDAG-NEXT:  # %bb.2: # %continue
 ; SDAG-NEXT:    movb $1, %al
 ; SDAG-NEXT:    retq
@@ -929,7 +929,7 @@ define zeroext i1 @smulobri64(i64 %v1, i64 %v2) {
 ; FAST-LABEL: smulobri64:
 ; FAST:       # %bb.0:
 ; FAST-NEXT:    imulq %rsi, %rdi
-; FAST-NEXT:    jo .LBB18_1
+; FAST-NEXT:    jb .LBB18_1
 ; FAST-NEXT:  # %bb.2: # %continue
 ; FAST-NEXT:    movb $1, %al
 ; FAST-NEXT:    andb $1, %al
@@ -943,7 +943,7 @@ define zeroext i1 @smulobri64(i64 %v1, i64 %v2) {
 ; WIN64-LABEL: smulobri64:
 ; WIN64:       # %bb.0:
 ; WIN64-NEXT:    imulq %rdx, %rcx
-; WIN64-NEXT:    jo .LBB18_1
+; WIN64-NEXT:    jb .LBB18_1
 ; WIN64-NEXT:  # %bb.2: # %continue
 ; WIN64-NEXT:    movb $1, %al
 ; WIN64-NEXT:    retq
@@ -1029,7 +1029,7 @@ define zeroext i1 @umulobri8(i8 %v1, i8 %v2) {
 ; SDAG-NEXT:    movl %edi, %eax
 ; SDAG-NEXT:    # kill: def $al killed $al killed $eax
 ; SDAG-NEXT:    mulb %sil
-; SDAG-NEXT:    jo .LBB19_1
+; SDAG-NEXT:    jb .LBB19_1
 ; SDAG-NEXT:  # %bb.2: # %continue
 ; SDAG-NEXT:    movb $1, %al
 ; SDAG-NEXT:    retq
@@ -1042,7 +1042,7 @@ define zeroext i1 @umulobri8(i8 %v1, i8 %v2) {
 ; FAST-NEXT:    movl %edi, %eax
 ; FAST-NEXT:    # kill: def $al killed $al killed $eax
 ; FAST-NEXT:    mulb %sil
-; FAST-NEXT:    seto %al
+; FAST-NEXT:    setb %al
 ; FAST-NEXT:    testb $1, %al
 ; FAST-NEXT:    jne .LBB19_1
 ; FAST-NEXT:  # %bb.2: # %continue
@@ -1059,7 +1059,7 @@ define zeroext i1 @umulobri8(i8 %v1, i8 %v2) {
 ; WIN64:       # %bb.0:
 ; WIN64-NEXT:    movl %ecx, %eax
 ; WIN64-NEXT:    mulb %dl
-; WIN64-NEXT:    jo .LBB19_1
+; WIN64-NEXT:    jb .LBB19_1
 ; WIN64-NEXT:  # %bb.2: # %continue
 ; WIN64-NEXT:    movb $1, %al
 ; WIN64-NEXT:    retq
@@ -1071,7 +1071,7 @@ define zeroext i1 @umulobri8(i8 %v1, i8 %v2) {
 ; WIN32:       # %bb.0:
 ; WIN32-NEXT:    movzbl {{[0-9]+}}(%esp), %eax
 ; WIN32-NEXT:    mulb {{[0-9]+}}(%esp)
-; WIN32-NEXT:    jo LBB19_1
+; WIN32-NEXT:    jb LBB19_1
 ; WIN32-NEXT:  # %bb.2: # %continue
 ; WIN32-NEXT:    movb $1, %al
 ; WIN32-NEXT:    retl
@@ -1096,7 +1096,7 @@ define zeroext i1 @umulobri16(i16 %v1, i16 %v2) {
 ; SDAG-NEXT:    movl %edi, %eax
 ; SDAG-NEXT:    # kill: def $ax killed $ax killed $eax
 ; SDAG-NEXT:    mulw %si
-; SDAG-NEXT:    jo .LBB20_1
+; SDAG-NEXT:    jb .LBB20_1
 ; SDAG-NEXT:  # %bb.2: # %continue
 ; SDAG-NEXT:    movb $1, %al
 ; SDAG-NEXT:    retq
@@ -1109,7 +1109,7 @@ define zeroext i1 @umulobri16(i16 %v1, i16 %v2) {
 ; FAST-NEXT:    movl %edi, %eax
 ; FAST-NEXT:    # kill: def $ax killed $ax killed $eax
 ; FAST-NEXT:    mulw %si
-; FAST-NEXT:    seto %al
+; FAST-NEXT:    setb %al
 ; FAST-NEXT:    testb $1, %al
 ; FAST-NEXT:    jne .LBB20_1
 ; FAST-NEXT:  # %bb.2: # %continue
@@ -1126,7 +1126,7 @@ define zeroext i1 @umulobri16(i16 %v1, i16 %v2) {
 ; WIN64:       # %bb.0:
 ; WIN64-NEXT:    movl %ecx, %eax
 ; WIN64-NEXT:    mulw %dx
-; WIN64-NEXT:    jo .LBB20_1
+; WIN64-NEXT:    jb .LBB20_1
 ; WIN64-NEXT:  # %bb.2: # %continue
 ; WIN64-NEXT:    movb $1, %al
 ; WIN64-NEXT:    retq
@@ -1138,7 +1138,7 @@ define zeroext i1 @umulobri16(i16 %v1, i16 %v2) {
 ; WIN32:       # %bb.0:
 ; WIN32-NEXT:    movzwl {{[0-9]+}}(%esp), %eax
 ; WIN32-NEXT:    mulw {{[0-9]+}}(%esp)
-; WIN32-NEXT:    jo LBB20_1
+; WIN32-NEXT:    jb LBB20_1
 ; WIN32-NEXT:  # %bb.2: # %continue
 ; WIN32-NEXT:    movb $1, %al
 ; WIN32-NEXT:    retl
@@ -1162,7 +1162,7 @@ define zeroext i1 @umulobri32(i32 %v1, i32 %v2) {
 ; SDAG:       # %bb.0:
 ; SDAG-NEXT:    movl %edi, %eax
 ; SDAG-NEXT:    mull %esi
-; SDAG-NEXT:    jo .LBB21_1
+; SDAG-NEXT:    jb .LBB21_1
 ; SDAG-NEXT:  # %bb.2: # %continue
 ; SDAG-NEXT:    movb $1, %al
 ; SDAG-NEXT:    retq
@@ -1174,7 +1174,7 @@ define zeroext i1 @umulobri32(i32 %v1, i32 %v2) {
 ; FAST:       # %bb.0:
 ; FAST-NEXT:    movl %edi, %eax
 ; FAST-NEXT:    mull %esi
-; FAST-NEXT:    jo .LBB21_1
+; FAST-NEXT:    jb .LBB21_1
 ; FAST-NEXT:  # %bb.2: # %continue
 ; FAST-NEXT:    movb $1, %al
 ; FAST-NEXT:    andb $1, %al
@@ -1189,7 +1189,7 @@ define zeroext i1 @umulobri32(i32 %v1, i32 %v2) {
 ; WIN64:       # %bb.0:
 ; WIN64-NEXT:    movl %ecx, %eax
 ; WIN64-NEXT:    mull %edx
-; WIN64-NEXT:    jo .LBB21_1
+; WIN64-NEXT:    jb .LBB21_1
 ; WIN64-NEXT:  # %bb.2: # %continue
 ; WIN64-NEXT:    movb $1, %al
 ; WIN64-NEXT:    retq
@@ -1201,7 +1201,7 @@ define zeroext i1 @umulobri32(i32 %v1, i32 %v2) {
 ; WIN32:       # %bb.0:
 ; WIN32-NEXT:    movl {{[0-9]+}}(%esp), %eax
 ; WIN32-NEXT:    mull {{[0-9]+}}(%esp)
-; WIN32-NEXT:    jo LBB21_1
+; WIN32-NEXT:    jb LBB21_1
 ; WIN32-NEXT:  # %bb.2: # %continue
 ; WIN32-NEXT:    movb $1, %al
 ; WIN32-NEXT:    retl
@@ -1225,7 +1225,7 @@ define zeroext i1 @umulobri64(i64 %v1, i64 %v2) {
 ; SDAG:       # %bb.0:
 ; SDAG-NEXT:    movq %rdi, %rax
 ; SDAG-NEXT:    mulq %rsi
-; SDAG-NEXT:    jo .LBB22_1
+; SDAG-NEXT:    jb .LBB22_1
 ; SDAG-NEXT:  # %bb.2: # %continue
 ; SDAG-NEXT:    movb $1, %al
 ; SDAG-NEXT:    retq
@@ -1237,7 +1237,7 @@ define zeroext i1 @umulobri64(i64 %v1, i64 %v2) {
 ; FAST:       # %bb.0:
 ; FAST-NEXT:    movq %rdi, %rax
 ; FAST-NEXT:    mulq %rsi
-; FAST-NEXT:    jo .LBB22_1
+; FAST-NEXT:    jb .LBB22_1
 ; FAST-NEXT:  # %bb.2: # %continue
 ; FAST-NEXT:    movb $1, %al
 ; FAST-NEXT:    andb $1, %al
@@ -1252,7 +1252,7 @@ define zeroext i1 @umulobri64(i64 %v1, i64 %v2) {
 ; WIN64:       # %bb.0:
 ; WIN64-NEXT:    movq %rcx, %rax
 ; WIN64-NEXT:    mulq %rdx
-; WIN64-NEXT:    jo .LBB22_1
+; WIN64-NEXT:    jb .LBB22_1
 ; WIN64-NEXT:  # %bb.2: # %continue
 ; WIN64-NEXT:    movb $1, %al
 ; WIN64-NEXT:    retq
@@ -1276,10 +1276,10 @@ define zeroext i1 @umulobri64(i64 %v1, i64 %v2) {
 ; WIN32-NEXT:    andb %dl, %cl
 ; WIN32-NEXT:    mull {{[0-9]+}}(%esp)
 ; WIN32-NEXT:    movl %eax, %edi
-; WIN32-NEXT:    seto %bl
+; WIN32-NEXT:    setb %bl
 ; WIN32-NEXT:    movl %esi, %eax
 ; WIN32-NEXT:    mull %ebp
-; WIN32-NEXT:    seto %ch
+; WIN32-NEXT:    setb %ch
 ; WIN32-NEXT:    orb %bl, %ch
 ; WIN32-NEXT:    orb %cl, %ch
 ; WIN32-NEXT:    leal (%edi,%eax), %esi
@@ -1319,7 +1319,7 @@ define i1 @bug27873(i64 %c1, i1 %c2) {
 ; LINUX-NEXT:    movq %rdi, %rax
 ; LINUX-NEXT:    movl $160, %ecx
 ; LINUX-NEXT:    mulq %rcx
-; LINUX-NEXT:    seto %al
+; LINUX-NEXT:    setb %al
 ; LINUX-NEXT:    orb %sil, %al
 ; LINUX-NEXT:    retq
 ;
@@ -1329,7 +1329,7 @@ define i1 @bug27873(i64 %c1, i1 %c2) {
 ; WIN64-NEXT:    movq %rcx, %rax
 ; WIN64-NEXT:    movl $160, %ecx
 ; WIN64-NEXT:    mulq %rcx
-; WIN64-NEXT:    seto %al
+; WIN64-NEXT:    setb %al
 ; WIN64-NEXT:    orb %r8b, %al
 ; WIN64-NEXT:    retq
 ;
@@ -1339,7 +1339,7 @@ define i1 @bug27873(i64 %c1, i1 %c2) {
 ; WIN32-NEXT:    movl $160, %eax
 ; WIN32-NEXT:    mull {{[0-9]+}}(%esp)
 ; WIN32-NEXT:    movl %eax, %ecx
-; WIN32-NEXT:    seto %bl
+; WIN32-NEXT:    setb %bl
 ; WIN32-NEXT:    movl $160, %eax
 ; WIN32-NEXT:    mull {{[0-9]+}}(%esp)
 ; WIN32-NEXT:    addl %ecx, %edx
@@ -1360,7 +1360,7 @@ define zeroext i1 @smuloi8_load(ptr %ptr1, i8 %v2, ptr %res) {
 ; SDAG-NEXT:    movl %esi, %eax
 ; SDAG-NEXT:    # kill: def $al killed $al killed $eax
 ; SDAG-NEXT:    imulb (%rdi)
-; SDAG-NEXT:    seto %cl
+; SDAG-NEXT:    setb %cl
 ; SDAG-NEXT:    movb %al, (%rdx)
 ; SDAG-NEXT:    movl %ecx, %eax
 ; SDAG-NEXT:    retq
@@ -1369,7 +1369,7 @@ define zeroext i1 @smuloi8_load(ptr %ptr1, i8 %v2, ptr %res) {
 ; FAST:       # %bb.0:
 ; FAST-NEXT:    movzbl (%rdi), %eax
 ; FAST-NEXT:    imulb %sil
-; FAST-NEXT:    seto %cl
+; FAST-NEXT:    setb %cl
 ; FAST-NEXT:    movb %al, (%rdx)
 ; FAST-NEXT:    andb $1, %cl
 ; FAST-NEXT:    movl %ecx, %eax
@@ -1379,7 +1379,7 @@ define zeroext i1 @smuloi8_load(ptr %ptr1, i8 %v2, ptr %res) {
 ; WIN64:       # %bb.0:
 ; WIN64-NEXT:    movl %edx, %eax
 ; WIN64-NEXT:    imulb (%rcx)
-; WIN64-NEXT:    seto %cl
+; WIN64-NEXT:    setb %cl
 ; WIN64-NEXT:    movb %al, (%r8)
 ; WIN64-NEXT:    movl %ecx, %eax
 ; WIN64-NEXT:    retq
@@ -1390,7 +1390,7 @@ define zeroext i1 @smuloi8_load(ptr %ptr1, i8 %v2, ptr %res) {
 ; WIN32-NEXT:    movl {{[0-9]+}}(%esp), %eax
 ; WIN32-NEXT:    movzbl (%eax), %eax
 ; WIN32-NEXT:    imulb {{[0-9]+}}(%esp)
-; WIN32-NEXT:    seto %cl
+; WIN32-NEXT:    setb %cl
 ; WIN32-NEXT:    movb %al, (%edx)
 ; WIN32-NEXT:    movl %ecx, %eax
 ; WIN32-NEXT:    retl
@@ -1408,7 +1408,7 @@ define zeroext i1 @smuloi8_load2(i8 %v1, ptr %ptr2, ptr %res) {
 ; SDAG-NEXT:    movl %edi, %eax
 ; SDAG-NEXT:    # kill: def $al killed $al killed $eax
 ; SDAG-NEXT:    imulb (%rsi)
-; SDAG-NEXT:    seto %cl
+; SDAG-NEXT:    setb %cl
 ; SDAG-NEXT:    movb %al, (%rdx)
 ; SDAG-NEXT:    movl %ecx, %eax
 ; SDAG-NEXT:    retq
@@ -1418,7 +1418,7 @@ define zeroext i1 @smuloi8_load2(i8 %v1, ptr %ptr2, ptr %res) {
 ; FAST-NEXT:    movl %edi, %eax
 ; FAST-NEXT:    # kill: def $al killed $al killed $eax
 ; FAST-NEXT:    imulb (%rsi)
-; FAST-NEXT:    seto %cl
+; FAST-NEXT:    setb %cl
 ; FAST-NEXT:    movb %al, (%rdx)
 ; FAST-NEXT:    andb $1, %cl
 ; FAST-NEXT:    movl %ecx, %eax
@@ -1428,7 +1428,7 @@ define zeroext i1 @smuloi8_load2(i8 %v1, ptr %ptr2, ptr %res) {
 ; WIN64:       # %bb.0:
 ; WIN64-NEXT:    movl %ecx, %eax
 ; WIN64-NEXT:    imulb (%rdx)
-; WIN64-NEXT:    seto %cl
+; WIN64-NEXT:    setb %cl
 ; WIN64-NEXT:    movb %al, (%r8)
 ; WIN64-NEXT:    movl %ecx, %eax
 ; WIN64-NEXT:    retq
@@ -1439,7 +1439,7 @@ define zeroext i1 @smuloi8_load2(i8 %v1, ptr %ptr2, ptr %res) {
 ; WIN32-NEXT:    movzbl {{[0-9]+}}(%esp), %eax
 ; WIN32-NEXT:    movl {{[0-9]+}}(%esp), %ecx
 ; WIN32-NEXT:    imulb (%ecx)
-; WIN32-NEXT:    seto %cl
+; WIN32-NEXT:    setb %cl
 ; WIN32-NEXT:    movb %al, (%edx)
 ; WIN32-NEXT:    movl %ecx, %eax
 ; WIN32-NEXT:    retl
@@ -1455,14 +1455,14 @@ define zeroext i1 @smuloi16_load(ptr %ptr1, i16 %v2, ptr %res) {
 ; SDAG-LABEL: smuloi16_load:
 ; SDAG:       # %bb.0:
 ; SDAG-NEXT:    imulw (%rdi), %si
-; SDAG-NEXT:    seto %al
+; SDAG-NEXT:    setb %al
 ; SDAG-NEXT:    movw %si, (%rdx)
 ; SDAG-NEXT:    retq
 ;
 ; FAST-LABEL: smuloi16_load:
 ; FAST:       # %bb.0:
 ; FAST-NEXT:    imulw (%rdi), %si
-; FAST-NEXT:    seto %al
+; FAST-NEXT:    setb %al
 ; FAST-NEXT:    movw %si, (%rdx)
 ; FAST-NEXT:    andb $1, %al
 ; FAST-NEXT:    retq
@@ -1470,7 +1470,7 @@ define zeroext i1 @smuloi16_load(ptr %ptr1, i16 %v2, ptr %res) {
 ; WIN64-LABEL: smuloi16_load:
 ; WIN64:       # %bb.0:
 ; WIN64-NEXT:    imulw (%rcx), %dx
-; WIN64-NEXT:    seto %al
+; WIN64-NEXT:    setb %al
 ; WIN64-NEXT:    movw %dx, (%r8)
 ; WIN64-NEXT:    retq
 ;
@@ -1480,7 +1480,7 @@ define zeroext i1 @smuloi16_load(ptr %ptr1, i16 %v2, ptr %res) {
 ; WIN32-NEXT:    movl {{[0-9]+}}(%esp), %eax
 ; WIN32-NEXT:    movzwl (%eax), %edx
 ; WIN32-NEXT:    imulw {{[0-9]+}}(%esp), %dx
-; WIN32-NEXT:    seto %al
+; WIN32-NEXT:    setb %al
 ; WIN32-NEXT:    movw %dx, (%ecx)
 ; WIN32-NEXT:    retl
   %v1 = load i16, ptr %ptr1
@@ -1495,14 +1495,14 @@ define zeroext i1 @smuloi16_load2(i16 %v1, ptr %ptr2, ptr %res) {
 ; SDAG-LABEL: smuloi16_load2:
 ; SDAG:       # %bb.0:
 ; SDAG-NEXT:    imulw (%rsi), %di
-; SDAG-NEXT:    seto %al
+; SDAG-NEXT:    setb %al
 ; SDAG-NEXT:    movw %di, (%rdx)
 ; SDAG-NEXT:    retq
 ;
 ; FAST-LABEL: smuloi16_load2:
 ; FAST:       # %bb.0:
 ; FAST-NEXT:    imulw (%rsi), %di
-; FAST-NEXT:    seto %al
+; FAST-NEXT:    setb %al
 ; FAST-NEXT:    movw %di, (%rdx)
 ; FAST-NEXT:    andb $1, %al
 ; FAST-NEXT:    retq
@@ -1510,7 +1510,7 @@ define zeroext i1 @smuloi16_load2(i16 %v1, ptr %ptr2, ptr %res) {
 ; WIN64-LABEL: smuloi16_load2:
 ; WIN64:       # %bb.0:
 ; WIN64-NEXT:    imulw (%rdx), %cx
-; WIN64-NEXT:    seto %al
+; WIN64-NEXT:    setb %al
 ; WIN64-NEXT:    movw %cx, (%r8)
 ; WIN64-NEXT:    retq
 ;
@@ -1520,7 +1520,7 @@ define zeroext i1 @smuloi16_load2(i16 %v1, ptr %ptr2, ptr %res) {
 ; WIN32-NEXT:    movl {{[0-9]+}}(%esp), %eax
 ; WIN32-NEXT:    movzwl {{[0-9]+}}(%esp), %edx
 ; WIN32-NEXT:    imulw (%eax), %dx
-; WIN32-NEXT:    seto %al
+; WIN32-NEXT:    setb %al
 ; WIN32-NEXT:    movw %dx, (%ecx)
 ; WIN32-NEXT:    retl
   %v2 = load i16, ptr %ptr2
@@ -1535,14 +1535,14 @@ define zeroext i1 @smuloi32_load(ptr %ptr1, i32 %v2, ptr %res) {
 ; SDAG-LABEL: smuloi32_load:
 ; SDAG:       # %bb.0:
 ; SDAG-NEXT:    imull (%rdi), %esi
-; SDAG-NEXT:    seto %al
+; SDAG-NEXT:    setb %al
 ; SDAG-NEXT:    movl %esi, (%rdx)
 ; SDAG-NEXT:    retq
 ;
 ; FAST-LABEL: smuloi32_load:
 ; FAST:       # %bb.0:
 ; FAST-NEXT:    imull (%rdi), %esi
-; FAST-NEXT:    seto %al
+; FAST-NEXT:    setb %al
 ; FAST-NEXT:    movl %esi, (%rdx)
 ; FAST-NEXT:    andb $1, %al
 ; FAST-NEXT:    retq
@@ -1550,7 +1550,7 @@ define zeroext i1 @smuloi32_load(ptr %ptr1, i32 %v2, ptr %res) {
 ; WIN64-LABEL: smuloi32_load:
 ; WIN64:       # %bb.0:
 ; WIN64-NEXT:    imull (%rcx), %edx
-; WIN64-NEXT:    seto %al
+; WIN64-NEXT:    setb %al
 ; WIN64-NEXT:    movl %edx, (%r8)
 ; WIN64-NEXT:    retq
 ;
@@ -1560,7 +1560,7 @@ define zeroext i1 @smuloi32_load(ptr %ptr1, i32 %v2, ptr %res) {
 ; WIN32-NEXT:    movl {{[0-9]+}}(%esp), %eax
 ; WIN32-NEXT:    movl (%eax), %edx
 ; WIN32-NEXT:    imull {{[0-9]+}}(%esp), %edx
-; WIN32-NEXT:    seto %al
+; WIN32-NEXT:    setb %al
 ; WIN32-NEXT:    movl %edx, (%ecx)
 ; WIN32-NEXT:    retl
   %v1 = load i32, ptr %ptr1
@@ -1575,14 +1575,14 @@ define zeroext i1 @smuloi32_load2(i32 %v1, ptr %ptr2, ptr %res) {
 ; SDAG-LABEL: smuloi32_load2:
 ; SDAG:       # %bb.0:
 ; SDAG-NEXT:    imull (%rsi), %edi
-; SDAG-NEXT:    seto %al
+; SDAG-NEXT:    setb %al
 ; SDAG-NEXT:    movl %edi, (%rdx)
 ; SDAG-NEXT:    retq
 ;
 ; FAST-LABEL: smuloi32_load2:
 ; FAST:       # %bb.0:
 ; FAST-NEXT:    imull (%rsi), %edi
-; FAST-NEXT:    seto %al
+; FAST-NEXT:    setb %al
 ; FAST-NEXT:    movl %edi, (%rdx)
 ; FAST-NEXT:    andb $1, %al
 ; FAST-NEXT:    retq
@@ -1590,7 +1590,7 @@ define zeroext i1 @smuloi32_load2(i32 %v1, ptr %ptr2, ptr %res) {
 ; WIN64-LABEL: smuloi32_load2:
 ; WIN64:       # %bb.0:
 ; WIN64-NEXT:    imull (%rdx), %ecx
-; WIN64-NEXT:    seto %al
+; WIN64-NEXT:    setb %al
 ; WIN64-NEXT:    movl %ecx, (%r8)
 ; WIN64-NEXT:    retq
 ;
@@ -1600,7 +1600,7 @@ define zeroext i1 @smuloi32_load2(i32 %v1, ptr %ptr2, ptr %res) {
 ; WIN32-NEXT:    movl {{[0-9]+}}(%esp), %eax
 ; WIN32-NEXT:    movl {{[0-9]+}}(%esp), %edx
 ; WIN32-NEXT:    imull (%eax), %edx
-; WIN32-NEXT:    seto %al
+; WIN32-NEXT:    setb %al
 ; WIN32-NEXT:    movl %edx, (%ecx)
 ; WIN32-NEXT:    retl
   %v2 = load i32, ptr %ptr2
@@ -1615,14 +1615,14 @@ define zeroext i1 @smuloi64_load(ptr %ptr1, i64 %v2, ptr %res) {
 ; SDAG-LABEL: smuloi64_load:
 ; SDAG:       # %bb.0:
 ; SDAG-NEXT:    imulq (%rdi), %rsi
-; SDAG-NEXT:    seto %al
+; SDAG-NEXT:    setb %al
 ; SDAG-NEXT:    movq %rsi, (%rdx)
 ; SDAG-NEXT:    retq
 ;
 ; FAST-LABEL: smuloi64_load:
 ; FAST:       # %bb.0:
 ; FAST-NEXT:    imulq (%rdi), %rsi
-; FAST-NEXT:    seto %al
+; FAST-NEXT:    setb %al
 ; FAST-NEXT:    movq %rsi, (%rdx)
 ; FAST-NEXT:    andb $1, %al
 ; FAST-NEXT:    retq
@@ -1630,7 +1630,7 @@ define zeroext i1 @smuloi64_load(ptr %ptr1, i64 %v2, ptr %res) {
 ; WIN64-LABEL: smuloi64_load:
 ; WIN64:       # %bb.0:
 ; WIN64-NEXT:    imulq (%rcx), %rdx
-; WIN64-NEXT:    seto %al
+; WIN64-NEXT:    setb %al
 ; WIN64-NEXT:    movq %rdx, (%r8)
 ; WIN64-NEXT:    retq
 ;
@@ -1708,14 +1708,14 @@ define zeroext i1 @smuloi64_load2(i64 %v1, ptr %ptr2, ptr %res) {
 ; SDAG-LABEL: smuloi64_load2:
 ; SDAG:       # %bb.0:
 ; SDAG-NEXT:    imulq (%rsi), %rdi
-; SDAG-NEXT:    seto %al
+; SDAG-NEXT:    setb %al
 ; SDAG-NEXT:    movq %rdi, (%rdx)
 ; SDAG-NEXT:    retq
 ;
 ; FAST-LABEL: smuloi64_load2:
 ; FAST:       # %bb.0:
 ; FAST-NEXT:    imulq (%rsi), %rdi
-; FAST-NEXT:    seto %al
+; FAST-NEXT:    setb %al
 ; FAST-NEXT:    movq %rdi, (%rdx)
 ; FAST-NEXT:    andb $1, %al
 ; FAST-NEXT:    retq
@@ -1723,7 +1723,7 @@ define zeroext i1 @smuloi64_load2(i64 %v1, ptr %ptr2, ptr %res) {
 ; WIN64-LABEL: smuloi64_load2:
 ; WIN64:       # %bb.0:
 ; WIN64-NEXT:    imulq (%rdx), %rcx
-; WIN64-NEXT:    seto %al
+; WIN64-NEXT:    setb %al
 ; WIN64-NEXT:    movq %rcx, (%r8)
 ; WIN64-NEXT:    retq
 ;
@@ -1803,7 +1803,7 @@ define zeroext i1 @umuloi8_load(ptr %ptr1, i8 %v2, ptr %res) {
 ; SDAG-NEXT:    movl %esi, %eax
 ; SDAG-NEXT:    # kill: def $al killed $al killed $eax
 ; SDAG-NEXT:    mulb (%rdi)
-; SDAG-NEXT:    seto %cl
+; SDAG-NEXT:    setb %cl
 ; SDAG-NEXT:    movb %al, (%rdx)
 ; SDAG-NEXT:    movl %ecx, %eax
 ; SDAG-NEXT:    retq
@@ -1812,7 +1812,7 @@ define zeroext i1 @umuloi8_load(ptr %ptr1, i8 %v2, ptr %res) {
 ; FAST:       # %bb.0:
 ; FAST-NEXT:    movzbl (%rdi), %eax
 ; FAST-NEXT:    mulb %sil
-; FAST-NEXT:    seto %cl
+; FAST-NEXT:    setb %cl
 ; FAST-NEXT:    movb %al, (%rdx)
 ; FAST-NEXT:    andb $1, %cl
 ; FAST-NEXT:    movl %ecx, %eax
@@ -1822,7 +1822,7 @@ define zeroext i1 @umuloi8_load(ptr %ptr1, i8 %v2, ptr %res) {
 ; WIN64:       # %bb.0:
 ; WIN64-NEXT:    movl %edx, %eax
 ; WIN64-NEXT:    mulb (%rcx)
-; WIN64-NEXT:    seto %cl
+; WIN64-NEXT:    setb %cl
 ; WIN64-NEXT:    movb %al, (%r8)
 ; WIN64-NEXT:    movl %ecx, %eax
 ; WIN64-NEXT:    retq
@@ -1833,7 +1833,7 @@ define zeroext i1 @umuloi8_load(ptr %ptr1, i8 %v2, ptr %res) {
 ; WIN32-NEXT:    movl {{[0-9]+}}(%esp), %eax
 ; WIN32-NEXT:    movzbl (%eax), %eax
 ; WIN32-NEXT:    mulb {{[0-9]+}}(%esp)
-; WIN32-NEXT:    seto %cl
+; WIN32-NEXT:    setb %cl
 ; WIN32-NEXT:    movb %al, (%edx)
 ; WIN32-NEXT:    movl %ecx, %eax
 ; WIN32-NEXT:    retl
@@ -1851,7 +1851,7 @@ define zeroext i1 @umuloi8_load2(i8 %v1, ptr %ptr2, ptr %res) {
 ; SDAG-NEXT:    movl %edi, %eax
 ; SDAG-NEXT:    # kill: def $al killed $al killed $eax
 ; SDAG-NEXT:    mulb (%rsi)
-; SDAG-NEXT:    seto %cl
+; SDAG-NEXT:    setb %cl
 ; SDAG-NEXT:    movb %al, (%rdx)
 ; SDAG-NEXT:    movl %ecx, %eax
 ; SDAG-NEXT:    retq
@@ -1861,7 +1861,7 @@ define zeroext i1 @umuloi8_load2(i8 %v1, ptr %ptr2, ptr %res) {
 ; FAST-NEXT:    movl %edi, %eax
 ; FAST-NEXT:    # kill: def $al killed $al killed $eax
 ; FAST-NEXT:    mulb (%rsi)
-; FAST-NEXT:    seto %cl
+; FAST-NEXT:    setb %cl
 ; FAST-NEXT:    movb %al, (%rdx)
 ; FAST-NEXT:    andb $1, %cl
 ; FAST-NEXT:    movl %ecx, %eax
@@ -1871,7 +1871,7 @@ define zeroext i1 @umuloi8_load2(i8 %v1, ptr %ptr2, ptr %res) {
 ; WIN64:       # %bb.0:
 ; WIN64-NEXT:    movl %ecx, %eax
 ; WIN64-NEXT:    mulb (%rdx)
-; WIN64-NEXT:    seto %cl
+; WIN64-NEXT:    setb %cl
 ; WIN64-NEXT:    movb %al, (%r8)
 ; WIN64-NEXT:    movl %ecx, %eax
 ; WIN64-NEXT:    retq
@@ -1882,7 +1882,7 @@ define zeroext i1 @umuloi8_load2(i8 %v1, ptr %ptr2, ptr %res) {
 ; WIN32-NEXT:    movzbl {{[0-9]+}}(%esp), %eax
 ; WIN32-NEXT:    movl {{[0-9]+}}(%esp), %ecx
 ; WIN32-NEXT:    mulb (%ecx)
-; WIN32-NEXT:    seto %cl
+; WIN32-NEXT:    setb %cl
 ; WIN32-NEXT:    movb %al, (%edx)
 ; WIN32-NEXT:    movl %ecx, %eax
 ; WIN32-NEXT:    retl
@@ -1901,7 +1901,7 @@ define zeroext i1 @umuloi16_load(ptr %ptr1, i16 %v2, ptr %res) {
 ; SDAG-NEXT:    movl %esi, %eax
 ; SDAG-NEXT:    # kill: def $ax killed $ax killed $eax
 ; SDAG-NEXT:    mulw (%rdi)
-; SDAG-NEXT:    seto %dl
+; SDAG-NEXT:    setb %dl
 ; SDAG-NEXT:    movw %ax, (%rcx)
 ; SDAG-NEXT:    movl %edx, %eax
 ; SDAG-NEXT:    retq
@@ -1911,7 +1911,7 @@ define zeroext i1 @umuloi16_load(ptr %ptr1, i16 %v2, ptr %res) {
 ; FAST-NEXT:    movq %rdx, %rcx
 ; FAST-NEXT:    movzwl (%rdi), %eax
 ; FAST-NEXT:    mulw %si
-; FAST-NEXT:    seto %dl
+; FAST-NEXT:    setb %dl
 ; FAST-NEXT:    movw %ax, (%rcx)
 ; FAST-NEXT:    andb $1, %dl
 ; FAST-NEXT:    movl %edx, %eax
@@ -1921,7 +1921,7 @@ define zeroext i1 @umuloi16_load(ptr %ptr1, i16 %v2, ptr %res) {
 ; WIN64:       # %bb.0:
 ; WIN64-NEXT:    movl %edx, %eax
 ; WIN64-NEXT:    mulw (%rcx)
-; WIN64-NEXT:    seto %cl
+; WIN64-NEXT:    setb %cl
 ; WIN64-NEXT:    movw %ax, (%r8)
 ; WIN64-NEXT:    movl %ecx, %eax
 ; WIN64-NEXT:    retq
@@ -1933,7 +1933,7 @@ define zeroext i1 @umuloi16_load(ptr %ptr1, i16 %v2, ptr %res) {
 ; WIN32-NEXT:    movl {{[0-9]+}}(%esp), %eax
 ; WIN32-NEXT:    movzwl (%eax), %eax
 ; WIN32-NEXT:    mulw {{[0-9]+}}(%esp)
-; WIN32-NEXT:    seto %cl
+; WIN32-NEXT:    setb %cl
 ; WIN32-NEXT:    movw %ax, (%esi)
 ; WIN32-NEXT:    movl %ecx, %eax
 ; WIN32-NEXT:    popl %esi
@@ -1953,7 +1953,7 @@ define zeroext i1 @umuloi16_load2(i16 %v1, ptr %ptr2, ptr %res) {
 ; SDAG-NEXT:    movl %edi, %eax
 ; SDAG-NEXT:    # kill: def $ax killed $ax killed $eax
 ; SDAG-NEXT:    mulw (%rsi)
-; SDAG-NEXT:    seto %dl
+; SDAG-NEXT:    setb %dl
 ; SDAG-NEXT:    movw %ax, (%rcx)
 ; SDAG-NEXT:    movl %edx, %eax
 ; SDAG-NEXT:    retq
@@ -1964,7 +1964,7 @@ define zeroext i1 @umuloi16_load2(i16 %v1, ptr %ptr2, ptr %res) {
 ; FAST-NEXT:    movl %edi, %eax
 ; FAST-NEXT:    # kill: def $ax killed $ax killed $eax
 ; FAST-NEXT:    mulw (%rsi)
-; FAST-NEXT:    seto %dl
+; FAST-NEXT:    setb %dl
 ; FAST-NEXT:    movw %ax, (%rcx)
 ; FAST-NEXT:    andb $1, %dl
 ; FAST-NEXT:    movl %edx, %eax
@@ -1974,7 +1974,7 @@ define zeroext i1 @umuloi16_load2(i16 %v1, ptr %ptr2, ptr %res) {
 ; WIN64:       # %bb.0:
 ; WIN64-NEXT:    movl %ecx, %eax
 ; WIN64-NEXT:    mulw (%rdx)
-; WIN64-NEXT:    seto %cl
+; WIN64-NEXT:    setb %cl
 ; WIN64-NEXT:    movw %ax, (%r8)
 ; WIN64-NEXT:    movl %ecx, %eax
 ; WIN64-NEXT:    retq
@@ -1986,7 +1986,7 @@ define zeroext i1 @umuloi16_load2(i16 %v1, ptr %ptr2, ptr %res) {
 ; WIN32-NEXT:    movzwl {{[0-9]+}}(%esp), %eax
 ; WIN32-NEXT:    movl {{[0-9]+}}(%esp), %ecx
 ; WIN32-NEXT:    mulw (%ecx)
-; WIN32-NEXT:    seto %cl
+; WIN32-NEXT:    setb %cl
 ; WIN32-NEXT:    movw %ax, (%esi)
 ; WIN32-NEXT:    movl %ecx, %eax
 ; WIN32-NEXT:    popl %esi
@@ -2005,7 +2005,7 @@ define zeroext i1 @umuloi32_load(ptr %ptr1, i32 %v2, ptr %res) {
 ; SDAG-NEXT:    movq %rdx, %rcx
 ; SDAG-NEXT:    movl %esi, %eax
 ; SDAG-NEXT:    mull (%rdi)
-; SDAG-NEXT:    seto %dl
+; SDAG-NEXT:    setb %dl
 ; SDAG-NEXT:    movl %eax, (%rcx)
 ; SDAG-NEXT:    movl %edx, %eax
 ; SDAG-NEXT:    retq
@@ -2015,7 +2015,7 @@ define zeroext i1 @umuloi32_load(ptr %ptr1, i32 %v2, ptr %res) {
 ; FAST-NEXT:    movq %rdx, %rcx
 ; FAST-NEXT:    movl (%rdi), %eax
 ; FAST-NEXT:    mull %esi
-; FAST-NEXT:    seto %dl
+; FAST-NEXT:    setb %dl
 ; FAST-NEXT:    movl %eax, (%rcx)
 ; FAST-NEXT:    andb $1, %dl
 ; FAST-NEXT:    movl %edx, %eax
@@ -2025,7 +2025,7 @@ define zeroext i1 @umuloi32_load(ptr %ptr1, i32 %v2, ptr %res) {
 ; WIN64:       # %bb.0:
 ; WIN64-NEXT:    movl %edx, %eax
 ; WIN64-NEXT:    mull (%rcx)
-; WIN64-NEXT:    seto %cl
+; WIN64-NEXT:    setb %cl
 ; WIN64-NEXT:    movl %eax, (%r8)
 ; WIN64-NEXT:    movl %ecx, %eax
 ; WIN64-NEXT:    retq
@@ -2037,7 +2037,7 @@ define zeroext i1 @umuloi32_load(ptr %ptr1, i32 %v2, ptr %res) {
 ; WIN32-NEXT:    movl {{[0-9]+}}(%esp), %eax
 ; WIN32-NEXT:    movl (%eax), %eax
 ; WIN32-NEXT:    mull {{[0-9]+}}(%esp)
-; WIN32-NEXT:    seto %cl
+; WIN32-NEXT:    setb %cl
 ; WIN32-NEXT:    movl %eax, (%esi)
 ; WIN32-NEXT:    movl %ecx, %eax
 ; WIN32-NEXT:    popl %esi
@@ -2056,7 +2056,7 @@ define zeroext i1 @umuloi32_load2(i32 %v1, ptr %ptr2, ptr %res) {
 ; SDAG-NEXT:    movq %rdx, %rcx
 ; SDAG-NEXT:    movl %edi, %eax
 ; SDAG-NEXT:    mull (%rsi)
-; SDAG-NEXT:    seto %dl
+; SDAG-NEXT:    setb %dl
 ; SDAG-NEXT:    movl %eax, (%rcx)
 ; SDAG-NEXT:    movl %edx, %eax
 ; SDAG-NEXT:    retq
@@ -2066,7 +2066,7 @@ define zeroext i1 @umuloi32_load2(i32 %v1, ptr %ptr2, ptr %res) {
 ; FAST-NEXT:    movq %rdx, %rcx
 ; FAST-NEXT:    movl %edi, %eax
 ; FAST-NEXT:    mull (%rsi)
-; FAST-NEXT:    seto %dl
+; FAST-NEXT:    setb %dl
 ; FAST-NEXT:    movl %eax, (%rcx)
 ; FAST-NEXT:    andb $1, %dl
 ; FAST-NEXT:    movl %edx, %eax
@@ -2076,7 +2076,7 @@ define zeroext i1 @umuloi32_load2(i32 %v1, ptr %ptr2, ptr %res) {
 ; WIN64:       # %bb.0:
 ; WIN64-NEXT:    movl %ecx, %eax
 ; WIN64-NEXT:    mull (%rdx)
-; WIN64-NEXT:    seto %cl
+; WIN64-NEXT:    setb %cl
 ; WIN64-NEXT:    movl %eax, (%r8)
 ; WIN64-NEXT:    movl %ecx, %eax
 ; WIN64-NEXT:    retq
@@ -2088,7 +2088,7 @@ define zeroext i1 @umuloi32_load2(i32 %v1, ptr %ptr2, ptr %res) {
 ; WIN32-NEXT:    movl {{[0-9]+}}(%esp), %eax
 ; WIN32-NEXT:    movl {{[0-9]+}}(%esp), %ecx
 ; WIN32-NEXT:    mull (%ecx)
-; WIN32-NEXT:    seto %cl
+; WIN32-NEXT:    setb %cl
 ; WIN32-NEXT:    movl %eax, (%esi)
 ; WIN32-NEXT:    movl %ecx, %eax
 ; WIN32-NEXT:    popl %esi
@@ -2107,7 +2107,7 @@ define zeroext i1 @umuloi64_load(ptr %ptr1, i64 %v2, ptr %res) {
 ; SDAG-NEXT:    movq %rdx, %rcx
 ; SDAG-NEXT:    movq %rsi, %rax
 ; SDAG-NEXT:    mulq (%rdi)
-; SDAG-NEXT:    seto %dl
+; SDAG-NEXT:    setb %dl
 ; SDAG-NEXT:    movq %rax, (%rcx)
 ; SDAG-NEXT:    movl %edx, %eax
 ; SDAG-NEXT:    retq
@@ -2117,7 +2117,7 @@ define zeroext i1 @umuloi64_load(ptr %ptr1, i64 %v2, ptr %res) {
 ; FAST-NEXT:    movq %rdx, %rcx
 ; FAST-NEXT:    movq (%rdi), %rax
 ; FAST-NEXT:    mulq %rsi
-; FAST-NEXT:    seto %dl
+; FAST-NEXT:    setb %dl
 ; FAST-NEXT:    movq %rax, (%rcx)
 ; FAST-NEXT:    andb $1, %dl
 ; FAST-NEXT:    movl %edx, %eax
@@ -2127,7 +2127,7 @@ define zeroext i1 @umuloi64_load(ptr %ptr1, i64 %v2, ptr %res) {
 ; WIN64:       # %bb.0:
 ; WIN64-NEXT:    movq %rdx, %rax
 ; WIN64-NEXT:    mulq (%rcx)
-; WIN64-NEXT:    seto %cl
+; WIN64-NEXT:    setb %cl
 ; WIN64-NEXT:    movq %rax, (%r8)
 ; WIN64-NEXT:    movl %ecx, %eax
 ; WIN64-NEXT:    retq
@@ -2149,10 +2149,10 @@ define zeroext i1 @umuloi64_load(ptr %ptr1, i64 %v2, ptr %res) {
 ; WIN32-NEXT:    andb %dl, %cl
 ; WIN32-NEXT:    mull {{[0-9]+}}(%esp)
 ; WIN32-NEXT:    movl %eax, %edi
-; WIN32-NEXT:    seto %bl
+; WIN32-NEXT:    setb %bl
 ; WIN32-NEXT:    movl %esi, %eax
 ; WIN32-NEXT:    mull %ebp
-; WIN32-NEXT:    seto %ch
+; WIN32-NEXT:    setb %ch
 ; WIN32-NEXT:    orb %bl, %ch
 ; WIN32-NEXT:    orb %cl, %ch
 ; WIN32-NEXT:    leal (%edi,%eax), %esi
@@ -2184,7 +2184,7 @@ define zeroext i1 @umuloi64_load2(i64 %v1, ptr %ptr2, ptr %res) {
 ; SDAG-NEXT:    movq %rdx, %rcx
 ; SDAG-NEXT:    movq %rdi, %rax
 ; SDAG-NEXT:    mulq (%rsi)
-; SDAG-NEXT:    seto %dl
+; SDAG-NEXT:    setb %dl
 ; SDAG-NEXT:    movq %rax, (%rcx)
 ; SDAG-NEXT:    movl %edx, %eax
 ; SDAG-NEXT:    retq
@@ -2194,7 +2194,7 @@ define zeroext i1 @umuloi64_load2(i64 %v1, ptr %ptr2, ptr %res) {
 ; FAST-NEXT:    movq %rdx, %rcx
 ; FAST-NEXT:    movq %rdi, %rax
 ; FAST-NEXT:    mulq (%rsi)
-; FAST-NEXT:    seto %dl
+; FAST-NEXT:    setb %dl
 ; FAST-NEXT:    movq %rax, (%rcx)
 ; FAST-NEXT:    andb $1, %dl
 ; FAST-NEXT:    movl %edx, %eax
@@ -2204,7 +2204,7 @@ define zeroext i1 @umuloi64_load2(i64 %v1, ptr %ptr2, ptr %res) {
 ; WIN64:       # %bb.0:
 ; WIN64-NEXT:    movq %rcx, %rax
 ; WIN64-NEXT:    mulq (%rdx)
-; WIN64-NEXT:    seto %cl
+; WIN64-NEXT:    setb %cl
 ; WIN64-NEXT:    movq %rax, (%r8)
 ; WIN64-NEXT:    movl %ecx, %eax
 ; WIN64-NEXT:    retq
@@ -2226,10 +2226,10 @@ define zeroext i1 @umuloi64_load2(i64 %v1, ptr %ptr2, ptr %res) {
 ; WIN32-NEXT:    andb %dl, %cl
 ; WIN32-NEXT:    mull %ebp
 ; WIN32-NEXT:    movl %eax, %edi
-; WIN32-NEXT:    seto %bl
+; WIN32-NEXT:    setb %bl
 ; WIN32-NEXT:    movl %esi, %eax
 ; WIN32-NEXT:    mull {{[0-9]+}}(%esp)
-; WIN32-NEXT:    seto %ch
+; WIN32-NEXT:    setb %ch
 ; WIN32-NEXT:    orb %bl, %ch
 ; WIN32-NEXT:    orb %cl, %ch
 ; WIN32-NEXT:    leal (%edi,%eax), %esi


### PR DESCRIPTION
For all possible MUL/IMUL it will always output CF==OF, and CF is better folding, so there's absolutely no reason the x86 backend should be checking OF instead of CF for any form of multiply.

Did the change in FastISel too for consistency.