### PR TITLE
Revert "[CodeGen] Use RegisterClassInfo for remaining allocation-order users"

### DIFF
--- a/llvm/lib/CodeGen/RegAllocPBQP.cpp
+++ b/llvm/lib/CodeGen/RegAllocPBQP.cpp
@@ -56,7 +56,6 @@
 #include "llvm/CodeGen/PBQP/Solution.h"
 #include "llvm/CodeGen/PBQPRAConstraint.h"
 #include "llvm/CodeGen/RegAllocRegistry.h"
-#include "llvm/CodeGen/RegisterClassInfo.h"
 #include "llvm/CodeGen/SlotIndexes.h"
 #include "llvm/CodeGen/Spiller.h"
 #include "llvm/CodeGen/TargetRegisterInfo.h"
@@ -155,8 +154,7 @@ private:
   void findVRegIntervalsToAlloc(const MachineFunction &MF, LiveIntervals &LIS);
 
   /// Constructs an initial graph.
-  void initializeGraph(PBQPRAGraph &G, VirtRegMap &VRM, Spiller &VRegSpiller,
-                       const RegisterClassInfo &RCI);
+  void initializeGraph(PBQPRAGraph &G, VirtRegMap &VRM, Spiller &VRegSpiller);
 
   /// Spill the given VReg.
   void spillVReg(Register VReg, SmallVectorImpl<Register> &NewIntervals,
@@ -172,8 +170,8 @@ private:
 
   /// Postprocessing before final spilling. Sets basic block "live in"
   /// variables.
-  void finalizeAlloc(MachineFunction &MF, LiveIntervals &LIS, VirtRegMap &VRM,
-                     const RegisterClassInfo &RCI) const;
+  void finalizeAlloc(MachineFunction &MF, LiveIntervals &LIS,
+                     VirtRegMap &VRM) const;
 
   void postOptimization(Spiller &VRegSpiller, LiveIntervals &LIS);
 };
