### PR TITLE
[CMake] Move -Wno-unused-but-set-parameter from MLIR up to LLVM

### DIFF
--- a/llvm/cmake/modules/HandleLLVMOptions.cmake
+++ b/llvm/cmake/modules/HandleLLVMOptions.cmake
@@ -920,6 +920,13 @@ if (LLVM_ENABLE_WARNINGS AND (LLVM_COMPILER_IS_GCC_COMPATIBLE OR CLANG_CL))
     if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 12.1)
       append("-Wno-dangling-pointer" CMAKE_CXX_FLAGS)
     endif()
+
+    # Silence a false positive GCC -Wunused-but-set-parameter warning in
+    # constexpr cases. See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85827
+    # for details
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "14.0")
+      append("-Wno-unused-but-set-parameter" CMAKE_CXX_FLAGS)
+    endif()
   endif()
 
   # The LLVM libraries have no stable C++ API, so -Wnoexcept-type is not useful.

--- a/mlir/CMakeLists.txt
+++ b/mlir/CMakeLists.txt
@@ -103,13 +103,6 @@ append_if(C_SUPPORTS_WERROR_MISMATCHED_TAGS "-Werror=mismatched-tags" CMAKE_C_FL
 append_if(C_SUPPORTS_WERROR_MISMATCHED_TAGS "-Werror=mismatched-tags" CMAKE_CXX_FLAGS)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-  # Silence a false positive GCC -Wunused-but-set-parameter warning in
-  # constexpr cases. See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85827
-  # for details
-  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "14.0")
-    check_cxx_compiler_flag("-Wno-unused-but-set-parameter" CXX_SUPPORTS_WNO_UNUSED_BUT_SET_PARAMETER)
-    append_if(CXX_SUPPORTS_WNO_UNUSED_BUT_SET_PARAMETER "-Wno-unused-but-set-parameter" CMAKE_CXX_FLAGS)
-  endif()
   # Silence a false positive GCC -Wdeprecated-copy warning in cases where
   # a copy operator is defined through "using" a base class copy operator.
   if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "12.0")


### PR DESCRIPTION
This warning is known to have false positives with GCC versions before 14.

Since 3aec6a40bb4e49f9ea181ac5c949b6c7c20a5465, this warning appears when building LLVMSupport as well - thus move the disabling of the warning up from MLIR to all of LLVM.

In HandleLLVMOptions, the common procedure is to not check for whether the options are supported or not, but to just hardcode the version ranges where the options are supported, per compiler.

This option (and -Wunused-but-set-parameter) is available in GCC since long before our minimum required version.