### PR TITLE
[RISCV][MC]Fix encoding for psati.dw/dh

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
@@ -367,8 +367,8 @@ class RVPPairShift_ri<bits<3> f, bit direction, string opcodestr,
 }
 
 class RVPPairShiftW_ri<bits<3> f, bit direction, string opcodestr,
-                       bit DefVXSAT = 0>
-    : RVPPairShift_ri<f, direction, opcodestr, uimm5, DefVXSAT> {
+                       Operand ImmType = uimm5, bit DefVXSAT = 0>
+    : RVPPairShift_ri<f, direction, opcodestr, ImmType, DefVXSAT> {
   bits<5> shamt;
 
   let Inst{26-25} = 0b01;
@@ -376,8 +376,8 @@ class RVPPairShiftW_ri<bits<3> f, bit direction, string opcodestr,
 }
 
 class RVPPairShiftH_ri<bits<3> f, bit direction, string opcodestr,
-                       bit DefVXSAT = 0>
-    : RVPPairShift_ri<f, direction, opcodestr, uimm4, DefVXSAT> {
+                       Operand ImmType = uimm4, bit DefVXSAT = 0>
+    : RVPPairShift_ri<f, direction, opcodestr, ImmType, DefVXSAT> {
   bits<4> shamt;
 
   let Inst{26-24} = 0b001;
@@ -1457,8 +1457,10 @@ let append Predicates = [IsRV32] in {
   def PSRARI_DH    : RVPPairShiftH_ri<0b101, 0b1, "psrari.dh">;
   def PSRARI_DW    : RVPPairShiftW_ri<0b101, 0b1, "psrari.dw">;
 
-  def PSATI_DH     : RVPPairShiftH_ri<0b110, 0b1, "psati.dh", DefVXSAT=1>;
-  def PSATI_DW     : RVPPairShiftW_ri<0b110, 0b1, "psati.dw", DefVXSAT=1>;
+  def PSATI_DH     : RVPPairShiftH_ri<0b110, 0b1, "psati.dh", uimm4_plus1,
+                                      DefVXSAT=1>;
+  def PSATI_DW     : RVPPairShiftW_ri<0b110, 0b1, "psati.dw", uimm5_plus1,
+                                      DefVXSAT=1>;
 
   def PSRL_DHS     : RVPPairShift_rr<0b000, 0b00, 0b1, "psrl.dhs">;
   def PSRL_DWS     : RVPPairShift_rr<0b000, 0b01, 0b1, "psrl.dws">;

--- a/llvm/test/MC/RISCV/rv32p-invalid.s
+++ b/llvm/test/MC/RISCV/rv32p-invalid.s
@@ -40,6 +40,10 @@ srari ra, sp, 100 # CHECK: :[[@LINE]]:15: error: immediate must be an integer in
 psati.h ra, sp, 100 # CHECK: :[[@LINE]]:17: error: immediate must be an integer in the range [1, 16]
 psati.w ra, sp, 24 # CHECK: :[[@LINE]]:1: error: instruction requires the following: RV64I Base Instruction Set
 sati ra, sp, 100 # CHECK: :[[@LINE]]:14: error: immediate must be an integer in the range [1, 32]
+psati.dh a0, a2, 0 # CHECK: :[[@LINE]]:18: error: immediate must be an integer in the range [1, 16]
+psati.dh a0, a2, 17 # CHECK: :[[@LINE]]:18: error: immediate must be an integer in the range [1, 16]
+psati.dw a0, a2, 0 # CHECK: :[[@LINE]]:18: error: immediate must be an integer in the range [1, 32]
+psati.dw a0, a2, 33 # CHECK: :[[@LINE]]:18: error: immediate must be an integer in the range [1, 32]
 
 psrl.ws a0, a1, a2 # CHECK: :[[@LINE]]:1: error: instruction requires the following: RV64I Base Instruction Set
 predsum.ws a0, a1, a2 # CHECK: :[[@LINE]]:1: error: instruction requires the following: RV64I Base Instruction Set

--- a/llvm/test/MC/RISCV/rv32p-valid.s
+++ b/llvm/test/MC/RISCV/rv32p-valid.s
@@ -1120,10 +1120,10 @@ psrari.dh a2, a2, 6
 # CHECK-ASM: encoding: [0x1b,0xe7,0x55,0x52]
 psrari.dw a4, a0, 5
 # CHECK-ASM-AND-OBJ: psati.dh s2, s2, 9
-# CHECK-ASM: encoding: [0x1b,0xe9,0x99,0x61]
+# CHECK-ASM: encoding: [0x1b,0xe9,0x89,0x61]
 psati.dh s2, s2, 9
 # CHECK-ASM-AND-OBJ: psati.dw t5, t3, 14
-# CHECK-ASM: encoding: [0x1b,0xef,0xee,0x62]
+# CHECK-ASM: encoding: [0x1b,0xef,0xde,0x62]
 psati.dw t5, t3, 14
 # CHECK-ASM-AND-OBJ: psrl.dhs a0, t1, t5
 # CHECK-ASM: encoding: [0x1b,0xe5,0xe3,0x09]


### PR DESCRIPTION
psati.dh: the width is specified by uimm4+1.
psati.dw: the width is specified by uimm5+1.
https://github.com/riscv/riscv-p-spec/blob/master/P-ext-proposal.adoc#psati-dh-rv32