### PR TITLE
[orc-rt] Compose Bedrock from object libraries

### DIFF
--- a/orc-rt/lib/bedrock/CMakeLists.txt
+++ b/orc-rt/lib/bedrock/CMakeLists.txt
@@ -74,16 +74,23 @@ else()
     "add an orc-rt/lib/bedrock/sys/<system>/ directory and compose it above")
 endif()
 
-add_library(orc-rt-bedrock STATIC ${ORC_RT_BEDROCK_SOURCES})
+add_library(orc-rt-bedrock-objects OBJECT ${ORC_RT_BEDROCK_SOURCES})
+
+target_link_libraries(orc-rt-bedrock-objects PUBLIC orc-rt-headers)
+
+# Apply RTTI and exceptions compile flags
+target_compile_options(orc-rt-bedrock-objects PRIVATE ${ORC_RT_COMPILE_FLAGS})
+
+# The shipped library: Bedrock's objects plus Support's (Support is never
+# shipped on its own).
+add_library(orc-rt-bedrock STATIC)
 
 target_link_libraries(orc-rt-bedrock PUBLIC orc-rt-headers)
 
-# Support is a build-only implementation detail: its objects are absorbed into
-# this archive, and it must not appear in the exported interface.
-target_link_libraries(orc-rt-bedrock PRIVATE $<BUILD_INTERFACE:orc-rt-support>)
+target_link_libraries(orc-rt-bedrock
+  PRIVATE $<BUILD_INTERFACE:orc-rt-bedrock-objects>
+          $<BUILD_INTERFACE:orc-rt-support-objects>)
 
-# Apply RTTI and exceptions compile flags
-target_compile_options(orc-rt-bedrock PRIVATE ${ORC_RT_COMPILE_FLAGS})
 # TODO: Use common runtimes infrastructure for output and install paths
 install(TARGETS orc-rt-bedrock
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/orc-rt/lib/support/CMakeLists.txt
+++ b/orc-rt/lib/support/CMakeLists.txt
@@ -25,9 +25,9 @@ endif()
 
 # Support is always an object library: it is embedded into the libraries that
 # ship, never shipped on its own.
-add_library(orc-rt-support OBJECT ${ORC_RT_SUPPORT_SOURCES})
+add_library(orc-rt-support-objects OBJECT ${ORC_RT_SUPPORT_SOURCES})
 
-target_link_libraries(orc-rt-support PUBLIC orc-rt-headers)
+target_link_libraries(orc-rt-support-objects PUBLIC orc-rt-headers)
 
 # Apply RTTI and exceptions compile flags
-target_compile_options(orc-rt-support PRIVATE ${ORC_RT_COMPILE_FLAGS})
+target_compile_options(orc-rt-support-objects PRIVATE ${ORC_RT_COMPILE_FLAGS})

--- a/orc-rt/test/unit/CMakeLists.txt
+++ b/orc-rt/test/unit/CMakeLists.txt
@@ -7,22 +7,24 @@ if (NOT TARGET llvm_gtest)
   return ()
 endif ()
 
-# Adds a unit test suite for one layer. link_lib is the layer's library; the
-# remaining arguments are sources.
-function(add_orc_rt_unittest test_name link_lib)
-  add_unittest(OrcRTUnitTests ${test_name} ${ARGN} DISABLE_LLVM_LINK_LLVM_DYLIB)
+# Adds a unit test suite. Sources come first; LINK_LIBS names the object
+# libraries the suite links and must come last.
+function(add_orc_rt_unittest test_name)
+  cmake_parse_arguments(ARG "" "" "LINK_LIBS" ${ARGN})
+  add_unittest(OrcRTUnitTests ${test_name} ${ARG_UNPARSED_ARGUMENTS}
+    DISABLE_LLVM_LINK_LLVM_DYLIB)
   target_compile_options(${test_name} PRIVATE ${ORC_RT_COMPILE_FLAGS})
   # Shared test helpers (CommonTestUtils.h, DirectCaller.h, ...) live at the
   # root of this directory, so tests in the layer subdirectories can include
   # them by bare name.
   target_include_directories(${test_name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-  target_link_libraries(${test_name} PRIVATE ${link_lib})
+  target_link_libraries(${test_name} PRIVATE ${ARG_LINK_LIBS})
 endfunction()
 
 # SupportTests links the Support objects and nothing else, so a new
-# support-to-bedrock dependency shows up here as a link error rather than
-# going unnoticed.
-add_orc_rt_unittest(SupportTests orc-rt-support
+# support-to-bedrock dependency shows up here as a link error rather than going
+# unnoticed. BedrockTests links both, Bedrock being a Support client.
+add_orc_rt_unittest(SupportTests
   support/AllocActionTest.cpp
   support/BitmaskEnumTest.cpp
   support/CAPICompileTest.c
@@ -61,9 +63,11 @@ add_orc_rt_unittest(SupportTests orc-rt-support
   support/sys/ErrnoTest.cpp
 
   tools/OptionParserTest.cpp
+
+  LINK_LIBS orc-rt-support-objects
   )
 
-add_orc_rt_unittest(BedrockTests orc-rt-bedrock
+add_orc_rt_unittest(BedrockTests
   bedrock/BootstrapInfoTest.cpp
   bedrock/ExecutorProcessInfoTest.cpp
   bedrock/InProcessControllerAccessTest.cpp
@@ -84,6 +88,8 @@ add_orc_rt_unittest(BedrockTests orc-rt-bedrock
 
   bedrock/sys/CPUFeaturesTest.cpp
   bedrock/sys/TargetTripleTest.cpp
+
+  LINK_LIBS orc-rt-bedrock-objects orc-rt-support-objects
   )
 
 # Build a shared library for NativeDylibManager tests.


### PR DESCRIPTION
Add orc-rt-bedrock-objects, and rename orc-rt-support to orc-rt-support-objects, leaving orc-rt-bedrock as a shipped library with no sources of its own that is composed from both. The -objects suffix marks targets that produce no artifact.

The unit tests now link the object libraries directly rather than the shipped library. This will allow them to continue working when Bedrock becomes buildable as a dylib with no C++ API exported.