### PR TITLE
[VPlan] Add IV steps cost tests for small trip counts and regions (NFC).

### DIFF
--- a/llvm/test/Transforms/LoopVectorize/AArch64/scalar-steps-cost.ll
+++ b/llvm/test/Transforms/LoopVectorize/AArch64/scalar-steps-cost.ll
@@ -49,3 +49,57 @@ exit:
   ret void
 }
 
+; Same as @scalar_steps_all_lanes, but with a constant trip count of 4. At VF 4
+; the vector body executes at most once.
+define i32 @scalar_steps_all_lanes_tc_eq_vf(ptr %start) {
+; CHECK-LABEL: LV: Checking a loop in 'scalar_steps_all_lanes_tc_eq_vf'
+; CHECK: Cost of 1 for VF 2: {{.*}} = SCALAR-STEPS {{.*}}, ir<1>, {{.*}}
+; CHECK: Cost of 1 for VF 4: {{.*}} = SCALAR-STEPS {{.*}}, ir<1>, {{.*}}
+entry:
+  br label %loop
+
+loop:
+  %iv = phi ptr [ %start, %entry ], [ %iv.next, %loop ]
+  %i = phi i64 [ 0, %entry ], [ %i.next, %loop ]
+  %rdx = phi i32 [ 0, %entry ], [ %rdx.next, %loop ]
+  %l = load i32, ptr %iv, align 1
+  %1 = and i32 %l, 1
+  %rdx.next = or i32 %rdx, %1
+  %iv.next = getelementptr i8, ptr %iv, i64 1
+  %i.next = add i64 %i, 1
+  %ec = icmp eq i64 %i.next, 4
+  br i1 %ec, label %exit, label %loop
+
+exit:
+  ret i32 %rdx.next
+}
+
+define void @scalar_steps_in_replicate_region(ptr noalias %dst, ptr noalias %src, i64 %n) {
+; CHECK-LABEL: LV: Checking a loop in 'scalar_steps_in_replicate_region'
+; CHECK: Cost of 0 for VF 2: {{.*}} = SCALAR-STEPS {{.*}}, ir<1>, {{.*}}
+; CHECK: Cost of 0 for VF 2: {{.*}} = SCALAR-STEPS {{.*}}, ir<1>, {{.*}}
+; CHECK: Cost of 0 for VF 4: {{.*}} = SCALAR-STEPS {{.*}}, ir<1>, {{.*}}
+; CHECK: Cost of 0 for VF 4: {{.*}} = SCALAR-STEPS {{.*}}, ir<1>, {{.*}}
+entry:
+  br label %loop
+
+loop:
+  %iv = phi i64 [ 0, %entry ], [ %iv.next, %latch ]
+  %gep.src = getelementptr inbounds i32, ptr %src, i64 %iv
+  %l = load i32, ptr %gep.src, align 4
+  %c = icmp sgt i32 %l, 0
+  br i1 %c, label %if.then, label %latch
+
+if.then:
+  %gep.dst = getelementptr inbounds i32, ptr %dst, i64 %iv
+  store i32 %l, ptr %gep.dst, align 4
+  br label %latch
+
+latch:
+  %iv.next = add nuw nsw i64 %iv, 1
+  %ec = icmp eq i64 %iv.next, %n
+  br i1 %ec, label %exit, label %loop
+
+exit:
+  ret void
+}


### PR DESCRIPTION
Add 2 tests covering missing cases: scalar-iv steps cost in single iteration loops, and cost in replicate regions.