### PR TITLE
[flang] Add -fdisable-real-16 option

### DIFF
--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -189,6 +189,9 @@ def warn_openmp_spec_incomplete : Warning<
   "the specification for OpenMP version %0 is still under development; "
   "the syntax and semantics of new features may be subject to change">,
   InGroup<ExperimentalOption>;
+def warn_real_kind_consistency_for_flang : Warning<
+  "'-fdisable-real-16' may cause SELECTED_REAL_KIND to return inconsistent results">,
+  InGroup<DiagGroup<"disable-real-16">>;
 def err_drv_invalid_thread_model_for_target : Error<
   "invalid thread model '%0' in '%1' for this target">;
 def err_drv_invalid_linker_name : Error<

--- a/clang/include/clang/Options/FlangOptions.td
+++ b/clang/include/clang/Options/FlangOptions.td
@@ -167,6 +167,8 @@ def fdisable_integer_2 : Flag<["-"],"fdisable-integer-2">, Group<f_Group>,
   HelpText<"Disable integer(KIND=2) from TargetCharacteristics">, Flags<[HelpHidden]>;
 def fdisable_integer_16 : Flag<["-"],"fdisable-integer-16">, Group<f_Group>,
   HelpText<"Disable integer(KIND=16) from TargetCharacteristics">, Flags<[HelpHidden]>;
+def fdisable_real_16 : Flag<["-"], "fdisable-real-16">, Group<f_Group>,
+  HelpText<"Disable real(KIND=16) from TargetCharacteristics">, Flags<[HelpHidden]>;
 def flarge_sizes : Flag<["-"],"flarge-sizes">, Group<f_Group>,
   HelpText<"Use INTEGER(KIND=8) for the result type in size-related intrinsics">;
 

