### PR TITLE
[offload][omp] Load and resolve device binaries through liboffload

### DIFF
--- a/offload/include/Program.h
+++ b/offload/include/Program.h
@@ -1,0 +1,47 @@
+//===------------ Program.h - liboffload program abstraction ------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Declares ProgramTy, which wraps a liboffload program handle (a device
+// image loaded via olCreateProgram) along with the routines used to resolve
+// its global-variable and kernel symbols.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _OMPTARGET_PROGRAM_H
+#define _OMPTARGET_PROGRAM_H
+
+#include "OffloadAPI.h"
+#include "Shared/APITypes.h"
+#include "llvm/Support/Error.h"
+
+class ProgramTy {
+public:
+  ProgramTy() = default;
+
+  /// Load \p Img onto \p Device within \p Context via liboffload.
+  static llvm::Expected<ProgramTy> create(ol_context_handle_t Context,
+                                          ol_device_handle_t Device,
+                                          __tgt_device_image *Img);
+
+  /// Resolve the device address of the global variable \p Name. If \p Size
+  /// is non-null, it is set to the size in bytes of the global
+  llvm::Expected<void *> getGlobalAddress(const char *Name,
+                                          size_t *Size = nullptr) const;
+
+  /// Resolve the opaque plugin kernel handle for the kernel \p Name.
+  llvm::Expected<void *> getKernelAddress(const char *Name) const;
+
+  ol_program_handle_t getHandle() const { return Handle; }
+
+private:
+  explicit ProgramTy(ol_program_handle_t Handle) : Handle(Handle) {}
+
+  ol_program_handle_t Handle = nullptr;
+};
+
+#endif

--- a/offload/include/Shared/APITypes.h
+++ b/offload/include/Shared/APITypes.h
@@ -62,11 +62,6 @@ struct __tgt_target_table {
       *EntriesEnd; // End of the table with all the entries (non inclusive)
 };
 
-/// This struct contains a handle to a loaded binary in the plugin device.
-struct __tgt_device_binary {
-  uintptr_t handle;
-};
-
 // clang-format on
 
 /// This struct contains information exchanged between different asynchronous

--- a/offload/include/device.h
+++ b/offload/include/device.h
@@ -36,6 +36,7 @@
 #include "GlobalHandler.h"
 #include "OffloadAPI.h"
 #include "PluginInterface.h"
+#include "Program.h"
 
 using GenericPluginTy = llvm::omp::target::plugin::GenericPluginTy;
 using DeviceInfo = llvm::omp::target::plugin::DeviceInfo;
@@ -69,7 +70,8 @@ struct DeviceTy {
   /// Provide access to the mapping handler.
   MappingInfoTy &getMappingInfo() { return MappingInfo; }
 
-  llvm::Expected<__tgt_device_binary> loadBinary(__tgt_device_image *Img);
+  /// Load \p Img onto the device and return the resulting program.
+  llvm::Expected<ProgramTy> loadBinary(__tgt_device_image *Img);
 
   // device memory allocation/deallocation routines
   /// Allocates \p Size bytes on the device, host or shared memory space
@@ -190,5 +192,11 @@ private:
   /// Flag to indicate pending images (true after construction).
   bool HasPendingImages = true;
 };
+
+/// Resolve the device address of the global variable \p Name in \p Program,
+/// recording it for kernel record/replay if recording is currently active.
+llvm::Expected<void *> getAndRecordGlobalAddress(DeviceTy &Device,
+                                                 const ProgramTy &Program,
+                                                 const char *Name);
 
 #endif

--- a/offload/liboffload/exports
+++ b/offload/liboffload/exports
@@ -16,12 +16,9 @@ global:
     "llvm::omp::target::plugin::GenericPluginTy::data_notify_unmapped(int, void*)";
     "llvm::omp::target::plugin::GenericPluginTy::data_unlock(int, void*)";
     "llvm::omp::target::plugin::GenericPluginTy::flush_queue(omp_interop_val_t*)";
