### PR TITLE
[flang] Enable wrap-unstructured-constructs-in-execute-region by default

### DIFF
--- a/flang/lib/Lower/PFTBuilder.cpp
+++ b/flang/lib/Lower/PFTBuilder.cpp
@@ -28,7 +28,7 @@ static llvm::cl::opt<bool> clDisableStructuredFir(
     llvm::cl::init(false), llvm::cl::Hidden);
 
 llvm::cl::opt<bool> wrapUnstructuredConstructsInExecuteRegion(
-    "wrap-unstructured-constructs-in-execute-region", llvm::cl::init(false),
+    "wrap-unstructured-constructs-in-execute-region", llvm::cl::init(true),
     llvm::cl::desc("try to wrap unstructured constructs' CFGs in "
                    "self-contained MLIR regions"));
 


### PR DESCRIPTION
More extensive testing since the flag was introduced, with the regressions it uncovered now fixed, see:
* https://github.com/llvm/llvm-project/pull/218674
* https://github.com/llvm/llvm-project/pull/217220
* https://github.com/llvm/llvm-project/pull/217842
* https://github.com/llvm/llvm-project/pull/216280