### PR TITLE
[offload][omp] Move is_accessible_ptr to liboffload

### DIFF
--- a/offload/liboffload/API/Memory.td
+++ b/offload/liboffload/API/Memory.td
@@ -266,6 +266,21 @@ def olMemUnregister : Function {
   let returns = [];
 }
 
+def olMemIsAccessible : Function {
+  let desc = "Checks whether the device can directly access memory at the given address.";
+  let details = [
+    "The memory does not need to have been allocated through liboffload; "
+    "any host or device pointer may be queried."
+  ];
+  let params = [
+    Param<"ol_device_handle_t", "Device", "handle of the device", PARAM_IN>,
+    Param<"const void*", "Ptr", "pointer to check", PARAM_IN>,
+    Param<"size_t", "Size", "size in bytes of the range starting at `Ptr` to check", PARAM_IN>,
+    Param<"bool*", "IsAccessible", "output pointer for the accessibility result", PARAM_OUT>
+  ];
+  let returns = [];
+}
+
 def ol_mem_migration_flags_t : Typedef {
   let desc = "Memory migration flags, indicating the direction data is migrated in.";
   let value = "uint32_t";

--- a/offload/liboffload/exports
+++ b/offload/liboffload/exports
@@ -20,7 +20,6 @@ global:
     "llvm::omp::target::plugin::GenericPluginTy::get_function(__tgt_device_binary, char const*, void**)";
     "llvm::omp::target::plugin::GenericPluginTy::get_global(__tgt_device_binary, unsigned long, char const*, void**)";
     "llvm::omp::target::plugin::GenericPluginTy::initialize_record_replay(int, long, void*, bool, bool, bool, bool, char const*, char const*)";
-    "llvm::omp::target::plugin::GenericPluginTy::is_accessible_ptr(int, void const*, unsigned long)";
     "llvm::omp::target::plugin::GenericPluginTy::is_initialized() const";
     "llvm::omp::target::plugin::GenericPluginTy::launch_kernel(int, void*, llvm::omp::target::plugin::KernelLaunchArgsTy&, __tgt_async_info*)";
     "llvm::omp::target::plugin::GenericPluginTy::load_binary(int, __tgt_device_image*, __tgt_device_binary*)";

--- a/offload/liboffload/src/OffloadImpl.cpp
+++ b/offload/liboffload/src/OffloadImpl.cpp
@@ -1652,6 +1652,20 @@ Error olMemUnregister_impl(ol_device_handle_t Device, void *Ptr,
       ->unregisterMemory(Ptr, Flags & OL_MEMORY_REGISTER_FLAG_UNLOCK_MEMORY);
 }
 
+Error olMemIsAccessible_impl(ol_device_handle_t Device, const void *Ptr,
+                             size_t Size, bool *IsAccessible) {
+  auto DeviceOrErr = Device->getDevice();
+  if (!DeviceOrErr)
+    return DeviceOrErr.takeError();
+
+  auto AccessibleOrErr = (*DeviceOrErr)->isAccessiblePtr(Ptr, Size);
+  if (!AccessibleOrErr)
+    return AccessibleOrErr.takeError();
+
+  *IsAccessible = *AccessibleOrErr;
+  return Error::success();
+}
+
 Error olQueryQueue_impl(ol_queue_handle_t Queue, bool *IsQueueWorkCompleted) {
   if (Queue->AsyncInfo->Queue) {
     auto DeviceOrErr = Queue->Device->getDevice();

--- a/offload/libompaccsupport/device.cpp
+++ b/offload/libompaccsupport/device.cpp
@@ -564,5 +564,10 @@ bool DeviceTy::useAutoZeroCopy() {
 }
 
 bool DeviceTy::isAccessiblePtr(const void *Ptr, size_t Size) {
-  return RTL->is_accessible_ptr(RTLDeviceID, Ptr, Size);
+  bool IsAccessible = false;
+  if (auto Res = olMemIsAccessible(DeviceHandle, Ptr, Size, &IsAccessible)) {
+    REPORT() << "Failure to check pointer accessibility: " << Res->Details;
+    return false;
+  }
+  return IsAccessible;
 }

--- a/offload/plugins-nextgen/common/include/PluginInterface.h
+++ b/offload/plugins-nextgen/common/include/PluginInterface.h
@@ -1755,9 +1755,6 @@ public:
   /// Returns if the plugin can support automatic copy.
   int32_t use_auto_zero_copy(int32_t DeviceId);
 
-  /// Returns if the associated storage is accessible for a given device.
-  int32_t is_accessible_ptr(int32_t DeviceId, const void *Ptr, size_t Size);
-
   /// Look up a global symbol in the given binary.
   int32_t get_global(__tgt_device_binary Binary, uint64_t Size,
                      const char *Name, void **DevicePtr);

--- a/offload/plugins-nextgen/common/src/PluginInterface.cpp
+++ b/offload/plugins-nextgen/common/src/PluginInterface.cpp
@@ -1668,22 +1668,6 @@ int32_t GenericPluginTy::use_auto_zero_copy(int32_t DeviceId) {
   return getDevice(DeviceId).useAutoZeroCopy();
 }
 
-int32_t GenericPluginTy::is_accessible_ptr(int32_t DeviceId, const void *Ptr,
-                                           size_t Size) {
-  auto HandleError = [&](Error Err) -> bool {
-    std::string ErrStr = toString(std::move(Err));
-    ODBG(OLDT_Device) << "Failure while checking accessibility of pointer "
-                      << Ptr << " for device " << DeviceId << ": " << ErrStr;
-    return false;
-  };
-
-  auto AccessibleOrErr = getDevice(DeviceId).isAccessiblePtr(Ptr, Size);
-  if (Error Err = AccessibleOrErr.takeError())
-    return HandleError(std::move(Err));
-
-  return *AccessibleOrErr;
-}
-
 int32_t GenericPluginTy::get_global(__tgt_device_binary Binary, uint64_t Size,
                                     const char *Name, void **DevicePtr) {
   assert(Binary.handle && "Invalid device binary handle");

--- a/offload/unittests/OffloadAPI/CMakeLists.txt
+++ b/offload/unittests/OffloadAPI/CMakeLists.txt
@@ -40,7 +40,8 @@ add_offload_unittest("memory"
     memory/olMemPrefetch.cpp
     memory/olGetMemInfo.cpp
     memory/olGetMemInfoSize.cpp
-    memory/olMemRegister.cpp)
+    memory/olMemRegister.cpp
+    memory/olMemIsAccessible.cpp)
 
 add_offload_unittest("platform"
     platform/olGetPlatformInfo.cpp

--- a/offload/unittests/OffloadAPI/memory/olMemIsAccessible.cpp
+++ b/offload/unittests/OffloadAPI/memory/olMemIsAccessible.cpp
@@ -1,0 +1,44 @@
+//===------- Offload API tests - olMemIsAccessible -----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "../common/Fixtures.hpp"
+#include <OffloadAPI.h>
+#include <gtest/gtest.h>
+
+using olMemIsAccessibleTest = OffloadDeviceTest;
+OFFLOAD_TESTS_INSTANTIATE_DEVICE_FIXTURE(olMemIsAccessibleTest);
+
+TEST_P(olMemIsAccessibleTest, SuccessDeviceAllocation) {
+  void *Ptr = nullptr;
+  ASSERT_SUCCESS(olMemAlloc(Device, OL_ALLOC_TYPE_DEVICE, 1024, &Ptr));
+  ASSERT_NE(Ptr, nullptr);
+
+  bool IsAccessible = false;
+  ASSERT_SUCCESS(olMemIsAccessible(Device, Ptr, 1024, &IsAccessible));
+  ASSERT_TRUE(IsAccessible);
+
+  ASSERT_SUCCESS(olMemFree(Ptr));
+}
+
+TEST_P(olMemIsAccessibleTest, SuccessHostAllocation) {
+  void *Ptr = nullptr;
+  ASSERT_SUCCESS(olMemAllocHost(Device, 1024, &Ptr));
+  ASSERT_NE(Ptr, nullptr);
+
+  bool IsAccessible = false;
+  ASSERT_SUCCESS(olMemIsAccessible(Device, Ptr, 1024, &IsAccessible));
+  ASSERT_TRUE(IsAccessible);
+
+  ASSERT_SUCCESS(olMemFree(Ptr));
+}
+
+TEST_P(olMemIsAccessibleTest, InvalidNullPointer) {
+  bool IsAccessible = false;
+  ASSERT_ERROR(OL_ERRC_INVALID_NULL_POINTER,
+               olMemIsAccessible(Device, nullptr, 1024, &IsAccessible));
+}


### PR DESCRIPTION
Implement a new method in liboffload to access isAccessiblePtr method in GenericDeviceTy and use it in libomptarget to substitute the direct call to GenericPluginTy.

Assisted by Claude.