### PR TITLE
[clang][Parse] Fix __extension__ not silencing diagnostics

### DIFF
--- a/clang/lib/Parse/ParseExprCXX.cpp
+++ b/clang/lib/Parse/ParseExprCXX.cpp
@@ -1882,15 +1882,15 @@ Sema::ConditionResult Parser::ParseCondition(StmtResult *InitStmt,
     return Sema::ConditionError();
   }
 
+  // The first clause of a condition may be a declaration used as an
+  // init-statement (C2y), and that declaration may be prefixed by one or more
+  // __extension__ markers. Consume them up front -- mirroring block-statement
+  // parsing -- so the disambiguation below sees the real start of the
+  // declaration. The markers also silence extension diagnostics for the rest
+  // of the condition, including the diagnostic for the init-statement
+  // extension itself.
+  std::optional<ExtensionRAIIObject> ExtensionGuard;
   if (Tok.is(tok::kw___extension__)) {
-    // The first clause of a condition may be a declaration used as an
-    // init-statement (C2y), and that declaration may be prefixed by one or more
-    // __extension__ markers. Consume them up front -- mirroring block-statement
-    // parsing -- so the disambiguation below sees the real start of the
-    // declaration. The markers also silence extension diagnostics for the rest
-    // of the condition, including the diagnostic for the init-statement
-    // extension itself.
-    std::optional<ExtensionRAIIObject> ExtensionGuard;
     ExtensionGuard.emplace(Diags);
     while (TryConsumeToken(tok::kw___extension__))
       ;

--- a/clang/test/Parser/extension-condition.c
+++ b/clang/test/Parser/extension-condition.c
@@ -1,0 +1,15 @@
+// RUN: %clang_cc1 %s -fsyntax-only -pedantic -verify -std=c17
+// RUN: %clang_cc1 %s -fsyntax-only -pedantic -verify -std=c2y
+// RUN: %clang_cc1 %s -fsyntax-only -pedantic -verify -x c++ -std=c++17
+
+// expected-no-diagnostics
+
+int f(int);
+
+void cond(int a) {
+  if (__extension__ ({ int r = f(a); r; })) {}
+  while (__extension__ ({ int r = f(a); r; })) { break; }
+  switch (__extension__ ({ int r = f(a); r; })) { default: break; }
+  do {} while (__extension__ ({ int r = f(a); r; }));
+  for (; __extension__ ({ int r = f(a); r; });) { break; }
+}


### PR DESCRIPTION
In ParseCondition(), the ExtensionRAIIObject went out of scope too early (before parsing the condition wrapped by `__extension__`), so -pedantic incorrectly raised diagnostics.
