### PR TITLE
[lldb] Remove return value from RemoveBreakpointOpcodesFromBuffer

### DIFF
--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -3658,8 +3658,8 @@ protected:
 
   llvm::Error FlushDelayedBreakpoints();
 
-  size_t RemoveBreakpointOpcodesFromBuffer(lldb::addr_t addr, size_t size,
-                                           uint8_t *buf) const;
+  void RemoveBreakpointOpcodesFromBuffer(lldb::addr_t addr, size_t size,
+                                         uint8_t *buf) const;
 
   void SynchronouslyNotifyStateChanged(lldb::StateType state);
 

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -1835,34 +1835,32 @@ void Process::RemoveConstituentFromBreakpointSite(
   }
 }
 
-size_t Process::RemoveBreakpointOpcodesFromBuffer(addr_t bp_addr, size_t size,
-                                                  uint8_t *buf) const {
-  size_t bytes_removed = 0;
+void Process::RemoveBreakpointOpcodesFromBuffer(addr_t bp_addr, size_t size,
+                                                uint8_t *buf) const {
   StopPointSiteList<BreakpointSite> bp_sites_in_range;
+  if (!m_breakpoint_site_list.FindInRange(bp_addr, bp_addr + size,
+                                          bp_sites_in_range))
+    return;
 
-  if (m_breakpoint_site_list.FindInRange(bp_addr, bp_addr + size,
-                                         bp_sites_in_range)) {
-    bp_sites_in_range.ForEach([bp_addr, size,
-                               buf](BreakpointSite *bp_site) -> void {
-      if (bp_site->GetType() == BreakpointSite::eSoftware) {
-        addr_t intersect_addr;
-        size_t intersect_size;
-        size_t opcode_offset;
-        if (bp_site->IntersectsRange(bp_addr, size, &intersect_addr,
-                                     &intersect_size, &opcode_offset)) {
-          assert(bp_addr <= intersect_addr && intersect_addr < bp_addr + size);
-          assert(bp_addr < intersect_addr + intersect_size &&
-                 intersect_addr + intersect_size <= bp_addr + size);
-          assert(opcode_offset + intersect_size <= bp_site->GetByteSize());
-          size_t buf_offset = intersect_addr - bp_addr;
-          ::memcpy(buf + buf_offset,
-                   bp_site->GetSavedOpcodeBytes() + opcode_offset,
-                   intersect_size);
-        }
+  bp_sites_in_range.ForEach([bp_addr, size,
+                             buf](BreakpointSite *bp_site) -> void {
+    if (bp_site->GetType() == BreakpointSite::eSoftware) {
+      addr_t intersect_addr;
+      size_t intersect_size;
+      size_t opcode_offset;
+      if (bp_site->IntersectsRange(bp_addr, size, &intersect_addr,
+                                   &intersect_size, &opcode_offset)) {
+        assert(bp_addr <= intersect_addr && intersect_addr < bp_addr + size);
+        assert(bp_addr < intersect_addr + intersect_size &&
+               intersect_addr + intersect_size <= bp_addr + size);
+        assert(opcode_offset + intersect_size <= bp_site->GetByteSize());
+        size_t buf_offset = intersect_addr - bp_addr;
+        ::memcpy(buf + buf_offset,
+                 bp_site->GetSavedOpcodeBytes() + opcode_offset,
+                 intersect_size);
       }
-    });
-  }
-  return bytes_removed;
+    }
+  });
 }
 
 size_t Process::GetSoftwareBreakpointTrapOpcode(BreakpointSite *bp_site) {


### PR DESCRIPTION
It was never set to anything and the one caller ignored it.