-    "llvm::omp::target::plugin::GenericPluginTy::get_function(__tgt_device_binary, char const*, void**)";
-    "llvm::omp::target::plugin::GenericPluginTy::get_global(__tgt_device_binary, unsigned long, char const*, void**)";
     "llvm::omp::target::plugin::GenericPluginTy::initialize_record_replay(int, long, void*, bool, bool, bool, bool, char const*, char const*)";
     "llvm::omp::target::plugin::GenericPluginTy::is_initialized() const";
     "llvm::omp::target::plugin::GenericPluginTy::launch_kernel(int, void*, llvm::omp::target::plugin::KernelLaunchArgsTy&, __tgt_async_info*)";
-    "llvm::omp::target::plugin::GenericPluginTy::load_binary(int, __tgt_device_image*, __tgt_device_binary*)";
     "llvm::omp::target::plugin::GenericPluginTy::release_interop(int, omp_interop_val_t*)";
     "llvm::omp::target::plugin::GenericPluginTy::set_device_identifier(int, int)";
     "llvm::omp::target::plugin::GenericPluginTy::sync_barrier(omp_interop_val_t*)";
@@ -34,6 +31,7 @@ global:
     __ol_tgt_GetPluginFromPlatform;
     __ol_tgt_GetPluginDeviceId;
     __ol_tgt_GetAsyncInfoFromQueue;
+    __ol_tgt_GetKernelFromSymbol;
   };
 local:
   *;

--- a/offload/liboffload/src/OffloadImpl.cpp
+++ b/offload/liboffload/src/OffloadImpl.cpp
@@ -1706,5 +1706,9 @@ __ol_tgt_GetAsyncInfoFromQueue(ol_queue_handle_t Queue) {
   return Queue->AsyncInfo;
 }
 
+extern "C" void *__ol_tgt_GetKernelFromSymbol(ol_symbol_handle_t Symbol) {
+  return std::get<GenericKernelTy *>(Symbol->PluginImpl);
+}
+
 } // namespace offload
 } // namespace llvm

--- a/offload/libompaccsupport/PluginManager.cpp
+++ b/offload/libompaccsupport/PluginManager.cpp
@@ -474,8 +474,8 @@ static int loadImagesOntoDevice(DeviceTy &Device) {
       }
 
       // 2) Load the image onto the given device.
