### PR TITLE
[LLVM][CodeGen][SVE] Add isel for constrained cast operations.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -367,10 +367,15 @@ static bool isMergePassthruOpcode(unsigned Opc) {
   case AArch64ISD::STRICT_FCEIL_MERGE_PASSTHRU:
   case AArch64ISD::STRICT_FFLOOR_MERGE_PASSTHRU:
   case AArch64ISD::STRICT_FNEARBYINT_MERGE_PASSTHRU:
+  case AArch64ISD::STRICT_FP_EXTEND_MERGE_PASSTHRU:
+  case AArch64ISD::STRICT_FP_ROUND_MERGE_PASSTHRU:
+  case AArch64ISD::STRICT_FRINT_MERGE_PASSTHRU:
   case AArch64ISD::STRICT_FROUND_MERGE_PASSTHRU:
   case AArch64ISD::STRICT_FROUNDEVEN_MERGE_PASSTHRU:
-  case AArch64ISD::STRICT_FTRUNC_MERGE_PASSTHRU:
   case AArch64ISD::STRICT_FSQRT_MERGE_PASSTHRU:
+  case AArch64ISD::STRICT_FTRUNC_MERGE_PASSTHRU:
+  case AArch64ISD::STRICT_SINT_TO_FP_MERGE_PASSTHRU:
+  case AArch64ISD::STRICT_UINT_TO_FP_MERGE_PASSTHRU:
     return true;
   }
 }
