### PR TITLE
[CMake] Link only the MLIR dialects ClangIR uses

### DIFF
--- a/clang/lib/CIR/CodeGen/CMakeLists.txt
+++ b/clang/lib/CIR/CodeGen/CMakeLists.txt
@@ -1,10 +1,9 @@
 set(
   LLVM_LINK_COMPONENTS
   Core
+  FrontendOpenMP
   Support
 )
-
-get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 
 add_clang_library(clangCIR
   CIRDataLayoutSpec.cpp
@@ -64,18 +63,23 @@ add_clang_library(clangCIR
   DEPENDS
   MLIRCIR
   MLIRCIROpInterfacesIncGen
-  ${dialect_libs}
 
   LINK_LIBS
   clangAST
   clangBasic
   clangCodeGenUtils
   clangLex
-  ${dialect_libs}
   CIRRegisterAllDialects
   CIROpenACCSupport
   CIROpenMPSupport
+  MLIRArithDialect
   MLIRCIR
   MLIRCIRInterfaces
+  MLIRDLTIDialect
+  MLIRLLVMDialect
+  MLIROpenACCDialect
+  MLIROpenMPDialect
+  MLIROpenMPUtils
+  MLIRPtrMemorySpaceInterfaces
   MLIRTargetLLVMIRImport
 )

--- a/clang/lib/CIR/FrontendAction/CMakeLists.txt
+++ b/clang/lib/CIR/FrontendAction/CMakeLists.txt
@@ -5,8 +5,6 @@ set(LLVM_LINK_COMPONENTS
   Support
   )
 
-get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
-
 add_clang_library(clangCIRFrontendAction
   CIRGenAction.cpp
   CIRDiagnosticHandler.cpp

--- a/clang/lib/CIR/Interfaces/CMakeLists.txt
+++ b/clang/lib/CIR/Interfaces/CMakeLists.txt
@@ -15,7 +15,6 @@ add_clang_library(MLIRCIRInterfaces
   MLIRCIROpInterfacesIncGen
 
   LINK_LIBS
-  ${dialect_libs}
   MLIRIR
   MLIRSupport
  )

--- a/clang/lib/CIR/Lowering/CMakeLists.txt
+++ b/clang/lib/CIR/Lowering/CMakeLists.txt
@@ -3,15 +3,12 @@ set(LLVM_LINK_COMPONENTS
   Support
   )
 
-get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
-
 add_clang_library(clangCIRLoweringCommon
   CIRPasses.cpp
   LoweringHelpers.cpp
 
   LINK_LIBS
   clangCIR
-  ${dialect_libs}
   MLIRCIR
   MLIRCIRTransforms
   MLIRTransforms

--- a/clang/lib/CIR/Lowering/DirectToLLVM/CMakeLists.txt
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/CMakeLists.txt
@@ -3,8 +3,6 @@ set(LLVM_LINK_COMPONENTS
   Support
   )
 
-get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
-
 add_clang_library(clangCIRLoweringDirectToLLVM
   LowerToLLVM.cpp
   LowerToLLVMIR.cpp
@@ -18,12 +16,16 @@ add_clang_library(clangCIRLoweringDirectToLLVM
 
   LINK_LIBS
   clangCIRLoweringCommon
-  ${dialect_libs}
   MLIRCIR
   MLIRCIRTargetLowering
   MLIRCIRTransforms
   MLIRBuiltinToLLVMIRTranslation
+  MLIRDLTIDialect
+  MLIRFuncDialect
+  MLIRLLVMCommonConversion
+  MLIRLLVMDialect
   MLIRLLVMToLLVMIRTranslation
+  MLIROpenMPDialect
   MLIROpenMPToLLVM
   MLIROpenMPToLLVMIRTranslation
   MLIROpenMPTransforms

--- a/clang/tools/cir-opt/CMakeLists.txt
+++ b/clang/tools/cir-opt/CMakeLists.txt
@@ -1,6 +1,3 @@
-get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
-get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
-
 include_directories(${LLVM_MAIN_SRC_DIR}/../mlir/include)
 include_directories(${CMAKE_BINARY_DIR}/tools/mlir/include)
 
@@ -39,16 +36,16 @@ clang_target_link_libraries(cir-opt
 
 target_link_libraries(cir-opt
   PRIVATE
-  ${dialect_libs}
-  ${conversion_libs}
   MLIRAnalysis
   MLIRDialect
   MLIRIR
+  MLIRLLVMDialect
   MLIRMemRefDialect
   MLIROpenMPTransforms
   MLIROptLib
   MLIRParser
   MLIRPass
+  MLIRReconcileUnrealizedCasts
   MLIRSideEffectInterfaces
   MLIRTransforms
   MLIRTransformUtils


### PR DESCRIPTION
CIR's sources reference Arith, DLTI, Func, LLVM, OpenACC, OpenMP and
Ptr, and cir-opt registers only the CIR dialects plus MemRef and LLVM.
Link those instead, which keeps Linalg, Vector, SPIRV, SparseTensor,
Tosa and GPU out of the clang build graph.

CLANG_ENABLE_CIR=ON adds 2135 build edges to the clang target; this
removes 694 of them.

LLM-aided
