### PR TITLE
llvm: Remove phantom ssp-buffers-size attributes from tests

### DIFF
--- a/llvm/test/CodeGen/AArch64/arm64-abi_align.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-abi_align.ll
@@ -507,10 +507,10 @@ entry:
   ret i32 %call
 }
 
-attributes #0 = { noinline nounwind readnone "relocation-model"="pic" "ssp-buffers-size"="8" }
-attributes #1 = { nounwind readonly "relocation-model"="pic" "ssp-buffers-size"="8" }
-attributes #2 = { noinline nounwind readonly "relocation-model"="pic" "ssp-buffers-size"="8" }
-attributes #3 = { nounwind "relocation-model"="pic" "ssp-buffers-size"="8" }
+attributes #0 = { noinline nounwind readnone "relocation-model"="pic" }
+attributes #1 = { nounwind readonly "relocation-model"="pic" }
+attributes #2 = { noinline nounwind readonly "relocation-model"="pic" }
+attributes #3 = { nounwind "relocation-model"="pic" }
 attributes #4 = { nounwind }
 attributes #5 = { nobuiltin }
 

--- a/llvm/test/CodeGen/AMDGPU/loop-address.ll
+++ b/llvm/test/CodeGen/AMDGPU/loop-address.ll
@@ -24,7 +24,7 @@ for.end:                                          ; preds = %for.body, %entry
   ret void
 }
 
-attributes #0 = { nounwind "relocation-model"="pic" "ssp-buffers-size"="8" }
+attributes #0 = { nounwind "relocation-model"="pic" }
 
 !opencl.kernels = !{!0, !1, !2, !3}
 

--- a/llvm/test/CodeGen/Hexagon/insert4.ll
+++ b/llvm/test/CodeGen/Hexagon/insert4.ll
@@ -103,7 +103,7 @@ declare i64 @llvm.hexagon.M2.dpmpyss.s0(i32, i32) #1
 
 declare i64 @llvm.hexagon.A2.vaddhs(i64, i64) #1
 
-attributes #0 = { nounwind "frame-pointer"="non-leaf" "realign-stack" "relocation-model"="static" "ssp-buffers-size"="8" }
+attributes #0 = { nounwind "frame-pointer"="non-leaf" "realign-stack" "relocation-model"="static" }
 attributes #1 = { nounwind readnone }
 
 !0 = !{!"short", !1}

--- a/llvm/test/CodeGen/Hexagon/vect/vect-v4i16.ll
+++ b/llvm/test/CodeGen/Hexagon/vect/vect-v4i16.ll
@@ -67,4 +67,4 @@ polly.stmt.for.body29:                            ; preds = %polly.stmt.for.body
   br i1 %exitcond, label %for.end.loopexit, label %polly.stmt.for.body29
 }
 
-attributes #0 = { nounwind "frame-pointer"="non-leaf" "realign-stack" "relocation-model"="static" "ssp-buffers-size"="8" }
+attributes #0 = { nounwind "frame-pointer"="non-leaf" "realign-stack" "relocation-model"="static" }

--- a/llvm/test/CodeGen/Hexagon/vect/vect-xor.ll
+++ b/llvm/test/CodeGen/Hexagon/vect/vect-xor.ll
@@ -34,4 +34,4 @@ polly.loop_body:                                  ; preds = %entry, %polly.loop_
   br i1 %0, label %polly.loop_body, label %polly.loop_after
 }
 
-attributes #0 = { nounwind "frame-pointer"="non-leaf" "realign-stack" "relocation-model"="static" "ssp-buffers-size"="8" }
+attributes #0 = { nounwind "frame-pointer"="non-leaf" "realign-stack" "relocation-model"="static" }

--- a/llvm/test/Transforms/LoopVectorize/dbg.value.ll
+++ b/llvm/test/Transforms/LoopVectorize/dbg.value.ll
@@ -35,7 +35,7 @@ for.end:
 }
 
 
-attributes #0 = { "frame-pointer"="non-leaf" "relocation-model"="pic" "ssp-buffers-size"="8" }
+attributes #0 = { "frame-pointer"="non-leaf" "relocation-model"="pic" }
 
 !llvm.dbg.cu = !{!11}
 !llvm.module.flags = !{!14}

--- a/llvm/test/Transforms/LoopVectorize/vectorize-once.ll
+++ b/llvm/test/Transforms/LoopVectorize/vectorize-once.ll
@@ -67,7 +67,7 @@ _ZSt10accumulateIPiiET0_T_S2_S1_.exit:
   ret i32 %__init.addr.0.lcssa.i
 }
 
-attributes #0 = { nounwind readonly ssp uwtable "frame-pointer"="non-leaf" "realign-stack" "relocation-model"="pic" "ssp-buffers-size"="8" }
+attributes #0 = { nounwind readonly ssp uwtable "frame-pointer"="non-leaf" "realign-stack" "relocation-model"="pic" }
 
 ; CHECK:      [[VEC_LOOP1]] = distinct !{[[VEC_LOOP1]], [[MD_IS_VEC:![0-9]+]], [[MD_RT_UNROLL_DIS:![0-9]+]]}
 ; CHECK-NEXT: [[MD_IS_VEC:![0-9]+]] = !{!"llvm.loop.isvectorized", i32 1}

--- a/llvm/test/Transforms/SimplifyCFG/volatile-phioper.ll
+++ b/llvm/test/Transforms/SimplifyCFG/volatile-phioper.ll
@@ -57,8 +57,8 @@ end:
 }
 declare i32 @Trace(...) #1
 
-attributes #0 = { nounwind ssp uwtable "frame-pointer"="non-leaf" "relocation-model"="pic" "ssp-buffers-size"="8" }
-attributes #1 = { "frame-pointer"="non-leaf" "relocation-model"="pic" "ssp-buffers-size"="8" }
+attributes #0 = { nounwind ssp uwtable "frame-pointer"="non-leaf" "relocation-model"="pic" }
+attributes #1 = { "frame-pointer"="non-leaf" "relocation-model"="pic" }
 attributes #2 = { nounwind }
 
 !0 = !{i32 1039}


### PR DESCRIPTION
"ssp-buffers-size" was never a real function attribute. There is
"stack-protector-buffer-size". This may have existed in a downstream
fork, but it's also irrelevant for these tests.

Co-authored-by: Claude (Claude-Opus-4.8) <noreply@anthropic.com>