### PR TITLE
[IR] Remove obsolete visited sets from type queries (NFC)

### DIFF
--- a/llvm/include/llvm/IR/DerivedTypes.h
+++ b/llvm/include/llvm/IR/DerivedTypes.h
@@ -354,23 +354,18 @@ public:
   bool isOpaque() const { return (getSubclassData() & SCDB_HasBody) == 0; }
 
   /// isSized - Return true if this is a sized type.
-  LLVM_ABI bool isSized(SmallPtrSetImpl<Type *> *Visited = nullptr) const;
+  LLVM_ABI bool isSized() const;
 
   /// Returns true if this struct contains a scalable vector.
-  LLVM_ABI bool isScalableTy(SmallPtrSetImpl<const Type *> &Visited) const;
-  using Type::isScalableTy;
+  LLVM_ABI bool isScalableTy() const;
 
   /// Return true if this type is or contains a target extension type that
   /// disallows being used as a global.
-  LLVM_ABI bool
-  containsNonGlobalTargetExtType(SmallPtrSetImpl<const Type *> &Visited) const;
-  using Type::containsNonGlobalTargetExtType;
+  LLVM_ABI bool containsNonGlobalTargetExtType() const;
 
   /// Return true if this type is or contains a target extension type that
   /// disallows being used as a local.
-  LLVM_ABI bool
-  containsNonLocalTargetExtType(SmallPtrSetImpl<const Type *> &Visited) const;
-  using Type::containsNonLocalTargetExtType;
+  LLVM_ABI bool containsNonLocalTargetExtType() const;
 
   /// Returns true if this struct contains homogeneous scalable vector types.
   /// Note that the definition of homogeneous scalable vector type is not

--- a/llvm/include/llvm/IR/Type.h
+++ b/llvm/include/llvm/IR/Type.h
@@ -33,7 +33,6 @@ class LLVMContext;
 class PointerType;
 class raw_ostream;
 class StringRef;
-template <typename PtrType> class SmallPtrSetImpl;
 
 /// The instances of the Type class are immutable: once they are created,
 /// they are never changed.  Also note that only one instance of a particular
@@ -208,19 +207,14 @@ public:
   LLVM_ABI bool isScalableTargetExtTy() const;
 
   /// Return true if this is a type whose size is a known multiple of vscale.
-  LLVM_ABI bool isScalableTy(SmallPtrSetImpl<const Type *> &Visited) const;
   LLVM_ABI bool isScalableTy() const;
 
   /// Return true if this type is or contains a target extension type that
   /// disallows being used as a global.
-  LLVM_ABI bool
-  containsNonGlobalTargetExtType(SmallPtrSetImpl<const Type *> &Visited) const;
   LLVM_ABI bool containsNonGlobalTargetExtType() const;
 
   /// Return true if this type is or contains a target extension type that
   /// disallows being used as a local.
-  LLVM_ABI bool
-  containsNonLocalTargetExtType(SmallPtrSetImpl<const Type *> &Visited) const;
   LLVM_ABI bool containsNonLocalTargetExtType() const;
 
   /// Return true if this is a FP type or a vector of FP.
@@ -323,7 +317,7 @@ public:
   /// Return true if it makes sense to take the size of this type. To get the
   /// actual size for a particular target, it is reasonable to use the
   /// DataLayout subsystem to do this.
-  bool isSized(SmallPtrSetImpl<Type*> *Visited = nullptr) const {
+  bool isSized() const {
     // If it's a primitive, it is always sized.
     if (getTypeID() == IntegerTyID || isFloatingPointTy() ||
         getTypeID() == PointerTyID || getTypeID() == X86_AMXTyID ||
@@ -335,7 +329,7 @@ public:
         !isVectorTy() && getTypeID() != TargetExtTyID)
       return false;
     // Otherwise we have to try harder to decide.
-    return isSizedDerivedType(Visited);
+    return isSizedDerivedType();
   }
 
   /// Return the basic size of this type if it is a primitive type. These are
@@ -524,8 +518,7 @@ private:
   /// Derived types like structures and arrays are sized iff all of the members
   /// of the type are sized as well. Since asking for their size is relatively
   /// uncommon, move this operation out-of-line.
-  LLVM_ABI bool
-  isSizedDerivedType(SmallPtrSetImpl<Type *> *Visited = nullptr) const;
+  LLVM_ABI bool isSizedDerivedType() const;
 };
 
 // Printing of types.

