### PR TITLE
[libc][baremetal] default NUM_TABLE_ENTRIES to a fixed value of 3 in TLSF

### DIFF
--- a/libc/src/__support/tlsf_table.h
+++ b/libc/src/__support/tlsf_table.h
@@ -32,7 +32,7 @@ struct DefaultFreeStoreConfig {
   static constexpr size_t UNIT_SIZE = BlockRef::MIN_ALIGN;
   static constexpr size_t STEP_SIZE_BITS = 3;
   static constexpr size_t NUM_STEP_BITS = 2;
-  static constexpr size_t NUM_TABLE_ENTRIES = sizeof(uintptr_t) == 8 ? 3 : 6;
+  static constexpr size_t NUM_TABLE_ENTRIES = 3;
   static constexpr bool USE_TRIE_FOR_OVERFLOW_BIN = true;
   static constexpr size_t LINEAR_SCAN_LIMIT = 16;
 };

--- a/libc/test/src/__support/tlsf_table_test.cpp
+++ b/libc/test/src/__support/tlsf_table_test.cpp
@@ -40,21 +40,20 @@ TEST(LlvmLibcTLSFTableTest, BinToMinSize) {
 
 TEST(LlvmLibcTLSFTableTest, OccupancyQueriesAndMutations) {
   Table table;
-  for (size_t i = 0; i < Table::TOTAL_BINS; ++i) {
+  for (size_t i = 0; i < Table::TOTAL_BINS; ++i)
     EXPECT_FALSE(table.is_occupied(i));
-  }
 
   table.mark_occupied(5);
   EXPECT_TRUE(table.is_occupied(5));
   EXPECT_FALSE(table.is_occupied(4));
   EXPECT_FALSE(table.is_occupied(6));
 
-  table.mark_occupied(100);
-  EXPECT_TRUE(table.is_occupied(100));
+  table.mark_occupied(Table::TOTAL_BINS - 3);
+  EXPECT_TRUE(table.is_occupied(Table::TOTAL_BINS - 3));
 
   table.mark_vacant(5);
   EXPECT_FALSE(table.is_occupied(5));
-  EXPECT_TRUE(table.is_occupied(100));
+  EXPECT_TRUE(table.is_occupied(Table::TOTAL_BINS - 3));
 }
 
 TEST(LlvmLibcTLSFTableTest, FindFirstOccupiedAfter) {


### PR DESCRIPTION
In baremetal allocator, TLSF table previous pin the words for bitmask to 6 (192 entries), which is too large for 32-bit devices and can cause shift overflow. This PR sets the limit to 3 words.