### PR TITLE
[Bazel] add missing libc math functions to bazel to match CMake

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -10771,6 +10771,16 @@ libc_math_function(
     additional_deps = [":__support_math_atan2"],
 )
 
+
+libc_math_function(
+    name = "atan2l",
+    additional_deps = [
+        ":__support_fputil_cast",
+        ":__support_math_atan2",
+        ":__support_math_atan2f128",
+    ],
+)
+
 libc_math_function(
     name = "atanhf",
     additional_deps = [":__support_math_atanhf"],
@@ -10932,6 +10942,13 @@ libc_math_function(
     name = "canonicalizef16",
     additional_deps = [
         ":__support_math_canonicalizef16",
+    ],
+)
+
+libc_math_function(
+    name = "canonicalizebf16",
+    additional_deps = [
+        ":__support_math_canonicalizebf16",
     ],
 )
 
@@ -12514,6 +12531,13 @@ libc_math_function(
 )
 
 libc_math_function(
+    name = "getpayloadbf16",
+    additional_deps = [
+        ":__support_math_getpayloadbf16",
+    ],
+)
+
+libc_math_function(
     name = "hypot",
     additional_deps = [
         ":__support_math_hypot",
@@ -13618,6 +13642,13 @@ libc_math_function(
 )
 
 libc_math_function(
+    name = "setpayloadbf16",
+    additional_deps = [
+        ":__support_math_setpayloadbf16",
+    ],
+)
+
+libc_math_function(
     name = "setpayloadsig",
     additional_deps = [
         ":__support_math_setpayloadsig",
@@ -13649,6 +13680,13 @@ libc_math_function(
     name = "setpayloadsigf16",
     additional_deps = [
         ":__support_math_setpayloadsigf16",
+    ],
+)
+
+libc_math_function(
+    name = "setpayloadsigbf16",
+    additional_deps = [
+        ":__support_math_setpayloadsigbf16",
     ],
 )
 

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -10771,7 +10771,6 @@ libc_math_function(
     additional_deps = [":__support_math_atan2"],
 )
 
-
 libc_math_function(
     name = "atan2l",
     additional_deps = [


### PR DESCRIPTION
fixes #221801
There are 501 instances of `add_entrypoint_object` in the CMakeLists.txt file. There are also 501 `libc_math_function` usages besides loading in the BUILD.bazel file. I tested the bazel build too.
There were 5 missing functions, `atan2l`, `canonicalizebf16`, `getpayloadbf16`, `setpayloadbf16`, `setpayloadsigbf16`.
Let me know if a function is missing. Used Claude to find missing items in the bazel file.
Assisted-by: Claude