### PR TITLE
[CIR] Register only the LLVM IR translations CIR lowers to

### DIFF
--- a/clang/test/CIR/Lowering/lifetime.cir
+++ b/clang/test/CIR/Lowering/lifetime.cir
@@ -1,4 +1,4 @@
-// RUN: cir-opt %s -cir-to-llvm -o - | mlir-translate -mlir-to-llvmir | FileCheck %s
+// RUN: cir-opt %s -cir-to-llvm -o - | cir-translate -mlir-to-llvmir | FileCheck %s
 
 !s32i = !cir.int<s, 32>
 

--- a/clang/test/CIR/Lowering/stack-save-restore.cir
+++ b/clang/test/CIR/Lowering/stack-save-restore.cir
@@ -1,5 +1,5 @@
 // RUN: cir-opt %s -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
-// RUN: cir-opt %s -cir-to-llvm -o - | mlir-translate -mlir-to-llvmir | FileCheck %s -check-prefix=LLVM
+// RUN: cir-opt %s -cir-to-llvm -o - | cir-translate -mlir-to-llvmir | FileCheck %s -check-prefix=LLVM
 
 !u8i = !cir.int<u, 8>
 

--- a/clang/test/CIR/Transforms/abi-lowering/byval-sret-arg-attr-lowering.cir
+++ b/clang/test/CIR/Transforms/abi-lowering/byval-sret-arg-attr-lowering.cir
@@ -2,7 +2,7 @@
 // RUN:   | FileCheck %s
 // RUN: cir-opt %s -cir-call-conv-lowering="classification-attr=test_classify" \
 // RUN:     -cir-to-llvm -o - 2>/dev/null \
-// RUN:   | mlir-translate -mlir-to-llvmir --allow-unregistered-dialect \
+// RUN:   | cir-translate -mlir-to-llvmir --allow-unregistered-dialect \
 // RUN:   | FileCheck %s --check-prefix=LLVM
 
 !s64i = !cir.int<s, 64>

--- a/clang/test/CIR/Transforms/abi-lowering/extend-signed-arg.cir
+++ b/clang/test/CIR/Transforms/abi-lowering/extend-signed-arg.cir
@@ -2,7 +2,7 @@
 // RUN:   | FileCheck %s
 // RUN: cir-opt %s -cir-call-conv-lowering="classification-attr=test_classify" \
 // RUN:   -cir-to-llvm -o - 2>/dev/null \
-// RUN:   | mlir-translate -mlir-to-llvmir --allow-unregistered-dialect \
+// RUN:   | cir-translate -mlir-to-llvmir --allow-unregistered-dialect \
 // RUN:   | FileCheck %s --check-prefix=LLVM
 
 !s8i = !cir.int<s, 8>

--- a/clang/test/CIR/Transforms/abi-lowering/x86_64-bitint.cir
+++ b/clang/test/CIR/Transforms/abi-lowering/x86_64-bitint.cir
@@ -1,6 +1,6 @@
 // RUN: cir-opt %s -cir-call-conv-lowering=target=x86_64 | FileCheck %s
 // RUN: cir-opt %s -cir-call-conv-lowering=target=x86_64 -cir-to-llvm -o - 2>/dev/null \
-// RUN:   | mlir-translate -mlir-to-llvmir --allow-unregistered-dialect \
+// RUN:   | cir-translate -mlir-to-llvmir --allow-unregistered-dialect \
 // RUN:   | FileCheck %s --check-prefix=LLVM
 
 !b17i = !cir.int<s, 17, bitint>

--- a/clang/test/CIR/Transforms/abi-lowering/x86_64-complex.cir
+++ b/clang/test/CIR/Transforms/abi-lowering/x86_64-complex.cir
@@ -1,6 +1,6 @@
 // RUN: cir-opt %s -cir-call-conv-lowering=target=x86_64 | FileCheck %s
 // RUN: cir-opt %s -cir-call-conv-lowering=target=x86_64 -cir-to-llvm -o - 2>/dev/null \