--- a/llvm/include/llvm/IR/Type.h
+++ b/llvm/include/llvm/IR/Type.h
@@ -33,6 +33,7 @@ class LLVMContext;
 class PointerType;
 class raw_ostream;
 class StringRef;
+template <typename PtrType> class SmallPtrSetImpl;
 
 /// The instances of the Type class are immutable: once they are created,
 /// they are never changed.  Also note that only one instance of a particular

--- a/llvm/include/llvm/SandboxIR/Type.h
+++ b/llvm/include/llvm/SandboxIR/Type.h
@@ -14,7 +14,6 @@
 #define LLVM_SANDBOXIR_TYPE_H
 
 #include "llvm/ADT/APInt.h"
-#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/Type.h"
 #include "llvm/Support/Compiler.h"
@@ -241,13 +240,7 @@ public:
   /// Return true if it makes sense to take the size of this type. To get the
   /// actual size for a particular target, it is reasonable to use the
   /// DataLayout subsystem to do this.
-  bool isSized(SmallPtrSetImpl<Type *> *Visited = nullptr) const {
-    SmallPtrSet<llvm::Type *, 8> LLVMVisited;
-    LLVMVisited.reserve(Visited->size());
-    for (Type *Ty : *Visited)
-      LLVMVisited.insert(Ty->LLVMTy);
-    return LLVMTy->isSized(&LLVMVisited);
-  }
+  bool isSized() const { return LLVMTy->isSized(); }
 
   /// Return the basic size of this type if it is a primitive type. These are
   /// fixed by LLVM and are not target-dependent.

--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -4916,8 +4916,7 @@ bool LLParser::parseValID(ValID &ID, PerFunctionState *PFS, Type *ExpectedTy) {
         }
       }
 
-      SmallPtrSet<Type*, 4> Visited;
-      if (!Indices.empty() && !Ty->isSized(&Visited))
+      if (!Indices.empty() && !Ty->isSized())
         return error(ID.Loc, "base element of getelementptr must be sized");
 
       if (!ConstantExpr::isSupportedGetElementPtr(Ty))
