### PR TITLE
[clang-tidy] Fix false positive in readability-non-const-parameter for atomic builtins

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/NonConstParameterCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/NonConstParameterCheck.cpp
@@ -66,7 +66,7 @@ void NonConstParameterCheck::registerMatchers(MatchFinder *Finder) {
   Finder->addMatcher(
       stmt(anyOf(unaryOperator(hasAnyOperatorName("++", "--")),
                  binaryOperator(), callExpr(), returnStmt(), cxxConstructExpr(),
-                 cxxUnresolvedConstructExpr()))
+                 cxxUnresolvedConstructExpr(), atomicExpr()))
           .bind("Mark"),
       this);
   Finder->addMatcher(varDecl(hasOwnInitializer(anything())).bind("Mark"), this);
@@ -113,6 +113,13 @@ void NonConstParameterCheck::check(const MatchFinder::MatchResult &Result) {
           markCanNotBeConst(Arg->IgnoreParenCasts(), false);
         }
       }
+    } else if (const auto *AE = dyn_cast<AtomicExpr>(S)) {
+      // Atomic builtins may write through their pointer operands, such as the
+      // 'expected' operand of a compare-exchange, which receives the old value
+      // when the exchange fails.
+      for (const Expr *SubExpr :
+           llvm::ArrayRef(AE->getSubExprs(), AE->getNumSubExprs()))
+        markCanNotBeConst(SubExpr->IgnoreParenCasts(), true);
     } else if (const auto *CE = dyn_cast<CXXConstructExpr>(S)) {
       for (const auto *Arg : CE->arguments())
         markCanNotBeConst(Arg->IgnoreParenCasts(), true);

--- a/clang-tools-extra/docs/ReleaseNotes.md
+++ b/clang-tools-extra/docs/ReleaseNotes.md
@@ -244,6 +244,12 @@ infrastructure are described first, followed by tool-specific sections.
   exclusively for overload resolution. Added the {option}`IgnoredTypes`
   option to allow customizing the set of ignored types.
 
+- Improved {doc}`readability-non-const-parameter
+  <clang-tidy/checks/readability/non-const-parameter>` check by fixing false
+  positives on pointers passed to atomic builtins, whose operands may be
+  written to, such as the `expected` parameter of
+  `atomic_compare_exchange_strong()`.
+
 - Improved {doc}`readability-trailing-comma
   <clang-tidy/checks/readability/trailing-comma>` check:
 

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/non-const-parameter.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/non-const-parameter.c
@@ -9,3 +9,40 @@ int f(p)
 {
     return *p;
 }
+
+// The 'expected' operand of a compare-exchange receives the old value when the
+// exchange fails.
+int atomic_cas(_Atomic int *obj, int *expected, int desired) {
+  return __c11_atomic_compare_exchange_strong(
+      obj, expected, desired, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+}
+
+int atomic_cas_weak(_Atomic int *obj, int *expected, int desired) {
+  return __c11_atomic_compare_exchange_weak(
+      obj, expected, desired, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+}
+
+// The non-'_n' load and exchange forms write their result through an operand.
+void atomic_load_out(int *obj, int *dest) {
+  __atomic_load(obj, dest, __ATOMIC_SEQ_CST);
+}
+
+void atomic_exchange_out(int *obj, int *val, int *old) {
+  __atomic_exchange(obj, val, old, __ATOMIC_SEQ_CST);
+}
+
+// Only the operands of the atomic builtin are affected. Other parameters are
+// still reported.
+// CHECK-MESSAGES: :[[@LINE+1]]:69: warning: pointer parameter 'unrelated' can be pointer to const [readability-non-const-parameter]
+int atomic_cas_unrelated(int *obj, int *expected, int desired, int *unrelated) {
+  // CHECK-FIXES: int atomic_cas_unrelated(int *obj, int *expected, int desired, const int *unrelated) {
+  return __atomic_compare_exchange_n(obj, expected, desired, 0,
+                                     __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST) +
+         *unrelated;
+}
+
+// Conservatively, operands of other atomic builtins are not suggested as const
+// either, matching the existing treatment of ordinary function calls.
+int atomic_load_ptr(int *p) {
+  return __atomic_load_n(p, __ATOMIC_SEQ_CST);
+}

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/non-const-parameter.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/non-const-parameter.cpp
@@ -524,3 +524,46 @@ struct QualifiedMemberOverload {
   }
   void withConstQualifier(const int *qualifiedMemberPtr) {}
 };
+
+// The 'expected' operand of a compare-exchange receives the old value when the
+// exchange fails.
+bool atomicCompareExchangeN(int *obj, int *expected, int desired) {
+  return __atomic_compare_exchange_n(obj, expected, desired, false,
+                                     __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+}
+
+bool atomicCompareExchange(int *obj, int *expected, int *desired) {
+  return __atomic_compare_exchange(obj, expected, desired, false,
+                                   __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+}
+
+// Operands are followed through pointer arithmetic.
+bool atomicCompareExchangeOffset(int *obj, int *expected, int desired) {
+  return __atomic_compare_exchange_n(obj, expected + 1, desired, false,
+                                     __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+}
+
+// The non-'_n' load and exchange forms write their result through an operand.
+void atomicLoadOut(int *obj, int *dest) {
+  __atomic_load(obj, dest, __ATOMIC_SEQ_CST);
+}
+
+void atomicExchangeOut(int *obj, int *val, int *old) {
+  __atomic_exchange(obj, val, old, __ATOMIC_SEQ_CST);
+}
+
+// Only the operands of the atomic builtin are affected. Other parameters are
+// still reported.
+// CHECK-MESSAGES: :[[@LINE+1]]:66: warning: pointer parameter 'unrelated' can be pointer to const
+int atomicCompareExchangeUnrelated(int *obj, int *expected, int *unrelated) {
+  // CHECK-FIXES: int atomicCompareExchangeUnrelated(int *obj, int *expected, const int *unrelated) {
+  return __atomic_compare_exchange_n(obj, expected, 0, false,
+                                     __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST) +
+         *unrelated;
+}
+
+// Conservatively, operands of other atomic builtins are not suggested as const
+// either, matching the existing treatment of ordinary function calls.
+int atomicLoad(int *p) {
+  return __atomic_load_n(p, __ATOMIC_SEQ_CST);
+}


### PR DESCRIPTION
Atomic builtins are represented in the AST by `AtomicExpr` rather than `CallExpr`, so `readability-non-const-parameter` never analysed their operands and assumed the pointed-to data was only read. It then suggested making those pointer parameters point to const, and applying the fix-it produced code that no longer compiles.

The most visible case is the `expected` operand of a compare-exchange, which per the C standard must be a pointer to non-const because it receives the old value when the exchange fails:
https://godbolt.org/z/sovKf3G3c

Before this change the check reported `expected` as a candidate for pointer-to-const. The GNU builtins are affected the same way, and there the address operand `obj` was reported too, as were the destination operand of `__atomic_load()` and the old-value operand of `__atomic_exchange()`.

Match `atomicExpr()` and mark all of its operands, mirroring how arguments of ordinary calls are already treated.
