### PR TITLE
[mlir][LLVM] Remove dead constant verifier return (NFC)

### DIFF
--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
@@ -3767,8 +3767,6 @@ LogicalResult LLVM::ConstantOp::verify() {
     return emitOpError()
            << "only supports integer, float, string or elements attributes";
   }
-
-  return success();
 }
 
 bool LLVM::ConstantOp::isBuildableWith(Attribute value, Type type) {


### PR DESCRIPTION
Every arm of the constant attribute-kind chain returns directly, leaving the final success return unreachable. Remove the dead statement.

Found by Coverity.

Assisted-by: Codex