-// RUN:   | mlir-translate -mlir-to-llvmir --allow-unregistered-dialect \
+// RUN:   | cir-translate -mlir-to-llvmir --allow-unregistered-dialect \
 // RUN:   | FileCheck %s --check-prefix=LLVM
 
 !s16i = !cir.int<s, 16>

--- a/clang/test/CIR/Transforms/abi-lowering/x86_64-empty-class.cir
+++ b/clang/test/CIR/Transforms/abi-lowering/x86_64-empty-class.cir
@@ -1,6 +1,6 @@
 // RUN: cir-opt %s -cir-call-conv-lowering=target=x86_64 | FileCheck %s
 // RUN: cir-opt %s -cir-call-conv-lowering=target=x86_64 -cir-to-llvm -o - 2>/dev/null \
-// RUN:   | mlir-translate -mlir-to-llvmir --allow-unregistered-dialect \
+// RUN:   | cir-translate -mlir-to-llvmir --allow-unregistered-dialect \
 // RUN:   | FileCheck %s --check-prefix=LLVM
 
 !s32i = !cir.int<s, 32>

--- a/clang/test/CIR/Transforms/abi-lowering/x86_64-scalars.cir
+++ b/clang/test/CIR/Transforms/abi-lowering/x86_64-scalars.cir
@@ -1,6 +1,6 @@
 // RUN: cir-opt %s -cir-call-conv-lowering=target=x86_64 | FileCheck %s
 // RUN: cir-opt %s -cir-call-conv-lowering=target=x86_64 -cir-to-llvm -o - 2>/dev/null \
-// RUN:   | mlir-translate -mlir-to-llvmir --allow-unregistered-dialect \
+// RUN:   | cir-translate -mlir-to-llvmir --allow-unregistered-dialect \
 // RUN:   | FileCheck %s --check-prefix=LLVM
 
 !s8i = !cir.int<s, 8>

--- a/clang/test/CIR/Transforms/abi-lowering/x86_64-struct-direct.cir
+++ b/clang/test/CIR/Transforms/abi-lowering/x86_64-struct-direct.cir
@@ -1,6 +1,6 @@
 // RUN: cir-opt %s -cir-call-conv-lowering=target=x86_64 | FileCheck %s
 // RUN: cir-opt %s -cir-call-conv-lowering=target=x86_64 -cir-to-llvm -o - 2>/dev/null \
-// RUN:   | mlir-translate -mlir-to-llvmir --allow-unregistered-dialect \
+// RUN:   | cir-translate -mlir-to-llvmir --allow-unregistered-dialect \
 // RUN:   | FileCheck %s --check-prefix=LLVM
 
 !s8i = !cir.int<s, 8>

--- a/clang/test/CIR/Transforms/abi-lowering/x86_64-union-coerce-shapes.cir
+++ b/clang/test/CIR/Transforms/abi-lowering/x86_64-union-coerce-shapes.cir
@@ -1,6 +1,6 @@
 // RUN: cir-opt %s -cir-call-conv-lowering=target=x86_64 | FileCheck %s
 // RUN: cir-opt %s -cir-call-conv-lowering=target=x86_64 -cir-to-llvm -o - 2>/dev/null \
-// RUN:   | mlir-translate -mlir-to-llvmir --allow-unregistered-dialect \
+// RUN:   | cir-translate -mlir-to-llvmir --allow-unregistered-dialect \
 // RUN:   | FileCheck %s --check-prefix=LLVM
 
 !s8i = !cir.int<s, 8>

--- a/clang/test/CIR/Transforms/abi-lowering/x86_64-union.cir
+++ b/clang/test/CIR/Transforms/abi-lowering/x86_64-union.cir
@@ -1,6 +1,6 @@
 // RUN: cir-opt %s -cir-call-conv-lowering=target=x86_64 | FileCheck %s
 // RUN: cir-opt %s -cir-call-conv-lowering=target=x86_64 -cir-to-llvm -o - 2>/dev/null \
-// RUN:   | mlir-translate -mlir-to-llvmir --allow-unregistered-dialect \
+// RUN:   | cir-translate -mlir-to-llvmir --allow-unregistered-dialect \
 // RUN:   | FileCheck %s --check-prefix=LLVM
 
 !s8i = !cir.int<s, 8>

