### PR TITLE
[PGO] Load branch uniformity profiles and mark availability

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/PGOInstrumentation.cpp
+++ b/llvm/lib/Transforms/Instrumentation/PGOInstrumentation.cpp
@@ -1788,9 +1788,9 @@ void PGOUseFunc::setBlockUniformityAttribute() {
   if (ProfileRecord.UniformityBits.empty())
     return;
 
-  // Annotate each uniform instrumented IR basic block so later codegen passes
-  // (MachineFunction) can consume it without relying on fragile block numbering
-  // heuristics.
+  // Mark the function as having uniformity profile, then annotate each uniform
+  // instrumented IR basic block so later codegen passes (MachineFunction) can
+  // consume it without relying on fragile block numbering heuristics.
   // Metadata presence on a terminator means uniform; divergent blocks have no
   // terminator metadata.
 
@@ -1799,13 +1799,28 @@ void PGOUseFunc::setBlockUniformityAttribute() {
 
   LLVMContext &Ctx = F.getContext();
   MDNode *UniformMD = MDNode::get(Ctx, {});
+  F.setMetadata(LLVMContext::MD_uniformity_profile, UniformMD);
+  DenseMap<CondBrInst *, bool> BranchUniformity;
   for (size_t I = 0, E = InstrumentBBs.size(); I < E; ++I) {
     BasicBlock *BB = InstrumentBBs[I];
     if (!BB || !BB->getTerminator())
       continue;
     bool IsUniform = ProfileRecord.isBlockUniform(I);
+    // A counter placed in a block with a single conditional predecessor also
+    // measures the active lanes on that outgoing edge. Record the branch as
+    // uniform only when every instrumented outgoing edge is uniform.
+    if (BasicBlock *Pred = BB->getSinglePredecessor()) {
+      if (auto *Branch = dyn_cast<CondBrInst>(Pred->getTerminator())) {
+        auto It = BranchUniformity.try_emplace(Branch, true).first;
+        It->second &= IsUniform;
+      }
+    }
     BB->getTerminator()->setMetadata(LLVMContext::MD_block_uniformity_profile,
                                      IsUniform ? UniformMD : nullptr);
+  }
+  for (auto [Branch, IsUniform] : BranchUniformity) {
+    Branch->setMetadata(LLVMContext::MD_branch_uniformity_profile,
+                        IsUniform ? UniformMD : nullptr);
   }
 
   LLVM_DEBUG({

--- a/llvm/unittests/Transforms/Instrumentation/PGOInstrumentationTest.cpp
+++ b/llvm/unittests/Transforms/Instrumentation/PGOInstrumentationTest.cpp
@@ -197,7 +197,7 @@ struct PGOInstrumentationUseTest : Test, WithParamInterface<bool> {};
 INSTANTIATE_TEST_SUITE_P(ExistingMetadata, PGOInstrumentationUseTest,
                          Values(false, true));
 
-TEST_P(PGOInstrumentationUseTest, BlockUniformityMetadataUsesPresence) {
+TEST_P(PGOInstrumentationUseTest, UniformityMetadataUsesPresence) {
   static constexpr StringRef Code = R"(
     define i32 @f(i1 %cond) {
     entry:
@@ -278,14 +278,30 @@ TEST_P(PGOInstrumentationUseTest, BlockUniformityMetadataUsesPresence) {
     ASSERT_THAT(UseFunction, NotNull());
     if (GetParam()) {
       MDNode *UniformMD = MDNode::get(Context, {});
+      UseFunction->setMetadata(LLVMContext::MD_uniformity_profile, UniformMD);
       for (BasicBlock &BB : *UseFunction)
         BB.getTerminator()->setMetadata(
             LLVMContext::MD_block_uniformity_profile, UniformMD);
+      UseFunction->getEntryBlock().getTerminator()->setMetadata(
+          LLVMContext::MD_branch_uniformity_profile, UniformMD);
     }
     ModulePassManager UseMPM;
     UseMPM.addPass(PGOInstrumentationUse("/profile.profdata", "", false, FS));
     UseMPM.run(*UseModule, MAM);
     EXPECT_FALSE(verifyModule(*UseModule, &errs()));
+
+    MDNode *FunctionMD =
+        UseFunction->getMetadata(LLVMContext::MD_uniformity_profile);
+    ASSERT_THAT(FunctionMD, NotNull());
+    EXPECT_EQ(FunctionMD->getNumOperands(), 0u);
+
+    auto *Branch =
+        cast<CondBrInst>(UseFunction->getEntryBlock().getTerminator());
+    MDNode *BranchMD =
+        Branch->getMetadata(LLVMContext::MD_branch_uniformity_profile);
+    EXPECT_EQ(BranchMD != nullptr, UniformityMask == 3);
+    if (BranchMD)
+      EXPECT_EQ(BranchMD->getNumOperands(), 0u);
 
     for (unsigned I = 0; I < NumCounters; ++I) {
       BasicBlock *BB = nullptr;


### PR DESCRIPTION
Uniformity profiles record block observations, but optimizations also need a compact hint about branch behavior and a way to tell whether uniformity profile data was loaded.

When uniformity data is present, this PR:

- attaches `uniformity.profile` to the function;
- keeps `block.uniformity.profile` on blocks classified as usually full-wave;
- derives `branch.uniformity.profile` from instrumented successor blocks; and
- marks a conditional branch only when every measured outgoing edge collected for it is classified as uniform.

The branch hint is derived from block observations; it does not claim that the profiler directly observed active-lane agreement at the branch. Existing annotations covered by the loaded observations are replaced, so a previous positive result is removed when the new data does not support it.

Depends on: #225284 (stacked on #221628).

RFC: https://discourse.llvm.org/t/rfc-profile-based-block-and-branch-uniformity-metadata/91764/9

Review this patch: https://github.com/llvm/llvm-project/compare/6180b492300aa3355cdf4279b0065da43e74eb60...760103188c6081b3bfd202d30210962375244129