### PR TITLE
[VPlan] Introduce VPlan::getOne (NFC)

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlan.h
+++ b/llvm/lib/Transforms/Vectorize/VPlan.h
@@ -5172,8 +5172,11 @@ public:
   /// Return a VPIRValue wrapping the null value of type \p Ty.
   VPIRValue *getZero(Type *Ty) { return getConstantInt(Ty, 0); }
 
+  /// Return a VPIRValue wrapping 1 of type \p Ty.
+  VPIRValue *getOne(Type *Ty) { return getConstantInt(Ty, 1); }
+
   /// Return a VPIRValue wrapping the AllOnes value of type \p Ty.
-  VPIRValue *getAllOnesValue(Type *Ty) {
+  VPIRValue *getAllOnes(Type *Ty) {
     return getConstantInt(APInt::getAllOnes(Ty->getIntegerBitWidth()));
   }
 

--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
@@ -957,7 +957,7 @@ static VPValue *optimizeEarlyExitInductionUser(VPlan &Plan, VPValue *Op,
   // changed it means the exit is using the incremented value, so we need to
   // add the step.
   if (Incoming != WideIV) {
-    VPValue *One = Plan.getConstantInt(CanonicalIVType, 1);
+    VPValue *One = Plan.getOne(CanonicalIVType);
     EndValue = B.createAdd(EndValue, One, DL);
   }
 
@@ -1086,7 +1086,7 @@ static VPValue *optimizeLatchExitIVUserViaSCEV(VPlan &Plan, VPValue *Op,
                              : InductionDescriptor::IK_IntInduction;
   Type *TCTy = ResumeTC->getScalarType();
   VPValue *ExitCount = Builder.createOverflowingOp(
-      Instruction::Sub, {ResumeTC, Plan.getConstantInt(TCTy, 1)},
+      Instruction::Sub, {ResumeTC, Plan.getOne(TCTy)},
       {/*HasNUW=*/true, /*HasNSW=*/false}, DebugLoc::getUnknown());
   return Builder.createDerivedIV(Kind, /*FPBinOp=*/nullptr, StartVPV, ExitCount,
                                  StepVPV);
@@ -1185,7 +1185,7 @@ static VPValue *simplifyLogicalRecipe(VPlan &Plan, VPSingleDefRecipe *Def,
 
   // x | AllOnes -> AllOnes
   if (match(Def, m_c_BinaryOr(m_VPValue(X), m_AllOnes())))
-    return Plan.getAllOnesValue(Def->getScalarType());
+    return Plan.getAllOnes(Def->getScalarType());
 
   // x | 0 -> x
   if (match(Def, m_c_BinaryOr(m_VPValue(X), m_ZeroInt())))
@@ -1193,7 +1193,7 @@ static VPValue *simplifyLogicalRecipe(VPlan &Plan, VPSingleDefRecipe *Def,
 
   // x | !x -> AllOnes
   if (match(Def, m_c_BinaryOr(m_VPValue(X), m_Not(m_Deferred(X)))))
-    return Plan.getAllOnesValue(Def->getScalarType());
+    return Plan.getAllOnes(Def->getScalarType());
 
   // x & 0 -> 0
   if (match(Def, m_c_BinaryAnd(m_VPValue(X), m_ZeroInt())))
@@ -1801,9 +1801,9 @@ static void narrowToSingleScalarRecipes(VPlan &Plan) {
         if (!Opc)
           continue;
         VPBuilder Builder(IntrR);
-        VPValue *SafeDivisor = Builder.createSelect(
-            IntrR->getOperand(2), IntrR->getOperand(1),
-            Plan.getConstantInt(IntrR->getScalarType(), 1));
+        VPValue *SafeDivisor =
+            Builder.createSelect(IntrR->getOperand(2), IntrR->getOperand(1),
+                                 Plan.getOne(IntrR->getScalarType()));
         VPValue *Clone = Builder.createNaryOp(
             *Opc, {IntrR->getOperand(0), SafeDivisor},
             VPIRFlags::getDefaultFlags(*Opc), IntrR->getDebugLoc());
@@ -2010,9 +2010,9 @@ static bool optimizeVectorInductionWidthForTCAndVFUF(VPlan &Plan,
     assert(!WideIV->getTruncInst() &&
            "canonical IV is not expected to have a truncation");
     auto *NewWideIV = new VPWidenIntOrFpInductionRecipe(
-        WideIV->getPHINode(), Plan.getZero(NewIVTy),
-        Plan.getConstantInt(NewIVTy, 1), WideIV->getVFValue(),
-        WideIV->getInductionDescriptor(), *WideIV, WideIV->getDebugLoc());
+        WideIV->getPHINode(), Plan.getZero(NewIVTy), Plan.getOne(NewIVTy),
+        WideIV->getVFValue(), WideIV->getInductionDescriptor(), *WideIV,
+        WideIV->getDebugLoc());
     NewWideIV->insertBefore(WideIV);
 
     auto *NewBTC = new VPWidenCastRecipe(
@@ -4326,7 +4326,7 @@ VPlanTransforms::narrowInterleaveGroups(VPlan &Plan,
     Plan.getVF().replaceAllUsesWith(VScale);
   } else {
     Step = UF;
-    Plan.getVF().replaceAllUsesWith(Plan.getConstantInt(CanIVTy, 1));
+    Plan.getVF().replaceAllUsesWith(Plan.getOne(CanIVTy));
   }
   // Materialize vector trip count with the narrowed step.
   materializeVectorTripCount(Plan, VectorPH, /*TailByMasking=*/false,


### PR DESCRIPTION
Similar to ScalarEvolution::getOne. While at it, rename getAllOnesValue to getAllOnes for consistency.