### PR TITLE
[BOLT][AArch64] Fix relocation type for `LDRSW`

### DIFF
--- a/bolt/lib/Target/AArch64/AArch64MCPlusBuilder.cpp
+++ b/bolt/lib/Target/AArch64/AArch64MCPlusBuilder.cpp
@@ -766,7 +766,7 @@ public:
     case AArch64::LDRSWl:
       AddrReg = DataReg;
       OpCode = AArch64::LDRSWui;
-      RelType = ELF::R_AARCH64_LDST64_ABS_LO12_NC;
+      RelType = ELF::R_AARCH64_LDST32_ABS_LO12_NC;
       break;
     default:
       llvm_unreachable("LDR (literal) or LDRSW (literal) expected");


### PR DESCRIPTION
Fix the incorrect relocation type for `LDRSW`. It should be `ELF::R_AARCH64_LDST32_ABS_LO12_NC`, but it was mistakenly set to `ELF::R_AARCH64_LDST64_ABS_LO12_NC` in PR #196051.