--- a/clang/test/CIR/Transforms/abi-lowering/x86_64-variadic-call.cir
+++ b/clang/test/CIR/Transforms/abi-lowering/x86_64-variadic-call.cir
@@ -1,6 +1,6 @@
 // RUN: cir-opt %s -cir-call-conv-lowering=target=x86_64 | FileCheck %s
 // RUN: cir-opt %s -cir-call-conv-lowering=target=x86_64 -cir-to-llvm -o - 2>/dev/null \
-// RUN:   | mlir-translate -mlir-to-llvmir --allow-unregistered-dialect \
+// RUN:   | cir-translate -mlir-to-llvmir --allow-unregistered-dialect \
 // RUN:   | FileCheck %s --check-prefix=LLVM
 
 !s8i = !cir.int<s, 8>

--- a/clang/test/CIR/Transforms/abi-lowering/x86_64-vector.cir
+++ b/clang/test/CIR/Transforms/abi-lowering/x86_64-vector.cir
@@ -4,7 +4,7 @@
 // RUN: cir-opt %s -cir-call-conv-lowering='target=x86_64 x86-avx-abi-level=avx512' \
 // RUN:   | FileCheck %s --check-prefix=AVX512
 // RUN: cir-opt %s -cir-call-conv-lowering=target=x86_64 -cir-to-llvm -o - 2>/dev/null \
-// RUN:   | mlir-translate -mlir-to-llvmir --allow-unregistered-dialect \
+// RUN:   | cir-translate -mlir-to-llvmir --allow-unregistered-dialect \
 // RUN:   | FileCheck %s --check-prefix=LLVM
 
 !s32i = !cir.int<s, 32>

--- a/clang/test/CIR/Transforms/abi-lowering/x86_64-vptr.cir
+++ b/clang/test/CIR/Transforms/abi-lowering/x86_64-vptr.cir
@@ -1,6 +1,6 @@
 // RUN: cir-opt %s -cir-call-conv-lowering=target=x86_64 | FileCheck %s
 // RUN: cir-opt %s -cir-call-conv-lowering=target=x86_64 -cir-to-llvm -o - 2>/dev/null \
-// RUN:   | mlir-translate -mlir-to-llvmir --allow-unregistered-dialect \
+// RUN:   | cir-translate -mlir-to-llvmir --allow-unregistered-dialect \
 // RUN:   | FileCheck %s --check-prefix=LLVM
 
 !s32i = !cir.int<s, 32>

--- a/clang/test/CIR/Transforms/abi-lowering/x86_64-wide-floats.cir
+++ b/clang/test/CIR/Transforms/abi-lowering/x86_64-wide-floats.cir
@@ -1,6 +1,6 @@
 // RUN: cir-opt %s -cir-call-conv-lowering=target=x86_64 | FileCheck %s
 // RUN: cir-opt %s -cir-call-conv-lowering=target=x86_64 -cir-to-llvm -o - 2>/dev/null \
-// RUN:   | mlir-translate -mlir-to-llvmir --allow-unregistered-dialect \
+// RUN:   | cir-translate -mlir-to-llvmir --allow-unregistered-dialect \
 // RUN:   | FileCheck %s --check-prefix=LLVM
 
 !s32i = !cir.int<s, 32>

--- a/clang/test/CMakeLists.txt
+++ b/clang/test/CMakeLists.txt
@@ -117,7 +117,6 @@ if(CLANG_ENABLE_CIR)
   list(APPEND CLANG_TEST_DEPS
     cir-opt
     cir-translate
-    mlir-translate
     )
   add_subdirectory(CIR/lib)
 endif()

--- a/clang/tools/cir-translate/CMakeLists.txt
+++ b/clang/tools/cir-translate/CMakeLists.txt
@@ -1,7 +1,3 @@
-get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
-get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
-get_property(translation_libs GLOBAL PROPERTY MLIR_TRANSLATION_LIBS)
-
 include_directories(${LLVM_MAIN_SRC_DIR}/../mlir/include)
 include_directories(${CMAKE_BINARY_DIR}/tools/mlir/include)
 
