### PR TITLE
[clang] Support DecompositionDecl in -ast-print

### DIFF
--- a/clang/lib/AST/DeclPrinter.cpp
+++ b/clang/lib/AST/DeclPrinter.cpp
@@ -52,7 +52,7 @@ namespace {
     void PrintObjCTypeParams(ObjCTypeParamList *Params);
     void PrintOpenACCRoutineOnLambda(Decl *D);
 
-    QualType printVarDeclSpecifiers(VarDecl *D);
+    void printVarDeclSpecifiers(VarDecl *D);
     void printVarInitializer(VarDecl *D);
 
   public:
@@ -972,7 +972,7 @@ void DeclPrinter::VisitLabelDecl(LabelDecl *D) {
   Out << *D << ":";
 }
 
-QualType DeclPrinter::printVarDeclSpecifiers(VarDecl *D) {
+void DeclPrinter::printVarDeclSpecifiers(VarDecl *D) {
   prettyPrintPragmas(D);
 
   if (std::optional<std::string> Attrs =
@@ -1015,16 +1015,16 @@ QualType DeclPrinter::printVarDeclSpecifiers(VarDecl *D) {
     }
   }
 
-  return T;
-}
-
-void DeclPrinter::VisitVarDecl(VarDecl *D) {
-  QualType T = printVarDeclSpecifiers(D);
-
+  // D->getName() is "" for a DecompositionDecl (it has no name of its own),
+  // which is exactly the declarator we want for one: just the type.
   printDeclType(T, (isa<ParmVarDecl>(D) && Policy.CleanUglifiedParameters &&
                     D->getIdentifier())
                        ? D->getIdentifier()->deuglifiedName()
                        : D->getName());
+}
+
+void DeclPrinter::VisitVarDecl(VarDecl *D) {
+  printVarDeclSpecifiers(D);
 
   if (std::optional<std::string> Attrs =
           prettyPrintAttributes(D, AttrPosAsWritten::Right))
@@ -1064,10 +1064,7 @@ void DeclPrinter::printVarInitializer(VarDecl *D) {
 }
 
 void DeclPrinter::VisitDecompositionDecl(DecompositionDecl *D) {
-  QualType T = printVarDeclSpecifiers(D);
-
-  // DecompositionDecl has no name of its own.
-  printDeclType(T, "");
+  printVarDeclSpecifiers(D);
 
   Out << " [";
   bool First = true;

--- a/clang/lib/AST/DeclPrinter.cpp
+++ b/clang/lib/AST/DeclPrinter.cpp
@@ -1067,11 +1067,9 @@ void DeclPrinter::VisitDecompositionDecl(DecompositionDecl *D) {
   printVarDeclSpecifiers(D);
 
   Out << " [";
-  bool First = true;
+  llvm::ListSeparator LS;
   for (BindingDecl *B : D->bindings()) {
-    if (!First)
-      Out << ", ";
-    First = false;
+    Out << LS;
     // FIXME: this drops the leading "..." for a pack binding.
     Out << B->getName();
   }

--- a/clang/lib/AST/DeclPrinter.cpp
+++ b/clang/lib/AST/DeclPrinter.cpp
@@ -52,6 +52,9 @@ namespace {
     void PrintObjCTypeParams(ObjCTypeParamList *Params);
     void PrintOpenACCRoutineOnLambda(Decl *D);
 
+    QualType printVarDeclSpecifiers(VarDecl *D);
+    void printVarInitializer(VarDecl *D);
+
   public:
     DeclPrinter(raw_ostream &Out, const PrintingPolicy &Policy,
                 const ASTContext &Context, unsigned Indentation = 0,
@@ -73,6 +76,7 @@ namespace {
     void VisitFriendTemplateDecl(FriendTemplateDecl *D);
     void VisitFieldDecl(FieldDecl *D);
     void VisitVarDecl(VarDecl *D);
+    void VisitDecompositionDecl(DecompositionDecl *D);
     void VisitLabelDecl(LabelDecl *D);
     void VisitParmVarDecl(ParmVarDecl *D);
     void VisitFileScopeAsmDecl(FileScopeAsmDecl *D);
@@ -459,6 +463,11 @@ void DeclPrinter::VisitDeclContext(DeclContext *DC, bool Indent) {
     // Don't print ObjCIvarDecls, as they are printed when visiting the
     // containing ObjCInterfaceDecl.
     if (isa<ObjCIvarDecl>(*D))
+      continue;
+
+    // Don't print BindingDecls, as they are printed when visiting the
+    // containing DecompositionDecl.
+    if (isa<BindingDecl>(*D))
       continue;
 
     // Skip over implicit declarations in pretty-printing mode.
@@ -963,7 +972,7 @@ void DeclPrinter::VisitLabelDecl(LabelDecl *D) {
   Out << *D << ":";
 }
 
-void DeclPrinter::VisitVarDecl(VarDecl *D) {
+QualType DeclPrinter::printVarDeclSpecifiers(VarDecl *D) {
   prettyPrintPragmas(D);
 
   if (std::optional<std::string> Attrs =
@@ -1006,6 +1015,12 @@ void DeclPrinter::VisitVarDecl(VarDecl *D) {
     }
   }
 
+  return T;
+}
+
+void DeclPrinter::VisitVarDecl(VarDecl *D) {
+  QualType T = printVarDeclSpecifiers(D);
+
   printDeclType(T, (isa<ParmVarDecl>(D) && Policy.CleanUglifiedParameters &&
                     D->getIdentifier())
                        ? D->getIdentifier()->deuglifiedName()
@@ -1015,6 +1030,10 @@ void DeclPrinter::VisitVarDecl(VarDecl *D) {
           prettyPrintAttributes(D, AttrPosAsWritten::Right))
     Out << ' ' << *Attrs;
 
+  printVarInitializer(D);
+}
+
+void DeclPrinter::printVarInitializer(VarDecl *D) {
   Expr *Init = D->getInit();
   if (!Policy.SuppressInitializers && Init) {
     bool ImplicitInit = false;
@@ -1042,6 +1061,26 @@ void DeclPrinter::VisitVarDecl(VarDecl *D) {
         Out << ")";
     }
   }
+}
+
+void DeclPrinter::VisitDecompositionDecl(DecompositionDecl *D) {
+  QualType T = printVarDeclSpecifiers(D);
+
+  // DecompositionDecl has no name of its own.
+  printDeclType(T, "");
+
+  Out << " [";
+  bool First = true;
+  for (BindingDecl *B : D->bindings()) {
+    if (!First)
+      Out << ", ";
+    First = false;
+    // FIXME: this drops the leading "..." for a pack binding.
+    Out << B->getName();
+  }
+  Out << "]";
+
+  printVarInitializer(D);
 }
 
 void DeclPrinter::VisitParmVarDecl(ParmVarDecl *D) {

--- a/clang/lib/AST/DeclPrinter.cpp
+++ b/clang/lib/AST/DeclPrinter.cpp
@@ -460,14 +460,9 @@ void DeclPrinter::VisitDeclContext(DeclContext *DC, bool Indent) {
   for (DeclContext::decl_iterator D = DC->decls_begin(), DEnd = DC->decls_end();
        D != DEnd; ++D) {
 
-    // Don't print ObjCIvarDecls, as they are printed when visiting the
-    // containing ObjCInterfaceDecl.
-    if (isa<ObjCIvarDecl>(*D))
-      continue;
-
-    // Don't print BindingDecls, as they are printed when visiting the
-    // containing DecompositionDecl.
-    if (isa<BindingDecl>(*D))
+    // Don't print ObjCIvarDecls or BindingDecls, as they are printed when
+    // visiting the containing ObjCInterfaceDecl or DecompositionDecl.
+    if (isa<ObjCIvarDecl, BindingDecl>(*D))
       continue;
 
     // Skip over implicit declarations in pretty-printing mode.

--- a/clang/lib/AST/DeclPrinter.cpp
+++ b/clang/lib/AST/DeclPrinter.cpp
@@ -1073,6 +1073,9 @@ void DeclPrinter::VisitDecompositionDecl(DecompositionDecl *D) {
     if (B->isParameterPack())
       Out << "...";
     Out << B->getName();
+    if (std::optional<std::string> Attrs =
+            prettyPrintAttributes(B, AttrPosAsWritten::Right))
+      Out << ' ' << *Attrs;
   }
   Out << "]";
 

--- a/clang/lib/AST/DeclPrinter.cpp
+++ b/clang/lib/AST/DeclPrinter.cpp
@@ -1070,7 +1070,8 @@ void DeclPrinter::VisitDecompositionDecl(DecompositionDecl *D) {
   llvm::ListSeparator LS;
   for (BindingDecl *B : D->bindings()) {
     Out << LS;
-    // FIXME: this drops the leading "..." for a pack binding.
+    if (B->isParameterPack())
+      Out << "...";
     Out << B->getName();
   }
   Out << "]";

--- a/clang/lib/AST/DeclPrinter.cpp
+++ b/clang/lib/AST/DeclPrinter.cpp
@@ -487,9 +487,13 @@ void DeclPrinter::VisitDeclContext(DeclContext *DC, bool Indent) {
     // only merges declarations directly referring to the tag, not typedefs.
     //
     // Check whether the current declaration should be grouped with a previous
-    // non-free-standing tag declaration.
+    // non-free-standing tag declaration. A decomposition declaration is always
+    // a declaration of its own -- it can never be one declarator among several
+    // -- but its deduced type can be the tag type owned by the preceding
+    // declaration, so exclude it explicitly.
     QualType CurDeclType = getDeclType(*D);
-    if (!Decls.empty() && !CurDeclType.isNull()) {
+    if (!Decls.empty() && !CurDeclType.isNull() &&
+        !isa<DecompositionDecl>(*D)) {
       QualType BaseType = GetBaseType(CurDeclType);
       if (const auto *TT = dyn_cast_or_null<TagType>(BaseType);
           TT && TT->isTagOwned()) {

--- a/clang/test/AST/ast-print-decomposition.cpp
+++ b/clang/test/AST/ast-print-decomposition.cpp
@@ -1,0 +1,66 @@
+// RUN: %clang_cc1 -std=c++20 -ast-print %s | FileCheck %s
+
+// The `[a, b]` binding list must survive -ast-print, not just the type.
+
+namespace std {
+using size_t = decltype(sizeof(0));
+template <typename> struct tuple_size;
+template <size_t, typename> struct tuple_element;
+} // namespace std
+
+namespace Aggregate {
+struct Pair { int a, b; };
+Pair get();
+Pair &getref();
+
+// CHECK-LABEL: void local() {
+void local() {
+  // CHECK-NEXT: auto [x, y] = get();
+  auto [x, y] = get();
+  // CHECK-NEXT: auto & [rx, ry] = getref();
+  auto &[rx, ry] = getref();
+  // CHECK-NEXT: const auto [cx, cy] = get();
+  const auto [cx, cy] = get();
+  // CHECK-NEXT: static auto [sx, sy] = get();
+  static auto [sx, sy] = get();
+}
+} // namespace Aggregate
+
+namespace Array {
+// CHECK-LABEL: void local() {
+void local() {
+  // CHECK-NEXT: int arr[3] = {1, 2, 3};
+  int arr[3] = {1, 2, 3};
+  // CHECK-NEXT: auto [a, b, c]
+  auto [a, b, c] = arr;
+}
+} // namespace Array
+
+namespace TupleLike {
+struct Two {};
+Two getTwo();
+} // namespace TupleLike
+
+template <> struct std::tuple_size<TupleLike::Two> { enum { value = 2 }; };
+template <> struct std::tuple_element<0, TupleLike::Two> { using type = int; };
+template <> struct std::tuple_element<1, TupleLike::Two> { using type = int; };
+
+namespace TupleLike {
+// get() must be found by ADL, so it needs to live here, not at global scope.
+template <std::size_t N> int get(Two);
+
+// CHECK-LABEL: void local() {
+void local() {
+  // CHECK-NEXT: auto [p, q] = getTwo();
+  auto [p, q] = getTwo();
+}
+} // namespace TupleLike
+
+namespace NamespaceScope {
+using Aggregate::Pair;
+using Aggregate::get;
+
+// CHECK: auto [gx, gy] = get();
+auto [gx, gy] = get();
+// CHECK-NOT: {{^;$}}
+} // namespace NamespaceScope

--- a/clang/test/AST/ast-print-decomposition.cpp
+++ b/clang/test/AST/ast-print-decomposition.cpp
@@ -76,3 +76,14 @@ template <unsigned N> void local() {
 }
 void (*p)() = local<0>;
 } // namespace Packs
+
+namespace Attributes {
+using Aggregate::Pair;
+using Aggregate::get;
+
+// CHECK-LABEL: void local() {
+void local() {
+  // CHECK-NEXT: auto [x {{\[\[}}maybe_unused{{\]\]}}, y] = get();
+  auto [x [[maybe_unused]], y] = get();
+}
+} // namespace Attributes

--- a/clang/test/AST/ast-print-decomposition.cpp
+++ b/clang/test/AST/ast-print-decomposition.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -std=c++20 -ast-print %s | FileCheck %s
+// RUN: %clang_cc1 -std=c++26 -ast-print %s | FileCheck %s
 
 // The `[a, b]` binding list must survive -ast-print, not just the type.
 
@@ -65,3 +65,14 @@ using Aggregate::get;
 auto [gx, gy] = get();
 // CHECK-NOT: {{^[[:space:]]*;[[:space:]]*$}}
 } // namespace NamespaceScope
+
+namespace Packs {
+// CHECK-LABEL: void local() {
+template <unsigned N> void local() {
+  // CHECK-NEXT: int arr[4] = {1, 2, 3, 4};
+  int arr[4] = {1, 2, 3, 4};
+  // CHECK-NEXT: auto [first, ...rest, last]
+  auto [first, ...rest, last] = arr;
+}
+void (*p)() = local<0>;
+} // namespace Packs

--- a/clang/test/AST/ast-print-decomposition.cpp
+++ b/clang/test/AST/ast-print-decomposition.cpp
@@ -71,7 +71,7 @@ namespace Packs {
 template <unsigned N> void local() {
   // CHECK-NEXT: int arr[4] = {1, 2, 3, 4};
   int arr[4] = {1, 2, 3, 4};
-  // CHECK-NEXT: auto [first, ...rest, last]
+  // CHECK-NEXT: auto [first, ...rest, last] = {{\{}}arr[*]{{(\})}};
   auto [first, ...rest, last] = arr;
 }
 void (*p)() = local<0>;

--- a/clang/test/AST/ast-print-decomposition.cpp
+++ b/clang/test/AST/ast-print-decomposition.cpp
@@ -31,7 +31,7 @@ namespace Array {
 void local() {
   // CHECK-NEXT: int arr[3] = {1, 2, 3};
   int arr[3] = {1, 2, 3};
-  // CHECK-NEXT: auto [a, b, c] = {{\{}}arr[*]{{(\})}};
+  // CHECK-NEXT: auto [a, b, c] = {arr[*]};
   auto [a, b, c] = arr;
 }
 } // namespace Array

--- a/clang/test/AST/ast-print-decomposition.cpp
+++ b/clang/test/AST/ast-print-decomposition.cpp
@@ -60,7 +60,8 @@ namespace NamespaceScope {
 using Aggregate::Pair;
 using Aggregate::get;
 
+// CHECK-NOT: {{^[[:space:]]*;[[:space:]]*$}}
 // CHECK: auto [gx, gy] = get();
 auto [gx, gy] = get();
-// CHECK-NOT: {{^;$}}
+// CHECK-NOT: {{^[[:space:]]*;[[:space:]]*$}}
 } // namespace NamespaceScope

--- a/clang/test/AST/ast-print-decomposition.cpp
+++ b/clang/test/AST/ast-print-decomposition.cpp
@@ -71,7 +71,7 @@ namespace Packs {
 template <unsigned N> void local() {
   // CHECK-NEXT: int arr[4] = {1, 2, 3, 4};
   int arr[4] = {1, 2, 3, 4};
-  // CHECK-NEXT: auto [first, ...rest, last] = {{\{}}arr[*]{{(\})}};
+  // CHECK-NEXT: auto [first, ...rest, last] = {arr[*]};
   auto [first, ...rest, last] = arr;
 }
 void (*p)() = local<0>;

--- a/clang/test/AST/ast-print-decomposition.cpp
+++ b/clang/test/AST/ast-print-decomposition.cpp
@@ -31,7 +31,7 @@ namespace Array {
 void local() {
   // CHECK-NEXT: int arr[3] = {1, 2, 3};
   int arr[3] = {1, 2, 3};
-  // CHECK-NEXT: auto [a, b, c]
+  // CHECK-NEXT: auto [a, b, c] = {{\{}}arr[*]{{(\})}};
   auto [a, b, c] = arr;
 }
 } // namespace Array

--- a/clang/test/AST/ast-print-decomposition.cpp
+++ b/clang/test/AST/ast-print-decomposition.cpp
@@ -83,7 +83,7 @@ using Aggregate::get;
 
 // CHECK-LABEL: void local() {
 void local() {
-  // CHECK-NEXT: auto [x {{\[\[}}maybe_unused{{\]\]}}, y] = get();
+  // CHECK-NEXT: auto [x {{\[\[}}maybe_unused]], y] = get();
   auto [x [[maybe_unused]], y] = get();
 }
 } // namespace Attributes

--- a/clang/test/AST/ast-print-decomposition.cpp
+++ b/clang/test/AST/ast-print-decomposition.cpp
@@ -87,3 +87,21 @@ void local() {
   auto [x [[maybe_unused]], y] = get();
 }
 } // namespace Attributes
+
+namespace OwnedTag {
+// At declaration-context scope the printer groups a tag declaration with the
+// declarators that follow it, so an owned tag type keeps `struct Owned { ... }
+// obj;` on one line. A decomposition declaration is a declaration of its own
+// and must never be pulled into that group, even though its deduced type is
+// precisely the tag type owned by `obj`'s declaration.
+// CHECK-LABEL: struct Owned {
+// CHECK: } obj;
+// CHECK-NEXT: auto [ox, oy] = obj;
+struct Owned { int a, b; } obj;
+auto [ox, oy] = obj;
+
+// A second declarator of an owned tag type still merges.
+// CHECK-NEXT: struct Merged {
+// CHECK: } m1, m2;
+struct Merged { int v; } m1, m2;
+} // namespace OwnedTag

--- a/clang/test/Analysis/anonymous-decls.cpp
+++ b/clang/test/Analysis/anonymous-decls.cpp
@@ -72,7 +72,7 @@ int main() {
 // CHECK-NEXT:   2: [B3.1] (ImplicitCastExpr, FunctionToPointerDecay, iterator_traits<pair<int, int> *>::reference (*)(void))
 // CHECK-NEXT:   3: __begin1
 // CHECK-NEXT:   4: * [B3.3] (OperatorCall)
-// CHECK-NEXT:   5: auto &;
+// CHECK-NEXT:   5: auto &{{.*}};
 // CHECK-NEXT:   6: get<0UL>
 // CHECK-NEXT:   7: [B3.6] (ImplicitCastExpr, FunctionToPointerDecay, tuple_element<0L, pair<int, int> >::type (*)(pair<int, int> &))
 // CHECK-NEXT:   8: decomposition-a-b

--- a/clang/test/Analysis/cfg.cpp
+++ b/clang/test/Analysis/cfg.cpp
@@ -659,7 +659,7 @@ bail:
 // CHECK-NEXT:    5: [B1.3]{{\[\[}}B1.4]]
 // CHECK-NEXT:    6: [B1.5] (ImplicitCastExpr, LValueToRValue, int)
 // CHECK-NEXT:    7: {{\{}}[B1.6]{{(\})}}
-// CHECK-NEXT:    8: auto = {{\{}}arr[*]{{(\})}};
+// CHECK-NEXT:    8: auto{{.*}} = {{\{}}arr[*]{{(\})}};
 void DecompositionDecl() {
   int arr[2];
 


### PR DESCRIPTION
`DeclPrinter` had no `VisitDecompositionDecl`, so `auto [a, b] = get();`
printed as `auto = get();`, silently dropping the binding list (worse
at namespace scope, where it also produced a stray empty statement per
binding).

Add `DeclPrinter::VisitDecompositionDecl`, printing the full
`type [bindings] = init;` form for all three decomposition kinds
(aggregate/member, array, tuple-like), matching what `VisitVarDecl` does
for an ordinary declaration. Specifier and initializer printing is
shared between the two via two helpers (`printVarDeclSpecifiers`,
`printVarInitializer`) so they can't drift apart.

Each binding prints correctly, including a pack's leading `...` and per-binding attributes. `BindingDecls` are skipped when walking a `DeclContext` directly, since each is already printed as part of its `DecompositionDecl;` a decomposition declaration is likewise kept out of the tag-declaration grouping in `VisitDeclContext`, which would otherwise merge it into a preceding `struct S { ... } obj;`.

Assisted-by: AI
