### PR TITLE
[llvm][Support/Blake3] fix build warning for unused variable

### DIFF
--- a/llvm/lib/Support/BLAKE3/blake3.c
+++ b/llvm/lib/Support/BLAKE3/blake3.c
@@ -362,7 +362,7 @@ compress_subtree_to_parent_node(const uint8_t *input, size_t input_len,
 #endif
 
   uint8_t cv_array[MAX_SIMD_DEGREE_OR_2 * BLAKE3_OUT_LEN];
-  size_t num_cvs = blake3_compress_subtree_wide(input, input_len, key,
+  size_t num_cvs __attribute__((unused)) = blake3_compress_subtree_wide(input, input_len, key,
                                                 chunk_counter, flags, cv_array, use_tbb);
   assert(num_cvs <= MAX_SIMD_DEGREE_OR_2);
   // The following loop never executes when MAX_SIMD_DEGREE_OR_2 is 2, because


### PR DESCRIPTION
Another way to fix this is `(void)num_cvs;` or tweaking the `#if` macro below, but this is the simplest approach.