### PR TITLE
[orc-rt] Add ORC_RT_ENABLE_PIC, default on.

### DIFF
--- a/orc-rt/CMakeLists.txt
+++ b/orc-rt/CMakeLists.txt
@@ -57,6 +57,15 @@ option(ORC_RT_ENABLE_ASSERTIONS "Enable assertions independent of build mode." O
 option(ORC_RT_ENABLE_PEDANTIC "Compile with pedantic enabled." ON)
 option(ORC_RT_ENABLE_WERROR "Fail and stop if a warning is triggered." OFF)
 
+option(ORC_RT_ENABLE_PIC "Build position-independent code." ON)
+if(NOT ORC_RT_ENABLE_PIC AND
+   "${CMAKE_C_FLAGS} ${CMAKE_CXX_FLAGS} ${CMAKE_ASM_FLAGS}" MATCHES "-fPIC")
+  message(WARNING
+    "ORC_RT_ENABLE_PIC is OFF, but -fPIC is already in CMAKE_C_FLAGS, "
+    "CMAKE_CXX_FLAGS or CMAKE_ASM_FLAGS, so the build will still be "
+    "position-independent.")
+endif()
+
 # --- Language runtime (RTTI / exceptions) ---
 option(ORC_RT_ENABLE_RTTI "Enable RTTI." ON)
 option(ORC_RT_ENABLE_EXCEPTIONS "Enable exceptions." ON)

--- a/orc-rt/lib/bedrock/CMakeLists.txt
+++ b/orc-rt/lib/bedrock/CMakeLists.txt
@@ -76,6 +76,9 @@ endif()
 
 add_library(orc-rt-bedrock-objects OBJECT ${ORC_RT_BEDROCK_SOURCES})
 
+set_target_properties(orc-rt-bedrock-objects PROPERTIES
+  POSITION_INDEPENDENT_CODE ${ORC_RT_ENABLE_PIC})
+
 target_link_libraries(orc-rt-bedrock-objects PUBLIC orc-rt-headers)
 
 # Apply RTTI and exceptions compile flags

--- a/orc-rt/lib/support/CMakeLists.txt
+++ b/orc-rt/lib/support/CMakeLists.txt
@@ -27,6 +27,9 @@ endif()
 # ship, never shipped on its own.
 add_library(orc-rt-support-objects OBJECT ${ORC_RT_SUPPORT_SOURCES})
 
+set_target_properties(orc-rt-support-objects PROPERTIES
+  POSITION_INDEPENDENT_CODE ${ORC_RT_ENABLE_PIC})
+
 target_link_libraries(orc-rt-support-objects PUBLIC orc-rt-headers)
 
 # Apply RTTI and exceptions compile flags


### PR DESCRIPTION
An upcoming patch will add support for building bedrock as a dylib.  In preparation for this, add ORC_RT_ENABLE_PIC option, and use it to set POSITION_INDEPENDENT_CODE (needed for shared library builds) on the bedrock and support object libraries.