### PR TITLE
[MLIR][linalg] Handle invalid elementwise kind safely

### DIFF
--- a/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
+++ b/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
@@ -5237,17 +5237,27 @@ void ElementwiseOp::print(OpAsmPrinter &p) {
 void ElementwiseOp::regionBuilder(
     ImplicitLocOpBuilder &b, Block &block, ArrayRef<NamedAttribute> attrs,
     function_ref<InFlightDiagnostic()> emitError) {
-  ElementwiseKind elemwiseKind;
+  std::optional<ElementwiseKind> elemwiseKind;
   for (auto attr : attrs) {
     if (attr.getName() == b.getStringAttr("kind")) {
       auto kindAttr = dyn_cast<ElementwiseKindAttr>(attr.getValue());
-      assert(kindAttr && "op kind attribute incorrectly set");
+      if (!kindAttr) {
+        if (emitError)
+          emitError() << "'kind' must be an ElementwiseKindAttr";
+        return;
+      }
       elemwiseKind = kindAttr.getValue();
       break;
     }
   }
 
-  ArityGroupAndKind groupAndKind = getArityGroupAndKind(elemwiseKind);
+  if (!elemwiseKind) {
+    if (emitError)
+      emitError() << "missing required 'kind' attribute";
+    return;
+  }
+
+  ArityGroupAndKind groupAndKind = getArityGroupAndKind(*elemwiseKind);
   auto arityGroup = groupAndKind.arityGroup;
   auto kind = groupAndKind.kind;
   if (emitError && block.getNumArguments() !=

--- a/mlir/test/Dialect/Linalg/elementwise/roundtrip.mlir
+++ b/mlir/test/Dialect/Linalg/elementwise/roundtrip.mlir
@@ -1,4 +1,7 @@
 // RUN: mlir-opt %s -split-input-file | FileCheck %s
+// RUN: mlir-opt %s -split-input-file \
+// RUN:   -test-linalg-elementwise-fusion-patterns=test-invalid-elementwise-kind-builder \
+// RUN:   | FileCheck %s
 //
 // Note - the functions are named @{unary|binary}_{identity|transpose|broadcast|transpose_a|...}_{exp|mul|div|..}
 

--- a/mlir/test/lib/Dialect/Linalg/TestLinalgElementwiseFusion.cpp
+++ b/mlir/test/lib/Dialect/Linalg/TestLinalgElementwiseFusion.cpp
@@ -143,6 +143,11 @@ struct TestLinalgElementwiseFusion
       llvm::cl::desc("Test fusion of producer ops with multiple uses"),
       llvm::cl::init(false)};
 
+  Option<bool> testInvalidElementwiseKindBuilder{
+      *this, "test-invalid-elementwise-kind-builder",
+      llvm::cl::desc("Test building an elementwise op with an invalid kind"),
+      llvm::cl::init(false)};
+
   ListOption<int64_t> collapseDimensions{
       *this, "collapse-dimensions-control",
       llvm::cl::desc("Test controlling dimension collapse pattern")};
@@ -150,6 +155,19 @@ struct TestLinalgElementwiseFusion
   void runOnOperation() override {
     MLIRContext *context = &this->getContext();
     func::FuncOp funcOp = this->getOperation();
+
+    if (testInvalidElementwiseKindBuilder) {
+      OpBuilder builder = OpBuilder::atBlockBegin(&funcOp.front());
+      linalg::ElementwiseOp missingKindOp = linalg::ElementwiseOp::create(
+          builder, funcOp.getLoc(), ValueRange{}, ValueRange{});
+      missingKindOp.erase();
+
+      NamedAttribute kind = builder.getNamedAttr("kind", builder.getUnitAttr());
+      linalg::ElementwiseOp wrongKindOp = linalg::ElementwiseOp::create(
+          builder, funcOp.getLoc(), ValueRange{}, ValueRange{}, kind);
+      wrongKindOp.erase();
+      return;
+    }
 
     if (fuseGenericOps) {
       RewritePatternSet fusionPatterns(context);


### PR DESCRIPTION
The generic elementwise builder accepts an attribute list. Avoid passing an uninitialized kind to region construction if a caller omits the required kind, and reject attributes of the wrong type rather than relying on an assertion.

Found by Coverity.

Assisted-by: Codex