### PR TITLE
[CIR] Handle ImportDecl in emitTopLevelDecl

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -2538,6 +2538,11 @@ void CIRGenModule::emitTopLevelDecl(Decl *decl) {
     emitDeclContext(cast<ExportDecl>(decl));
     break;
 
+  case Decl::Import:
+    // Nothing to emit for C++20 module imports. Initializers run through
+    // the imported module.
+    break;
+
   case Decl::Var:
   case Decl::Decomposition:
   case Decl::VarTemplateSpecialization: {

--- a/clang/test/CIR/CodeGen/Inputs/modules-import-iface.cppm
+++ b/clang/test/CIR/CodeGen/Inputs/modules-import-iface.cppm
@@ -1,0 +1,2 @@
+export module m;
+export int f() { return 1; }

--- a/clang/test/CIR/CodeGen/modules-import-impl.cpp
+++ b/clang/test/CIR/CodeGen/modules-import-impl.cpp
@@ -8,7 +8,7 @@
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
 // RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu \
 // RUN:   -emit-llvm -fmodule-file=m=%t.pcm %s -o %t.og.ll
-// RUN: FileCheck --check-prefix=OGCG --input-file=%t.og.ll %s
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t.og.ll %s
 
 module m;
 
@@ -19,6 +19,3 @@ int g() { return f() + 1; }
 
 // LLVM-LABEL: define {{.*}} i32 @_ZW1m1gv()
 // LLVM:         {{%.+}} = call {{.*}} i32 @_ZW1m1fv()
-
-// OGCG-LABEL: define {{.*}} i32 @_ZW1m1gv()
-// OGCG:         {{%.+}} = call {{.*}} i32 @_ZW1m1fv()

--- a/clang/test/CIR/CodeGen/modules-import-impl.cpp
+++ b/clang/test/CIR/CodeGen/modules-import-impl.cpp
@@ -1,0 +1,24 @@
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu \
+// RUN:   -emit-module-interface %S/Inputs/modules-import-iface.cppm -o %t.pcm
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu \
+// RUN:   -fclangir -emit-cir -fmodule-file=m=%t.pcm %s -o %t.cir
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu \
+// RUN:   -fclangir -emit-llvm -fmodule-file=m=%t.pcm %s -o %t.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu \
+// RUN:   -emit-llvm -fmodule-file=m=%t.pcm %s -o %t.og.ll
+// RUN: FileCheck --check-prefix=OGCG --input-file=%t.og.ll %s
+
+module m;
+
+int g() { return f() + 1; }
+
+// CIR-LABEL: cir.func {{.*}} @_ZW1m1gv(
+// CIR:         {{%.+}} = cir.call @_ZW1m1fv() : () -> (!s32i {{.*}})
+
+// LLVM-LABEL: define {{.*}} i32 @_ZW1m1gv()
+// LLVM:         {{%.+}} = call {{.*}} i32 @_ZW1m1fv()
+
+// OGCG-LABEL: define {{.*}} i32 @_ZW1m1gv()
+// OGCG:         {{%.+}} = call {{.*}} i32 @_ZW1m1fv()

--- a/clang/test/CIR/CodeGen/modules-import.cpp
+++ b/clang/test/CIR/CodeGen/modules-import.cpp
@@ -8,7 +8,7 @@
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
 // RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu \
 // RUN:   -emit-llvm -fmodule-file=m=%t.pcm %s -o %t.og.ll
-// RUN: FileCheck --check-prefix=OGCG --input-file=%t.og.ll %s
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t.og.ll %s
 
 import m;
 
@@ -19,6 +19,3 @@ int use_it() { return f(); }
 
 // LLVM-LABEL: define {{.*}} i32 @_Z6use_itv()
 // LLVM:         {{%.+}} = call {{.*}} i32 @_ZW1m1fv()
-
-// OGCG-LABEL: define {{.*}} i32 @_Z6use_itv()
-// OGCG:         {{%.+}} = call {{.*}} i32 @_ZW1m1fv()

--- a/clang/test/CIR/CodeGen/modules-import.cpp
+++ b/clang/test/CIR/CodeGen/modules-import.cpp
@@ -1,0 +1,24 @@
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu \
+// RUN:   -emit-module-interface %S/Inputs/modules-import-iface.cppm -o %t.pcm
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu \
+// RUN:   -fclangir -emit-cir -fmodule-file=m=%t.pcm %s -o %t.cir
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu \
+// RUN:   -fclangir -emit-llvm -fmodule-file=m=%t.pcm %s -o %t.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu \
+// RUN:   -emit-llvm -fmodule-file=m=%t.pcm %s -o %t.og.ll
+// RUN: FileCheck --check-prefix=OGCG --input-file=%t.og.ll %s
+
+import m;
+
+int use_it() { return f(); }
+
+// CIR-LABEL: cir.func {{.*}} @_Z6use_itv(
+// CIR:         {{%.+}} = cir.call @_ZW1m1fv() : () -> (!s32i {{.*}})
+
+// LLVM-LABEL: define {{.*}} i32 @_Z6use_itv()
+// LLVM:         {{%.+}} = call {{.*}} i32 @_ZW1m1fv()
+
+// OGCG-LABEL: define {{.*}} i32 @_Z6use_itv()
+// OGCG:         {{%.+}} = call {{.*}} i32 @_ZW1m1fv()


### PR DESCRIPTION
Importing TUs and module implementation units failed with "declaration of kind: Import". 

Initializers run through the imported module, as in classic CodeGen, so handle it as a no-op. 