### PR TITLE
[CIR][CMake] Configure MLIR as a dependency-only project

### DIFF
--- a/clang/CMakeLists.txt
+++ b/clang/CMakeLists.txt
@@ -195,9 +195,10 @@ if(CLANG_ENABLE_CIR)
     message(FATAL_ERROR
       "ClangIR is not yet supported in the standalone build.")
   endif()
-  if (NOT "${LLVM_ENABLE_PROJECTS}" MATCHES "MLIR|mlir")
+  if (NOT "mlir" IN_LIST LLVM_ENABLE_PROJECTS AND
+      NOT "mlir" IN_LIST LLVM_DEPENDENCY_ONLY_PROJECTS)
     message(FATAL_ERROR
-      "Cannot build ClangIR without MLIR in LLVM_ENABLE_PROJECTS")
+      "Cannot build ClangIR without MLIR enabled")
   endif()
 endif()
 

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -205,6 +205,13 @@ if ("flang" IN_LIST LLVM_ENABLE_PROJECTS)
   endif ()
 endif()
 
+if (CLANG_ENABLE_CIR AND "clang" IN_LIST LLVM_ENABLE_PROJECTS AND
+    NOT "mlir" IN_LIST LLVM_ENABLE_PROJECTS AND
+    NOT "mlir" IN_LIST LLVM_DEPENDENCY_ONLY_PROJECTS)
+  message(STATUS "Enabling MLIR as a dependency to ClangIR")
+  list(APPEND LLVM_DEPENDENCY_ONLY_PROJECTS "mlir")
+endif()
+
 if ("lldb" IN_LIST LLVM_ENABLE_PROJECTS)
   if (NOT "clang" IN_LIST LLVM_ENABLE_PROJECTS)
     message(STATUS "Enabling clang as a dependency of lldb")


### PR DESCRIPTION
ClangIR requires MLIR, but enabling CIR currently requires users to list MLIR explicitly in LLVM_ENABLE_PROJECTS. That also attaches all MLIR build, install, unit-test, and lit targets to the corresponding LLVM aggregates.

When Clang is selected and CLANG_ENABLE_CIR is enabled, record MLIR in LLVM_DEPENDENCY_ONLY_PROJECTS unless it is already available. This configures the MLIR targets used by CIR without changing LLVM_ENABLE_PROJECTS or enabling MLIR's aggregate targets.

Keep explicit MLIR selections unchanged and retain the existing standalone ClangIR restriction. Clang builds with CIR disabled continue to omit MLIR.

Assisted-by: Codex