### PR TITLE
[Github] Match backend:NVPTX files outside llvm/

### DIFF
--- a/.github/new-prs-labeler.yml
+++ b/.github/new-prs-labeler.yml
@@ -1065,14 +1065,14 @@ backend:AMDGPU:
 backend:NVPTX:
   - changed-files:
     - any-glob-to-any-file:
-      - 'llvm/**/*nvvm*'
-      - 'llvm/**/*NVVM*'
-      - 'llvm/**/*nvptx*'
-      - 'llvm/**/*NVPTX*'
-      - 'llvm/**/*nvvm*/**'
-      - 'llvm/**/*NVVM*/**'
-      - 'llvm/**/*nvptx*/**'
-      - 'llvm/**/*NVPTX*/**'
+      - '**/*nvvm*'
+      - '**/*NVVM*'
+      - '**/*nvptx*'
+      - '**/*NVPTX*'
+      - '**/*nvvm*/**'
+      - '**/*NVVM*/**'
+      - '**/*nvptx*/**'
+      - '**/*NVPTX*/**'
 
 backend:MIPS:
   - changed-files:


### PR DESCRIPTION
The backend:NVPTX labeler rules are anchored to the llvm/ subtree (every glob starts with llvm/**), so NVPTX/NVVM-related files elsewhere in the tree never get the label. In particular, ClangIR's lowering under clang/ touches NVPTX code but the PR is not tagged backend:NVPTX.

This drops the llvm/ prefix so the patterns match anywhere in the tree.