### PR TITLE
[compiler-rt] Add llvm-link deps when building compiler-rt builtins for spirv64 targets

### DIFF
--- a/llvm/runtimes/CMakeLists.txt
+++ b/llvm/runtimes/CMakeLists.txt
@@ -221,8 +221,15 @@ if(compiler_rt_path)
   foreach(target ${builtin_targets})
     check_apple_target(${target} builtin)
 
+    # builtins-spirv64* targets will invoke llvm-link to combine all
+    # bitcode from static archive library into libclang_rt.builtins.bc.
+    # Need to add dependency on llvm-link for it.
+    set(builtin_deps clang-resource-headers)
+    if(target MATCHES "^spirv64" AND TARGET llvm-link)
+      list(APPEND builtin_deps llvm-link)
+    endif()
     builtin_register_target(${compiler_rt_path} ${target}
-      DEPENDS clang-resource-headers
+      DEPENDS ${builtin_deps}
       CMAKE_ARGS -DLLVM_DEFAULT_TARGET_TRIPLE=${target}
       EXTRA_ARGS TARGET_TRIPLE ${target})
 


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/214149 uses llvm-link to create libclang_rt.builtins.bc from static archive library. It is better to follow libclc approach to add llvm-link dependency for builtin-spirv64* in llvm runtime CMakeLists.txt.