### PR TITLE
[Clang][WebAssembly] Add wasm_global declaration attribute

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -2602,6 +2602,12 @@ def WebAssemblyImportName : InheritableAttr,
   let Subjects = SubjectList<[Function, GlobalVar], ErrorDiag>;
 }
 
+def WebAssemblyGlobal : InheritableAttr, TargetSpecificAttr<TargetWebAssembly> {
+  let Spellings = [Clang<"wasm_global">];
+  let Documentation = [WebAssemblyGlobalDocs];
+  let Subjects = SubjectList<[GlobalVar], ErrorDiag>;
+}
+
 def NoSplitStack : InheritableAttr {
   let Spellings = [GCC<"no_split_stack">];
   let Subjects = SubjectList<[Function], ErrorDiag>;

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -7337,6 +7337,18 @@ request a specific field name be used instead.
   }];
 }
 
+def WebAssemblyGlobalDocs : Documentation {
+  let Category = DocCatVariable;
+  let Content = [{
+Clang supports the `[[clang::wasm_global]]` attribute for the WebAssembly
+target. This attribute declares that a variable is stored as a WebAssembly
+global rather than in linear memory.
+
+WebAssembly globals can be imported or exported using the
+`import_module`, `import_name`, and `export_name` attributes.
+  }];
+}
+
 def ArtificialDocs : Documentation {
   let Category = DocCatFunction;
   let Content = [{

--- a/clang/include/clang/Sema/SemaWasm.h
+++ b/clang/include/clang/Sema/SemaWasm.h
@@ -50,6 +50,7 @@ public:
   void handleWebAssemblyExportNameAttr(Decl *D, const ParsedAttr &AL);
   void handleWebAssemblyImportModuleAttr(Decl *D, const ParsedAttr &AL);
   void handleWebAssemblyImportNameAttr(Decl *D, const ParsedAttr &AL);
+  void handleWebAssemblyGlobalAttr(Decl *D, const ParsedAttr &AL);
 };
 } // namespace clang
 

--- a/clang/lib/CodeGen/Targets/WebAssembly.cpp
+++ b/clang/lib/CodeGen/Targets/WebAssembly.cpp
@@ -9,6 +9,7 @@
 #include "ABIInfoImpl.h"
 #include "TargetInfo.h"
 #include "clang/Basic/DiagnosticFrontend.h"
+#include "llvm/Support/WasmAddressSpaces.h"
 
 using namespace clang;
 using namespace clang::CodeGen;
@@ -53,6 +54,14 @@ public:
       : TargetCodeGenInfo(std::make_unique<WebAssemblyABIInfo>(CGT, K)) {
     SwiftInfo =
         std::make_unique<SwiftABIInfo>(CGT, /*SwiftErrorInRegister=*/false);
+  }
+
+  LangAS getGlobalVarAddressSpace(CodeGenModule &CGM,
+                                  const VarDecl *D) const override {
+    if (D && D->hasAttr<WebAssemblyGlobalAttr>())
+      return getLangASFromTargetAS(
+          llvm::WebAssembly::WASM_ADDRESS_SPACE_VAR);
+    return TargetCodeGenInfo::getGlobalVarAddressSpace(CGM, D);
   }
 
   void setTargetAttributes(const Decl *D, llvm::GlobalValue *GV,

--- a/clang/lib/CodeGen/Targets/WebAssembly.cpp
+++ b/clang/lib/CodeGen/Targets/WebAssembly.cpp
@@ -59,8 +59,7 @@ public:
   LangAS getGlobalVarAddressSpace(CodeGenModule &CGM,
                                   const VarDecl *D) const override {
     if (D && D->hasAttr<WebAssemblyGlobalAttr>())
-      return getLangASFromTargetAS(
-          llvm::WebAssembly::WASM_ADDRESS_SPACE_VAR);
+      return getLangASFromTargetAS(llvm::WebAssembly::WASM_ADDRESS_SPACE_VAR);
     return TargetCodeGenInfo::getGlobalVarAddressSpace(CGM, D);
   }
 

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -7750,6 +7750,9 @@ ProcessDeclAttribute(Sema &S, Decl *D, const ParsedAttr &AL,
   case ParsedAttr::AT_WebAssemblyImportName:
     S.Wasm().handleWebAssemblyImportNameAttr(D, AL);
     break;
+  case ParsedAttr::AT_WebAssemblyGlobal:
+    S.Wasm().handleWebAssemblyGlobalAttr(D, AL);
+    break;
   case ParsedAttr::AT_IBOutlet:
     S.ObjC().handleIBOutlet(D, AL);
     break;

--- a/clang/lib/Sema/SemaWasm.cpp
+++ b/clang/lib/Sema/SemaWasm.cpp
@@ -462,8 +462,8 @@ void SemaWasm::handleWebAssemblyGlobalAttr(Decl *D, const ParsedAttr &AL) {
   ASTContext &Context = getASTContext();
   auto *VD = cast<VarDecl>(D);
   VD->setType(Context.getAddrSpaceQualType(
-      VD->getType(), getLangASFromTargetAS(
-                         llvm::WebAssembly::WASM_ADDRESS_SPACE_VAR)));
+      VD->getType(),
+      getLangASFromTargetAS(llvm::WebAssembly::WASM_ADDRESS_SPACE_VAR)));
   D->addAttr(::new (Context) WebAssemblyGlobalAttr(Context, AL));
 }
 

--- a/clang/lib/Sema/SemaWasm.cpp
+++ b/clang/lib/Sema/SemaWasm.cpp
@@ -20,6 +20,7 @@
 #include "clang/Basic/TargetInfo.h"
 #include "clang/Sema/Attr.h"
 #include "clang/Sema/Sema.h"
+#include "llvm/Support/WasmAddressSpaces.h"
 
 namespace clang {
 
@@ -455,6 +456,15 @@ void SemaWasm::handleWebAssemblyExportNameAttr(Decl *D, const ParsedAttr &AL) {
 
   D->addAttr(::new (Context) WebAssemblyExportNameAttr(Context, AL, Str));
   D->addAttr(UsedAttr::CreateImplicit(Context));
+}
+
+void SemaWasm::handleWebAssemblyGlobalAttr(Decl *D, const ParsedAttr &AL) {
+  ASTContext &Context = getASTContext();
+  auto *VD = cast<VarDecl>(D);
+  VD->setType(Context.getAddrSpaceQualType(
+      VD->getType(), getLangASFromTargetAS(
+                         llvm::WebAssembly::WASM_ADDRESS_SPACE_VAR)));
+  D->addAttr(::new (Context) WebAssemblyGlobalAttr(Context, AL));
 }
 
 } // namespace clang

--- a/clang/test/CodeGen/WebAssembly/wasm-global-attribute.cpp
+++ b/clang/test/CodeGen/WebAssembly/wasm-global-attribute.cpp
@@ -1,0 +1,16 @@
+// RUN: %clang_cc1 -triple wasm32-unknown-unknown-wasm -emit-llvm -o - %s | FileCheck %s
+
+extern "C" {
+int exported_g [[clang::wasm_global]] = 42;
+
+extern const int imported_g [[clang::wasm_global]]
+    __attribute__((import_module("env"), import_name("imported_g")));
+
+int get_import(void) { return imported_g; }
+}
+
+// CHECK: @exported_g = addrspace(1) global i32 42, align 4
+// CHECK: @imported_g = external addrspace(1) constant i32, align 4 #0
+// CHECK: define{{.*}} @get_import()
+// CHECK: load i32, ptr addrspace(1) @imported_g
+// CHECK: attributes #0 = { "wasm-import-module"="env" "wasm-import-name"="imported_g" }

--- a/clang/test/Misc/pragma-attribute-supported-attributes-list.test
+++ b/clang/test/Misc/pragma-attribute-supported-attributes-list.test
@@ -236,6 +236,7 @@
 // CHECK-NEXT: Weak (SubjectMatchRule_variable, SubjectMatchRule_function, SubjectMatchRule_record)
 // CHECK-NEXT: WeakRef (SubjectMatchRule_variable, SubjectMatchRule_function)
 // CHECK-NEXT: WebAssemblyExportName (SubjectMatchRule_function, SubjectMatchRule_variable_is_global)
+// CHECK-NEXT: WebAssemblyGlobal (SubjectMatchRule_variable_is_global)
 // CHECK-NEXT: WebAssemblyImportModule (SubjectMatchRule_function, SubjectMatchRule_variable_is_global)
 // CHECK-NEXT: WebAssemblyImportName (SubjectMatchRule_function, SubjectMatchRule_variable_is_global)
 // CHECK-NEXT: WorkGroupSizeHint (SubjectMatchRule_function)

--- a/llvm/include/llvm/Support/WasmAddressSpaces.h
+++ b/llvm/include/llvm/Support/WasmAddressSpaces.h
@@ -1,4 +1,4 @@
-//===--- llvm/CodeGen/WasmAddressSpaces.h -----------------------*- C++ -*-===//
+//===---------------- WasmAddressSpaces.h ----------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,22 +6,21 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// Address Spaces for WebAssembly Type Handling
+// Address spaces for WebAssembly IR and type handling.
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LLVM_LIB_TARGET_WEBASSEMBLY_UTILS_WASMADDRESSSPACES_H
-#define LLVM_LIB_TARGET_WEBASSEMBLY_UTILS_WASMADDRESSSPACES_H
+#ifndef LLVM_SUPPORT_WASMADDRESSSPACES_H
+#define LLVM_SUPPORT_WASMADDRESSSPACES_H
 
 namespace llvm {
-
 namespace WebAssembly {
 
 enum WasmAddressSpace : unsigned {
   // Default address space, for pointers to linear memory (stack, heap, data).
   WASM_ADDRESS_SPACE_DEFAULT = 0,
   // A non-integral address space for pointers to named objects outside of
-  // linear memory: WebAssembly globals or WebAssembly locals.  Loads and stores
+  // linear memory: WebAssembly globals or WebAssembly locals. Loads and stores
   // to these pointers are lowered to global.get / global.set or local.get /
   // local.set, as appropriate.
   WASM_ADDRESS_SPACE_VAR = 1
@@ -38,7 +37,6 @@ inline bool isValidAddressSpace(unsigned AS) {
 }
 
 } // namespace WebAssembly
-
 } // namespace llvm
 
-#endif // LLVM_LIB_TARGET_WEBASSEMBLY_UTILS_WASMADDRESSSPACES_H
+#endif // LLVM_SUPPORT_WASMADDRESSSPACES_H

--- a/llvm/lib/Target/WebAssembly/Utils/WebAssemblyTypeUtilities.h
+++ b/llvm/lib/Target/WebAssembly/Utils/WebAssemblyTypeUtilities.h
@@ -16,11 +16,11 @@
 #define LLVM_LIB_TARGET_WEBASSEMBLY_UTILS_WEBASSEMBLYTYPEUTILITIES_H
 
 #include "MCTargetDesc/WebAssemblyMCTypeUtilities.h"
-#include "WasmAddressSpaces.h"
 #include "llvm/BinaryFormat/Wasm.h"
 #include "llvm/CodeGenTypes/MachineValueType.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/MC/MCSymbolWasm.h"
+#include "llvm/Support/WasmAddressSpaces.h"
 
 namespace llvm {
 

--- a/llvm/lib/Target/WebAssembly/WebAssemblyFastISel.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyFastISel.cpp
@@ -16,7 +16,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "MCTargetDesc/WebAssemblyMCTargetDesc.h"
-#include "Utils/WasmAddressSpaces.h"
 #include "WebAssemblyMachineFunctionInfo.h"
 #include "WebAssemblySubtarget.h"
 #include "WebAssemblyUtilities.h"
@@ -33,6 +32,7 @@
 #include "llvm/IR/Function.h"
 #include "llvm/IR/GetElementPtrTypeIterator.h"
 #include "llvm/IR/GlobalVariable.h"
+#include "llvm/Support/WasmAddressSpaces.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/IntrinsicsWebAssembly.h"
 #include "llvm/IR/Operator.h"

--- a/llvm/lib/Target/WebAssembly/WebAssemblyFastISel.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyFastISel.cpp
@@ -32,10 +32,10 @@
 #include "llvm/IR/Function.h"
 #include "llvm/IR/GetElementPtrTypeIterator.h"
 #include "llvm/IR/GlobalVariable.h"
-#include "llvm/Support/WasmAddressSpaces.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/IntrinsicsWebAssembly.h"
 #include "llvm/IR/Operator.h"
+#include "llvm/Support/WasmAddressSpaces.h"
 
 using namespace llvm;
 

--- a/llvm/lib/Target/WebAssembly/WebAssemblyRefTypeMem2Local.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyRefTypeMem2Local.cpp
@@ -12,7 +12,6 @@
 ///
 //===----------------------------------------------------------------------===//
 
-#include "Utils/WasmAddressSpaces.h"
 #include "Utils/WebAssemblyTypeUtilities.h"
 #include "WebAssembly.h"
 #include "llvm/IR/Analysis.h"
@@ -22,6 +21,7 @@
 #include "llvm/IR/PassManager.h"
 #include "llvm/IR/ValueHandle.h"
 #include "llvm/Pass.h"
+#include "llvm/Support/WasmAddressSpaces.h"
 using namespace llvm;
 
 #define DEBUG_TYPE "wasm-ref-type-mem2local"


### PR DESCRIPTION
In current main branch, declaring a WebAssembly globals require the confusing [[clang::address_space(1)]], exposing an internal address-space number to users. Add [[clang::wasm_global]] and test imported and exported globals.