-      auto BinaryOrErr = Device.loadBinary(Img);
-      if (llvm::Error Err = BinaryOrErr.takeError()) {
+      auto LoadedOrErr = Device.loadBinary(Img);
+      if (llvm::Error Err = LoadedOrErr.takeError()) {
         REPORT() << "Failed to load image " << llvm::toString(std::move(Err));
         Rc = OFFLOAD_FAIL;
         break;
@@ -489,14 +489,20 @@ static int loadImagesOntoDevice(DeviceTy &Device) {
         if (Entry.Kind != object::OffloadKind::OFK_OpenMP)
           continue;
 
-        __tgt_device_binary &Binary = *BinaryOrErr;
+        ProgramTy &Program = *LoadedOrErr;
 
         llvm::offloading::EntryTy DeviceEntry = Entry;
         if (Entry.Size) {
-          if (!(Entry.Flags & OMP_DECLARE_TARGET_INDIRECT_VTABLE))
-            if (Device.RTL->get_global(Binary, Entry.Size, Entry.SymbolName,
-                                       &DeviceEntry.Address) != OFFLOAD_SUCCESS)
-              REPORT() << "Failed to load symbol " << Entry.SymbolName;
+          if (!(Entry.Flags & OMP_DECLARE_TARGET_INDIRECT_VTABLE)) {
+            auto AddrOrErr =
+                getAndRecordGlobalAddress(Device, Program, Entry.SymbolName);
+            if (!AddrOrErr) {
+              REPORT() << "Failed to load symbol " << Entry.SymbolName << ": "
+                       << llvm::toString(AddrOrErr.takeError());
+            } else {
+              DeviceEntry.Address = *AddrOrErr;
+            }
+          }
 
           // If unified memory is active, the corresponding global is a device
           // reference to the host global. We need to initialize the pointer on
@@ -511,9 +517,13 @@ static int loadImagesOntoDevice(DeviceTy &Device) {
               REPORT() << "Failed to write symbol for USM " << Entry.SymbolName;
           }
         } else if (Entry.Address) {
-          if (Device.RTL->get_function(Binary, Entry.SymbolName,
-                                       &DeviceEntry.Address) != OFFLOAD_SUCCESS)
-            REPORT() << "Failed to load kernel " << Entry.SymbolName;
+          auto AddrOrErr = Program.getKernelAddress(Entry.SymbolName);
+          if (!AddrOrErr) {
+            REPORT() << "Failed to load kernel " << Entry.SymbolName << ": "
+                     << llvm::toString(AddrOrErr.takeError());
+          } else {
+            DeviceEntry.Address = *AddrOrErr;
+          }
         }
         ODBG(ODT_Mapping) << "Entry point " << Entry.Address << " maps to"
                           << (Entry.Size ? " global" : "") << " "

--- a/offload/libompaccsupport/Program.cpp
+++ b/offload/libompaccsupport/Program.cpp
@@ -1,0 +1,69 @@
+//===------------ Program.cpp - liboffload program abstraction ----------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "Program.h"
+#include "OffloadError.h"
+
+#include <cstdint>
+
+using namespace llvm;
+
+// Temporary helper to help transition of libomptarget to liboffload: returns
+// the opaque plugin kernel handle backing a kernel symbol, for use with the
+// legacy plugin launch interface until kernel launch itself is migrated to
+// liboffload.
+extern "C" void *__ol_tgt_GetKernelFromSymbol(ol_symbol_handle_t Symbol);
+
+Expected<ProgramTy> ProgramTy::create(ol_context_handle_t Context,
+                                      ol_device_handle_t Device,
+                                      __tgt_device_image *Img) {
+  ol_program_handle_t Handle;
+  size_t ImageSize = reinterpret_cast<uintptr_t>(Img->ImageEnd) -
+                     reinterpret_cast<uintptr_t>(Img->ImageStart);
+  if (auto Res =
+          olCreateProgram(Context, Device, Img->ImageStart, ImageSize, &Handle))
+    return error::createOffloadError(error::ErrorCode::INVALID_BINARY,
+                                     "failed to load binary %p: %s", Img,
+                                     Res->Details);
+
+  return ProgramTy(Handle);
+}
+
+Expected<void *> ProgramTy::getGlobalAddress(const char *Name,
+                                             size_t *Size) const {
+  ol_symbol_handle_t Symbol;
+  if (auto Res =
+          olGetSymbol(Handle, Name, OL_SYMBOL_KIND_GLOBAL_VARIABLE, &Symbol))
+    return error::createOffloadError(error::ErrorCode::INVALID_BINARY,
+                                     "failed to find global symbol %s: %s",
+                                     Name, Res->Details);
+
+  void *Address = nullptr;
+  if (auto Res = olGetSymbolInfo(Symbol, OL_SYMBOL_INFO_GLOBAL_VARIABLE_ADDRESS,
+                                 sizeof(Address), &Address))
+    return error::createOffloadError(
+        error::ErrorCode::INVALID_BINARY,
+        "failed to get device address of global symbol %s: %s", Name,
+        Res->Details);
+
+  if (Size && olGetSymbolInfo(Symbol, OL_SYMBOL_INFO_GLOBAL_VARIABLE_SIZE,
+                              sizeof(*Size), Size))
+    *Size = 0;
+
+  return Address;
+}
+
+Expected<void *> ProgramTy::getKernelAddress(const char *Name) const {
+  ol_symbol_handle_t Symbol;
+  if (auto Res = olGetSymbol(Handle, Name, OL_SYMBOL_KIND_KERNEL, &Symbol))
+    return error::createOffloadError(error::ErrorCode::INVALID_BINARY,
+                                     "failed to find kernel symbol %s: %s",
+                                     Name, Res->Details);
+
+  return __ol_tgt_GetKernelFromSymbol(Symbol);
+}

--- a/offload/libompaccsupport/device.cpp
+++ b/offload/libompaccsupport/device.cpp
@@ -122,13 +122,31 @@ llvm::Error DeviceTy::deinit() {
   return llvm::Error::success();
 }
 
+// Resolve the device address of the global variable \p Name in \p Program,
+// recording it for kernel record/replay if recording is currently active.
+llvm::Expected<void *> getAndRecordGlobalAddress(DeviceTy &Device,
+                                                 const ProgramTy &Program,
+                                                 const char *Name) {
+  size_t Size = 0;
+  auto AddrOrErr = Program.getGlobalAddress(Name, &Size);
+  if (!AddrOrErr)
+    return AddrOrErr;
+
+  GenericDeviceTy &GenericDevice = Device.RTL->getDevice(Device.RTLDeviceID);
+  RecordReplayTy *RecordReplay = GenericDevice.getRecordReplay();
+  if (RecordReplay && RecordReplay->isRecording())
+    RecordReplay->addGlobal(Name, Size, *AddrOrErr);
+
+  return AddrOrErr;
+}
+
 // Extract the mapping of host function pointers to device function pointers
 // from the entry table. Functions marked as 'indirect' in OpenMP will have
 // offloading entries generated for them which map the host's function pointer
 // to a global containing the corresponding function pointer on the device.
 static llvm::Expected<std::pair<void *, uint64_t>>
 setupIndirectCallTable(DeviceTy &Device, __tgt_device_image *Image,
-                       __tgt_device_binary Binary) {
+                       const ProgramTy &Program) {
   AsyncInfoTy AsyncInfo(Device);
   llvm::ArrayRef<llvm::offloading::EntryTy> Entries(Image->EntriesBegin,
                                                     Image->EntriesEnd);
@@ -146,11 +164,12 @@ setupIndirectCallTable(DeviceTy &Device, __tgt_device_image *Image,
       // VTable and Entry.Size is the total size of the VTable. Unlike the
       // indirect function case below, the Global is not of size Entry.Size and
       // is instead of size PtrSize (sizeof(void*)).
-      void *Vtable;
       void *res;
-      if (Device.RTL->get_global(Binary, PtrSize, Entry.SymbolName, &Vtable))
-        return error::createOffloadError(error::ErrorCode::INVALID_BINARY,
-                                         "failed to load %s", Entry.SymbolName);
+      auto VtableOrErr =
+          getAndRecordGlobalAddress(Device, Program, Entry.SymbolName);
+      if (!VtableOrErr)
+        return VtableOrErr.takeError();
+      void *Vtable = *VtableOrErr;
 
       // HstPtr = Entry.Address;
       if (Device.retrieveData(&res, Vtable, PtrSize, AsyncInfo))
@@ -173,10 +192,11 @@ setupIndirectCallTable(DeviceTy &Device, __tgt_device_image *Image,
       // dealing with a single function pointer (not a VTable)
       assert(Entry.Size == PtrSize && "Global not a function pointer?");
       auto &[HstPtr, DevPtr] = IndirectCallTable.emplace_back();
-      void *Ptr;
-      if (Device.RTL->get_global(Binary, Entry.Size, Entry.SymbolName, &Ptr))
-        return error::createOffloadError(error::ErrorCode::INVALID_BINARY,
-                                         "failed to load %s", Entry.SymbolName);
+      auto PtrOrErr =
+          getAndRecordGlobalAddress(Device, Program, Entry.SymbolName);
+      if (!PtrOrErr)
+        return PtrOrErr.takeError();
+      void *Ptr = *PtrOrErr;
 
       HstPtr = Entry.Address;
       if (Device.retrieveData(&DevPtr, Ptr, Entry.Size, AsyncInfo))
@@ -215,22 +235,23 @@ setupIndirectCallTable(DeviceTy &Device, __tgt_device_image *Image,
 }
 
 // Load binary to device and perform global initialization if needed.
-llvm::Expected<__tgt_device_binary>
-DeviceTy::loadBinary(__tgt_device_image *Img) {
-  __tgt_device_binary Binary;
-
-  if (RTL->load_binary(RTLDeviceID, Img, &Binary) != OFFLOAD_SUCCESS)
-    return error::createOffloadError(error::ErrorCode::INVALID_BINARY,
-                                     "failed to load binary %p", Img);
+llvm::Expected<ProgramTy> DeviceTy::loadBinary(__tgt_device_image *Img) {
+  auto ProgramOrErr = ProgramTy::create(Context, DeviceHandle, Img);
+  if (!ProgramOrErr)
+    return ProgramOrErr.takeError();
+  ProgramTy Program = std::move(*ProgramOrErr);
 
   // This symbol is optional.
-  void *DeviceEnvironmentPtr;
-  if (RTL->get_global(Binary, sizeof(DeviceEnvironmentTy),
-                      "__omp_rtl_device_environment", &DeviceEnvironmentPtr))
-    return Binary;
+  auto DeviceEnvironmentPtrOrErr =
+      getAndRecordGlobalAddress(*this, Program, "__omp_rtl_device_environment");
+  if (!DeviceEnvironmentPtrOrErr) {
+    llvm::consumeError(DeviceEnvironmentPtrOrErr.takeError());
+    return std::move(Program);
+  }
+  void *DeviceEnvironmentPtr = *DeviceEnvironmentPtrOrErr;
 
   // Obtain a table mapping host function pointers to device function pointers.
-  auto CallTablePairOrErr = setupIndirectCallTable(*this, Img, Binary);
+  auto CallTablePairOrErr = setupIndirectCallTable(*this, Img, Program);
   if (!CallTablePairOrErr)
     return CallTablePairOrErr.takeError();
 
@@ -254,7 +275,7 @@ DeviceTy::loadBinary(__tgt_device_image *Img) {
     return error::createOffloadError(error::ErrorCode::INVALID_BINARY,
                                      "failed to copy data");
 
-  return Binary;
+  return std::move(Program);
 }
 
 void *DeviceTy::allocData(int64_t Size, void *HstPtr, int32_t Kind) {

--- a/offload/libomptarget/CMakeLists.txt
+++ b/offload/libomptarget/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library(omptarget SHARED
   ../libompaccsupport/PluginManager.cpp
   ../libompaccsupport/DeviceImage.cpp
   ../libompaccsupport/Mapping.cpp
+  ../libompaccsupport/Program.cpp
 
   KernelLanguage/API.cpp
 )

--- a/offload/plugins-nextgen/common/include/PluginInterface.h
+++ b/offload/plugins-nextgen/common/include/PluginInterface.h
@@ -1706,10 +1706,6 @@ public:
                                    const char *ReportFilename,
                                    const char *OutputDirPath);
 
-  /// Loads the associated binary into the plugin and returns a handle to it.
-  int32_t load_binary(int32_t DeviceId, __tgt_device_image *TgtImage,
-                      __tgt_device_binary *Binary);
-
   /// Allocates memory that is accessively to the given device.
   void *data_alloc(int32_t DeviceId, int64_t Size, void *HostPtr, int32_t Kind);
 
@@ -1742,14 +1738,6 @@ public:
 
   /// Returns if the plugin can support automatic copy.
   int32_t use_auto_zero_copy(int32_t DeviceId);
-
-  /// Look up a global symbol in the given binary.
-  int32_t get_global(__tgt_device_binary Binary, uint64_t Size,
-                     const char *Name, void **DevicePtr);
-
-  /// Look up a kernel function in the given binary.
-  int32_t get_function(__tgt_device_binary Binary, const char *Name,
-                       void **KernelPtr);
 
   /// Return the interop specification that the plugin supports
   /// It might not be one of the user specified ones.

--- a/offload/plugins-nextgen/common/src/PluginInterface.cpp
+++ b/offload/plugins-nextgen/common/src/PluginInterface.cpp
@@ -1502,29 +1502,6 @@ int32_t GenericPluginTy::initialize_record_replay(
   return OFFLOAD_SUCCESS;
 }
 
-int32_t GenericPluginTy::load_binary(int32_t DeviceId,
-                                     __tgt_device_image *TgtImage,
-                                     __tgt_device_binary *Binary) {
-  GenericDeviceTy &Device = getDevice(DeviceId);
-
-  StringRef Buffer(reinterpret_cast<const char *>(TgtImage->ImageStart),
-                   utils::getPtrDiff(TgtImage->ImageEnd, TgtImage->ImageStart));
-  auto ImageOrErr = Device.loadBinary(*this, Buffer, /*Context=*/nullptr);
-  if (!ImageOrErr) {
-    auto Err = ImageOrErr.takeError();
-    REPORT() << "Failure to load binary image " << TgtImage << " on device "
-             << DeviceId << ": " << toString(std::move(Err));
-    return OFFLOAD_FAIL;
-  }
-
-  DeviceImageTy *Image = *ImageOrErr;
-  assert(Image != nullptr && "Invalid Image");
-
-  *Binary = __tgt_device_binary{reinterpret_cast<uint64_t>(Image)};
-
-  return OFFLOAD_SUCCESS;
-}
-
 void *GenericPluginTy::data_alloc(int32_t DeviceId, int64_t Size, void *HostPtr,
                                   int32_t Kind) {
   auto AllocOrErr = getDevice(DeviceId).dataAlloc(
@@ -1635,56 +1612,6 @@ int32_t GenericPluginTy::set_device_identifier(int32_t UserId,
 
 int32_t GenericPluginTy::use_auto_zero_copy(int32_t DeviceId) {
   return getDevice(DeviceId).useAutoZeroCopy();
-}
-
-int32_t GenericPluginTy::get_global(__tgt_device_binary Binary, uint64_t Size,
-                                    const char *Name, void **DevicePtr) {
-  assert(Binary.handle && "Invalid device binary handle");
-  DeviceImageTy &Image = *reinterpret_cast<DeviceImageTy *>(Binary.handle);
-
-  GenericDeviceTy &Device = Image.getDevice();
-
-  GlobalTy DeviceGlobal(Name, Size);
-  GenericGlobalHandlerTy &GHandler = getGlobalHandler();
-  if (auto Err =
-          GHandler.getGlobalMetadataFromDevice(Device, Image, DeviceGlobal)) {
-    consumeError(std::move(Err));
-    return OFFLOAD_FAIL;
-  }
-
-  *DevicePtr = DeviceGlobal.getPtr();
-  assert(DevicePtr && "Invalid device global's address");
-
-  // Save the loaded globals if we are recording.
-  RecordReplayTy *RecordReplay = Device.getRecordReplay();
-  if (RecordReplay && RecordReplay->isRecording())
-    RecordReplay->addGlobal(Name, Size, *DevicePtr);
-
-  return OFFLOAD_SUCCESS;
-}
-
-int32_t GenericPluginTy::get_function(__tgt_device_binary Binary,
-                                      const char *Name, void **KernelPtr) {
-  assert(Binary.handle && "Invalid device binary handle");
-  DeviceImageTy &Image = *reinterpret_cast<DeviceImageTy *>(Binary.handle);
-
-  GenericDeviceTy &Device = Image.getDevice();
-
-  auto KernelOrErr = Device.constructKernel(Name);
-  if (Error Err = KernelOrErr.takeError()) {
-    REPORT() << "Failure to look up kernel: " << toString(std::move(Err));
-    return OFFLOAD_FAIL;
-  }
-
-  GenericKernelTy &Kernel = *KernelOrErr;
-  if (auto Err = Kernel.init(Device, Image)) {
-    REPORT() << "Failure to init kernel: " << toString(std::move(Err));
-    return OFFLOAD_FAIL;
-  }
-
-  // Note that this is not the kernel's device address.
-  *KernelPtr = &Kernel;
-  return OFFLOAD_SUCCESS;
 }
 
 /// Create OpenMP interop with the given interop context


### PR DESCRIPTION
Create a new abstraction (Program) that uses liboffload to load the binary and do symbol resolution instead of calling the PluginInterface directly.
Remove from GenericPluginTy load_binary, get_global and get_function.

Assisted by Claude.