@@ -9056,8 +9055,7 @@ int LLParser::parseAlloc(Instruction *&Inst, PerFunctionState &PFS) {
   if (Size && !Size->getType()->isIntegerTy())
     return error(SizeLoc, "element count must have integer type");
 
-  SmallPtrSet<Type *, 4> Visited;
-  if (!Alignment && !Ty->isSized(&Visited))
+  if (!Alignment && !Ty->isSized())
     return error(TyLoc, "Cannot allocate unsized type");
   if (!Alignment)
     Alignment = M->getDataLayout().getPrefTypeAlign(Ty);
@@ -9126,8 +9124,7 @@ int LLParser::parseLoad(Instruction *&Inst, PerFunctionState &PFS) {
     return error(Loc,
                  "atomic elementwise load cannot be sequentially consistent");
 
-  SmallPtrSet<Type *, 4> Visited;
-  if (!Alignment && !Ty->isSized(&Visited))
+  if (!Alignment && !Ty->isSized())
     return error(ExplicitTypeLoc, "loading unsized types is not allowed");
   if (!Alignment)
     Alignment = M->getDataLayout().getABITypeAlign(Ty);
@@ -9197,8 +9194,7 @@ int LLParser::parseStore(Instruction *&Inst, PerFunctionState &PFS) {
     return error(Loc,
                  "atomic elementwise store cannot be sequentially consistent");
 
-  SmallPtrSet<Type *, 4> Visited;
-  if (!Alignment && !Val->getType()->isSized(&Visited))
+  if (!Alignment && !Val->getType()->isSized())
     return error(Loc, "storing unsized types is not allowed");
   if (!Alignment)
     Alignment = M->getDataLayout().getABITypeAlign(Val->getType());
@@ -9485,8 +9481,7 @@ int LLParser::parseGetElementPtr(Instruction *&Inst, PerFunctionState &PFS) {
     Indices.push_back(Val);
   }
 
-  SmallPtrSet<Type*, 4> Visited;
-  if (!Indices.empty() && !Ty->isSized(&Visited))
+  if (!Indices.empty() && !Ty->isSized())
     return error(Loc, "base element of getelementptr must be sized");
 
   auto *STy = dyn_cast<StructType>(Ty);

--- a/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
+++ b/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
@@ -6405,8 +6405,7 @@ Error BitcodeReader::parseFunctionBody(Function *F) {
       const DataLayout &DL = TheModule->getDataLayout();
       unsigned AS = Record.size() == 5 ? Record[4] : DL.getAllocaAddrSpace();
 
-      SmallPtrSet<Type *, 4> Visited;
-      if (!Align && !Ty->isSized(&Visited))
+      if (!Align && !Ty->isSized())
         return error("alloca of unsized type");
       if (!Align)
         Align = DL.getPrefTypeAlign(Ty);
@@ -6451,8 +6450,7 @@ Error BitcodeReader::parseFunctionBody(Function *F) {
       MaybeAlign Align;
       if (Error Err = parseAlignmentValue(Record[OpNum], Align))
         return Err;
-      SmallPtrSet<Type *, 4> Visited;
-      if (!Align && !Ty->isSized(&Visited))
+      if (!Align && !Ty->isSized())
         return error("load of unsized type");
       if (!Align)
         Align = TheModule->getDataLayout().getABITypeAlign(Ty);
@@ -6537,8 +6535,7 @@ Error BitcodeReader::parseFunctionBody(Function *F) {
       MaybeAlign Align;
       if (Error Err = parseAlignmentValue(Record[OpNum], Align))
         return Err;
-      SmallPtrSet<Type *, 4> Visited;
-      if (!Align && !Val->getType()->isSized(&Visited))
+      if (!Align && !Val->getType()->isSized())
         return error("store of unsized type");
       if (!Align)
         Align = TheModule->getDataLayout().getABITypeAlign(Val->getType());

--- a/llvm/lib/IR/Type.cpp
+++ b/llvm/lib/IR/Type.cpp
@@ -58,14 +58,6 @@ bool Type::isByteTy(unsigned BitWidth) const {
   return isByteTy() && cast<ByteType>(this)->getBitWidth() == BitWidth;
 }
 
-bool Type::isScalableTy(SmallPtrSetImpl<const Type *> &Visited) const {
-  if (const auto *ATy = dyn_cast<ArrayType>(this))
-    return ATy->getElementType()->isScalableTy(Visited);
-  if (const auto *STy = dyn_cast<StructType>(this))
-    return STy->isScalableTy(Visited);
-  return getTypeID() == ScalableVectorTyID || isScalableTargetExtTy();
-}
-
 bool Type::isScalableTy() const {
   switch (getTypeID()) {
   case ScalableVectorTyID:
@@ -73,45 +65,32 @@ bool Type::isScalableTy() const {
   case TargetExtTyID:
     return isScalableTargetExtTy();
   case ArrayTyID:
-  case StructTyID: {
-    SmallPtrSet<const Type *, 4> Visited;
-    return isScalableTy(Visited);
-  }
+    return cast<ArrayType>(this)->getElementType()->isScalableTy();
+  case StructTyID:
+    return cast<StructType>(this)->isScalableTy();
   default:
     return false;
   }
 }
 
-bool Type::containsNonGlobalTargetExtType(
-    SmallPtrSetImpl<const Type *> &Visited) const {
+bool Type::containsNonGlobalTargetExtType() const {
   if (const auto *ATy = dyn_cast<ArrayType>(this))
-    return ATy->getElementType()->containsNonGlobalTargetExtType(Visited);
+    return ATy->getElementType()->containsNonGlobalTargetExtType();
   if (const auto *STy = dyn_cast<StructType>(this))
-    return STy->containsNonGlobalTargetExtType(Visited);
+    return STy->containsNonGlobalTargetExtType();
   if (auto *TT = dyn_cast<TargetExtType>(this))
     return !TT->hasProperty(TargetExtType::CanBeGlobal);
   return false;
 }
 
-bool Type::containsNonGlobalTargetExtType() const {
-  SmallPtrSet<const Type *, 4> Visited;
-  return containsNonGlobalTargetExtType(Visited);
-}
-
-bool Type::containsNonLocalTargetExtType(
-    SmallPtrSetImpl<const Type *> &Visited) const {
+bool Type::containsNonLocalTargetExtType() const {
   if (const auto *ATy = dyn_cast<ArrayType>(this))
-    return ATy->getElementType()->containsNonLocalTargetExtType(Visited);
+    return ATy->getElementType()->containsNonLocalTargetExtType();
   if (const auto *STy = dyn_cast<StructType>(this))
-    return STy->containsNonLocalTargetExtType(Visited);
+    return STy->containsNonLocalTargetExtType();
   if (auto *TT = dyn_cast<TargetExtType>(this))
     return !TT->hasProperty(TargetExtType::CanBeLocal);
   return false;
-}
-
-bool Type::containsNonLocalTargetExtType() const {
-  SmallPtrSet<const Type *, 4> Visited;
-  return containsNonLocalTargetExtType(Visited);
 }
 
 const fltSemantics &Type::getFltSemantics() const {
@@ -273,17 +252,17 @@ bool Type::isFirstClassType() const {
   }
 }
 
-bool Type::isSizedDerivedType(SmallPtrSetImpl<Type*> *Visited) const {
+bool Type::isSizedDerivedType() const {
   if (auto *ATy = dyn_cast<ArrayType>(this))
-    return ATy->getElementType()->isSized(Visited);
+    return ATy->getElementType()->isSized();
 
   if (auto *VTy = dyn_cast<VectorType>(this))
-    return VTy->getElementType()->isSized(Visited);
+    return VTy->getElementType()->isSized();
 
   if (auto *TTy = dyn_cast<TargetExtType>(this))
-    return TTy->getLayoutType()->isSized(Visited);
+    return TTy->getLayoutType()->isSized();
 
-  return cast<StructType>(this)->isSized(Visited);
+  return cast<StructType>(this)->isSized();
 }
 
 //===----------------------------------------------------------------------===//
@@ -512,18 +491,15 @@ StructType *StructType::get(LLVMContext &Context, ArrayRef<Type*> ETypes,
   return ST;
 }
 
-bool StructType::isScalableTy(SmallPtrSetImpl<const Type *> &Visited) const {
+bool StructType::isScalableTy() const {
   if ((getSubclassData() & SCDB_ContainsScalableVector) != 0)
     return true;
 
   if ((getSubclassData() & SCDB_NotContainsScalableVector) != 0)
     return false;
 
-  if (!Visited.insert(this).second)
-    return false;
-
   for (Type *Ty : elements()) {
-    if (Ty->isScalableTy(Visited)) {
+    if (Ty->isScalableTy()) {
       const_cast<StructType *>(this)->setSubclassData(
           getSubclassData() | SCDB_ContainsScalableVector);
       return true;
@@ -539,19 +515,15 @@ bool StructType::isScalableTy(SmallPtrSetImpl<const Type *> &Visited) const {
   return false;
 }
 
-bool StructType::containsNonGlobalTargetExtType(
-    SmallPtrSetImpl<const Type *> &Visited) const {
+bool StructType::containsNonGlobalTargetExtType() const {
   if ((getSubclassData() & SCDB_ContainsNonGlobalTargetExtType) != 0)
     return true;
 
   if ((getSubclassData() & SCDB_NotContainsNonGlobalTargetExtType) != 0)
     return false;
 
-  if (!Visited.insert(this).second)
-    return false;
-
   for (Type *Ty : elements()) {
-    if (Ty->containsNonGlobalTargetExtType(Visited)) {
+    if (Ty->containsNonGlobalTargetExtType()) {
       const_cast<StructType *>(this)->setSubclassData(
           getSubclassData() | SCDB_ContainsNonGlobalTargetExtType);
       return true;
@@ -567,19 +539,15 @@ bool StructType::containsNonGlobalTargetExtType(
   return false;
 }
 
-bool StructType::containsNonLocalTargetExtType(
-    SmallPtrSetImpl<const Type *> &Visited) const {
+bool StructType::containsNonLocalTargetExtType() const {
   if ((getSubclassData() & SCDB_ContainsNonLocalTargetExtType) != 0)
     return true;
 
   if ((getSubclassData() & SCDB_NotContainsNonLocalTargetExtType) != 0)
     return false;
 
-  if (!Visited.insert(this).second)
-    return false;
-
   for (Type *Ty : elements()) {
-    if (Ty->containsNonLocalTargetExtType(Visited)) {
+    if (Ty->containsNonLocalTargetExtType()) {
       const_cast<StructType *>(this)->setSubclassData(
           getSubclassData() | SCDB_ContainsNonLocalTargetExtType);
       return true;
@@ -730,13 +698,10 @@ StructType *StructType::create(ArrayRef<Type*> Elements) {
   return create(Elements[0]->getContext(), Elements, StringRef());
 }
 
-bool StructType::isSized(SmallPtrSetImpl<Type*> *Visited) const {
+bool StructType::isSized() const {
   if ((getSubclassData() & SCDB_IsSized) != 0)
     return true;
   if (isOpaque())
-    return false;
-
-  if (Visited && !Visited->insert(const_cast<StructType*>(this)).second)
     return false;
 
   // Okay, our struct is sized if all of the elements are, but if one of the
@@ -756,7 +721,7 @@ bool StructType::isSized(SmallPtrSetImpl<Type*> *Visited) const {
     // types and is handled by the if-statement before this for-loop.
     if (Ty->isScalableTy())
       return false;
-    if (!Ty->isSized(Visited))
+    if (!Ty->isSized())
       return false;
   }
 

--- a/llvm/lib/IR/Type.cpp
+++ b/llvm/lib/IR/Type.cpp
@@ -73,14 +73,13 @@ bool Type::isScalableTy() const {
   case TargetExtTyID:
     return isScalableTargetExtTy();
   case ArrayTyID:
-  case StructTyID:
-    break;
+  case StructTyID: {
+    SmallPtrSet<const Type *, 4> Visited;
+    return isScalableTy(Visited);
+  }
   default:
     return false;
   }
-
-  SmallPtrSet<const Type *, 4> Visited;
-  return isScalableTy(Visited);
 }
 
 bool Type::containsNonGlobalTargetExtType(

--- a/llvm/lib/IR/Type.cpp
+++ b/llvm/lib/IR/Type.cpp
@@ -67,6 +67,18 @@ bool Type::isScalableTy(SmallPtrSetImpl<const Type *> &Visited) const {
 }
 
 bool Type::isScalableTy() const {
+  switch (getTypeID()) {
+  case ScalableVectorTyID:
+    return true;
+  case TargetExtTyID:
+    return isScalableTargetExtTy();
+  case ArrayTyID:
+  case StructTyID:
+    break;
+  default:
+    return false;
+  }
+
   SmallPtrSet<const Type *, 4> Visited;
   return isScalableTy(Visited);
 }

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -2292,8 +2292,7 @@ void Verifier::verifyParameterAttrs(AttributeSet Attrs, Type *Ty,
     }
     if (Attrs.hasAttribute(Attribute::ByVal)) {
       Type *ByValTy = Attrs.getByValType();
-      SmallPtrSet<Type *, 4> Visited;
-      Check(ByValTy->isSized(&Visited),
+      Check(ByValTy->isSized(),
             "Attribute 'byval' does not support unsized types!", V);
       // Check if it is or contains a target extension type that disallows being
       // used on the stack.
@@ -2303,24 +2302,21 @@ void Verifier::verifyParameterAttrs(AttributeSet Attrs, Type *Ty,
             "huge 'byval' arguments are unsupported", V);
     }
     if (Attrs.hasAttribute(Attribute::ByRef)) {
-      SmallPtrSet<Type *, 4> Visited;
-      Check(Attrs.getByRefType()->isSized(&Visited),
+      Check(Attrs.getByRefType()->isSized(),
             "Attribute 'byref' does not support unsized types!", V);
       Check(DL.getTypeAllocSize(Attrs.getByRefType()).getKnownMinValue() <
                 (1ULL << 32),
             "huge 'byref' arguments are unsupported", V);
     }
     if (Attrs.hasAttribute(Attribute::InAlloca)) {
-      SmallPtrSet<Type *, 4> Visited;
-      Check(Attrs.getInAllocaType()->isSized(&Visited),
+      Check(Attrs.getInAllocaType()->isSized(),
             "Attribute 'inalloca' does not support unsized types!", V);
       Check(DL.getTypeAllocSize(Attrs.getInAllocaType()).getKnownMinValue() <
                 (1ULL << 32),
             "huge 'inalloca' arguments are unsupported", V);
     }
     if (Attrs.hasAttribute(Attribute::Preallocated)) {
-      SmallPtrSet<Type *, 4> Visited;
-      Check(Attrs.getPreallocatedType()->isSized(&Visited),
+      Check(Attrs.getPreallocatedType()->isSized(),
             "Attribute 'preallocated' does not support unsized types!", V);
       Check(
           DL.getTypeAllocSize(Attrs.getPreallocatedType()).getKnownMinValue() <
@@ -4833,8 +4829,7 @@ void Verifier::visitAllocaInst(AllocaInst &AI) {
           "Non-logical alloca disallowed for this module.");
 
   Type *Ty = AI.getAllocatedType();
-  SmallPtrSet<Type*, 4> Visited;
-  Check(Ty->isSized(&Visited), "Cannot allocate unsized type", &AI);
+  Check(Ty->isSized(), "Cannot allocate unsized type", &AI);
   // Check if it's a target extension type that disallows being used on the
   // stack.
   Check(!Ty->containsNonLocalTargetExtType(),

--- a/llvm/unittests/SandboxIR/TypesTest.cpp
+++ b/llvm/unittests/SandboxIR/TypesTest.cpp
@@ -6,7 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/AsmParser/Parser.h"
 #include "llvm/IR/BasicBlock.h"
 #include "llvm/IR/Constants.h"
@@ -172,8 +171,7 @@ define void @foo(i32 %v0) {
   // Check isAggregateType().
   EXPECT_FALSE(Int32Ty->isAggregateType());
   // Check isSized().
-  SmallPtrSet<sandboxir::Type *, 1> Visited;
-  EXPECT_TRUE(Int32Ty->isSized(&Visited));
+  EXPECT_TRUE(Int32Ty->isSized());
   // Check getPrimitiveSizeInBits().
   EXPECT_EQ(VecTy32x2->getPrimitiveSizeInBits(), 32u * 2);
   // Check getScalarSizeInBits().


### PR DESCRIPTION
Recursive types have been rejected since 2024 (#114799), making the visited sets in type queries unnecessary.

Improves CTMark geomean -0.08% on  aarch64-O0-g. Also improves compile-time slightly for several other targets.

https://llvm-compile-time-tracker.com/compare.php?from=97cbc1e404b980edc58bfbcabb6f1c61793b624b&to=45c1423e7e38b6950ae760fc159ecb69cafdd691&stat=instructions%3Au

Assisted-by: codex