### PR TITLE
[mlir][PDLL] Reject overflowing unregistered result indices

### DIFF
--- a/mlir/lib/Tools/PDLL/CodeGen/MLIRGen.cpp
+++ b/mlir/lib/Tools/PDLL/CodeGen/MLIRGen.cpp
@@ -22,6 +22,7 @@
 #include "llvm/ADT/ScopedHashTable.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/TypeSwitch.h"
+#include <cstdint>
 #include <optional>
 
 using namespace mlir;
@@ -448,8 +449,9 @@ Value CodeGen::genExprImpl(const ast::MemberAccessExpr *expr) {
     if (!odsOp) {
       assert(llvm::isDigit(name[0]) &&
              "unregistered op only allows numeric indexing");
-      unsigned resultIndex;
-      name.getAsInteger(/*Radix=*/10, resultIndex);
+      int32_t resultIndex = 0;
+      if (name.getAsInteger(/*Radix=*/10, resultIndex))
+        llvm_unreachable("result index should have been validated");
       IntegerAttr index = builder.getI32IntegerAttr(resultIndex);
       return pdl::ResultOp::create(builder, loc, genType(expr->getType()),
                                    parentExprs[0], index);

--- a/mlir/lib/Tools/PDLL/Parser/Parser.cpp
+++ b/mlir/lib/Tools/PDLL/Parser/Parser.cpp
@@ -30,6 +30,7 @@
 #include "llvm/Support/VirtualFileSystem.h"
 #include "llvm/TableGen/Error.h"
 #include "llvm/TableGen/Parser.h"
+#include <cstdint>
 #include <optional>
 #include <string>
 
@@ -2809,8 +2810,12 @@ FailureOr<ast::Type> Parser::validateMemberAccess(ast::Expr *parentExpr,
       if (it != results.end())
         return it->isVariadic() ? valueRangeTy : valueTy;
     } else if (llvm::isDigit(name[0])) {
-      // Allow unchecked numeric indexing of the results of unregistered
-      // operations. It returns a single value.
+      int32_t index;
+      if (name.getAsInteger(/*Radix=*/10, index))
+        return emitError(loc, "result index is too large");
+
+      // Allow numeric indexing of the results of unregistered operations. It
+      // returns a single value because the result signature is unknown.
       return valueTy;
     }
   } else if (auto tupleType = dyn_cast<ast::TupleType>(parentType)) {

--- a/mlir/test/mlir-pdll/Parser/expr-failure.pdll
+++ b/mlir/test/mlir-pdll/Parser/expr-failure.pdll
@@ -399,3 +399,11 @@ Pattern {
   // CHECK: expected `>` after type literal
   let foo = type<"";
 }
+
+// -----
+
+Pattern {
+  let op: Op<my_dialect.unregistered>;
+  // CHECK: result index is too large
+  let result = op.2147483648;
+}


### PR DESCRIPTION
Unregistered operation result access accepts numeric member names, but code generation emits a nonnegative I32 attribute. Reject values outside the signed 32-bit range before building the AST and use the matching type in codegen.

Found by Coverity.

Assisted-by: Codex