### PR TITLE
[libc] Embeddeding API for seek and close

### DIFF
--- a/libc/config/baremetal/aarch64/entrypoints.txt
+++ b/libc/config/baremetal/aarch64/entrypoints.txt
@@ -128,6 +128,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.stdio.feof
     libc.src.stdio.ferror
     libc.src.stdio.fflush
+    libc.src.stdio.fclose
     libc.src.stdio.fgetc
     libc.src.stdio.fgets
     libc.src.stdio.fprintf
@@ -136,6 +137,10 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.stdio.fread
     libc.src.stdio.fscanf
     libc.src.stdio.fwrite
+    libc.src.stdio.fseek
+    libc.src.stdio.fseeko
+    libc.src.stdio.ftell
+    libc.src.stdio.ftello
     libc.src.stdio.getc
     libc.src.stdio.getchar
     libc.src.stdio.printf

--- a/libc/config/baremetal/arm/entrypoints.txt
+++ b/libc/config/baremetal/arm/entrypoints.txt
@@ -128,6 +128,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.stdio.feof
     libc.src.stdio.ferror
     libc.src.stdio.fflush
+    libc.src.stdio.fclose
     libc.src.stdio.fgetc
     libc.src.stdio.fgets
     libc.src.stdio.fprintf
@@ -136,6 +137,10 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.stdio.fread
     libc.src.stdio.fscanf
     libc.src.stdio.fwrite
+    libc.src.stdio.fseek
+    libc.src.stdio.fseeko
+    libc.src.stdio.ftell
+    libc.src.stdio.ftello
     libc.src.stdio.getc
     libc.src.stdio.getchar
     libc.src.stdio.printf

--- a/libc/src/__support/OSUtil/baremetal/io.h
+++ b/libc/src/__support/OSUtil/baremetal/io.h
@@ -9,8 +9,9 @@
 #ifndef LLVM_LIBC_SRC___SUPPORT_OSUTIL_BAREMETAL_IO_H
 #define LLVM_LIBC_SRC___SUPPORT_OSUTIL_BAREMETAL_IO_H
 
-#include "include/llvm-libc-types/size_t.h"
-#include "include/llvm-libc-types/ssize_t.h"
+#include "hdr/types/off_t.h"
+#include "hdr/types/size_t.h"
+#include "hdr/types/ssize_t.h"
 #include "src/__support/CPP/string_view.h"
 #include "src/__support/macros/config.h"
 
