### PR TITLE
[llvm][llvm-readobj][NFC] clang-format COFFDumper.cpp

### DIFF
--- a/llvm/tools/llvm-readobj/COFFDumper.cpp
+++ b/llvm/tools/llvm-readobj/COFFDumper.cpp
@@ -133,8 +133,10 @@ private:
   void printRVATable(uint64_t TableVA, uint64_t Count, uint64_t EntrySize,
                      PrintExtraCB PrintExtra = nullptr);
 
-  void printCodeViewSymbolSection(StringRef SectionName, const SectionRef &Section);
-  void printCodeViewTypeSection(StringRef SectionName, const SectionRef &Section);
+  void printCodeViewSymbolSection(StringRef SectionName,
+                                  const SectionRef &Section);
+  void printCodeViewTypeSection(StringRef SectionName,
+                                const SectionRef &Section);
   StringRef getFileNameForFileOffset(uint32_t FileOffset);
   void printFileNameForOffset(StringRef Label, uint32_t FileOffset);
   void printTypeIndex(StringRef FieldName, TypeIndex TI) {
@@ -178,11 +180,11 @@ private:
                                     StringRef SectionContents,
                                     const void *RelocPtr, StringRef &Name);
   void printImportedSymbols(iterator_range<imported_symbol_iterator> Range);
-  void printDelayImportedSymbols(
-      const DelayImportDirectoryEntryRef &I,
-      iterator_range<imported_symbol_iterator> Range);
+  void
+  printDelayImportedSymbols(const DelayImportDirectoryEntryRef &I,
+                            iterator_range<imported_symbol_iterator> Range);
 
-  typedef DenseMap<const coff_section*, std::vector<RelocationRef> > RelocMapTy;
+  typedef DenseMap<const coff_section *, std::vector<RelocationRef>> RelocMapTy;
 
   const llvm::object::COFFObjectFile *Obj;
   bool RelocCached = false;
@@ -665,7 +667,7 @@ static std::error_code getSymbolAuxData(const COFFObjectFile *Obj,
                                         uint8_t AuxSymbolIdx, const T *&Aux) {
   ArrayRef<uint8_t> AuxData = Obj->getSymbolAuxData(Symbol);
   AuxData = AuxData.slice(AuxSymbolIdx * Obj->getSymbolTableEntrySize());
-  Aux = reinterpret_cast<const T*>(AuxData.data());
+  Aux = reinterpret_cast<const T *>(AuxData.data());
   return std::error_code();
 }
 
