### PR TITLE
[Mips] Fix buildbot failure of MIPS I double store using SWC1

### DIFF
--- a/llvm/lib/Target/Mips/MipsInstrFPU.td
+++ b/llvm/lib/Target/Mips/MipsInstrFPU.td
@@ -864,12 +864,7 @@ class ExtractElementF64Base<RegisterOperand RO> :
   PseudoSE<(outs GPR32Opnd:$dst), (ins RO:$src, i32imm:$n),
            [(set GPR32Opnd:$dst, (MipsExtractElementF64 RO:$src, imm:$n))]>;
 
-class ExtractElementF64Base_FPR<RegisterOperand RO> :
-  PseudoSE<(outs FGR32Opnd:$dst), (ins RO:$src, i32imm:$n),
-           [(set FGR32Opnd:$dst, (MipsExtractElementF64_FPR RO:$src, imm:$n))]>;
-
 def ExtractElementF64 : ExtractElementF64Base<AFGR64Opnd>, FGR_32, HARDFLOAT;
-def ExtractElementF64_FPR : ExtractElementF64Base_FPR<AFGR64Opnd>, FGR_32, HARDFLOAT;
 def ExtractElementF64_64 : ExtractElementF64Base<FGR64Opnd>, FGR_64, HARDFLOAT;
 
 def PseudoTRUNC_W_S : MipsAsmPseudoInst<(outs FGR32Opnd:$fd),
