### PR TITLE
[ORC] Add TargetParser to OrcShared's dependencies.

### DIFF
--- a/llvm/examples/HowToUseLLJIT/CMakeLists.txt
+++ b/llvm/examples/HowToUseLLJIT/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(LLVM_LINK_COMPONENTS
   Core
   OrcJIT
+  OrcShared
   Support
   nativecodegen
   )

--- a/llvm/examples/Kaleidoscope/BuildingAJIT/Chapter1/CMakeLists.txt
+++ b/llvm/examples/Kaleidoscope/BuildingAJIT/Chapter1/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LLVM_LINK_COMPONENTS
   InstCombine
   Object
   OrcJIT
+  OrcShared
   RuntimeDyld
   ScalarOpts
   Support

--- a/llvm/examples/Kaleidoscope/BuildingAJIT/Chapter2/CMakeLists.txt
+++ b/llvm/examples/Kaleidoscope/BuildingAJIT/Chapter2/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LLVM_LINK_COMPONENTS
   InstCombine
   Object
   OrcJIT
+  OrcShared
   RuntimeDyld
   ScalarOpts
   Support

--- a/llvm/examples/Kaleidoscope/BuildingAJIT/Chapter3/CMakeLists.txt
+++ b/llvm/examples/Kaleidoscope/BuildingAJIT/Chapter3/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LLVM_LINK_COMPONENTS
   InstCombine
   Object
   OrcJIT
+  OrcShared
   RuntimeDyld
   ScalarOpts
   Support

--- a/llvm/examples/Kaleidoscope/BuildingAJIT/Chapter4/CMakeLists.txt
+++ b/llvm/examples/Kaleidoscope/BuildingAJIT/Chapter4/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LLVM_LINK_COMPONENTS
   InstCombine
   Object
   OrcJIT
+  OrcShared
   RuntimeDyld
   ScalarOpts
   Support

--- a/llvm/examples/Kaleidoscope/Chapter4/CMakeLists.txt
+++ b/llvm/examples/Kaleidoscope/Chapter4/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LLVM_LINK_COMPONENTS
   InstCombine
   Object
   OrcJIT
+  OrcShared
   Passes
   RuntimeDyld
   ScalarOpts

--- a/llvm/examples/Kaleidoscope/Chapter5/CMakeLists.txt
+++ b/llvm/examples/Kaleidoscope/Chapter5/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LLVM_LINK_COMPONENTS
   InstCombine
   Object
   OrcJIT
+  OrcShared
   Passes
   RuntimeDyld
   ScalarOpts

--- a/llvm/examples/Kaleidoscope/Chapter6/CMakeLists.txt
+++ b/llvm/examples/Kaleidoscope/Chapter6/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LLVM_LINK_COMPONENTS
   InstCombine
   Object
   OrcJIT
+  OrcShared
   Passes
   RuntimeDyld
   ScalarOpts

--- a/llvm/examples/Kaleidoscope/Chapter7/CMakeLists.txt
+++ b/llvm/examples/Kaleidoscope/Chapter7/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LLVM_LINK_COMPONENTS
   InstCombine
   Object
   OrcJIT
+  OrcShared
   Passes
   RuntimeDyld
   ScalarOpts

