### PR TITLE
[DA] Refactor dependence analysis (NFC)

### DIFF
--- a/llvm/include/llvm/Analysis/DependenceAnalysis.h
+++ b/llvm/include/llvm/Analysis/DependenceAnalysis.h
@@ -339,8 +339,6 @@ private:
     const SCEV *Dst;
     enum ClassificationKind { ZIV, SIV, RDIV, MIV, NonLinear } Classification;
     SmallBitVector Loops;
-    SmallBitVector GroupLoops;
-    SmallBitVector Group;
   };
 
   struct CoefficientInfo {

--- a/llvm/lib/Analysis/DependenceAnalysis.cpp
+++ b/llvm/lib/Analysis/DependenceAnalysis.cpp
@@ -1597,8 +1597,6 @@ bool DependenceInfo::exactTestImpl(const SCEVAddRecExpr *Src,
   if (DstUM)
     LLVM_DEBUG(dbgs() << "\t    DstUM = " << *DstUM << "\n");
 
-  APInt TU(APInt::getSignedMaxValue(Bits));
-  APInt TL(APInt::getSignedMinValue(Bits));
   OverflowSafeSignedAPInt TC = CM.sdiv(G);
   OverflowSafeSignedAPInt TX = OverflowSafeSignedAPInt(X) * TC;
   OverflowSafeSignedAPInt TY = OverflowSafeSignedAPInt(Y) * TC;
@@ -1643,8 +1641,8 @@ bool DependenceInfo::exactTestImpl(const SCEVAddRecExpr *Src,
   if (!OptTL || !OptTU)
     return false;
 
-  TL = std::move(*OptTL);
-  TU = std::move(*OptTU);
+  APInt TL = std::move(*OptTL);
+  APInt TU = std::move(*OptTU);
   LLVM_DEBUG(dbgs() << "\t    TL = " << TL << "\n");
   LLVM_DEBUG(dbgs() << "\t    TU = " << TU << "\n");
 
@@ -1859,7 +1857,7 @@ bool DependenceInfo::gcdMIVtest(const SCEV *Src, const SCEV *Dst,
   const SCEVConstant *Constant = dyn_cast<SCEVConstant>(Delta);
   if (!Constant)
     return false;
-  APInt ConstDelta = cast<SCEVConstant>(Constant)->getAPInt();
+  APInt ConstDelta = Constant->getAPInt();
   LLVM_DEBUG(dbgs() << "    ConstDelta = " << ConstDelta << "\n");
   if (ConstDelta == 0)
     return false;
@@ -1887,7 +1885,7 @@ bool DependenceInfo::gcdMIVtest(const SCEV *Src, const SCEV *Dst,
     const Loop *CurLoop = AddRec->getLoop();
     RunningGCD = 0;
     const SCEV *SrcCoeff = AddRec->getStepRecurrence(*SE);
-    const SCEV *DstCoeff = SE->getMinusSCEV(SrcCoeff, SrcCoeff);
+    const SCEV *DstCoeff = SE->getZero(SrcCoeff->getType());
 
     if (!accumulateCoefficientsGCD(Src, CurLoop, SrcCoeff, RunningGCD) ||
         !accumulateCoefficientsGCD(Dst, CurLoop, DstCoeff, RunningGCD))
@@ -2780,8 +2778,7 @@ DependenceInfo::depends(Instruction *Src, Instruction *Dst,
     for (unsigned P = 0; P < Pairs; ++P) {
       SmallBitVector Loops;
       Subscript::ClassificationKind TestClass =
-          classifyPair(Pair[P].Src, LI->getLoopFor(Src->getParent()),
-                       Pair[P].Dst, LI->getLoopFor(Dst->getParent()), Loops);
+          classifyPair(Pair[P].Src, SrcLoop, Pair[P].Dst, DstLoop, Loops);
 
       if (TestClass != Subscript::ZIV && TestClass != Subscript::SIV &&
           TestClass != Subscript::RDIV) {
@@ -2805,13 +2802,8 @@ DependenceInfo::depends(Instruction *Src, Instruction *Dst,
     assert(Pair[P].Src->getType()->isIntegerTy() && "Src must be an integer");
     assert(Pair[P].Dst->getType()->isIntegerTy() && "Dst must be an integer");
     Pair[P].Loops.resize(MaxLevels + 1);
-    Pair[P].GroupLoops.resize(MaxLevels + 1);
-    Pair[P].Group.resize(Pairs);
     Pair[P].Classification =
-        classifyPair(Pair[P].Src, LI->getLoopFor(Src->getParent()), Pair[P].Dst,
-                     LI->getLoopFor(Dst->getParent()), Pair[P].Loops);
-    Pair[P].GroupLoops = Pair[P].Loops;
-    Pair[P].Group.set(P);
+        classifyPair(Pair[P].Src, SrcLoop, Pair[P].Dst, DstLoop, Pair[P].Loops);
     LLVM_DEBUG(dbgs() << "    subscript " << P << "\n");
     LLVM_DEBUG(dbgs() << "\tsrc = " << *Pair[P].Src << "\n");
     LLVM_DEBUG(dbgs() << "\tdst = " << *Pair[P].Dst << "\n");
@@ -2834,10 +2826,8 @@ DependenceInfo::depends(Instruction *Src, Instruction *Dst,
     case Subscript::NonLinear:
       // ignore these, but collect loops for later
       ++NonlinearSubscriptPairs;
-      collectCommonLoops(Pair[SI].Src, LI->getLoopFor(Src->getParent()),
-                         Pair[SI].Loops);
-      collectCommonLoops(Pair[SI].Dst, LI->getLoopFor(Dst->getParent()),
-                         Pair[SI].Loops);
+      collectCommonLoops(Pair[SI].Src, SrcLoop, Pair[SI].Loops);
+      collectCommonLoops(Pair[SI].Dst, DstLoop, Pair[SI].Loops);
       break;
     case Subscript::ZIV:
       LLVM_DEBUG(dbgs() << ", ZIV\n");


### PR DESCRIPTION
Remove some unnecessary part of DA.

- Remove unused `GroupLoops` and `Group` subscript state.
- Reuse the already-computed source and destination loops.
- Simplify `APInt` initialization and zero SCEV construction.
- Replace redundant casts with direct typed accessors.