### PR TITLE
[TableGen] Escape single quotes when emitting a string table as char literals

### DIFF
--- a/llvm/lib/TableGen/StringToOffsetTable.cpp
+++ b/llvm/lib/TableGen/StringToOffsetTable.cpp
@@ -72,7 +72,10 @@ void StringToOffsetTable::EmitStringTableDef(raw_ostream &OS,
     ListSeparator CharSep(", ");
     for (char C : Str) {
       OS << CharSep << "'";
-      OS.write_escaped(StringRef(&C, 1));
+      if (C == '\'')
+        OS << "\\'";
+      else
+        OS.write_escaped(StringRef(&C, 1));
       OS << "'";
     }
     OS << CharSep << "'\\0'";


### PR DESCRIPTION
Fix a latent bug in StringToOffsetTable, which led to breakage after #218845

```
C:\_work\llvm-project\llvm-project\build\tools\clang\include\clang/Options/Options.inc(135,18): error: expected expression
C:\_work\llvm-project\llvm-project\build\tools\clang\include\clang/Options/Options.inc(135,24): warning: invalid suffix on literal; C++11 requires a space between literal and identifier [-Wreserved-user-defined-literal]
  135 |   'D', 'o', 'n', ''', 't', ' ', 'e', 'm', 'i', 't', ' ', 'e', 'r', 'r', 'o', 'r', 's', ' ', 'o', 'n', ' ', 'i', 'n', 'v', 'a', 'l', 'i', 'd', ' ', 'a', 'n', 'a', 'l', 'y', 'z', 'e', 'r', '-', 'c', 'o', 'n', 'f', 'i', 'g', ' ', 'i', 'n', 'p', 'u', 't', 's', '\0',
      |                        ^
```