### PR TITLE
[Clang] Fixed getPredefinedExprDecl Assert When No Lambda Scope

### DIFF
--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -2118,25 +2118,31 @@ static PredefinedIdentKind getPredefinedExprKind(tok::TokenKind Kind) {
 /// to determine the value of a PredefinedExpr. This can be either a
 /// block, lambda, captured statement, function, otherwise a nullptr.
 static Decl *getPredefinedExprDecl(Sema &S, DeclContext *DC) {
-  auto LSI = S.FunctionScopes.rbegin();
 
-  auto tryAdjustLambdaContext = [&S, &LSI](DeclContext *&DC) {
+  for (; DC; DC = DC->getParent()) {
+    // Skip this DC if we are in a lambda declaration context but not yet in
+    // the compound statement.
     if (isLambdaCallOperator(DC)) {
-      auto E = S.FunctionScopes.rend();
-      while (LSI != E && !isa<LambdaScopeInfo>(*LSI))
-        ++LSI;
-      assert(LSI != E && "Should be in a lambda scope info");
-      if (dyn_cast<LambdaScopeInfo>(*LSI)->BeforeCompoundStatement)
-        DC = DC->getParent();
-      ++LSI;
-    }
-  };
 
-  tryAdjustLambdaContext(DC);
-  while (DC &&
-         !isa<BlockDecl, CapturedDecl, FunctionDecl, ObjCMethodDecl>(DC)) {
-    DC = DC->getParent();
-    tryAdjustLambdaContext(DC);
+      LambdaScopeInfo *MatchingLSI = nullptr;
+      for (auto Scope = S.FunctionScopes.rbegin();
+           Scope != S.FunctionScopes.rend(); Scope++) {
+        if (auto *LSI = dyn_cast<LambdaScopeInfo>(*Scope)) {
+          assert(LSI->CallOperator && "LSI missing an associated CallOperator");
+
+          if (cast<DeclContext>(LSI->CallOperator) == DC) {
+            MatchingLSI = LSI;
+            break;
+          }
+        }
+      }
+
+      if (MatchingLSI && MatchingLSI->BeforeCompoundStatement)
+        continue;
+    }
+
+    if (isa<BlockDecl, CapturedDecl, FunctionDecl, ObjCMethodDecl>(DC))
+      break;
   }
 
   return cast_or_null<Decl>(DC);

--- a/clang/test/Sema/ms_predefined_expr.cpp
+++ b/clang/test/Sema/ms_predefined_expr.cpp
@@ -206,3 +206,9 @@ void test_in_constexpr_struct_init() {
   } constexpr c1 = { { "F:" __FUNCTION__ } }; // expected-warning{{expansion of predefined identifier '__FUNCTION__' to a string literal is a Microsoft extension}}
   ASSERT_EQ("F:" __FUNCTION__, c1.s.F); // expected-warning{{expansion of predefined identifier '__FUNCTION__' to a string literal is a Microsoft extension}}
 }
+
+namespace GH221564 {
+  auto l = [](auto a) { return 42; }; // expected-note{{defined here}}
+  using L = decltype(l);
+  auto L::operator()() const { return {"<="}; } // expected-error{{out-of-line definition of 'operator()' does not match any declaration}}
+}


### PR DESCRIPTION
**Problem**
`getPredefinedExprDecl` searches through the chain of `DeclContext`s for the appropriate context for predefined expressions such as `__func__` to refer to. In the case of a lambda context before the compound statement, it needs to use the higher function context instead. It does this by skipping the context when encountering this case but the code assumes there will always be an associated `LambdaScopeInfo` sitting on the `FunctionScopes` stack but it's possible for there not to be one in the case of an `operator()` definition on a lambda type such as `auto lambda_type::operator()() const { ... }`.

**Solution**
If there are no `LambdaScopeInfo`s on the stack, it is not within an actual lambda anyway so the skip doesn't need to happen. Also check the stack for the `LambdaScopeInfo` that matches the exact `DeclContext`.

**Assumptions**
That not having a `LambdaScopeInfo` on the stack is valid and can be used to represent this case.

Fixes #221564