### PR TITLE
[lld][ELF] Remove --fortran-common

### DIFF
--- a/lld/ELF/Config.h
+++ b/lld/ELF/Config.h
@@ -364,7 +364,6 @@ struct Config {
   bool fixCortexA53Errata843419;
   bool fixCortexA8;
   bool formatBinary = false;
-  bool fortranCommon;
   bool gcSections;
   bool gdbIndex;
   bool gnuHash = false;

--- a/lld/ELF/Driver.cpp
+++ b/lld/ELF/Driver.cpp
@@ -1460,8 +1460,6 @@ static void readConfigs(Ctx &ctx, opt::InputArgList &args) {
   ctx.arg.cmseOutputLib = args.getLastArgValue(OPT_out_implib);
   ctx.arg.fixCortexA8 =
       args.hasArg(OPT_fix_cortex_a8) && !args.hasArg(OPT_relocatable);
-  ctx.arg.fortranCommon =
-      args.hasFlag(OPT_fortran_common, OPT_no_fortran_common, false);
   ctx.arg.gcSections = args.hasFlag(OPT_gc_sections, OPT_no_gc_sections, false);
   ctx.arg.gnuUnique = args.hasFlag(OPT_gnu_unique, OPT_no_gnu_unique, true);
   ctx.arg.gdbIndex = args.hasFlag(OPT_gdb_index, OPT_no_gdb_index, false);

--- a/lld/ELF/Options.td
+++ b/lld/ELF/Options.td
@@ -83,10 +83,6 @@ defm optimize_bb_jumps: BB<"optimize-bb-jumps",
     "Remove direct jumps at the end to the next basic block",
     "Do not remove any direct jumps at the end to the next basic block (default)">;
 
-defm fortran_common : BB<"fortran-common",
-    "Search archive members for definitions to override COMMON symbols (default)",
-    "Do not search archive members for definitions to override COMMON symbols">;
-
 defm split_stack_adjust_size
     : Eq<"split-stack-adjust-size",
          "Specify adjustment to stack size when a split-stack function calls a "

--- a/lld/ELF/Symbols.cpp
+++ b/lld/ELF/Symbols.cpp
@@ -659,13 +659,6 @@ void Symbol::resolve(Ctx &ctx, const LazySymbol &other) {
     // See the comment in resolve(Ctx &, const Undefined &).
     if (isDefined()) {
       ctx.backwardReferences.erase(this);
-    } else if (isCommon() && ctx.arg.fortranCommon &&
-               other.file->shouldExtractForCommon(getName())) {
-      // For common objects, we want to look for global or weak definitions that
-      // should be extracted as the canonical definition instead.
-      ctx.backwardReferences.erase(this);
-      other.overwrite(*this);
-      other.extract(ctx);
     }
     return;
   }

--- a/lld/docs/ld.lld.1
+++ b/lld/docs/ld.lld.1
@@ -378,8 +378,6 @@ Do not demangle symbol names.
 Inhibit output of an
 .Li .interp
 section.
-.It Fl -no-fortran-common
-Do not search archive members for definitions to override COMMON symbols.
 .It Fl -no-gc-sections
 Disable garbage collection of unused sections.
 .It Fl -no-gnu-unique

--- a/lld/test/ELF/common-archive-lookup.s
+++ b/lld/test/ELF/common-archive-lookup.s
@@ -25,12 +25,6 @@
 ## Bitcode archive.
 # RUN: llvm-ar crs 4.a 1.bc 2.bc
 
-# RUN: ld.lld -o 1 main.o 1.a --fortran-common
-# RUN: llvm-objdump -D -j .data 1 | FileCheck --check-prefix=TEST1 %s
-
-# RUN: ld.lld -o 2 main.o --start-lib 1.o strong_data_only.o --end-lib --fortran-common
-# RUN: llvm-objdump -D -j .data 2 | FileCheck --check-prefix=TEST1 %s
-
 # RUN: ld.lld -o 3 main.o 2.a
 # RUN: llvm-objdump -t 3 | FileCheck --check-prefix=BSS %s
 
@@ -45,35 +39,24 @@
 # RUN: ld.lld -o 7 main.o 2.o --start-lib 1.o strong_data_only.o --end-lib
 # RUN: llvm-objdump -D -j .data 7 | FileCheck --check-prefix=TEST2 %s
 
-# RUN: not ld.lld -o 8 main.o 1.a strong_data_only.o --fortran-common 2>&1 | \
-# RUN:   FileCheck --check-prefix=ERR %s
+# RUN: ld.lld -o 8 main.o 1.a strong_data_only.o
+# RUN: llvm-objdump -D -j .data 8 | FileCheck --check-prefix=TEST1 %s
 
-# RUN: not ld.lld -o 9 main.o --start-lib 1.o 2.o --end-lib  strong_data_only.o --fortran-common 2>&1 | \
-# RUN:   FileCheck --check-prefix=ERR %s
+# RUN: ld.lld -o 9 main.o --start-lib 1.o 2.o --end-lib strong_data_only.o
+# RUN: llvm-objdump -D -j .data 9 | FileCheck --check-prefix=TEST1 %s
 
-# ERR: ld.lld: error: duplicate symbol: block
-
-# RUN: ld.lld --no-fortran-common -o 10 main.o 1.a
-# RUN: llvm-readobj --syms 10 | FileCheck --check-prefix=NFC %s
 # RUN: ld.lld -o 10 main.o 1.a
 # RUN: llvm-readobj --syms 10 | FileCheck --check-prefix=NFC %s
 
-# RUN: ld.lld --no-fortran-common -o 11 main.o --start-lib 1.o strong_data_only.o --end-lib
+# RUN: ld.lld  -o 11 main.o --start-lib 1.o strong_data_only.o --end-lib
 # RUN: llvm-readobj --syms 11 | FileCheck --check-prefix=NFC %s
 
-# RUN: ld.lld -o out main.o 4.a --fortran-common --lto-emit-asm
-# RUN: FileCheck --check-prefix=ASM %s < out.lto.s
-
-# RUN: rm out.lto.s
-# RUN: ld.lld -o out main.o --start-lib 1.bc 2.bc --end-lib --fortran-common --lto-emit-asm
-# RUN: FileCheck --check-prefix=ASM %s < out.lto.s
+# RUN: ld.lld -o out main.o 4.a -y block | FileCheck --check-prefix=LTO_COMMON_A %s
+# RUN: ld.lld -o out main.o --start-lib 1.bc 2.bc --end-lib -y block | \
+# RUN:   FileCheck --check-prefix=LTO_COMMON %s
 
 ## COMMON overrides weak. Don't extract 3.bc which provides a weak definition.
 # RUN: ld.lld main.o --start-lib 1.bc 3.bc --end-lib -y block | FileCheck --check-prefix=LTO_WEAK %s
-
-## Old FORTRAN that mixes use of COMMON blocks and BLOCK DATA requires that we
-## search through archives for non-tentative definitions (from the BLOCK DATA)
-## to replace the tentative definitions (from the COMMON block(s)).
 
 ## Ensure we have used the initialized definition of 'block' instead of a
 ## common definition.
@@ -104,10 +87,13 @@
 # MAP:       28 8 3.a(2.o):(.data)
 # MAP-NEXT:  28 1 block
 
-# ASM:         .type   block,@object
-# ASM:       block:
-# ASM-NEXT:    .long 5
-# ASM:         .size   block, 20
+# LTO_COMMON_A:     4.a(1.bc): common definition of block
+# LTO_COMMON_A:     <internal>: reference to block
+# LTO_COMMON_A-NOT: {{.}}
+
+# LTO_COMMON:     1.bc: common definition of block
+# LTO_COMMON:     <internal>: reference to block
+# LTO_COMMON-NOT: {{.}}
 
 # LTO_WEAK:     1.bc: common definition of block
 # LTO_WEAK:     <internal>: reference to block

--- a/lld/test/ELF/warn-backrefs.s
+++ b/lld/test/ELF/warn-backrefs.s
@@ -77,8 +77,7 @@
 # RUN: llvm-ar rcs %tcomm.a %tcomm.o
 # RUN: llvm-ar rcs %tstrong.a %tstrong.o
 # RUN: ld.lld --warn-backrefs %tcomm.a %t1.o %t5.o 2>&1 -o /dev/null | FileCheck --check-prefix=COMM %s
-# RUN: ld.lld --fatal-warnings --fortran-common --warn-backrefs %tcomm.a %t1.o %t5.o %tstrong.a 2>&1 -o /dev/null
-# RUN: ld.lld --warn-backrefs --no-fortran-common %tcomm.a %t1.o %t5.o %tstrong.a 2>&1 -o /dev/null | FileCheck --check-prefix=COMM %s
+# RUN: ld.lld --warn-backrefs %tcomm.a %t1.o %t5.o %tstrong.a 2>&1 -o /dev/null | FileCheck --check-prefix=COMM %s
 
 # COMM: ld.lld: warning: backward reference detected: obj in {{.*}}5.o refers to {{.*}}comm.a
 


### PR DESCRIPTION
The option is removed as requested.
COMMON symbols now follow the ordinary extraction rule

Closes #205015 