### PR TITLE
[MLIR][LLVM] Shard generated operation definitions (NFC)

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/CMakeLists.txt
+++ b/mlir/include/mlir/Dialect/LLVMIR/CMakeLists.txt
@@ -23,6 +23,11 @@ mlir_tablegen(LLVMIntrinsicOps.h.inc -gen-op-decls)
 mlir_tablegen(LLVMIntrinsicOps.cpp.inc -gen-op-defs)
 add_mlir_dialect_tablegen_target(MLIRLLVMIntrinsicOpsIncGen)
 
+set(LLVM_TARGET_DEFINITIONS LLVMAllOps.td)
+mlir_tablegen(LLVMAllOps.h.inc -gen-op-decls -op-shard-count=8)
+mlir_tablegen(LLVMAllOps.cpp.inc -gen-op-defs -op-shard-count=8)
+add_mlir_dialect_tablegen_target(MLIRLLVMAllOpsIncGen)
+
 add_mlir_doc(LLVMOps LLVMOps Dialects/ -gen-op-doc -dialect=llvm)
 add_mlir_doc(LLVMIntrinsicOps LLVMIntrinsicOps Dialects/ -gen-op-doc -dialect=llvm)
 

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMAllOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMAllOps.td
@@ -1,0 +1,18 @@
+//===-- LLVMAllOps.td - Combined LLVM dialect operations ---*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVMIR_ALL_OPS
+#define LLVMIR_ALL_OPS
+
+// Keep core and intrinsic operations in one sharded definition set so they
+// share a single dialect registration hook. Their original files are still
+// generated separately for existing declarations and consumers.
+include "mlir/Dialect/LLVMIR/LLVMOps.td"
+include "mlir/Dialect/LLVMIR/LLVMIntrinsicOps.td"
+
+#endif // LLVMIR_ALL_OPS

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMIntrinsicOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMIntrinsicOps.td
@@ -587,7 +587,7 @@ class LLVM_ConstrainedFCmpIntrBase<string mnem>
         /*traits=*/[Pure, SameTypeOperands,
           TypesMatchWith<"result type has i1 element type and same shape as "
                          "operands", "arg_0", "res",
-                         "::getI1SameShape($_self)">,
+                         "::mlir::LLVM::getI1SameShape($_self)">,
           DeclareOpInterfaceMethods<FPExceptionBehaviorOpInterface>],
         /*requiresFastmath=*/1> {
   let arguments = (ins FCmpPredicate:$predicate,

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
@@ -177,7 +177,7 @@ def LLVM_AShrOp : LLVM_IntArithmeticOpWithExactFlag<"ashr", "AShr", [Pure]>;
 class LLVM_ArithmeticCmpOp<string mnemonic, list<Trait> traits = []> :
     LLVM_Op<mnemonic, traits # [SameTypeOperands, TypesMatchWith<
     "result type has i1 element type and same shape as operands",
-    "lhs", "res", "::getI1SameShape($_self)">]> {
+    "lhs", "res", "::mlir::LLVM::getI1SameShape($_self)">]> {
   let results = (outs LLVM_ScalarOrVectorOf<I1>:$res);
 }
 

--- a/mlir/lib/Dialect/LLVMIR/CMakeLists.txt
+++ b/mlir/lib/Dialect/LLVMIR/CMakeLists.txt
@@ -1,5 +1,18 @@
 add_subdirectory(Transforms)
 
+set(LLVM_OPTIONAL_SOURCES
+  IR/LLVMOps.cpp
+  )
+
+set(LLVM_TARGET_DEFINITIONS IR/LLVMOps.cpp)
+foreach(index RANGE 7)
+  set(LLVM_SHARDED_SRC LLVMOps.${index}.cpp)
+  list(APPEND LLVM_SHARDED_SRCS ${LLVM_SHARDED_SRC})
+  tablegen(MLIR_SRC_SHARDER ${LLVM_SHARDED_SRC}
+    -op-shard-index=${index})
+endforeach()
+add_public_tablegen_target(MLIRLLVMOpsShardGen)
+
 add_mlir_dialect_library(MLIRLLVMDialect
   IR/FunctionCallUtils.cpp
   IR/LLVMAttrs.cpp
@@ -9,6 +22,7 @@ add_mlir_dialect_library(MLIRLLVMDialect
   IR/LLVMTypes.cpp
   IR/LLVMTypeSyntax.cpp
   IR/LLVMDialectBytecode.cpp
+  ${LLVM_SHARDED_SRCS}
 
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/LLVMIR
@@ -17,7 +31,9 @@ add_mlir_dialect_library(MLIRLLVMDialect
   MLIRLLVMDialectBytecodeIncGen
   MLIRLLVMInterfacesIncGen
   MLIRLLVMIntrinsicOpsIncGen
+  MLIRLLVMAllOpsIncGen
   MLIRLLVMOpsIncGen
+  MLIRLLVMOpsShardGen
   MLIRLLVMTranslationDialectInterfaceIncGen
   MLIRLLVMTypesIncGen
   MLIROpenMPOpsIncGen

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
@@ -12,6 +12,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+
+#include "IR/LLVMOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMAttrs.h"
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"
 #include "mlir/IR/Attributes.h"
@@ -88,7 +90,7 @@ static LogicalResult verifySymbolAttrUse(FlatSymbolRefAttr symbol,
 
 /// Returns a boolean type that has the same shape as `type`. It supports both
 /// fixed size vectors as well as scalable vectors.
-static Type getI1SameShape(Type type) {
+Type mlir::LLVM::getI1SameShape(Type type) {
   Type i1Type = IntegerType::get(type.getContext(), 1);
   if (LLVM::isCompatibleVectorType(type))
     return LLVM::getVectorType(i1Type, LLVM::getVectorNumElements(type));
@@ -142,11 +144,12 @@ static RetTy parseOptionalLLVMKeyword(OpAsmParser &parser,
   return static_cast<RetTy>(index);
 }
 
-static void printLLVMLinkage(OpAsmPrinter &p, Operation *, LinkageAttr val) {
+void mlir::LLVM::printLLVMLinkage(OpAsmPrinter &p, Operation *,
+                                  LinkageAttr val) {
   p << stringifyLinkage(val.getLinkage());
 }
 
-static ParseResult parseLLVMLinkage(OpAsmParser &p, LinkageAttr &val) {
+ParseResult mlir::LLVM::parseLLVMLinkage(OpAsmParser &p, LinkageAttr &val) {
   val = LinkageAttr::get(
       p.getContext(),
       parseOptionalLLVMKeyword<LLVM::Linkage>(p, LLVM::Linkage::External));
@@ -203,10 +206,10 @@ static void printOneOpBundle(OpAsmPrinter &p, OperandRange operands,
   p << ")";
 }
 
-static void printOpBundles(OpAsmPrinter &p, Operation *op,
-                           OperandRangeRange opBundleOperands,
-                           TypeRangeRange opBundleOperandTypes,
-                           std::optional<ArrayAttr> opBundleTags) {
+void mlir::LLVM::printOpBundles(OpAsmPrinter &p, Operation *op,
+                                OperandRangeRange opBundleOperands,
+                                TypeRangeRange opBundleOperandTypes,
+                                std::optional<ArrayAttr> opBundleTags) {
   if (opBundleOperands.empty())
     return;
   assert(opBundleTags && "expect operand bundle tags");
@@ -251,7 +254,7 @@ static ParseResult parseOneOpBundle(
   return success();
 }
 
-static std::optional<ParseResult> parseOpBundles(
+std::optional<ParseResult> mlir::LLVM::parseOpBundles(
     OpAsmParser &p,
     SmallVector<SmallVector<OpAsmParser::UnresolvedOperand>> &opBundleOperands,
     SmallVector<SmallVector<Type>> &opBundleOperandTypes,
@@ -554,7 +557,7 @@ void SwitchOp::build(OpBuilder &builder, OperationState &result, Value value,
 
 /// <cases> ::= `[` (case (`,` case )* )? `]`
 /// <case>  ::= integer `:` bb-id (`(` ssa-use-and-type-list `)`)?
-static ParseResult parseSwitchOpCases(
+ParseResult mlir::LLVM::parseSwitchOpCases(
     OpAsmParser &parser, Type flagType, DenseIntElementsAttr &caseValues,
     SmallVectorImpl<Block *> &caseDestinations,
     SmallVectorImpl<SmallVector<OpAsmParser::UnresolvedOperand>> &caseOperands,
@@ -596,11 +599,11 @@ static ParseResult parseSwitchOpCases(
   return parser.parseRSquare();
 }
 
-static void printSwitchOpCases(OpAsmPrinter &p, SwitchOp op, Type flagType,
-                               DenseIntElementsAttr caseValues,
-                               SuccessorRange caseDestinations,
-                               OperandRangeRange caseOperands,
-                               const TypeRangeRange &caseOperandTypes) {
+void mlir::LLVM::printSwitchOpCases(OpAsmPrinter &p, SwitchOp op, Type flagType,
+                                    DenseIntElementsAttr caseValues,
+                                    SuccessorRange caseDestinations,
+                                    OperandRangeRange caseOperands,
+                                    const TypeRangeRange &caseOperandTypes) {
   p << '[';
   p.printNewline();
   if (!caseValues) {
@@ -735,10 +738,10 @@ void GEPOp::build(OpBuilder &builder, OperationState &result, Type resultType,
         SmallVector<GEPArg>(indices), noWrapFlags, attributes);
 }
 
-static ParseResult
-parseGEPIndices(OpAsmParser &parser,
-                SmallVectorImpl<OpAsmParser::UnresolvedOperand> &indices,
-                DenseI32ArrayAttr &rawConstantIndices) {
+ParseResult mlir::LLVM::parseGEPIndices(
+    OpAsmParser &parser,
+    SmallVectorImpl<OpAsmParser::UnresolvedOperand> &indices,
+    DenseI32ArrayAttr &rawConstantIndices) {
   SmallVector<int32_t> constantIndices;
 
   auto idxParser = [&]() -> ParseResult {
@@ -763,9 +766,9 @@ parseGEPIndices(OpAsmParser &parser,
   return success();
 }
 
-static void printGEPIndices(OpAsmPrinter &printer, LLVM::GEPOp gepOp,
-                            OperandRange indices,
-                            DenseI32ArrayAttr rawConstantIndices) {
+void mlir::LLVM::printGEPIndices(OpAsmPrinter &printer, LLVM::GEPOp gepOp,
+                                 OperandRange indices,
+                                 DenseI32ArrayAttr rawConstantIndices) {
   llvm::interleaveComma(
       GEPIndicesAdaptor<OperandRange>(rawConstantIndices, indices), printer,
       [&](PointerUnion<IntegerAttr, Value> cst) {
@@ -2215,10 +2218,9 @@ void InsertValueOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
 }
 
 /// Infer the value type from the container type and position.
-static ParseResult
-parseInsertExtractValueElementType(AsmParser &parser, Type &valueType,
-                                   Type containerType,
-                                   DenseI64ArrayAttr position) {
+ParseResult mlir::LLVM::parseInsertExtractValueElementType(
+    AsmParser &parser, Type &valueType, Type containerType,
+    DenseI64ArrayAttr position) {
   valueType = getInsertExtractValueElementType(
       [&](StringRef msg) {
         return parser.emitError(parser.getCurrentLocation(), msg);
@@ -2228,10 +2230,9 @@ parseInsertExtractValueElementType(AsmParser &parser, Type &valueType,
 }
 
 /// Nothing to print for an inferred type.
-static void printInsertExtractValueElementType(AsmPrinter &printer,
-                                               Operation *op, Type valueType,
-                                               Type containerType,
-                                               DenseI64ArrayAttr position) {}
+void mlir::LLVM::printInsertExtractValueElementType(
+    AsmPrinter &printer, Operation *op, Type valueType, Type containerType,
+    DenseI64ArrayAttr position) {}
 
 LogicalResult InsertValueOp::verify() {
   auto emitError = [this](StringRef msg) { return emitOpError(msg); };
@@ -3055,8 +3056,9 @@ void ShuffleVectorOp::build(OpBuilder &builder, OperationState &state, Value v1,
 }
 
 /// Build the result type of a shuffle vector operation.
-static ParseResult parseShuffleType(AsmParser &parser, Type v1Type,
-                                    Type &resType, DenseI32ArrayAttr mask) {
+ParseResult mlir::LLVM::parseShuffleType(AsmParser &parser, Type v1Type,
+                                         Type &resType,
+                                         DenseI32ArrayAttr mask) {
   if (!LLVM::isCompatibleVectorType(v1Type))
     return parser.emitError(parser.getCurrentLocation(),
                             "expected an LLVM compatible vector type");
@@ -3067,8 +3069,9 @@ static ParseResult parseShuffleType(AsmParser &parser, Type v1Type,
 }
 
 /// Nothing to do when the result type is inferred.
-static void printShuffleType(AsmPrinter &printer, Operation *op, Type v1Type,
-                             Type resType, DenseI32ArrayAttr mask) {}
+void mlir::LLVM::printShuffleType(AsmPrinter &printer, Operation *op,
+                                  Type v1Type, Type resType,
+                                  DenseI32ArrayAttr mask) {}
 
 LogicalResult ShuffleVectorOp::verify() {
   if (LLVM::isScalableVectorType(getV1().getType()) &&
@@ -3852,7 +3855,7 @@ LogicalResult AtomicRMWOp::verify() {
 //===----------------------------------------------------------------------===//
 
 /// Returns an LLVM struct type that contains a value type and a boolean type.
-static LLVMStructType getValAndBoolStructType(Type valType) {
+LLVMStructType mlir::LLVM::getValAndBoolStructType(Type valType) {
   auto boolType = IntegerType::get(valType.getContext(), 1);
   return LLVMStructType::getLiteral(valType.getContext(), {valType, boolType});
 }
@@ -4409,7 +4412,7 @@ void IndirectBrOp::build(OpBuilder &odsBuilder, OperationState &odsState,
   odsState.addSuccessors(successors);
 }
 
-static ParseResult parseIndirectBrOpSucessors(
+ParseResult mlir::LLVM::parseIndirectBrOpSucessors(
     OpAsmParser &parser, Type &flagType,
     SmallVectorImpl<Block *> &succOperandBlocks,
     SmallVectorImpl<SmallVector<OpAsmParser::UnresolvedOperand>> &succOperands,
@@ -4441,10 +4444,9 @@ static ParseResult parseIndirectBrOpSucessors(
   return success();
 }
 
-static void
-printIndirectBrOpSucessors(OpAsmPrinter &p, IndirectBrOp op, Type flagType,
-                           SuccessorRange succs, OperandRangeRange succOperands,
-                           const TypeRangeRange &succOperandsTypes) {
+void mlir::LLVM::printIndirectBrOpSucessors(
+    OpAsmPrinter &p, IndirectBrOp op, Type flagType, SuccessorRange succs,
+    OperandRangeRange succOperands, const TypeRangeRange &succOperandsTypes) {
   p << "[";
   llvm::interleave(
       llvm::zip(succs, succOperands),
@@ -4624,27 +4626,13 @@ void LLVMDialect::initialize() {
   // clang-format on
   registerTypes();
 
-  addOperations<
-#define GET_OP_LIST
-#include "mlir/Dialect/LLVMIR/LLVMOps.cpp.inc"
-
-      ,
-#define GET_OP_LIST
-#include "mlir/Dialect/LLVMIR/LLVMIntrinsicOps.cpp.inc"
-
-      >();
+  registerLLVMDialectOperations(this);
 
   // Support unknown operations because not all LLVM operations are registered.
   allowUnknownOperations();
   declarePromisedInterface<DialectInlinerInterface, LLVMDialect>();
   detail::addBytecodeInterface(this);
 }
-
-#define GET_OP_CLASSES
-#include "mlir/Dialect/LLVMIR/LLVMOps.cpp.inc"
-
-#define GET_OP_CLASSES
-#include "mlir/Dialect/LLVMIR/LLVMIntrinsicOps.cpp.inc"
 
 LogicalResult LLVMDialect::verifyDataLayoutString(
     StringRef descr, llvm::function_ref<void(const Twine &)> reportError) {

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMOps.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMOps.cpp
@@ -1,0 +1,17 @@
+//===- LLVMOps.cpp - LLVM dialect operation definitions ------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+
+#include "IR/LLVMOps.h"
+#include "mlir/IR/DialectImplementation.h"
+
+using namespace mlir;
+using namespace mlir::LLVM;
+
+#include "mlir/Dialect/LLVMIR/LLVMAllOps.cpp.inc"

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMOps.h
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMOps.h
@@ -1,0 +1,91 @@
+//===- LLVMOps.h - LLVM operation implementation helpers -------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_LIB_DIALECT_LLVMIR_IR_LLVMOPS_H
+#define MLIR_LIB_DIALECT_LLVMIR_IR_LLVMOPS_H
+
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+
+#include <optional>
+
+namespace mlir::LLVM {
+
+mlir::Type getI1SameShape(mlir::Type type);
+mlir::LLVM::LLVMStructType getValAndBoolStructType(mlir::Type valType);
+
+void printLLVMLinkage(mlir::OpAsmPrinter &p, mlir::Operation *,
+                      mlir::LLVM::LinkageAttr val);
+mlir::ParseResult parseLLVMLinkage(mlir::OpAsmParser &p,
+                                   mlir::LLVM::LinkageAttr &val);
+
+void printOpBundles(mlir::OpAsmPrinter &p, mlir::Operation *op,
+                    mlir::OperandRangeRange opBundleOperands,
+                    mlir::TypeRangeRange opBundleOperandTypes,
+                    std::optional<mlir::ArrayAttr> opBundleTags);
+std::optional<mlir::ParseResult> parseOpBundles(
+    mlir::OpAsmParser &p,
+    mlir::SmallVector<mlir::SmallVector<mlir::OpAsmParser::UnresolvedOperand>>
+        &opBundleOperands,
+    mlir::SmallVector<mlir::SmallVector<mlir::Type>> &opBundleOperandTypes,
+    mlir::ArrayAttr &opBundleTags);
+
+mlir::ParseResult parseSwitchOpCases(
+    mlir::OpAsmParser &parser, mlir::Type flagType,
+    mlir::DenseIntElementsAttr &caseValues,
+    mlir::SmallVectorImpl<mlir::Block *> &caseDestinations,
+    mlir::SmallVectorImpl<
+        mlir::SmallVector<mlir::OpAsmParser::UnresolvedOperand>> &caseOperands,
+    mlir::SmallVectorImpl<mlir::SmallVector<mlir::Type>> &caseOperandTypes);
+void printSwitchOpCases(mlir::OpAsmPrinter &p, mlir::LLVM::SwitchOp op,
+                        mlir::Type flagType,
+                        mlir::DenseIntElementsAttr caseValues,
+                        mlir::SuccessorRange caseDestinations,
+                        mlir::OperandRangeRange caseOperands,
+                        const mlir::TypeRangeRange &caseOperandTypes);
+
+mlir::ParseResult parseGEPIndices(
+    mlir::OpAsmParser &parser,
+    mlir::SmallVectorImpl<mlir::OpAsmParser::UnresolvedOperand> &indices,
+    mlir::DenseI32ArrayAttr &rawConstantIndices);
+void printGEPIndices(mlir::OpAsmPrinter &printer, mlir::LLVM::GEPOp gepOp,
+                     mlir::OperandRange indices,
+                     mlir::DenseI32ArrayAttr rawConstantIndices);
+
+mlir::ParseResult parseInsertExtractValueElementType(
+    mlir::AsmParser &parser, mlir::Type &valueType, mlir::Type containerType,
+    mlir::DenseI64ArrayAttr position);
+void printInsertExtractValueElementType(mlir::AsmPrinter &printer,
+                                        mlir::Operation *op,
+                                        mlir::Type valueType,
+                                        mlir::Type containerType,
+                                        mlir::DenseI64ArrayAttr position);
+
+mlir::ParseResult parseShuffleType(mlir::AsmParser &parser, mlir::Type v1Type,
+                                   mlir::Type &resType,
+                                   mlir::DenseI32ArrayAttr mask);
+void printShuffleType(mlir::AsmPrinter &printer, mlir::Operation *op,
+                      mlir::Type v1Type, mlir::Type resType,
+                      mlir::DenseI32ArrayAttr mask);
+
+mlir::ParseResult parseIndirectBrOpSucessors(
+    mlir::OpAsmParser &parser, mlir::Type &flagType,
+    mlir::SmallVectorImpl<mlir::Block *> &succOperandBlocks,
+    mlir::SmallVectorImpl<
+        mlir::SmallVector<mlir::OpAsmParser::UnresolvedOperand>> &succOperands,
+    mlir::SmallVectorImpl<mlir::SmallVector<mlir::Type>> &succOperandsTypes);
+void printIndirectBrOpSucessors(mlir::OpAsmPrinter &p,
+                                mlir::LLVM::IndirectBrOp op,
+                                mlir::Type flagType, mlir::SuccessorRange succs,
+                                mlir::OperandRangeRange succOperands,
+                                const mlir::TypeRangeRange &succOperandsTypes);
+
+} // namespace mlir::LLVM
+
+#include "mlir/Dialect/LLVMIR/LLVMAllOps.h.inc"
+
+#endif // MLIR_LIB_DIALECT_LLVMIR_IR_LLVMOPS_H


### PR DESCRIPTION
LLVMDialect.cpp includes both the 55,078-line core operation definitions and the 95,769-line intrinsic operation definitions. Generate the combined operation set in eight shards, use the generated registration hook, and expose only the parser, printer, and type-inference helpers needed by generated code.

Assisted-by: Codex