### PR TITLE
[orc-rt] Hide symbols by default in Bedrock and Support libs.

### DIFF
--- a/orc-rt/lib/bedrock/CMakeLists.txt
+++ b/orc-rt/lib/bedrock/CMakeLists.txt
@@ -77,7 +77,11 @@ endif()
 add_library(orc-rt-bedrock-objects OBJECT ${ORC_RT_BEDROCK_SOURCES})
 
 set_target_properties(orc-rt-bedrock-objects PROPERTIES
-  POSITION_INDEPENDENT_CODE ${ORC_RT_ENABLE_PIC})
+  POSITION_INDEPENDENT_CODE ${ORC_RT_ENABLE_PIC}
+  C_VISIBILITY_PRESET hidden
+  CXX_VISIBILITY_PRESET hidden
+  VISIBILITY_INLINES_HIDDEN ON
+)
 
 target_link_libraries(orc-rt-bedrock-objects PUBLIC orc-rt-headers)
 

--- a/orc-rt/lib/support/CMakeLists.txt
+++ b/orc-rt/lib/support/CMakeLists.txt
@@ -28,7 +28,11 @@ endif()
 add_library(orc-rt-support-objects OBJECT ${ORC_RT_SUPPORT_SOURCES})
 
 set_target_properties(orc-rt-support-objects PROPERTIES
-  POSITION_INDEPENDENT_CODE ${ORC_RT_ENABLE_PIC})
+  POSITION_INDEPENDENT_CODE ${ORC_RT_ENABLE_PIC}
+  C_VISIBILITY_PRESET hidden
+  CXX_VISIBILITY_PRESET hidden
+  VISIBILITY_INLINES_HIDDEN ON
+)
 
 target_link_libraries(orc-rt-support-objects PUBLIC orc-rt-headers)
 


### PR DESCRIPTION
Hides C/C++ symbols by default in the orc-rt Bedrock and Support libraries. Only explicitly annotated APIs should be exposed by these libraries.