### PR TITLE
[clang][bytecode] Save Record::Field PrimType

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -1210,9 +1210,8 @@ bool Compiler<Emitter>::VisitCastExpr(const CastExpr *E) {
     const Record *R = this->getRecord(E->getType());
     assert(R);
     const Record::Field *RF = R->getField(UnionField);
-    QualType FieldType = RF->Decl->getType();
 
-    if (OptPrimType PT = classify(FieldType)) {
+    if (OptPrimType PT = RF->T) {
       if (!this->visit(SubExpr))
         return false;
       if (RF->isBitField())
@@ -3695,11 +3694,11 @@ bool Compiler<Emitter>::VisitTypeTraitExpr(const TypeTraitExpr *E) {
     if (!R || R->getNumFields() == 0)
       return false;
     const Record::Field *Field = R->getField(0U);
-    PrimType FieldT = classifyPrim(Field->Decl->getType());
-    if (!this->emitConst(CmpInfo.getValueInfo(Result)->getIntValue(), FieldT,
+    assert(Field->T);
+    if (!this->emitConst(CmpInfo.getValueInfo(Result)->getIntValue(), *Field->T,
                          E))
       return false;
-    return this->emitInitField(FieldT, Field->Offset, E);
+    return this->emitInitField(*Field->T, Field->Offset, E);
   }
 
   PrimType T = classifyPrim(E->getType());
@@ -4027,11 +4026,9 @@ bool Compiler<Emitter>::VisitSourceLocExpr(const SourceLocExpr *E) {
     const Record::Field *F = R->getField(I);
     const APValue &FieldValue = V.getStructField(I);
 
-    PrimType FieldT = classifyPrim(F->Decl->getType());
-
-    if (!this->visitAPValue(FieldValue, FieldT, E))
+    if (!this->visitAPValue(FieldValue, *F->T, E))
       return false;
-    if (!this->emitInitField(FieldT, F->Offset, E))
+    if (!this->emitInitField(*F->T, F->Offset, E))
       return false;
   }
 
@@ -4849,7 +4846,7 @@ bool Compiler<Emitter>::VisitCXXStdInitializerListExpr(
   if (!this->emitInitFieldPtr(R->getField(0u)->Offset, E))
     return false;
 
-  PrimType SecondFieldT = classifyPrim(R->getField(1u)->Decl->getType());
+  PrimType SecondFieldT = *R->getField(1u)->T;
   if (isIntegerOrBoolType(SecondFieldT)) {
     if (!this->emitConst(ArrayType->getSize(), SecondFieldT, E))
       return false;
@@ -5946,7 +5943,7 @@ bool Compiler<Emitter>::visitAPValueInitializer(const APValue &Val,
       const Record::Field *RF = R->getField(I);
       QualType FieldType = RF->Decl->getType();
       // Fields.
-      if (OptPrimType PT = classify(FieldType)) {
+      if (OptPrimType PT = RF->T) {
         if (!this->visitAPValue(F, *PT, Info))
           return false;
         if (!this->emitInitField(*PT, RF->Offset, Info))
@@ -5995,7 +5992,7 @@ bool Compiler<Emitter>::visitAPValueInitializer(const APValue &Val,
     const Record::Field *RF = R->getField(UnionField);
     QualType FieldType = RF->Decl->getType();
 
-    if (OptPrimType PT = classify(FieldType)) {
+    if (OptPrimType PT = RF->T) {
       if (!this->visitAPValue(F, *PT, Info))
         return false;
       if (RF->isBitField())
@@ -8926,7 +8923,7 @@ bool Compiler<Emitter>::emitHLSLAggregateSplat(PrimType SrcT,
         continue;
 
       QualType FieldType = F.Decl->getType();
-      if (OptPrimType FieldT = classify(FieldType)) {
+      if (OptPrimType FieldT = F.T) {
         if (!this->emitGetLocal(SrcT, SrcOffset, E))
           return false;
         if (!this->emitPrimCast(SrcT, *FieldT, FieldType, E))
@@ -9114,7 +9111,7 @@ bool Compiler<Emitter>::emitHLSLFlattenAggregate(
       if (!this->emitGetPtrFieldPop(F.Offset, E))
         return false;
 
-      if (OptPrimType FieldT = classify(FieldType)) {
+      if (OptPrimType FieldT = F.T) {
         if (!this->emitLoadPop(*FieldT, E))
           return false;
         if (!saveToLocal(*FieldT))
@@ -9227,7 +9224,7 @@ bool Compiler<Emitter>::emitHLSLConstructAggregate(
         continue;
 
       QualType FieldType = F.Decl->getType();
-      if (OptPrimType FieldT = classify(FieldType)) {
+      if (OptPrimType FieldT = F.T) {
         if (!loadAndCast(*FieldT, FieldType))
           return false;
         if (F.isBitField()) {

--- a/clang/lib/AST/ByteCode/InterpBuiltin.cpp
+++ b/clang/lib/AST/ByteCode/InterpBuiltin.cpp
@@ -6867,7 +6867,7 @@ static bool copyRecord(InterpState &S, CodePtr OpPC, PtrView Src, PtrView Dest,
 
   auto copyField = [&](const Record::Field &F, bool Activate) -> bool {
     PtrView DestField = Dest.atField(F.Offset);
-    if (OptPrimType FT = S.Ctx.classify(F.Decl->getType())) {
+    if (OptPrimType FT = F.T) {
       TYPE_SWITCH(*FT, {
         DestField.deref<T>() = Src.atField(F.Offset).deref<T>();
         if (Src.atField(F.Offset).isInitialized())

--- a/clang/lib/AST/ByteCode/Program.cpp
+++ b/clang/lib/AST/ByteCode/Program.cpp
@@ -325,7 +325,8 @@ Record *Program::getOrCreateRecord(const RecordDecl *RD) {
     const bool IsMutable = FD->isMutable();
     const bool IsVolatile = FT.isVolatileQualified();
     const Descriptor *Desc;
-    if (OptPrimType T = Ctx.classify(FT)) {
+    OptPrimType T = Ctx.classify(FT);
+    if (T) {
       Desc = createDescriptor(FD, *T, nullptr, IsConst,
                               /*IsTemporary=*/false, IsMutable, IsVolatile);
       HasPtrField = HasPtrField || (T == PT_Ptr);
@@ -339,7 +340,7 @@ Record *Program::getOrCreateRecord(const RecordDecl *RD) {
     } else {
       Desc = allocateDescriptor(FD);
     }
-    Fields.emplace_back(FD, Desc, BaseSize);
+    Fields.emplace_back(FD, Desc, BaseSize, T);
     BaseSize += align(Desc->getAllocSize());
   }
 

--- a/clang/lib/AST/ByteCode/Record.h
+++ b/clang/lib/AST/ByteCode/Record.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_CLANG_AST_INTERP_RECORD_H
 #define LLVM_CLANG_AST_INTERP_RECORD_H
 
+#include "PrimType.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclCXX.h"
 
@@ -29,6 +30,7 @@ public:
     const FieldDecl *Decl;
     const Descriptor *Desc;
     unsigned Offset;
+    OptPrimType T;
     bool IsBitField;
     bool IsUnnamedBitField;
 
@@ -39,8 +41,9 @@ public:
       return Decl->getBitWidthValue();
     }
 
-    Field(const FieldDecl *D, const Descriptor *Desc, unsigned Offset)
-        : Decl(D), Desc(Desc), Offset(Offset) {
+    Field(const FieldDecl *D, const Descriptor *Desc, unsigned Offset,
+          OptPrimType T)
+        : Decl(D), Desc(Desc), Offset(Offset), T(T) {
       IsBitField = Decl->isBitField();
       IsUnnamedBitField = IsBitField && Decl->isUnnamedBitField();
     }


### PR DESCRIPTION
This does not increase the size of `Record::Field` but lets us avoid classifying fields all the time.