### PR TITLE
[GlobalISel] Avoid copying complex pattern renderers (NFC)

### DIFF
--- a/llvm/include/llvm/CodeGen/GlobalISel/GIMatchTableExecutorImpl.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/GIMatchTableExecutorImpl.h
@@ -862,7 +862,7 @@ bool GIMatchTableExecutor::executeMatchTable(
           (Exec.*ExecInfo.ComplexPredicates[ComplexPredicateID])(
               State.MIs[InsnID]->getOperand(OpIdx));
       if (Renderer)
-        State.Renderers[RendererID] = *Renderer;
+        State.Renderers[RendererID] = std::move(*Renderer);
       else if (handleReject() == RejectAndGiveUp)
         return false;
       break;


### PR DESCRIPTION
They're immediately destroyed after being copied, move them instead.

Improves aarch64-O0-g CTMark geomean -0.10%.

https://llvm-compile-time-tracker.com/compare.php?from=97cbc1e404b980edc58bfbcabb6f1c61793b624b&to=69a2cfb9a265b7c4a18ef7121a7afb239c886d13&stat=instructions:u

Assisted-by: codex