### PR TITLE
[Attributor] Don't heap-to-stack an allocation whose size is unknown

### DIFF
--- a/llvm/include/llvm/Analysis/MemoryBuiltins.h
+++ b/llvm/include/llvm/Analysis/MemoryBuiltins.h
@@ -113,6 +113,12 @@ LLVM_ABI std::optional<APInt> getAllocSize(
       return V;
     });
 
+/// Return true if the size of the allocation performed by \p CB can be
+/// determined, as a constant or as a value ObjectSizeOffsetEvaluator can
+/// materialize at runtime.
+LLVM_ABI bool hasComputableAllocSize(const CallBase *CB,
+                                     const TargetLibraryInfo *TLI);
+
 /// If this is a call to an allocation function that initializes memory to a
 /// fixed value, return said value in the requested type.  Otherwise, return
 /// nullptr.

--- a/llvm/lib/Analysis/MemoryBuiltins.cpp
+++ b/llvm/lib/Analysis/MemoryBuiltins.cpp
@@ -411,6 +411,13 @@ llvm::getAllocSize(const CallBase *CB, const TargetLibraryInfo *TLI,
   return Size;
 }
 
+bool llvm::hasComputableAllocSize(const CallBase *CB,
+                                  const TargetLibraryInfo *TLI) {
+  // Keep in sync with ObjectSizeOffsetEvaluator::visitCallBase.
+  std::optional<AllocFnsTy> FnData = getAllocationSize(CB, TLI);
+  return FnData && FnData->AllocTy != StrDupLike;
+}
+
 Constant *llvm::getInitialValueOfAllocation(const Value *V,
                                             const TargetLibraryInfo *TLI,
                                             Type *Ty) {

--- a/llvm/lib/Transforms/IPO/AttributorAttributes.cpp
+++ b/llvm/lib/Transforms/IPO/AttributorAttributes.cpp
@@ -7282,6 +7282,18 @@ ChangeStatus AAHeapToStackFunction::updateImpl(Attributor &A) {
     }
 
     std::optional<APInt> Size = getSize(A, *this, AI);
+
+    // manifest() needs a size, either the constant above or one
+    // ObjectSizeOffsetEvaluator can materialize.
+    if (!Size && !hasComputableAllocSize(AI.CB, TLI)) {
+      LLVM_DEBUG(dbgs() << "[H2S] Unsizable allocation: " << *AI.CB << "\n");
+      AI.Status = AllocationInfo::INVALID;
+      Changed = ChangeStatus::CHANGED;
+      continue;
+    }
+
+    // A globalized local is exempt from the size cap: moving it to the stack is
+    // worthwhile however large it is.
     if (!AI.IsGlobalizedLocal && MaxHeapToStackSize != -1) {
       if (!Size || Size->ugt(MaxHeapToStackSize)) {
         LLVM_DEBUG({

--- a/llvm/test/Transforms/Attributor/heap_to_stack_gpu.ll
+++ b/llvm/test/Transforms/Attributor/heap_to_stack_gpu.ll
@@ -304,7 +304,7 @@ define void @test9() {
 ; CHECK-NEXT:    [[I:%.*]] = tail call noalias ptr @malloc(i64 noundef 4)
 ; CHECK-NEXT:    tail call void @no_sync_func(ptr nofree captures(none) [[I]])
 ; CHECK-NEXT:    store i32 10, ptr [[I]], align 4
-; CHECK-NEXT:    tail call void @foo_nounw(ptr nofree nonnull align 4 dereferenceable(4) [[I]]) #[[ATTR8:[0-9]+]]
+; CHECK-NEXT:    tail call void @foo_nounw(ptr nofree nonnull align 4 dereferenceable(4) [[I]]) #[[ATTR9:[0-9]+]]
 ; CHECK-NEXT:    tail call void @free(ptr nonnull align 4 captures(none) dereferenceable(4) [[I]])
 ; CHECK-NEXT:    ret void
 ;
@@ -345,7 +345,7 @@ define void @test11() {
 ; CHECK-LABEL: define {{[^@]+}}@test11() {
 ; CHECK-NEXT:  bb:
 ; CHECK-NEXT:    [[I:%.*]] = tail call noalias ptr @malloc(i64 noundef 4)
-; CHECK-NEXT:    tail call void @sync_will_return(ptr [[I]]) #[[ATTR8]]
+; CHECK-NEXT:    tail call void @sync_will_return(ptr [[I]]) #[[ATTR9]]
 ; CHECK-NEXT:    tail call void @free(ptr captures(none) [[I]])
 ; CHECK-NEXT:    ret void
 ;
@@ -599,7 +599,7 @@ define void @test16c(i8 %v, ptr %P) {
 ; CHECK-NEXT:  bb:
 ; CHECK-NEXT:    [[I:%.*]] = tail call noalias ptr @malloc(i64 noundef 4)
 ; CHECK-NEXT:    store ptr [[I]], ptr [[P]], align 8
-; CHECK-NEXT:    tail call void @no_sync_func(ptr nofree captures(none) [[I]]) #[[ATTR8]]
+; CHECK-NEXT:    tail call void @no_sync_func(ptr nofree captures(none) [[I]]) #[[ATTR9]]
 ; CHECK-NEXT:    tail call void @free(ptr captures(none) [[I]])
 ; CHECK-NEXT:    ret void
 ;
@@ -633,7 +633,7 @@ define void @test17() {
 ; CHECK-NEXT:  bb:
 ; CHECK-NEXT:    [[I_H2S:%.*]] = alloca i8, i64 4, align 1, addrspace(5)
 ; CHECK-NEXT:    [[MALLOC_CAST:%.*]] = addrspacecast ptr addrspace(5) [[I_H2S]] to ptr
-; CHECK-NEXT:    tail call void @usei8(ptr noalias nofree captures(none) [[MALLOC_CAST]]) #[[ATTR9:[0-9]+]]
+; CHECK-NEXT:    tail call void @usei8(ptr noalias nofree captures(none) [[MALLOC_CAST]]) #[[ATTR10:[0-9]+]]
 ; CHECK-NEXT:    ret void
 ;
 bb:
@@ -647,7 +647,7 @@ define void @test17b() {
 ; CHECK-LABEL: define {{[^@]+}}@test17b() {
 ; CHECK-NEXT:  bb:
 ; CHECK-NEXT:    [[I:%.*]] = tail call noalias ptr @__kmpc_alloc_shared(i64 noundef 4)
-; CHECK-NEXT:    tail call void @usei8(ptr nofree [[I]]) #[[ATTR9]]
+; CHECK-NEXT:    tail call void @usei8(ptr nofree [[I]]) #[[ATTR10]]
 ; CHECK-NEXT:    tail call void @__kmpc_free_shared(ptr captures(none) [[I]], i64 noundef 4)
 ; CHECK-NEXT:    ret void
 ;
@@ -665,7 +665,7 @@ define void @move_alloca() {
 ; CHECK-NEXT:    br label [[NOT_ENTRY:%.*]]
 ; CHECK:       not_entry:
 ; CHECK-NEXT:    [[MALLOC_CAST:%.*]] = addrspacecast ptr addrspace(5) [[I_H2S]] to ptr
-; CHECK-NEXT:    tail call void @usei8(ptr noalias nofree captures(none) [[MALLOC_CAST]]) #[[ATTR9]]
+; CHECK-NEXT:    tail call void @usei8(ptr noalias nofree captures(none) [[MALLOC_CAST]]) #[[ATTR10]]
 ; CHECK-NEXT:    ret void
 ;
 entry:
@@ -686,7 +686,7 @@ define void @test16e(i8 %v) norecurse {
 ; CHECK-NEXT:  bb:
 ; CHECK-NEXT:    [[I:%.*]] = tail call noalias ptr @__kmpc_alloc_shared(i64 noundef 4)
 ; CHECK-NEXT:    store ptr [[I]], ptr @G, align 8
-; CHECK-NEXT:    call void @usei8(ptr nofree captures(none) [[I]]) #[[ATTR10:[0-9]+]]
+; CHECK-NEXT:    call void @usei8(ptr nofree captures(none) [[I]]) #[[ATTR11:[0-9]+]]
 ; CHECK-NEXT:    tail call void @__kmpc_free_shared(ptr noalias captures(none) [[I]], i64 noundef 4)
 ; CHECK-NEXT:    ret void
 ;
@@ -708,7 +708,7 @@ define void @test16f(i8 %v) norecurse {
 ; CHECK-NEXT:    [[I_H2S:%.*]] = alloca i8, i64 4, align 1, addrspace(5)
 ; CHECK-NEXT:    [[MALLOC_CAST:%.*]] = addrspacecast ptr addrspace(5) [[I_H2S]] to ptr
 ; CHECK-NEXT:    store ptr [[MALLOC_CAST]], ptr @Gtl, align 8
-; CHECK-NEXT:    call void @usei8(ptr nofree captures(none) [[MALLOC_CAST]]) #[[ATTR10]]
+; CHECK-NEXT:    call void @usei8(ptr nofree captures(none) [[MALLOC_CAST]]) #[[ATTR11]]
 ; CHECK-NEXT:    ret void
 ;
 bb:
@@ -725,13 +725,35 @@ define void @convert_large_kmpc_alloc_shared() {
 ; CHECK-NEXT:  bb:
 ; CHECK-NEXT:    [[I_H2S:%.*]] = alloca i8, i64 256, align 1, addrspace(5)
 ; CHECK-NEXT:    [[MALLOC_CAST:%.*]] = addrspacecast ptr addrspace(5) [[I_H2S]] to ptr
-; CHECK-NEXT:    tail call void @usei8(ptr noalias nofree captures(none) [[MALLOC_CAST]]) #[[ATTR9]]
+; CHECK-NEXT:    tail call void @usei8(ptr noalias nofree captures(none) [[MALLOC_CAST]]) #[[ATTR10]]
 ; CHECK-NEXT:    ret void
 ;
 bb:
   %i = tail call noalias ptr @__kmpc_alloc_shared(i64 256)
   tail call void @usei8(ptr nocapture nofree %i) nosync nounwind willreturn
   tail call void @__kmpc_free_shared(ptr %i, i64 256)
+  ret void
+}
+
+; A globalized-local allocator with no allocsize, which is what
+; DeadArgumentElimination leaves behind once it deletes a dead size argument.
+; The size is not recoverable, so the allocation has to stay on the heap even
+; though globalized locals are exempt from the size cap.
+
+declare ptr @__kmpc_alloc_shared_no_size() allockind("alloc,uninitialized") "alloc-family"="__kmpc_alloc_shared"
+
+define void @no_allocsize_kmpc_alloc_shared() {
+; CHECK-LABEL: define {{[^@]+}}@no_allocsize_kmpc_alloc_shared() {
+; CHECK-NEXT:  bb:
+; CHECK-NEXT:    [[I:%.*]] = tail call noalias ptr @__kmpc_alloc_shared_no_size()
+; CHECK-NEXT:    tail call void @usei8(ptr noalias nofree captures(none) [[I]]) #[[ATTR10]]
+; CHECK-NEXT:    tail call void @__kmpc_free_shared(ptr noalias captures(none) [[I]], i64 noundef 4)
+; CHECK-NEXT:    ret void
+;
+bb:
+  %i = tail call noalias ptr @__kmpc_alloc_shared_no_size()
+  tail call void @usei8(ptr nocapture nofree %i) nosync nounwind willreturn
+  tail call void @__kmpc_free_shared(ptr %i, i64 4)
   ret void
 }
 
@@ -745,9 +767,10 @@ bb:
 ; CHECK: attributes #[[ATTR5:[0-9]+]] = { allockind("alloc,uninitialized") allocsize(0) "alloc-family"="__kmpc_alloc_shared" }
 ; CHECK: attributes #[[ATTR6:[0-9]+]] = { allockind("free") "alloc-family"="__kmpc_alloc_shared" }
 ; CHECK: attributes #[[ATTR7]] = { norecurse }
-; CHECK: attributes #[[ATTR8]] = { nounwind }
-; CHECK: attributes #[[ATTR9]] = { nosync nounwind willreturn }
-; CHECK: attributes #[[ATTR10]] = { nocallback nosync nounwind willreturn }
+; CHECK: attributes #[[ATTR8:[0-9]+]] = { allockind("alloc,uninitialized") "alloc-family"="__kmpc_alloc_shared" }
+; CHECK: attributes #[[ATTR9]] = { nounwind }
+; CHECK: attributes #[[ATTR10]] = { nosync nounwind willreturn }
+; CHECK: attributes #[[ATTR11]] = { nocallback nosync nounwind willreturn }
 ;.
 ;; NOTE: These prefixes are unused and the list is autogenerated. Do not add tests below this line:
 ; CGSCC: {{.*}}


### PR DESCRIPTION
`AAHeapToStackFunction::manifest()` assumes `ObjectSizeOffsetEvaluator` can size
the allocation it is converting, and asserts when it cannot. Nothing establishes
that beforehand: an allocation function is recognized by its `allockind`
attribute, which does not imply `allocsize`, and the evaluator returns unknown
for a call it has neither an `allocsize` nor a TLI entry for. Such calls are
rejected today by accident rather than on purpose, because `updateImpl()`
invalidates them when the `-max-heap-to-stack-size` cap comparison fails on a
missing size. Globalized locals are exempt from that cap, since moving one to the
stack is worth doing however large it is, and the exemption takes the
unknown-size check with it — so a globalized-local allocator carrying no
`allocsize` reaches `manifest()` and the compiler asserts. Turning the cap off
reaches the same assert for any allocator, with no OpenMP involved; `strdup` is
the in-tree precedent for an allocation function the evaluator will not size.

Check for a computable size separately from the cap, using a new
`hasComputableAllocSize()` in `MemoryBuiltins` that mirrors what
`ObjectSizeOffsetEvaluator::visitCallBase` accepts. The check belongs in
`updateImpl()` rather than in `manifest()`, because `AAKernelInfo::updateImpl()`
consults `isAssumedHeapToStack()` when deciding that a store needs no SPMD guard,
so promising the conversion at the fixpoint and declining it at manifest time
would leave that store unguarded in shared memory, which is a data race rather
than a missed optimization. The dynamic-size case that makes the pass worth
having is unaffected: an allocation with an `allocsize` and a non-constant
argument still gets its `alloca`. `heap_to_stack_gpu.ll` gains a globalized-local
allocator with no `allocsize`, which asserts without this change and needs no
flag to reach.

## Testing

Tested on `main` at `2edc68ceee32`. Full `llvm/test`: 48368 passed, 77 expected
failures, none unexpected.