--- a/llvm/examples/Kaleidoscope/Chapter9/CMakeLists.txt
+++ b/llvm/examples/Kaleidoscope/Chapter9/CMakeLists.txt
@@ -3,6 +3,7 @@ set(LLVM_LINK_COMPONENTS
   ExecutionEngine
   Object
   OrcJIT
+  OrcShared
   Support
   TargetParser
   native

--- a/llvm/examples/OrcV2Examples/LLJITDumpObjects/CMakeLists.txt
+++ b/llvm/examples/OrcV2Examples/LLJITDumpObjects/CMakeLists.txt
@@ -4,6 +4,7 @@ set(LLVM_LINK_COMPONENTS
   IRReader
   JITLink
   OrcJIT
+  OrcShared
   Support
   nativecodegen
   )

--- a/llvm/examples/OrcV2Examples/LLJITRemovableCode/CMakeLists.txt
+++ b/llvm/examples/OrcV2Examples/LLJITRemovableCode/CMakeLists.txt
@@ -4,6 +4,7 @@ set(LLVM_LINK_COMPONENTS
   IPO
   IRReader
   OrcJIT
+  OrcShared
   ScalarOpts
   Support
   nativecodegen

--- a/llvm/examples/OrcV2Examples/LLJITWithCustomObjectLinkingLayer/CMakeLists.txt
+++ b/llvm/examples/OrcV2Examples/LLJITWithCustomObjectLinkingLayer/CMakeLists.txt
@@ -3,6 +3,7 @@ set(LLVM_LINK_COMPONENTS
   IRReader
   JITLink
   OrcJIT
+  OrcShared
   Support
   nativecodegen
   )

--- a/llvm/examples/OrcV2Examples/LLJITWithExecutorProcessControl/CMakeLists.txt
+++ b/llvm/examples/OrcV2Examples/LLJITWithExecutorProcessControl/CMakeLists.txt
@@ -3,6 +3,7 @@ set(LLVM_LINK_COMPONENTS
   ExecutionEngine
   IRReader
   OrcJIT
+  OrcShared
   Support
   nativecodegen
   )

--- a/llvm/examples/OrcV2Examples/LLJITWithGDBRegistrationListener/CMakeLists.txt
+++ b/llvm/examples/OrcV2Examples/LLJITWithGDBRegistrationListener/CMakeLists.txt
@@ -4,6 +4,7 @@ set(LLVM_LINK_COMPONENTS
   IRReader
   JITLink
   OrcJIT
+  OrcShared
   OrcTargetProcess
   Support
   nativecodegen

--- a/llvm/examples/OrcV2Examples/LLJITWithInitializers/CMakeLists.txt
+++ b/llvm/examples/OrcV2Examples/LLJITWithInitializers/CMakeLists.txt
@@ -4,6 +4,7 @@ set(LLVM_LINK_COMPONENTS
   IRReader
   JITLink
   OrcJIT
+  OrcShared
   Support
   nativecodegen
   )

--- a/llvm/examples/OrcV2Examples/LLJITWithLazyReexports/CMakeLists.txt
+++ b/llvm/examples/OrcV2Examples/LLJITWithLazyReexports/CMakeLists.txt
@@ -3,6 +3,7 @@ set(LLVM_LINK_COMPONENTS
   ExecutionEngine
   IRReader
   OrcJIT
+  OrcShared
   Support
   nativecodegen
   )

--- a/llvm/examples/OrcV2Examples/LLJITWithObjectCache/CMakeLists.txt
+++ b/llvm/examples/OrcV2Examples/LLJITWithObjectCache/CMakeLists.txt
@@ -3,6 +3,7 @@ set(LLVM_LINK_COMPONENTS
   ExecutionEngine
   IRReader
   OrcJIT
+  OrcShared
   Support
   nativecodegen
   )

--- a/llvm/examples/OrcV2Examples/LLJITWithOptimizingIRTransform/CMakeLists.txt
+++ b/llvm/examples/OrcV2Examples/LLJITWithOptimizingIRTransform/CMakeLists.txt
@@ -4,6 +4,7 @@ set(LLVM_LINK_COMPONENTS
   IPO
   IRReader
   OrcJIT
+  OrcShared
   ScalarOpts
   Support
   nativecodegen

--- a/llvm/examples/OrcV2Examples/LLJITWithSymbolAliases/CMakeLists.txt
+++ b/llvm/examples/OrcV2Examples/LLJITWithSymbolAliases/CMakeLists.txt
@@ -3,6 +3,7 @@ set(LLVM_LINK_COMPONENTS
   ExecutionEngine
   IRReader
   OrcJIT
+  OrcShared
   Support
   nativecodegen
   )

--- a/llvm/examples/OrcV2Examples/LLJITWithThinLTOSummaries/CMakeLists.txt
+++ b/llvm/examples/OrcV2Examples/LLJITWithThinLTOSummaries/CMakeLists.txt
@@ -3,6 +3,7 @@ set(LLVM_LINK_COMPONENTS
   Core
   ExecutionEngine
   OrcJIT
+  OrcShared
   OrcTargetProcess
   Support
   TargetParser

--- a/llvm/examples/OrcV2Examples/OrcV2CBindingsAddObjectFile/CMakeLists.txt
+++ b/llvm/examples/OrcV2Examples/OrcV2CBindingsAddObjectFile/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LLVM_LINK_COMPONENTS
   JITLink
   MC
   OrcJIT
+  OrcShared
   Support
   Target
   nativecodegen

--- a/llvm/examples/OrcV2Examples/OrcV2CBindingsBasicUsage/CMakeLists.txt
+++ b/llvm/examples/OrcV2Examples/OrcV2CBindingsBasicUsage/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LLVM_LINK_COMPONENTS
   JITLink
   MC
   OrcJIT
+  OrcShared
   Support
   Target
   nativecodegen

--- a/llvm/examples/OrcV2Examples/OrcV2CBindingsDumpObjects/CMakeLists.txt
+++ b/llvm/examples/OrcV2Examples/OrcV2CBindingsDumpObjects/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LLVM_LINK_COMPONENTS
   JITLink
   MC
   OrcJIT
+  OrcShared
   Support
   Target
   nativecodegen

--- a/llvm/examples/OrcV2Examples/OrcV2CBindingsIRTransforms/CMakeLists.txt
+++ b/llvm/examples/OrcV2Examples/OrcV2CBindingsIRTransforms/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LLVM_LINK_COMPONENTS
   JITLink
   MC
   OrcJIT
+  OrcShared
   Passes
   Support
   Target

--- a/llvm/examples/OrcV2Examples/OrcV2CBindingsLazy/CMakeLists.txt
+++ b/llvm/examples/OrcV2Examples/OrcV2CBindingsLazy/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LLVM_LINK_COMPONENTS
   JITLink
   MC
   OrcJIT
+  OrcShared
   Support
   Target
   nativecodegen

--- a/llvm/examples/OrcV2Examples/OrcV2CBindingsMCJITLikeMemoryManager/CMakeLists.txt
+++ b/llvm/examples/OrcV2Examples/OrcV2CBindingsMCJITLikeMemoryManager/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LLVM_LINK_COMPONENTS
   JITLink
   MC
   OrcJIT
+  OrcShared
   Support
   Target
   nativecodegen

--- a/llvm/examples/OrcV2Examples/OrcV2CBindingsRemovableCode/CMakeLists.txt
+++ b/llvm/examples/OrcV2Examples/OrcV2CBindingsRemovableCode/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LLVM_LINK_COMPONENTS
   JITLink
   MC
   OrcJIT
+  OrcShared
   Support
   Target
   nativecodegen

--- a/llvm/examples/OrcV2Examples/OrcV2CBindingsVeryLazy/CMakeLists.txt
+++ b/llvm/examples/OrcV2Examples/OrcV2CBindingsVeryLazy/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LLVM_LINK_COMPONENTS
   JITLink
   MC
   OrcJIT
+  OrcShared
   Support
   Target
   nativecodegen

--- a/llvm/examples/SpeculativeJIT/CMakeLists.txt
+++ b/llvm/examples/SpeculativeJIT/CMakeLists.txt
@@ -2,6 +2,7 @@ set(LLVM_LINK_COMPONENTS
   Core
   IRReader
   OrcJIT
+  OrcShared
   OrcTargetProcess
   ExecutionEngine
   Support


### PR DESCRIPTION
OrcShared depends on TargetParser as of e91092685ea.