### PR TITLE
[DebugInfo] Ignore undefined constexpr constructors in constructor homing.

### DIFF
--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -3239,11 +3239,17 @@ static bool canUseCtorHoming(const CXXRecordDecl *RD) {
   if (isClassOrMethodDLLImport(RD))
     return false;
 
-  if (RD->isLambda() || RD->isAggregate() ||
-      RD->hasTrivialDefaultConstructor() ||
-      RD->hasConstexprNonCopyMoveConstructor())
+  if (RD->isLambda() || RD->isAggregate() || RD->hasTrivialDefaultConstructor())
     return false;
 
+  // Skip this optimization if the class has an implicit constexpr default
+  // constructor, since those constructors can be invoked without emitting type
+  // information for the constructor.
+  if (RD->needsImplicitDefaultConstructor() &&
+      RD->defaultedDefaultConstructorIsConstexpr())
+    return false;
+
+  bool HasNonDeletedCtor = false;
   for (const CXXConstructorDecl *Ctor : RD->ctors()) {
     if (Ctor->isCopyOrMoveConstructor())
       continue;
@@ -3254,11 +3260,15 @@ static bool canUseCtorHoming(const CXXRecordDecl *RD) {
       // copy/move constructor, which does not enable homing.
       if (CtorDef->isDelegatingConstructor())
         continue;
+      // Skip this optimization if we see a defined constexpr constructor, which
+      // can be invoked without emitting type info.
+      if (Ctor->isConstexpr() && !Ctor->isDeleted())
+        return false;
     }
     if (!Ctor->isDeleted())
-      return true;
+      HasNonDeletedCtor = true;
   }
-  return false;
+  return HasNonDeletedCtor;
 }
 
 static bool shouldOmitDefinition(llvm::codegenoptions::DebugInfoKind DebugKind,

--- a/clang/test/DebugInfo/CXX/limited-ctor.cpp
+++ b/clang/test/DebugInfo/CXX/limited-ctor.cpp
@@ -27,10 +27,9 @@ struct E {
   constexpr E(){};
 } TestE;
 
-// Restored by this revert: a constexpr constructor that is only declared keeps
-// the class exempt from constructor homing. See Aliased below for a case where
-// narrowing the exemption to defined constructors homes the type nowhere.
-// CHECK-DAG: !DICompositeType(tag: DW_TAG_structure_type, name: "DeclaredConstexpr"{{.*}}DIFlagTypePassByValue
+// Declared but not defined constexpr constructor should not emit full debug
+// info.
+// CHECK-DAG: !DICompositeType(tag: DW_TAG_structure_type, name: "DeclaredConstexpr"{{.*}}flags: DIFlagFwdDecl
 struct DeclaredConstexpr {
   constexpr DeclaredConstexpr();
 } TestDeclaredConstexpr;


### PR DESCRIPTION
This is a roll-forward of https://github.com/llvm/llvm-project/pull/218165, which inadvertantly caused missing debug info in https://github.com/llvm/llvm-project/issues/221560 due to an existing issue with standard-layout unions and layout-compatible aliasing (see [[class.mem]](https://timsong-cpp.github.io/cppwp/n3337/class.mem#19)).

Constexpr constructors without a visible definition in the TU are not callable in a constexpr context, which means it is not possible to construct a type in constexpr without emitting debug info for the constructor itself. Although undefined constexpr constructors are still callable, they are normal out of line functions, requiring a definition to link against.