### PR TITLE
[lldb] Fix -Wunused-template

### DIFF
--- a/lldb/unittests/Protocol/ProtocolMCPServerTest.cpp
+++ b/lldb/unittests/Protocol/ProtocolMCPServerTest.cpp
@@ -211,41 +211,7 @@ public:
     Response resp = promised_result.get_future().get();
     return toJSON(resp);
   }
-
-  template <typename Result>
-  Expected<json::Value>
-  Capture(llvm::unique_function<void(Reply<Result>)> &fn) {
-    std::promise<llvm::Expected<Result>> promised_result;
-    fn([&promised_result](llvm::Expected<Result> result) {
-      promised_result.set_value(std::move(result));
-    });
-    Run();
-    llvm::Expected<Result> result = promised_result.get_future().get();
-    if (!result)
-      return result.takeError();
-    return toJSON(*result);
-  }
-
-  template <typename Result, typename Params>
-  Expected<json::Value>
-  Capture(llvm::unique_function<void(const Params &, Reply<Result>)> &fn,
-          const Params &params) {
-    std::promise<llvm::Expected<Result>> promised_result;
-    fn(params, [&promised_result](llvm::Expected<Result> result) {
-      promised_result.set_value(std::move(result));
-    });
-    Run();
-    llvm::Expected<Result> result = promised_result.get_future().get();
-    if (!result)
-      return result.takeError();
-    return toJSON(*result);
-  }
 };
-
-template <typename T>
-inline testing::internal::EqMatcher<llvm::json::Value> HasJSON(T x) {
-  return testing::internal::EqMatcher<llvm::json::Value>(toJSON(x));
-}
 
 } // namespace
 

--- a/lldb/unittests/TestingSupport/TestUtilities.h
+++ b/lldb/unittests/TestingSupport/TestUtilities.h
@@ -65,7 +65,7 @@ private:
   std::string Buffer;
 };
 
-template <typename T> static llvm::Expected<T> roundtripJSON(const T &input) {
+template <typename T> llvm::Expected<T> roundtripJSON(const T &input) {
   std::string encoded;
   llvm::raw_string_ostream OS(encoded);
   OS << toJSON(input);


### PR DESCRIPTION
This warning was enabled by default in clang 23.1.0 (although reverted for 23.1.1). These fixes still make sense to perform though. Template definitions in headers should not use static, and others are completely unused.