### PR TITLE
[OpenMP] Remove the LocationDescription constructor that dropped the location.

### DIFF
--- a/llvm/include/llvm/Frontend/OpenMP/OMPIRBuilder.h
+++ b/llvm/include/llvm/Frontend/OpenMP/OMPIRBuilder.h
@@ -744,7 +744,6 @@ public:
   struct LocationDescription {
     LocationDescription(const IRBuilderBase &IRB)
         : IP(IRB.saveIP()), DL(IRB.getCurrentDebugLocation()) {}
-    LocationDescription(const InsertPointTy &IP) : IP(IP) {}
     LocationDescription(const InsertPointTy &IP, const DebugLoc &DL)
         : IP(IP), DL(DL) {}
     InsertPointTy IP;


### PR DESCRIPTION
LocationDescription had an implicit conversion from a bare insertion point, so     `ompBuilder->emitSomething(someInsertPoint, ...)` compiled happily and silently  produced an empty debug location. Because  updateToLocation() installs the location unconditionally, this was worse than a missing assignment: it cleared whatever the builder was carrying, and the emitted runtime call ended up with no !dbg. On the device those calls are inlinable, so the verifier rejects them once the runtime carries debug info -- which is how this kept turning up as bug reports rather than as anything visible at the callsite.
    
With the callers in OMPIRBuilder, OpenMPOpt, the MLIR translation and clang all converted, the constructor can go, and the compiler will now refuse the shape that caused the problem. Callers have to say which location they mean: pass the IRBuilder to take its current one, or spell out the insertion point and location as a pair.