### PR TITLE
Add openmp test to profcheck xfail list

### DIFF
--- a/llvm/utils/profcheck-xfail.txt
+++ b/llvm/utils/profcheck-xfail.txt
@@ -97,6 +97,7 @@ Transforms/OpenMP/custom_state_machines.ll
 Transforms/OpenMP/custom_state_machines_remarks.ll
 Transforms/OpenMP/get_hardware_num_threads_in_block_fold.ll
 Transforms/OpenMP/gpu_state_machine_function_ptr_replacement.ll
+Transforms/OpenMP/indirect_call_specialization_cap.ll
 Transforms/OpenMP/parallel_region_merging.ll
 Transforms/OpenMP/parallel_region_merging_debug_loc.ll
 Transforms/OpenMP/single_threaded_execution.ll


### PR DESCRIPTION
Introduced in PR #219323. Looking at the PR, and given we haven't yet addressed openmp profcheck failures, the change is highly unlikely to have introduced a new regression (it's exposing existing ones)