@@ -20,12 +16,16 @@ clang_target_link_libraries(cir-translate
 
 target_link_libraries(cir-translate
   PRIVATE
-  ${dialect_libs}
-  ${conversion_libs}
-  ${translation_libs}
   MLIRAnalysis
+  MLIRBuiltinToLLVMIRTranslation
   MLIRDialect
+  MLIRDLTIDialect
+  MLIRFuncDialect
   MLIRIR
+  MLIRLLVMDialect
+  MLIRLLVMToLLVMIRTranslation
+  MLIROpenMPToLLVMIRTranslation
+  MLIRTargetLLVMIRExport
   MLIROptLib
   MLIRParser
   MLIRPass

--- a/clang/tools/cir-translate/cir-translate.cpp
+++ b/clang/tools/cir-translate/cir-translate.cpp
@@ -17,9 +17,11 @@
 #include "mlir/Dialect/OpenMP/Utils/Utils.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/MLIRContext.h"
-#include "mlir/InitAllTranslations.h"
 #include "mlir/Support/LogicalResult.h"
-#include "mlir/Target/LLVMIR/Dialect/All.h"
+#include "mlir/Target/LLVMIR/Dialect/Builtin/BuiltinToLLVMIRTranslation.h"
+#include "mlir/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.h"
+#include "mlir/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.h"
+#include "mlir/Target/LLVMIR/Export.h"
 #include "mlir/Tools/mlir-translate/MlirTranslateMain.h"
 #include "mlir/Tools/mlir-translate/Translation.h"
 
@@ -144,6 +146,12 @@ llvm::LogicalResult prepareCIRModuleForTranslation(mlir::ModuleOp mod) {
 } // namespace
 } // namespace cir
 
+static void registerLLVMIRTranslations(mlir::DialectRegistry &registry) {
+  mlir::registerBuiltinDialectTranslation(registry);
+  mlir::registerLLVMDialectTranslation(registry);
+  mlir::registerOpenMPDialectTranslation(registry);
+}
+
 void registerToLLVMTranslation() {
   static llvm::cl::opt<bool> disableCCLowering(
       "disable-cc-lowering",
@@ -172,12 +180,35 @@ void registerToLLVMTranslation() {
       [](mlir::DialectRegistry &registry) {
         cir::registerAllDialects(registry);
         registry.insert<mlir::func::FuncDialect>();
-        mlir::registerAllToLLVMIRTranslations(registry);
+        registerLLVMIRTranslations(registry);
         cir::direct::registerCIRDialectTranslation(registry);
+      });
+}
+
+// Mirrors mlir::registerToLLVMIRTranslation, restricted to the dialects CIR
+// lowers to so that the ClangIR tests need not depend on mlir-translate, which
+// links every MLIR dialect.
+static void registerMLIRToLLVMIRTranslation() {
+  mlir::TranslateFromMLIRRegistration registration(
+      "mlir-to-llvmir", "Translate MLIR to LLVMIR",
+      [](mlir::Operation *op, mlir::raw_ostream &output) {
+        llvm::LLVMContext llvmContext;
+        std::unique_ptr<llvm::Module> llvmModule =
+            mlir::translateModuleToLLVMIR(op, llvmContext);
+        if (!llvmModule)
+          return mlir::failure();
+        llvmModule->renumberMetadataForAssembly();
+        llvmModule->print(output, nullptr);
+        return mlir::success();
+      },
+      [](mlir::DialectRegistry &registry) {
+        registry.insert<mlir::DLTIDialect, mlir::func::FuncDialect>();
+        registerLLVMIRTranslations(registry);
       });
 }
 
 int main(int argc, char **argv) {
   registerToLLVMTranslation();
+  registerMLIRToLLVMIRTranslation();
   return failed(mlir::mlirTranslateMain(argc, argv, "CIR Translation Tool"));
 }


### PR DESCRIPTION
The ClangIR tests reach LLVM IR through mlir-translate, which links every
MLIR dialect and translation, so building check-clang builds most of MLIR.
Register mlir-to-llvmir in cir-translate over the same three dialects and
use it instead. Remove the dependency on `mlir-translate` to run CIR tests.

ninja check-clang drops from 6499 to 5853 build edges.

LLM-aided
