### PR TITLE
[MLIR][VectorToGPU] Cache slice analysis in getOpToConvert

### DIFF
--- a/mlir/lib/Conversion/VectorToGPU/VectorToGPU.cpp
+++ b/mlir/lib/Conversion/VectorToGPU/VectorToGPU.cpp
@@ -344,9 +344,6 @@ static SetVector<Operation *> getOpToConvert(mlir::Operation *op,
   DenseMap<Operation *, SmallVector<Operation *>> backwardSliceCache;
   DenseMap<Operation *, SmallVector<Operation *>> forwardSliceCache;
   DenseMap<Operation *, bool> supportsMMAMatrixTypeCache;
-  // Once we have expanded a seed to its full use/def component, every op in
-  // that component would rediscover the same set again.
-  DenseSet<Operation *> analyzedOps;
 
   auto getCachedBackwardSlice =
       [&](Operation *currentOp) -> ArrayRef<Operation *> {
@@ -399,7 +396,7 @@ static SetVector<Operation *> getOpToConvert(mlir::Operation *op,
     if (!isa<vector::ContractionOp>(nestedOp) &&
         !elementwiseSupportsMMAMatrixType(nestedOp))
       return;
-    if (analyzedOps.contains(nestedOp))
+    if (backwardSliceCache.contains(nestedOp))
       return;
 
     SetVector<Operation *> dependentOps;
@@ -410,9 +407,6 @@ static SetVector<Operation *> getOpToConvert(mlir::Operation *op,
       dependentOps.insert_range(getCachedBackwardSlice(currentOp));
       dependentOps.insert_range(getCachedForwardSlice(currentOp));
     }
-
-    analyzedOps.insert_range(dependentOps);
-
     // If any instruction cannot use MMA matrix type drop the whole
     // chain. MMA matrix are stored in an opaque type so they cannot be used
     // by all operations.

--- a/mlir/lib/Conversion/VectorToGPU/VectorToGPU.cpp
+++ b/mlir/lib/Conversion/VectorToGPU/VectorToGPU.cpp
@@ -359,7 +359,7 @@ static SetVector<Operation *> getOpToConvert(mlir::Operation *op,
         getBackwardSlice(currentOp, &backwardSlice, backwardSliceOptions);
     assert(result.succeeded() && "expected a backward slice");
     (void)result;
-    it->second.append(backwardSlice.begin(), backwardSlice.end());
+    it->second = backwardSlice.takeVector();
     return it->second;
   };
 
@@ -382,7 +382,7 @@ static SetVector<Operation *> getOpToConvert(mlir::Operation *op,
     } else {
       getForwardSlice(currentOp, &forwardSlice, forwardSliceOptions);
     }
-    it->second.append(forwardSlice.begin(), forwardSlice.end());
+    it->second = forwardSlice.takeVector();
     return it->second;
   };
 

--- a/mlir/lib/Conversion/VectorToGPU/VectorToGPU.cpp
+++ b/mlir/lib/Conversion/VectorToGPU/VectorToGPU.cpp
@@ -325,48 +325,6 @@ static bool supportsMMaMatrixType(Operation *op, bool useNvGpu) {
   return elementwiseSupportsMMAMatrixType(op);
 }
 
-/// Return an unsorted slice handling scf.for region differently than
-/// `getSlice`. In scf.for we only want to include as part of the slice elements
-/// that are part of the use/def chain.
-static SetVector<Operation *>
-getSliceContract(Operation *op,
-                 const BackwardSliceOptions &backwardSliceOptions,
-                 const ForwardSliceOptions &forwardSliceOptions) {
-  SetVector<Operation *> slice;
-  slice.insert(op);
-  unsigned currentIndex = 0;
-  SetVector<Operation *> backwardSlice;
-  SetVector<Operation *> forwardSlice;
-  while (currentIndex != slice.size()) {
-    auto *currentOp = (slice)[currentIndex];
-    // Compute and insert the backwardSlice starting from currentOp.
-    backwardSlice.clear();
-    LogicalResult result =
-        getBackwardSlice(currentOp, &backwardSlice, backwardSliceOptions);
-    assert(result.succeeded() && "expected a backward slice");
-    (void)result;
-    slice.insert_range(backwardSlice);
-
-    // Compute and insert the forwardSlice starting from currentOp.
-    forwardSlice.clear();
-    // Special case for ForOp, we don't want to include the whole region but
-    // only the value using the region arguments.
-    // TODO: We should refine this to only care about the region arguments being
-    // converted to matrix type.
-    if (auto forOp = dyn_cast<scf::ForOp>(currentOp)) {
-      for (Value forOpResult : forOp.getResults())
-        getForwardSlice(forOpResult, &forwardSlice, forwardSliceOptions);
-      for (BlockArgument &arg : forOp.getRegionIterArgs())
-        getForwardSlice(arg, &forwardSlice, forwardSliceOptions);
-    } else {
-      getForwardSlice(currentOp, &forwardSlice, forwardSliceOptions);
-    }
-    slice.insert_range(forwardSlice);
-    ++currentIndex;
-  }
-  return slice;
-}
-
 // Analyze slice of operations based on convert op to figure out if the whole
 // slice can be converted to MMA operations.
 static SetVector<Operation *> getOpToConvert(mlir::Operation *op,
@@ -383,20 +341,83 @@ static SetVector<Operation *> getOpToConvert(mlir::Operation *op,
   ForwardSliceOptions forwardSliceOptions;
   forwardSliceOptions.filter = hasVectorSrc;
 
+  DenseMap<Operation *, SmallVector<Operation *>> backwardSliceCache;
+  DenseMap<Operation *, SmallVector<Operation *>> forwardSliceCache;
+  DenseMap<Operation *, bool> supportsMMAMatrixTypeCache;
+  // Once we have expanded a seed to its full use/def component, every op in
+  // that component would rediscover the same set again.
+  DenseSet<Operation *> analyzedOps;
+
+  auto getCachedBackwardSlice =
+      [&](Operation *currentOp) -> ArrayRef<Operation *> {
+    auto [it, inserted] = backwardSliceCache.try_emplace(currentOp);
+    if (!inserted)
+      return it->second;
+
+    SetVector<Operation *> backwardSlice;
+    LogicalResult result =
+        getBackwardSlice(currentOp, &backwardSlice, backwardSliceOptions);
+    assert(result.succeeded() && "expected a backward slice");
+    (void)result;
+    it->second.append(backwardSlice.begin(), backwardSlice.end());
+    return it->second;
+  };
+
+  auto getCachedForwardSlice =
+      [&](Operation *currentOp) -> ArrayRef<Operation *> {
+    auto [it, inserted] = forwardSliceCache.try_emplace(currentOp);
+    if (!inserted)
+      return it->second;
+
+    SetVector<Operation *> forwardSlice;
+    // Special case for ForOp, we don't want to include the whole region but
+    // only the value using the region arguments.
+    // TODO: We should refine this to only care about the region arguments being
+    // converted to matrix type.
+    if (auto forOp = dyn_cast<scf::ForOp>(currentOp)) {
+      for (Value forOpResult : forOp.getResults())
+        getForwardSlice(forOpResult, &forwardSlice, forwardSliceOptions);
+      for (BlockArgument &arg : forOp.getRegionIterArgs())
+        getForwardSlice(arg, &forwardSlice, forwardSliceOptions);
+    } else {
+      getForwardSlice(currentOp, &forwardSlice, forwardSliceOptions);
+    }
+    it->second.append(forwardSlice.begin(), forwardSlice.end());
+    return it->second;
+  };
+
+  auto cachedSupportsMMAMatrixType = [&](Operation *currentOp) {
+    auto [it, inserted] =
+        supportsMMAMatrixTypeCache.try_emplace(currentOp, false);
+    if (inserted)
+      it->second = supportsMMaMatrixType(currentOp, useNvGpu);
+    return it->second;
+  };
+
   SetVector<Operation *> opToConvert;
   op->walk([&](Operation *nestedOp) {
     if (!isa<vector::ContractionOp>(nestedOp) &&
         !elementwiseSupportsMMAMatrixType(nestedOp))
       return;
-    if (opToConvert.contains(nestedOp))
+    if (analyzedOps.contains(nestedOp))
       return;
-    SetVector<Operation *> dependentOps =
-        getSliceContract(nestedOp, backwardSliceOptions, forwardSliceOptions);
+
+    SetVector<Operation *> dependentOps;
+    dependentOps.insert(nestedOp);
+    unsigned currentIndex = 0;
+    while (currentIndex != dependentOps.size()) {
+      Operation *currentOp = dependentOps[currentIndex++];
+      dependentOps.insert_range(getCachedBackwardSlice(currentOp));
+      dependentOps.insert_range(getCachedForwardSlice(currentOp));
+    }
+
+    analyzedOps.insert_range(dependentOps);
+
     // If any instruction cannot use MMA matrix type drop the whole
     // chain. MMA matrix are stored in an opaque type so they cannot be used
     // by all operations.
-    if (llvm::any_of(dependentOps, [useNvGpu](Operation *op) {
-          if (!supportsMMaMatrixType(op, useNvGpu)) {
+    if (llvm::any_of(dependentOps, [&](Operation *op) {
+          if (!cachedSupportsMMAMatrixType(op)) {
             LDBG() << "cannot convert op: " << *op;
             return true;
           }


### PR DESCRIPTION
  ConvertVectorToGPU spent a lot of time rebuilding the same backward and forward slices for overlapping vector/MMA use-def components, which was especially visible on int8 cases.

  This change caches backward slices, forward slices, and supportsMMaMatrixType() results per operation, and marks fully expanded components as already analyzed. That avoids repeatedly rediscovering and revalidating the same component from multiple seeds without changing the lowering itself.

  The resulting conversion is unchanged, but compile time for the affected int8 case drops significantly.