@@ -47,9 +48,21 @@ namespace LIBC_NAMESPACE_DECL {
 
 struct __llvm_libc_stdio_cookie;
 
+// Return the number of bytes read, which can be less than `size` and is zero at
+// end-of-file. On failure, return a negative errno value.
 extern "C" ssize_t __llvm_libc_stdio_read(void *cookie, char *buf, size_t size);
+
+// Return the number of bytes written, which can be less than `size`. On
+// failure, return a negative errno value.
 extern "C" ssize_t __llvm_libc_stdio_write(void *cookie, const char *buf,
                                            size_t size);
+
+// Return the resulting absolute file position on success. On failure, return a
+// negative errno value.
+extern "C" off_t __llvm_libc_stdio_seek(void *cookie, off_t offset, int whence);
+
+// Return 0 on success or EOF on failure, matching fclose.
+extern "C" int __llvm_libc_stdio_close(void *cookie);
 
 void write_to_stderr(cpp::string_view msg);
 

--- a/libc/src/stdio/baremetal/CMakeLists.txt
+++ b/libc/src/stdio/baremetal/CMakeLists.txt
@@ -10,6 +10,61 @@ add_object_library(
     libc.src.__support.OSUtil.osutil
 )
 
+add_entrypoint_object(
+  fclose
+  SRCS fclose.cpp
+  HDRS ../fclose.h
+  DEPENDS
+    libc.src.__support.OSUtil.osutil
+    libc.src.__support.macros.config
+)
+
+add_entrypoint_object(
+  fseek
+  SRCS fseek.cpp
+  HDRS ../fseek.h
+  DEPENDS
+    libc.hdr.errno_macros
+    libc.src.__support.OSUtil.osutil
+    libc.src.__support.macros.config
+    libc.src.errno.errno
+)
+
+add_entrypoint_object(
+  ftell
+  SRCS ftell.cpp
+  HDRS ../ftell.h
+  DEPENDS
+    libc.hdr.errno_macros
+    libc.hdr.stdio_macros
+    libc.src.__support.OSUtil.osutil
+    libc.src.__support.macros.config
+    libc.src.errno.errno
+)
+
+add_entrypoint_object(
+  fseeko
+  SRCS fseeko.cpp
+  HDRS ../fseeko.h
+  DEPENDS
+    libc.hdr.errno_macros
+    libc.src.__support.OSUtil.osutil
+    libc.src.__support.macros.config
+    libc.src.errno.errno
+)
+
+add_entrypoint_object(
+  ftello
+  SRCS ftello.cpp
+  HDRS ../ftello.h
+  DEPENDS
+    libc.hdr.errno_macros
+    libc.hdr.stdio_macros
+    libc.src.__support.OSUtil.osutil
+    libc.src.__support.macros.config
+    libc.src.errno.errno
+)
+
 add_header_library(
   vfprintf_internal
   HDRS

--- a/libc/src/stdio/baremetal/fclose.cpp
+++ b/libc/src/stdio/baremetal/fclose.cpp
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains the bare-metal implementation of fclose.
+///
+//===----------------------------------------------------------------------===//
+
+#include "src/stdio/fclose.h"
+
+#include "src/__support/OSUtil/io.h"
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(int, fclose, (::FILE * stream)) {
+  return __llvm_libc_stdio_close(stream);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/stdio/baremetal/fseek.cpp
+++ b/libc/src/stdio/baremetal/fseek.cpp
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains the bare-metal implementation of fseek.
+///
+//===----------------------------------------------------------------------===//
+
+#include "src/stdio/fseek.h"
+
+#include "hdr/errno_macros.h"
+#include "src/__support/OSUtil/io.h"
+#include "src/__support/common.h"
+#include "src/__support/libc_errno.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(int, fseek, (::FILE * stream, long offset, int whence)) {
+  if (stream == nullptr) {
+    libc_errno = EINVAL;
+    return -1;
+  }
+  off_t result =
+      __llvm_libc_stdio_seek(stream, static_cast<off_t>(offset), whence);
+  if (result < 0) {
+    libc_errno = static_cast<int>(-result);
+    return -1;
+  }
+  return 0;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/stdio/baremetal/fseeko.cpp
+++ b/libc/src/stdio/baremetal/fseeko.cpp
@@ -1,0 +1,37 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains the bare-metal implementation of fseeko.
+///
+//===----------------------------------------------------------------------===//
+
+#include "src/stdio/fseeko.h"
+
+#include "hdr/errno_macros.h"
+#include "src/__support/OSUtil/io.h"
+#include "src/__support/common.h"
+#include "src/__support/libc_errno.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(int, fseeko, (::FILE * stream, off_t offset, int whence)) {
+  if (stream == nullptr) {
+    libc_errno = EINVAL;
+    return -1;
+  }
+  off_t result = __llvm_libc_stdio_seek(stream, offset, whence);
+  if (result < 0) {
+    libc_errno = static_cast<int>(-result);
+    return -1;
+  }
+  return 0;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/stdio/baremetal/ftell.cpp
+++ b/libc/src/stdio/baremetal/ftell.cpp
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains the bare-metal implementation of ftell.
+///
+//===----------------------------------------------------------------------===//
+
+#include "src/stdio/ftell.h"
+
+#include "hdr/errno_macros.h"
+#include "hdr/stdio_macros.h"
+#include "src/__support/OSUtil/io.h"
+#include "src/__support/common.h"
+#include "src/__support/libc_errno.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(long, ftell, (::FILE * stream)) {
+  if (stream == nullptr) {
+    libc_errno = EINVAL;
+    return -1;
+  }
+  off_t result = __llvm_libc_stdio_seek(stream, 0, SEEK_CUR);
+  if (result < 0) {
+    libc_errno = static_cast<int>(-result);
+    return -1;
+  }
+  return static_cast<long>(result);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/stdio/baremetal/ftello.cpp
+++ b/libc/src/stdio/baremetal/ftello.cpp
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains the bare-metal implementation of ftello.
+///
+//===----------------------------------------------------------------------===//
+
+#include "src/stdio/ftello.h"
+
+#include "hdr/errno_macros.h"
+#include "hdr/stdio_macros.h"
+#include "src/__support/OSUtil/io.h"
+#include "src/__support/common.h"
+#include "src/__support/libc_errno.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(off_t, ftello, (::FILE * stream)) {
+  if (stream == nullptr) {
+    libc_errno = EINVAL;
+    return static_cast<off_t>(-1);
+  }
+  off_t result = __llvm_libc_stdio_seek(stream, 0, SEEK_CUR);
+  if (result < 0) {
+    libc_errno = static_cast<int>(-result);
+    return static_cast<off_t>(-1);
+  }
+  return result;
+}
+
+} // namespace LIBC_NAMESPACE_DECL


### PR DESCRIPTION
This change introduces two new symbols to the embedding API hooks: __llvm_libc_stdio_seek and __llvm_libc_stdio_close. These are used to implement fclose, fseek, fseeko, ftell and ftello for baremetal.

The implementation was extracted from #221211.

Authored-by: voltur01