### PR TITLE
[llvm-readobj] Exclude Mach-O dylib IDs from needed libraries

### DIFF
--- a/llvm/test/tools/llvm-readobj/MachO/needed-libs.test
+++ b/llvm/test/tools/llvm-readobj/MachO/needed-libs.test
@@ -1,10 +1,6 @@
+## LC_ID_DYLIB names the library itself, not a dependency.
 # RUN: yaml2obj %s -o %t.o
 # RUN: llvm-readobj --needed-libs %t.o | FileCheck %s
-
-## LC_ID_DYLIB names the library itself, not a dependency. A load command with
-## the same name must still be included in the dependency list.
-# RUN: yaml2obj %s -DID=/usr/lib/libSystem.B.dylib -o %t.same-name.o
-# RUN: llvm-readobj --needed-libs %t.same-name.o | FileCheck %s
 
 # CHECK:      NeededLibraries [
 # CHECK-NEXT:   /usr/lib/libLazy.dylib
@@ -32,7 +28,7 @@ LoadCommands:
       timestamp:       2
       current_version: 81985536
       compatibility_version: 65536
-    Content:         [[ID=/usr/lib/libSelf.dylib]]
+    Content:         /usr/lib/libSelf.dylib
   - cmd:             LC_LOAD_DYLIB
     cmdsize:         56
     dylib:

--- a/llvm/test/tools/llvm-readobj/MachO/needed-libs.test
+++ b/llvm/test/tools/llvm-readobj/MachO/needed-libs.test
@@ -1,8 +1,17 @@
 # RUN: yaml2obj %s -o %t.o
 # RUN: llvm-readobj --needed-libs %t.o | FileCheck %s
 
+## LC_ID_DYLIB names the library itself, not a dependency. A load command with
+## the same name must still be included in the dependency list.
+# RUN: yaml2obj %s -DID=/usr/lib/libSystem.B.dylib -o %t.same-name.o
+# RUN: llvm-readobj --needed-libs %t.same-name.o | FileCheck %s
+
 # CHECK:      NeededLibraries [
+# CHECK-NEXT:   /usr/lib/libLazy.dylib
+# CHECK-NEXT:   /usr/lib/libReexport.dylib
 # CHECK-NEXT:   /usr/lib/libSystem.B.dylib
+# CHECK-NEXT:   /usr/lib/libUpward.dylib
+# CHECK-NEXT:   /usr/lib/libWeak.dylib
 # CHECK-NEXT: ]
 
 !mach-o
@@ -10,12 +19,20 @@ FileHeader:
   magic:           0xFEEDFACF
   cputype:         0x01000007
   cpusubtype:      0x00000003
-  filetype:        0x00000001
-  ncmds:           1
-  sizeofcmds:      56
+  filetype:        0x00000006
+  ncmds:           6
+  sizeofcmds:      336
   flags:           0x00002000
   reserved:        0x00000000
 LoadCommands:
+  - cmd:             LC_ID_DYLIB
+    cmdsize:         56
+    dylib:
+      name:            24
+      timestamp:       2
+      current_version: 81985536
+      compatibility_version: 65536
+    Content:         [[ID=/usr/lib/libSelf.dylib]]
   - cmd:             LC_LOAD_DYLIB
     cmdsize:         56
     dylib:
@@ -24,3 +41,35 @@ LoadCommands:
       current_version: 81985536
       compatibility_version: 65536
     Content:         /usr/lib/libSystem.B.dylib
+  - cmd:             LC_LOAD_WEAK_DYLIB
+    cmdsize:         56
+    dylib:
+      name:            24
+      timestamp:       2
+      current_version: 81985536
+      compatibility_version: 65536
+    Content:         /usr/lib/libWeak.dylib
+  - cmd:             LC_REEXPORT_DYLIB
+    cmdsize:         56
+    dylib:
+      name:            24
+      timestamp:       2
+      current_version: 81985536
+      compatibility_version: 65536
+    Content:         /usr/lib/libReexport.dylib
+  - cmd:             LC_LAZY_LOAD_DYLIB
+    cmdsize:         56
+    dylib:
+      name:            24
+      timestamp:       2
+      current_version: 81985536
+      compatibility_version: 65536
+    Content:         /usr/lib/libLazy.dylib
+  - cmd:             LC_LOAD_UPWARD_DYLIB
+    cmdsize:         56
+    dylib:
+      name:            24
+      timestamp:       2
+      current_version: 81985536
+      compatibility_version: 65536
+    Content:         /usr/lib/libUpward.dylib

--- a/llvm/tools/llvm-readobj/MachODumper.cpp
+++ b/llvm/tools/llvm-readobj/MachODumper.cpp
@@ -824,7 +824,6 @@ void MachODumper::printNeededLibraries() {
 
   for (const auto &Command : Obj->load_commands()) {
     if (Command.C.cmd == MachO::LC_LOAD_DYLIB ||
-        Command.C.cmd == MachO::LC_ID_DYLIB ||
         Command.C.cmd == MachO::LC_LOAD_WEAK_DYLIB ||
         Command.C.cmd == MachO::LC_REEXPORT_DYLIB ||
         Command.C.cmd == MachO::LC_LAZY_LOAD_DYLIB ||


### PR DESCRIPTION
For Mach-O files, `--needed-libs` includes `LC_ID_DYLIB`, causing a dynamic
library to list its own install name as a dependency.

Exclude this command while retaining the actual dependency load commands.

Fixes #39505.

Assisted-by: OpenAI Codex (implementation, tests, and initial description).
