### PR TITLE
[Github] Make code-format-helper --extensions ordering deterministic

### DIFF
--- a/llvm/utils/git/code-format-helper.py
+++ b/llvm/utils/git/code-format-helper.py
@@ -197,7 +197,7 @@ class ClangFormatHelper(FormatHelper):
                 ext.strip(".")
             )  # Exclude periods since git-clang-format takes extensions without them
         cf_cmd.append("--extensions")
-        cf_cmd.append(",".join(extensions))
+        cf_cmd.append(",".join(sorted(extensions)))
 
         cf_cmd.append("--")
         cf_cmd += self._cpp_files


### PR DESCRIPTION
`ClangFormatHelper._construct_command` collects the extensions of the changed files into a `set` and joins it directly:

```python
extensions = set()
for file in self._cpp_files:
    _, ext = os.path.splitext(file)
    extensions.add(ext.strip("."))
cf_cmd.append("--extensions")
cf_cmd.append(",".join(extensions))
```

Python randomizes `str` hashing per process, so the `--extensions` argument comes out in a different order on every run for the *same* set of changed files.

### Why it is visible

That command string is not internal. It is the one embedded in the bot's PR comment under *"You can test this locally with the following command"* (via the `instructions` property), and it is what gets printed to the CI log by `print(f"Running: {' '.join(cf_cmd)}")`. So identical input produces a different reproducer line on each run, and re-running the formatting job on an unchanged PR rewrites the comment with a command that differs only in extension order.

### Reproducer

```python
import os, subprocess, sys

FILES = ["clang/a.cpp", "clang/b.h", "clang/c.inc",
         "clang/d.cl", "clang/e.cxx", "clang/f.hpp"]

SNIPPET = r'''
import os, sys
extensions = set()
for file in sys.argv[1:]:
    _, ext = os.path.splitext(file)
    extensions.add(ext.strip("."))
print(",".join(extensions))
'''

seen = set()
for seed in range(1, 13):
    env = dict(os.environ, PYTHONHASHSEED=str(seed))
    seen.add(subprocess.run([sys.executable, "-c", SNIPPET, *FILES],
                            capture_output=True, text=True, env=env).stdout.strip())

print(f"distinct --extensions strings across 12 runs: {len(seen)}")
for s in sorted(seen):
    print("   ", s)
assert len(seen) == 1, f"NON-DETERMINISTIC: {len(seen)} different strings for identical input"
```

Before the change — 12 runs, 12 different arguments, assertion fails (exit 1):

```
distinct --extensions strings across 12 runs: 12
    cl,cxx,cpp,h,hpp,inc
    cl,h,cxx,hpp,inc,cpp
    cpp,cxx,h,hpp,inc,cl
    cpp,hpp,h,inc,cxx,cl
    cxx,h,cl,inc,hpp,cpp
    h,cl,inc,cpp,hpp,cxx
    h,cpp,inc,cxx,cl,hpp
    h,inc,cl,cpp,cxx,hpp
    hpp,cl,h,cpp,inc,cxx
    hpp,inc,cl,cpp,cxx,h
    inc,cl,h,cxx,hpp,cpp
    inc,hpp,cpp,cxx,h,cl
AssertionError: NON-DETERMINISTIC: 12 different strings for identical input
```

After the change (same script with `sorted(extensions)`) — 1 distinct string, assertion passes (exit 0):

```
distinct --extensions strings across 12 runs: 1
    cl,cpp,cxx,h,hpp,inc
```

### Note on extensionless files

`should_include_extensionless_file` intentionally lets `libcxx/include` headers through, which puts an empty string into the set. That is load-bearing: `git-clang-format`'s `filter_by_extension` keeps extensionless files only when `"" in allowed_extensions`. Sorting preserves the entry (it simply sorts first), so `libcxx/include` headers are unaffected — verified with `["libcxx/include/vector", "clang/a.cpp"]`, which still yields `,cpp`.

I have read and reviewed this change and can answer questions about it. Tool assistance is disclosed with an `Assisted-by:` trailer in the commit message, per the [AI tool policy](https://llvm.org/docs/AIToolPolicy.html).