@@ -1062,6 +1057,12 @@ let AdditionalPredicates = [NotInMicroMips] in {
 def : MipsPat<(f64 fpimm0), (DMTC1 ZERO_64)>, ISA_MIPS3, GPR_64, FGR_64;
 def : MipsPat<(f64 fpimm0neg), (FNEG_D64 (DMTC1 ZERO_64))>, ISA_MIPS3, GPR_64,
       FGR_64;
+
+def : MipsPat<(f32 (MipsExtractElementF64_FPR AFGR64Opnd:$src, 0)),
+              (EXTRACT_SUBREG AFGR64Opnd:$src, sub_lo)>;
+
+def : MipsPat<(f32 (MipsExtractElementF64_FPR AFGR64Opnd:$src, 1)),
+              (EXTRACT_SUBREG AFGR64Opnd:$src, sub_hi)>;
 
 def : MipsPat<(f64 (any_sint_to_fp GPR32Opnd:$src)), 
               (PseudoCVT_D64_W GPR32Opnd:$src)>, FGR_64;

--- a/llvm/lib/Target/Mips/MipsSEInstrInfo.cpp
+++ b/llvm/lib/Target/Mips/MipsSEInstrInfo.cpp
@@ -532,22 +532,6 @@ bool MipsSEInstrInfo::expandPostRAPseudo(MachineInstr &MI) const {
   case Mips::BuildPairF64_64:
     expandBuildPairF64(MBB, MI, isMicroMips, true);
     break;
-  case Mips::ExtractElementF64_FPR: {
-    Register DstReg = MI.getOperand(0).getReg();
-    Register SrcReg = MI.getOperand(1).getReg();
-    int64_t Index = MI.getOperand(2).getImm();
-
-    unsigned SubRegIdx = (Index == 0) ? Mips::sub_lo : Mips::sub_hi;
-    Register SubReg = TRI->getSubReg(SrcReg, SubRegIdx);
-
-    if (SubReg && SubReg != DstReg) {
-      BuildMI(MBB, MI, MI.getDebugLoc(), get(Mips::FMOV_S), DstReg)
-          .addReg(SubReg, RegState::Kill);
-    }
-
-    MI.eraseFromParent();
-    return true;
-  }
   case Mips::ExtractElementF64:
     expandExtractElementF64(MBB, MI, isMicroMips, false);
     break;

--- a/llvm/lib/Target/Mips/MipsSEInstrInfo.cpp
+++ b/llvm/lib/Target/Mips/MipsSEInstrInfo.cpp
@@ -532,7 +532,22 @@ bool MipsSEInstrInfo::expandPostRAPseudo(MachineInstr &MI) const {
   case Mips::BuildPairF64_64:
     expandBuildPairF64(MBB, MI, isMicroMips, true);
     break;
-  case Mips::ExtractElementF64_FPR:
+  case Mips::ExtractElementF64_FPR: {
+    Register DstReg = MI.getOperand(0).getReg();
+    Register SrcReg = MI.getOperand(1).getReg();
+    int64_t Index = MI.getOperand(2).getImm();
+
+    unsigned SubRegIdx = (Index == 0) ? Mips::sub_lo : Mips::sub_hi;
+    Register SubReg = TRI->getSubReg(SrcReg, SubRegIdx);
+
+    if (SubReg && SubReg != DstReg) {
+      BuildMI(MBB, MI, MI.getDebugLoc(), get(Mips::FMOV_S), DstReg)
+          .addReg(SubReg, RegState::Kill);
+    }
+
+    MI.eraseFromParent();
+    return true;
+  }
   case Mips::ExtractElementF64:
     expandExtractElementF64(MBB, MI, isMicroMips, false);
     break;

--- a/llvm/lib/Target/Mips/MipsScheduleGeneric.td
+++ b/llvm/lib/Target/Mips/MipsScheduleGeneric.td
@@ -871,7 +871,7 @@ def : InstRW<[GenericWriteFPUMoveGPRFPU], (instrs BuildPairF64,
                                            MFC1, MFC1_D64, MFHC1_D32,
                                            MFHC1_D64, MTC1, MTC1_D64,
                                            MTHC1_D32, MTHC1_D64,
-                                           BuildPairF64_FPR, ExtractElementF64_FPR)>;
+                                           BuildPairF64_FPR)>;
 
 // swc1, swxc1
 def : InstRW<[GenericWriteFPUStore], (instrs SDC1, SDC164, SDXC1, SDXC164,

--- a/llvm/lib/Target/Mips/MipsScheduleP5600.td
+++ b/llvm/lib/Target/Mips/MipsScheduleP5600.td
@@ -573,7 +573,7 @@ def : InstRW<[P5600WriteMoveFPUToGPR], (instregex "^COPY_S_[BHWD]$")>;
 def : InstRW<[P5600WriteMoveFPUToGPR], (instrs BC1F, BC1FL, BC1T, BC1TL, CFC1,
                                         MFC1, MFC1_D64, MFHC1_D32, MFHC1_D64,
                                         MOVF_I, MOVT_I, ExtractElementF64,
-                                        ExtractElementF64_64, ExtractElementF64_FPR)>;
+                                        ExtractElementF64_64)>;
 
 // swc1, swxc1, st.[bhwd]
 def : InstRW<[P5600WriteStoreFPUS], (instrs SDC1, SDC164, SDXC1, SDXC164,

--- a/llvm/test/CodeGen/Mips/mips1-not-support-ldc1-sdc1.ll
+++ b/llvm/test/CodeGen/Mips/mips1-not-support-ldc1-sdc1.ll
@@ -27,21 +27,17 @@ entry:
 define void @test_swc1(double %a) #0 {
 ; MIPS1-LE-LABEL: test_swc1:
 ; MIPS1-LE:       # %bb.0: # %entry
-; MIPS1-LE-NEXT:    mov.s $f0, $f13
 ; MIPS1-LE-NEXT:    lui	$1, %hi(test)
-; MIPS1-LE-NEXT:    swc1 $f0, %lo(test+4)($1)
-; MIPS1-LE-NEXT:    mov.s $f0, $f12
+; MIPS1-LE-NEXT:    swc1 $f13, %lo(test+4)($1)
 ; MIPS1-LE-NEXT:    jr $ra
-; MIPS1-LE-NEXT:    swc1 $f0, %lo(test)($1)
+; MIPS1-LE-NEXT:    swc1 $f12, %lo(test)($1)
 
 ; MIPS1-BE-LABEL: test_swc1:
 ; MIPS1-BE:       # %bb.0: # %entry
-; MIPS1-BE-NEXT:    mov.s $f0, $f12
 ; MIPS1-BE-NEXT:    lui	$1, %hi(test)
-; MIPS1-BE-NEXT:    swc1 $f0, %lo(test+4)($1)
-; MIPS1-BE-NEXT:    mov.s $f0, $f13
+; MIPS1-BE-NEXT:    swc1 $f12, %lo(test+4)($1)
 ; MIPS1-BE-NEXT:    jr $ra
-; MIPS1-BE-NEXT:    swc1 $f0, %lo(test)($1)
+; MIPS1-BE-NEXT:    swc1 $f13, %lo(test)($1)
 entry:
   store double %a, ptr @test, align 8
   ret void

--- a/llvm/test/CodeGen/Mips/mips1-not-support-ldc1-sdc1.ll
+++ b/llvm/test/CodeGen/Mips/mips1-not-support-ldc1-sdc1.ll
@@ -27,19 +27,19 @@ entry:
 define void @test_swc1(double %a) #0 {
 ; MIPS1-LE-LABEL: test_swc1:
 ; MIPS1-LE:       # %bb.0: # %entry
-; MIPS1-LE-NEXT:    mfc1 $f0, $f13
+; MIPS1-LE-NEXT:    mov.s $f0, $f13
 ; MIPS1-LE-NEXT:    lui	$1, %hi(test)
 ; MIPS1-LE-NEXT:    swc1 $f0, %lo(test+4)($1)
-; MIPS1-LE-NEXT:    mfc1 $f0, $f12
+; MIPS1-LE-NEXT:    mov.s $f0, $f12
 ; MIPS1-LE-NEXT:    jr $ra
 ; MIPS1-LE-NEXT:    swc1 $f0, %lo(test)($1)
 
 ; MIPS1-BE-LABEL: test_swc1:
 ; MIPS1-BE:       # %bb.0: # %entry
-; MIPS1-BE-NEXT:    mfc1 $f0, $f12
+; MIPS1-BE-NEXT:    mov.s $f0, $f12
 ; MIPS1-BE-NEXT:    lui	$1, %hi(test)
 ; MIPS1-BE-NEXT:    swc1 $f0, %lo(test+4)($1)
-; MIPS1-BE-NEXT:    mfc1 $f0, $f13
+; MIPS1-BE-NEXT:    mov.s $f0, $f13
 ; MIPS1-BE-NEXT:    jr $ra
 ; MIPS1-BE-NEXT:    swc1 $f0, %lo(test)($1)
 entry:


### PR DESCRIPTION
Expand ExtractElementF64_FPR to FMOV_S instead of MFC1 to avoid incorrect integer store.

Fix x86_64-expensive-checks compile error as for pr https://github.com/llvm/llvm-project/pull/209362.

Fix #62190.