### PR TITLE
[lldb] Small changes to StopPointSiteList::FindInRange

### DIFF
--- a/lldb/include/lldb/Breakpoint/StopPointSiteList.h
+++ b/lldb/include/lldb/Breakpoint/StopPointSiteList.h
@@ -185,6 +185,9 @@ public:
   /// Find breakpoint sites that in any way overlap the range starting at
   /// \a lower_bound and ending at \a upper_bound (but not including it).
   /// Zero sized sites are treated as never overlapping.
+  ///
+  /// \return
+  ///   \b true if any sites were added to \a bp_site_list, \b false otherwise.
   bool FindInRange(lldb::addr_t lower_bound, lldb::addr_t upper_bound,
                    StopPointSiteList &bp_site_list) const {
     if (lower_bound > upper_bound)
@@ -215,7 +218,7 @@ public:
       if (pos->second->GetByteSize() != 0)
         bp_site_list.Add(pos->second);
 
-    return true;
+    return !bp_site_list.IsEmpty();
   }
 
   typedef void (*StopPointSiteSPMapFunc)(StopPointSite &site, void *baton);

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -2630,10 +2630,6 @@ size_t Process::WriteMemory(addr_t addr, const void *buf, size_t size,
   if (!m_breakpoint_site_list.FindInRange(addr, addr + size, bp_sites_in_range))
     return WriteMemoryPrivate(addr, buf, size, error);
 
-  // No breakpoint sites overlap
-  if (bp_sites_in_range.IsEmpty())
-    return WriteMemoryPrivate(addr, buf, size, error);
-
   const uint8_t *ubuf = (const uint8_t *)buf;
   uint64_t bytes_written = 0;
 


### PR DESCRIPTION
1. Make the return value indicate an empty list or not. (I would return a list, but you cannot copy this list and I don't want to make a larger change right now)
2. Remove a redundant write at one of the call sites.