### PR TITLE
[lldb][test] Bump utility expression timeout to 10 minutes

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -890,6 +890,9 @@ class Base(unittest.TestCase):
             "settings set target.auto-apply-fixits false",
             # Testsuite runs in parallel and the host can have also other load.
             "settings set plugin.process.gdb-remote.packet-timeout 60",
+            # LLDB-internal utility expressions can take very long when the
+            # host is under heavy load.
+            "settings set target.process.utility-expression-timeout 600",
             'settings set symbols.clang-modules-cache-path "{}"'.format(
                 configuration.lldb_module_cache_dir
             ),


### PR DESCRIPTION
LLDB needs to sometimes run utility expressions such as loading libraries via a call to `dlopen`. These utility expressions have a timeout associated with them which is only 15 seconds (and 60 on sanitized builds).

I suspect our expressions reaching this timeout is the reason why TestLoadUsingPaths.py sometimes fails to load libraries and produces this error:

```
  File "../TestLoadUsingPaths.py", line 78, in test_load_using_paths
      self.assertNotEqual(token, lldb.LLDB_INVALID_IMAGE_TOKEN, "Got a valid token")
```

This patch bumps the timeout to 10 minutes. There is no good reason why this timeout should exist in the first place on test bots, and maybe we should remove them or make them fatal errors on the test bots. But for now this patch should at least fix the test randomly failing on very slow bots.