### PR TITLE
[mlir][AMDGPU] Move gather index vectors at final use (NFC)

### DIFF
--- a/mlir/lib/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.cpp
+++ b/mlir/lib/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.cpp
@@ -4315,7 +4315,7 @@ struct AMDGPULowerDescriptor : public ConvertOpToLLVMPattern<DescriptorOp> {
 
     SmallVector<Value> indicesI32Vector;
     if (elementType == i32) {
-      indicesI32Vector = indicesVector;
+      indicesI32Vector = std::move(indicesVector);
     } else {
       for (unsigned i = 0; i < targetSize; ++i) {
         Value index = indicesVector[i];
@@ -4329,7 +4329,7 @@ struct AMDGPULowerDescriptor : public ConvertOpToLLVMPattern<DescriptorOp> {
 
     SmallVector<Value> indicesToInsert;
     if (elementType == i32) {
-      indicesToInsert = indicesI32Vector;
+      indicesToInsert = std::move(indicesI32Vector);
     } else {
       unsigned size = indicesI32Vector.size() / 2;
       for (unsigned i = 0; i < size; ++i) {

--- a/mlir/test/Conversion/AMDGPUToROCDL/gfx1250.mlir
+++ b/mlir/test/Conversion/AMDGPUToROCDL/gfx1250.mlir
@@ -849,6 +849,25 @@ func.func @make_gather_dma_descriptor(%base: !amdgpu.tdm_gather_base<i32, i16>, 
   func.return %descriptor : !amdgpu.tdm_descriptor
 }
 
+// CHECK-LABEL: func @make_gather_dma_descriptor_i32
+// CHECK-SAME: (%[[BASE:.+]]: !amdgpu.tdm_gather_base<i32, i32>, %[[INDICES:.+]]: vector<5xi32>)
+func.func @make_gather_dma_descriptor_i32(%base: !amdgpu.tdm_gather_base<i32, i32>, %indices: vector<5xi32>) -> !amdgpu.tdm_descriptor {
+  // CHECK: %[[IDX0:.+]] = llvm.extractelement %[[INDICES]][{{.*}}] : vector<5xi32>
+  // CHECK: %[[IDX1:.+]] = llvm.extractelement %[[INDICES]][{{.*}}] : vector<5xi32>
+  // CHECK: %[[IDX2:.+]] = llvm.extractelement %[[INDICES]][{{.*}}] : vector<5xi32>
+  // CHECK: %[[IDX3:.+]] = llvm.extractelement %[[INDICES]][{{.*}}] : vector<5xi32>
+  // CHECK-NEXT: %[[DGROUP2_INIT:.+]] = llvm.mlir.poison : vector<4xi32>
+  // CHECK-NEXT: %[[DGROUP2_0:.+]] = llvm.insertelement %[[IDX0]], %[[DGROUP2_INIT]][{{.*}}]
+  // CHECK-NEXT: %[[DGROUP2_1:.+]] = llvm.insertelement %[[IDX1]], %[[DGROUP2_0]][{{.*}}]
+  // CHECK-NEXT: %[[DGROUP2_2:.+]] = llvm.insertelement %[[IDX2]], %[[DGROUP2_1]][{{.*}}]
+  // CHECK-NEXT: %[[DGROUP2:.+]] = llvm.insertelement %[[IDX3]], %[[DGROUP2_2]][{{.*}}]
+  // CHECK-NEXT: %[[IDX4:.+]] = llvm.extractelement %[[INDICES]][{{.*}}] : vector<5xi32>
+  // CHECK-NEXT: %[[DGROUP3_INIT:.+]] = llvm.mlir.poison : vector<4xi32>
+  // CHECK-NEXT: %[[DGROUP3:.+]] = llvm.insertelement %[[IDX4]], %[[DGROUP3_INIT]][{{.*}}]
+  %descriptor = amdgpu.make_gather_dma_descriptor %base[%indices] globalSize [128, 64] globalStride [64, 1] sharedSize [128, 64] : !amdgpu.tdm_gather_base<i32, i32>, vector<5xi32> -> !amdgpu.tdm_descriptor
+  func.return %descriptor : !amdgpu.tdm_descriptor
+}
+
 /// LDS barriers
 
 // CHECK-LABEL: func @ds_barrier_init


### PR DESCRIPTION
The gather lowering copies two temporary vectors into the next construction stage and never reads the source vectors again. Move their storage instead.

Found by Coverity.

Assisted-by: Codex