### PR TITLE
[MLIR][spirv] Shard generated operation definitions (NFC)

### DIFF
--- a/mlir/include/mlir/Dialect/SPIRV/IR/CMakeLists.txt
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/CMakeLists.txt
@@ -1,4 +1,11 @@
-add_mlir_dialect(SPIRVOps spirv)
+set(LLVM_TARGET_DEFINITIONS SPIRVOps.td)
+mlir_tablegen(SPIRVOps.h.inc -gen-op-decls -op-shard-count=8)
+mlir_tablegen(SPIRVOps.cpp.inc -gen-op-defs -op-shard-count=8)
+mlir_tablegen(SPIRVOpsTypes.h.inc -gen-typedef-decls -typedefs-dialect=spirv)
+mlir_tablegen(SPIRVOpsTypes.cpp.inc -gen-typedef-defs -typedefs-dialect=spirv)
+mlir_tablegen(SPIRVOpsDialect.h.inc -gen-dialect-decls -dialect=spirv)
+mlir_tablegen(SPIRVOpsDialect.cpp.inc -gen-dialect-defs -dialect=spirv)
+add_mlir_dialect_tablegen_target(MLIRSPIRVOpsIncGen)
 add_mlir_doc(SPIRVOps SPIRVOps Dialects/ -gen-op-doc -dialect=spirv)
 
 set(LLVM_TARGET_DEFINITIONS SPIRVBase.td)

--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVOps.h
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVOps.h
@@ -38,6 +38,7 @@ class OpBuilder;
 
 namespace spirv {
 class VerCapExtAttr;
+class SPIRVDialect;
 } // namespace spirv
 } // namespace mlir
 

--- a/mlir/lib/Dialect/SPIRV/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/SPIRV/IR/CMakeLists.txt
@@ -2,6 +2,19 @@ set(LLVM_TARGET_DEFINITIONS SPIRVCanonicalization.td)
 mlir_tablegen(SPIRVCanonicalization.inc -gen-rewriters)
 add_public_tablegen_target(MLIRSPIRVCanonicalizationIncGen)
 
