### PR TITLE
[IR] Memory effects for floating-point operations

### DIFF
--- a/clang/test/CodeGenOpenCL/cl20-device-side-enqueue-attributes.cl
+++ b/clang/test/CodeGenOpenCL/cl20-device-side-enqueue-attributes.cl
@@ -206,7 +206,7 @@ kernel void device_side_enqueue(global float *a, global float *b, int i) {
 // STRICTFP: attributes #[[ATTR0]] = { convergent noinline norecurse nounwind optnone strictfp "stack-protector-buffer-size"="8" }
 // STRICTFP: attributes #[[ATTR1:[0-9]+]] = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 // STRICTFP: attributes #[[ATTR2]] = { convergent noinline nounwind optnone strictfp "stack-protector-buffer-size"="8" }
-// STRICTFP: attributes #[[ATTR3:[0-9]+]] = { nocallback nofree nosync nounwind strictfp willreturn memory(inaccessiblemem: readwrite) }
+// STRICTFP: attributes #[[ATTR3:[0-9]+]] = { nocallback nofree nosync nounwind strictfp willreturn memory(fpcontrol: read, fpstatus: readwrite) }
 // STRICTFP: attributes #[[ATTR4]] = { convergent nounwind strictfp "stack-protector-buffer-size"="8" }
 // STRICTFP: attributes #[[ATTR5]] = { convergent nounwind strictfp }
 // STRICTFP: attributes #[[ATTR6]] = { strictfp }

--- a/llvm/include/llvm/AsmParser/LLToken.h
+++ b/llvm/include/llvm/AsmParser/LLToken.h
@@ -212,6 +212,8 @@ enum Kind {
   kw_target_mem0,
   kw_target_mem1,
   kw_errnomem,
+  kw_fpcontrol,
+  kw_fpstatus,
 
   // Legacy attributes:
   kw_argmemonly,

--- a/llvm/include/llvm/IR/InstrTypes.h
+++ b/llvm/include/llvm/IR/InstrTypes.h
@@ -2013,6 +2013,16 @@ public:
   LLVM_ABI bool onlyAccessesInaccessibleMemOrArgMem() const;
   LLVM_ABI void setOnlyAccessesInaccessibleMemOrArgMem();
 
+  /// Determine if the function may only access memory that cannot be pointed
+  /// by any pointer.
+  LLVM_ABI bool onlyAccessesNonaddressableMemory() const;
+  LLVM_ABI void setOnlyAccessesNonaddressableMemory();
+
+  /// Determine if the function may only access memory that cannot be pointed
+  /// by any pointer or memory pointed to by its arguments.
+  LLVM_ABI bool onlyAccessesNonaddressableMemOrArgMem() const;
+  LLVM_ABI void setOnlyAccessesNonaddressableMemOrArgMem();
+
   /// Determine if the call cannot return.
   bool doesNotReturn() const { return hasFnAttr(Attribute::NoReturn); }
   void setDoesNotReturn() { addFnAttr(Attribute::NoReturn); }

--- a/llvm/include/llvm/IR/Intrinsics.td
+++ b/llvm/include/llvm/IR/Intrinsics.td
@@ -54,6 +54,27 @@ def IntrInaccessibleMemOnly : IntrinsicProperty;
 // by the module being compiled. This is a weaker form of IntrArgMemOnly.
 def IntrInaccessibleMemOrArgMemOnly : IntrinsicProperty;
 
+/// This intrinsic only may read floating-point control modes.
+def IntrReadFPControlOnly : IntrinsicProperty;
+
+/// This intrinsic only may write floating-point control modes.
+def IntrWriteFPControlOnly : IntrinsicProperty;
+
+/// This intrinsic only may update floating-point status bits (read-OR-write).
+def IntrUpdateFPStatusOnly : IntrinsicProperty;
+
+/// This intrinsic only may read floating-point environment (control modes and
+/// status bits).
+def IntrReadFPEnvironmentOnly : IntrinsicProperty;
+
+/// This intrinsic only may write floating-point environment (control modes and
+/// status bits).
+def IntrWriteFPEnvironmentOnly : IntrinsicProperty;
+
+/// This intrinsic only may update floating-point status bits (read-OR-write) or
+/// read control modes.
+def IntrFPOperationOnly : IntrinsicProperty;
+
 // Tablegen representation of IRMemLocation.
 class IntrinsicMemoryLocation;
 
@@ -63,6 +84,8 @@ def ArgMem : IntrinsicMemoryLocation;
 def InaccessibleMem : IntrinsicMemoryLocation;
 def TargetMem0 : IntrinsicMemoryLocation;
 def TargetMem1 : IntrinsicMemoryLocation;
+def FPControlMem : IntrinsicMemoryLocation;
+def FPStatusMem : IntrinsicMemoryLocation;
 
 // The list of IRMemoryLocations that are read from.
 class IntrRead<list<IntrinsicMemoryLocation> idx> : IntrinsicProperty {
@@ -1370,16 +1393,21 @@ def int_objectsize : DefaultAttrsIntrinsic<[llvm_anyint_ty],
 //===--------------- Access to Floating Point Environment -----------------===//
 //
 
-let IntrProperties = [IntrInaccessibleMemOnly] in {
-  def int_get_rounding  : DefaultAttrsIntrinsic<[llvm_i32_ty], []>;
-  def int_set_rounding  : DefaultAttrsIntrinsic<[], [llvm_i32_ty]>;
-  def int_get_fpenv     : DefaultAttrsIntrinsic<[llvm_anyint_ty], []>;
-  def int_set_fpenv     : DefaultAttrsIntrinsic<[], [llvm_anyint_ty]>;
-  def int_reset_fpenv   : DefaultAttrsIntrinsic<[], []>;
-  def int_get_fpmode    : DefaultAttrsIntrinsic<[llvm_anyint_ty], []>;
-  def int_set_fpmode    : DefaultAttrsIntrinsic<[], [llvm_anyint_ty]>;
-  def int_reset_fpmode  : DefaultAttrsIntrinsic<[], []>;
-}
+def int_get_rounding  : DefaultAttrsIntrinsic<[llvm_i32_ty], [],
+                            [IntrReadFPControlOnly]>;
+def int_set_rounding  : DefaultAttrsIntrinsic<[], [llvm_i32_ty],
+                            [IntrWriteFPControlOnly]>;
+def int_get_fpenv     : DefaultAttrsIntrinsic<[llvm_anyint_ty], [],
+                            [IntrReadFPEnvironmentOnly]>;
+def int_set_fpenv     : DefaultAttrsIntrinsic<[], [llvm_anyint_ty],
+                            [IntrWriteFPEnvironmentOnly]>;
+def int_reset_fpenv   : DefaultAttrsIntrinsic<[], [],
+                            [IntrWriteFPEnvironmentOnly]>;
+def int_get_fpmode    : DefaultAttrsIntrinsic<[llvm_anyint_ty], [],
+                            [IntrReadFPControlOnly]>;
+def int_set_fpmode    : DefaultAttrsIntrinsic<[], [llvm_anyint_ty],
+                            [IntrWriteFPControlOnly]>;
+def int_reset_fpmode  : DefaultAttrsIntrinsic<[], [], [IntrWriteFPControlOnly]>;
 
 //===--------------- Floating Point Properties ----------------------------===//
 //
@@ -1399,7 +1427,8 @@ def int_is_fpclass
 /// floating point environment.
 def IntrStrictFP : IntrinsicProperty;
 
-let IntrProperties = [IntrInaccessibleMemOnly, IntrStrictFP] in {
+// Constrained functions that depend on the current rounding mode.
+let IntrProperties = [IntrFPOperationOnly, IntrStrictFP] in {
   def int_experimental_constrained_fadd : DefaultAttrsIntrinsic<[ llvm_anyfloat_ty ],
                                                     [ LLVMMatchType<0>,
                                                       LLVMMatchType<0>,
@@ -1440,14 +1469,6 @@ let IntrProperties = [IntrInaccessibleMemOnly, IntrStrictFP] in {
                                                          llvm_metadata_ty,
                                                          llvm_metadata_ty ]>;
 
-  def int_experimental_constrained_fptosi : DefaultAttrsIntrinsic<[ llvm_anyint_ty ],
-                                                    [ llvm_anyfloat_ty,
-                                                      llvm_metadata_ty ]>;
-
-  def int_experimental_constrained_fptoui : DefaultAttrsIntrinsic<[ llvm_anyint_ty ],
-                                                    [ llvm_anyfloat_ty,
-                                                      llvm_metadata_ty ]>;
-
   def int_experimental_constrained_sitofp : DefaultAttrsIntrinsic<[ llvm_anyfloat_ty ],
                                                        [ llvm_anyint_ty,
                                                          llvm_metadata_ty,
@@ -1462,10 +1483,6 @@ let IntrProperties = [IntrInaccessibleMemOnly, IntrStrictFP] in {
                                                        [ llvm_anyfloat_ty,
                                                          llvm_metadata_ty,
                                                          llvm_metadata_ty ]>;
-
-  def int_experimental_constrained_fpext : DefaultAttrsIntrinsic<[ llvm_anyfloat_ty ],
-                                                     [ llvm_anyfloat_ty,
-                                                       llvm_metadata_ty ]>;
 
   // These intrinsics are sensitive to the rounding mode so we need constrained
   // versions of each of them.  When strict rounding and exception control are
@@ -1567,6 +1584,21 @@ let IntrProperties = [IntrInaccessibleMemOnly, IntrStrictFP] in {
                                                       [ llvm_any_scalar_float_ty,
                                                         llvm_metadata_ty,
                                                         llvm_metadata_ty ]>;
+}
+
+// Constrained functions that do not depend on the current rounding mode.
+let IntrProperties = [IntrUpdateFPStatusOnly, IntrStrictFP] in {
+  def int_experimental_constrained_fptosi : DefaultAttrsIntrinsic<[ llvm_anyint_ty ],
+                                                    [ llvm_anyfloat_ty,
+                                                      llvm_metadata_ty ]>;
+
+  def int_experimental_constrained_fptoui : DefaultAttrsIntrinsic<[ llvm_anyint_ty ],
+                                                    [ llvm_anyfloat_ty,
+                                                      llvm_metadata_ty ]>;
+  def int_experimental_constrained_fpext : DefaultAttrsIntrinsic<[ llvm_anyfloat_ty ],
+                                                     [ llvm_anyfloat_ty,
+                                                       llvm_metadata_ty ]>;
+
   def int_experimental_constrained_maxnum : DefaultAttrsIntrinsic<[ llvm_anyfloat_ty ],
                                                       [ LLVMMatchType<0>,
                                                         LLVMMatchType<0>,

--- a/llvm/include/llvm/Support/ModRef.h
+++ b/llvm/include/llvm/Support/ModRef.h
@@ -69,10 +69,15 @@ enum class IRMemLocation {
   /// Represents target specific state.
   TargetMem0 = 4,
   TargetMem1 = 5,
+  /// Floating-point control modes.
+  FPControl = 6,
+  /// Floating-point status bits.
+  FPStatus = 7,
 
   /// Helpers to iterate all locations in the MemoryEffectsBase class.
   First = ArgMem,
-  Last = TargetMem1,
+  LastMem = TargetMem1,
+  Last = FPStatus,
 };
 
 template <typename LocationEnum> class MemoryEffectsBase {
@@ -102,9 +107,20 @@ public:
     return enum_seq_inclusive(Location::First, Location::Last,
                               force_iteration_on_noniterable_enum);
   }
+  /// Returns iterator over all supported memory location kinds, without
+  /// floating-point registers.
+  static auto mem_locations() {
+    return enum_seq_inclusive(Location::First, Location::LastMem,
+                              force_iteration_on_noniterable_enum);
+  }
   /// Returns iterator over all target location kinds
   static auto targetMemLocations() {
     return enum_seq_inclusive(Location::TargetMem0, Location::TargetMem1,
+                              force_iteration_on_noniterable_enum);
+  }
+  /// Returns iterator over floating-point state locations.
+  static auto fpenvLocations() {
+    return enum_seq_inclusive(Location::FPControl, Location::FPStatus,
                               force_iteration_on_noniterable_enum);
   }
 
@@ -119,9 +135,24 @@ public:
       setModRef(Loc, MR);
   }
 
+  /// Create MemoryEffectsBase that can access any location with the given
+  /// ModRefInfo, excluding floating-point locations.
+  /// The boolean argument value is not used, it only allows to distinguish
+  /// between constructors.
+  MemoryEffectsBase(ModRefInfo MR, bool) {
+    for (Location Loc : mem_locations())
+      setModRef(Loc, MR);
+  }
+
   /// Create MemoryEffectsBase that can read and write any memory.
   static MemoryEffectsBase unknown() {
     return MemoryEffectsBase(ModRefInfo::ModRef);
+  }
+
+  /// Create MemoryEffectsBase that can read and write any memory except
+  /// floating-point registers.
+  static MemoryEffectsBase unknown_mem() {
+    return MemoryEffectsBase(ModRefInfo::ModRef, false);
   }
 
   /// Create MemoryEffectsBase that cannot read or write any memory.
@@ -129,14 +160,16 @@ public:
     return MemoryEffectsBase(ModRefInfo::NoModRef);
   }
 
-  /// Create MemoryEffectsBase that can read any memory.
+  /// Create MemoryEffectsBase that can read any memory excluding floating-point
+  /// registers.
   static MemoryEffectsBase readOnly() {
-    return MemoryEffectsBase(ModRefInfo::Ref);
+    return MemoryEffectsBase(ModRefInfo::Ref, false);
   }
 
-  /// Create MemoryEffectsBase that can write any memory.
+  /// Create MemoryEffectsBase that can write any memory excluding
+  /// floating-point registers.
   static MemoryEffectsBase writeOnly() {
-    return MemoryEffectsBase(ModRefInfo::Mod);
+    return MemoryEffectsBase(ModRefInfo::Mod, false);
   }
 
   /// Create MemoryEffectsBase that can only access argument memory.
@@ -160,6 +193,45 @@ public:
     return MemoryEffectsBase(Location::Other, MR);
   }
 
+  /// Create MemoryEffectsBase that can only access floating-point control mode
+  /// registers.
+  static MemoryEffectsBase fpcontrolOnly(ModRefInfo MR = ModRefInfo::ModRef) {
+    return MemoryEffectsBase(Location::FPControl, MR);
+  }
+
+  /// Create MemoryEffectsBase that can only access floating-point status
+  /// register.
+  static MemoryEffectsBase fpstatusOnly(ModRefInfo MR = ModRefInfo::ModRef) {
+    return MemoryEffectsBase(Location::FPStatus, MR);
+  }
+
+  /// Create MemoryEffectsBase that can only access floating-point state
+  /// register.
+  static MemoryEffectsBase
+  fpenvironmentOnly(ModRefInfo MR = ModRefInfo::ModRef) {
+    return MemoryEffectsBase(Location::FPControl, MR) |
+           MemoryEffectsBase(Location::FPStatus, MR);
+  }
+
+  /// Create MemoryEffectsBase that can only access floating-point environment:
+  /// read control modes and update status bits. This access is typical for
+  /// floating-point operations like `fadd` and similar.
+  static MemoryEffectsBase fpoperationOnly() {
+    return MemoryEffectsBase(Location::FPControl, ModRefInfo::Ref) |
+           MemoryEffectsBase(Location::FPStatus, ModRefInfo::ModRef);
+  }
+
+  /// Create MemoryEffectsBase that can only access memory that cannot be
+  /// addressed by any pointer.
+  static MemoryEffectsBase
+  nonaddressableMemOnly(ModRefInfo MR = ModRefInfo::ModRef) {
+    MemoryEffectsBase MEB = none();
+    MEB.setModRef(Location::InaccessibleMem, MR);
+    MEB.setModRef(Location::FPControl, MR);
+    MEB.setModRef(Location::FPStatus, MR);
+    return MEB;
+  }
+
   /// Create MemoryEffectsBase that can only access inaccessible or argument
   /// memory.
   static MemoryEffectsBase
@@ -168,6 +240,18 @@ public:
     FRMB.setModRef(Location::ArgMem, MR);
     FRMB.setModRef(Location::InaccessibleMem, MR);
     return FRMB;
+  }
+
+  /// Create MemoryEffectsBase that can only access memory that cannot be
+  /// addressed by any pointer or memory pointed by arguments.
+  static MemoryEffectsBase
+  nonaddressableOrArgMemOnly(ModRefInfo MR = ModRefInfo::ModRef) {
+    MemoryEffectsBase MEB = none();
+    MEB.setModRef(Location::ArgMem, MR);
+    MEB.setModRef(Location::InaccessibleMem, MR);
+    MEB.setModRef(Location::FPControl, MR);
+    MEB.setModRef(Location::FPStatus, MR);
+    return MEB;
   }
 
   /// Create MemoryEffectsBase that can only access inaccessible or errno
@@ -266,6 +350,15 @@ public:
     return getWithoutLoc(Location::InaccessibleMem).doesNotAccessMemory();
   }
 
+  /// Whether this function only (at most) accesses memory that cannot be
+  /// addressed by any pointer.
+  bool onlyAccessesNonaddressableMem() const {
+    return getWithoutLoc(Location::InaccessibleMem)
+        .getWithoutLoc(Location::FPControl)
+        .getWithoutLoc(Location::FPStatus)
+        .doesNotAccessMemory();
+  }
+
   /// Whether this function only (at most) accesses inaccessible or target
   /// memory.
   bool onlyAccessesInaccessibleOrTargetMem() const {
@@ -295,6 +388,22 @@ public:
     return true;
   }
 
+  /// Whether location represents floating-point environment.
+  static bool isFPEnvMemLoc(IRMemLocation Loc) {
+    for (auto L : fpenvLocations())
+      if (Loc == L)
+        return true;
+    return false;
+  }
+
+  /// Whether all floating-point locations are not accessed.
+  bool doesNotAccessFPEnv() const {
+    for (auto L : fpenvLocations())
+      if (getModRef(L) != ModRefInfo::NoModRef)
+        return false;
+    return true;
+  }
+
   /// Whether this function only (at most) accesses errno memory.
   bool onlyAccessesErrnoMem() const {
     return getWithoutLoc(Location::ErrnoMem).doesNotAccessMemory();
@@ -304,6 +413,16 @@ public:
   /// memory.
   bool onlyAccessesInaccessibleOrArgMem() const {
     return getWithoutLoc(Location::InaccessibleMem)
+        .getWithoutLoc(Location::ArgMem)
+        .doesNotAccessMemory();
+  }
+
+  /// Whether this function only (at most) accesses argument and memory that
+  /// cannot be addressed by any pointer.
+  bool onlyAccessesNonaddressableOrArgMem() const {
+    return getWithoutLoc(Location::InaccessibleMem)
+        .getWithoutLoc(Location::FPControl)
+        .getWithoutLoc(Location::FPStatus)
         .getWithoutLoc(Location::ArgMem)
         .doesNotAccessMemory();
   }

--- a/llvm/include/llvm/Transforms/IPO/Attributor.h
+++ b/llvm/include/llvm/Transforms/IPO/Attributor.h
@@ -3548,7 +3548,7 @@ struct AANoSync
     SmallVector<Attribute, 2> Attrs;
     A.getAttrs(IRP, {Attribute::Memory}, Attrs, IgnoreSubsumingPositions);
 
-    MemoryEffects ME = MemoryEffects::unknown();
+    MemoryEffects ME = MemoryEffects::unknown_mem();
     for (const Attribute &Attr : Attrs)
       ME &= Attr.getMemoryEffects();
 
@@ -3765,7 +3765,7 @@ struct AAWillReturn
     A.getAttrs(IRP, {Attribute::Memory}, Attrs,
                /* IgnoreSubsumingPositions */ false);
 
-    MemoryEffects ME = MemoryEffects::unknown();
+    MemoryEffects ME = MemoryEffects::unknown_mem();
     for (const Attribute &Attr : Attrs)
       ME &= Attr.getMemoryEffects();
     return ME.onlyReadsMemory();

--- a/llvm/lib/Analysis/AliasAnalysis.cpp
+++ b/llvm/lib/Analysis/AliasAnalysis.cpp
@@ -246,8 +246,8 @@ ModRefInfo AAResults::getModRefInfo(const CallBase *Call,
 }
 
 ModRefInfo
-getModRefInfoInaccessibleAndTargetMemLoc(const MemoryEffects CallUse,
-                                         const MemoryEffects CallDef) {
+getModRefInfoNonaddressableAndTargetMemLoc(const MemoryEffects CallUse,
+                                           const MemoryEffects CallDef) {
 
   ModRefInfo Result = ModRefInfo::NoModRef;
   auto addModRefInfoForLoc = [&](IRMemLocation L) {
@@ -263,6 +263,8 @@ getModRefInfoInaccessibleAndTargetMemLoc(const MemoryEffects CallUse,
   };
 
   addModRefInfoForLoc(IRMemLocation::InaccessibleMem);
+  for (auto Loc : MemoryEffects::fpenvLocations())
+    addModRefInfoForLoc(Loc);
   for (auto Loc : MemoryEffects::targetMemLocations())
     addModRefInfoForLoc(Loc);
   return Result;
@@ -376,7 +378,7 @@ ModRefInfo AAResults::getModRefInfo(const CallBase *Call1,
   // then check the relation between the same locations.
   if (Call1B.onlyAccessesInaccessibleOrTargetMem() &&
       Call2B.onlyAccessesInaccessibleOrTargetMem())
-    return getModRefInfoInaccessibleAndTargetMemLoc(Call1B, Call2B);
+    return getModRefInfoNonaddressableAndTargetMemLoc(Call1B, Call2B);
 
   return Result;
 }

--- a/llvm/lib/Analysis/BasicAliasAnalysis.cpp
+++ b/llvm/lib/Analysis/BasicAliasAnalysis.cpp
@@ -958,9 +958,12 @@ ModRefInfo BasicAAResult::getModRefInfo(const CallBase *Call,
       return ModRefInfo::Mod;
 
   // We can completely ignore inaccessible memory here, because MemoryLocations
-  // can only reference accessible memory.
+  // can only reference accessible memory. The same is true for floating-point
+  // registers.
   auto ME = AAQI.AAR.getMemoryEffects(Call, AAQI)
-                .getWithoutLoc(IRMemLocation::InaccessibleMem);
+                .getWithoutLoc(IRMemLocation::InaccessibleMem)
+                .getWithoutLoc(IRMemLocation::FPControl)
+                .getWithoutLoc(IRMemLocation::FPStatus);
   if (ME.doesNotAccessMemory())
     return ModRefInfo::NoModRef;
 

--- a/llvm/lib/Analysis/GlobalsModRef.cpp
+++ b/llvm/lib/Analysis/GlobalsModRef.cpp
@@ -237,7 +237,7 @@ void GlobalsAAResult::DeletionCallbackHandle::deleted() {
 
 MemoryEffects GlobalsAAResult::getMemoryEffects(const Function *F) {
   if (FunctionInfo *FI = getFunctionInfo(F))
-    return MemoryEffects(FI->getModRefInfo());
+    return MemoryEffects(FI->getModRefInfo(), false); // Skip FP registers.
 
   return MemoryEffects::unknown();
 }

--- a/llvm/lib/AsmParser/LLLexer.cpp
+++ b/llvm/lib/AsmParser/LLLexer.cpp
@@ -727,6 +727,8 @@ lltok::Kind LLLexer::LexIdentifier() {
   KEYWORD(target_mem);
   KEYWORD(inaccessiblemem);
   KEYWORD(errnomem);
+  KEYWORD(fpcontrol);
+  KEYWORD(fpstatus);
   KEYWORD(argmemonly);
   KEYWORD(inaccessiblememonly);
   KEYWORD(inaccessiblemem_or_argmemonly);

--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -2760,6 +2760,10 @@ static SmallVector<MemoryEffects::Location, 2> keywordToLoc(lltok::Kind Tok) {
     return {Loc::InaccessibleMem};
   case lltok::kw_errnomem:
     return {Loc::ErrnoMem};
+  case lltok::kw_fpcontrol:
+    return {Loc::FPControl};
+  case lltok::kw_fpstatus:
+    return {Loc::FPStatus};
   case lltok::kw_target_mem0:
     return {Loc::TargetMem0};
   case lltok::kw_target_mem1:
@@ -2835,7 +2839,8 @@ std::optional<MemoryEffects> LLParser::parseMemoryAttr() {
     std::optional<ModRefInfo> MR = keywordToModRef(Lex.getKind());
     if (!MR) {
       if (Locs.empty())
-        tokError("expected memory location (argmem, inaccessiblemem, errnomem) "
+        tokError("expected memory location (argmem, inaccessiblemem, errnomem, "
+                 "fpcontrol, fpstatus) "
                  "or access kind (none, read, write, readwrite)");
       else
         tokError("expected access kind (none, read, write, readwrite)");
@@ -2860,7 +2865,7 @@ std::optional<MemoryEffects> LLParser::parseMemoryAttr() {
         tokError("default access kind must be specified first");
         return std::nullopt;
       }
-      ME = MemoryEffects(*MR);
+      ME = MemoryEffects(*MR, false);
     }
 
     if (EatIfPresent(lltok::rparen))

--- a/llvm/lib/IR/Attributes.cpp
+++ b/llvm/lib/IR/Attributes.cpp
@@ -644,13 +644,31 @@ std::string Attribute::getAsString(bool InAttrGrp) const {
       OS << getModRefStr(OtherMR);
     }
 
-    bool TargetPrintedForAll = false;
+    bool SkipLocGroup = false;
+    IRMemLocation LastToSkip;
     for (auto Loc : MemoryEffects::locations()) {
       ModRefInfo MR = ME.getModRef(Loc);
-      if (MR == OtherMR)
+      if (MR == OtherMR && !MemoryEffects::isFPEnvMemLoc(Loc))
         continue;
 
-      if (!First && !TargetPrintedForAll)
+      if (SkipLocGroup) {
+        if (Loc == LastToSkip)
+          SkipLocGroup = false;
+        continue;
+      }
+
+      if (MemoryEffects::isFPEnvMemLoc(Loc)) {
+        // If access to a floating-point location is absent, do not print it.
+        if (ME.doesNotAccessFPEnv()) {
+          SkipLocGroup = true;
+          LastToSkip = IRMemLocation::FPStatus;
+          continue;
+        }
+        if (ME.getModRef(Loc) == ModRefInfo::NoModRef)
+          continue;
+      }
+
+      if (!First && !SkipLocGroup)
         OS << ", ";
       First = false;
 
@@ -658,12 +676,10 @@ std::string Attribute::getAsString(bool InAttrGrp) const {
       // If more targets are added it should do something like:
       // memory(target_mem:read, target_mem3:none, target_mem5:write).
       if (ME.isTargetMemLoc(Loc) && ME.isTargetMemLocSameForAll()) {
-        if (!TargetPrintedForAll) {
-          OS << "target_mem: ";
-          OS << getModRefStr(MR);
-          TargetPrintedForAll = true;
-        }
-        // Only works when target memories are last to be listed in Location.
+        OS << "target_mem: ";
+        OS << getModRefStr(MR);
+        SkipLocGroup = true;
+        LastToSkip = IRMemLocation::TargetMem1;
         continue;
       }
 
@@ -684,6 +700,12 @@ std::string Attribute::getAsString(bool InAttrGrp) const {
         break;
       case IRMemLocation::TargetMem1:
         OS << "target_mem1: ";
+        break;
+      case IRMemLocation::FPControl:
+        OS << "fpcontrol: ";
+        break;
+      case IRMemLocation::FPStatus:
+        OS << "fpstatus: ";
         break;
       }
       OS << getModRefStr(MR);

--- a/llvm/lib/IR/Instructions.cpp
+++ b/llvm/lib/IR/Instructions.cpp
@@ -727,6 +727,21 @@ void CallBase::setOnlyAccessesInaccessibleMemOrArgMem() {
                    MemoryEffects::inaccessibleOrArgMemOnly());
 }
 
+bool CallBase::onlyAccessesNonaddressableMemory() const {
+  return getMemoryEffects().onlyAccessesNonaddressableMem();
+}
+void CallBase::setOnlyAccessesNonaddressableMemory() {
+  setMemoryEffects(getMemoryEffects() & MemoryEffects::nonaddressableMemOnly());
+}
+
+bool CallBase::onlyAccessesNonaddressableMemOrArgMem() const {
+  return getMemoryEffects().onlyAccessesNonaddressableOrArgMem();
+}
+void CallBase::setOnlyAccessesNonaddressableMemOrArgMem() {
+  setMemoryEffects(getMemoryEffects() &
+                   MemoryEffects::nonaddressableOrArgMemOnly());
+}
+
 CaptureInfo CallBase::getCaptureInfo(unsigned OpNo) const {
   if (OpNo < arg_size()) {
     // If the argument is passed byval, the callee does not have access to the

--- a/llvm/lib/Support/ModRef.cpp
+++ b/llvm/lib/Support/ModRef.cpp
@@ -55,6 +55,12 @@ raw_ostream &llvm::operator<<(raw_ostream &OS, MemoryEffects ME) {
     case IRMemLocation::TargetMem1:
       OS << "TargetMem1: ";
       break;
+    case IRMemLocation::FPControl:
+      OS << "FPControl: ";
+      break;
+    case IRMemLocation::FPStatus:
+      OS << "FPStatus: ";
+      break;
     }
     OS << ME.getModRef(Loc);
   });

--- a/llvm/lib/Transforms/IPO/Attributor.cpp
+++ b/llvm/lib/Transforms/IPO/Attributor.cpp
@@ -3116,7 +3116,9 @@ ChangeStatus Attributor::rewriteFunctionSignatures(
           return !T->isPtrOrPtrVectorTy() ||
                  NewFn->hasParamAttribute(ArgNo, Attribute::ReadNone);
         })) {
-      NewFn->setMemoryEffects(ME - MemoryEffects::argMemOnly());
+      ME -= MemoryEffects::argMemOnly();
+      ME -= MemoryEffects::fpenvironmentOnly();
+      NewFn->setMemoryEffects(ME);
     }
 
     // Since we have now created the new function, splice the body of the old

--- a/llvm/lib/Transforms/IPO/AttributorAttributes.cpp
+++ b/llvm/lib/Transforms/IPO/AttributorAttributes.cpp
@@ -8185,7 +8185,7 @@ struct AAMemoryBehaviorFunction final : public AAMemoryBehaviorImpl {
     // we could determine read/write per location. This would also have the
     // benefit of only one place trying to manifest the memory attribute.
     Function &F = cast<Function>(getAnchorValue());
-    MemoryEffects ME = MemoryEffects::unknown();
+    MemoryEffects ME = MemoryEffects::unknown_mem();
     if (isAssumedReadNone())
       ME = MemoryEffects::none();
     else if (isAssumedReadOnly())
@@ -8223,7 +8223,7 @@ struct AAMemoryBehaviorCallSite final
   ChangeStatus manifest(Attributor &A) override {
     // TODO: Deduplicate this with AAMemoryBehaviorFunction.
     CallBase &CB = cast<CallBase>(getAnchorValue());
-    MemoryEffects ME = MemoryEffects::unknown();
+    MemoryEffects ME = MemoryEffects::unknown_mem();
     if (isAssumedReadNone())
       ME = MemoryEffects::none();
     else if (isAssumedReadOnly())
@@ -8547,7 +8547,7 @@ struct AAMemoryLocationImpl : public AAMemoryLocation {
           State.addKnownBits(inverseLocation(NO_ARGUMENT_MEM, true, true));
         else {
           // Remove location information, only keep read/write info.
-          ME = MemoryEffects(ME.getModRef());
+          ME = MemoryEffects(ME.getModRef(), false);
           A.manifestAttrs(IRP,
                           Attribute::getWithMemoryEffects(
                               IRP.getAnchorValue().getContext(), ME),
@@ -8561,7 +8561,7 @@ struct AAMemoryLocationImpl : public AAMemoryLocation {
               NO_INACCESSIBLE_MEM | NO_ARGUMENT_MEM, true, true));
         else {
           // Remove location information, only keep read/write info.
-          ME = MemoryEffects(ME.getModRef());
+          ME = MemoryEffects(ME.getModRef(), false);
           A.manifestAttrs(IRP,
                           Attribute::getWithMemoryEffects(
                               IRP.getAnchorValue().getContext(), ME),

--- a/llvm/lib/Transforms/IPO/FunctionAttrs.cpp
+++ b/llvm/lib/Transforms/IPO/FunctionAttrs.cpp
@@ -285,7 +285,7 @@ static void addMemoryAttrs(const SCCNodeSet &SCCNodes, AARGetterT &&AARGetter,
     ME |= FnME;
     RecursiveArgME |= FnRecursiveArgME;
     // Reached bottom of the lattice, we will not be able to improve the result.
-    if (ME == MemoryEffects::unknown())
+    if (ME == MemoryEffects::unknown_mem())
       return;
   }
 

--- a/llvm/lib/Transforms/InstCombine/InstCombinePHI.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombinePHI.cpp
@@ -661,7 +661,7 @@ static bool isSafeAndProfitableToSinkLoad(LoadInst *L) {
       // Calls that only access inaccessible memory do not block sinking the
       // load.
       if (auto *CB = dyn_cast<CallBase>(BBI))
-        if (CB->onlyAccessesInaccessibleMemory())
+        if (CB->onlyAccessesNonaddressableMemory())
           continue;
       return false;
     }

--- a/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
@@ -656,6 +656,8 @@ void llvm::removeASanIncompatibleFnAttributes(Function &F, bool ReadsArgMem) {
   // memory.
   if (!F.getMemoryEffects()
            .getWithoutLoc(IRMemLocation::InaccessibleMem)
+           .getWithoutLoc(IRMemLocation::FPControl)
+           .getWithoutLoc(IRMemLocation::FPStatus)
            .doesNotAccessMemory() &&
       !isModAndRefSet(F.getMemoryEffects().getModRef(IRMemLocation::Other))) {
     F.setMemoryEffects(F.getMemoryEffects() |

--- a/llvm/lib/Transforms/Scalar/DeadStoreElimination.cpp
+++ b/llvm/lib/Transforms/Scalar/DeadStoreElimination.cpp
@@ -861,7 +861,7 @@ static bool canSkipDef(MemoryDef *D, bool DefVisibleToCaller) {
   // Calls that only access inaccessible memory cannot read or write any memory
   // locations we consider for elimination.
   if (auto *CB = dyn_cast<CallBase>(DI))
-    if (CB->onlyAccessesInaccessibleMemory())
+    if (CB->onlyAccessesNonaddressableMemory())
       return true;
 
   // We can eliminate stores to locations not visible to the caller across
@@ -1502,7 +1502,7 @@ bool DSEState::isCompleteOverwrite(const MemoryLocation &DefLoc,
     return false;
 
   if (auto *CB = dyn_cast<CallBase>(UseInst))
-    if (CB->onlyAccessesInaccessibleMemory())
+    if (CB->onlyAccessesNonaddressableMemory())
       return false;
 
   int64_t InstWriteOffset, DepWriteOffset;
@@ -1610,7 +1610,7 @@ bool DSEState::isReadClobber(const MemoryLocation &DefLoc,
     return false;
 
   if (auto *CB = dyn_cast<CallBase>(UseInst))
-    if (CB->onlyAccessesInaccessibleMemory())
+    if (CB->onlyAccessesNonaddressableMemory())
       return false;
 
   return isRefSet(BatchAA.getModRefInfo(UseInst, DefLoc));
@@ -2551,7 +2551,7 @@ DSEState::getInitializesArgMemLoc(const Instruction *I) {
     // Check whether "CurArg" could alias with global variables. We require
     // either it's function local and isn't captured before or the "CB" only
     // accesses arg or inaccessible mem.
-    if (!Inits.empty() && !CB->onlyAccessesInaccessibleMemOrArgMem() &&
+    if (!Inits.empty() && !CB->onlyAccessesNonaddressableMemOrArgMem() &&
         !isFuncLocalAndNotCaptured(CurArg, CB, EA))
       Inits = ConstantRangeList();
 

--- a/llvm/lib/Transforms/Scalar/IndVarSimplify.cpp
+++ b/llvm/lib/Transforms/Scalar/IndVarSimplify.cpp
@@ -1839,7 +1839,7 @@ static bool crashingBBWithoutEffect(const BasicBlock &BB) {
     // Now if the loop stored a non-nullptr to %a, we could cause a nullptr
     // dereference by skipping over loop iterations.
     if (const auto *CB = dyn_cast<CallBase>(&I)) {
-      if (CB->onlyAccessesInaccessibleMemory())
+      if (CB->onlyAccessesNonaddressableMemory())
         return true;
     }
     return isa<UnreachableInst>(I);

--- a/llvm/lib/Transforms/Scalar/LoopVersioningLICM.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopVersioningLICM.cpp
@@ -317,7 +317,7 @@ bool LoopVersioningLICM::instructionSafeForVersioning(Instruction *I) {
     // llvm.pseudoprobe (used for sample-based profiling under
     // -fpseudo-probe-for-profiling).
     if (Call->mayThrow() ||
-        !AA->getMemoryEffects(Call).onlyAccessesInaccessibleMem()) {
+        !AA->getMemoryEffects(Call).onlyAccessesNonaddressableMem()) {
       LLVM_DEBUG(dbgs() << "    Unsafe call site found.\n");
       return false;
     }

--- a/llvm/lib/Transforms/Scalar/MemCpyOptimizer.cpp
+++ b/llvm/lib/Transforms/Scalar/MemCpyOptimizer.cpp
@@ -380,7 +380,7 @@ Instruction *MemCpyOptPass::tryMergingIntoMemset(Instruction *StartInst,
     // Calls that only access inaccessible memory do not block merging
     // accessible stores.
     if (auto *CB = dyn_cast<CallBase>(BI)) {
-      if (CB->onlyAccessesInaccessibleMemory())
+      if (CB->onlyAccessesNonaddressableMemory())
         continue;
     }
 

--- a/llvm/lib/Transforms/Utils/InlineFunction.cpp
+++ b/llvm/lib/Transforms/Utils/InlineFunction.cpp
@@ -1314,7 +1314,7 @@ static void AddAliasScopeMetadata(CallBase &CB, ValueToValueMapTy &VMap,
           MemoryEffects ME = CalleeAAR->getMemoryEffects(Call);
 
           // We'll retain this knowledge without additional metadata.
-          if (ME.onlyAccessesInaccessibleMem())
+          if (ME.onlyAccessesNonaddressableMem())
             continue;
 
           if (ME.onlyAccessesArgPointees())

--- a/llvm/lib/Transforms/Utils/LoopPeel.cpp
+++ b/llvm/lib/Transforms/Utils/LoopPeel.cpp
@@ -452,7 +452,7 @@ static unsigned peelToTurnInvariantLoadsDereferenceable(Loop &L,
       // Calls that only access inaccessible memory can never alias with loads.
       if (I.mayWriteToMemory() &&
           !(isa<CallBase>(I) &&
-            cast<CallBase>(I).onlyAccessesInaccessibleMemory()))
+            cast<CallBase>(I).onlyAccessesNonaddressableMemory()))
         return 0;
 
       if (LoadUsers.contains(&I))

--- a/llvm/test/Assembler/fp-intrinsics-attr.ll
+++ b/llvm/test/Assembler/fp-intrinsics-attr.ll
@@ -255,10 +255,10 @@ declare double @llvm.experimental.constrained.fmuladd.f64(double, double, double
 ; CHECK: @llvm.experimental.constrained.fmuladd.f64({{.*}}) #[[ATTR1]]
 
 declare i32 @llvm.experimental.constrained.fptosi.i32.f64(double, metadata)
-; CHECK: @llvm.experimental.constrained.fptosi.i32.f64({{.*}}) #[[ATTR1]]
+; CHECK: @llvm.experimental.constrained.fptosi.i32.f64({{.*}}) #[[ATTR2:[0-9]+]]
 
 declare i32 @llvm.experimental.constrained.fptoui.i32.f64(double, metadata)
-; CHECK: @llvm.experimental.constrained.fptoui.i32.f64({{.*}}) #[[ATTR1]]
+; CHECK: @llvm.experimental.constrained.fptoui.i32.f64({{.*}}) #[[ATTR2]]
 
 declare double @llvm.experimental.constrained.sitofp.f64.i32(i32, metadata, metadata)
 ; CHECK: @llvm.experimental.constrained.sitofp.f64.i32({{.*}}) #[[ATTR1]]
@@ -270,7 +270,7 @@ declare float @llvm.experimental.constrained.fptrunc.f32.f64(double, metadata, m
 ; CHECK: @llvm.experimental.constrained.fptrunc.f32.f64({{.*}}) #[[ATTR1]]
 
 declare double @llvm.experimental.constrained.fpext.f64.f32(float, metadata)
-; CHECK: @llvm.experimental.constrained.fpext.f64.f32({{.*}}) #[[ATTR1]]
+; CHECK: @llvm.experimental.constrained.fpext.f64.f32({{.*}}) #[[ATTR2]]
 
 declare double @llvm.experimental.constrained.sqrt.f64(double, metadata, metadata)
 ; CHECK: @llvm.experimental.constrained.sqrt.f64({{.*}}) #[[ATTR1]]
@@ -339,44 +339,45 @@ declare i64 @llvm.experimental.constrained.llrint.i64.f64(double, metadata, meta
 ; CHECK: @llvm.experimental.constrained.llrint.i64.f64({{.*}}) #[[ATTR1]]
 
 declare double @llvm.experimental.constrained.maxnum.f64(double, double, metadata)
-; CHECK: @llvm.experimental.constrained.maxnum.f64({{.*}}) #[[ATTR1]]
+; CHECK: @llvm.experimental.constrained.maxnum.f64({{.*}}) #[[ATTR2]]
 
 declare double @llvm.experimental.constrained.minnum.f64(double, double, metadata)
-; CHECK: @llvm.experimental.constrained.minnum.f64({{.*}}) #[[ATTR1]]
+; CHECK: @llvm.experimental.constrained.minnum.f64({{.*}}) #[[ATTR2]]
 
 declare double @llvm.experimental.constrained.maximum.f64(double, double, metadata)
-; CHECK: @llvm.experimental.constrained.maximum.f64({{.*}}) #[[ATTR1]]
+; CHECK: @llvm.experimental.constrained.maximum.f64({{.*}}) #[[ATTR2]]
 
 declare double @llvm.experimental.constrained.minimum.f64(double, double, metadata)
-; CHECK: @llvm.experimental.constrained.minimum.f64({{.*}}) #[[ATTR1]]
+; CHECK: @llvm.experimental.constrained.minimum.f64({{.*}}) #[[ATTR2]]
 
 declare double @llvm.experimental.constrained.ceil.f64(double, metadata)
-; CHECK: @llvm.experimental.constrained.ceil.f64({{.*}}) #[[ATTR1]]
+; CHECK: @llvm.experimental.constrained.ceil.f64({{.*}}) #[[ATTR2]]
 
 declare double @llvm.experimental.constrained.floor.f64(double, metadata)
-; CHECK: @llvm.experimental.constrained.floor.f64({{.*}}) #[[ATTR1]]
+; CHECK: @llvm.experimental.constrained.floor.f64({{.*}}) #[[ATTR2]]
 
 declare i32 @llvm.experimental.constrained.lround.i32.f64(double, metadata)
-; CHECK: @llvm.experimental.constrained.lround.i32.f64({{.*}}) #[[ATTR1]]
+; CHECK: @llvm.experimental.constrained.lround.i32.f64({{.*}}) #[[ATTR2]]
 
 declare i64 @llvm.experimental.constrained.llround.i64.f64(double, metadata)
-; CHECK: @llvm.experimental.constrained.llround.i64.f64({{.*}}) #[[ATTR1]]
+; CHECK: @llvm.experimental.constrained.llround.i64.f64({{.*}}) #[[ATTR2]]
 
 declare double @llvm.experimental.constrained.round.f64(double, metadata)
-; CHECK: @llvm.experimental.constrained.round.f64({{.*}}) #[[ATTR1]]
+; CHECK: @llvm.experimental.constrained.round.f64({{.*}}) #[[ATTR2]]
 
 declare double @llvm.experimental.constrained.roundeven.f64(double, metadata)
-; CHECK: @llvm.experimental.constrained.roundeven.f64({{.*}}) #[[ATTR1]]
+; CHECK: @llvm.experimental.constrained.roundeven.f64({{.*}}) #[[ATTR2]]
 
 declare double @llvm.experimental.constrained.trunc.f64(double, metadata)
-; CHECK: @llvm.experimental.constrained.trunc.f64({{.*}}) #[[ATTR1]]
+; CHECK: @llvm.experimental.constrained.trunc.f64({{.*}}) #[[ATTR2]]
 
 declare i1 @llvm.experimental.constrained.fcmp.f64(double, double, metadata, metadata)
-; CHECK: @llvm.experimental.constrained.fcmp.f64({{.*}}) #[[ATTR1]]
+; CHECK: @llvm.experimental.constrained.fcmp.f64({{.*}}) #[[ATTR2]]
 
 declare i1 @llvm.experimental.constrained.fcmps.f64(double, double, metadata, metadata)
-; CHECK: @llvm.experimental.constrained.fcmps.f64({{.*}}) #[[ATTR1]]
+; CHECK: @llvm.experimental.constrained.fcmps.f64({{.*}}) #[[ATTR2]]
 
 ; CHECK: attributes #[[ATTR0]] = {{{.*}} strictfp {{.*}}}
-; CHECK: attributes #[[ATTR1]] = { {{.*}} strictfp {{.*}} }
+; CHECK: attributes #[[ATTR1]] = { {{.*}} strictfp {{.*}} memory(fpcontrol: read, fpstatus: readwrite) {{.*}}}
+; CHECK: attributes #[[ATTR2]] = { {{.*}} strictfp {{.*}} memory(fpstatus: readwrite) {{.*}}}
 

--- a/llvm/test/Assembler/memory-attribute-errors.ll
+++ b/llvm/test/Assembler/memory-attribute-errors.ll
@@ -13,16 +13,16 @@
 ; MISSING-ARGS: error: expected '('
 declare void @fn() memory
 ;--- empty.ll
-; EMPTY: error: expected memory location (argmem, inaccessiblemem, errnomem) or access kind (none, read, write, readwrite)
+; EMPTY: error: expected memory location (argmem, inaccessiblemem, errnomem, fpcontrol, fpstatus) or access kind (none, read, write, readwrite)
 declare void @fn() memory()
 ;--- unterminated.ll
 ; UNTERMINATED: error: unterminated memory attribute
 declare void @fn() memory(read
 ;--- invalid-kind.ll
-; INVALID-KIND: error: expected memory location (argmem, inaccessiblemem, errnomem) or access kind (none, read, write, readwrite)
+; INVALID-KIND: error: expected memory location (argmem, inaccessiblemem, errnomem, fpcontrol, fpstatus) or access kind (none, read, write, readwrite)
 declare void @fn() memory(foo)
 ;--- other.ll
-; OTHER: error: expected memory location (argmem, inaccessiblemem, errnomem) or access kind (none, read, write, readwrite)
+; OTHER: error: expected memory location (argmem, inaccessiblemem, errnomem, fpcontrol, fpstatus) or access kind (none, read, write, readwrite)
 declare void @fn() memory(other: read)
 ;--- missing-colon.ll
 ; MISSING-COLON: error: expected ':' after location

--- a/llvm/test/Assembler/memory-attribute.ll
+++ b/llvm/test/Assembler/memory-attribute.ll
@@ -148,3 +148,33 @@ declare void @fn_write_target_mem_read_write()
 ; CHECK: @fn_all_readwrite
 declare void @fn_all_readwrite()
     memory(readwrite, target_mem: read)
+
+; CHECK: Function Attrs: memory(fpcontrol: read)
+; CHECK: @fn_read_fpcontrol
+declare void @fn_read_fpcontrol()
+    memory(fpcontrol: read)
+
+; CHECK: Function Attrs: memory(fpcontrol: write)
+; CHECK: @fn_write_fpcontrol
+declare void @fn_write_fpcontrol()
+    memory(fpcontrol: write)
+
+; CHECK: Function Attrs: memory(fpstatus: read)
+; CHECK: @fn_read_fpstatus
+declare void @fn_read_fpstatus()
+    memory(fpstatus: read)
+
+; CHECK: Function Attrs: memory(fpstatus: readwrite)
+; CHECK: @fn_readwrite_fpstatus
+declare void @fn_readwrite_fpstatus()
+    memory(fpstatus: readwrite)
+
+; CHECK: Function Attrs: memory(fpcontrol: read, fpstatus: readwrite)
+; CHECK: @fn_read_fpcontrol_readwrite_fpstatus
+declare void @fn_read_fpcontrol_readwrite_fpstatus()
+    memory(fpcontrol: read, fpstatus: readwrite)
+
+; CHECK: Function Attrs: memory(write, fpcontrol: read)
+; CHECK: @fn_read_fpcontrol_write_mem
+declare void @fn_read_fpcontrol_write_mem()
+    memory(write, fpcontrol: read)

--- a/llvm/test/CodeGen/AMDGPU/amdgpu-simplify-libcall-rootn.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdgpu-simplify-libcall-rootn.ll
@@ -1985,7 +1985,7 @@ attributes #2 = { noinline }
 ;.
 ; NOPRELINK: attributes #[[ATTR0]] = { strictfp }
 ; NOPRELINK: attributes #[[ATTR1:[0-9]+]] = { nocallback nocreateundeforpoison nofree nosync nounwind speculatable willreturn memory(none) }
-; NOPRELINK: attributes #[[ATTR2:[0-9]+]] = { nocallback nofree nosync nounwind strictfp willreturn memory(inaccessiblemem: readwrite) }
+; NOPRELINK: attributes #[[ATTR2:[0-9]+]] = { nocallback nofree nosync nounwind strictfp willreturn memory(fpcontrol: read, fpstatus: readwrite) }
 ; NOPRELINK: attributes #[[ATTR3]] = { noinline }
 ; NOPRELINK: attributes #[[ATTR4]] = { nobuiltin }
 ;.

--- a/llvm/test/Transforms/Attributor/nofpclass.ll
+++ b/llvm/test/Transforms/Attributor/nofpclass.ll
@@ -1906,13 +1906,13 @@ define <8 x float> @shufflevector_shufflevector(<4 x float> nofpclass(inf nan) %
 }
 
 define float @constrained_sitofp(i32 %arg) strictfp {
-; TUNIT: Function Attrs: mustprogress nofree norecurse nosync nounwind strictfp willreturn memory(inaccessiblemem: readwrite)
+; TUNIT: Function Attrs: mustprogress nofree norecurse nosync nounwind strictfp willreturn
 ; TUNIT-LABEL: define nofpclass(nan nzero sub) float @constrained_sitofp
 ; TUNIT-SAME: (i32 [[ARG:%.*]]) #[[ATTR8:[0-9]+]] {
 ; TUNIT-NEXT:    [[VAL:%.*]] = call nofpclass(nan nzero sub) float @llvm.experimental.constrained.sitofp.f32.i32(i32 [[ARG]], metadata !"round.dynamic", metadata !"fpexcept.strict") #[[ATTR27:[0-9]+]]
 ; TUNIT-NEXT:    ret float [[VAL]]
 ;
-; CGSCC: Function Attrs: mustprogress nofree norecurse nosync nounwind strictfp willreturn memory(inaccessiblemem: readwrite)
+; CGSCC: Function Attrs: mustprogress nofree norecurse nosync nounwind strictfp willreturn
 ; CGSCC-LABEL: define nofpclass(nan nzero sub) float @constrained_sitofp
 ; CGSCC-SAME: (i32 [[ARG:%.*]]) #[[ATTR8:[0-9]+]] {
 ; CGSCC-NEXT:    [[VAL:%.*]] = call nofpclass(nan nzero sub) float @llvm.experimental.constrained.sitofp.f32.i32(i32 [[ARG]], metadata !"round.dynamic", metadata !"fpexcept.strict") #[[ATTR26:[0-9]+]]
@@ -1923,13 +1923,13 @@ define float @constrained_sitofp(i32 %arg) strictfp {
 }
 
 define float @constrained_uitofp(i32 %arg) strictfp {
-; TUNIT: Function Attrs: mustprogress nofree norecurse nosync nounwind strictfp willreturn memory(inaccessiblemem: readwrite)
+; TUNIT: Function Attrs: mustprogress nofree norecurse nosync nounwind strictfp willreturn
 ; TUNIT-LABEL: define nofpclass(nan ninf nzero sub nnorm) float @constrained_uitofp
 ; TUNIT-SAME: (i32 [[ARG:%.*]]) #[[ATTR8]] {
 ; TUNIT-NEXT:    [[VAL:%.*]] = call nofpclass(nan ninf nzero sub nnorm) float @llvm.experimental.constrained.uitofp.f32.i32(i32 [[ARG]], metadata !"round.dynamic", metadata !"fpexcept.strict") #[[ATTR27]]
 ; TUNIT-NEXT:    ret float [[VAL]]
 ;
-; CGSCC: Function Attrs: mustprogress nofree norecurse nosync nounwind strictfp willreturn memory(inaccessiblemem: readwrite)
+; CGSCC: Function Attrs: mustprogress nofree norecurse nosync nounwind strictfp willreturn
 ; CGSCC-LABEL: define nofpclass(nan ninf nzero sub nnorm) float @constrained_uitofp
 ; CGSCC-SAME: (i32 [[ARG:%.*]]) #[[ATTR8]] {
 ; CGSCC-NEXT:    [[VAL:%.*]] = call nofpclass(nan ninf nzero sub nnorm) float @llvm.experimental.constrained.uitofp.f32.i32(i32 [[ARG]], metadata !"round.dynamic", metadata !"fpexcept.strict") #[[ATTR26]]

--- a/llvm/test/Verifier/fp-intrinsics-pass.ll
+++ b/llvm/test/Verifier/fp-intrinsics-pass.ll
@@ -38,5 +38,5 @@ entry:
   ret double %fsqrt
 }
 
-; CHECK: attributes #[[ATTR]] = { nocallback nofree nosync nounwind strictfp willreturn memory(inaccessiblemem: readwrite) }
+; CHECK: attributes #[[ATTR]] = { nocallback nofree nosync nounwind strictfp willreturn memory(fpcontrol: read, fpstatus: readwrite) }
 ; CHECK: attributes #[[STRICTFP]] = { strictfp }

--- a/llvm/unittests/IR/AttributesTest.cpp
+++ b/llvm/unittests/IR/AttributesTest.cpp
@@ -818,4 +818,83 @@ TEST(Attributes, ListIntersect) {
   ASSERT_TRUE(Res->hasParamAttr(3, Attribute::ByVal));
 }
 
+TEST(Attributes, AsString) {
+  LLVMContext C;
+  Attribute Attr;
+
+  {
+    MemoryEffects ME = MemoryEffects::none();
+    for (auto Loc : MemoryEffects::targetMemLocations())
+      ME |= MemoryEffects(Loc, ModRefInfo::ModRef);
+    Attr = Attribute::get(C, Attribute::Memory, ME.toIntValue());
+    EXPECT_EQ("memory(target_mem: readwrite)", Attr.getAsString());
+  }
+  {
+    MemoryEffects ME =
+        MemoryEffects(IRMemLocation::TargetMem0, ModRefInfo::ModRef) |
+        MemoryEffects(IRMemLocation::TargetMem1, ModRefInfo::Ref);
+    Attr = Attribute::get(C, Attribute::Memory, ME.toIntValue());
+    EXPECT_EQ("memory(target_mem0: readwrite, target_mem1: read)",
+              Attr.getAsString());
+  }
+  {
+    MemoryEffects ME = MemoryEffects::otherMemOnly(ModRefInfo::Ref);
+    for (auto Loc : MemoryEffects::targetMemLocations())
+      ME |= MemoryEffects(Loc, ModRefInfo::Ref);
+    Attr = Attribute::get(C, Attribute::Memory, ME.toIntValue());
+    EXPECT_EQ("memory(read, argmem: none, inaccessiblemem: none, "
+              "errnomem: none)",
+              Attr.getAsString());
+  }
+  {
+    MemoryEffects ME =
+        MemoryEffects::otherMemOnly(ModRefInfo::Ref) |
+        MemoryEffects(IRMemLocation::TargetMem0, ModRefInfo::ModRef) |
+        MemoryEffects(IRMemLocation::TargetMem1, ModRefInfo::Ref);
+    Attr = Attribute::get(C, Attribute::Memory, ME.toIntValue());
+    EXPECT_EQ("memory(read, argmem: none, inaccessiblemem: none, "
+              "errnomem: none, target_mem0: readwrite)",
+              Attr.getAsString());
+  }
+
+  {
+    MemoryEffects ME = MemoryEffects::fpcontrolOnly();
+    Attr = Attribute::get(C, Attribute::Memory, ME.toIntValue());
+    EXPECT_EQ("memory(fpcontrol: readwrite)", Attr.getAsString());
+  }
+  {
+    MemoryEffects ME = MemoryEffects::fpcontrolOnly(ModRefInfo::Ref);
+    Attr = Attribute::get(C, Attribute::Memory, ME.toIntValue());
+    EXPECT_EQ("memory(fpcontrol: read)", Attr.getAsString());
+  }
+  {
+    MemoryEffects ME = MemoryEffects::otherMemOnly(ModRefInfo::Ref) |
+                       MemoryEffects::fpcontrolOnly(ModRefInfo::Ref);
+    Attr = Attribute::get(C, Attribute::Memory, ME.toIntValue());
+    EXPECT_EQ("memory(read, argmem: none, inaccessiblemem: none, "
+              "errnomem: none, target_mem: none, fpcontrol: read)",
+              Attr.getAsString());
+  }
+  {
+    MemoryEffects ME = MemoryEffects::otherMemOnly(ModRefInfo::Ref) |
+                       MemoryEffects::fpcontrolOnly(ModRefInfo::Ref) |
+                       MemoryEffects::fpstatusOnly(ModRefInfo::Ref);
+    Attr = Attribute::get(C, Attribute::Memory, ME.toIntValue());
+    EXPECT_EQ("memory(read, argmem: none, inaccessiblemem: none, "
+              "errnomem: none, target_mem: none, fpcontrol: read, "
+              "fpstatus: read)",
+              Attr.getAsString());
+  }
+  {
+    MemoryEffects ME = MemoryEffects::otherMemOnly(ModRefInfo::Mod) |
+                       MemoryEffects::fpcontrolOnly(ModRefInfo::Ref) |
+                       MemoryEffects::fpstatusOnly(ModRefInfo::ModRef);
+    Attr = Attribute::get(C, Attribute::Memory, ME.toIntValue());
+    EXPECT_EQ("memory(write, argmem: none, inaccessiblemem: none, "
+              "errnomem: none, target_mem: none, fpcontrol: read, "
+              "fpstatus: readwrite)",
+              Attr.getAsString());
+  }
+}
+
 } // end anonymous namespace

--- a/llvm/unittests/Support/ModRefTest.cpp
+++ b/llvm/unittests/Support/ModRefTest.cpp
@@ -21,7 +21,8 @@ TEST(ModRefTest, PrintMemoryEffects) {
   raw_string_ostream OS(S);
   OS << MemoryEffects::none();
   EXPECT_EQ(S, "ArgMem: NoModRef, InaccessibleMem: NoModRef, ErrnoMem: "
-               "NoModRef, Other: NoModRef, TargetMem0: NoModRef, TargetMem1: NoModRef");
+               "NoModRef, Other: NoModRef, TargetMem0: NoModRef, "
+               "TargetMem1: NoModRef, FPControl: NoModRef, FPStatus: NoModRef");
 }
 
 } // namespace

--- a/llvm/utils/TableGen/Basic/CodeGenIntrinsics.cpp
+++ b/llvm/utils/TableGen/Basic/CodeGenIntrinsics.cpp
@@ -503,6 +503,18 @@ void CodeGenIntrinsic::setProperty(const Record *R) {
     ME &= MemoryEffects::argMemOnly();
   else if (R->getName() == "IntrInaccessibleMemOnly")
     ME &= MemoryEffects::inaccessibleMemOnly();
+  else if (R->getName() == "IntrReadFPControlOnly")
+    ME &= MemoryEffects::fpcontrolOnly(ModRefInfo::Ref);
+  else if (R->getName() == "IntrWriteFPControlOnly")
+    ME &= MemoryEffects::fpcontrolOnly(ModRefInfo::Mod);
+  else if (R->getName() == "IntrUpdateFPStatusOnly")
+    ME &= MemoryEffects::fpstatusOnly(ModRefInfo::ModRef);
+  else if (R->getName() == "IntrReadFPEnvironmentOnly")
+    ME &= MemoryEffects::fpenvironmentOnly(ModRefInfo::Ref);
+  else if (R->getName() == "IntrWriteFPEnvironmentOnly")
+    ME &= MemoryEffects::fpenvironmentOnly(ModRefInfo::Mod);
+  else if (R->getName() == "IntrFPOperationOnly")
+    ME &= MemoryEffects::fpoperationOnly();
   else if (R->isSubClassOf("IntrRead")) {
     MemoryEffects ReadMask = MemoryEffects::writeOnly();
     for (const Record *RLoc : R->getValueAsListOfDefs("MemLoc"))
@@ -664,6 +676,8 @@ CodeGenIntrinsic::getValueAsIRMemLocation(const Record *R) const {
           .Case("TargetMem0", IRMemLocation::TargetMem0)
           .Case("TargetMem1", IRMemLocation::TargetMem1)
           .Case("InaccessibleMem", IRMemLocation::InaccessibleMem)
+          .Case("FPControl", IRMemLocation::FPControl)
+          .Case("FPStatus", IRMemLocation::FPStatus)
           .Default(IRMemLocation::Other); // fallback enum
 
   if (Loc == IRMemLocation::Other)


### PR DESCRIPTION
Floating-point operations in a strictfp function have side effects, which are modeled using memory effects in the form of a read-write access to "inaccessible memory". This helps maintain strictfp semantics but may hinder optimizations. Floating-point operations may depend on rounding mode or not - this fact may be used to reorder them in a more optimal way. Similarly, functions that control floating-point environment (like `set_rounding`, `set_fpmode` etc.) also have more specific access than generic read-write. Also, "inaccessible memory" is used in cases other than FP operation, this results in unnecessary restrictions.

This change implements two new memory location to use instead of the access to "inaccessible memory". The "fpcontrol" location is used to represent access to floating-point control modes, of which only rounding mode is currently supported. The other location, "fpstatus", represents access to floating-point exceptions. Together they replace the use of "inaccessible memory".

The new memory locations are not supported in all cases. The Attributor does not support them now, as these locations do not exactly represent memory. Writing to a floating-point control register inside a function does not mean that the function itself changes some floating-point control mode. Supporting these locations in the Attributor requires additional considerations and, probably, new attributes.