### PR TITLE
[GlobalISel] Drop redundant scalable-dest check in G_EXTRACT_SUBVECTOR lowering (NFC)

### DIFF
--- a/llvm/lib/CodeGen/GlobalISel/LegalizerHelper.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/LegalizerHelper.cpp
@@ -5008,7 +5008,7 @@ LegalizerHelper::lower(MachineInstr &MI, unsigned TypeIdx, LLT LowerHintTy) {
     LLT SrcTy = MRI.getType(SrcReg);
     LLT DstTy = MRI.getType(DstReg);
 
-    if (SrcTy.isScalable() || DstTy.isScalable())
+    if (SrcTy.isScalable())
       return UnableToLegalize;
 
     if (SrcTy.getScalarType() != DstTy.getScalarType())


### PR DESCRIPTION
The scalarizing lowering of G_EXTRACT_SUBVECTOR bails out for both a
scalable source and a scalable destination.
According to llvm/docs/GlobalISel/GenericOpcode.md, G_EXTRACT_SUBVECTOR
only supports extracting a fixed vector from a scalable vector, never a
scalable vector from a fixed one.
This means that a fixed source implies a fixed destination, making the
DstTy.isScalable() check redundant.

Remove it. NFC.