### PR TITLE
[BOLT][RISCV] Remove redundant AUIPCs when rewriting call pairs

### DIFF
--- a/bolt/lib/Passes/FixRISCVCallsPass.cpp
+++ b/bolt/lib/Passes/FixRISCVCallsPass.cpp
@@ -55,6 +55,8 @@ void FixRISCVCallsPass::runOnFunction(BinaryFunction &BF) {
         auto L = BC.scopeLock();
 
         MIB->createNoop(*II);
+        // Mark the replacement NOP for removal by the later RemoveNops pass.
+        MIB->addAnnotation(*II, "NOP", static_cast<uint32_t>(1));
 
         if (MIB->isTailCall(*NextII))
           MIB->createTailCall(*NextII, Target, Ctx);

--- a/bolt/test/RISCV/call-link-register.s
+++ b/bolt/test/RISCV/call-link-register.s
@@ -9,14 +9,12 @@
 _start:
 // CHECK-LABEL: <_start>:
 /// The auipc of the pair, replaced by a nop once the call is rewritten.
-// CHECK-NEXT: nop
 // CHECK-NEXT: jal t0, 0x{{.*}} <f>
   call t0, f
 /// A jal in direct range is rewritten on its own, with no auipc to nop out.
 // CHECK-NEXT: jal t0, 0x{{.*}} <f>
   jal t0, f
 /// A call that already links through ra keeps ra.
-// CHECK-NEXT: nop
 // CHECK-NEXT: jal 0x{{.*}} <f>
   call f
 // CHECK-NEXT: jal 0x{{.*}} <f>

--- a/bolt/test/RISCV/relax.s
+++ b/bolt/test/RISCV/relax.s
@@ -18,9 +18,8 @@
 
 // OBJDUMP:      0000000000600000 <_start>:
 // OBJDUMP-NEXT:     jal 0x600040 <near_f>
-// OBJDUMP-NEXT:     nop
 // OBJDUMP-NEXT:     auipc ra, 0x200
-// OBJDUMP-NEXT:     jalr 0x78(ra)
+// OBJDUMP-NEXT:     jalr 0x7c(ra)
 // OBJDUMP-NEXT:     j 0x600040 <near_f>
 // OBJDUMP:      0000000000600040 <near_f>:
 // OBJDUMP:      0000000000800080 <far_f>:


### PR DESCRIPTION
`FixRISCVCallsPass` replaces the AUIPC instruction with a Noop when converting an AUIPC/JALR pair into a call or tail-call pseudo. Add the `NOP` annotation so the existing RemoveNops pass can remove it, avoiding an unnecessary instruction in the output. 