### PR TITLE
[clang-format] Don't force binary operator onto unary star and amp in a requires clause

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -789,6 +789,8 @@ features cannot lower the translation-unit ABI level;
 - `QualifierOrder` now supports `typedef`, `consteval`, `constinit`,
   `thread_local`, `extern`, `mutable`, `signed`, `unsigned`, `long`, `short`,
   and `explicit` declaration specifiers.
+- Fixed a regression that annotated a leading `*` or `&` in a `requires()`
+  clause as a binary operator (#GH221767)
 
 ### libclang
 

--- a/clang/lib/Format/UnwrappedLineParser.cpp
+++ b/clang/lib/Format/UnwrappedLineParser.cpp
@@ -2368,7 +2368,7 @@ bool UnwrappedLineParser::tryToParseLambda() {
     case tok::l_brace:
       break;
     case tok::l_paren:
-      parseParens(/*AmpAmpTokenType=*/TT_PointerOrReference);
+      parseParens(/*StarAndAmpTokenType=*/TT_PointerOrReference);
       break;
     case tok::l_square:
       parseSquare();
@@ -2667,9 +2667,10 @@ bool UnwrappedLineParser::parseBracedList(bool IsAngleBracket, bool IsEnum) {
 
 /// Parses a pair of parentheses (and everything between them).
 /// \param StarAndAmpTokenType If different than TT_Unknown sets this type for
-/// all (double) ampersands and stars. This applies for all nested scopes as
-/// well, this is disabled within a (potential) template argument <>, and thus
-/// also if we find only a <.
+/// all double ampersands, and, if it is TT_PointerOrReference, for all single
+/// ampersands and stars as well. This applies for all nested scopes as well,
+/// this is disabled within a (potential) template argument <>, and thus also if
+/// we find only a <.
 ///
 /// Returns whether there is a `=` token between the parentheses.
 bool UnwrappedLineParser::parseParens(TokenType StarAndAmpTokenType,
@@ -2821,6 +2822,10 @@ bool UnwrappedLineParser::parseParens(TokenType StarAndAmpTokenType,
       break;
     case tok::star:
     case tok::amp:
+      if (StarAndAmpTokenType == TT_PointerOrReference && ExcessLess == 0)
+        FormatTok->setFinalizedType(StarAndAmpTokenType);
+      nextToken();
+      break;
     case tok::ampamp:
       if (StarAndAmpTokenType != TT_Unknown && ExcessLess == 0)
         FormatTok->setFinalizedType(StarAndAmpTokenType);
@@ -3789,7 +3794,7 @@ void UnwrappedLineParser::parseConstraintExpression() {
     case tok::l_paren:
       if (!TopLevelParensAllowed)
         return;
-      parseParens(/*AmpAmpTokenType=*/TT_BinaryOperator);
+      parseParens(/*StarAndAmpTokenType=*/TT_BinaryOperator);
       TopLevelParensAllowed = false;
       break;
 

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -24531,6 +24531,10 @@ TEST_F(FormatTest, RequiresClauses) {
                "  requires(std::same_as<int, T>)\n"
                "decltype(auto) fun() {}");
 
+  verifyFormat("template <typename T>\n"
+               "  requires(!*T::foo && pred(&T::bar))\n"
+               "struct S;");
+
   auto Style = getLLVMStyle();
 
   verifyFormat(

--- a/clang/unittests/Format/TokenAnnotatorTest.cpp
+++ b/clang/unittests/Format/TokenAnnotatorTest.cpp
@@ -1358,6 +1358,20 @@ TEST_F(TokenAnnotatorTest, UnderstandsRequiresClausesAndConcepts) {
   EXPECT_TOKEN(Tokens[35], tok::identifier, TT_Unknown);
 
   Tokens = annotate("template <typename T>\n"
+                    "  requires(*T::value)\n"
+                    "struct Foo;");
+  ASSERT_EQ(Tokens.size(), 16u) << Tokens;
+  EXPECT_TOKEN(Tokens[5], tok::kw_requires, TT_RequiresClause);
+  EXPECT_TOKEN(Tokens[7], tok::star, TT_UnaryOperator);
+
+  Tokens = annotate("template <typename T>\n"
+                    "  requires(pred(&T::x))\n"
+                    "struct Foo;");
+  ASSERT_EQ(Tokens.size(), 19u) << Tokens;
+  EXPECT_TOKEN(Tokens[5], tok::kw_requires, TT_RequiresClause);
+  EXPECT_TOKEN(Tokens[9], tok::amp, TT_UnaryOperator);
+
+  Tokens = annotate("template <typename T>\n"
                     "void foo(T) noexcept requires Bar<T>;");
   ASSERT_EQ(Tokens.size(), 18u) << Tokens;
   EXPECT_TOKEN(Tokens[11], tok::kw_requires, TT_RequiresClause);


### PR DESCRIPTION
fixes https://github.com/llvm/llvm-project/issues/221767

input:
```cpp
template <typename T>
  requires(*T::value && pred(&T::f))
struct B;
```
became
```cpp
template <typename T>
  requires(* T::value && pred(& T::f))
struct B;
```
because the unary `*` and `&` operators were treated as binary.

**AI disclosure:** used claude code to produce the initial fix then rewrote its output