### PR TITLE
[SelectionDAG] Handle scalable INSERT_SUBVECTOR in ComputeNumSignBits

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -5423,12 +5423,15 @@ unsigned SelectionDAG::ComputeNumSignBits(SDValue Op, const APInt &DemandedElts,
     return Tmp;
   }
   case ISD::INSERT_SUBVECTOR: {
-    if (VT.isScalableVector())
-      break;
-    // Demand any elements from the subvector and the remainder from the src its
-    // inserted into.
     SDValue Src = Op.getOperand(0);
     SDValue Sub = Op.getOperand(1);
+    if (VT.isScalableVector()) {
+      Tmp = ComputeNumSignBits(Sub, Depth + 1);
+      Tmp = std::min(Tmp, ComputeNumSignBits(Src, Depth + 1));
+      return Tmp;
+    }
+    // Demand any elements from the subvector and the remainder from the src its
+    // inserted into.
     uint64_t Idx = Op.getConstantOperandVal(2);
     unsigned NumSubElts = Sub.getValueType().getVectorNumElements();
     APInt DemandedSubElts = DemandedElts.extractBits(NumSubElts, Idx);

--- a/llvm/test/CodeGen/AArch64/sve-insert-vector.ll
+++ b/llvm/test/CodeGen/AArch64/sve-insert-vector.ll
@@ -1543,4 +1543,79 @@ define <vscale x 4 x float> @insert_nxv1f32_nxv4f32_3(<vscale x 4 x float> %vec,
   ret <vscale x 4 x float> %retval
 }
 
+define <vscale x 4 x i32> @insert_nxv4i32_nxv2i32_signbits(<vscale x 4 x i32> %vec, <vscale x 4 x i32> %subvec) {
+; CHECK-LABEL: insert_nxv4i32_nxv2i32_signbits:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    asr z0.s, z0.s, #24
+; CHECK-NEXT:    asr z1.s, z1.s, #16
+; CHECK-NEXT:    uunpklo z1.d, z1.s
+; CHECK-NEXT:    uunpkhi z0.d, z0.s
+; CHECK-NEXT:    uzp1 z0.s, z1.s, z0.s
+; CHECK-NEXT:    ret
+  %base = ashr <vscale x 4 x i32> %vec, splat (i32 24)
+  %sub0 = ashr <vscale x 4 x i32> %subvec, splat (i32 16)
+  %sub = call <vscale x 2 x i32> @llvm.vector.extract.nxv2i32.nxv4i32(<vscale x 4 x i32> %sub0, i64 0)
+  %res = call <vscale x 4 x i32> @llvm.vector.insert.nxv4i32.nxv2i32(<vscale x 4 x i32> %base, <vscale x 2 x i32> %sub, i64 0)
+  %shl = shl <vscale x 4 x i32> %res, splat (i32 16)
+  %sext = ashr <vscale x 4 x i32> %shl, splat (i32 16)
+  ret <vscale x 4 x i32> %sext
+}
+
+define <vscale x 4 x i32> @insert_nxv4i32_v2i32_signbits(<vscale x 4 x i32> %vec, <4 x i32> %subvec) {
+; CHECK-LABEL: insert_nxv4i32_v2i32_signbits:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    asr z0.s, z0.s, #24
+; CHECK-NEXT:    sshr v1.2s, v1.2s, #16
+; CHECK-NEXT:    ptrue p0.s, vl2
+; CHECK-NEXT:    mov z0.s, p0/m, z1.s
+; CHECK-NEXT:    ret
+  %base = ashr <vscale x 4 x i32> %vec, splat (i32 24)
+  %sub0 = ashr <4 x i32> %subvec, splat (i32 16)
+  %sub = call <2 x i32> @llvm.vector.extract.v2i32.v4i32(<4 x i32> %sub0, i64 0)
+  %res = call <vscale x 4 x i32> @llvm.vector.insert.nxv4i32.v2i32(<vscale x 4 x i32> %base, <2 x i32> %sub, i64 0)
+  %shl = shl <vscale x 4 x i32> %res, splat (i32 16)
+  %sext = ashr <vscale x 4 x i32> %shl, splat (i32 16)
+  ret <vscale x 4 x i32> %sext
+}
+
+define <vscale x 4 x i32> @insert_nxv4i32_nxv2i32_signbits_insufficient_base(<vscale x 4 x i32> %vec, <vscale x 4 x i32> %subvec) {
+; CHECK-LABEL: insert_nxv4i32_nxv2i32_signbits_insufficient_base:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    asr z0.s, z0.s, #15
+; CHECK-NEXT:    asr z1.s, z1.s, #16
+; CHECK-NEXT:    ptrue p0.s
+; CHECK-NEXT:    uunpklo z1.d, z1.s
+; CHECK-NEXT:    uunpkhi z0.d, z0.s
+; CHECK-NEXT:    uzp1 z0.s, z1.s, z0.s
+; CHECK-NEXT:    sxth z0.s, p0/m, z0.s
+; CHECK-NEXT:    ret
+  %base = ashr <vscale x 4 x i32> %vec, splat (i32 15)
+  %sub0 = ashr <vscale x 4 x i32> %subvec, splat (i32 16)
+  %sub = call <vscale x 2 x i32> @llvm.vector.extract.nxv2i32.nxv4i32(<vscale x 4 x i32> %sub0, i64 0)
+  %res = call <vscale x 4 x i32> @llvm.vector.insert.nxv4i32.nxv2i32(<vscale x 4 x i32> %base, <vscale x 2 x i32> %sub, i64 0)
+  %shl = shl <vscale x 4 x i32> %res, splat (i32 16)
+  %sext = ashr <vscale x 4 x i32> %shl, splat (i32 16)
+  ret <vscale x 4 x i32> %sext
+}
+
+define <vscale x 4 x i32> @insert_nxv4i32_nxv2i32_signbits_insufficient_sub(<vscale x 4 x i32> %vec, <vscale x 4 x i32> %subvec) {
+; CHECK-LABEL: insert_nxv4i32_nxv2i32_signbits_insufficient_sub:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    asr z0.s, z0.s, #24
+; CHECK-NEXT:    asr z1.s, z1.s, #15
+; CHECK-NEXT:    ptrue p0.s
+; CHECK-NEXT:    uunpklo z1.d, z1.s
+; CHECK-NEXT:    uunpkhi z0.d, z0.s
+; CHECK-NEXT:    uzp1 z0.s, z1.s, z0.s
+; CHECK-NEXT:    sxth z0.s, p0/m, z0.s
+; CHECK-NEXT:    ret
+  %base = ashr <vscale x 4 x i32> %vec, splat (i32 24)
+  %sub0 = ashr <vscale x 4 x i32> %subvec, splat (i32 15)
+  %sub = call <vscale x 2 x i32> @llvm.vector.extract.nxv2i32.nxv4i32(<vscale x 4 x i32> %sub0, i64 0)
+  %res = call <vscale x 4 x i32> @llvm.vector.insert.nxv4i32.nxv2i32(<vscale x 4 x i32> %base, <vscale x 2 x i32> %sub, i64 0)
+  %shl = shl <vscale x 4 x i32> %res, splat (i32 16)
+  %sext = ashr <vscale x 4 x i32> %shl, splat (i32 16)
+  ret <vscale x 4 x i32> %sext
+}
+
 attributes #0 = { vscale_range(2,2) }

--- a/llvm/unittests/Target/AArch64/AArch64SelectionDAGTest.cpp
+++ b/llvm/unittests/Target/AArch64/AArch64SelectionDAGTest.cpp
@@ -211,6 +211,47 @@ TEST_F(AArch64SelectionDAGTest, ComputeNumSignBitsSVE_EXTRACT_SUBVECTOR) {
   EXPECT_EQ(DAG->ComputeNumSignBits(Op, DemandedElts), 7u);
 }
 
+TEST_F(AArch64SelectionDAGTest, ComputeNumSignBitsSVE_INSERT_SUBVECTOR) {
+  SDLoc Loc;
+  SDValue Src = DAG->getNode(ISD::SIGN_EXTEND, Loc, MVT::nxv4i32,
+                             DAG->getRegister(0, MVT::nxv4i8));
+  SDValue Sub = DAG->getNode(ISD::SIGN_EXTEND, Loc, MVT::nxv2i32,
+                             DAG->getRegister(1, MVT::nxv2i16));
+  SDValue SrcWithFewerSignBits = DAG->getNode(
+      ISD::SIGN_EXTEND, Loc, MVT::nxv4i32, DAG->getRegister(0, MVT::nxv4i16));
+  SDValue SubWithMoreSignBits = DAG->getNode(
+      ISD::SIGN_EXTEND, Loc, MVT::nxv2i32, DAG->getRegister(1, MVT::nxv2i8));
+
+  for (unsigned Idx : {0u, 2u}) {
+    SDValue Index = DAG->getConstant(Idx, Loc, MVT::i64);
+    SDValue Op =
+        DAG->getNode(ISD::INSERT_SUBVECTOR, Loc, MVT::nxv4i32, Src, Sub, Index);
+    EXPECT_EQ(DAG->ComputeNumSignBits(Op), 17u);
+
+    Op = DAG->getNode(ISD::INSERT_SUBVECTOR, Loc, MVT::nxv4i32,
+                      SrcWithFewerSignBits, SubWithMoreSignBits, Index);
+    EXPECT_EQ(DAG->ComputeNumSignBits(Op), 17u);
+  }
+}
+
+TEST_F(AArch64SelectionDAGTest,
+       ComputeNumSignBitsSVE_INSERT_SUBVECTOR_FixedSubvector) {
+  SDLoc Loc;
+  SDValue Src = DAG->getNode(ISD::SIGN_EXTEND, Loc, MVT::nxv4i32,
+                             DAG->getRegister(0, MVT::nxv4i8));
+  SDValue Lane0 = DAG->getNode(ISD::SIGN_EXTEND, Loc, MVT::i32,
+                               DAG->getRegister(1, MVT::i8));
+  SDValue Lane1 = DAG->getNode(ISD::SIGN_EXTEND, Loc, MVT::i32,
+                               DAG->getRegister(2, MVT::i16));
+  SDValue Sub = DAG->getBuildVector(MVT::v2i32, Loc, {Lane0, Lane1});
+
+  for (unsigned Idx : {0u, 2u}) {
+    SDValue Op = DAG->getNode(ISD::INSERT_SUBVECTOR, Loc, MVT::nxv4i32, Src,
+                              Sub, DAG->getConstant(Idx, Loc, MVT::i64));
+    EXPECT_EQ(DAG->ComputeNumSignBits(Op), 17u);
+  }
+}
+
 TEST_F(AArch64SelectionDAGTest, ComputeNumSignBits_VASHR) {
   SDLoc Loc;
   auto VecVT = MVT::v8i8;

--- a/llvm/unittests/Target/AArch64/AArch64SelectionDAGTest.cpp
+++ b/llvm/unittests/Target/AArch64/AArch64SelectionDAGTest.cpp
@@ -211,47 +211,6 @@ TEST_F(AArch64SelectionDAGTest, ComputeNumSignBitsSVE_EXTRACT_SUBVECTOR) {
   EXPECT_EQ(DAG->ComputeNumSignBits(Op, DemandedElts), 7u);
 }
 
-TEST_F(AArch64SelectionDAGTest, ComputeNumSignBitsSVE_INSERT_SUBVECTOR) {
-  SDLoc Loc;
-  SDValue Src = DAG->getNode(ISD::SIGN_EXTEND, Loc, MVT::nxv4i32,
-                             DAG->getRegister(0, MVT::nxv4i8));
-  SDValue Sub = DAG->getNode(ISD::SIGN_EXTEND, Loc, MVT::nxv2i32,
-                             DAG->getRegister(1, MVT::nxv2i16));
-  SDValue SrcWithFewerSignBits = DAG->getNode(
-      ISD::SIGN_EXTEND, Loc, MVT::nxv4i32, DAG->getRegister(0, MVT::nxv4i16));
-  SDValue SubWithMoreSignBits = DAG->getNode(
-      ISD::SIGN_EXTEND, Loc, MVT::nxv2i32, DAG->getRegister(1, MVT::nxv2i8));
-
-  for (unsigned Idx : {0u, 2u}) {
-    SDValue Index = DAG->getConstant(Idx, Loc, MVT::i64);
-    SDValue Op =
-        DAG->getNode(ISD::INSERT_SUBVECTOR, Loc, MVT::nxv4i32, Src, Sub, Index);
-    EXPECT_EQ(DAG->ComputeNumSignBits(Op), 17u);
-
-    Op = DAG->getNode(ISD::INSERT_SUBVECTOR, Loc, MVT::nxv4i32,
-                      SrcWithFewerSignBits, SubWithMoreSignBits, Index);
-    EXPECT_EQ(DAG->ComputeNumSignBits(Op), 17u);
-  }
-}
-
-TEST_F(AArch64SelectionDAGTest,
-       ComputeNumSignBitsSVE_INSERT_SUBVECTOR_FixedSubvector) {
-  SDLoc Loc;
-  SDValue Src = DAG->getNode(ISD::SIGN_EXTEND, Loc, MVT::nxv4i32,
-                             DAG->getRegister(0, MVT::nxv4i8));
-  SDValue Lane0 = DAG->getNode(ISD::SIGN_EXTEND, Loc, MVT::i32,
-                               DAG->getRegister(1, MVT::i8));
-  SDValue Lane1 = DAG->getNode(ISD::SIGN_EXTEND, Loc, MVT::i32,
-                               DAG->getRegister(2, MVT::i16));
-  SDValue Sub = DAG->getBuildVector(MVT::v2i32, Loc, {Lane0, Lane1});
-
-  for (unsigned Idx : {0u, 2u}) {
-    SDValue Op = DAG->getNode(ISD::INSERT_SUBVECTOR, Loc, MVT::nxv4i32, Src,
-                              Sub, DAG->getConstant(Idx, Loc, MVT::i64));
-    EXPECT_EQ(DAG->ComputeNumSignBits(Op), 17u);
-  }
-}
-
 TEST_F(AArch64SelectionDAGTest, ComputeNumSignBits_VASHR) {
   SDLoc Loc;
   auto VecVT = MVT::v8i8;


### PR DESCRIPTION
Handle scalable INSERT_SUBVECTOR in SelectionDAG as a pre-fix for #220976.

Add coverage for scalable subvectors and fixed subvectors inserted into scalable vectors.