### PR TITLE
[Clang] Avoid calling hasBody() when calling getBody() directly after

### DIFF
--- a/clang/include/clang/AST/ASTNodeTraverser.h
+++ b/clang/include/clang/AST/ASTNodeTraverser.h
@@ -806,8 +806,8 @@ public:
       for (const ParmVarDecl *Parameter : D->parameters())
         Visit(Parameter);
 
-    if (D->hasBody())
-      Visit(D->getBody());
+    if (Stmt *Body = D->getBody())
+      Visit(Body);
   }
 
   void VisitObjCCategoryDecl(const ObjCCategoryDecl *D) {

--- a/clang/lib/AST/ODRHash.cpp
+++ b/clang/lib/AST/ODRHash.cpp
@@ -434,28 +434,21 @@ public:
     for (auto Param : Method->parameters())
       Hash.AddSubDecl(Param);
 
-    if (Method->hasBody()) {
-      const bool IsDefinition = Method->isThisDeclarationADefinition();
-      Hash.AddBoolean(IsDefinition);
-      if (IsDefinition) {
-        Stmt *Body = Method->getBody();
-        Hash.AddBoolean(Body);
-        if (Body)
-          AddStmt(Body);
+    const bool IsDefinition = Method->isThisDeclarationADefinition();
+    Hash.AddBoolean(IsDefinition);
+    if (IsDefinition) {
+      AddStmt(Method->getBody());
 
-        // Filter out sub-Decls which will not be processed in order to get an
-        // accurate count of Decl's.
-        llvm::SmallVector<const Decl *, 16> Decls;
-        for (Decl *SubDecl : Method->decls())
-          if (ODRHash::isSubDeclToBeProcessed(SubDecl, Method))
-            Decls.push_back(SubDecl);
+      // Filter out sub-Decls which will not be processed in order to get an
+      // accurate count of Decl's.
+      llvm::SmallVector<const Decl *, 16> Decls;
+      for (Decl *SubDecl : Method->decls())
+        if (ODRHash::isSubDeclToBeProcessed(SubDecl, Method))
+          Decls.push_back(SubDecl);
 
-        ID.AddInteger(Decls.size());
-        for (auto SubDecl : Decls)
-          Hash.AddSubDecl(SubDecl);
-      }
-    } else {
-      Hash.AddBoolean(false);
+      ID.AddInteger(Decls.size());
+      for (auto SubDecl : Decls)
+        Hash.AddSubDecl(SubDecl);
     }
 
     Inherited::VisitObjCMethodDecl(Method);

--- a/clang/lib/Analysis/UnsafeBufferUsage.cpp
+++ b/clang/lib/Analysis/UnsafeBufferUsage.cpp
@@ -4293,7 +4293,7 @@ fixVariable(const VarDecl *VD, FixitStrategy::Kind K,
         // also covers call-operator of lamdas
         isa<CXXMethodDecl>(FD) ||
         // skip when the function body is a try-block
-        (FD->hasBody() && isa<CXXTryStmt>(FD->getBody())) ||
+        isa_and_nonnull<CXXTryStmt>(FD->getBody()) ||
         FD->isOverloadedOperator()) {
       DEBUG_NOTE_DECL_FAIL(VD, " : unsupported function decl");
       return {}; // TODO test all these cases

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
@@ -901,14 +901,13 @@ void CIRGenFunction::emitDestructorBody(FunctionArgList &args) {
   // by Sema), but the Itanium ABI doesn't make them optional and Clang may
   // in fact emit references to them from other compilations, so emit them
   // as functions containing a trap instruction.
+  Stmt *body = dtor->getBody();
   if (dtorType != Dtor_Base && dtor->getParent()->isAbstract()) {
-    SourceLocation loc =
-        dtor->hasBody() ? dtor->getBody()->getBeginLoc() : dtor->getLocation();
+    SourceLocation loc = body ? body->getBeginLoc() : dtor->getLocation();
     emitTrap(getLoc(loc), true);
     return;
   }
 
-  Stmt *body = dtor->getBody();
   assert(body && !cir::MissingFeatures::incrementProfileCounter());
 
   // The call to operator delete in a deleting destructor happens

--- a/clang/lib/CodeGen/CoverageMappingGen.cpp
+++ b/clang/lib/CodeGen/CoverageMappingGen.cpp
@@ -618,9 +618,9 @@ struct EmptyCoverageMappingBuilder : public CoverageMappingBuilder {
       : CoverageMappingBuilder(CVM, SM, LangOpts) {}
 
   void VisitDecl(const Decl *D) {
-    if (!D->hasBody())
+    Stmt *Body = D->getBody();
+    if (!Body)
       return;
-    auto Body = D->getBody();
     SourceLocation Start = getStart(Body);
     SourceLocation End = getEnd(Body);
     if (!SM.isWrittenInSameFile(Start, End)) {

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -2101,9 +2101,9 @@ static void handleNakedAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
 // ExprWithCleanups). We could expand this to perform control-flow analysis for
 // more complex patterns.
 static bool isKnownToAlwaysThrow(const FunctionDecl *FD) {
-  if (!FD->hasBody())
-    return false;
   const Stmt *Body = FD->getBody();
+  if (!Body)
+    return false;
   const Stmt *OnlyStmt = nullptr;
 
   if (const auto *Compound = dyn_cast<CompoundStmt>(Body)) {

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -9416,8 +9416,8 @@ ComputeDefaultedComparisonExceptionSpec(Sema &S, SourceLocation Loc,
 
   // The common case is that we just defined the comparison function. In that
   // case, just look at whether the body can throw.
-  if (FD->hasBody()) {
-    ExceptSpec.CalledStmt(FD->getBody());
+  if (Stmt *FunctionBody = FD->getBody()) {
+    ExceptSpec.CalledStmt(FunctionBody);
   } else {
     // Otherwise, build a body so we can check it. This should ideally only
     // happen when we're not actually marking the function referenced. (This is

--- a/clang/lib/StaticAnalyzer/Checkers/IvarInvalidationChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/IvarInvalidationChecker.cpp
@@ -421,7 +421,7 @@ visit(const ObjCImplementationDecl *ImplD) const {
     // Get the corresponding method in the @implementation.
     const ObjCMethodDecl *D = ImplD->getMethod(InterfD->getSelector(),
                                                InterfD->isInstanceMethod());
-    if (D && D->hasBody()) {
+    if (Stmt *Body; D && (Body = D->getBody())) {
       AtImplementationContainsAtLeastOnePartialInvalidationMethod = true;
 
       bool CalledAnotherInvalidationMethod = false;
@@ -431,7 +431,7 @@ visit(const ObjCImplementationDecl *ImplD) const {
                     PropSetterToIvarMap,
                     PropGetterToIvarMap,
                     PropertyToIvarMap,
-                    BR.getContext()).VisitStmt(D->getBody());
+                    BR.getContext()).VisitStmt(Body);
       // If another invalidation method was called, trust that full invalidation
       // has occurred.
       if (CalledAnotherInvalidationMethod)
@@ -470,7 +470,7 @@ visit(const ObjCImplementationDecl *ImplD) const {
     // Get the corresponding method in the @implementation.
     const ObjCMethodDecl *D = ImplD->getMethod(InterfD->getSelector(),
                                                InterfD->isInstanceMethod());
-    if (D && D->hasBody()) {
+    if (Stmt *Body; D && (Body = D->getBody())) {
       AtImplementationContainsAtLeastOneInvalidationMethod = true;
 
       // Get a copy of ivars needing invalidation.
@@ -482,7 +482,7 @@ visit(const ObjCImplementationDecl *ImplD) const {
                     PropSetterToIvarMap,
                     PropGetterToIvarMap,
                     PropertyToIvarMap,
-                    BR.getContext()).VisitStmt(D->getBody());
+                    BR.getContext()).VisitStmt(Body);
       // If another invalidation method was called, trust that full invalidation
       // has occurred.
       if (CalledAnotherInvalidationMethod)

--- a/clang/lib/StaticAnalyzer/Checkers/MallocChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/MallocChecker.cpp
@@ -941,13 +941,18 @@ protected:
     // branch. That said, would a synthesized body ever intend to handle
     // ownership? As of today they don't. And if they did, how would we
     // put notes inside it, given that it doesn't match any source locations?
-    if (!FD || !FD->hasBody())
+    if (!FD)
       return false;
+
+    Stmt *Body = FD->getBody();
+    if (!Body)
+      return false;
+
     using namespace clang::ast_matchers;
 
     auto Matches = match(findAll(stmt(anyOf(cxxDeleteExpr().bind("delete"),
                                             callExpr().bind("call")))),
-                         *FD->getBody(), ACtx);
+                         *Body, ACtx);
     for (BoundNodes Match : Matches) {
       if (Match.getNodeAs<CXXDeleteExpr>("delete"))
         return true;

--- a/clang/lib/StaticAnalyzer/Checkers/RunLoopAutoreleaseLeakChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/RunLoopAutoreleaseLeakChecker.cpp
@@ -82,9 +82,8 @@ static void emitDiagnostics(BoundNodes &Match,
                             BugReporter &BR,
                             AnalysisManager &AM,
                             const RunLoopAutoreleaseLeakChecker *Checker) {
-
-  assert(D->hasBody());
   const Stmt *DeclBody = D->getBody();
+  assert(DeclBody);
 
   AnalysisDeclContext *ADC = AM.getAnalysisDeclContext(D);
 

--- a/clang/lib/StaticAnalyzer/Checkers/StreamChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/StreamChecker.cpp
@@ -763,12 +763,16 @@ protected:
     // branch. That said, would a synthesized body ever intend to handle
     // ownership? As of today they don't. And if they did, how would we
     // put notes inside it, given that it doesn't match any source locations?
-    if (!FD || !FD->hasBody())
+    if (!FD)
       return false;
+
+    Stmt *Body = FD->getBody();
+    if (!Body)
+      return false;
+
     using namespace clang::ast_matchers;
 
-    auto Matches =
-        match(findAll(callExpr().bind("call")), *FD->getBody(), ACtx);
+    auto Matches = match(findAll(callExpr().bind("call")), *Body, ACtx);
     for (BoundNodes Match : Matches) {
       if (const auto *Call = Match.getNodeAs<CallExpr>("call"))
         if (isClosingCallAsWritten(*Call))

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/RefCntblBaseVirtualDtorChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/RefCntblBaseVirtualDtorChecker.cpp
@@ -65,8 +65,8 @@ public:
 
   bool VisitCallExpr(const CallExpr *CE) {
     const Decl *D = CE->getCalleeDecl();
-    if (D && D->hasBody())
-      return VisitBody(D->getBody());
+    if (Stmt *Body; D && (Body = D->getBody()))
+      return VisitBody(Body);
     else {
       auto name = safeGetName(D);
       if (name == "ensureOnMainThread" || name == "ensureOnMainRunLoop") {

--- a/clang/lib/StaticAnalyzer/Core/BugReporterVisitors.cpp
+++ b/clang/lib/StaticAnalyzer/Core/BugReporterVisitors.cpp
@@ -520,14 +520,17 @@ static bool potentiallyWritesIntoIvar(const Decl *Parent,
                                       const ObjCIvarDecl *Ivar) {
   using namespace ast_matchers;
   const char *IvarBind = "Ivar";
-  if (!Parent || !Parent->hasBody())
+  if (!Parent)
+    return false;
+  Stmt *Body = Parent->getBody();
+  if (!Body)
     return false;
   StatementMatcher WriteIntoIvarM = binaryOperator(
       hasOperatorName("="),
       hasLHS(ignoringParenImpCasts(
           objcIvarRefExpr(hasDeclaration(equalsNode(Ivar))).bind(IvarBind))));
   StatementMatcher ParentM = stmt(hasDescendant(WriteIntoIvarM));
-  auto Matches = match(ParentM, *Parent->getBody(), Parent->getASTContext());
+  auto Matches = match(ParentM, *Body, Parent->getASTContext());
   for (BoundNodes &Match : Matches) {
     auto IvarRef = Match.getNodeAs<ObjCIvarRefExpr>(IvarBind);
     if (IvarRef->isFreeIvar())

--- a/clang/lib/StaticAnalyzer/Frontend/ModelConsumer.cpp
+++ b/clang/lib/StaticAnalyzer/Frontend/ModelConsumer.cpp
@@ -32,8 +32,8 @@ bool ModelConsumer::HandleTopLevelDecl(DeclGroupRef DeclGroup) {
   for (const Decl *D : DeclGroup) {
     // Only interested in definitions.
     const auto *func = llvm::dyn_cast<FunctionDecl>(D);
-    if (func && func->hasBody()) {
-      Bodies.insert(std::make_pair(func->getName(), func->getBody()));
+    if (Stmt *Body; func && (Body = func->getBody())) {
+      Bodies.insert(std::make_pair(func->getName(), Body));
     }
   }
   return true;


### PR DESCRIPTION
`hasBody()` and `getBody()` are virtual functions, so calling them multiple times should be avoided.
