### PR TITLE
[lldb] Auto-load Python scripts from .framework bundles

### DIFF
--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
@@ -199,10 +199,9 @@ PlatformDarwin::PutFile(const lldb_private::FileSpec &source,
 }
 
 llvm::SmallDenseMap<FileSpec, LoadScriptFromSymFile>
-PlatformDarwin::LocateExecutableScriptingResourcesFromDSYM(
+PlatformDarwin::LocateScriptingResourcesInPythonDir(
     Stream &feedback_stream, FileSpec module_spec, const Target &target,
-    const FileSpec &symfile_spec) {
-
+    llvm::StringRef python_dir) {
   assert(target.GetDebugger().GetScriptInterpreter() &&
          "Trying to locate scripting resources but no ScriptInterpreter is "
          "available.");
@@ -217,14 +216,9 @@ PlatformDarwin::LocateExecutableScriptingResourcesFromDSYM(
 
     StreamString path_string;
     StreamString original_path_string;
-    // for OSX we are going to be in
-    // .dSYM/Contents/Resources/DWARF/<basename> let us go to
-    // .dSYM/Contents/Resources/Python/<basename>.py and see if the
-    // file exists
-    path_string.Format("{0}/../Python/{1}.py", symfile_spec.GetDirectory(),
+    path_string.Format("{0}/{1}.py", python_dir,
                        sanitized_name.GetSanitizedName());
-    original_path_string.Format("{0}/../Python/{1}.py",
-                                symfile_spec.GetDirectory(),
+    original_path_string.Format("{0}/{1}.py", python_dir,
                                 sanitized_name.GetOriginalName());
 
     FileSpec script_fspec(path_string.GetString());
@@ -232,8 +226,8 @@ PlatformDarwin::LocateExecutableScriptingResourcesFromDSYM(
     FileSpec orig_script_fspec(original_path_string.GetString());
     FileSystem::Instance().Resolve(orig_script_fspec);
 
-    WarnIfInvalidUnsanitizedScriptExists(feedback_stream, sanitized_name,
-                                         orig_script_fspec, script_fspec);
+    Platform::WarnIfInvalidUnsanitizedScriptExists(
+        feedback_stream, sanitized_name, orig_script_fspec, script_fspec);
 
     if (FileSystem::Instance().Exists(script_fspec)) {
       LoadScriptFromSymFile load_style =
@@ -253,6 +247,52 @@ PlatformDarwin::LocateExecutableScriptingResourcesFromDSYM(
   }
 
   return file_specs;
+}
+
+/// Returns the root of the innermost bundle containing \c path that can carry
+/// scripting resources, if any. Callers that care which kind of bundle it is
+/// can read the extension back off the returned FileSpec.
+static std::optional<FileSpec> GetBundleRoot(const FileSpec &path) {
+  static constexpr llvm::StringLiteral kBundleExtensions[] = {".dSYM",
+                                                              ".framework"};
+
+  const std::string path_string = path.GetPath();
+  if (llvm::none_of(kBundleExtensions, [&](llvm::StringRef extension) {
+        return llvm::StringRef(path_string).contains(extension);
+      }))
+    return std::nullopt;
+
+  FileSpec bundle = path;
+  while (bundle.RemoveLastPathComponent()) {
+    if (llvm::is_contained(kBundleExtensions, bundle.GetFileNameExtension()))
+      return bundle;
+  }
+
+  return std::nullopt;
+}
+
+llvm::SmallDenseMap<FileSpec, LoadScriptFromSymFile>
+PlatformDarwin::LocateExecutableScriptingResourcesFromDSYM(
+    Stream &feedback_stream, FileSpec module_spec, const Target &target,
+    const FileSpec &symfile_spec) {
+  // On macOS, the symbol file FileSpec will point to
+  // .dSYM/Contents/Resources/DWARF/<basename>, so look for the python resource
+  // next to it in .dSYM/Contents/Resources/Python/<basename>.py.
+  return LocateScriptingResourcesInPythonDir(
+      feedback_stream, std::move(module_spec), target,
+      llvm::formatv("{0}/../Python", symfile_spec.GetDirectory()).str());
+}
+
+llvm::SmallDenseMap<FileSpec, LoadScriptFromSymFile>
+PlatformDarwin::LocateExecutableScriptingResourcesFromFramework(
+    Stream &feedback_stream, FileSpec module_spec, const Target &target,
+    const FileSpec &framework_spec) {
+  // On macOS, "Resources" is a symlink into the currently selected version,
+  // which FileSystem::Resolve follows; on platforms with flat bundles it is a
+  // real directory. Either way the same relative path applies.
+  return LocateScriptingResourcesInPythonDir(
+      feedback_stream, std::move(module_spec), target,
+      llvm::formatv("{0}/Resources/Python", framework_spec.GetPath()).str());
 }
 
 llvm::SmallDenseMap<FileSpec, LoadScriptFromSymFile>
@@ -278,54 +318,61 @@ PlatformDarwin::LocateExecutableScriptingResourcesForPlatform(
   if (!module_spec)
     return empty;
 
-  SymbolFile *symfile = module.GetSymbolFile();
-  if (!symfile)
-    return empty;
+  // A dSYM's scripts take priority over the ones inside the bundle itself.
+  // The symbol file is only needed to find them, so it must not gate the
+  // framework lookup below.
+  if (SymbolFile *symfile = module.GetSymbolFile()) {
+    if (ObjectFile *objfile = symfile->GetObjectFile()) {
+      const FileSpec &symfile_spec = objfile->GetFileSpec();
+      if (symfile_spec &&
+          llvm::StringRef(symfile_spec.GetPath())
+              .contains_insensitive(".dSYM/Contents/Resources/DWARF") &&
+          FileSystem::Instance().Exists(symfile_spec)) {
+        llvm::SmallDenseMap<FileSpec, LoadScriptFromSymFile> file_specs =
+            LocateExecutableScriptingResourcesFromDSYM(
+                feedback_stream, module_spec, *target, symfile_spec);
+        if (!file_specs.empty())
+          return file_specs;
+      }
+    }
+  }
 
-  ObjectFile *objfile = symfile->GetObjectFile();
-  if (!objfile)
-    return empty;
-
-  const FileSpec &symfile_spec = objfile->GetFileSpec();
-  if (symfile_spec &&
-      llvm::StringRef(symfile_spec.GetPath())
-          .contains_insensitive(".dSYM/Contents/Resources/DWARF") &&
-      FileSystem::Instance().Exists(symfile_spec))
-    return LocateExecutableScriptingResourcesFromDSYM(
-        feedback_stream, module_spec, *target, symfile_spec);
+  // Scripts inside a framework are a distribution mechanism of their own: they
+  // require neither debug info nor a symbol file, which a shipping framework
+  // generally lacks.
+  if (std::optional<FileSpec> bundle_spec = GetBundleRoot(module_spec);
+      bundle_spec && bundle_spec->GetFileNameExtension() == ".framework")
+    return LocateExecutableScriptingResourcesFromFramework(
+        feedback_stream, module_spec, *target, *bundle_spec);
 
   return empty;
 }
 
 bool PlatformDarwin::IsSymbolFileTrusted(Module &module) {
 #if defined(__APPLE__)
-  SymbolFile *symfile = module.GetSymbolFile();
-  if (!symfile)
-    return false;
+  auto is_trusted_bundle = [](const FileSpec &path) {
+    std::optional<FileSpec> bundle_spec = GetBundleRoot(path);
+    if (!bundle_spec)
+      return false;
 
-  ObjectFile *objfile = symfile->GetObjectFile();
-  if (!objfile)
-    return false;
+    if (!HostInfoMacOSX::IsBundleCodeSignTrusted(*bundle_spec))
+      return false;
 
-  std::string symfile_path = objfile->GetFileSpec().GetPath();
-  llvm::StringRef path_ref(symfile_path);
-
-  // Find the .dSYM bundle root from the symfile path, which is typically
-  // .dSYM/Contents/Resources/DWARF/<name>.
-  auto pos = path_ref.find(".dSYM/");
-  if (pos == llvm::StringRef::npos)
-    return false;
-
-  FileSpec bundle_spec(path_ref.substr(0, pos + 5));
-
-  if (HostInfoMacOSX::IsBundleCodeSignTrusted(bundle_spec)) {
     LLDB_LOG(GetLog(LLDBLog::Modules),
-             "dSYM bundle '{0}' has valid trusted code signature",
-             bundle_spec.GetPath());
+             "{0} bundle '{1}' has valid trusted code signature",
+             bundle_spec->GetFileNameExtension(), bundle_spec->GetPath());
     return true;
-  }
+  };
 
-  return false;
+  // Trust follows whichever bundle could supply a script, so the two candidate
+  // locations are keyed off different paths: a dSYM is reached through the
+  // symbol file, a framework through the module itself.
+  if (SymbolFile *symfile = module.GetSymbolFile())
+    if (ObjectFile *objfile = symfile->GetObjectFile())
+      if (is_trusted_bundle(objfile->GetFileSpec()))
+        return true;
+
+  return is_trusted_bundle(module.GetFileSpec());
 #else
   return false;
 #endif

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.h
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.h
@@ -160,10 +160,43 @@ public:
                                              const Target &target,
                                              const FileSpec &symfile_spec);
 
+  /// Helper function for \c LocateExecutableScriptingResources
+  /// which gathers FileSpecs for executable scripts (currently
+  /// just Python) from a .framework bundle's Python directory.
+  ///
+  /// \param[out] feedback_stream Any warnings/errors are printed into this
+  /// stream.
+  ///
+  /// \param[in] module_spec FileSpec of the Module for which to locate
+  /// scripting resources.
+  ///
+  /// \param[in] target Target which owns the ScriptInterpreter which is
+  /// eventually used for loading the scripting resources.
+  ///
+  /// \param[in] framework_spec FileSpec for the root of the .framework bundle
+  /// containing the Module. The scripting resources are loaded from the
+  /// Resources/Python directory inside that bundle.
+  /// E.g., \c /path/to/Foo.framework
+  ///
+  static llvm::SmallDenseMap<FileSpec, LoadScriptFromSymFile>
+  LocateExecutableScriptingResourcesFromFramework(
+      Stream &feedback_stream, FileSpec module_spec, const Target &target,
+      const FileSpec &framework_spec);
+
   llvm::Expected<FileSpecList>
   GetSafeAutoLoadPaths(const Target &target) const override;
 
 protected:
+  /// Shared implementation behind \c LocateExecutableScriptingResourcesFromDSYM
+  /// and \c LocateExecutableScriptingResourcesFromFramework. Extensions are
+  /// stripped off the module name one at a time until a matching script is
+  /// found, so \c libFoo.1.dylib can be served by \c libFoo.py.
+  static llvm::SmallDenseMap<FileSpec, LoadScriptFromSymFile>
+  LocateScriptingResourcesInPythonDir(Stream &feedback_stream,
+                                      FileSpec module_spec,
+                                      const Target &target,
+                                      llvm::StringRef python_dir);
+
   static const char *GetCompatibleArch(ArchSpec::Core core, size_t idx);
 
   struct CrashInfoAnnotations {

--- a/lldb/test/Shell/Platform/AutoLoad/Darwin/framework-dsym-takes-priority.test
+++ b/lldb/test/Shell/Platform/AutoLoad/Darwin/framework-dsym-takes-priority.test
@@ -1,0 +1,31 @@
+# REQUIRES: python, system-darwin
+#
+# Test that when both a dSYM script and a framework script exist,
+# the dSYM script takes priority.
+
+# RUN: split-file %s %t
+# RUN: mkdir -p %t/TestFramework.framework/Resources/Python
+# RUN: %clang_host -g %t/main.c -o %t/TestFramework.framework/TestFramework
+# RUN: mkdir -p %t/TestFramework.framework/TestFramework.dSYM/Contents/Resources/Python
+
+# RUN: cp %t/dsym_script.py %t/TestFramework.framework/TestFramework.dSYM/Contents/Resources/Python/TestFramework.py
+# RUN: cp %t/framework_script.py %t/TestFramework.framework/Resources/Python/TestFramework.py
+# RUN: %lldb -b \
+# RUN:   -o 'settings set target.load-script-from-symbol-file true' \
+# RUN:   -o 'target create %t/TestFramework.framework/TestFramework' 2>&1 \
+# RUN:   | FileCheck %s --implicit-check-not=FRAMEWORK_SCRIPT
+
+# CHECK: DSYM_SCRIPT
+
+#--- main.c
+int main() { return 0; }
+
+#--- dsym_script.py
+import sys
+def __lldb_init_module(debugger, internal_dict):
+    print("DSYM_SCRIPT", file=sys.stderr)
+
+#--- framework_script.py
+import sys
+def __lldb_init_module(debugger, internal_dict):
+    print("FRAMEWORK_SCRIPT", file=sys.stderr)

--- a/lldb/test/Shell/Platform/AutoLoad/Darwin/framework-fallback-no-dsym-script.test
+++ b/lldb/test/Shell/Platform/AutoLoad/Darwin/framework-fallback-no-dsym-script.test
@@ -1,0 +1,23 @@
+# REQUIRES: python, system-darwin
+#
+# Test that when a dSYM exists but has no Python script inside,
+# the script inside the .framework bundle is loaded as a fallback.
+
+# RUN: split-file %s %t
+# RUN: mkdir -p %t/TestFramework.framework/Resources/Python
+# RUN: %clang_host -g %t/main.c -o %t/TestFramework.framework/TestFramework
+
+# RUN: cp %t/framework_script.py %t/TestFramework.framework/Resources/Python/TestFramework.py
+# RUN: %lldb -b \
+# RUN:   -o 'settings set target.load-script-from-symbol-file true' \
+# RUN:   -o 'target create %t/TestFramework.framework/TestFramework' 2>&1 | FileCheck %s
+
+# CHECK: FRAMEWORK_FALLBACK
+
+#--- main.c
+int main() { return 0; }
+
+#--- framework_script.py
+import sys
+def __lldb_init_module(debugger, internal_dict):
+    print("FRAMEWORK_FALLBACK", file=sys.stderr)

--- a/lldb/test/Shell/Platform/AutoLoad/Darwin/framework-python-script.test
+++ b/lldb/test/Shell/Platform/AutoLoad/Darwin/framework-python-script.test
@@ -1,0 +1,46 @@
+# REQUIRES: python, system-darwin
+#
+# Tests that we load a Python script from inside a .framework bundle and the
+# various ways target.load-script-from-symbol-file controls that behaviour.
+#
+# The binary is deliberately built without debug info, so there is no dSYM and
+# no symbol file: shipping scripts in a framework is a distribution mechanism
+# in its own right and must not depend on either.
+
+# RUN: split-file %s %t
+# RUN: mkdir -p %t/TestFramework.framework/Resources/Python
+# RUN: %clang_host %t/main.c -o %t/TestFramework.framework/TestFramework
+# RUN: cp %t/framework_script.py %t/TestFramework.framework/Resources/Python/TestFramework.py
+#
+# RUN: %lldb -b \
+# RUN:   -o 'settings set target.load-script-from-symbol-file false' \
+# RUN:   -o 'target create %t/TestFramework.framework/TestFramework' 2>&1 \
+# RUN:   | FileCheck %s --implicit-check-not=FRAMEWORK_SCRIPT --implicit-check-not=warning
+#
+# RUN: %lldb -b \
+# RUN:   -o 'settings set target.load-script-from-symbol-file warn' \
+# RUN:   -o 'target create %t/TestFramework.framework/TestFramework' 2>&1 \
+# RUN:   | FileCheck %s --implicit-check-not=FRAMEWORK_SCRIPT --check-prefix=CHECK-WARN --strict-whitespace
+#
+# RUN: %lldb -b \
+# RUN:   -o 'settings set target.load-script-from-symbol-file true' \
+# RUN:   -o 'target create %t/TestFramework.framework/TestFramework' 2>&1 \
+# RUN:   | FileCheck %s --implicit-check-not=warning --check-prefix=CHECK-LOADED
+
+# CHECK-WARN:      warning: 'TestFramework' contains an untrusted debug script. To run this script in this debug session:
+# CHECK-WARN-EMPTY:
+# CHECK-WARN-NEXT:{{^}}    command script import "{{.*}}/TestFramework.framework/Resources/Python/TestFramework.py"
+# CHECK-WARN-EMPTY:
+# CHECK-WARN-NEXT: To run all discovered debug scripts in this session:
+# CHECK-WARN-EMPTY:
+# CHECK-WARN-NEXT:{{^}}    settings set target.load-script-from-symbol-file true
+
+# CHECK-LOADED: FRAMEWORK_SCRIPT
+
+#--- main.c
+int main() { return 0; }
+
+#--- framework_script.py
+import sys
+def __lldb_init_module(debugger, internal_dict):
+    print("FRAMEWORK_SCRIPT", file=sys.stderr)

--- a/lldb/unittests/Platform/PlatformDarwinTest.cpp
+++ b/lldb/unittests/Platform/PlatformDarwinTest.cpp
@@ -74,6 +74,18 @@ protected:
     llvm::sys::path::append(m_tmp_dsym_python_dir, "Python");
     ASSERT_FALSE(llvm::sys::fs::create_directory(m_tmp_dsym_python_dir))
         << "Failed to create test dSYM Python directory.";
+
+    // Create <test-root>/TestFramework.framework
+    m_tmp_framework_dir = m_tmp_root_dir;
+    llvm::sys::path::append(m_tmp_framework_dir, "TestFramework.framework");
+    ASSERT_FALSE(llvm::sys::fs::create_directory(m_tmp_framework_dir))
+        << "Failed to create test framework directory.";
+
+    // Create <test-root>/TestFramework.framework/Resources/Python
+    m_tmp_framework_python_dir = m_tmp_framework_dir;
+    llvm::sys::path::append(m_tmp_framework_python_dir, "Resources", "Python");
+    ASSERT_FALSE(llvm::sys::fs::create_directories(m_tmp_framework_python_dir))
+        << "Failed to create test framework Python directory.";
   };
 
   void TearDown() override {
@@ -92,6 +104,12 @@ protected:
 
   /// <test-root>/.dSYM/Contents/Resources/Python
   llvm::SmallString<128> m_tmp_dsym_python_dir;
+
+  /// <test-root>/TestFramework.framework
+  llvm::SmallString<128> m_tmp_framework_dir;
+
+  /// <test-root>/TestFramework.framework/Resources/Python
+  llvm::SmallString<128> m_tmp_framework_python_dir;
 
   SubsystemRAII<FileSystem, HostInfo, PlatformMacOSX,
                 MockScriptInterpreterPython>
@@ -768,6 +786,65 @@ INSTANTIATE_TEST_SUITE_P(PlatformDarwinLocateWithSpecialCharsTest,
                          PlatformDarwinLocateWithSpecialCharsTestFixture,
                          testing::ValuesIn(std::vector<SpecialCharTestCase>{
                              {' ', '_'}, {'.', '_'}, {'-', '_'}, {'+', 'x'}}));
+
+TEST_F(PlatformDarwinLocateTest,
+       LocateExecutableScriptingResourcesFromFramework_Basic) {
+  // Tests that a script inside <framework>/Resources/Python is found.
+
+  // Create dummy module file at
+  // <test-root>/TestFramework.framework/TestFramework
+  FileSpec module_fspec(CreateFile("TestFramework", m_tmp_framework_dir));
+  ASSERT_TRUE(module_fspec);
+
+  CreateFile("TestFramework.py", m_tmp_framework_python_dir);
+  CreateFile("TestFramework.txt", m_tmp_framework_python_dir);
+
+  StreamString ss;
+  auto fspecs = std::static_pointer_cast<PlatformDarwin>(m_platform_sp)
+                    ->LocateExecutableScriptingResourcesFromFramework(
+                        ss, module_fspec, *m_target_sp,
+                        FileSpec(m_tmp_framework_dir.str()));
+  EXPECT_EQ(fspecs.size(), 1u);
+  EXPECT_EQ(fspecs.begin()->getFirst().GetFilename(), "TestFramework.py");
+}
+
+TEST_F(PlatformDarwinLocateTest,
+       LocateExecutableScriptingResourcesFromFramework_StripExtensions) {
+  // Tests that module names are stripped down until the basename matches
+  // the Python script, same as for dSYMs.
+
+  FileSpec module_fspec(
+      CreateFile("TestFramework.o.1.ext", m_tmp_framework_dir));
+  ASSERT_TRUE(module_fspec);
+
+  CreateFile("TestFramework.py", m_tmp_framework_python_dir);
+
+  StreamString ss;
+  auto fspecs = std::static_pointer_cast<PlatformDarwin>(m_platform_sp)
+                    ->LocateExecutableScriptingResourcesFromFramework(
+                        ss, module_fspec, *m_target_sp,
+                        FileSpec(m_tmp_framework_dir.str()));
+  EXPECT_EQ(fspecs.size(), 1u);
+  EXPECT_EQ(fspecs.begin()->getFirst().GetFilename(), "TestFramework.py");
+}
+
+TEST_F(PlatformDarwinLocateTest,
+       LocateExecutableScriptingResourcesFromFramework_NoMatch) {
+  // Tests that a non-Python resource with a matching stem isn't picked up.
+
+  FileSpec module_fspec(CreateFile("TestFramework", m_tmp_framework_dir));
+  ASSERT_TRUE(module_fspec);
+
+  CreateFile("TestFramework.txt", m_tmp_framework_python_dir);
+  CreateFile("SomeOtherModule.py", m_tmp_framework_python_dir);
+
+  StreamString ss;
+  auto fspecs = std::static_pointer_cast<PlatformDarwin>(m_platform_sp)
+                    ->LocateExecutableScriptingResourcesFromFramework(
+                        ss, module_fspec, *m_target_sp,
+                        FileSpec(m_tmp_framework_dir.str()));
+  EXPECT_EQ(fspecs.size(), 0u);
+}
 
 TEST_F(PlatformDarwinLocateTest, GetSafeAutoLoadPaths) {
   // Tests PlatformDarwin::GetSafeAutoLoadPaths returns a path into the SDK on

--- a/lldb/unittests/SBTestingSupport/CMakeLists.txt
+++ b/lldb/unittests/SBTestingSupport/CMakeLists.txt
@@ -9,4 +9,5 @@ add_lldb_library(lldbSBUtilityHelpers
     lldbHost
     lldbUtilityHelpers
     llvm_gtest
+    LLVMTestingSupport
   )


### PR DESCRIPTION
LLDB can already auto-load a module's Python scripts out of a code-signed dSYM bundle, but frameworks had no equivalent: a framework that wanted to ship data-formatters (or any other scripted extension) had to either piggy-back on a dSYM or rely on a pre-configured safe auto-load path.

This teaches `PlatformDarwin` to look for `<Foo>.framework/Resources/Python/ <name>.py`, making a framework bundle a distribution mechanism in its own right. In particular the lookup deliberately does not require the module to have debug info, a symbol file, or a dSYM, since a shipping framework typically has none of those.

Trust works the same way it does for dSYMs: `IsSymbolFileTrusted` now falls back to code-signing the framework bundle via `HostInfoMacOSX::IsBundleCodeSignTrusted`, so a signed framework is reported as trusted and an unsigned one keeps the existing warn-only behaviour.

A dSYM still wins when both carry a script for the same module; the framework is consulted when the dSYM has none.

The extension-stripping search shared by both lookups is factored out into `LocateScriptingResourcesInPythonDir`, leaving the dSYM behaviour unchanged.