### PR TITLE
[flang][docs] Add flang to full list of projects in top-level LLVM CMake docs

### DIFF
--- a/llvm/docs/CMake.md
+++ b/llvm/docs/CMake.md
@@ -641,7 +641,7 @@ sub-projects. Nearly all of these variable names begin with `LLVM_`.
 
     The full list is:
 
-    `bolt;clang;clang-tools-extra;compiler-rt;cross-project-tests;libc;libclc;lld;lldb;mlir;openmp;polly`
+    `bolt;clang;clang-tools-extra;compiler-rt;cross-project-tests;flang;libc;libclc;lld;lldb;mlir;openmp;polly`
 
     :::{note}
     Some projects listed here can also go in `LLVM_ENABLE_RUNTIMES`. They should only appear in one of the two lists. If a project is a valid possibility for both, prefer putting it in `LLVM_ENABLE_RUNTIMES`.


### PR DESCRIPTION
The top-level LLVM CMake docs do not include `flang` as a valid value for the *full* list of projects valid for `LLVM_ENABLE_PROJECTS`, even though it is per the `flang` project documentation.