### PR TITLE
[GlobalISel] Fix duplicate finalizeLowering calls (NFC)

### DIFF
--- a/llvm/lib/CodeGen/FinalizeISel.cpp
+++ b/llvm/lib/CodeGen/FinalizeISel.cpp
@@ -47,7 +47,9 @@ static std::pair<bool, bool> runImpl(MachineFunction &MF) {
   const TargetInstrInfo *TII = MF.getSubtarget().getInstrInfo();
   const TargetLowering *TLI = MF.getSubtarget().getTargetLowering();
 
-  TLI->finalizeLowering(MF);
+  // GlobalISel finalizes lowering in InstructionSelect.
+  if (!MF.getProperties().hasSelected())
+    TLI->finalizeLowering(MF);
 
   // Iterate through each instruction in the function, looking for pseudos.
   for (MachineFunction::iterator I = MF.begin(), E = MF.end(); I != E; ++I) {

--- a/llvm/lib/CodeGen/GlobalISel/InstructionSelect.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/InstructionSelect.cpp
@@ -342,7 +342,6 @@ bool InstructionSelectImpl::selectMachineFunction(MachineFunction &MF) {
     }
   }
 
-  // FIXME: FinalizeISel pass calls finalizeLowering, so it's called twice.
   auto &TLI = *MF.getSubtarget().getTargetLowering();
   TLI.finalizeLowering(MF);
 

--- a/llvm/lib/Target/SPIRV/SPIRVISelLowering.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVISelLowering.cpp
@@ -523,8 +523,6 @@ static void validateVec1Ops(const SPIRVSubtarget &STI, MachineRegisterInfo *MRI,
 // TODO: the logic of inserting additional bitcast's is to be moved
 // to pre-IRTranslation passes eventually
 void SPIRVTargetLowering::finalizeLowering(MachineFunction &MF) const {
-  // finalizeLowering() is called twice (see GlobalISel/InstructionSelect.cpp)
-  // We'd like to avoid the needless second processing pass.
   if (MF.getRegInfo().reservedRegsFrozen())
     return;
 


### PR DESCRIPTION
Improves CTMark geomean -0.07% on aarch64-O0-g.

https://llvm-compile-time-tracker.com/compare.php?from=97cbc1e404b980edc58bfbcabb6f1c61793b624b&to=d8b1a78ba013d5e687acc0e8bf00d3d77749f3db&stat=instructions:u

Assisted-by: codex