--- a/clang/lib/Driver/ToolChains/Flang.cpp
+++ b/clang/lib/Driver/ToolChains/Flang.cpp
@@ -812,7 +812,8 @@ void Flang::addTargetOptions(const ArgList &Args, ArgStringList &CmdArgs,
                    options::OPT_fno_atomic_fine_grained_memory,
                    options::OPT_fatomic_remote_memory,
                    options::OPT_fno_atomic_remote_memory,
-                   options::OPT_munsafe_fp_atomics});
+                   options::OPT_munsafe_fp_atomics,
+                   options::OPT_fdisable_real_16});
 }
 
 void Flang::addOffloadOptions(Compilation &C, const InputInfoList &Inputs,

--- a/flang/lib/Frontend/CompilerInvocation.cpp
+++ b/flang/lib/Frontend/CompilerInvocation.cpp
@@ -575,7 +575,9 @@ static void parseCodeGenArgs(Fortran::frontend::CodeGenOptions &opts,
 ///
 /// \param [in] opts The target options instance to update
 /// \param [in] args The list of input arguments (from the compiler invocation)
-static void parseTargetArgs(TargetOptions &opts, llvm::opt::ArgList &args) {
+/// \param [out] diags DiagnosticsEngine to report errors with
+static void parseTargetArgs(TargetOptions &opts, llvm::opt::ArgList &args,
+                            clang::DiagnosticsEngine &diags) {
   if (const llvm::opt::Arg *a = args.getLastArg(clang::options::OPT_triple))
     opts.triple = a->getValue();
 
@@ -604,6 +606,11 @@ static void parseTargetArgs(TargetOptions &opts, llvm::opt::ArgList &args) {
 
   if (args.hasArg(clang::options::OPT_fdisable_real_3))
     opts.disabledRealKinds.push_back(3);
+
+  if (args.hasArg(clang::options::OPT_fdisable_real_16)) {
+    opts.disabledRealKinds.push_back(16);
+    diags.Report(clang::diag::warn_real_kind_consistency_for_flang);
+  }
 
   if (args.hasArg(clang::options::OPT_fdisable_integer_2))
     opts.disabledIntegerKinds.push_back(2);
@@ -1452,7 +1459,7 @@ static bool parseOpenMPArgs(CompilerInvocation &res, llvm::opt::ArgList &args,
 ///
 /// \param [out] invoc Stores the processed arguments
 /// \param [in] args The compiler invocation arguments to parse
-/// \param [out] diags DiagnosticsEngine to report erros with
+/// \param [out] diags DiagnosticsEngine to report errors with
 static bool parseIntegerOverflowArgs(CompilerInvocation &invoc,
                                      llvm::opt::ArgList &args,
                                      clang::DiagnosticsEngine &diags) {
@@ -1518,7 +1525,7 @@ static void setIEEEFPModesArgs(Fortran::common::LangOptions &opts,
 ///
 /// \param [out] invoc Stores the processed arguments
 /// \param [in] args The compiler invocation arguments to parse
-/// \param [out] diags DiagnosticsEngine to report erros with
+/// \param [out] diags DiagnosticsEngine to report errors with
 static bool parseFloatingPointArgs(CompilerInvocation &invoc,
                                    llvm::opt::ArgList &args,
                                    clang::DiagnosticsEngine &diags) {
@@ -1598,7 +1605,7 @@ static bool parseFloatingPointArgs(CompilerInvocation &invoc,
 ///
 /// \param [out] invoc Stores the processed arguments
 /// \param [in] args The compiler invocation arguments to parse
-/// \param [out] diags DiagnosticsEngine to report erros with
+/// \param [out] diags DiagnosticsEngine to report errors with
 static bool parseVScaleArgs(CompilerInvocation &invoc, llvm::opt::ArgList &args,
                             clang::DiagnosticsEngine &diags) {
   const auto *vscaleMin = args.getLastArg(clang::options::OPT_mvscale_min_EQ);
@@ -1830,7 +1837,7 @@ bool CompilerInvocation::createFromArgs(
   }
 
   success &= parseFrontendArgs(invoc.getFrontendOpts(), args, diags);
-  parseTargetArgs(invoc.getTargetOpts(), args);
+  parseTargetArgs(invoc.getTargetOpts(), args, diags);
   parsePreprocessorArgs(invoc.getPreprocessorOpts(), args);
   parseCodeGenArgs(invoc.getCodeGenOpts(), args, diags);
   success &= parseDoConcurrentMapping(invoc.getCodeGenOpts(), args, diags);

--- a/flang/test/Driver/disable-real-16.f90
+++ b/flang/test/Driver/disable-real-16.f90
@@ -1,0 +1,10 @@
+! Test -fdisable-real-16 works as expected.
+
+! RUN: %flang -### -c %s 2>&1 \
+! RUN:   | FileCheck %s --check-prefix=NO-OPTION
+
+! RUN: %flang -### -c -fdisable-real-16 %s 2>&1 \
+! RUN:   | FileCheck %s --check-prefix=DISABLE
+
+! NO-OPTION-NOT: -fdisable-real-16
+! DISABLE: -fdisable-real-16

--- a/flang/test/Evaluate/fold-selected_real_kind-disable-16.f90
+++ b/flang/test/Evaluate/fold-selected_real_kind-disable-16.f90
@@ -1,0 +1,7 @@
+! Tests folding of SELECTED_REAL_KIND
+
+! RUN: %python %S/test_folding.py %s %flang_fc1 -fdisable-real-16
+
+module m
+  logical, parameter :: test_16 = selected_real_kind(p=33) == -1
+end

--- a/flang/test/Lower/disable-real-16.f90
+++ b/flang/test/Lower/disable-real-16.f90
@@ -1,0 +1,11 @@
+! Ensure argument -fdisable-real-16 works as expected.
+
+! RUN: not %flang_fc1 -emit-hlfir -fdisable-real-16 %s -o - 2>&1 | FileCheck %s --check-prefixes=F128-DISABLE,WARN
+
+! WARN: warning: '-fdisable-real-16' may cause SELECTED_REAL_KIND to return inconsistent results [-Wdisable-real-16]
+! F128-DISABLE: error: REAL(KIND=16) is not an enabled type for this target
+! F128-DISABLE: error: COMPLEX(KIND=16) is not an enabled type for this target
+subroutine test_r16()
+  real(16) :: r0
+  complex(16) :: c0
+end subroutine


### PR DESCRIPTION
Add a new option, -fdisable-real-16, that forces REAL(16) to be treated as unavailable regardless of target capabilities.

This option prevents constant folding from reporting that kind=16 is available, as in the following example:

  integer, parameter :: k = merge(16, 4, &
    selected_real_kind(p=33) .eq. 16)
  real(kind=k) :: r

In particular, it avoids cases where selected_real_kind(p=33) evaluates to 16 at compile time and causes code to depend on unavailable quadruple-precision runtime libraries, leading to link failures.