### PR TITLE
[TailRecElim] Handle discarded-call return conflicts with a shift accumulator

### DIFF
--- a/llvm/lib/Transforms/Scalar/TailRecursionElimination.cpp
+++ b/llvm/lib/Transforms/Scalar/TailRecursionElimination.cpp
@@ -50,6 +50,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/Transforms/Scalar/TailRecursionElimination.h"
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/Statistic.h"
@@ -452,6 +453,11 @@ static bool isUnaryAccumulatorRecurrence(Instruction *I) {
 // will be rewritten to return the accumulator, so all of them have to yield the
 // same base-case constant. Return that constant, or nullptr on failure.
 //
+// RetSelects are the selects already inserted for call sites eliminated via
+// the "found return value" mechanism instead of the accumulator one. Their
+// original `ret` is gone, so they'd otherwise be invisible to the scan above,
+// but they still have to agree on the same base-case constant.
+//
 // FIXME: There is a room for improvement here in the future, e.g., consider
 // non-constant values and multiple base cases -- e.g., we want to be able to
 // handle code like:
@@ -462,9 +468,17 @@ static bool isUnaryAccumulatorRecurrence(Instruction *I) {
 //  return f(x-1) << 1;
 // }
 // ```
-static Constant *findBaseCaseRetConstant(Function &F,
-                                         Instruction *AccRecInstr) {
+static Constant *findBaseCaseRetConstant(Function &F, Instruction *AccRecInstr,
+                                         ArrayRef<SelectInst *> RetSelects) {
   Constant *BaseCaseVal = nullptr;
+
+  // Records C as the base-case constant the first time it's seen, and
+  // otherwise checks that it agrees with the one already on record.
+  auto AgreesWithBaseCase = [&](Constant *C) {
+    if (!BaseCaseVal)
+      BaseCaseVal = C;
+    return BaseCaseVal == C;
+  };
 
   for (BasicBlock &BB : F) {
     auto *RI = dyn_cast<ReturnInst>(BB.getTerminator());
@@ -483,12 +497,13 @@ static Constant *findBaseCaseRetConstant(Function &F,
     // not eliminated) must be rejected: returning the accumulator in its place
     // would drop that computation.
     auto *C = dyn_cast<Constant>(RV);
-    if (!C)
+    if (!C || !AgreesWithBaseCase(C))
       return nullptr;
+  }
 
-    if (!BaseCaseVal)
-      BaseCaseVal = C;
-    else if (BaseCaseVal != C)
+  for (SelectInst *SI : RetSelects) {
+    auto *C = dyn_cast<Constant>(SI->getFalseValue());
+    if (!C || !AgreesWithBaseCase(C))
       return nullptr;
   }
 
@@ -498,8 +513,9 @@ static Constant *findBaseCaseRetConstant(Function &F,
 // This function checks whether the instruction I can be used
 // to perform accumulator recursion elimination for the
 // call instruction CI.
-static Constant *canTransformAccumulatorRecursion(Instruction *I,
-                                                  CallInst *CI) {
+static Constant *
+canTransformAccumulatorRecursion(Instruction *I, CallInst *CI,
+                                 ArrayRef<SelectInst *> RetSelects) {
   bool IsUnaryAccumulatorRecurrence = isUnaryAccumulatorRecurrence(I);
   if ((!I->isAssociative() || !I->isCommutative()) &&
       !IsUnaryAccumulatorRecurrence)
@@ -517,7 +533,8 @@ static Constant *canTransformAccumulatorRecursion(Instruction *I,
 
     // findTRECandidate guarantees CI is a recursive call to its own
     // function, so scan the enclosing function for the base-case return.
-    AccInitVal = findBaseCaseRetConstant(*CI->getFunction(), /*AccRecInstr=*/I);
+    AccInitVal = findBaseCaseRetConstant(*CI->getFunction(), /*AccRecInstr=*/I,
+                                         RetSelects);
     if (!AccInitVal)
       return nullptr;
   } else {
@@ -815,7 +832,8 @@ bool TailRecursionEliminator::eliminateCall(CallInst *CI) {
     // arithmetic operation that could be transformed using accumulator
     // recursion elimination. Check to see if this is the case, and if so,
     // remember which instruction accumulates for later.
-    Constant *AccInitVal = canTransformAccumulatorRecursion(&*BBI, CI);
+    Constant *AccInitVal =
+        canTransformAccumulatorRecursion(&*BBI, CI, RetSelects);
 
     if (AccPN || !AccInitVal)
       return false; // We cannot eliminate the tail recursion!

--- a/llvm/lib/Transforms/Scalar/TailRecursionElimination.cpp
+++ b/llvm/lib/Transforms/Scalar/TailRecursionElimination.cpp
@@ -50,7 +50,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/Transforms/Scalar/TailRecursionElimination.h"
-#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/Statistic.h"
@@ -447,114 +446,6 @@ static bool isUnaryAccumulatorRecurrence(Instruction *I) {
   return isa<ConstantInt>(I->getOperand(1));
 }
 
-// Find the base-case return value for function F, given the accumulator
-// recursion instruction AccRecInstr that is about to be eliminated. Every
-// return other than the one fed by AccRecInstr survives the transformation and
-// will be rewritten to return the accumulator, so all of them have to yield the
-// same base-case constant. Return that constant, or nullptr on failure.
-//
-// RetSelects are the selects already inserted for call sites eliminated via
-// the "found return value" mechanism instead of the accumulator one. Their
-// original `ret` is gone, so they'd otherwise be invisible to the scan above,
-// but they still have to agree on the same base-case constant.
-//
-// FIXME: There is a room for improvement here in the future, e.g., consider
-// non-constant values and multiple base cases -- e.g., we want to be able to
-// handle code like:
-// ```
-// int f(int x) {
-//  if (x == 1) return 1;
-//  if (x == 10) return 10;
-//  return f(x-1) << 1;
-// }
-// ```
-static Constant *findBaseCaseRetConstant(Function &F, Instruction *AccRecInstr,
-                                         ArrayRef<SelectInst *> RetSelects) {
-  Constant *BaseCaseVal = nullptr;
-
-  // Records C as the base-case constant the first time it's seen, and
-  // otherwise checks that it agrees with the one already on record.
-  auto AgreesWithBaseCase = [&](Constant *C) {
-    if (!BaseCaseVal)
-      BaseCaseVal = C;
-    return BaseCaseVal == C;
-  };
-
-  for (BasicBlock &BB : F) {
-    auto *RI = dyn_cast<ReturnInst>(BB.getTerminator());
-    if (!RI || !RI->getReturnValue())
-      continue;
-
-    Value *RV = RI->getReturnValue();
-
-    // This is the recursive case being turned into a loop: the return goes
-    // away along with AccRecInstr.
-    if (RV == AccRecInstr)
-      continue;
-
-    // Anything else has to be the base case. In particular a return still
-    // computing from a recursive call (e.g. a second recursion site that is
-    // not eliminated) must be rejected: returning the accumulator in its place
-    // would drop that computation.
-    auto *C = dyn_cast<Constant>(RV);
-    if (!C || !AgreesWithBaseCase(C))
-      return nullptr;
-  }
-
-  for (SelectInst *SI : RetSelects) {
-    auto *C = dyn_cast<Constant>(SI->getFalseValue());
-    if (!C || !AgreesWithBaseCase(C))
-      return nullptr;
-  }
-
-  return BaseCaseVal;
-}
-
-// This function checks whether the instruction I can be used
-// to perform accumulator recursion elimination for the
-// call instruction CI.
-static Constant *
-canTransformAccumulatorRecursion(Instruction *I, CallInst *CI,
-                                 ArrayRef<SelectInst *> RetSelects) {
-  bool IsUnaryAccumulatorRecurrence = isUnaryAccumulatorRecurrence(I);
-  if ((!I->isAssociative() || !I->isCommutative()) &&
-      !IsUnaryAccumulatorRecurrence)
-    return nullptr;
-
-  assert(I->getNumOperands() >= 2 &&
-         "Associative/commutative operations should have at least 2 args!");
-
-  Constant *AccInitVal = nullptr;
-  if (IsUnaryAccumulatorRecurrence) {
-    // For unary accumulator recurrences, we require that the recursive call
-    // is always on the first operand.
-    if (I->getOperand(0) != CI)
-      return nullptr;
-
-    // findTRECandidate guarantees CI is a recursive call to its own
-    // function, so scan the enclosing function for the base-case return.
-    AccInitVal = findBaseCaseRetConstant(*CI->getFunction(), /*AccRecInstr=*/I,
-                                         RetSelects);
-    if (!AccInitVal)
-      return nullptr;
-  } else {
-    AccInitVal = ConstantExpr::getIdentity(I, I->getType());
-    if (!AccInitVal)
-      return nullptr;
-
-    // Exactly one operand should be the result of the call instruction.
-    if ((I->getOperand(0) == CI && I->getOperand(1) == CI) ||
-        (I->getOperand(0) != CI && I->getOperand(1) != CI))
-      return nullptr;
-  }
-
-  // The only user of this instruction we allow is a single return instruction.
-  if (!I->hasOneUse() || !isa<ReturnInst>(I->user_back()))
-    return nullptr;
-
-  return AccInitVal;
-}
-
 namespace {
 class TailRecursionEliminator {
   Function &F;
@@ -614,6 +505,10 @@ class TailRecursionEliminator {
     }
   }
 
+  Constant *findBaseCaseRetConstant(Instruction *AccRecInstr);
+
+  Constant *canTransformAccumulatorRecursion(Instruction *I, CallInst *CI);
+
   CallInst *findTRECandidate(BasicBlock *BB);
 
   void createTailRecurseLoopHeader(CallInst *CI);
@@ -637,6 +532,113 @@ public:
                         ProfileSummaryInfo *PSI, bool UpdateFunctionEntryCount);
 };
 } // namespace
+
+// Find the base-case return value for the function, given the accumulator
+// recursion instruction AccRecInstr that is about to be eliminated. Every
+// return other than the one fed by AccRecInstr survives the transformation and
+// will be rewritten to return the accumulator, so all of them have to yield the
+// same base-case constant. Return that constant, or nullptr on failure.
+//
+// RetSelects are the selects already inserted for call sites eliminated via
+// the "found return value" mechanism instead of the accumulator one. Their
+// original `ret` is gone, so they'd otherwise be invisible to the scan below,
+// but they still have to agree on the same base-case constant.
+//
+// FIXME: There is a room for improvement here in the future, e.g., consider
+// non-constant values and multiple base cases -- e.g., we want to be able to
+// handle code like:
+// ```
+// int f(int x) {
+//  if (x == 1) return 1;
+//  if (x == 10) return 10;
+//  return f(x-1) << 1;
+// }
+// ```
+Constant *
+TailRecursionEliminator::findBaseCaseRetConstant(Instruction *AccRecInstr) {
+  Constant *BaseCaseVal = nullptr;
+
+  // Records C as the base-case constant the first time it's seen, and
+  // otherwise checks that it agrees with the one already on record.
+  auto SetOrMatchBaseCase = [&](Constant *C) {
+    if (!BaseCaseVal)
+      BaseCaseVal = C;
+    return BaseCaseVal == C;
+  };
+
+  for (BasicBlock &BB : F) {
+    auto *RI = dyn_cast<ReturnInst>(BB.getTerminator());
+    if (!RI || !RI->getReturnValue())
+      continue;
+
+    Value *RV = RI->getReturnValue();
+
+    // This is the recursive case being turned into a loop: the return goes
+    // away along with AccRecInstr.
+    if (RV == AccRecInstr)
+      continue;
+
+    // Anything else has to be the base case. In particular a return still
+    // computing from a recursive call (e.g. a second recursion site that is
+    // not eliminated) must be rejected: returning the accumulator in its place
+    // would drop that computation.
+    auto *C = dyn_cast<Constant>(RV);
+    if (!C || !SetOrMatchBaseCase(C))
+      return nullptr;
+  }
+
+  for (SelectInst *SI : RetSelects) {
+    auto *C = dyn_cast<Constant>(SI->getFalseValue());
+    if (!C || !SetOrMatchBaseCase(C))
+      return nullptr;
+  }
+
+  return BaseCaseVal;
+}
+
+// This function checks whether the instruction I can be used
+// to perform accumulator recursion elimination for the
+// call instruction CI.
+Constant *
+TailRecursionEliminator::canTransformAccumulatorRecursion(Instruction *I,
+                                                          CallInst *CI) {
+  bool IsUnaryAccumulatorRecurrence = isUnaryAccumulatorRecurrence(I);
+  if ((!I->isAssociative() || !I->isCommutative()) &&
+      !IsUnaryAccumulatorRecurrence)
+    return nullptr;
+
+  assert(I->getNumOperands() >= 2 &&
+         "Associative/commutative operations should have at least 2 args!");
+
+  Constant *AccInitVal = nullptr;
+  if (IsUnaryAccumulatorRecurrence) {
+    // For unary accumulator recurrences, we require that the recursive call
+    // is always on the first operand.
+    if (I->getOperand(0) != CI)
+      return nullptr;
+
+    // findTRECandidate guarantees CI is a recursive call to its own
+    // function, so scan the enclosing function for the base-case return.
+    AccInitVal = findBaseCaseRetConstant(/*AccRecInstr=*/I);
+    if (!AccInitVal)
+      return nullptr;
+  } else {
+    AccInitVal = ConstantExpr::getIdentity(I, I->getType());
+    if (!AccInitVal)
+      return nullptr;
+
+    // Exactly one operand should be the result of the call instruction.
+    if ((I->getOperand(0) == CI && I->getOperand(1) == CI) ||
+        (I->getOperand(0) != CI && I->getOperand(1) != CI))
+      return nullptr;
+  }
+
+  // The only user of this instruction we allow is a single return instruction.
+  if (!I->hasOneUse() || !isa<ReturnInst>(I->user_back()))
+    return nullptr;
+
+  return AccInitVal;
+}
 
 CallInst *TailRecursionEliminator::findTRECandidate(BasicBlock *BB) {
   Instruction *TI = BB->getTerminator();
@@ -832,8 +834,7 @@ bool TailRecursionEliminator::eliminateCall(CallInst *CI) {
     // arithmetic operation that could be transformed using accumulator
     // recursion elimination. Check to see if this is the case, and if so,
     // remember which instruction accumulates for later.
-    Constant *AccInitVal =
-        canTransformAccumulatorRecursion(&*BBI, CI, RetSelects);
+    Constant *AccInitVal = canTransformAccumulatorRecursion(&*BBI, CI);
 
     if (AccPN || !AccInitVal)
       return false; // We cannot eliminate the tail recursion!

--- a/llvm/test/Transforms/TailCallElim/shl-accumulator-opt.ll
+++ b/llvm/test/Transforms/TailCallElim/shl-accumulator-opt.ll
@@ -239,3 +239,39 @@ other:
   %res = sub i32 %call2, 3
   ret i32 %res
 }
+
+; Negative test: a sibling call site that discards its own recursive call and
+; unconditionally returns a fixed constant must still agree with the shift
+; accumulator's base case.
+; int f(int x) {
+;   if (x == 0) return 1;
+;   if (x == 3) { f(x - 1); return 2; }
+;   return f(x - 1) << 1;
+; }
+define i32 @test_neg_discarded_call_conflicting_base(i32 %x) {
+; CHECK-LABEL: define i32 @test_neg_discarded_call_conflicting_base(
+; CHECK-NOT: accumulator.tr
+; CHECK: select {{.*}}, i32 2
+;
+entry:
+  %isbase = icmp eq i32 %x, 0
+  br i1 %isbase, label %base, label %rec
+
+rec:
+  %issp = icmp eq i32 %x, 3
+  br i1 %issp, label %special, label %normal
+
+special:
+  %d = sub i32 %x, 1
+  %c1 = tail call i32 @test_neg_discarded_call_conflicting_base(i32 %d)
+  ret i32 2
+
+normal:
+  %dec = sub i32 %x, 1
+  %c = tail call i32 @test_neg_discarded_call_conflicting_base(i32 %dec)
+  %shl = shl i32 %c, 1
+  ret i32 %shl
+
+base:
+  ret i32 1
+}

--- a/llvm/test/Transforms/TailCallElim/shl-accumulator-opt.ll
+++ b/llvm/test/Transforms/TailCallElim/shl-accumulator-opt.ll
@@ -250,8 +250,31 @@ other:
 ; }
 define i32 @test_neg_discarded_call_conflicting_base(i32 %x) {
 ; CHECK-LABEL: define i32 @test_neg_discarded_call_conflicting_base(
-; CHECK-NOT: accumulator.tr
-; CHECK: select {{.*}}, i32 2
+; CHECK-SAME: i32 [[X:%.*]]) {
+; CHECK-NEXT:  [[ENTRY:.*]]:
+; CHECK-NEXT:    br label %[[TAILRECURSE:.*]]
+; CHECK:       [[TAILRECURSE]]:
+; CHECK-NEXT:    [[X_TR:%.*]] = phi i32 [ [[X]], %[[ENTRY]] ], [ [[D:%.*]], %[[DISCARD:.*]] ]
+; CHECK-NEXT:    [[RET_TR:%.*]] = phi i32 [ poison, %[[ENTRY]] ], [ [[CURRENT_RET_TR:%.*]], %[[DISCARD]] ]
+; CHECK-NEXT:    [[RET_KNOWN_TR:%.*]] = phi i1 [ false, %[[ENTRY]] ], [ true, %[[DISCARD]] ]
+; CHECK-NEXT:    [[ISBASE:%.*]] = icmp eq i32 [[X_TR]], 0
+; CHECK-NEXT:    br i1 [[ISBASE]], label %[[BASE:.*]], label %[[REC:.*]]
+; CHECK:       [[REC]]:
+; CHECK-NEXT:    [[ISSP:%.*]] = icmp eq i32 [[X_TR]], 3
+; CHECK-NEXT:    br i1 [[ISSP]], label %[[DISCARD]], label %[[NORMAL:.*]]
+; CHECK:       [[DISCARD]]:
+; CHECK-NEXT:    [[D]] = sub i32 [[X_TR]], 1
+; CHECK-NEXT:    [[CURRENT_RET_TR]] = select i1 [[RET_KNOWN_TR]], i32 [[RET_TR]], i32 2
+; CHECK-NEXT:    br label %[[TAILRECURSE]]
+; CHECK:       [[NORMAL]]:
+; CHECK-NEXT:    [[DEC:%.*]] = sub i32 [[X_TR]], 1
+; CHECK-NEXT:    [[C:%.*]] = tail call i32 @test_neg_discarded_call_conflicting_base(i32 [[DEC]])
+; CHECK-NEXT:    [[SHL:%.*]] = shl i32 [[C]], 1
+; CHECK-NEXT:    [[CURRENT_RET_TR1:%.*]] = select i1 [[RET_KNOWN_TR]], i32 [[RET_TR]], i32 [[SHL]]
+; CHECK-NEXT:    ret i32 [[CURRENT_RET_TR1]]
+; CHECK:       [[BASE]]:
+; CHECK-NEXT:    [[CURRENT_RET_TR2:%.*]] = select i1 [[RET_KNOWN_TR]], i32 [[RET_TR]], i32 1
+; CHECK-NEXT:    ret i32 [[CURRENT_RET_TR2]]
 ;
 entry:
   %isbase = icmp eq i32 %x, 0
@@ -259,9 +282,9 @@ entry:
 
 rec:
   %issp = icmp eq i32 %x, 3
-  br i1 %issp, label %special, label %normal
+  br i1 %issp, label %discard, label %normal
 
-special:
+discard:
   %d = sub i32 %x, 1
   %c1 = tail call i32 @test_neg_discarded_call_conflicting_base(i32 %d)
   ret i32 2


### PR DESCRIPTION
Fixes a follow-up miscompile from #181331, reported by nikic in https://github.com/llvm/llvm-project/pull/181331#issuecomment-5509668449, similar but unrelated to #214503.

`findBaseCaseRetConstant` only scanned live `ret` instructions to check that a shift accumulator's base case is consistent everywhere. A sibling call site that discards its own recursive call and returns a fixed constant is eliminated earlier, so its `ret` is already gone by the time the scan runs. The scan missed it and `cleanupAndFinalize` would silently replace that constant with the accumulator value.

With this PR we also check the false-value of already-inserted selects for consistency, bailing out the accumulator transform on conflict.

