### PR TITLE
[GlobalISel] Avoid double DenseMap lookups in ValueToVRegInfo (NFC)

### DIFF
--- a/llvm/lib/CodeGen/GlobalISel/IRTranslator.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/IRTranslator.cpp
@@ -129,19 +129,23 @@ class IRTranslatorImpl {
     inline const_vreg_iterator vregs_end() const { return ValToVRegs.end(); }
 
     VRegListT *getVRegs(const Value &V) {
-      auto It = ValToVRegs.find(&V);
-      if (It != ValToVRegs.end())
+      auto [It, Inserted] = ValToVRegs.try_emplace(&V);
+      if (!Inserted)
         return It->second;
 
-      return insertVRegs(V);
+      // We placement new using our fast allocator since we never try to free
+      // the vectors until translation is finished.
+      It->second = new (VRegAlloc.Allocate()) VRegListT();
+      return It->second;
     }
 
     OffsetListT *getOffsets(const Value &V) {
-      auto It = TypeToOffsets.find(V.getType());
-      if (It != TypeToOffsets.end())
+      auto [It, Inserted] = TypeToOffsets.try_emplace(V.getType());
+      if (!Inserted)
         return It->second;
 
-      return insertOffsets(V);
+      It->second = new (OffsetAlloc.Allocate()) OffsetListT();
+      return It->second;
     }
 
     const_vreg_iterator findVRegs(const Value &V) const {
@@ -158,23 +162,6 @@ class IRTranslatorImpl {
     }
 
   private:
-    VRegListT *insertVRegs(const Value &V) {
-      assert(!ValToVRegs.contains(&V) && "Value already exists");
-
-      // We placement new using our fast allocator since we never try to free
-      // the vectors until translation is finished.
-      auto *VRegList = new (VRegAlloc.Allocate()) VRegListT();
-      ValToVRegs[&V] = VRegList;
-      return VRegList;
-    }
-
-    OffsetListT *insertOffsets(const Value &V) {
-      assert(!TypeToOffsets.contains(V.getType()) && "Type already exists");
-
-      auto *OffsetList = new (OffsetAlloc.Allocate()) OffsetListT();
-      TypeToOffsets[V.getType()] = OffsetList;
-      return OffsetList;
-    }
     SpecificBumpPtrAllocator<VRegListT> VRegAlloc;
     SpecificBumpPtrAllocator<OffsetListT> OffsetAlloc;
 


### PR DESCRIPTION
Improves CTMark geomean -0.06% on aarch64-O0-g.

https://llvm-compile-time-tracker.com/compare.php?from=97cbc1e404b980edc58bfbcabb6f1c61793b624b&to=fbf62152c51f2327cb2f4a382df90b3f345a8866&stat=instructions:u

Assisted-by: codex