+set(LLVM_OPTIONAL_SOURCES
+  SPIRVOpDefinitions.cpp
+  )
+
+set(LLVM_TARGET_DEFINITIONS SPIRVOpDefinitions.cpp)
+foreach(index RANGE 7)
+  set(SPIRV_SHARDED_SRC SPIRVOpDefinitions.${index}.cpp)
+  list(APPEND SPIRV_SHARDED_SRCS ${SPIRV_SHARDED_SRC})
+  tablegen(MLIR_SRC_SHARDER ${SPIRV_SHARDED_SRC}
+    -op-shard-index=${index})
+endforeach()
+add_public_tablegen_target(MLIRSPIRVOpsShardGen)
+
 add_mlir_dialect_library(MLIRSPIRVDialect
   ArmGraphOps.cpp
   AtomicOps.cpp
@@ -25,6 +38,7 @@ add_mlir_dialect_library(MLIRSPIRVDialect
   SPIRVTosaOps.cpp
   SPIRVTypes.cpp
   TargetAndABI.cpp
+  ${SPIRV_SHARDED_SRCS}
 
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/SPIRV
@@ -39,6 +53,7 @@ add_mlir_dialect_library(MLIRSPIRVDialect
   MLIRSPIRVEnumsIncGen
   MLIRSPIRVImageInterfacesIncGen
   MLIRSPIRVOpsIncGen
+  MLIRSPIRVOpsShardGen
 
   LINK_LIBS PUBLIC
   MLIRControlFlowInterfaces

--- a/mlir/lib/Dialect/SPIRV/IR/SPIRVDialect.cpp
+++ b/mlir/lib/Dialect/SPIRV/IR/SPIRVDialect.cpp
@@ -127,11 +127,7 @@ void SPIRVDialect::initialize() {
   registerAttributes();
   registerTypes();
 
-  // Add SPIR-V ops.
-  addOperations<
-#define GET_OP_LIST
-#include "mlir/Dialect/SPIRV/IR/SPIRVOps.cpp.inc"
-      >();
+  registerSPIRVDialectOperations(this);
 
   addInterfaces<SPIRVInlinerInterface>();
 

--- a/mlir/lib/Dialect/SPIRV/IR/SPIRVOpDefinition.cpp
+++ b/mlir/lib/Dialect/SPIRV/IR/SPIRVOpDefinition.cpp
@@ -6,14 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// Defines the TableGen'erated SPIR-V op implementation in the SPIR-V dialect.
-// These are placed in a separate file to reduce the total amount of code in
-// SPIRVOps.cpp and make that file faster to recompile.
+// Defines helpers referenced by the TableGen-generated SPIR-V operation
+// implementations.
 //
 //===----------------------------------------------------------------------===//
 
 #include "mlir/Dialect/SPIRV/IR/SPIRVOps.h"
 
+#include "SPIRVOpDefinition.h"
 #include "SPIRVParsingUtils.h"
 
 #include "mlir/IR/TypeUtilities.h"
@@ -21,7 +21,7 @@
 namespace mlir::spirv {
 /// Returns true if the given op is a function-like op or nested in a
 /// function-like op without a module-like op in the middle.
-static bool isNestedInFunctionOpInterface(Operation *op) {
+bool isNestedInFunctionOpInterface(Operation *op) {
   if (!op)
     return false;
   if (op->hasTrait<OpTrait::SymbolTable>())
@@ -33,7 +33,7 @@ static bool isNestedInFunctionOpInterface(Operation *op) {
 
 /// Returns true if the given op is a GraphARM op or nested in a
 /// GraphARM op without a module-like op in the middle.
-static bool isNestedInGraphARMOpInterface(Operation *op) {
+bool isNestedInGraphARMOpInterface(Operation *op) {
   if (!op)
     return false;
   if (op->hasTrait<OpTrait::SymbolTable>())
@@ -45,13 +45,13 @@ static bool isNestedInGraphARMOpInterface(Operation *op) {
 
 /// Returns true if the given op is an module-like op that maintains a symbol
 /// table.
-static bool isDirectInModuleLikeOp(Operation *op) {
+bool isDirectInModuleLikeOp(Operation *op) {
   return op && op->hasTrait<OpTrait::SymbolTable>();
 }
 
 /// Returns a boolean scalar or vector type matching the shape of the given
 /// type. Scalar inputs yield i1, vector inputs yield vector<Nxi1>.
-static Type getMatchingBoolType(Type operandType) {
+Type getMatchingBoolType(Type operandType) {
   Builder builder(operandType.getContext());
   Type resultType = builder.getIntegerType(1);
   if (auto vecType = dyn_cast<VectorType>(operandType))
@@ -59,8 +59,8 @@ static Type getMatchingBoolType(Type operandType) {
   return resultType;
 }
 
-static ParseResult parseImageOperands(OpAsmParser &parser,
-                                      spirv::ImageOperandsAttr &attr) {
+ParseResult parseImageOperands(OpAsmParser &parser,
+                               spirv::ImageOperandsAttr &attr) {
   // Expect image operands
   if (parser.parseOptionalLSquare())
     return success();
@@ -74,8 +74,8 @@ static ParseResult parseImageOperands(OpAsmParser &parser,
   return parser.parseRSquare();
 }
 
-static void printImageOperands(OpAsmPrinter &printer, Operation *imageOp,
-                               spirv::ImageOperandsAttr attr) {
+void printImageOperands(OpAsmPrinter &printer, Operation *imageOp,
+                        spirv::ImageOperandsAttr attr) {
   if (attr) {
     auto strImageOperands = stringifyImageOperands(attr.getValue());
     printer << "[\"" << strImageOperands << "\"]";
@@ -85,7 +85,7 @@ static void printImageOperands(OpAsmPrinter &printer, Operation *imageOp,
 /// Adapted from the cf.switch implementation.
 /// <cases> ::= `default` `:` bb-id (`(` ssa-use-and-type-list `)`)?
 ///             ( `,` integer `:` bb-id (`(` ssa-use-and-type-list `)`)? )*
-static ParseResult parseSwitchOpCases(
+ParseResult parseSwitchOpCases(
     OpAsmParser &parser, Type &selectorType, Block *&defaultTarget,
     SmallVectorImpl<OpAsmParser::UnresolvedOperand> &defaultOperands,
     SmallVectorImpl<Type> &defaultOperandTypes, DenseIntElementsAttr &literals,
@@ -136,12 +136,12 @@ static ParseResult parseSwitchOpCases(
   return success();
 }
 
-static void
-printSwitchOpCases(OpAsmPrinter &p, SwitchOp op, Type selectorType,
-                   Block *defaultTarget, OperandRange defaultOperands,
-                   TypeRange defaultOperandTypes, DenseIntElementsAttr literals,
-                   SuccessorRange targets, OperandRangeRange targetOperands,
-                   const TypeRangeRange &targetOperandTypes) {
+void printSwitchOpCases(OpAsmPrinter &p, SwitchOp op, Type selectorType,
+                        Block *defaultTarget, OperandRange defaultOperands,
+                        TypeRange defaultOperandTypes,
+                        DenseIntElementsAttr literals, SuccessorRange targets,
+                        OperandRangeRange targetOperands,
+                        const TypeRangeRange &targetOperandTypes) {
   p << "  default: ";
   p.printSuccessorAndUseList(defaultTarget, defaultOperands);
 
@@ -160,7 +160,3 @@ printSwitchOpCases(OpAsmPrinter &p, SwitchOp op, Type selectorType,
 }
 
 } // namespace mlir::spirv
-
-// TablenGen'erated operation definitions.
-#define GET_OP_CLASSES
-#include "mlir/Dialect/SPIRV/IR/SPIRVOps.cpp.inc"

--- a/mlir/lib/Dialect/SPIRV/IR/SPIRVOpDefinition.h
+++ b/mlir/lib/Dialect/SPIRV/IR/SPIRVOpDefinition.h
@@ -1,0 +1,43 @@
+//===- SPIRVOpDefinition.h - SPIR-V op implementation helpers --*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_LIB_DIALECT_SPIRV_IR_SPIRVOPDEFINITION_H
+#define MLIR_LIB_DIALECT_SPIRV_IR_SPIRVOPDEFINITION_H
+
+#include "mlir/Dialect/SPIRV/IR/SPIRVOps.h"
+
+namespace mlir::spirv {
+
+bool isNestedInFunctionOpInterface(Operation *op);
+bool isNestedInGraphARMOpInterface(Operation *op);
+bool isDirectInModuleLikeOp(Operation *op);
+Type getMatchingBoolType(Type operandType);
+
+ParseResult parseImageOperands(OpAsmParser &parser,
+                               spirv::ImageOperandsAttr &attr);
+void printImageOperands(OpAsmPrinter &printer, Operation *imageOp,
+                        spirv::ImageOperandsAttr attr);
+
+ParseResult parseSwitchOpCases(
+    OpAsmParser &parser, Type &selectorType, Block *&defaultTarget,
+    SmallVectorImpl<OpAsmParser::UnresolvedOperand> &defaultOperands,
+    SmallVectorImpl<Type> &defaultOperandTypes, DenseIntElementsAttr &literals,
+    SmallVectorImpl<Block *> &targets,
+    SmallVectorImpl<SmallVector<OpAsmParser::UnresolvedOperand>>
+        &targetOperands,
+    SmallVectorImpl<SmallVector<Type>> &targetOperandTypes);
+void printSwitchOpCases(OpAsmPrinter &p, SwitchOp op, Type selectorType,
+                        Block *defaultTarget, OperandRange defaultOperands,
+                        TypeRange defaultOperandTypes,
+                        DenseIntElementsAttr literals, SuccessorRange targets,
+                        OperandRangeRange targetOperands,
+                        const TypeRangeRange &targetOperandTypes);
+
+} // namespace mlir::spirv
+
+#endif // MLIR_LIB_DIALECT_SPIRV_IR_SPIRVOPDEFINITION_H

--- a/mlir/lib/Dialect/SPIRV/IR/SPIRVOpDefinitions.cpp
+++ b/mlir/lib/Dialect/SPIRV/IR/SPIRVOpDefinitions.cpp
@@ -1,0 +1,17 @@
+//===- SPIRVOpDefinitions.cpp - Generated SPIR-V op definitions ----------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/SPIRV/IR/SPIRVDialect.h"
+#include "mlir/Dialect/SPIRV/IR/SPIRVOps.h"
+
+#include "SPIRVOpDefinition.h"
+
+using namespace mlir;
+using namespace mlir::spirv;
+
+#include "mlir/Dialect/SPIRV/IR/SPIRVOps.cpp.inc"


### PR DESCRIPTION
Generate SPIR-V operation definitions in eight shards and use the generated registration hook. Keep parser, printer, and verification helpers in the existing implementation TU and expose them through a private header.

Assisted-by: Codex