### PR TITLE
[GlobalISel] Lazily reserve worklist maps (NFC)

### DIFF
--- a/llvm/include/llvm/CodeGen/GlobalISel/GISelWorkList.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/GISelWorkList.h
@@ -33,8 +33,6 @@ class GISelWorkList {
 #endif
 
 public:
-  GISelWorkList() : WorklistMap(N) {}
-
   bool empty() const { return WorklistMap.empty(); }
 
   unsigned size() const { return WorklistMap.size(); }
@@ -60,8 +58,8 @@ public:
   // It also asserts if there are any duplicate elements found.
   void finalize() {
     assert(WorklistMap.empty() && "Expecting empty worklistmap");
-    if (Worklist.size() > N)
-      WorklistMap.reserve(Worklist.size());
+    if (!Worklist.empty())
+      WorklistMap.reserve(Worklist.size() > N ? Worklist.size() : N);
     for (unsigned i = 0; i < Worklist.size(); ++i)
       if (!WorklistMap.try_emplace(Worklist[i], i).second)
         llvm_unreachable("Duplicate elements in the list");


### PR DESCRIPTION
Small -0.03% geomean improvement on CTMark aarch64-O0-g, but consistent little improvements across the board.

https://llvm-compile-time-tracker.com/compare.php?from=97cbc1e404b980edc58bfbcabb6f1c61793b624b&to=1729db67721b79fcb72469111d543e6df28c1185&stat=instructions:u

Assisted-by: codex