@@ -1691,10 +1696,10 @@ AArch64TargetLowering::AArch64TargetLowering(const TargetMachine &TM,
       setOperationAction(ISD::CTPOP, VT, Custom);
       setOperationAction(ISD::CTTZ, VT, Custom);
       setOperationAction(ISD::INSERT_SUBVECTOR, VT, Custom);
-      setOperationAction(ISD::UINT_TO_FP, VT, Custom);
-      setOperationAction(ISD::SINT_TO_FP, VT, Custom);
-      setOperationAction(ISD::FP_TO_UINT, VT, Custom);
-      setOperationAction(ISD::FP_TO_SINT, VT, Custom);
+      setOperationAction({ISD::UINT_TO_FP, ISD::STRICT_UINT_TO_FP}, VT, Custom);
+      setOperationAction({ISD::SINT_TO_FP, ISD::STRICT_SINT_TO_FP}, VT, Custom);
+      setOperationAction({ISD::FP_TO_UINT, ISD::STRICT_FP_TO_UINT}, VT, Custom);
+      setOperationAction({ISD::FP_TO_SINT, ISD::STRICT_FP_TO_SINT}, VT, Custom);
       setOperationAction(ISD::FP_TO_UINT_SAT, VT, Custom);
       setOperationAction(ISD::FP_TO_SINT_SAT, VT, Custom);
       setOperationAction(ISD::MLOAD, VT, Custom);
@@ -1888,7 +1893,7 @@ AArch64TargetLowering::AArch64TargetLowering(const TargetMachine &TM,
       setOperationAction({ISD::FCEIL, ISD::STRICT_FCEIL}, VT, Custom);
       setOperationAction({ISD::FFLOOR, ISD::STRICT_FFLOOR}, VT, Custom);
       setOperationAction({ISD::FNEARBYINT, ISD::STRICT_FNEARBYINT}, VT, Custom);
-      setOperationAction(ISD::FRINT, VT, Custom);
+      setOperationAction({ISD::FRINT, ISD::STRICT_FRINT}, VT, Custom);
       setOperationAction(ISD::LRINT, VT, Custom);
       setOperationAction(ISD::LLRINT, VT, Custom);
       setOperationAction({ISD::FROUND, ISD::STRICT_FROUND}, VT, Custom);
@@ -1896,8 +1901,8 @@ AArch64TargetLowering::AArch64TargetLowering(const TargetMachine &TM,
       setOperationAction({ISD::FTRUNC, ISD::STRICT_FTRUNC}, VT, Custom);
       setOperationAction({ISD::FSQRT, ISD::STRICT_FSQRT}, VT, Custom);
       setOperationAction(ISD::FABS, VT, Custom);
-      setOperationAction(ISD::FP_EXTEND, VT, Custom);
-      setOperationAction(ISD::FP_ROUND, VT, Custom);
+      setOperationAction({ISD::FP_EXTEND, ISD::STRICT_FP_EXTEND}, VT, Custom);
+      setOperationAction({ISD::FP_ROUND, ISD::STRICT_FP_ROUND}, VT, Custom);
       setOperationAction(ISD::VECREDUCE_FADD, VT, Custom);
       setOperationAction(ISD::VECREDUCE_FMAX, VT, Custom);
       setOperationAction(ISD::VECREDUCE_FMIN, VT, Custom);
@@ -1939,19 +1944,12 @@ AArch64TargetLowering::AArch64TargetLowering(const TargetMachine &TM,
 
       // TODO: These require custom lowering.
       setOperationAction(ISD::STRICT_FLDEXP, VT, Expand);
-      setOperationAction(ISD::STRICT_FRINT, VT, Expand);
       setOperationAction(ISD::STRICT_PSEUDO_FMIN, VT, Expand);
       setOperationAction(ISD::STRICT_PSEUDO_FMAX, VT, Expand);
       setOperationAction(ISD::STRICT_LROUND, VT, Expand);
       setOperationAction(ISD::STRICT_LLROUND, VT, Expand);
       setOperationAction(ISD::STRICT_LRINT, VT, Expand);
       setOperationAction(ISD::STRICT_LLRINT, VT, Expand);
-      setOperationAction(ISD::STRICT_FP_TO_SINT, VT, Expand);
-      setOperationAction(ISD::STRICT_FP_TO_UINT, VT, Expand);
-      setOperationAction(ISD::STRICT_SINT_TO_FP, VT, Expand);
-      setOperationAction(ISD::STRICT_UINT_TO_FP, VT, Expand);
-      setOperationAction(ISD::STRICT_FP_ROUND, VT, Expand);
-      setOperationAction(ISD::STRICT_FP_EXTEND, VT, Expand);
       setOperationAction(ISD::STRICT_FSETCC, VT, Expand);
       setOperationAction(ISD::STRICT_FSETCCS, VT, Expand);
 
@@ -4961,10 +4959,16 @@ static void simplifySetCCIntoEq(ISD::CondCode &CC, SDValue &LHS, SDValue &RHS,
 SDValue AArch64TargetLowering::LowerFP_EXTEND(SDValue Op,
                                               SelectionDAG &DAG) const {
   EVT VT = Op.getValueType();
+  bool IsStrict = Op->isStrictFPOpcode();
+
   if (VT.isScalableVector()) {
     SDValue SrcVal = Op.getOperand(0);
 
     if (VT == MVT::nxv2f64 && SrcVal.getValueType() == MVT::nxv2bf16) {
+      // TODO: Missing support for bfloat strict-fp operations.
+      if (IsStrict)
+        return SDValue();
+
       // Break conversion in two with the first part converting to f32 and the
       // second using native f32->VT instructions.
       SDLoc DL(Op);
@@ -4972,13 +4976,15 @@ SDValue AArch64TargetLowering::LowerFP_EXTEND(SDValue Op,
                          DAG.getNode(ISD::FP_EXTEND, DL, MVT::nxv2f32, SrcVal));
     }
 
-    return LowerToPredicatedOp(Op, DAG, AArch64ISD::FP_EXTEND_MERGE_PASSTHRU);
+    return LowerToPredicatedOp(Op, DAG,
+                               IsStrict
+                                   ? AArch64ISD::STRICT_FP_EXTEND_MERGE_PASSTHRU
+                                   : AArch64ISD::FP_EXTEND_MERGE_PASSTHRU);
   }
 
   if (useSVEForFixedLengthVectorVT(VT, !Subtarget->isNeonAvailable()))
     return LowerFixedLengthFPExtendToSVE(Op, DAG);
 
-  bool IsStrict = Op->isStrictFPOpcode();
   SDValue Op0 = Op.getOperand(IsStrict ? 1 : 0);
   EVT Op0VT = Op0.getValueType();
   if (VT == MVT::f64) {
@@ -5018,7 +5024,14 @@ SDValue AArch64TargetLowering::LowerFP_ROUND(SDValue Op,
       return Op;
 
     if (VT.getScalarType() != MVT::bf16)
-      return LowerToPredicatedOp(Op, DAG, AArch64ISD::FP_ROUND_MERGE_PASSTHRU);
+      return LowerToPredicatedOp(
+          Op, DAG,
+          IsStrict ? AArch64ISD::STRICT_FP_ROUND_MERGE_PASSTHRU
+                   : AArch64ISD::FP_ROUND_MERGE_PASSTHRU);
+
+    // TODO: Missing support for bfloat strict-fp operations.
+    if (IsStrict)
+      return SDValue();
 
     SDLoc DL(Op);
     constexpr EVT I32 = MVT::nxv4i32;
@@ -5155,9 +5168,6 @@ SDValue AArch64TargetLowering::LowerVectorFP_TO_INT(SDValue Op,
   bool IsStrict = Op->isStrictFPOpcode();
   EVT InVT = Op.getOperand(IsStrict ? 1 : 0).getValueType();
   EVT VT = Op.getValueType();
-
-  assert(!(IsStrict && VT.isScalableVector()) &&
-         "Unimplemented SVE support for STRICT_FP_to_INT!");
 
   // f16 conversions are promoted to f32 when full fp16 is not supported.
   if ((InVT.getVectorElementType() == MVT::f16 && !Subtarget->hasFullFP16()) ||
@@ -5475,11 +5485,8 @@ SDValue AArch64TargetLowering::LowerVectorINT_TO_FP(SDValue Op,
   unsigned Opc = Op.getOpcode();
   bool IsSigned = Opc == ISD::SINT_TO_FP || Opc == ISD::STRICT_SINT_TO_FP;
 
-  assert(!(IsStrict && VT.isScalableVector()) &&
-         "Unimplemented SVE support for ISD:::STRICT_INT_TO_FP!");
-
   // NOTE: i1->bf16 does not require promotion to f32.
-  if (VT.isScalableVector() && InVT.getVectorElementType() == MVT::i1) {
+  if (InVT.isScalableVectorOf(MVT::i1) && !IsStrict) {
     SDValue FalseVal = DAG.getConstantFP(0.0, DL, VT);
     SDValue TrueVal = IsSigned ? DAG.getConstantFP(-1.0, DL, VT)
                                : DAG.getConstantFP(1.0, DL, VT);
@@ -5492,8 +5499,7 @@ SDValue AArch64TargetLowering::LowerVectorINT_TO_FP(SDValue Op,
     if (IsStrict) {
       SDValue Val = DAG.getNode(Op.getOpcode(), DL, {F32, MVT::Other},
                                 {Op.getOperand(0), In});
-      return DAG.getNode(ISD::STRICT_FP_ROUND, DL,
-                         {Op.getValueType(), MVT::Other},
+      return DAG.getNode(ISD::STRICT_FP_ROUND, DL, Op->getVTList(),
                          {Val.getValue(1), Val.getValue(0),
                           DAG.getIntPtrConstant(0, DL, /*isTarget=*/true)});
     }
@@ -5507,8 +5513,11 @@ SDValue AArch64TargetLowering::LowerVectorINT_TO_FP(SDValue Op,
     if (VT == MVT::nxv8f32)
       return Op;
 
-    unsigned Opcode = IsSigned ? AArch64ISD::SINT_TO_FP_MERGE_PASSTHRU
-                               : AArch64ISD::UINT_TO_FP_MERGE_PASSTHRU;
+    unsigned Opcode =
+        IsStrict ? (IsSigned ? AArch64ISD::STRICT_SINT_TO_FP_MERGE_PASSTHRU
+                             : AArch64ISD::STRICT_UINT_TO_FP_MERGE_PASSTHRU)
+                 : (IsSigned ? AArch64ISD::SINT_TO_FP_MERGE_PASSTHRU
+                             : AArch64ISD::UINT_TO_FP_MERGE_PASSTHRU);
     return LowerToPredicatedOp(Op, DAG, Opcode);
   }
 
@@ -8831,6 +8840,9 @@ SDValue AArch64TargetLowering::LowerOperation(SDValue Op,
                                AArch64ISD::STRICT_FNEARBYINT_MERGE_PASSTHRU);
   case ISD::FRINT:
     return LowerToPredicatedOp(Op, DAG, AArch64ISD::FRINT_MERGE_PASSTHRU);
+  case ISD::STRICT_FRINT:
+    return LowerToPredicatedOp(Op, DAG,
+                               AArch64ISD::STRICT_FRINT_MERGE_PASSTHRU);
   case ISD::FROUND:
     return LowerToPredicatedOp(Op, DAG, AArch64ISD::FROUND_MERGE_PASSTHRU);
   case ISD::STRICT_FROUND:
@@ -35406,6 +35418,10 @@ static unsigned getSVEOpcodeForFPToInt(unsigned Opc) {
   case ISD::FP_TO_SINT_SAT:
   case ISD::FP_TO_SINT:
     return AArch64ISD::FCVTZS_MERGE_PASSTHRU;
+  case ISD::STRICT_FP_TO_SINT:
+    return AArch64ISD::STRICT_FCVTZS_MERGE_PASSTHRU;
+  case ISD::STRICT_FP_TO_UINT:
+    return AArch64ISD::STRICT_FCVTZU_MERGE_PASSTHRU;
   default:
     llvm_unreachable("Unexpected opcode");
   }
@@ -35413,13 +35429,10 @@ static unsigned getSVEOpcodeForFPToInt(unsigned Opc) {
 
 SDValue AArch64TargetLowering::LowerFPToIntToSVE(SDValue Op,
                                                  SelectionDAG &DAG) const {
-  // Strict FP_TO_INT is not yet implemented.
-  if (Op->isStrictFPOpcode())
-    return SDValue();
-
+  bool IsStrict = Op->isStrictFPOpcode();
   unsigned Opc = Op.getOpcode();
-  EVT InVT = Op.getOperand(0).getValueType();
   EVT VT = Op.getValueType();
+  EVT InVT = Op.getOperand(IsStrict ? 1 : 0).getValueType();
 
   // bf16 inputs need promotion before conversion.
   if (InVT.getVectorElementType() == MVT::bf16)
@@ -35445,11 +35458,13 @@ SDValue AArch64TargetLowering::LowerFPToIntToSVE(SDValue Op,
       return Op;
 
     SmallVector<SDValue, 4> Operands;
+    if (IsStrict)
+      Operands.push_back(Op.getOperand(0));
     Operands.push_back(getPredicateForVector(DAG, DL, VT));
-    Operands.push_back(Op.getOperand(0));
+    Operands.push_back(Op.getOperand(IsStrict ? 1 : 0));
     Operands.push_back(DAG.getPOISON(VT));
-    return DAG.getNode(getSVEOpcodeForFPToInt(Opc), DL, VT, Operands,
-                       Op->getFlags());
+    return DAG.getNode(getSVEOpcodeForFPToInt(Opc), DL, Op->getVTList(),
+                       Operands, Op->getFlags());
   }
 
   bool OverrideNEON = !Subtarget->isNeonAvailable();
@@ -35463,10 +35478,13 @@ SDValue AArch64TargetLowering::LowerFPToIntToSVE(SDValue Op,
 SDValue
 AArch64TargetLowering::LowerFixedLengthFPToIntToSVE(SDValue Op,
                                                     SelectionDAG &DAG) const {
+  // Strict FP_TO_INT is not yet implemented.
+  if (Op->isStrictFPOpcode())
+    return SDValue();
+
   EVT VT = Op.getValueType();
   unsigned Opc = Op.getOpcode();
   assert(VT.isFixedLengthVector() && "Expected fixed length vector type!");
-  assert(!Op->isStrictFPOpcode() && "Strict FP_TO_INT not yet supported");
   unsigned Opcode = getSVEOpcodeForFPToInt(Op.getOpcode());
 
   bool IsSaturating = Opc == ISD::FP_TO_UINT_SAT || Opc == ISD::FP_TO_SINT_SAT;

--- a/llvm/lib/Target/AArch64/AArch64SVEInstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64SVEInstrInfo.td
@@ -335,7 +335,6 @@ def AArch64abs_mt    : SDNode<"AArch64ISD::ABS_MERGE_PASSTHRU", SDT_AArch64Arith
 def AArch64neg_mt    : SDNode<"AArch64ISD::NEG_MERGE_PASSTHRU", SDT_AArch64Arith>;
 def AArch64sxt_mt    : SDNode<"AArch64ISD::SIGN_EXTEND_INREG_MERGE_PASSTHRU", SDT_AArch64IntExtend>;
 def AArch64uxt_mt    : SDNode<"AArch64ISD::ZERO_EXTEND_INREG_MERGE_PASSTHRU", SDT_AArch64IntExtend>;
-def AArch64frintx_mt : SDNode<"AArch64ISD::FRINT_MERGE_PASSTHRU", SDT_AArch64Arith>;
 def AArch64frint32x_mt : SDNode<"AArch64ISD::FRINT32_MERGE_PASSTHRU", SDT_AArch64Arith>;
 def AArch64frint64x_mt : SDNode<"AArch64ISD::FRINT64_MERGE_PASSTHRU", SDT_AArch64Arith>;
 def AArch64frint32z_mt : SDNode<"AArch64ISD::FTRUNC32_MERGE_PASSTHRU", SDT_AArch64Arith>;
@@ -352,6 +351,7 @@ defm AArch64frintm_mt : def_strict_fp_3op<"FFLOOR_MERGE_PASSTHRU",     SDT_AArch
 defm AArch64frinti_mt : def_strict_fp_3op<"FNEARBYINT_MERGE_PASSTHRU", SDT_AArch64Arith>;
 defm AArch64frinta_mt : def_strict_fp_3op<"FROUND_MERGE_PASSTHRU",     SDT_AArch64Arith>;
 defm AArch64frintn_mt : def_strict_fp_3op<"FROUNDEVEN_MERGE_PASSTHRU", SDT_AArch64Arith>;
+defm AArch64frintx_mt : def_strict_fp_3op<"FRINT_MERGE_PASSTHRU",      SDT_AArch64Arith>;
 defm AArch64frintz_mt : def_strict_fp_3op<"FTRUNC_MERGE_PASSTHRU",     SDT_AArch64Arith>;
 defm AArch64fsqrt_mt  : def_strict_fp_3op<"FSQRT_MERGE_PASSTHRU",      SDT_AArch64Arith>;
 
@@ -450,13 +450,13 @@ def SDT_AArch64FCVTR : SDTypeProfile<1, 4, [
   SDTCVecEltisVT<1,i1>
 ]>;
 
-def AArch64fcvtr_mt  : SDNode<"AArch64ISD::FP_ROUND_MERGE_PASSTHRU", SDT_AArch64FCVTR>;
-def AArch64fcvte_mt  : SDNode<"AArch64ISD::FP_EXTEND_MERGE_PASSTHRU", SDT_AArch64FCVT>;
-def AArch64ucvtf_mt  : SDNode<"AArch64ISD::UINT_TO_FP_MERGE_PASSTHRU", SDT_AArch64FCVT>;
-def AArch64scvtf_mt  : SDNode<"AArch64ISD::SINT_TO_FP_MERGE_PASSTHRU", SDT_AArch64FCVT>;
-def AArch64fcvtx_mt  : SDNode<"AArch64ISD::FCVTX_MERGE_PASSTHRU", SDT_AArch64FCVT>;
-def AArch64fcvtzu_mt : SDNode<"AArch64ISD::FCVTZU_MERGE_PASSTHRU", SDT_AArch64FCVT>;
-def AArch64fcvtzs_mt : SDNode<"AArch64ISD::FCVTZS_MERGE_PASSTHRU", SDT_AArch64FCVT>;
+defm AArch64fcvtr_mt  : def_strict_fp_4op<"FP_ROUND_MERGE_PASSTHRU",  SDT_AArch64FCVTR>;
+defm AArch64fcvte_mt  : def_strict_fp_3op<"FP_EXTEND_MERGE_PASSTHRU", SDT_AArch64FCVT>;
+defm AArch64ucvtf_mt  : def_strict_fp_3op<"UINT_TO_FP_MERGE_PASSTHRU", SDT_AArch64FCVT>;
+defm AArch64scvtf_mt  : def_strict_fp_3op<"SINT_TO_FP_MERGE_PASSTHRU", SDT_AArch64FCVT>;
+defm AArch64fcvtx_mt  : def_strict_fp_3op<"FCVTX_MERGE_PASSTHRU", SDT_AArch64FCVT>;
+defm AArch64fcvtzu_mt : def_strict_fp_3op<"FCVTZU_MERGE_PASSTHRU", SDT_AArch64FCVT>;
+defm AArch64fcvtzs_mt : def_strict_fp_3op<"FCVTZS_MERGE_PASSTHRU", SDT_AArch64FCVT>;
 
 def AArch64clasta_n     : SDNode<"AArch64ISD::CLASTA_N",   SDT_AArch64ReduceWithInit>;
 def AArch64clastb_n     : SDNode<"AArch64ISD::CLASTB_N",   SDT_AArch64ReduceWithInit>;

--- a/llvm/test/CodeGen/AArch64/sve-fp-constrained-intrinsics.ll
+++ b/llvm/test/CodeGen/AArch64/sve-fp-constrained-intrinsics.ll
@@ -394,20 +394,200 @@ define <vscale x 2 x double> @fmuladd_nxv2f64(<vscale x 2 x double> %a, <vscale 
 }
 
 ;
-;constrained.fpext (TODO)
+; constrained.fpext
 ;
 
-;
-;constrained.fptosi (TODO)
-;
+define <vscale x 2 x float> @fpext_nxv2f16_to_nxv2f32(<vscale x 2 x half> %a) {
+; CHECK-LABEL: fpext_nxv2f16_to_nxv2f32:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    ptrue p0.d
+; CHECK-NEXT:    fcvt z0.s, p0/m, z0.h
+; CHECK-NEXT:    ret
+  %r = call <vscale x 2 x float> @llvm.experimental.constrained.fpext(<vscale x 2 x half> %a, metadata !"fpexcept.strict")
+  ret <vscale x 2 x float> %r
+}
+
+define <vscale x 2 x double> @fpext_nxv2f16_to_nxv2f64(<vscale x 2 x half> %a) {
+; CHECK-LABEL: fpext_nxv2f16_to_nxv2f64:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    ptrue p0.d
+; CHECK-NEXT:    fcvt z0.d, p0/m, z0.h
+; CHECK-NEXT:    ret
+  %r = call <vscale x 2 x double> @llvm.experimental.constrained.fpext(<vscale x 2 x half> %a, metadata !"fpexcept.strict")
+  ret <vscale x 2 x double> %r
+}
+
+define <vscale x 2 x double> @fpext_nxv2f32_nxv2f64(<vscale x 2 x float> %a) {
+; CHECK-LABEL: fpext_nxv2f32_nxv2f64:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    ptrue p0.d
+; CHECK-NEXT:    fcvt z0.d, p0/m, z0.s
+; CHECK-NEXT:    ret
+  %r = call <vscale x 2 x double> @llvm.experimental.constrained.fpext(<vscale x 2 x float> %a, metadata !"fpexcept.strict")
+  ret <vscale x 2 x double> %r
+}
 
 ;
-;constrained.fptoui (TODO)
+; constrained.fptosi
 ;
 
+define <vscale x 2 x i64> @fptosi_nxv2f16_to_nxv2i64(<vscale x 2 x half> %a) {
+; CHECK-LABEL: fptosi_nxv2f16_to_nxv2i64:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    ptrue p0.d
+; CHECK-NEXT:    fcvtzs z0.d, p0/m, z0.h
+; CHECK-NEXT:    ret
+  %r = call <vscale x 2 x i64> @llvm.experimental.constrained.fptosi(<vscale x 2 x half> %a, metadata !"fpexcept.strict")
+  ret <vscale x 2 x i64> %r
+}
+
+define <vscale x 4 x i32> @fptosi_nxv4f16_to_nxv4i32(<vscale x 4 x half> %a) {
+; CHECK-LABEL: fptosi_nxv4f16_to_nxv4i32:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    ptrue p0.s
+; CHECK-NEXT:    fcvtzs z0.s, p0/m, z0.h
+; CHECK-NEXT:    ret
+  %r = call <vscale x 4 x i32> @llvm.experimental.constrained.fptosi(<vscale x 4 x half> %a, metadata !"fpexcept.strict")
+  ret <vscale x 4 x i32> %r
+}
+
+define <vscale x 8 x i16> @fptosi_nxv8f16_to_nxv8i16(<vscale x 8 x half> %a) {
+; CHECK-LABEL: fptosi_nxv8f16_to_nxv8i16:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    ptrue p0.h
+; CHECK-NEXT:    fcvtzs z0.h, p0/m, z0.h
+; CHECK-NEXT:    ret
+  %r = call <vscale x 8 x i16> @llvm.experimental.constrained.fptosi(<vscale x 8 x half> %a, metadata !"fpexcept.strict")
+  ret <vscale x 8 x i16> %r
+}
+
+define <vscale x 2 x i64> @fptosi_nxv2f32_to_nxv2i64(<vscale x 2 x float> %a) {
+; CHECK-LABEL: fptosi_nxv2f32_to_nxv2i64:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    ptrue p0.d
+; CHECK-NEXT:    fcvtzs z0.d, p0/m, z0.s
+; CHECK-NEXT:    ret
+  %r = call <vscale x 2 x i64> @llvm.experimental.constrained.fptosi(<vscale x 2 x float> %a, metadata !"fpexcept.strict")
+  ret <vscale x 2 x i64> %r
+}
+
+define <vscale x 4 x i32> @fptosi_nxv4f32_to_nxv4i32(<vscale x 4 x float> %a) {
+; CHECK-LABEL: fptosi_nxv4f32_to_nxv4i32:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    ptrue p0.s
+; CHECK-NEXT:    fcvtzs z0.s, p0/m, z0.s
+; CHECK-NEXT:    ret
+  %r = call <vscale x 4 x i32> @llvm.experimental.constrained.fptosi(<vscale x 4 x float> %a, metadata !"fpexcept.strict")
+  ret <vscale x 4 x i32> %r
+}
+
+define <vscale x 2 x i64> @fptosi_nxv2f64_to_nxv2i64(<vscale x 2 x double> %a) {
+; CHECK-LABEL: fptosi_nxv2f64_to_nxv2i64:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    ptrue p0.d
+; CHECK-NEXT:    fcvtzs z0.d, p0/m, z0.d
+; CHECK-NEXT:    ret
+  %r = call <vscale x 2 x i64> @llvm.experimental.constrained.fptosi(<vscale x 2 x double> %a, metadata !"fpexcept.strict")
+  ret <vscale x 2 x i64> %r
+}
+
 ;
-;constrained.fptrunc (TODO)
+; constrained.fptoui
 ;
+
+define <vscale x 2 x i64> @fptoui_nxv2f16_to_nxv2i64(<vscale x 2 x half> %a) {
+; CHECK-LABEL: fptoui_nxv2f16_to_nxv2i64:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    ptrue p0.d
+; CHECK-NEXT:    fcvtzu z0.d, p0/m, z0.h
+; CHECK-NEXT:    ret
+  %r = call <vscale x 2 x i64> @llvm.experimental.constrained.fptoui(<vscale x 2 x half> %a, metadata !"fpexcept.strict")
+  ret <vscale x 2 x i64> %r
+}
+
+define <vscale x 4 x i32> @fptoui_nxv4f16_to_nxv4i32(<vscale x 4 x half> %a) {
+; CHECK-LABEL: fptoui_nxv4f16_to_nxv4i32:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    ptrue p0.s
+; CHECK-NEXT:    fcvtzu z0.s, p0/m, z0.h
+; CHECK-NEXT:    ret
+  %r = call <vscale x 4 x i32> @llvm.experimental.constrained.fptoui(<vscale x 4 x half> %a, metadata !"fpexcept.strict")
+  ret <vscale x 4 x i32> %r
+}
+
+define <vscale x 8 x i16> @fptoui_nxv8f16_to_nxv8i16(<vscale x 8 x half> %a) {
+; CHECK-LABEL: fptoui_nxv8f16_to_nxv8i16:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    ptrue p0.h
+; CHECK-NEXT:    fcvtzu z0.h, p0/m, z0.h
+; CHECK-NEXT:    ret
+  %r = call <vscale x 8 x i16> @llvm.experimental.constrained.fptoui(<vscale x 8 x half> %a, metadata !"fpexcept.strict")
+  ret <vscale x 8 x i16> %r
+}
+
+define <vscale x 2 x i64> @fptoui_nxv2f32_to_nxv2i64(<vscale x 2 x float> %a) {
+; CHECK-LABEL: fptoui_nxv2f32_to_nxv2i64:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    ptrue p0.d
+; CHECK-NEXT:    fcvtzu z0.d, p0/m, z0.s
+; CHECK-NEXT:    ret
+  %r = call <vscale x 2 x i64> @llvm.experimental.constrained.fptoui(<vscale x 2 x float> %a, metadata !"fpexcept.strict")
+  ret <vscale x 2 x i64> %r
+}
+
+define <vscale x 4 x i32> @fptoui_nxv4f32_to_nxv4i32(<vscale x 4 x float> %a) {
+; CHECK-LABEL: fptoui_nxv4f32_to_nxv4i32:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    ptrue p0.s
+; CHECK-NEXT:    fcvtzu z0.s, p0/m, z0.s
+; CHECK-NEXT:    ret
+  %r = call <vscale x 4 x i32> @llvm.experimental.constrained.fptoui(<vscale x 4 x float> %a, metadata !"fpexcept.strict")
+  ret <vscale x 4 x i32> %r
+}
+
+define <vscale x 2 x i64> @fptoui_nxv2f64_to_nxv2i64(<vscale x 2 x double> %a) {
+; CHECK-LABEL: fptoui_nxv2f64_to_nxv2i64:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    ptrue p0.d
+; CHECK-NEXT:    fcvtzu z0.d, p0/m, z0.d
+; CHECK-NEXT:    ret
+  %r = call <vscale x 2 x i64> @llvm.experimental.constrained.fptoui(<vscale x 2 x double> %a, metadata !"fpexcept.strict")
+  ret <vscale x 2 x i64> %r
+}
+
+;
+; constrained.fptrunc
+;
+
+define <vscale x 2 x half> @fptrunc_nv2f32_to_nxv2f16(<vscale x 2 x float> %a) {
+; CHECK-LABEL: fptrunc_nv2f32_to_nxv2f16:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    ptrue p0.d
+; CHECK-NEXT:    fcvt z0.h, p0/m, z0.s
+; CHECK-NEXT:    ret
+  %r = call <vscale x 2 x half> @llvm.experimental.constrained.fptrunc(<vscale x 2 x float> %a, metadata !"round.dynamic", metadata !"fpexcept.strict")
+  ret <vscale x 2 x half> %r
+}
+
+define <vscale x 2 x half> @fptrunc_nv2f64_to_nxv2f16(<vscale x 2 x double> %a) {
+; CHECK-LABEL: fptrunc_nv2f64_to_nxv2f16:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    ptrue p0.d
+; CHECK-NEXT:    fcvt z0.h, p0/m, z0.d
+; CHECK-NEXT:    ret
+  %r = call <vscale x 2 x half> @llvm.experimental.constrained.fptrunc(<vscale x 2 x double> %a, metadata !"round.dynamic", metadata !"fpexcept.strict")
+  ret <vscale x 2 x half> %r
+}
+
+define <vscale x 2 x float> @fptrunc_nv2f64_to_nxv2f32(<vscale x 2 x double> %a) {
+; CHECK-LABEL: fptrunc_nv2f64_to_nxv2f32:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    ptrue p0.d
+; CHECK-NEXT:    fcvt z0.s, p0/m, z0.d
+; CHECK-NEXT:    ret
+  %r = call <vscale x 2 x float> @llvm.experimental.constrained.fptrunc(<vscale x 2 x double> %a, metadata !"round.dynamic", metadata !"fpexcept.strict")
+  ret <vscale x 2 x float> %r
+}
 
 ;
 ; constrained.frem (TODO)
@@ -815,8 +995,68 @@ define <vscale x 2 x double> @nearbyint_nxv2f64(<vscale x 2 x double> %a) {
 }
 
 ;
-; constrained.rint (TODO)
+; constrained.rint
 ;
+
+define <vscale x 2 x half> @rint_nxv2f16(<vscale x 2 x half> %a) {
+; CHECK-LABEL: rint_nxv2f16:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    ptrue p0.d
+; CHECK-NEXT:    frintx z0.h, p0/m, z0.h
+; CHECK-NEXT:    ret
+  %r = call <vscale x 2 x half> @llvm.experimental.constrained.rint(<vscale x 2 x half> %a, metadata !"round.dynamic", metadata !"fpexcept.strict")
+  ret <vscale x 2 x half> %r
+}
+
+define <vscale x 4 x half> @rint_nxv4f16(<vscale x 4 x half> %a) {
+; CHECK-LABEL: rint_nxv4f16:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    ptrue p0.s
+; CHECK-NEXT:    frintx z0.h, p0/m, z0.h
+; CHECK-NEXT:    ret
+  %r = call <vscale x 4 x half> @llvm.experimental.constrained.rint(<vscale x 4 x half> %a, metadata !"round.dynamic", metadata !"fpexcept.strict")
+  ret <vscale x 4 x half> %r
+}
+
+define <vscale x 8 x half> @rint_nxv8f16(<vscale x 8 x half> %a) {
+; CHECK-LABEL: rint_nxv8f16:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    ptrue p0.h
+; CHECK-NEXT:    frintx z0.h, p0/m, z0.h
+; CHECK-NEXT:    ret
+  %r = call <vscale x 8 x half> @llvm.experimental.constrained.rint(<vscale x 8 x half> %a, metadata !"round.dynamic", metadata !"fpexcept.strict")
+  ret <vscale x 8 x half> %r
+}
+
+define <vscale x 2 x float> @rint_nxv2f32(<vscale x 2 x float> %a) {
+; CHECK-LABEL: rint_nxv2f32:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    ptrue p0.d
+; CHECK-NEXT:    frintx z0.s, p0/m, z0.s
+; CHECK-NEXT:    ret
+  %r = call <vscale x 2 x float> @llvm.experimental.constrained.rint(<vscale x 2 x float> %a, metadata !"round.dynamic", metadata !"fpexcept.strict")
+  ret <vscale x 2 x float> %r
+}
+
+define <vscale x 4 x float> @rint_nxv4f32(<vscale x 4 x float> %a) {
+; CHECK-LABEL: rint_nxv4f32:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    ptrue p0.s
+; CHECK-NEXT:    frintx z0.s, p0/m, z0.s
+; CHECK-NEXT:    ret
+  %r = call <vscale x 4 x float> @llvm.experimental.constrained.rint(<vscale x 4 x float> %a, metadata !"round.dynamic", metadata !"fpexcept.strict")
+  ret <vscale x 4 x float> %r
+}
+
+define <vscale x 2 x double> @rint_nxv2f64(<vscale x 2 x double> %a) {
+; CHECK-LABEL: rint_nxv2f64:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    ptrue p0.d
+; CHECK-NEXT:    frintx z0.d, p0/m, z0.d
+; CHECK-NEXT:    ret
+  %r = call <vscale x 2 x double> @llvm.experimental.constrained.rint(<vscale x 2 x double> %a, metadata !"round.dynamic", metadata !"fpexcept.strict")
+  ret <vscale x 2 x double> %r
+}
 
 ;
 ; constrained.round
@@ -1011,8 +1251,68 @@ define <vscale x 2 x double> @sqrt_nxv2f64(<vscale x 2 x double> %a) {
 }
 
 ;
-; constrained_sitofp (TODO)
+; constrained_sitofp
 ;
+
+define <vscale x 8 x half> @sitofp_nxv8i16_to_nxv8f16(<vscale x 8 x i16> %a) {
+; CHECK-LABEL: sitofp_nxv8i16_to_nxv8f16:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    ptrue p0.h
+; CHECK-NEXT:    scvtf z0.h, p0/m, z0.h
+; CHECK-NEXT:    ret
+  %r = call <vscale x 8 x half> @llvm.experimental.constrained.sitofp(<vscale x 8 x i16> %a, metadata !"round.dynamic", metadata !"fpexcept.strict")
+  ret <vscale x 8 x half> %r
+}
+
+define <vscale x 4 x half> @sitofp_nxv4i32_to_nxv4f16(<vscale x 4 x i32> %a) {
+; CHECK-LABEL: sitofp_nxv4i32_to_nxv4f16:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    ptrue p0.s
+; CHECK-NEXT:    scvtf z0.h, p0/m, z0.s
+; CHECK-NEXT:    ret
+  %r = call <vscale x 4 x half> @llvm.experimental.constrained.sitofp(<vscale x 4 x i32> %a, metadata !"round.dynamic", metadata !"fpexcept.strict")
+  ret <vscale x 4 x half> %r
+}
+
+define <vscale x 4 x float> @sitofp_nxv4i32_to_nxv4f32(<vscale x 4 x i32> %a) {
+; CHECK-LABEL: sitofp_nxv4i32_to_nxv4f32:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    ptrue p0.s
+; CHECK-NEXT:    scvtf z0.s, p0/m, z0.s
+; CHECK-NEXT:    ret
+  %r = call <vscale x 4 x float> @llvm.experimental.constrained.sitofp(<vscale x 4 x i32> %a, metadata !"round.dynamic", metadata !"fpexcept.strict")
+  ret <vscale x 4 x float> %r
+}
+
+define <vscale x 2 x half> @sitofp_nxv2i64_to_nxv2f16(<vscale x 2 x i64> %a) {
+; CHECK-LABEL: sitofp_nxv2i64_to_nxv2f16:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    ptrue p0.d
+; CHECK-NEXT:    scvtf z0.h, p0/m, z0.d
+; CHECK-NEXT:    ret
+  %r = call <vscale x 2 x half> @llvm.experimental.constrained.sitofp(<vscale x 2 x i64> %a, metadata !"round.dynamic", metadata !"fpexcept.strict")
+  ret <vscale x 2 x half> %r
+}
+
+define <vscale x 2 x float> @sitofp_nxv2i64_to_nxv2f32(<vscale x 2 x i64> %a) {
+; CHECK-LABEL: sitofp_nxv2i64_to_nxv2f32:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    ptrue p0.d
+; CHECK-NEXT:    scvtf z0.s, p0/m, z0.d
+; CHECK-NEXT:    ret
+  %r = call <vscale x 2 x float> @llvm.experimental.constrained.sitofp(<vscale x 2 x i64> %a, metadata !"round.dynamic", metadata !"fpexcept.strict")
+  ret <vscale x 2 x float> %r
+}
+
+define <vscale x 2 x double> @sitofp_nxv2i64_to_nxv2f64(<vscale x 2 x i64> %a) {
+; CHECK-LABEL: sitofp_nxv2i64_to_nxv2f64:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    ptrue p0.d
+; CHECK-NEXT:    scvtf z0.d, p0/m, z0.d
+; CHECK-NEXT:    ret
+  %r = call <vscale x 2 x double> @llvm.experimental.constrained.sitofp(<vscale x 2 x i64> %a, metadata !"round.dynamic", metadata !"fpexcept.strict")
+  ret <vscale x 2 x double> %r
+}
 
 ;
 ; constrained.trunc
@@ -1079,6 +1379,65 @@ define <vscale x 2 x double> @trunc_nxv2f64(<vscale x 2 x double> %a) {
 }
 
 ;
-; constrained_uitofp (TODO)
+; constrained_uitofp
 ;
 
+define <vscale x 8 x half> @uitofp_nxv8i16_to_nxv8f16(<vscale x 8 x i16> %a) {
+; CHECK-LABEL: uitofp_nxv8i16_to_nxv8f16:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    ptrue p0.h
+; CHECK-NEXT:    ucvtf z0.h, p0/m, z0.h
+; CHECK-NEXT:    ret
+  %r = call <vscale x 8 x half> @llvm.experimental.constrained.uitofp(<vscale x 8 x i16> %a, metadata !"round.dynamic", metadata !"fpexcept.strict")
+  ret <vscale x 8 x half> %r
+}
+
+define <vscale x 4 x half> @uitofp_nxv4i32_to_nxv4f16(<vscale x 4 x i32> %a) {
+; CHECK-LABEL: uitofp_nxv4i32_to_nxv4f16:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    ptrue p0.s
+; CHECK-NEXT:    ucvtf z0.h, p0/m, z0.s
+; CHECK-NEXT:    ret
+  %r = call <vscale x 4 x half> @llvm.experimental.constrained.uitofp(<vscale x 4 x i32> %a, metadata !"round.dynamic", metadata !"fpexcept.strict")
+  ret <vscale x 4 x half> %r
+}
+
+define <vscale x 4 x float> @uitofp_nxv4i32_to_nxv4f32(<vscale x 4 x i32> %a) {
+; CHECK-LABEL: uitofp_nxv4i32_to_nxv4f32:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    ptrue p0.s
+; CHECK-NEXT:    ucvtf z0.s, p0/m, z0.s
+; CHECK-NEXT:    ret
+  %r = call <vscale x 4 x float> @llvm.experimental.constrained.uitofp(<vscale x 4 x i32> %a, metadata !"round.dynamic", metadata !"fpexcept.strict")
+  ret <vscale x 4 x float> %r
+}
+
+define <vscale x 2 x half> @uitofp_nxv2i64_to_nxv2f16(<vscale x 2 x i64> %a) {
+; CHECK-LABEL: uitofp_nxv2i64_to_nxv2f16:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    ptrue p0.d
+; CHECK-NEXT:    ucvtf z0.h, p0/m, z0.d
+; CHECK-NEXT:    ret
+  %r = call <vscale x 2 x half> @llvm.experimental.constrained.uitofp(<vscale x 2 x i64> %a, metadata !"round.dynamic", metadata !"fpexcept.strict")
+  ret <vscale x 2 x half> %r
+}
+
+define <vscale x 2 x float> @uitofp_nxv2i64_to_nxv2f32(<vscale x 2 x i64> %a) {
+; CHECK-LABEL: uitofp_nxv2i64_to_nxv2f32:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    ptrue p0.d
+; CHECK-NEXT:    ucvtf z0.s, p0/m, z0.d
+; CHECK-NEXT:    ret
+  %r = call <vscale x 2 x float> @llvm.experimental.constrained.uitofp(<vscale x 2 x i64> %a, metadata !"round.dynamic", metadata !"fpexcept.strict")
+  ret <vscale x 2 x float> %r
+}
+
+define <vscale x 2 x double> @uitofp_nxv2i64_to_nxv2f64(<vscale x 2 x i64> %a) {
+; CHECK-LABEL: uitofp_nxv2i64_to_nxv2f64:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    ptrue p0.d
+; CHECK-NEXT:    ucvtf z0.d, p0/m, z0.d
+; CHECK-NEXT:    ret
+  %r = call <vscale x 2 x double> @llvm.experimental.constrained.uitofp(<vscale x 2 x i64> %a, metadata !"round.dynamic", metadata !"fpexcept.strict")
+  ret <vscale x 2 x double> %r
+}


### PR DESCRIPTION
Implements lowering for constrained variants of fpext, fptosi, fptoui, fptrunc, rint, sitofp and uitofp. Support covers scalable vectors of half, float and double element type, with bfloat support due in a follow-up PR.