### PR TITLE
[offload][omp] Route RPC callback registration through liboffload

### DIFF
--- a/offload/liboffload/exports
+++ b/offload/liboffload/exports
@@ -7,7 +7,6 @@ global:
   extern "C++" {
     error::OffloadError::ID;
     "error::OffloadErrCategory()";
-    "llvm::omp::target::RPCServerTy::registerCallback(unsigned int (*)(void*, unsigned int))";
     "llvm::omp::target::plugin::GenericPluginTy::async_barrier(omp_interop_val_t*)";
     "llvm::omp::target::plugin::GenericPluginTy::create_interop(int, int, interop_spec_t*)";
     "llvm::omp::target::plugin::GenericPluginTy::data_alloc(int, long, void*, int)";

--- a/offload/liboffload/exports
+++ b/offload/liboffload/exports
@@ -22,7 +22,6 @@ global:
     "llvm::omp::target::plugin::GenericPluginTy::is_initialized() const";
     "llvm::omp::target::plugin::GenericPluginTy::launch_kernel(int, void*, llvm::omp::target::plugin::KernelLaunchArgsTy&, __tgt_async_info*)";
     "llvm::omp::target::plugin::GenericPluginTy::load_binary(int, __tgt_device_image*, __tgt_device_binary*)";
-    "llvm::omp::target::plugin::GenericPluginTy::number_of_devices()";
     "llvm::omp::target::plugin::GenericPluginTy::release_interop(int, omp_interop_val_t*)";
     "llvm::omp::target::plugin::GenericPluginTy::set_device_identifier(int, int)";
     "llvm::omp::target::plugin::GenericPluginTy::sync_barrier(omp_interop_val_t*)";

--- a/offload/liboffload/src/OffloadImpl.cpp
+++ b/offload/liboffload/src/OffloadImpl.cpp
@@ -465,6 +465,10 @@ Error olGetPlatformInfoSize_impl(ol_platform_handle_t Platform,
 
 Error olPlatformRegisterRPCCallback_impl(ol_platform_handle_t Platform,
                                          ol_platform_rpc_cb_t Callback) {
+  if (!Platform->Plugin || !Platform->Plugin->is_initialized() ||
+      Platform->Plugin->getNumDevices() == 0)
+    return Error::success();
+
   Platform->Plugin->getRPCServer().registerCallback(Callback);
   return Error::success();
 }

--- a/offload/libomptarget/interface.cpp
+++ b/offload/libomptarget/interface.cpp
@@ -652,7 +652,11 @@ EXTERN void __tgt_register_rpc_callback(unsigned (*Callback)(void *,
   if (!PM)
     return;
 
-  for (auto &Plugin : PM->plugins())
-    if (Plugin.is_initialized() && Plugin.getNumDevices() > 0)
-      Plugin.getRPCServer().registerCallback(Callback);
+  olIteratePlatforms(
+      [](ol_platform_handle_t Platform, void *Data) {
+        olPlatformRegisterRPCCallback(
+            Platform, reinterpret_cast<ol_platform_rpc_cb_t>(Data));
+        return true;
+      },
+      reinterpret_cast<void *>(Callback));
 }

--- a/offload/plugins-nextgen/common/include/PluginInterface.h
+++ b/offload/plugins-nextgen/common/include/PluginInterface.h
@@ -1699,9 +1699,6 @@ public:
   /// Returns non-zero if the \p Image is compatible with the device.
   int32_t isDeviceCompatible(int32_t DeviceId, StringRef Image);
 
-  /// Return the number of devices this plugin can support.
-  int32_t number_of_devices();
-
   /// Initializes the record and replay mechanism inside the plugin.
   int32_t initialize_record_replay(int32_t DeviceId, int64_t MemorySize,
                                    void *VAddr, bool IsRecord, bool IsNative,

--- a/offload/plugins-nextgen/common/src/PluginInterface.cpp
+++ b/offload/plugins-nextgen/common/src/PluginInterface.cpp
@@ -1485,8 +1485,6 @@ int32_t GenericPluginTy::isDeviceCompatible(int32_t DeviceId, StringRef Image) {
   }
 }
 
-int32_t GenericPluginTy::number_of_devices() { return getNumDevices(); }
-
 int32_t GenericPluginTy::initialize_record_replay(
     int32_t DeviceId, int64_t MemorySize, void *VAddr, bool IsRecord,
     bool IsNative, bool SaveOutput, bool EmitReport, const char *ReportFilename,


### PR DESCRIPTION
Use olPlatformRegisterRPCCallback to register RPC callbacks.

Remove unused number_of_devices from GenericPluginTy.

Assisted by Claude