### PR TITLE
[SPIRV] Preserve DebugGlobalVariable emission order.

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVNonSemanticDebugHandler.h
+++ b/llvm/lib/Target/SPIRV/SPIRVNonSemanticDebugHandler.h
@@ -101,7 +101,7 @@ class SPIRVNonSemanticDebugHandler : public DebugHandlerBase {
     const DIExpression *Expr = nullptr;
     const GlobalVariable *LLVMGV = nullptr;
   };
-  DenseMap<const DIGlobalVariable *, GlobalVariableDebugInfo>
+  MapVector<const DIGlobalVariable *, GlobalVariableDebugInfo>
       GlobalVariableDebugInfoMap;
 
   // Distinct DILexicalBlock and DINamespace scopes, parent-before-child


### PR DESCRIPTION
Iterate GlobalVariableDebugInfoMap with MapVector so OpString and DebugGlobalVariable follow insertion order.

The following tests had non-deterministic output, although didn't fail due to the use of CHECK-DAG:

- llvm/test/CodeGen/SPIRV/debug-info/debug-global-variable-multi-gve.ll
- llvm/test/CodeGen/SPIRV/debug-info/debug-lexical-block-namespace.ll
- llvm/test/CodeGen/SPIRV/debug-info/debug-type-pointer.ll