### PR TITLE
[LLVM-C] Add LLVMBuildByteCast

### DIFF
--- a/llvm/include/llvm-c/Core.h
+++ b/llvm/include/llvm-c/Core.h
@@ -5063,6 +5063,8 @@ LLVM_C_ABI LLVMValueRef LLVMBuildIntToPtr(LLVMBuilderRef, LLVMValueRef Val,
                                           LLVMTypeRef DestTy, const char *Name);
 LLVM_C_ABI LLVMValueRef LLVMBuildBitCast(LLVMBuilderRef, LLVMValueRef Val,
                                          LLVMTypeRef DestTy, const char *Name);
+LLVM_C_ABI LLVMValueRef LLVMBuildByteCast(LLVMBuilderRef, LLVMValueRef Val,
+                                          LLVMTypeRef DestTy, const char *Name);
 LLVM_C_ABI LLVMValueRef LLVMBuildAddrSpaceCast(LLVMBuilderRef, LLVMValueRef Val,
                                                LLVMTypeRef DestTy,
                                                const char *Name);

--- a/llvm/lib/IR/Core.cpp
+++ b/llvm/lib/IR/Core.cpp
@@ -4358,6 +4358,12 @@ LLVMValueRef LLVMBuildBitCast(LLVMBuilderRef B, LLVMValueRef Val,
   return wrap(unwrap(B)->CreateBitCast(unwrap(Val), unwrap(DestTy), Name));
 }
 
+LLVMValueRef LLVMBuildByteCast(LLVMBuilderRef B, LLVMValueRef Val,
+                               LLVMTypeRef DestTy, const char *Name) {
+  return wrap(unwrap(B)->CreateCast(Instruction::ByteCast, unwrap(Val),
+                                    unwrap(DestTy), Name));
+}
+
 LLVMValueRef LLVMBuildAddrSpaceCast(LLVMBuilderRef B, LLVMValueRef Val,
                                     LLVMTypeRef DestTy, const char *Name) {
   return wrap(unwrap(B)->CreateAddrSpaceCast(unwrap(Val), unwrap(DestTy), Name));

--- a/llvm/test/Bindings/llvm-c/bytecast.ll
+++ b/llvm/test/Bindings/llvm-c/bytecast.ll
@@ -1,0 +1,53 @@
+; RUN: llvm-as < %s | llvm-dis > %t.orig
+; RUN: llvm-as < %s | llvm-c-test --echo > %t.echo
+; RUN: diff -w %t.orig %t.echo
+
+define b64 @int_to_byte(i64 %i) {
+  %b = bytecast i64 %i to b64
+  ret b64 %b
+}
+
+define i64 @byte_to_int(b64 %b) {
+  %i = bytecast b64 %b to i64
+  ret i64 %i
+}
+
+define double @byte_to_fp(b64 %b) {
+  %d = bytecast b64 %b to double
+  ret double %d
+}
+
+define b64 @fp_to_byte(double %d) {
+  %b = bytecast double %d to b64
+  ret b64 %b
+}
+
+define ptr @byte_to_ptr(b64 %b) {
+  %p = bytecast b64 %b to ptr
+  ret ptr %p
+}
+
+define b64 @ptr_to_byte(ptr %p) {
+  %b = bytecast ptr %p to b64
+  ret b64 %b
+}
+
+define ptr addrspace(1) @byte_to_ptr_as1(b64 %b) {
+  %p = bytecast b64 %b to ptr addrspace(1)
+  ret ptr addrspace(1) %p
+}
+
+define <4 x i8> @byte_vector_to_int_vector(<4 x b8> %b) {
+  %i = bytecast <4 x b8> %b to <4 x i8>
+  ret <4 x i8> %i
+}
+
+define i64 @byte_vector_to_scalar(<2 x b32> %b) {
+  %i = bytecast <2 x b32> %b to i64
+  ret i64 %i
+}
+
+define <2 x b32> @scalar_to_byte_vector(i64 %i) {
+  %b = bytecast i64 %i to <2 x b32>
+  ret <2 x b32> %b
+}

--- a/llvm/tools/llvm-c-test/echo.cpp
+++ b/llvm/tools/llvm-c-test/echo.cpp
@@ -814,6 +814,11 @@ struct FunCloner {
         Dst = LLVMBuildBitCast(Builder, V, CloneType(Src), Name);
         break;
       }
+      case LLVMByteCast: {
+        LLVMValueRef V = CloneValue(LLVMGetOperand(Src, 0));
+        Dst = LLVMBuildByteCast(Builder, V, CloneType(Src), Name);
+        break;
+      }
       case LLVMICmp: {
         LLVMIntPredicate Pred = LLVMGetICmpPredicate(Src);
         LLVMBool IsSameSign = LLVMGetICmpSameSign(Src);


### PR DESCRIPTION
## Summary
- Add `LLVMBuildByteCast` C API builder mirroring `LLVMBuildBitCast`.
- Teach `llvm-c-test --echo` to clone `bytecast` instructions via the new builder.
- Add `llvm/test/Bindings/llvm-c/bytecast.ll` round-trip coverage.

## Test plan
- [x] `ninja check-llvm` passes on this branch
- [x] `llvm/test/Bindings/llvm-c/bytecast.ll` passes

Depends on #221884


Made with [Cursor](https://cursor.com)