### PR TITLE
[mlir][llvm] Gate unhandled function metadata warning

### DIFF
--- a/mlir/lib/Target/LLVMIR/ModuleImport.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleImport.cpp
@@ -3381,6 +3381,8 @@ LogicalResult ModuleImport::processFunction(llvm::Function *func) {
 
     llvm::MDNode *metadataNode = node;
     auto emitUnhandledFunctionMetadataWarning = [&]() {
+      if (!emitExpensiveWarnings)
+        return;
       emitWarning(funcOp.getLoc())
           << "unhandled function metadata: "
           << diagMD(metadataNode, llvmModule.get()) << " on " << diag(*func);

--- a/mlir/test/Target/LLVMIR/Import/function-attributes.ll
+++ b/mlir/test/Target/LLVMIR/Import/function-attributes.ll
@@ -1,4 +1,4 @@
-; RUN: mlir-translate -import-llvm -split-input-file %s --verify-diagnostics | FileCheck %s
+; RUN: mlir-translate -import-llvm -emit-expensive-warnings -split-input-file %s --verify-diagnostics | FileCheck %s
 
 ; CHECK: llvm.func internal @func_internal
 define internal void @func_internal() {

--- a/mlir/test/Target/LLVMIR/Import/function-metadata.ll
+++ b/mlir/test/Target/LLVMIR/Import/function-metadata.ll
@@ -1,5 +1,5 @@
-; RUN: mlir-translate -import-llvm -split-input-file %s | FileCheck %s
-; RUN: mlir-translate -import-llvm -split-input-file %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=WARN
+; RUN: mlir-translate -import-llvm -split-input-file %s --verify-diagnostics | FileCheck %s
+; RUN: mlir-translate -import-llvm -emit-expensive-warnings -split-input-file %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=WARN
 
 ; CHECK-LABEL: llvm.func @repeated_type_metadata
 ; CHECK-SAME: function_metadata


### PR DESCRIPTION
Emit the warning for unhandled function metadata only when expensive warnings are requested, matching how the flag is already used for instruction metadata.

Co-Authored-By: Claude Opus 5