### PR TITLE
[MLIR][math] Remove dead IPowI fold return (NFC)

### DIFF
--- a/mlir/lib/Dialect/Math/IR/MathOps.cpp
+++ b/mlir/lib/Dialect/Math/IR/MathOps.cpp
@@ -456,8 +456,6 @@ OpFoldResult math::IPowIOp::fold(FoldAdaptor adaptor) {
           curBase *= curBase;
         }
       });
-
-  return Attribute();
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
The folder returns the constant-fold helper result directly, remove the unreachable fallback after the helper call.

Found by Coverity.

Assisted-by: Codex