### PR TITLE
[Support] [CMake] Only pass -Wno-c99-extensions to Clang, not GCC

### DIFF
--- a/llvm/lib/Support/CMakeLists.txt
+++ b/llvm/lib/Support/CMakeLists.txt
@@ -407,7 +407,7 @@ target_include_directories(LLVMSupport
   ${LLVM_SOURCE_DIR}/../libc
 )
 
-if(NOT MSVC)
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   target_compile_options(LLVMSupport PRIVATE "-Wno-c99-extensions") # _Complex warnings.
 endif()
 


### PR DESCRIPTION
GCC doesn't support this option, only Clang.

GCC doesn't warn if an unrecognized `-Wno-<foo>` option is passed, but if GCC produces other warnings, it also adds a note about `-Wno-<foo>` not being recognized, and that it may have been intended to silence the warning that was produced.