### PR TITLE
[AMDGPU] Remove dead D16ImageDimIntrinsic and lookupD16ImageDimIntrinsic (NFC)

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUInstrInfo.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUInstrInfo.h
@@ -40,12 +40,6 @@ struct RsrcIntrinsic {
 };
 const RsrcIntrinsic *lookupRsrcIntrinsic(unsigned Intr);
 
-struct D16ImageDimIntrinsic {
-  unsigned Intr;
-  unsigned D16HelperIntr;
-};
-const D16ImageDimIntrinsic *lookupD16ImageDimIntrinsic(unsigned Intr);
-
 struct ImageDimIntrinsicInfo {
   unsigned Intr;
   unsigned BaseOpcode;

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
@@ -45,7 +45,6 @@ using namespace llvm;
 #include "AMDGPUGenInstrInfo.inc"
 
 namespace llvm::AMDGPU {
-#define GET_D16ImageDimIntrinsics_IMPL
 #define GET_ImageDimIntrinsicTable_IMPL
 #define GET_RsrcIntrinsics_IMPL
 #include "AMDGPUGenSearchableTables.inc"


### PR DESCRIPTION
The corresponding TableGen table and callers were removed on June 21,
2018 in commit 7a9c03f484fee744b1cbcc45e77f949b4ebfcbee, leaving behind
the struct, the declaration, and the unused macro definition.

Assisted-by: Antigravity