@@ -563,7 +561,6 @@ void RegAllocPBQP::getAnalysisUsage(AnalysisUsage &au) const {
   au.addRequired<MachineBlockFrequencyInfoWrapperPass>();
   au.addRequired<MachineLoopInfoWrapperPass>();
   au.addRequired<MachineDominatorTreeWrapperPass>();
-  au.addRequired<MachineRegisterClassInfoWrapperPass>();
   au.addRequired<VirtRegMapWrapperLegacy>();
   au.addPreserved<VirtRegMapWrapperLegacy>();
   MachineFunctionPass::getAnalysisUsage(au);
@@ -593,8 +590,7 @@ static bool isACalleeSavedRegister(MCRegister Reg,
 }
 
 void RegAllocPBQP::initializeGraph(PBQPRAGraph &G, VirtRegMap &VRM,
-                                   Spiller &VRegSpiller,
-                                   const RegisterClassInfo &RCI) {
+                                   Spiller &VRegSpiller) {
   MachineFunction &MF = G.getMetadata().MF;
 
   LiveIntervals &LIS = G.getMetadata().LIS;
@@ -628,8 +624,11 @@ void RegAllocPBQP::initializeGraph(PBQPRAGraph &G, VirtRegMap &VRM,
 
     // Compute an initial allowed set for the current vreg.
     std::vector<MCRegister> VRegAllowed;
-    for (MCPhysReg R : RCI.getOrder(TRC)) {
+    ArrayRef<MCPhysReg> RawPRegOrder = TRI.getRawAllocationOrder(*TRC, MF);
+    for (MCPhysReg R : RawPRegOrder) {
       MCRegister PReg(R);
+      if (MRI.isReserved(PReg))
+        continue;
 
       // vregLI crosses a regmask operand that clobbers preg.
       if (!RegMaskOverlaps.empty() && !RegMaskOverlaps.test(PReg))
@@ -755,9 +754,10 @@ bool RegAllocPBQP::mapPBQPToRegAlloc(const PBQPRAGraph &G,
   return !AnotherRoundNeeded;
 }
 
-void RegAllocPBQP::finalizeAlloc(MachineFunction &MF, LiveIntervals &LIS,
-                                 VirtRegMap &VRM,
-                                 const RegisterClassInfo &RCI) const {
+void RegAllocPBQP::finalizeAlloc(MachineFunction &MF,
+                                 LiveIntervals &LIS,
+                                 VirtRegMap &VRM) const {
+  const TargetRegisterInfo &TRI = *MF.getSubtarget().getRegisterInfo();
   MachineRegisterInfo &MRI = MF.getRegInfo();
 
   // First allocate registers for the empty intervals.
@@ -767,10 +767,16 @@ void RegAllocPBQP::finalizeAlloc(MachineFunction &MF, LiveIntervals &LIS,
     Register PReg = MRI.getSimpleHint(LI.reg());
 
     if (PReg == 0) {
-      ArrayRef<MCPhysReg> Order = RCI.getOrder(MRI.getRegClass(LI.reg()));
-      assert(!Order.empty() &&
+      const TargetRegisterClass &RC = *MRI.getRegClass(LI.reg());
+      ArrayRef<MCPhysReg> RawPRegOrder = TRI.getRawAllocationOrder(RC, MF);
+      for (MCRegister CandidateReg : RawPRegOrder) {
+        if (!VRM.getRegInfo().isReserved(CandidateReg)) {
+          PReg = CandidateReg;
+          break;
+        }
+      }
+      assert(PReg &&
              "No un-reserved physical registers in this register class");
-      PReg = Order.front();
     }
 
     VRM.assignVirt2Phys(LI.reg(), PReg);
@@ -812,9 +818,6 @@ bool RegAllocPBQP::runOnMachineFunction(MachineFunction &MF) {
 
   MF.getRegInfo().freezeReservedRegs();
 
-  const RegisterClassInfo &RCI =
-      getAnalysis<MachineRegisterClassInfoWrapperPass>().getRCI();
-
   LLVM_DEBUG(dbgs() << "PBQP Register Allocating for " << MF.getName() << "\n");
 
   // Allocator main loop:
@@ -854,7 +857,7 @@ bool RegAllocPBQP::runOnMachineFunction(MachineFunction &MF) {
       (void) Round;
 
       PBQPRAGraph G(PBQPRAGraph::GraphMetadata(MF, LIS, MBFI));
-      initializeGraph(G, VRM, *VRegSpiller, RCI);
+      initializeGraph(G, VRM, *VRegSpiller);
       ConstraintsRoot->apply(G);
 
 #ifndef NDEBUG
@@ -878,7 +881,7 @@ bool RegAllocPBQP::runOnMachineFunction(MachineFunction &MF) {
   }
 
   // Finalise allocation, allocate empty ranges.
-  finalizeAlloc(MF, LIS, VRM, RCI);
+  finalizeAlloc(MF, LIS, VRM);
   postOptimization(*VRegSpiller, LIS);
   VRegsToAlloc.clear();
   EmptyIntervalVRegs.clear();

--- a/llvm/lib/Target/AMDGPU/AMDGPURewriteAGPRCopyMFMA.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURewriteAGPRCopyMFMA.cpp
@@ -33,7 +33,6 @@
 #include "llvm/CodeGen/MachineDominators.h"
 #include "llvm/CodeGen/MachineFrameInfo.h"
 #include "llvm/CodeGen/MachineFunctionPass.h"
-#include "llvm/CodeGen/RegisterClassInfo.h"
 #include "llvm/CodeGen/SlotIndexes.h"
 #include "llvm/CodeGen/VirtRegMap.h"
 #include "llvm/InitializePasses.h"
@@ -693,6 +692,7 @@ bool AMDGPURewriteAGPRCopyMFMAImpl::run(MachineFunction &MF) const {
 class AMDGPURewriteAGPRCopyMFMALegacy : public MachineFunctionPass {
 public:
   static char ID;
+  RegisterClassInfo RegClassInfo;
 
   AMDGPURewriteAGPRCopyMFMALegacy() : MachineFunctionPass(ID) {}
 
@@ -707,14 +707,12 @@ public:
     AU.addRequired<VirtRegMapWrapperLegacy>();
     AU.addRequired<LiveRegMatrixWrapperLegacy>();
     AU.addRequired<LiveStacksWrapperLegacy>();
-    AU.addRequired<MachineRegisterClassInfoWrapperPass>();
     AU.addRequired<MachineDominatorTreeWrapperPass>();
 
     AU.addPreserved<LiveIntervalsWrapperPass>();
     AU.addPreserved<VirtRegMapWrapperLegacy>();
     AU.addPreserved<LiveRegMatrixWrapperLegacy>();
     AU.addPreserved<LiveStacksWrapperLegacy>();
-    AU.addPreserved<MachineRegisterClassInfoWrapperPass>();
     AU.addPreserved<MachineDominatorTreeWrapperPass>();
 
     AU.setPreservesAll();
@@ -730,7 +728,6 @@ INITIALIZE_PASS_DEPENDENCY(LiveIntervalsWrapperPass)
 INITIALIZE_PASS_DEPENDENCY(VirtRegMapWrapperLegacy)
 INITIALIZE_PASS_DEPENDENCY(LiveRegMatrixWrapperLegacy)
 INITIALIZE_PASS_DEPENDENCY(LiveStacksWrapperLegacy)
-INITIALIZE_PASS_DEPENDENCY(MachineRegisterClassInfoWrapperPass)
 INITIALIZE_PASS_DEPENDENCY(MachineDominatorTreeWrapperPass)
 INITIALIZE_PASS_END(AMDGPURewriteAGPRCopyMFMALegacy, DEBUG_TYPE,
                     "AMDGPU Rewrite AGPR-Copy-MFMA", false, false)
@@ -745,13 +742,14 @@ bool AMDGPURewriteAGPRCopyMFMALegacy::runOnMachineFunction(
   if (skipFunction(MF.getFunction()))
     return false;
 
+  RegClassInfo.runOnMachineFunction(MF);
+
   auto &VRM = getAnalysis<VirtRegMapWrapperLegacy>().getVRM();
   auto &LRM = getAnalysis<LiveRegMatrixWrapperLegacy>().getLRM();
   auto &LIS = getAnalysis<LiveIntervalsWrapperPass>().getLIS();
   auto &LSS = getAnalysis<LiveStacksWrapperLegacy>().getLS();
-  auto &RCI = getAnalysis<MachineRegisterClassInfoWrapperPass>().getRCI();
   auto &MDT = getAnalysis<MachineDominatorTreeWrapperPass>().getDomTree();
-  AMDGPURewriteAGPRCopyMFMAImpl Impl(MF, VRM, LRM, LIS, LSS, RCI, MDT);
+  AMDGPURewriteAGPRCopyMFMAImpl Impl(MF, VRM, LRM, LIS, LSS, RegClassInfo, MDT);
   return Impl.run(MF);
 }
 
@@ -762,10 +760,11 @@ AMDGPURewriteAGPRCopyMFMAPass::run(MachineFunction &MF,
   LiveRegMatrix &LRM = MFAM.getResult<LiveRegMatrixAnalysis>(MF);
   LiveIntervals &LIS = MFAM.getResult<LiveIntervalsAnalysis>(MF);
   LiveStacks &LSS = MFAM.getResult<LiveStacksAnalysis>(MF);
-  RegisterClassInfo &RCI = MFAM.getResult<MachineRegisterClassAnalysis>(MF);
   MachineDominatorTree &MDT = MFAM.getResult<MachineDominatorTreeAnalysis>(MF);
+  RegisterClassInfo RegClassInfo;
+  RegClassInfo.runOnMachineFunction(MF);
 
-  AMDGPURewriteAGPRCopyMFMAImpl Impl(MF, VRM, LRM, LIS, LSS, RCI, MDT);
+  AMDGPURewriteAGPRCopyMFMAImpl Impl(MF, VRM, LRM, LIS, LSS, RegClassInfo, MDT);
   if (!Impl.run(MF))
     return PreservedAnalyses::all();
   auto PA = getMachineFunctionPassPreservedAnalyses();
@@ -774,7 +773,6 @@ AMDGPURewriteAGPRCopyMFMAPass::run(MachineFunction &MF,
       .preserve<VirtRegMapAnalysis>()
       .preserve<SlotIndexesAnalysis>()
       .preserve<LiveIntervalsAnalysis>()
-      .preserve<LiveRegMatrixAnalysis>()
-      .preserve<MachineRegisterClassAnalysis>();
+      .preserve<LiveRegMatrixAnalysis>();
   return PA;
 }

--- a/llvm/lib/Target/ARM/ARMLoadStoreOptimizer.cpp
+++ b/llvm/lib/Target/ARM/ARMLoadStoreOptimizer.cpp
@@ -106,13 +106,13 @@ struct ARMLoadStoreOpt {
   const TargetLowering *TL;
   ARMFunctionInfo *AFI;
   LiveRegUnits LiveRegs;
-  const RegisterClassInfo *RCI = nullptr;
+  RegisterClassInfo RegClassInfo;
   MachineBasicBlock::const_iterator LiveRegPos;
   bool LiveRegsValid;
+  bool RegClassInfoValid;
   bool isThumb1, isThumb2;
 
-  bool runOnMachineFunction(MachineFunction &Fn,
-                            const RegisterClassInfo &RegClassInfo);
+  bool runOnMachineFunction(MachineFunction &Fn);
 
 private:
   /// A set of load/store MachineInstrs with same base register sorted by
@@ -200,7 +200,6 @@ struct ARMLoadStoreOptLegacy : public MachineFunctionPass {
   StringRef getPassName() const override { return ARM_LOAD_STORE_OPT_NAME; }
 
   void getAnalysisUsage(AnalysisUsage &AU) const override {
-    AU.addRequired<MachineRegisterClassInfoWrapperPass>();
     AU.addPreserved<MachineRegisterClassInfoWrapperPass>();
     MachineFunctionPass::getAnalysisUsage(AU);
   }
@@ -210,11 +209,8 @@ char ARMLoadStoreOptLegacy::ID = 0;
 
 } // end anonymous namespace
 
-INITIALIZE_PASS_BEGIN(ARMLoadStoreOptLegacy, "arm-ldst-opt",
-                      ARM_LOAD_STORE_OPT_NAME, false, false)
-INITIALIZE_PASS_DEPENDENCY(MachineRegisterClassInfoWrapperPass)
-INITIALIZE_PASS_END(ARMLoadStoreOptLegacy, "arm-ldst-opt",
-                    ARM_LOAD_STORE_OPT_NAME, false, false)
+INITIALIZE_PASS(ARMLoadStoreOptLegacy, "arm-ldst-opt", ARM_LOAD_STORE_OPT_NAME,
+                false, false)
 
 static bool definesCPSR(const MachineInstr &MI) {
   for (const auto &MO : MI.operands()) {
@@ -596,8 +592,13 @@ void ARMLoadStoreOpt::UpdateBaseRegUses(MachineBasicBlock &MBB,
 
 /// Return the first register of class \p RegClass that is not in \p Regs.
 unsigned ARMLoadStoreOpt::findFreeReg(const TargetRegisterClass &RegClass) {
-  for (unsigned Reg : RCI->getOrder(&RegClass))
-    if (LiveRegs.available(Reg))
+  if (!RegClassInfoValid) {
+    RegClassInfo.runOnMachineFunction(*MF);
+    RegClassInfoValid = true;
+  }
+
+  for (unsigned Reg : RegClassInfo.getOrder(&RegClass))
+    if (LiveRegs.available(Reg) && !MF->getRegInfo().isReserved(Reg))
       return Reg;
   return 0;
 }
@@ -2106,16 +2107,15 @@ bool ARMLoadStoreOpt::CombineMovBx(MachineBasicBlock &MBB) {
   llvm_unreachable("tMOVr doesn't kill a reg before tBX_RET?");
 }
 
-bool ARMLoadStoreOpt::runOnMachineFunction(
-    MachineFunction &Fn, const RegisterClassInfo &RegClassInfo) {
+bool ARMLoadStoreOpt::runOnMachineFunction(MachineFunction &Fn) {
   MF = &Fn;
   STI = &Fn.getSubtarget<ARMSubtarget>();
   TL = STI->getTargetLowering();
   AFI = Fn.getInfo<ARMFunctionInfo>();
   TII = STI->getInstrInfo();
   TRI = STI->getRegisterInfo();
-  RCI = &RegClassInfo;
 
+  RegClassInfoValid = false;
   isThumb2 = AFI->isThumb2Function();
   isThumb1 = AFI->isThumbFunction() && !isThumb2;
 
@@ -2144,8 +2144,7 @@ bool ARMLoadStoreOptLegacy::runOnMachineFunction(MachineFunction &MF) {
   if (skipFunction(MF.getFunction()))
     return false;
   ARMLoadStoreOpt Impl;
-  return Impl.runOnMachineFunction(
-      MF, getAnalysis<MachineRegisterClassInfoWrapperPass>().getRCI());
+  return Impl.runOnMachineFunction(MF);
 }
 
 #define ARM_PREALLOC_LOAD_STORE_OPT_NAME                                       \
@@ -3345,13 +3344,11 @@ PreservedAnalyses
 ARMLoadStoreOptPass::run(MachineFunction &MF,
                          MachineFunctionAnalysisManager &MFAM) {
   ARMLoadStoreOpt Impl;
-  bool Changed = Impl.runOnMachineFunction(
-      MF, MFAM.getResult<MachineRegisterClassAnalysis>(MF));
+  bool Changed = Impl.runOnMachineFunction(MF);
   if (!Changed)
     return PreservedAnalyses::all();
   PreservedAnalyses PA = getMachineFunctionPassPreservedAnalyses();
   PA.preserveSet<CFGAnalyses>();
-  PA.preserve<MachineRegisterClassAnalysis>();
   return PA;
 }
 


### PR DESCRIPTION
Reverts llvm/llvm-project#216510

breaks tests MIOpen/CK shard 1-4 in CI

queueing this up in case we want to save a bit of time