### PR TITLE
[Clang] Add the vector element option to the past-the-end and null pointer constexpr notes

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -674,6 +674,8 @@ features cannot lower the translation-unit ABI level;
   declaration. (#GH217489)
 - Fixed an assertion failure when instantiating a block that captures
   `this` via a member access through a dependent base class.
+- Fixed an assertion failure when diagnosing a constant expression that
+  accesses a vector element through a past-the-end or null pointer. (#GH220256)
 - Fixed `DiagnoseUnguardedAvailability::TraverseIfStmt` dereferencing a nullptr
   on `if consteval {}`. (#GH220004)
 

--- a/clang/include/clang/Basic/DiagnosticASTKinds.td
+++ b/clang/include/clang/Basic/DiagnosticASTKinds.td
@@ -141,7 +141,8 @@ def note_constexpr_past_end : Note<
 def note_constexpr_past_end_subobject : Note<
   "cannot %select{access base class of|access derived class of|access field of|"
   "access array element of|ERROR|"
-  "access real component of|access imaginary component of}0 "
+  "access real component of|access imaginary component of|"
+  "access vector element of}0 "
   "pointer past the end of object">;
 def note_non_null_attribute_failed : Note<
   "null passed to a callee that requires a non-null argument">;
@@ -149,7 +150,7 @@ def note_constexpr_null_subobject : Note<
   "cannot %select{access base class of|access derived class of|access field of|"
   "access array element of|perform pointer arithmetic on|"
   "access real component of|"
-  "access imaginary component of}0 null pointer">;
+  "access imaginary component of|access vector element of}0 null pointer">;
 def note_constexpr_null_callee
     : Note<"%0 evaluates to a null function pointer">;
 def note_constexpr_function_param_value_unknown : Note<

--- a/clang/test/SemaCXX/constexpr-vectors-access-elements.cpp
+++ b/clang/test/SemaCXX/constexpr-vectors-access-elements.cpp
@@ -19,6 +19,7 @@ constexpr TwoIntsVecSize c[3] = {{0,1}, {2,3}, {4,5}};
 static_assert(c[0][0] == 0);
 static_assert(c[1][1] == 3);
 static_assert(c[2][3]); // expected-error {{not an integral constant expression}} expected-note {{cannot refer to element 3 of array of 2 elements}}
+static_assert(c[3][0]); // expected-error {{not an integral constant expression}} expected-note {{cannot access vector element of pointer past the end of object}}
 
 // make sure clang rejects taking address of a vector element
 static_assert(&a[0]); // expected-error {{address of vector element requested}}
@@ -35,6 +36,13 @@ static_assert(b.s0 == 1 && b.s1 == 2 && b.s2 == 3 && b.s3 == 4);
 static_assert(b.x == 1 && b.y == 2 && b.z == 3 && b.w == 4);
 static_assert(b.r == 1 && b.g == 2 && b.b == 3 && b.a == 4);
 static_assert(b[5]); // expected-error {{not an integral constant expression}} expected-note {{cannot refer to element 5 of array of 4 elements}}
+
+// GH220256: element access through a past-the-end or null pointer.
+constexpr FourIntsExtVec arr[2] = {{1,2,3,4}, {5,6,7,8}};
+static_assert(arr[2][0]); // expected-error {{not an integral constant expression}} expected-note {{cannot access vector element of pointer past the end of object}}
+constexpr FourIntsExtVec *np = nullptr;
+static_assert(np[0][0]); // expected-error {{not an integral constant expression}} expected-note {{cannot access vector element of null pointer}}
+static_assert(np->x); // expected-error {{not an integral constant expression}} expected-note {{cannot access vector element of null pointer}}
 
 // FIXME: support selecting multiple elements
 static_assert(b.lo.lo == 1); // expected-error {{not an integral constant expression}}


### PR DESCRIPTION
CheckSubobjectKind gained CSK_VectorElement in 77534291fcbd (constant
evaluation of vector element access), but the two notes whose %select is
indexed by that enum, note_constexpr_past_end_subobject and
note_constexpr_null_subobject, were left at seven options. Accessing a
vector element through a one-past-the-end or null pointer in a constant
expression therefore formatted select option 7 of 7 and tripped the
"Value for integer select modifier was larger than the number of options"
assertion in HandleSelectModifier:

```cpp
typedef __attribute__((ext_vector_type(4))) float float4;
float4 foo[2] = {{1, 2}};
static_assert(foo[2][0], "");
```

Add "access vector element of" as the eighth option of both notes, so the
above now reports "cannot access vector element of pointer past the end of
object", and the null pointer forms (np[0][0], np->x) report "cannot access
vector element of null pointer".

The experimental bytecode interpreter also crashes on this input, but
with a different assertion (Pointer.h: `Offset != PastEndMark`); that is a
separate bug and not addressed here.

Fixes #220256