@@ -698,7 +700,7 @@ void COFFDumper::printDataDirectory(uint32_t Index,
 
 void COFFDumper::printFileHeaders() {
   time_t TDS = Obj->getTimeDateStamp();
-  char FormattedTime[20] = { };
+  char FormattedTime[20] = {};
   strftime(FormattedTime, 20, "%Y-%m-%d %H:%M:%S", gmtime(&TDS));
 
   {
@@ -706,8 +708,8 @@ void COFFDumper::printFileHeaders() {
     W.printEnum("Machine", Obj->getMachine(),
                 EnumStrings(ImageFileMachineType));
     W.printNumber("SectionCount", Obj->getNumberOfSections());
-    W.printHex   ("TimeDateStamp", FormattedTime, Obj->getTimeDateStamp());
-    W.printHex   ("PointerToSymbolTable", Obj->getPointerToSymbolTable());
+    W.printHex("TimeDateStamp", FormattedTime, Obj->getTimeDateStamp());
+    W.printHex("PointerToSymbolTable", Obj->getPointerToSymbolTable());
     W.printNumber("SymbolCount", Obj->getNumberOfSymbols());
     W.printNumber("StringTableSize", Obj->getStringTableSize());
     W.printNumber("OptionalHeaderSize", Obj->getSizeOfOptionalHeader());
@@ -748,19 +750,18 @@ void COFFDumper::printDOSHeader(const dos_header *DH) {
   W.printNumber("AddressOfNewExeHeader", DH->AddressOfNewExeHeader);
 }
 
-template <class PEHeader>
-void COFFDumper::printPEHeader(const PEHeader *Hdr) {
+template <class PEHeader> void COFFDumper::printPEHeader(const PEHeader *Hdr) {
   DictScope D(W, "ImageOptionalHeader");
-  W.printHex   ("Magic", Hdr->Magic);
+  W.printHex("Magic", Hdr->Magic);
   W.printNumber("MajorLinkerVersion", Hdr->MajorLinkerVersion);
   W.printNumber("MinorLinkerVersion", Hdr->MinorLinkerVersion);
   W.printNumber("SizeOfCode", Hdr->SizeOfCode);
   W.printNumber("SizeOfInitializedData", Hdr->SizeOfInitializedData);
   W.printNumber("SizeOfUninitializedData", Hdr->SizeOfUninitializedData);
-  W.printHex   ("AddressOfEntryPoint", Hdr->AddressOfEntryPoint);
-  W.printHex   ("BaseOfCode", Hdr->BaseOfCode);
+  W.printHex("AddressOfEntryPoint", Hdr->AddressOfEntryPoint);
+  W.printHex("BaseOfCode", Hdr->BaseOfCode);
   printBaseOfDataField(Hdr);
-  W.printHex   ("ImageBase", Hdr->ImageBase);
+  W.printHex("ImageBase", Hdr->ImageBase);
   W.printNumber("SectionAlignment", Hdr->SectionAlignment);
   W.printNumber("FileAlignment", Hdr->FileAlignment);
   W.printNumber("MajorOperatingSystemVersion",
@@ -773,7 +774,7 @@ void COFFDumper::printPEHeader(const PEHeader *Hdr) {
   W.printNumber("MinorSubsystemVersion", Hdr->MinorSubsystemVersion);
   W.printNumber("SizeOfImage", Hdr->SizeOfImage);
   W.printNumber("SizeOfHeaders", Hdr->SizeOfHeaders);
-  W.printHex   ("CheckSum", Hdr->CheckSum);
+  W.printHex("CheckSum", Hdr->CheckSum);
   W.printEnum("Subsystem", Hdr->Subsystem, EnumStrings(PEWindowsSubsystem));
   W.printFlags("Characteristics", Hdr->DLLCharacteristics,
                EnumStrings(PEDLLCharacteristics));
@@ -785,12 +786,22 @@ void COFFDumper::printPEHeader(const PEHeader *Hdr) {
 
   if (Hdr->NumberOfRvaAndSize > 0) {
     DictScope D(W, "DataDirectory");
-    static const char * const directory[] = {
-      "ExportTable", "ImportTable", "ResourceTable", "ExceptionTable",
-      "CertificateTable", "BaseRelocationTable", "Debug", "Architecture",
-      "GlobalPtr", "TLSTable", "LoadConfigTable", "BoundImport", "IAT",
-      "DelayImportDescriptor", "CLRRuntimeHeader", "Reserved"
-    };
+    static const char *const directory[] = {"ExportTable",
+                                            "ImportTable",
+                                            "ResourceTable",
+                                            "ExceptionTable",
+                                            "CertificateTable",
+                                            "BaseRelocationTable",
+                                            "Debug",
+                                            "Architecture",
+                                            "GlobalPtr",
+                                            "TLSTable",
+                                            "LoadConfigTable",
+                                            "BoundImport",
+                                            "IAT",
+                                            "DelayImportDescriptor",
+                                            "CLRRuntimeHeader",
+                                            "Reserved"};
 
     for (uint32_t i = 0; i < Hdr->NumberOfRvaAndSize; ++i)
       if (i < std::size(directory))
@@ -838,8 +849,8 @@ void COFFDumper::printCOFFDebugDirectory() {
       // FIXME: Data visualization for IMAGE_DEBUG_TYPE_VC_FEATURE and
       // IMAGE_DEBUG_TYPE_POGO?
       ArrayRef<uint8_t> RawData;
-      if (Error E = Obj->getRvaAndSizeAsBytes(D.AddressOfRawData,
-                                                         D.SizeOfData, RawData))
+      if (Error E = Obj->getRvaAndSizeAsBytes(D.AddressOfRawData, D.SizeOfData,
+                                              RawData))
         reportError(std::move(E), Obj->getFileName());
       if (D.Type == COFF::IMAGE_DEBUG_TYPE_EX_DLLCHARACTERISTICS) {
         // FIXME right now the only possible value would fit in 8 bits,
@@ -858,8 +869,7 @@ void COFFDumper::printRVATable(uint64_t TableVA, uint64_t Count,
   uintptr_t TableStart, TableEnd;
   if (Error E = Obj->getVaPtr(TableVA, TableStart))
     reportError(std::move(E), Obj->getFileName());
-  if (Error E =
-          Obj->getVaPtr(TableVA + Count * EntrySize - 1, TableEnd))
+  if (Error E = Obj->getVaPtr(TableVA + Count * EntrySize - 1, TableEnd))
     reportError(std::move(E), Obj->getFileName());
   TableEnd++;
   for (uintptr_t I = TableStart; I < TableEnd; I += EntrySize) {
@@ -991,14 +1001,14 @@ void COFFDumper::printCOFFLoadConfig() {
 
   if (Tables.GuardFidTableVA) {
     ListScope LS(W, "GuardFidTable");
-    printRVATable(Tables.GuardFidTableVA, Tables.GuardFidTableCount,
-                  4 + Stride, PrintExtra);
+    printRVATable(Tables.GuardFidTableVA, Tables.GuardFidTableCount, 4 + Stride,
+                  PrintExtra);
   }
 
   if (Tables.GuardIatTableVA) {
     ListScope LS(W, "GuardIatTable");
-    printRVATable(Tables.GuardIatTableVA, Tables.GuardIatTableCount,
-                  4 + Stride, PrintExtra);
+    printRVATable(Tables.GuardIatTableVA, Tables.GuardIatTableCount, 4 + Stride,
+                  PrintExtra);
   }
 
   if (Tables.GuardLJmpTableVA) {
@@ -1433,7 +1443,7 @@ void COFFDumper::printCodeViewSymbolsSubsection(StringRef Subsection,
   ArrayRef<uint8_t> BinaryData(Subsection.bytes_begin(),
                                Subsection.bytes_end());
   auto CODD = std::make_unique<COFFObjectDumpDelegate>(*this, Section, Obj,
-                                                        SectionContents);
+                                                       SectionContents);
   CVSymbolDumper CVSD(W, Types, CodeViewContainer::ObjectFile, std::move(CODD),
                       CompilationCPUType, opts::CodeViewSubsectionBytes);
   CVSymbolArray Symbols;
@@ -1596,12 +1606,12 @@ void COFFDumper::printSectionHeaders() {
     DictScope D(W, "Section");
     W.printNumber("Number", SectionNumber);
     W.printBinary("Name", Name, Section->Name);
-    W.printHex   ("VirtualSize", Section->VirtualSize);
-    W.printHex   ("VirtualAddress", Section->VirtualAddress);
+    W.printHex("VirtualSize", Section->VirtualSize);
+    W.printHex("VirtualAddress", Section->VirtualAddress);
     W.printNumber("RawDataSize", Section->SizeOfRawData);
-    W.printHex   ("PointerToRawData", Section->PointerToRawData);
-    W.printHex   ("PointerToRelocations", Section->PointerToRelocations);
-    W.printHex   ("PointerToLineNumbers", Section->PointerToLinenumbers);
+    W.printHex("PointerToRawData", Section->PointerToRawData);
+    W.printHex("PointerToRelocations", Section->PointerToRelocations);
+    W.printHex("PointerToLineNumbers", Section->PointerToLinenumbers);
     W.printNumber("RelocationCount", Section->NumberOfRelocations);
     W.printNumber("LineNumberCount", Section->NumberOfLinenumbers);
     W.printFlags("Characteristics", Section->Characteristics,
@@ -1683,11 +1693,9 @@ void COFFDumper::printRelocation(const SectionRef &Section,
     W.printString("Symbol", SymbolName.empty() ? "-" : SymbolName);
     W.printNumber("SymbolIndex", SymbolIndex);
   } else {
-    raw_ostream& OS = W.startLine();
-    OS << W.hex(Offset)
-       << " " << RelocName
-       << " " << (SymbolName.empty() ? "-" : SymbolName)
-       << " (" << SymbolIndex << ")"
+    raw_ostream &OS = W.startLine();
+    OS << W.hex(Offset) << " " << RelocName << " "
+       << (SymbolName.empty() ? "-" : SymbolName) << " (" << SymbolIndex << ")"
        << "\n";
   }
 }
@@ -1796,8 +1804,8 @@ void COFFDumper::printSymbol(const SymbolRef &Sym) {
       W.printNumber("Number", AuxNumber);
       W.printEnum("Selection", Aux->Selection, EnumStrings(ImageCOMDATSelect));
 
-      if (Section && Section->Characteristics & COFF::IMAGE_SCN_LNK_COMDAT
-          && Aux->Selection == COFF::IMAGE_COMDAT_SELECT_ASSOCIATIVE) {
+      if (Section && Section->Characteristics & COFF::IMAGE_SCN_LNK_COMDAT &&
+          Aux->Selection == COFF::IMAGE_COMDAT_SELECT_ASSOCIATIVE) {
         Expected<const coff_section *> Assoc = Obj->getSection(AuxNumber);
         if (!Assoc)
           reportError(Assoc.takeError(), Obj->getFileName());
@@ -1829,9 +1837,9 @@ void COFFDumper::printUnwindInfo() {
   switch (Obj->getMachine()) {
   case COFF::IMAGE_FILE_MACHINE_AMD64: {
     Win64EH::Dumper Dumper(W);
-    Win64EH::Dumper::SymbolResolver
-    Resolver = [](const object::coff_section *Section, uint64_t Offset,
-                  SymbolRef &Symbol, void *user_data) -> std::error_code {
+    Win64EH::Dumper::SymbolResolver Resolver =
+        [](const object::coff_section *Section, uint64_t Offset,
+           SymbolRef &Symbol, void *user_data) -> std::error_code {
       COFFDumper *Dumper = reinterpret_cast<COFFDumper *>(user_data);
       return Dumper->resolveSymbol(Section, Offset, Symbol);
     };
@@ -1935,7 +1943,8 @@ void COFFDumper::printCOFFImports() {
   }
 
   // Delay imports
-  for (const DelayImportDirectoryEntryRef &I : Obj->delay_import_directories()) {
+  for (const DelayImportDirectoryEntryRef &I :
+       Obj->delay_import_directories()) {
     DictScope Import(W, "DelayImport");
     StringRef Name;
     if (Error E = I.getName(Name))
@@ -1999,14 +2008,22 @@ void COFFDumper::printCOFFDirectives() {
 
 static std::string getBaseRelocTypeName(uint8_t Type) {
   switch (Type) {
-  case COFF::IMAGE_REL_BASED_ABSOLUTE: return "ABSOLUTE";
-  case COFF::IMAGE_REL_BASED_HIGH: return "HIGH";
-  case COFF::IMAGE_REL_BASED_LOW: return "LOW";
-  case COFF::IMAGE_REL_BASED_HIGHLOW: return "HIGHLOW";
-  case COFF::IMAGE_REL_BASED_HIGHADJ: return "HIGHADJ";
-  case COFF::IMAGE_REL_BASED_ARM_MOV32T: return "ARM_MOV32(T)";
-  case COFF::IMAGE_REL_BASED_DIR64: return "DIR64";
-  default: return "unknown (" + llvm::utostr(Type) + ")";
+  case COFF::IMAGE_REL_BASED_ABSOLUTE:
+    return "ABSOLUTE";
+  case COFF::IMAGE_REL_BASED_HIGH:
+    return "HIGH";
+  case COFF::IMAGE_REL_BASED_LOW:
+    return "LOW";
+  case COFF::IMAGE_REL_BASED_HIGHLOW:
+    return "HIGHLOW";
+  case COFF::IMAGE_REL_BASED_HIGHADJ:
+    return "HIGHADJ";
+  case COFF::IMAGE_REL_BASED_ARM_MOV32T:
+    return "ARM_MOV32(T)";
+  case COFF::IMAGE_REL_BASED_DIR64:
+    return "DIR64";
+  default:
+    return "unknown (" + llvm::utostr(Type) + ")";
   }
 }
 


### PR DESCRIPTION
Prior to changes to it in #221224.

This formats the whole file, and when it's landed I'll add the commit hash to .git-blame-ignore-revs.