### PR TITLE
[X86] LowerCLMUL - fix unpack order of vXi32 CLMUL/CLMULH codegen

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -33854,8 +33854,8 @@ static SDValue LowerCLMUL(SDValue Op, const X86Subtarget &Subtarget,
                                DAG.getTargetConstant(0x11, DL, MVT::i8));
     // Pack together lowest elements.
     SDValue Res02 = getUnpackl(DAG, DL, VT, DAG.getBitcast(VT, Res0),
-                               DAG.getBitcast(VT, Res1));
-    SDValue Res13 = getUnpackl(DAG, DL, VT, DAG.getBitcast(VT, Res2),
+                               DAG.getBitcast(VT, Res2));
+    SDValue Res13 = getUnpackl(DAG, DL, VT, DAG.getBitcast(VT, Res1),
                                DAG.getBitcast(VT, Res3));
     return getUnpack(DAG, DL, VT, Res02, Res13, IsHigh);
   }

--- a/llvm/test/CodeGen/X86/clmul-vector-256.ll
+++ b/llvm/test/CodeGen/X86/clmul-vector-256.ll
@@ -466,23 +466,23 @@ define <8 x i32> @clmul_v8i32(<8 x i32> %a, <8 x i32> %b) nounwind {
 ; AVX1-NEXT:    vextractf128 $1, %ymm1, %xmm2
 ; AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm3
 ; AVX1-NEXT:    vpclmulqdq $17, %xmm2, %xmm3, %xmm4
-; AVX1-NEXT:    vpsrlq $32, %xmm2, %xmm5
-; AVX1-NEXT:    vpsrlq $32, %xmm3, %xmm6
-; AVX1-NEXT:    vpclmulqdq $17, %xmm5, %xmm6, %xmm7
-; AVX1-NEXT:    vpunpckldq {{.*#+}} xmm4 = xmm4[0],xmm7[0],xmm4[1],xmm7[1]
+; AVX1-NEXT:    vpclmulqdq $0, %xmm2, %xmm3, %xmm5
+; AVX1-NEXT:    vpunpckldq {{.*#+}} xmm4 = xmm5[0],xmm4[0],xmm5[1],xmm4[1]
+; AVX1-NEXT:    vpsrlq $32, %xmm2, %xmm2
+; AVX1-NEXT:    vpsrlq $32, %xmm3, %xmm3
+; AVX1-NEXT:    vpclmulqdq $17, %xmm2, %xmm3, %xmm5
 ; AVX1-NEXT:    vpclmulqdq $0, %xmm2, %xmm3, %xmm2
-; AVX1-NEXT:    vpclmulqdq $0, %xmm5, %xmm6, %xmm3
-; AVX1-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm3[0],xmm2[1],xmm3[1]
-; AVX1-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm4[0],xmm2[1],xmm4[1]
+; AVX1-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm5[0],xmm2[1],xmm5[1]
+; AVX1-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm4[0],xmm2[0],xmm4[1],xmm2[1]
 ; AVX1-NEXT:    vpclmulqdq $17, %xmm1, %xmm0, %xmm3
-; AVX1-NEXT:    vpsrlq $32, %xmm1, %xmm4
-; AVX1-NEXT:    vpsrlq $32, %xmm0, %xmm5
-; AVX1-NEXT:    vpclmulqdq $17, %xmm4, %xmm5, %xmm6
-; AVX1-NEXT:    vpunpckldq {{.*#+}} xmm3 = xmm3[0],xmm6[0],xmm3[1],xmm6[1]
+; AVX1-NEXT:    vpclmulqdq $0, %xmm1, %xmm0, %xmm4
+; AVX1-NEXT:    vpunpckldq {{.*#+}} xmm3 = xmm4[0],xmm3[0],xmm4[1],xmm3[1]
+; AVX1-NEXT:    vpsrlq $32, %xmm1, %xmm1
+; AVX1-NEXT:    vpsrlq $32, %xmm0, %xmm0
+; AVX1-NEXT:    vpclmulqdq $17, %xmm1, %xmm0, %xmm4
 ; AVX1-NEXT:    vpclmulqdq $0, %xmm1, %xmm0, %xmm0
-; AVX1-NEXT:    vpclmulqdq $0, %xmm4, %xmm5, %xmm1
-; AVX1-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm0[0],xmm1[0],xmm0[1],xmm1[1]
-; AVX1-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm0[0],xmm3[0],xmm0[1],xmm3[1]
+; AVX1-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm0[0],xmm4[0],xmm0[1],xmm4[1]
+; AVX1-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm3[0],xmm0[0],xmm3[1],xmm0[1]
 ; AVX1-NEXT:    vinsertf128 $1, %xmm2, %ymm0, %ymm0
 ; AVX1-NEXT:    retq
 ;
@@ -491,50 +491,50 @@ define <8 x i32> @clmul_v8i32(<8 x i32> %a, <8 x i32> %b) nounwind {
 ; AVX2-PCLMUL-NEXT:    vextracti128 $1, %ymm1, %xmm2
 ; AVX2-PCLMUL-NEXT:    vextracti128 $1, %ymm0, %xmm3
 ; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm2, %xmm3, %xmm4
-; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm2, %xmm5
-; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm3, %xmm6
-; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm5, %xmm6, %xmm7
-; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm4 = xmm4[0],xmm7[0],xmm4[1],xmm7[1]
+; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm2, %xmm3, %xmm5
+; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm4 = xmm5[0],xmm4[0],xmm5[1],xmm4[1]
+; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm2, %xmm2
+; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm3, %xmm3
+; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm2, %xmm3, %xmm5
 ; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm2, %xmm3, %xmm2
-; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm5, %xmm6, %xmm3
-; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm3[0],xmm2[1],xmm3[1]
-; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm4[0],xmm2[1],xmm4[1]
+; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm5[0],xmm2[1],xmm5[1]
+; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm4[0],xmm2[0],xmm4[1],xmm2[1]
 ; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm1, %xmm0, %xmm3
-; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm1, %xmm4
-; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm0, %xmm5
-; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm4, %xmm5, %xmm6
-; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm3 = xmm3[0],xmm6[0],xmm3[1],xmm6[1]
+; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm1, %xmm0, %xmm4
+; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm3 = xmm4[0],xmm3[0],xmm4[1],xmm3[1]
+; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm1, %xmm1
+; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm0, %xmm0
+; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm1, %xmm0, %xmm4
 ; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm1, %xmm0, %xmm0
-; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm4, %xmm5, %xmm1
-; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm0[0],xmm1[0],xmm0[1],xmm1[1]
-; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm0[0],xmm3[0],xmm0[1],xmm3[1]
+; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm0[0],xmm4[0],xmm0[1],xmm4[1]
+; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm3[0],xmm0[0],xmm3[1],xmm0[1]
 ; AVX2-PCLMUL-NEXT:    vinserti128 $1, %xmm2, %ymm0, %ymm0
 ; AVX2-PCLMUL-NEXT:    retq
 ;
 ; AVX2-VPCLMULQDQ-LABEL: clmul_v8i32:
 ; AVX2-VPCLMULQDQ:       # %bb.0:
 ; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $17, %ymm1, %ymm0, %ymm2
-; AVX2-VPCLMULQDQ-NEXT:    vpsrlq $32, %ymm1, %ymm3
-; AVX2-VPCLMULQDQ-NEXT:    vpsrlq $32, %ymm0, %ymm4
-; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $17, %ymm3, %ymm4, %ymm5
-; AVX2-VPCLMULQDQ-NEXT:    vpunpckldq {{.*#+}} ymm2 = ymm2[0],ymm5[0],ymm2[1],ymm5[1],ymm2[4],ymm5[4],ymm2[5],ymm5[5]
+; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $0, %ymm1, %ymm0, %ymm3
+; AVX2-VPCLMULQDQ-NEXT:    vpunpckldq {{.*#+}} ymm2 = ymm3[0],ymm2[0],ymm3[1],ymm2[1],ymm3[4],ymm2[4],ymm3[5],ymm2[5]
+; AVX2-VPCLMULQDQ-NEXT:    vpsrlq $32, %ymm1, %ymm1
+; AVX2-VPCLMULQDQ-NEXT:    vpsrlq $32, %ymm0, %ymm0
+; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $17, %ymm1, %ymm0, %ymm3
 ; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $0, %ymm1, %ymm0, %ymm0
-; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $0, %ymm3, %ymm4, %ymm1
-; AVX2-VPCLMULQDQ-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm0[0],ymm1[0],ymm0[1],ymm1[1],ymm0[4],ymm1[4],ymm0[5],ymm1[5]
-; AVX2-VPCLMULQDQ-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm0[0],ymm2[0],ymm0[1],ymm2[1],ymm0[4],ymm2[4],ymm0[5],ymm2[5]
+; AVX2-VPCLMULQDQ-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm0[0],ymm3[0],ymm0[1],ymm3[1],ymm0[4],ymm3[4],ymm0[5],ymm3[5]
+; AVX2-VPCLMULQDQ-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm2[0],ymm0[0],ymm2[1],ymm0[1],ymm2[4],ymm0[4],ymm2[5],ymm0[5]
 ; AVX2-VPCLMULQDQ-NEXT:    retq
 ;
 ; AVX512-LABEL: clmul_v8i32:
 ; AVX512:       # %bb.0:
 ; AVX512-NEXT:    vpclmulqdq $17, %ymm1, %ymm0, %ymm2
-; AVX512-NEXT:    vpsrlq $32, %ymm1, %ymm3
-; AVX512-NEXT:    vpsrlq $32, %ymm0, %ymm4
-; AVX512-NEXT:    vpclmulqdq $17, %ymm3, %ymm4, %ymm5
-; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm2 = ymm2[0],ymm5[0],ymm2[1],ymm5[1],ymm2[4],ymm5[4],ymm2[5],ymm5[5]
+; AVX512-NEXT:    vpclmulqdq $0, %ymm1, %ymm0, %ymm3
+; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm2 = ymm3[0],ymm2[0],ymm3[1],ymm2[1],ymm3[4],ymm2[4],ymm3[5],ymm2[5]
+; AVX512-NEXT:    vpsrlq $32, %ymm1, %ymm1
+; AVX512-NEXT:    vpsrlq $32, %ymm0, %ymm0
+; AVX512-NEXT:    vpclmulqdq $17, %ymm1, %ymm0, %ymm3
 ; AVX512-NEXT:    vpclmulqdq $0, %ymm1, %ymm0, %ymm0
-; AVX512-NEXT:    vpclmulqdq $0, %ymm3, %ymm4, %ymm1
-; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm0[0],ymm1[0],ymm0[1],ymm1[1],ymm0[4],ymm1[4],ymm0[5],ymm1[5]
-; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm0[0],ymm2[0],ymm0[1],ymm2[1],ymm0[4],ymm2[4],ymm0[5],ymm2[5]
+; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm0[0],ymm3[0],ymm0[1],ymm3[1],ymm0[4],ymm3[4],ymm0[5],ymm3[5]
+; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm2[0],ymm0[0],ymm2[1],ymm0[1],ymm2[4],ymm0[4],ymm2[5],ymm0[5]
 ; AVX512-NEXT:    retq
   %res = call <8 x i32> @llvm.clmul.v8i32(<8 x i32> %a, <8 x i32> %b)
   ret <8 x i32> %res
@@ -1163,14 +1163,14 @@ define <16 x i16> @clmulr_v16i16(<16 x i16> %a, <16 x i16> %b) nounwind {
 ; AVX512-NEXT:    vpmovzxwd {{.*#+}} zmm1 = ymm1[0],zero,ymm1[1],zero,ymm1[2],zero,ymm1[3],zero,ymm1[4],zero,ymm1[5],zero,ymm1[6],zero,ymm1[7],zero,ymm1[8],zero,ymm1[9],zero,ymm1[10],zero,ymm1[11],zero,ymm1[12],zero,ymm1[13],zero,ymm1[14],zero,ymm1[15],zero
 ; AVX512-NEXT:    vpmovzxwd {{.*#+}} zmm0 = ymm0[0],zero,ymm0[1],zero,ymm0[2],zero,ymm0[3],zero,ymm0[4],zero,ymm0[5],zero,ymm0[6],zero,ymm0[7],zero,ymm0[8],zero,ymm0[9],zero,ymm0[10],zero,ymm0[11],zero,ymm0[12],zero,ymm0[13],zero,ymm0[14],zero,ymm0[15],zero
 ; AVX512-NEXT:    vpclmulqdq $17, %zmm1, %zmm0, %zmm2
-; AVX512-NEXT:    vpsrlq $32, %zmm1, %zmm3
-; AVX512-NEXT:    vpsrlq $32, %zmm0, %zmm4
-; AVX512-NEXT:    vpclmulqdq $17, %zmm3, %zmm4, %zmm5
-; AVX512-NEXT:    vpunpckldq {{.*#+}} zmm2 = zmm2[0],zmm5[0],zmm2[1],zmm5[1],zmm2[4],zmm5[4],zmm2[5],zmm5[5],zmm2[8],zmm5[8],zmm2[9],zmm5[9],zmm2[12],zmm5[12],zmm2[13],zmm5[13]
+; AVX512-NEXT:    vpclmulqdq $0, %zmm1, %zmm0, %zmm3
+; AVX512-NEXT:    vpunpckldq {{.*#+}} zmm2 = zmm3[0],zmm2[0],zmm3[1],zmm2[1],zmm3[4],zmm2[4],zmm3[5],zmm2[5],zmm3[8],zmm2[8],zmm3[9],zmm2[9],zmm3[12],zmm2[12],zmm3[13],zmm2[13]
+; AVX512-NEXT:    vpsrlq $32, %zmm1, %zmm1
+; AVX512-NEXT:    vpsrlq $32, %zmm0, %zmm0
+; AVX512-NEXT:    vpclmulqdq $17, %zmm1, %zmm0, %zmm3
 ; AVX512-NEXT:    vpclmulqdq $0, %zmm1, %zmm0, %zmm0
-; AVX512-NEXT:    vpclmulqdq $0, %zmm3, %zmm4, %zmm1
-; AVX512-NEXT:    vpunpckldq {{.*#+}} zmm0 = zmm0[0],zmm1[0],zmm0[1],zmm1[1],zmm0[4],zmm1[4],zmm0[5],zmm1[5],zmm0[8],zmm1[8],zmm0[9],zmm1[9],zmm0[12],zmm1[12],zmm0[13],zmm1[13]
-; AVX512-NEXT:    vpunpckldq {{.*#+}} zmm0 = zmm0[0],zmm2[0],zmm0[1],zmm2[1],zmm0[4],zmm2[4],zmm0[5],zmm2[5],zmm0[8],zmm2[8],zmm0[9],zmm2[9],zmm0[12],zmm2[12],zmm0[13],zmm2[13]
+; AVX512-NEXT:    vpunpckldq {{.*#+}} zmm0 = zmm0[0],zmm3[0],zmm0[1],zmm3[1],zmm0[4],zmm3[4],zmm0[5],zmm3[5],zmm0[8],zmm3[8],zmm0[9],zmm3[9],zmm0[12],zmm3[12],zmm0[13],zmm3[13]
+; AVX512-NEXT:    vpunpckldq {{.*#+}} zmm0 = zmm2[0],zmm0[0],zmm2[1],zmm0[1],zmm2[4],zmm0[4],zmm2[5],zmm0[5],zmm2[8],zmm0[8],zmm2[9],zmm0[9],zmm2[12],zmm0[12],zmm2[13],zmm0[13]
 ; AVX512-NEXT:    vpsrld $15, %zmm0, %zmm0
 ; AVX512-NEXT:    vpmovdw %zmm0, %ymm0
 ; AVX512-NEXT:    retq
@@ -1189,41 +1189,39 @@ define <8 x i32> @clmulr_v8i32(<8 x i32> %a, <8 x i32> %b) nounwind {
 ; AVX1-NEXT:    vpblendw {{.*#+}} xmm3 = xmm1[0,1],xmm2[2,3],xmm1[4,5],xmm2[6,7]
 ; AVX1-NEXT:    vpblendw {{.*#+}} xmm4 = xmm0[0,1],xmm2[2,3],xmm0[4,5],xmm2[6,7]
 ; AVX1-NEXT:    vpclmulqdq $17, %xmm3, %xmm4, %xmm5
-; AVX1-NEXT:    vpsrlq $32, %xmm1, %xmm6
-; AVX1-NEXT:    vpsrlq $32, %xmm0, %xmm7
-; AVX1-NEXT:    vpclmulqdq $17, %xmm6, %xmm7, %xmm8
-; AVX1-NEXT:    vpunpckldq {{.*#+}} xmm5 = xmm5[0],xmm8[0],xmm5[1],xmm8[1]
 ; AVX1-NEXT:    vpclmulqdq $0, %xmm3, %xmm4, %xmm3
-; AVX1-NEXT:    vpclmulqdq $0, %xmm6, %xmm7, %xmm4
-; AVX1-NEXT:    vpunpckldq {{.*#+}} xmm3 = xmm3[0],xmm4[0],xmm3[1],xmm4[1]
-; AVX1-NEXT:    vpunpckhdq {{.*#+}} xmm3 = xmm3[2],xmm5[2],xmm3[3],xmm5[3]
+; AVX1-NEXT:    vpunpckldq {{.*#+}} xmm3 = xmm3[0],xmm5[0],xmm3[1],xmm5[1]
+; AVX1-NEXT:    vpsrlq $32, %xmm1, %xmm4
+; AVX1-NEXT:    vpsrlq $32, %xmm0, %xmm5
+; AVX1-NEXT:    vpclmulqdq $17, %xmm4, %xmm5, %xmm6
+; AVX1-NEXT:    vpclmulqdq $0, %xmm4, %xmm5, %xmm4
+; AVX1-NEXT:    vpunpckldq {{.*#+}} xmm4 = xmm4[0],xmm6[0],xmm4[1],xmm6[1]
+; AVX1-NEXT:    vpunpckhdq {{.*#+}} xmm3 = xmm3[2],xmm4[2],xmm3[3],xmm4[3]
 ; AVX1-NEXT:    vpaddd %xmm3, %xmm3, %xmm3
 ; AVX1-NEXT:    vextractf128 $1, %ymm1, %xmm5
 ; AVX1-NEXT:    vpblendw {{.*#+}} xmm6 = xmm5[0,1],xmm2[2,3],xmm5[4,5],xmm2[6,7]
 ; AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm7
 ; AVX1-NEXT:    vpblendw {{.*#+}} xmm2 = xmm7[0,1],xmm2[2,3],xmm7[4,5],xmm2[6,7]
-; AVX1-NEXT:    vpclmulqdq $17, %xmm6, %xmm2, %xmm9
-; AVX1-NEXT:    vpsrlq $32, %xmm5, %xmm10
-; AVX1-NEXT:    vpsrlq $32, %xmm7, %xmm11
-; AVX1-NEXT:    vpclmulqdq $17, %xmm10, %xmm11, %xmm12
-; AVX1-NEXT:    vpunpckldq {{.*#+}} xmm9 = xmm9[0],xmm12[0],xmm9[1],xmm12[1]
+; AVX1-NEXT:    vpclmulqdq $17, %xmm6, %xmm2, %xmm8
 ; AVX1-NEXT:    vpclmulqdq $0, %xmm6, %xmm2, %xmm2
-; AVX1-NEXT:    vpclmulqdq $0, %xmm10, %xmm11, %xmm6
-; AVX1-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm6[0],xmm2[1],xmm6[1]
-; AVX1-NEXT:    vpunpckhdq {{.*#+}} xmm2 = xmm2[2],xmm9[2],xmm2[3],xmm9[3]
+; AVX1-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm8[0],xmm2[1],xmm8[1]
+; AVX1-NEXT:    vpsrlq $32, %xmm5, %xmm6
+; AVX1-NEXT:    vpsrlq $32, %xmm7, %xmm8
+; AVX1-NEXT:    vpclmulqdq $17, %xmm6, %xmm8, %xmm9
+; AVX1-NEXT:    vpclmulqdq $0, %xmm6, %xmm8, %xmm6
+; AVX1-NEXT:    vpunpckldq {{.*#+}} xmm6 = xmm6[0],xmm9[0],xmm6[1],xmm9[1]
+; AVX1-NEXT:    vpunpckhdq {{.*#+}} xmm2 = xmm2[2],xmm6[2],xmm2[3],xmm6[3]
 ; AVX1-NEXT:    vpaddd %xmm2, %xmm2, %xmm2
 ; AVX1-NEXT:    vinsertf128 $1, %xmm2, %ymm3, %ymm2
 ; AVX1-NEXT:    vpclmulqdq $17, %xmm1, %xmm0, %xmm3
-; AVX1-NEXT:    vpunpckldq {{.*#+}} xmm3 = xmm3[0],xmm8[0],xmm3[1],xmm8[1]
 ; AVX1-NEXT:    vpclmulqdq $0, %xmm1, %xmm0, %xmm0
-; AVX1-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm0[0],xmm4[0],xmm0[1],xmm4[1]
 ; AVX1-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm0[0],xmm3[0],xmm0[1],xmm3[1]
+; AVX1-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm0[0],xmm4[0],xmm0[1],xmm4[1]
 ; AVX1-NEXT:    vpsrld $31, %xmm0, %xmm0
 ; AVX1-NEXT:    vpclmulqdq $17, %xmm5, %xmm7, %xmm1
-; AVX1-NEXT:    vpunpckldq {{.*#+}} xmm1 = xmm1[0],xmm12[0],xmm1[1],xmm12[1]
 ; AVX1-NEXT:    vpclmulqdq $0, %xmm5, %xmm7, %xmm3
-; AVX1-NEXT:    vpunpckldq {{.*#+}} xmm3 = xmm3[0],xmm6[0],xmm3[1],xmm6[1]
 ; AVX1-NEXT:    vpunpckldq {{.*#+}} xmm1 = xmm3[0],xmm1[0],xmm3[1],xmm1[1]
+; AVX1-NEXT:    vpunpckldq {{.*#+}} xmm1 = xmm1[0],xmm6[0],xmm1[1],xmm6[1]
 ; AVX1-NEXT:    vpsrld $31, %xmm1, %xmm1
 ; AVX1-NEXT:    vinsertf128 $1, %xmm1, %ymm0, %ymm0
 ; AVX1-NEXT:    vorps %ymm2, %ymm0, %ymm0
@@ -1237,37 +1235,35 @@ define <8 x i32> @clmulr_v8i32(<8 x i32> %a, <8 x i32> %b) nounwind {
 ; AVX2-PCLMUL-NEXT:    vextracti128 $1, %ymm0, %xmm5
 ; AVX2-PCLMUL-NEXT:    vpblendd {{.*#+}} xmm6 = xmm5[0],xmm3[1],xmm5[2],xmm3[3]
 ; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm4, %xmm6, %xmm7
-; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm2, %xmm8
-; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm5, %xmm9
-; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm8, %xmm9, %xmm10
-; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm7[0],xmm10[0],xmm7[1],xmm10[1]
 ; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm4, %xmm6, %xmm4
-; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm8, %xmm9, %xmm6
-; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm4 = xmm4[0],xmm6[0],xmm4[1],xmm6[1]
-; AVX2-PCLMUL-NEXT:    vpunpckhdq {{.*#+}} xmm4 = xmm4[2],xmm7[2],xmm4[3],xmm7[3]
+; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm4 = xmm4[0],xmm7[0],xmm4[1],xmm7[1]
+; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm2, %xmm6
+; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm5, %xmm7
+; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm6, %xmm7, %xmm8
+; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm6, %xmm7, %xmm6
+; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm6 = xmm6[0],xmm8[0],xmm6[1],xmm8[1]
+; AVX2-PCLMUL-NEXT:    vpunpckhdq {{.*#+}} xmm4 = xmm4[2],xmm6[2],xmm4[3],xmm6[3]
 ; AVX2-PCLMUL-NEXT:    vpblendd {{.*#+}} xmm7 = xmm1[0],xmm3[1],xmm1[2],xmm3[3]
 ; AVX2-PCLMUL-NEXT:    vpblendd {{.*#+}} xmm3 = xmm0[0],xmm3[1],xmm0[2],xmm3[3]
 ; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm7, %xmm3, %xmm8
-; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm1, %xmm9
-; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm0, %xmm11
-; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm9, %xmm11, %xmm12
-; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm8 = xmm8[0],xmm12[0],xmm8[1],xmm12[1]
 ; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm7, %xmm3, %xmm3
-; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm9, %xmm11, %xmm7
-; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm3 = xmm3[0],xmm7[0],xmm3[1],xmm7[1]
-; AVX2-PCLMUL-NEXT:    vpunpckhdq {{.*#+}} xmm3 = xmm3[2],xmm8[2],xmm3[3],xmm8[3]
+; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm3 = xmm3[0],xmm8[0],xmm3[1],xmm8[1]
+; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm1, %xmm7
+; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm0, %xmm8
+; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm7, %xmm8, %xmm9
+; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm7, %xmm8, %xmm7
+; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm7[0],xmm9[0],xmm7[1],xmm9[1]
+; AVX2-PCLMUL-NEXT:    vpunpckhdq {{.*#+}} xmm3 = xmm3[2],xmm7[2],xmm3[3],xmm7[3]
 ; AVX2-PCLMUL-NEXT:    vinserti128 $1, %xmm4, %ymm3, %ymm3
 ; AVX2-PCLMUL-NEXT:    vpaddd %ymm3, %ymm3, %ymm3
 ; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm2, %xmm5, %xmm4
-; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm4 = xmm4[0],xmm10[0],xmm4[1],xmm10[1]
 ; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm2, %xmm5, %xmm2
-; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm6[0],xmm2[1],xmm6[1]
 ; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm4[0],xmm2[1],xmm4[1]
+; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm6[0],xmm2[1],xmm6[1]
 ; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm1, %xmm0, %xmm4
-; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm4 = xmm4[0],xmm12[0],xmm4[1],xmm12[1]
 ; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm1, %xmm0, %xmm0
-; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm0[0],xmm7[0],xmm0[1],xmm7[1]
 ; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm0[0],xmm4[0],xmm0[1],xmm4[1]
+; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm0[0],xmm7[0],xmm0[1],xmm7[1]
 ; AVX2-PCLMUL-NEXT:    vinserti128 $1, %xmm2, %ymm0, %ymm0
 ; AVX2-PCLMUL-NEXT:    vpsrld $31, %ymm0, %ymm0
 ; AVX2-PCLMUL-NEXT:    vpor %ymm3, %ymm0, %ymm0
@@ -1276,23 +1272,22 @@ define <8 x i32> @clmulr_v8i32(<8 x i32> %a, <8 x i32> %b) nounwind {
 ; AVX2-VPCLMULQDQ-LABEL: clmulr_v8i32:
 ; AVX2-VPCLMULQDQ:       # %bb.0:
 ; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $17, %ymm1, %ymm0, %ymm2
+; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $0, %ymm1, %ymm0, %ymm3
+; AVX2-VPCLMULQDQ-NEXT:    vpunpckldq {{.*#+}} ymm2 = ymm3[0],ymm2[0],ymm3[1],ymm2[1],ymm3[4],ymm2[4],ymm3[5],ymm2[5]
 ; AVX2-VPCLMULQDQ-NEXT:    vpsrlq $32, %ymm1, %ymm3
 ; AVX2-VPCLMULQDQ-NEXT:    vpsrlq $32, %ymm0, %ymm4
 ; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $17, %ymm3, %ymm4, %ymm5
-; AVX2-VPCLMULQDQ-NEXT:    vpunpckldq {{.*#+}} ymm2 = ymm2[0],ymm5[0],ymm2[1],ymm5[1],ymm2[4],ymm5[4],ymm2[5],ymm5[5]
-; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $0, %ymm1, %ymm0, %ymm6
 ; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $0, %ymm3, %ymm4, %ymm3
-; AVX2-VPCLMULQDQ-NEXT:    vpunpckldq {{.*#+}} ymm4 = ymm6[0],ymm3[0],ymm6[1],ymm3[1],ymm6[4],ymm3[4],ymm6[5],ymm3[5]
-; AVX2-VPCLMULQDQ-NEXT:    vpunpckldq {{.*#+}} ymm2 = ymm4[0],ymm2[0],ymm4[1],ymm2[1],ymm4[4],ymm2[4],ymm4[5],ymm2[5]
+; AVX2-VPCLMULQDQ-NEXT:    vpunpckldq {{.*#+}} ymm3 = ymm3[0],ymm5[0],ymm3[1],ymm5[1],ymm3[4],ymm5[4],ymm3[5],ymm5[5]
+; AVX2-VPCLMULQDQ-NEXT:    vpunpckldq {{.*#+}} ymm2 = ymm2[0],ymm3[0],ymm2[1],ymm3[1],ymm2[4],ymm3[4],ymm2[5],ymm3[5]
 ; AVX2-VPCLMULQDQ-NEXT:    vpsrld $31, %ymm2, %ymm2
 ; AVX2-VPCLMULQDQ-NEXT:    vpxor %xmm4, %xmm4, %xmm4
 ; AVX2-VPCLMULQDQ-NEXT:    vpblendd {{.*#+}} ymm1 = ymm1[0],ymm4[1],ymm1[2],ymm4[3],ymm1[4],ymm4[5],ymm1[6],ymm4[7]
 ; AVX2-VPCLMULQDQ-NEXT:    vpblendd {{.*#+}} ymm0 = ymm0[0],ymm4[1],ymm0[2],ymm4[3],ymm0[4],ymm4[5],ymm0[6],ymm4[7]
 ; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $17, %ymm1, %ymm0, %ymm4
-; AVX2-VPCLMULQDQ-NEXT:    vpunpckldq {{.*#+}} ymm4 = ymm4[0],ymm5[0],ymm4[1],ymm5[1],ymm4[4],ymm5[4],ymm4[5],ymm5[5]
 ; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $0, %ymm1, %ymm0, %ymm0
-; AVX2-VPCLMULQDQ-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm0[0],ymm3[0],ymm0[1],ymm3[1],ymm0[4],ymm3[4],ymm0[5],ymm3[5]
-; AVX2-VPCLMULQDQ-NEXT:    vpunpckhdq {{.*#+}} ymm0 = ymm0[2],ymm4[2],ymm0[3],ymm4[3],ymm0[6],ymm4[6],ymm0[7],ymm4[7]
+; AVX2-VPCLMULQDQ-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm0[0],ymm4[0],ymm0[1],ymm4[1],ymm0[4],ymm4[4],ymm0[5],ymm4[5]
+; AVX2-VPCLMULQDQ-NEXT:    vpunpckhdq {{.*#+}} ymm0 = ymm0[2],ymm3[2],ymm0[3],ymm3[3],ymm0[6],ymm3[6],ymm0[7],ymm3[7]
 ; AVX2-VPCLMULQDQ-NEXT:    vpaddd %ymm0, %ymm0, %ymm0
 ; AVX2-VPCLMULQDQ-NEXT:    vpor %ymm0, %ymm2, %ymm0
 ; AVX2-VPCLMULQDQ-NEXT:    retq
@@ -1300,23 +1295,22 @@ define <8 x i32> @clmulr_v8i32(<8 x i32> %a, <8 x i32> %b) nounwind {
 ; AVX512-LABEL: clmulr_v8i32:
 ; AVX512:       # %bb.0:
 ; AVX512-NEXT:    vpclmulqdq $17, %ymm1, %ymm0, %ymm2
+; AVX512-NEXT:    vpclmulqdq $0, %ymm1, %ymm0, %ymm3
+; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm2 = ymm3[0],ymm2[0],ymm3[1],ymm2[1],ymm3[4],ymm2[4],ymm3[5],ymm2[5]
 ; AVX512-NEXT:    vpsrlq $32, %ymm1, %ymm3
 ; AVX512-NEXT:    vpsrlq $32, %ymm0, %ymm4
 ; AVX512-NEXT:    vpclmulqdq $17, %ymm3, %ymm4, %ymm5
-; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm2 = ymm2[0],ymm5[0],ymm2[1],ymm5[1],ymm2[4],ymm5[4],ymm2[5],ymm5[5]
-; AVX512-NEXT:    vpclmulqdq $0, %ymm1, %ymm0, %ymm6
 ; AVX512-NEXT:    vpclmulqdq $0, %ymm3, %ymm4, %ymm3
-; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm4 = ymm6[0],ymm3[0],ymm6[1],ymm3[1],ymm6[4],ymm3[4],ymm6[5],ymm3[5]
-; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm2 = ymm4[0],ymm2[0],ymm4[1],ymm2[1],ymm4[4],ymm2[4],ymm4[5],ymm2[5]
+; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm3 = ymm3[0],ymm5[0],ymm3[1],ymm5[1],ymm3[4],ymm5[4],ymm3[5],ymm5[5]
+; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm2 = ymm2[0],ymm3[0],ymm2[1],ymm3[1],ymm2[4],ymm3[4],ymm2[5],ymm3[5]
 ; AVX512-NEXT:    vpsrld $31, %ymm2, %ymm2
 ; AVX512-NEXT:    vpxor %xmm4, %xmm4, %xmm4
 ; AVX512-NEXT:    vpblendd {{.*#+}} ymm1 = ymm1[0],ymm4[1],ymm1[2],ymm4[3],ymm1[4],ymm4[5],ymm1[6],ymm4[7]
 ; AVX512-NEXT:    vpblendd {{.*#+}} ymm0 = ymm0[0],ymm4[1],ymm0[2],ymm4[3],ymm0[4],ymm4[5],ymm0[6],ymm4[7]
 ; AVX512-NEXT:    vpclmulqdq $17, %ymm1, %ymm0, %ymm4
-; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm4 = ymm4[0],ymm5[0],ymm4[1],ymm5[1],ymm4[4],ymm5[4],ymm4[5],ymm5[5]
 ; AVX512-NEXT:    vpclmulqdq $0, %ymm1, %ymm0, %ymm0
-; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm0[0],ymm3[0],ymm0[1],ymm3[1],ymm0[4],ymm3[4],ymm0[5],ymm3[5]
-; AVX512-NEXT:    vpunpckhdq {{.*#+}} ymm0 = ymm0[2],ymm4[2],ymm0[3],ymm4[3],ymm0[6],ymm4[6],ymm0[7],ymm4[7]
+; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm0[0],ymm4[0],ymm0[1],ymm4[1],ymm0[4],ymm4[4],ymm0[5],ymm4[5]
+; AVX512-NEXT:    vpunpckhdq {{.*#+}} ymm0 = ymm0[2],ymm3[2],ymm0[3],ymm3[3],ymm0[6],ymm3[6],ymm0[7],ymm3[7]
 ; AVX512-NEXT:    vpaddd %ymm0, %ymm0, %ymm0
 ; AVX512-NEXT:    vpor %ymm0, %ymm2, %ymm0
 ; AVX512-NEXT:    retq
@@ -1980,14 +1974,14 @@ define <16 x i16> @clmulh_v16i16(<16 x i16> %a, <16 x i16> %b) nounwind {
 ; AVX512-NEXT:    vpmovzxwd {{.*#+}} zmm1 = ymm1[0],zero,ymm1[1],zero,ymm1[2],zero,ymm1[3],zero,ymm1[4],zero,ymm1[5],zero,ymm1[6],zero,ymm1[7],zero,ymm1[8],zero,ymm1[9],zero,ymm1[10],zero,ymm1[11],zero,ymm1[12],zero,ymm1[13],zero,ymm1[14],zero,ymm1[15],zero
 ; AVX512-NEXT:    vpmovzxwd {{.*#+}} zmm0 = ymm0[0],zero,ymm0[1],zero,ymm0[2],zero,ymm0[3],zero,ymm0[4],zero,ymm0[5],zero,ymm0[6],zero,ymm0[7],zero,ymm0[8],zero,ymm0[9],zero,ymm0[10],zero,ymm0[11],zero,ymm0[12],zero,ymm0[13],zero,ymm0[14],zero,ymm0[15],zero
 ; AVX512-NEXT:    vpclmulqdq $17, %zmm1, %zmm0, %zmm2
-; AVX512-NEXT:    vpsrlq $32, %zmm1, %zmm3
-; AVX512-NEXT:    vpsrlq $32, %zmm0, %zmm4
-; AVX512-NEXT:    vpclmulqdq $17, %zmm3, %zmm4, %zmm5
-; AVX512-NEXT:    vpunpckldq {{.*#+}} zmm2 = zmm2[0],zmm5[0],zmm2[1],zmm5[1],zmm2[4],zmm5[4],zmm2[5],zmm5[5],zmm2[8],zmm5[8],zmm2[9],zmm5[9],zmm2[12],zmm5[12],zmm2[13],zmm5[13]
+; AVX512-NEXT:    vpclmulqdq $0, %zmm1, %zmm0, %zmm3
+; AVX512-NEXT:    vpunpckldq {{.*#+}} zmm2 = zmm3[0],zmm2[0],zmm3[1],zmm2[1],zmm3[4],zmm2[4],zmm3[5],zmm2[5],zmm3[8],zmm2[8],zmm3[9],zmm2[9],zmm3[12],zmm2[12],zmm3[13],zmm2[13]
+; AVX512-NEXT:    vpsrlq $32, %zmm1, %zmm1
+; AVX512-NEXT:    vpsrlq $32, %zmm0, %zmm0
+; AVX512-NEXT:    vpclmulqdq $17, %zmm1, %zmm0, %zmm3
 ; AVX512-NEXT:    vpclmulqdq $0, %zmm1, %zmm0, %zmm0
-; AVX512-NEXT:    vpclmulqdq $0, %zmm3, %zmm4, %zmm1
-; AVX512-NEXT:    vpunpckldq {{.*#+}} zmm0 = zmm0[0],zmm1[0],zmm0[1],zmm1[1],zmm0[4],zmm1[4],zmm0[5],zmm1[5],zmm0[8],zmm1[8],zmm0[9],zmm1[9],zmm0[12],zmm1[12],zmm0[13],zmm1[13]
-; AVX512-NEXT:    vpunpckldq {{.*#+}} zmm0 = zmm0[0],zmm2[0],zmm0[1],zmm2[1],zmm0[4],zmm2[4],zmm0[5],zmm2[5],zmm0[8],zmm2[8],zmm0[9],zmm2[9],zmm0[12],zmm2[12],zmm0[13],zmm2[13]
+; AVX512-NEXT:    vpunpckldq {{.*#+}} zmm0 = zmm0[0],zmm3[0],zmm0[1],zmm3[1],zmm0[4],zmm3[4],zmm0[5],zmm3[5],zmm0[8],zmm3[8],zmm0[9],zmm3[9],zmm0[12],zmm3[12],zmm0[13],zmm3[13]
+; AVX512-NEXT:    vpunpckldq {{.*#+}} zmm0 = zmm2[0],zmm0[0],zmm2[1],zmm0[1],zmm2[4],zmm0[4],zmm2[5],zmm0[5],zmm2[8],zmm0[8],zmm2[9],zmm0[9],zmm2[12],zmm0[12],zmm2[13],zmm0[13]
 ; AVX512-NEXT:    vpsrld $16, %zmm0, %zmm0
 ; AVX512-NEXT:    vpmovdw %zmm0, %ymm0
 ; AVX512-NEXT:    retq
@@ -2008,25 +2002,25 @@ define <8 x i32> @clmulh_v8i32(<8 x i32> %a, <8 x i32> %b) nounwind {
 ; AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm5
 ; AVX1-NEXT:    vpblendw {{.*#+}} xmm6 = xmm5[0,1],xmm3[2,3],xmm5[4,5],xmm3[6,7]
 ; AVX1-NEXT:    vpclmulqdq $17, %xmm4, %xmm6, %xmm7
+; AVX1-NEXT:    vpclmulqdq $0, %xmm4, %xmm6, %xmm4
+; AVX1-NEXT:    vpunpckldq {{.*#+}} xmm4 = xmm4[0],xmm7[0],xmm4[1],xmm7[1]
 ; AVX1-NEXT:    vpsrlq $32, %xmm2, %xmm2
 ; AVX1-NEXT:    vpsrlq $32, %xmm5, %xmm5
-; AVX1-NEXT:    vpclmulqdq $17, %xmm2, %xmm5, %xmm8
-; AVX1-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm7[0],xmm8[0],xmm7[1],xmm8[1]
-; AVX1-NEXT:    vpclmulqdq $0, %xmm4, %xmm6, %xmm4
+; AVX1-NEXT:    vpclmulqdq $17, %xmm2, %xmm5, %xmm6
 ; AVX1-NEXT:    vpclmulqdq $0, %xmm2, %xmm5, %xmm2
-; AVX1-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm4[0],xmm2[0],xmm4[1],xmm2[1]
-; AVX1-NEXT:    vpunpckhdq {{.*#+}} xmm2 = xmm2[2],xmm7[2],xmm2[3],xmm7[3]
+; AVX1-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm6[0],xmm2[1],xmm6[1]
+; AVX1-NEXT:    vpunpckhdq {{.*#+}} xmm2 = xmm4[2],xmm2[2],xmm4[3],xmm2[3]
 ; AVX1-NEXT:    vpblendw {{.*#+}} xmm4 = xmm1[0,1],xmm3[2,3],xmm1[4,5],xmm3[6,7]
 ; AVX1-NEXT:    vpblendw {{.*#+}} xmm3 = xmm0[0,1],xmm3[2,3],xmm0[4,5],xmm3[6,7]
 ; AVX1-NEXT:    vpclmulqdq $17, %xmm4, %xmm3, %xmm5
+; AVX1-NEXT:    vpclmulqdq $0, %xmm4, %xmm3, %xmm3
+; AVX1-NEXT:    vpunpckldq {{.*#+}} xmm3 = xmm3[0],xmm5[0],xmm3[1],xmm5[1]
 ; AVX1-NEXT:    vpsrlq $32, %xmm1, %xmm1
 ; AVX1-NEXT:    vpsrlq $32, %xmm0, %xmm0
-; AVX1-NEXT:    vpclmulqdq $17, %xmm1, %xmm0, %xmm6
-; AVX1-NEXT:    vpunpckldq {{.*#+}} xmm5 = xmm5[0],xmm6[0],xmm5[1],xmm6[1]
-; AVX1-NEXT:    vpclmulqdq $0, %xmm4, %xmm3, %xmm3
+; AVX1-NEXT:    vpclmulqdq $17, %xmm1, %xmm0, %xmm4
 ; AVX1-NEXT:    vpclmulqdq $0, %xmm1, %xmm0, %xmm0
-; AVX1-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm3[0],xmm0[0],xmm3[1],xmm0[1]
-; AVX1-NEXT:    vpunpckhdq {{.*#+}} xmm0 = xmm0[2],xmm5[2],xmm0[3],xmm5[3]
+; AVX1-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm0[0],xmm4[0],xmm0[1],xmm4[1]
+; AVX1-NEXT:    vpunpckhdq {{.*#+}} xmm0 = xmm3[2],xmm0[2],xmm3[3],xmm0[3]
 ; AVX1-NEXT:    vinsertf128 $1, %xmm2, %ymm0, %ymm0
 ; AVX1-NEXT:    retq
 ;
@@ -2038,25 +2032,25 @@ define <8 x i32> @clmulh_v8i32(<8 x i32> %a, <8 x i32> %b) nounwind {
 ; AVX2-PCLMUL-NEXT:    vextracti128 $1, %ymm0, %xmm5
 ; AVX2-PCLMUL-NEXT:    vpblendd {{.*#+}} xmm6 = xmm5[0],xmm3[1],xmm5[2],xmm3[3]
 ; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm4, %xmm6, %xmm7
+; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm4, %xmm6, %xmm4
+; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm4 = xmm4[0],xmm7[0],xmm4[1],xmm7[1]
 ; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm2, %xmm2
 ; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm5, %xmm5
-; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm2, %xmm5, %xmm8
-; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm7[0],xmm8[0],xmm7[1],xmm8[1]
-; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm4, %xmm6, %xmm4
+; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm2, %xmm5, %xmm6
 ; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm2, %xmm5, %xmm2
-; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm4[0],xmm2[0],xmm4[1],xmm2[1]
-; AVX2-PCLMUL-NEXT:    vpunpckhdq {{.*#+}} xmm2 = xmm2[2],xmm7[2],xmm2[3],xmm7[3]
+; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm6[0],xmm2[1],xmm6[1]
+; AVX2-PCLMUL-NEXT:    vpunpckhdq {{.*#+}} xmm2 = xmm4[2],xmm2[2],xmm4[3],xmm2[3]
 ; AVX2-PCLMUL-NEXT:    vpblendd {{.*#+}} xmm4 = xmm1[0],xmm3[1],xmm1[2],xmm3[3]
 ; AVX2-PCLMUL-NEXT:    vpblendd {{.*#+}} xmm3 = xmm0[0],xmm3[1],xmm0[2],xmm3[3]
 ; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm4, %xmm3, %xmm5
+; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm4, %xmm3, %xmm3
+; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm3 = xmm3[0],xmm5[0],xmm3[1],xmm5[1]
 ; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm1, %xmm1
 ; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm0, %xmm0
-; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm1, %xmm0, %xmm6
-; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm5 = xmm5[0],xmm6[0],xmm5[1],xmm6[1]
-; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm4, %xmm3, %xmm3
+; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm1, %xmm0, %xmm4
 ; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm1, %xmm0, %xmm0
-; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm3[0],xmm0[0],xmm3[1],xmm0[1]
-; AVX2-PCLMUL-NEXT:    vpunpckhdq {{.*#+}} xmm0 = xmm0[2],xmm5[2],xmm0[3],xmm5[3]
+; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm0[0],xmm4[0],xmm0[1],xmm4[1]
+; AVX2-PCLMUL-NEXT:    vpunpckhdq {{.*#+}} xmm0 = xmm3[2],xmm0[2],xmm3[3],xmm0[3]
 ; AVX2-PCLMUL-NEXT:    vinserti128 $1, %xmm2, %ymm0, %ymm0
 ; AVX2-PCLMUL-NEXT:    retq
 ;
@@ -2066,14 +2060,14 @@ define <8 x i32> @clmulh_v8i32(<8 x i32> %a, <8 x i32> %b) nounwind {
 ; AVX2-VPCLMULQDQ-NEXT:    vpblendd {{.*#+}} ymm3 = ymm1[0],ymm2[1],ymm1[2],ymm2[3],ymm1[4],ymm2[5],ymm1[6],ymm2[7]
 ; AVX2-VPCLMULQDQ-NEXT:    vpblendd {{.*#+}} ymm2 = ymm0[0],ymm2[1],ymm0[2],ymm2[3],ymm0[4],ymm2[5],ymm0[6],ymm2[7]
 ; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $17, %ymm3, %ymm2, %ymm4
+; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $0, %ymm3, %ymm2, %ymm2
+; AVX2-VPCLMULQDQ-NEXT:    vpunpckldq {{.*#+}} ymm2 = ymm2[0],ymm4[0],ymm2[1],ymm4[1],ymm2[4],ymm4[4],ymm2[5],ymm4[5]
 ; AVX2-VPCLMULQDQ-NEXT:    vpsrlq $32, %ymm1, %ymm1
 ; AVX2-VPCLMULQDQ-NEXT:    vpsrlq $32, %ymm0, %ymm0
-; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $17, %ymm1, %ymm0, %ymm5
-; AVX2-VPCLMULQDQ-NEXT:    vpunpckldq {{.*#+}} ymm4 = ymm4[0],ymm5[0],ymm4[1],ymm5[1],ymm4[4],ymm5[4],ymm4[5],ymm5[5]
-; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $0, %ymm3, %ymm2, %ymm2
+; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $17, %ymm1, %ymm0, %ymm3
 ; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $0, %ymm1, %ymm0, %ymm0
-; AVX2-VPCLMULQDQ-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm2[0],ymm0[0],ymm2[1],ymm0[1],ymm2[4],ymm0[4],ymm2[5],ymm0[5]
-; AVX2-VPCLMULQDQ-NEXT:    vpunpckhdq {{.*#+}} ymm0 = ymm0[2],ymm4[2],ymm0[3],ymm4[3],ymm0[6],ymm4[6],ymm0[7],ymm4[7]
+; AVX2-VPCLMULQDQ-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm0[0],ymm3[0],ymm0[1],ymm3[1],ymm0[4],ymm3[4],ymm0[5],ymm3[5]
+; AVX2-VPCLMULQDQ-NEXT:    vpunpckhdq {{.*#+}} ymm0 = ymm2[2],ymm0[2],ymm2[3],ymm0[3],ymm2[6],ymm0[6],ymm2[7],ymm0[7]
 ; AVX2-VPCLMULQDQ-NEXT:    retq
 ;
 ; AVX512-LABEL: clmulh_v8i32:
@@ -2082,14 +2076,14 @@ define <8 x i32> @clmulh_v8i32(<8 x i32> %a, <8 x i32> %b) nounwind {
 ; AVX512-NEXT:    vpblendd {{.*#+}} ymm3 = ymm1[0],ymm2[1],ymm1[2],ymm2[3],ymm1[4],ymm2[5],ymm1[6],ymm2[7]
 ; AVX512-NEXT:    vpblendd {{.*#+}} ymm2 = ymm0[0],ymm2[1],ymm0[2],ymm2[3],ymm0[4],ymm2[5],ymm0[6],ymm2[7]
 ; AVX512-NEXT:    vpclmulqdq $17, %ymm3, %ymm2, %ymm4
+; AVX512-NEXT:    vpclmulqdq $0, %ymm3, %ymm2, %ymm2
+; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm2 = ymm2[0],ymm4[0],ymm2[1],ymm4[1],ymm2[4],ymm4[4],ymm2[5],ymm4[5]
 ; AVX512-NEXT:    vpsrlq $32, %ymm1, %ymm1
 ; AVX512-NEXT:    vpsrlq $32, %ymm0, %ymm0
-; AVX512-NEXT:    vpclmulqdq $17, %ymm1, %ymm0, %ymm5
-; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm4 = ymm4[0],ymm5[0],ymm4[1],ymm5[1],ymm4[4],ymm5[4],ymm4[5],ymm5[5]
-; AVX512-NEXT:    vpclmulqdq $0, %ymm3, %ymm2, %ymm2
+; AVX512-NEXT:    vpclmulqdq $17, %ymm1, %ymm0, %ymm3
 ; AVX512-NEXT:    vpclmulqdq $0, %ymm1, %ymm0, %ymm0
-; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm2[0],ymm0[0],ymm2[1],ymm0[1],ymm2[4],ymm0[4],ymm2[5],ymm0[5]
-; AVX512-NEXT:    vpunpckhdq {{.*#+}} ymm0 = ymm0[2],ymm4[2],ymm0[3],ymm4[3],ymm0[6],ymm4[6],ymm0[7],ymm4[7]
+; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm0[0],ymm3[0],ymm0[1],ymm3[1],ymm0[4],ymm3[4],ymm0[5],ymm3[5]
+; AVX512-NEXT:    vpunpckhdq {{.*#+}} ymm0 = ymm2[2],ymm0[2],ymm2[3],ymm0[3],ymm2[6],ymm0[6],ymm2[7],ymm0[7]
 ; AVX512-NEXT:    retq
   %a.ext = zext <8 x i32> %a to <8 x i64>
   %b.ext = zext <8 x i32> %b to <8 x i64>

--- a/llvm/test/CodeGen/X86/clmul-vector-512.ll
+++ b/llvm/test/CodeGen/X86/clmul-vector-512.ll
@@ -224,14 +224,14 @@ define <16 x i32> @clmul_v16i32(<16 x i32> %a, <16 x i32> %b) nounwind {
 ; AVX512-LABEL: clmul_v16i32:
 ; AVX512:       # %bb.0:
 ; AVX512-NEXT:    vpclmulqdq $17, %zmm1, %zmm0, %zmm2
-; AVX512-NEXT:    vpsrlq $32, %zmm1, %zmm3
-; AVX512-NEXT:    vpsrlq $32, %zmm0, %zmm4
-; AVX512-NEXT:    vpclmulqdq $17, %zmm3, %zmm4, %zmm5
-; AVX512-NEXT:    vpunpckldq {{.*#+}} zmm2 = zmm2[0],zmm5[0],zmm2[1],zmm5[1],zmm2[4],zmm5[4],zmm2[5],zmm5[5],zmm2[8],zmm5[8],zmm2[9],zmm5[9],zmm2[12],zmm5[12],zmm2[13],zmm5[13]
+; AVX512-NEXT:    vpclmulqdq $0, %zmm1, %zmm0, %zmm3
+; AVX512-NEXT:    vpunpckldq {{.*#+}} zmm2 = zmm3[0],zmm2[0],zmm3[1],zmm2[1],zmm3[4],zmm2[4],zmm3[5],zmm2[5],zmm3[8],zmm2[8],zmm3[9],zmm2[9],zmm3[12],zmm2[12],zmm3[13],zmm2[13]
+; AVX512-NEXT:    vpsrlq $32, %zmm1, %zmm1
+; AVX512-NEXT:    vpsrlq $32, %zmm0, %zmm0
+; AVX512-NEXT:    vpclmulqdq $17, %zmm1, %zmm0, %zmm3
 ; AVX512-NEXT:    vpclmulqdq $0, %zmm1, %zmm0, %zmm0
-; AVX512-NEXT:    vpclmulqdq $0, %zmm3, %zmm4, %zmm1
-; AVX512-NEXT:    vpunpckldq {{.*#+}} zmm0 = zmm0[0],zmm1[0],zmm0[1],zmm1[1],zmm0[4],zmm1[4],zmm0[5],zmm1[5],zmm0[8],zmm1[8],zmm0[9],zmm1[9],zmm0[12],zmm1[12],zmm0[13],zmm1[13]
-; AVX512-NEXT:    vpunpckldq {{.*#+}} zmm0 = zmm0[0],zmm2[0],zmm0[1],zmm2[1],zmm0[4],zmm2[4],zmm0[5],zmm2[5],zmm0[8],zmm2[8],zmm0[9],zmm2[9],zmm0[12],zmm2[12],zmm0[13],zmm2[13]
+; AVX512-NEXT:    vpunpckldq {{.*#+}} zmm0 = zmm0[0],zmm3[0],zmm0[1],zmm3[1],zmm0[4],zmm3[4],zmm0[5],zmm3[5],zmm0[8],zmm3[8],zmm0[9],zmm3[9],zmm0[12],zmm3[12],zmm0[13],zmm3[13]
+; AVX512-NEXT:    vpunpckldq {{.*#+}} zmm0 = zmm2[0],zmm0[0],zmm2[1],zmm0[1],zmm2[4],zmm0[4],zmm2[5],zmm0[5],zmm2[8],zmm0[8],zmm2[9],zmm0[9],zmm2[12],zmm0[12],zmm2[13],zmm0[13]
 ; AVX512-NEXT:    retq
   %res = call <16 x i32> @llvm.clmul.v16i32(<16 x i32> %a, <16 x i32> %b)
   ret <16 x i32> %res
@@ -923,20 +923,19 @@ define <16 x i32> @clmulr_v16i32(<16 x i32> %a, <16 x i32> %b) nounwind {
 ; AVX512-NEXT:    vpandq %zmm2, %zmm1, %zmm3
 ; AVX512-NEXT:    vpandq %zmm2, %zmm0, %zmm2
 ; AVX512-NEXT:    vpclmulqdq $17, %zmm3, %zmm2, %zmm4
-; AVX512-NEXT:    vpsrlq $32, %zmm1, %zmm5
-; AVX512-NEXT:    vpsrlq $32, %zmm0, %zmm6
-; AVX512-NEXT:    vpclmulqdq $17, %zmm5, %zmm6, %zmm7
-; AVX512-NEXT:    vpunpckldq {{.*#+}} zmm4 = zmm4[0],zmm7[0],zmm4[1],zmm7[1],zmm4[4],zmm7[4],zmm4[5],zmm7[5],zmm4[8],zmm7[8],zmm4[9],zmm7[9],zmm4[12],zmm7[12],zmm4[13],zmm7[13]
 ; AVX512-NEXT:    vpclmulqdq $0, %zmm3, %zmm2, %zmm2
-; AVX512-NEXT:    vpclmulqdq $0, %zmm5, %zmm6, %zmm3
-; AVX512-NEXT:    vpunpckldq {{.*#+}} zmm2 = zmm2[0],zmm3[0],zmm2[1],zmm3[1],zmm2[4],zmm3[4],zmm2[5],zmm3[5],zmm2[8],zmm3[8],zmm2[9],zmm3[9],zmm2[12],zmm3[12],zmm2[13],zmm3[13]
-; AVX512-NEXT:    vpunpckhdq {{.*#+}} zmm2 = zmm2[2],zmm4[2],zmm2[3],zmm4[3],zmm2[6],zmm4[6],zmm2[7],zmm4[7],zmm2[10],zmm4[10],zmm2[11],zmm4[11],zmm2[14],zmm4[14],zmm2[15],zmm4[15]
+; AVX512-NEXT:    vpunpckldq {{.*#+}} zmm2 = zmm2[0],zmm4[0],zmm2[1],zmm4[1],zmm2[4],zmm4[4],zmm2[5],zmm4[5],zmm2[8],zmm4[8],zmm2[9],zmm4[9],zmm2[12],zmm4[12],zmm2[13],zmm4[13]
+; AVX512-NEXT:    vpsrlq $32, %zmm1, %zmm3
+; AVX512-NEXT:    vpsrlq $32, %zmm0, %zmm4
+; AVX512-NEXT:    vpclmulqdq $17, %zmm3, %zmm4, %zmm5
+; AVX512-NEXT:    vpclmulqdq $0, %zmm3, %zmm4, %zmm3
+; AVX512-NEXT:    vpunpckldq {{.*#+}} zmm3 = zmm3[0],zmm5[0],zmm3[1],zmm5[1],zmm3[4],zmm5[4],zmm3[5],zmm5[5],zmm3[8],zmm5[8],zmm3[9],zmm5[9],zmm3[12],zmm5[12],zmm3[13],zmm5[13]
+; AVX512-NEXT:    vpunpckhdq {{.*#+}} zmm2 = zmm2[2],zmm3[2],zmm2[3],zmm3[3],zmm2[6],zmm3[6],zmm2[7],zmm3[7],zmm2[10],zmm3[10],zmm2[11],zmm3[11],zmm2[14],zmm3[14],zmm2[15],zmm3[15]
 ; AVX512-NEXT:    vpaddd %zmm2, %zmm2, %zmm2
 ; AVX512-NEXT:    vpclmulqdq $17, %zmm1, %zmm0, %zmm4
-; AVX512-NEXT:    vpunpckldq {{.*#+}} zmm4 = zmm4[0],zmm7[0],zmm4[1],zmm7[1],zmm4[4],zmm7[4],zmm4[5],zmm7[5],zmm4[8],zmm7[8],zmm4[9],zmm7[9],zmm4[12],zmm7[12],zmm4[13],zmm7[13]
 ; AVX512-NEXT:    vpclmulqdq $0, %zmm1, %zmm0, %zmm0
-; AVX512-NEXT:    vpunpckldq {{.*#+}} zmm0 = zmm0[0],zmm3[0],zmm0[1],zmm3[1],zmm0[4],zmm3[4],zmm0[5],zmm3[5],zmm0[8],zmm3[8],zmm0[9],zmm3[9],zmm0[12],zmm3[12],zmm0[13],zmm3[13]
 ; AVX512-NEXT:    vpunpckldq {{.*#+}} zmm0 = zmm0[0],zmm4[0],zmm0[1],zmm4[1],zmm0[4],zmm4[4],zmm0[5],zmm4[5],zmm0[8],zmm4[8],zmm0[9],zmm4[9],zmm0[12],zmm4[12],zmm0[13],zmm4[13]
+; AVX512-NEXT:    vpunpckldq {{.*#+}} zmm0 = zmm0[0],zmm3[0],zmm0[1],zmm3[1],zmm0[4],zmm3[4],zmm0[5],zmm3[5],zmm0[8],zmm3[8],zmm0[9],zmm3[9],zmm0[12],zmm3[12],zmm0[13],zmm3[13]
 ; AVX512-NEXT:    vpsrld $31, %zmm0, %zmm0
 ; AVX512-NEXT:    vpord %zmm2, %zmm0, %zmm0
 ; AVX512-NEXT:    retq
@@ -1652,14 +1651,14 @@ define <16 x i32> @clmulh_v16i32(<16 x i32> %a, <16 x i32> %b) nounwind {
 ; AVX512-NEXT:    vpandq %zmm2, %zmm1, %zmm3
 ; AVX512-NEXT:    vpandq %zmm2, %zmm0, %zmm2
 ; AVX512-NEXT:    vpclmulqdq $17, %zmm3, %zmm2, %zmm4
+; AVX512-NEXT:    vpclmulqdq $0, %zmm3, %zmm2, %zmm2
+; AVX512-NEXT:    vpunpckldq {{.*#+}} zmm2 = zmm2[0],zmm4[0],zmm2[1],zmm4[1],zmm2[4],zmm4[4],zmm2[5],zmm4[5],zmm2[8],zmm4[8],zmm2[9],zmm4[9],zmm2[12],zmm4[12],zmm2[13],zmm4[13]
 ; AVX512-NEXT:    vpsrlq $32, %zmm1, %zmm1
 ; AVX512-NEXT:    vpsrlq $32, %zmm0, %zmm0
-; AVX512-NEXT:    vpclmulqdq $17, %zmm1, %zmm0, %zmm5
-; AVX512-NEXT:    vpunpckldq {{.*#+}} zmm4 = zmm4[0],zmm5[0],zmm4[1],zmm5[1],zmm4[4],zmm5[4],zmm4[5],zmm5[5],zmm4[8],zmm5[8],zmm4[9],zmm5[9],zmm4[12],zmm5[12],zmm4[13],zmm5[13]
-; AVX512-NEXT:    vpclmulqdq $0, %zmm3, %zmm2, %zmm2
+; AVX512-NEXT:    vpclmulqdq $17, %zmm1, %zmm0, %zmm3
 ; AVX512-NEXT:    vpclmulqdq $0, %zmm1, %zmm0, %zmm0
-; AVX512-NEXT:    vpunpckldq {{.*#+}} zmm0 = zmm2[0],zmm0[0],zmm2[1],zmm0[1],zmm2[4],zmm0[4],zmm2[5],zmm0[5],zmm2[8],zmm0[8],zmm2[9],zmm0[9],zmm2[12],zmm0[12],zmm2[13],zmm0[13]
-; AVX512-NEXT:    vpunpckhdq {{.*#+}} zmm0 = zmm0[2],zmm4[2],zmm0[3],zmm4[3],zmm0[6],zmm4[6],zmm0[7],zmm4[7],zmm0[10],zmm4[10],zmm0[11],zmm4[11],zmm0[14],zmm4[14],zmm0[15],zmm4[15]
+; AVX512-NEXT:    vpunpckldq {{.*#+}} zmm0 = zmm0[0],zmm3[0],zmm0[1],zmm3[1],zmm0[4],zmm3[4],zmm0[5],zmm3[5],zmm0[8],zmm3[8],zmm0[9],zmm3[9],zmm0[12],zmm3[12],zmm0[13],zmm3[13]
+; AVX512-NEXT:    vpunpckhdq {{.*#+}} zmm0 = zmm2[2],zmm0[2],zmm2[3],zmm0[3],zmm2[6],zmm0[6],zmm2[7],zmm0[7],zmm2[10],zmm0[10],zmm2[11],zmm0[11],zmm2[14],zmm0[14],zmm2[15],zmm0[15]
 ; AVX512-NEXT:    retq
   %a.ext = zext <16 x i32> %a to <16 x i64>
   %b.ext = zext <16 x i32> %b to <16 x i64>

--- a/llvm/test/CodeGen/X86/clmul-vector.ll
+++ b/llvm/test/CodeGen/X86/clmul-vector.ll
@@ -440,23 +440,23 @@ define <8 x i16> @clmul_v8i16(<8 x i16> %a, <8 x i16> %b) nounwind {
 ; AVX2-PCLMUL-NEXT:    vpmovzxwd {{.*#+}} ymm0 = xmm0[0],zero,xmm0[1],zero,xmm0[2],zero,xmm0[3],zero,xmm0[4],zero,xmm0[5],zero,xmm0[6],zero,xmm0[7],zero
 ; AVX2-PCLMUL-NEXT:    vextracti128 $1, %ymm0, %xmm3
 ; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm2, %xmm3, %xmm4
-; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm2, %xmm5
-; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm3, %xmm6
-; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm5, %xmm6, %xmm7
-; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm4 = xmm4[0],xmm7[0],xmm4[1],xmm7[1]
+; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm2, %xmm3, %xmm5
+; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm4 = xmm5[0],xmm4[0],xmm5[1],xmm4[1]
+; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm2, %xmm2
+; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm3, %xmm3
+; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm2, %xmm3, %xmm5
 ; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm2, %xmm3, %xmm2
-; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm5, %xmm6, %xmm3
-; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm3[0],xmm2[1],xmm3[1]
-; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm4[0],xmm2[1],xmm4[1]
+; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm5[0],xmm2[1],xmm5[1]
+; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm4[0],xmm2[0],xmm4[1],xmm2[1]
 ; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm1, %xmm0, %xmm3
-; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm1, %xmm4
-; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm0, %xmm5
-; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm4, %xmm5, %xmm6
-; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm3 = xmm3[0],xmm6[0],xmm3[1],xmm6[1]
+; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm1, %xmm0, %xmm4
+; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm3 = xmm4[0],xmm3[0],xmm4[1],xmm3[1]
+; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm1, %xmm1
+; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm0, %xmm0
+; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm1, %xmm0, %xmm4
 ; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm1, %xmm0, %xmm0
-; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm4, %xmm5, %xmm1
-; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm0[0],xmm1[0],xmm0[1],xmm1[1]
-; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm0[0],xmm3[0],xmm0[1],xmm3[1]
+; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm0[0],xmm4[0],xmm0[1],xmm4[1]
+; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm3[0],xmm0[0],xmm3[1],xmm0[1]
 ; AVX2-PCLMUL-NEXT:    vinserti128 $1, %xmm2, %ymm0, %ymm0
 ; AVX2-PCLMUL-NEXT:    vpshufb {{.*#+}} ymm0 = ymm0[0,1,4,5,8,9,12,13,u,u,u,u,u,u,u,u,16,17,20,21,24,25,28,29,u,u,u,u,u,u,u,u]
 ; AVX2-PCLMUL-NEXT:    vpermq {{.*#+}} ymm0 = ymm0[0,2,2,3]
@@ -469,14 +469,14 @@ define <8 x i16> @clmul_v8i16(<8 x i16> %a, <8 x i16> %b) nounwind {
 ; AVX2-VPCLMULQDQ-NEXT:    vpmovzxwd {{.*#+}} ymm1 = xmm1[0],zero,xmm1[1],zero,xmm1[2],zero,xmm1[3],zero,xmm1[4],zero,xmm1[5],zero,xmm1[6],zero,xmm1[7],zero
 ; AVX2-VPCLMULQDQ-NEXT:    vpmovzxwd {{.*#+}} ymm0 = xmm0[0],zero,xmm0[1],zero,xmm0[2],zero,xmm0[3],zero,xmm0[4],zero,xmm0[5],zero,xmm0[6],zero,xmm0[7],zero
 ; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $17, %ymm1, %ymm0, %ymm2
-; AVX2-VPCLMULQDQ-NEXT:    vpsrlq $32, %ymm1, %ymm3
-; AVX2-VPCLMULQDQ-NEXT:    vpsrlq $32, %ymm0, %ymm4
-; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $17, %ymm3, %ymm4, %ymm5
-; AVX2-VPCLMULQDQ-NEXT:    vpunpckldq {{.*#+}} ymm2 = ymm2[0],ymm5[0],ymm2[1],ymm5[1],ymm2[4],ymm5[4],ymm2[5],ymm5[5]
+; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $0, %ymm1, %ymm0, %ymm3
+; AVX2-VPCLMULQDQ-NEXT:    vpunpckldq {{.*#+}} ymm2 = ymm3[0],ymm2[0],ymm3[1],ymm2[1],ymm3[4],ymm2[4],ymm3[5],ymm2[5]
+; AVX2-VPCLMULQDQ-NEXT:    vpsrlq $32, %ymm1, %ymm1
+; AVX2-VPCLMULQDQ-NEXT:    vpsrlq $32, %ymm0, %ymm0
+; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $17, %ymm1, %ymm0, %ymm3
 ; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $0, %ymm1, %ymm0, %ymm0
-; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $0, %ymm3, %ymm4, %ymm1
-; AVX2-VPCLMULQDQ-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm0[0],ymm1[0],ymm0[1],ymm1[1],ymm0[4],ymm1[4],ymm0[5],ymm1[5]
-; AVX2-VPCLMULQDQ-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm0[0],ymm2[0],ymm0[1],ymm2[1],ymm0[4],ymm2[4],ymm0[5],ymm2[5]
+; AVX2-VPCLMULQDQ-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm0[0],ymm3[0],ymm0[1],ymm3[1],ymm0[4],ymm3[4],ymm0[5],ymm3[5]
+; AVX2-VPCLMULQDQ-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm2[0],ymm0[0],ymm2[1],ymm0[1],ymm2[4],ymm0[4],ymm2[5],ymm0[5]
 ; AVX2-VPCLMULQDQ-NEXT:    vpshufb {{.*#+}} ymm0 = ymm0[0,1,4,5,8,9,12,13,u,u,u,u,u,u,u,u,16,17,20,21,24,25,28,29,u,u,u,u,u,u,u,u]
 ; AVX2-VPCLMULQDQ-NEXT:    vpermq {{.*#+}} ymm0 = ymm0[0,2,2,3]
 ; AVX2-VPCLMULQDQ-NEXT:    # kill: def $xmm0 killed $xmm0 killed $ymm0
@@ -488,14 +488,14 @@ define <8 x i16> @clmul_v8i16(<8 x i16> %a, <8 x i16> %b) nounwind {
 ; AVX512-NEXT:    vpmovzxwd {{.*#+}} ymm1 = xmm1[0],zero,xmm1[1],zero,xmm1[2],zero,xmm1[3],zero,xmm1[4],zero,xmm1[5],zero,xmm1[6],zero,xmm1[7],zero
 ; AVX512-NEXT:    vpmovzxwd {{.*#+}} ymm0 = xmm0[0],zero,xmm0[1],zero,xmm0[2],zero,xmm0[3],zero,xmm0[4],zero,xmm0[5],zero,xmm0[6],zero,xmm0[7],zero
 ; AVX512-NEXT:    vpclmulqdq $17, %ymm1, %ymm0, %ymm2
-; AVX512-NEXT:    vpsrlq $32, %ymm1, %ymm3
-; AVX512-NEXT:    vpsrlq $32, %ymm0, %ymm4
-; AVX512-NEXT:    vpclmulqdq $17, %ymm3, %ymm4, %ymm5
-; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm2 = ymm2[0],ymm5[0],ymm2[1],ymm5[1],ymm2[4],ymm5[4],ymm2[5],ymm5[5]
+; AVX512-NEXT:    vpclmulqdq $0, %ymm1, %ymm0, %ymm3
+; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm2 = ymm3[0],ymm2[0],ymm3[1],ymm2[1],ymm3[4],ymm2[4],ymm3[5],ymm2[5]
+; AVX512-NEXT:    vpsrlq $32, %ymm1, %ymm1
+; AVX512-NEXT:    vpsrlq $32, %ymm0, %ymm0
+; AVX512-NEXT:    vpclmulqdq $17, %ymm1, %ymm0, %ymm3
 ; AVX512-NEXT:    vpclmulqdq $0, %ymm1, %ymm0, %ymm0
-; AVX512-NEXT:    vpclmulqdq $0, %ymm3, %ymm4, %ymm1
-; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm0[0],ymm1[0],ymm0[1],ymm1[1],ymm0[4],ymm1[4],ymm0[5],ymm1[5]
-; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm0[0],ymm2[0],ymm0[1],ymm2[1],ymm0[4],ymm2[4],ymm0[5],ymm2[5]
+; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm0[0],ymm3[0],ymm0[1],ymm3[1],ymm0[4],ymm3[4],ymm0[5],ymm3[5]
+; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm2[0],ymm0[0],ymm2[1],ymm0[1],ymm2[4],ymm0[4],ymm2[5],ymm0[5]
 ; AVX512-NEXT:    vpmovdw %ymm0, %xmm0
 ; AVX512-NEXT:    vzeroupper
 ; AVX512-NEXT:    retq
@@ -749,44 +749,45 @@ define <4 x i32> @clmul_v4i32(<4 x i32> %a, <4 x i32> %b) nounwind {
 ;
 ; SSE-PCLMUL-LABEL: clmul_v4i32:
 ; SSE-PCLMUL:       # %bb.0:
-; SSE-PCLMUL-NEXT:    movdqa %xmm0, %xmm2
-; SSE-PCLMUL-NEXT:    pclmulqdq $17, %xmm1, %xmm2
 ; SSE-PCLMUL-NEXT:    movdqa %xmm0, %xmm3
-; SSE-PCLMUL-NEXT:    pclmulqdq $0, %xmm1, %xmm0
+; SSE-PCLMUL-NEXT:    pclmulqdq $17, %xmm1, %xmm3
+; SSE-PCLMUL-NEXT:    movdqa %xmm0, %xmm2
+; SSE-PCLMUL-NEXT:    pclmulqdq $0, %xmm1, %xmm2
+; SSE-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm2 = xmm2[0],xmm3[0],xmm2[1],xmm3[1]
 ; SSE-PCLMUL-NEXT:    psrlq $32, %xmm1
-; SSE-PCLMUL-NEXT:    psrlq $32, %xmm3
-; SSE-PCLMUL-NEXT:    movdqa %xmm3, %xmm4
-; SSE-PCLMUL-NEXT:    pclmulqdq $17, %xmm1, %xmm4
-; SSE-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm2 = xmm2[0],xmm4[0],xmm2[1],xmm4[1]
-; SSE-PCLMUL-NEXT:    pclmulqdq $0, %xmm1, %xmm3
+; SSE-PCLMUL-NEXT:    psrlq $32, %xmm0
+; SSE-PCLMUL-NEXT:    movdqa %xmm0, %xmm3
+; SSE-PCLMUL-NEXT:    pclmulqdq $17, %xmm1, %xmm3
+; SSE-PCLMUL-NEXT:    pclmulqdq $0, %xmm1, %xmm0
 ; SSE-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm0 = xmm0[0],xmm3[0],xmm0[1],xmm3[1]
-; SSE-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm0 = xmm0[0],xmm2[0],xmm0[1],xmm2[1]
+; SSE-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm2 = xmm2[0],xmm0[0],xmm2[1],xmm0[1]
+; SSE-PCLMUL-NEXT:    movdqa %xmm2, %xmm0
 ; SSE-PCLMUL-NEXT:    retq
 ;
 ; AVX2-LABEL: clmul_v4i32:
 ; AVX2:       # %bb.0:
 ; AVX2-NEXT:    vpclmulqdq $17, %xmm1, %xmm0, %xmm2
-; AVX2-NEXT:    vpsrlq $32, %xmm1, %xmm3
-; AVX2-NEXT:    vpsrlq $32, %xmm0, %xmm4
-; AVX2-NEXT:    vpclmulqdq $17, %xmm3, %xmm4, %xmm5
-; AVX2-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm5[0],xmm2[1],xmm5[1]
+; AVX2-NEXT:    vpclmulqdq $0, %xmm1, %xmm0, %xmm3
+; AVX2-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm3[0],xmm2[0],xmm3[1],xmm2[1]
+; AVX2-NEXT:    vpsrlq $32, %xmm1, %xmm1
+; AVX2-NEXT:    vpsrlq $32, %xmm0, %xmm0
+; AVX2-NEXT:    vpclmulqdq $17, %xmm1, %xmm0, %xmm3
 ; AVX2-NEXT:    vpclmulqdq $0, %xmm1, %xmm0, %xmm0
-; AVX2-NEXT:    vpclmulqdq $0, %xmm3, %xmm4, %xmm1
-; AVX2-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm0[0],xmm1[0],xmm0[1],xmm1[1]
-; AVX2-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm0[0],xmm2[0],xmm0[1],xmm2[1]
+; AVX2-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm0[0],xmm3[0],xmm0[1],xmm3[1]
+; AVX2-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm2[0],xmm0[0],xmm2[1],xmm0[1]
 ; AVX2-NEXT:    retq
 ;
 ; AVX512-LABEL: clmul_v4i32:
 ; AVX512:       # %bb.0:
 ; AVX512-NEXT:    vpclmulqdq $17, %xmm1, %xmm0, %xmm2
-; AVX512-NEXT:    vpsrlq $32, %xmm1, %xmm3
-; AVX512-NEXT:    vpsrlq $32, %xmm0, %xmm4
-; AVX512-NEXT:    vpclmulqdq $17, %xmm3, %xmm4, %xmm5
-; AVX512-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm5[0],xmm2[1],xmm5[1]
+; AVX512-NEXT:    vpclmulqdq $0, %xmm1, %xmm0, %xmm3
+; AVX512-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm3[0],xmm2[0],xmm3[1],xmm2[1]
+; AVX512-NEXT:    vpsrlq $32, %xmm1, %xmm1
+; AVX512-NEXT:    vpsrlq $32, %xmm0, %xmm0
+; AVX512-NEXT:    vpclmulqdq $17, %xmm1, %xmm0, %xmm3
 ; AVX512-NEXT:    vpclmulqdq $0, %xmm1, %xmm0, %xmm0
-; AVX512-NEXT:    vpclmulqdq $0, %xmm3, %xmm4, %xmm1
-; AVX512-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm0[0],xmm1[0],xmm0[1],xmm1[1]
-; AVX512-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm0[0],xmm2[0],xmm0[1],xmm2[1]
+; AVX512-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm0[0],xmm3[0],xmm0[1],xmm3[1]
+; AVX512-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm2[0],xmm0[0],xmm2[1],xmm0[1]
 ; AVX512-NEXT:    retq
   %res = call <4 x i32> @llvm.clmul.v4i32(<4 x i32> %a, <4 x i32> %b)
   ret <4 x i32> %res
@@ -1620,23 +1621,23 @@ define <8 x i16> @clmulr_v8i16(<8 x i16> %a, <8 x i16> %b) nounwind {
 ; AVX2-PCLMUL-NEXT:    vpmovzxwd {{.*#+}} ymm0 = xmm0[0],zero,xmm0[1],zero,xmm0[2],zero,xmm0[3],zero,xmm0[4],zero,xmm0[5],zero,xmm0[6],zero,xmm0[7],zero
 ; AVX2-PCLMUL-NEXT:    vextracti128 $1, %ymm0, %xmm3
 ; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm2, %xmm3, %xmm4
-; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm2, %xmm5
-; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm3, %xmm6
-; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm5, %xmm6, %xmm7
-; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm4 = xmm4[0],xmm7[0],xmm4[1],xmm7[1]
+; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm2, %xmm3, %xmm5
+; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm4 = xmm5[0],xmm4[0],xmm5[1],xmm4[1]
+; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm2, %xmm2
+; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm3, %xmm3
+; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm2, %xmm3, %xmm5
 ; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm2, %xmm3, %xmm2
-; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm5, %xmm6, %xmm3
-; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm3[0],xmm2[1],xmm3[1]
-; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm4[0],xmm2[1],xmm4[1]
+; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm5[0],xmm2[1],xmm5[1]
+; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm4[0],xmm2[0],xmm4[1],xmm2[1]
 ; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm1, %xmm0, %xmm3
-; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm1, %xmm4
-; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm0, %xmm5
-; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm4, %xmm5, %xmm6
-; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm3 = xmm3[0],xmm6[0],xmm3[1],xmm6[1]
+; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm1, %xmm0, %xmm4
+; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm3 = xmm4[0],xmm3[0],xmm4[1],xmm3[1]
+; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm1, %xmm1
+; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm0, %xmm0
+; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm1, %xmm0, %xmm4
 ; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm1, %xmm0, %xmm0
-; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm4, %xmm5, %xmm1
-; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm0[0],xmm1[0],xmm0[1],xmm1[1]
-; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm0[0],xmm3[0],xmm0[1],xmm3[1]
+; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm0[0],xmm4[0],xmm0[1],xmm4[1]
+; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm3[0],xmm0[0],xmm3[1],xmm0[1]
 ; AVX2-PCLMUL-NEXT:    vinserti128 $1, %xmm2, %ymm0, %ymm0
 ; AVX2-PCLMUL-NEXT:    vpsrld $15, %ymm0, %ymm0
 ; AVX2-PCLMUL-NEXT:    vpshufb {{.*#+}} ymm0 = ymm0[0,1,4,5,8,9,12,13,u,u,u,u,u,u,u,u,16,17,20,21,24,25,28,29,u,u,u,u,u,u,u,u]
@@ -1650,14 +1651,14 @@ define <8 x i16> @clmulr_v8i16(<8 x i16> %a, <8 x i16> %b) nounwind {
 ; AVX2-VPCLMULQDQ-NEXT:    vpmovzxwd {{.*#+}} ymm1 = xmm1[0],zero,xmm1[1],zero,xmm1[2],zero,xmm1[3],zero,xmm1[4],zero,xmm1[5],zero,xmm1[6],zero,xmm1[7],zero
 ; AVX2-VPCLMULQDQ-NEXT:    vpmovzxwd {{.*#+}} ymm0 = xmm0[0],zero,xmm0[1],zero,xmm0[2],zero,xmm0[3],zero,xmm0[4],zero,xmm0[5],zero,xmm0[6],zero,xmm0[7],zero
 ; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $17, %ymm1, %ymm0, %ymm2
-; AVX2-VPCLMULQDQ-NEXT:    vpsrlq $32, %ymm1, %ymm3
-; AVX2-VPCLMULQDQ-NEXT:    vpsrlq $32, %ymm0, %ymm4
-; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $17, %ymm3, %ymm4, %ymm5
-; AVX2-VPCLMULQDQ-NEXT:    vpunpckldq {{.*#+}} ymm2 = ymm2[0],ymm5[0],ymm2[1],ymm5[1],ymm2[4],ymm5[4],ymm2[5],ymm5[5]
+; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $0, %ymm1, %ymm0, %ymm3
+; AVX2-VPCLMULQDQ-NEXT:    vpunpckldq {{.*#+}} ymm2 = ymm3[0],ymm2[0],ymm3[1],ymm2[1],ymm3[4],ymm2[4],ymm3[5],ymm2[5]
+; AVX2-VPCLMULQDQ-NEXT:    vpsrlq $32, %ymm1, %ymm1
+; AVX2-VPCLMULQDQ-NEXT:    vpsrlq $32, %ymm0, %ymm0
+; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $17, %ymm1, %ymm0, %ymm3
 ; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $0, %ymm1, %ymm0, %ymm0
-; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $0, %ymm3, %ymm4, %ymm1
-; AVX2-VPCLMULQDQ-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm0[0],ymm1[0],ymm0[1],ymm1[1],ymm0[4],ymm1[4],ymm0[5],ymm1[5]
-; AVX2-VPCLMULQDQ-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm0[0],ymm2[0],ymm0[1],ymm2[1],ymm0[4],ymm2[4],ymm0[5],ymm2[5]
+; AVX2-VPCLMULQDQ-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm0[0],ymm3[0],ymm0[1],ymm3[1],ymm0[4],ymm3[4],ymm0[5],ymm3[5]
+; AVX2-VPCLMULQDQ-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm2[0],ymm0[0],ymm2[1],ymm0[1],ymm2[4],ymm0[4],ymm2[5],ymm0[5]
 ; AVX2-VPCLMULQDQ-NEXT:    vpsrld $15, %ymm0, %ymm0
 ; AVX2-VPCLMULQDQ-NEXT:    vpshufb {{.*#+}} ymm0 = ymm0[0,1,4,5,8,9,12,13,u,u,u,u,u,u,u,u,16,17,20,21,24,25,28,29,u,u,u,u,u,u,u,u]
 ; AVX2-VPCLMULQDQ-NEXT:    vpermq {{.*#+}} ymm0 = ymm0[0,2,2,3]
@@ -1670,14 +1671,14 @@ define <8 x i16> @clmulr_v8i16(<8 x i16> %a, <8 x i16> %b) nounwind {
 ; AVX512-NEXT:    vpmovzxwd {{.*#+}} ymm1 = xmm1[0],zero,xmm1[1],zero,xmm1[2],zero,xmm1[3],zero,xmm1[4],zero,xmm1[5],zero,xmm1[6],zero,xmm1[7],zero
 ; AVX512-NEXT:    vpmovzxwd {{.*#+}} ymm0 = xmm0[0],zero,xmm0[1],zero,xmm0[2],zero,xmm0[3],zero,xmm0[4],zero,xmm0[5],zero,xmm0[6],zero,xmm0[7],zero
 ; AVX512-NEXT:    vpclmulqdq $17, %ymm1, %ymm0, %ymm2
-; AVX512-NEXT:    vpsrlq $32, %ymm1, %ymm3
-; AVX512-NEXT:    vpsrlq $32, %ymm0, %ymm4
-; AVX512-NEXT:    vpclmulqdq $17, %ymm3, %ymm4, %ymm5
-; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm2 = ymm2[0],ymm5[0],ymm2[1],ymm5[1],ymm2[4],ymm5[4],ymm2[5],ymm5[5]
+; AVX512-NEXT:    vpclmulqdq $0, %ymm1, %ymm0, %ymm3
+; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm2 = ymm3[0],ymm2[0],ymm3[1],ymm2[1],ymm3[4],ymm2[4],ymm3[5],ymm2[5]
+; AVX512-NEXT:    vpsrlq $32, %ymm1, %ymm1
+; AVX512-NEXT:    vpsrlq $32, %ymm0, %ymm0
+; AVX512-NEXT:    vpclmulqdq $17, %ymm1, %ymm0, %ymm3
 ; AVX512-NEXT:    vpclmulqdq $0, %ymm1, %ymm0, %ymm0
-; AVX512-NEXT:    vpclmulqdq $0, %ymm3, %ymm4, %ymm1
-; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm0[0],ymm1[0],ymm0[1],ymm1[1],ymm0[4],ymm1[4],ymm0[5],ymm1[5]
-; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm0[0],ymm2[0],ymm0[1],ymm2[1],ymm0[4],ymm2[4],ymm0[5],ymm2[5]
+; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm0[0],ymm3[0],ymm0[1],ymm3[1],ymm0[4],ymm3[4],ymm0[5],ymm3[5]
+; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm2[0],ymm0[0],ymm2[1],ymm0[1],ymm2[4],ymm0[4],ymm2[5],ymm0[5]
 ; AVX512-NEXT:    vpsrld $15, %ymm0, %ymm0
 ; AVX512-NEXT:    vpmovdw %ymm0, %xmm0
 ; AVX512-NEXT:    vzeroupper
@@ -2059,23 +2060,22 @@ define <4 x i32> @clmulr_v4i32(<4 x i32> %a, <4 x i32> %b) nounwind {
 ; SSE2-PCLMUL-NEXT:    pand %xmm0, %xmm2
 ; SSE2-PCLMUL-NEXT:    movdqa %xmm2, %xmm4
 ; SSE2-PCLMUL-NEXT:    pclmulqdq $17, %xmm3, %xmm4
-; SSE2-PCLMUL-NEXT:    movdqa %xmm0, %xmm5
-; SSE2-PCLMUL-NEXT:    movdqa %xmm0, %xmm6
-; SSE2-PCLMUL-NEXT:    pclmulqdq $17, %xmm1, %xmm6
+; SSE2-PCLMUL-NEXT:    pclmulqdq $0, %xmm3, %xmm2
+; SSE2-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm2 = xmm2[0],xmm4[0],xmm2[1],xmm4[1]
+; SSE2-PCLMUL-NEXT:    movdqa %xmm0, %xmm3
+; SSE2-PCLMUL-NEXT:    movdqa %xmm0, %xmm4
+; SSE2-PCLMUL-NEXT:    pclmulqdq $17, %xmm1, %xmm4
 ; SSE2-PCLMUL-NEXT:    pclmulqdq $0, %xmm1, %xmm0
 ; SSE2-PCLMUL-NEXT:    psrlq $32, %xmm1
-; SSE2-PCLMUL-NEXT:    psrlq $32, %xmm5
-; SSE2-PCLMUL-NEXT:    movdqa %xmm5, %xmm7
-; SSE2-PCLMUL-NEXT:    pclmulqdq $17, %xmm1, %xmm7
-; SSE2-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm4 = xmm4[0],xmm7[0],xmm4[1],xmm7[1]
-; SSE2-PCLMUL-NEXT:    pclmulqdq $0, %xmm3, %xmm2
-; SSE2-PCLMUL-NEXT:    pclmulqdq $0, %xmm1, %xmm5
-; SSE2-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm2 = xmm2[0],xmm5[0],xmm2[1],xmm5[1]
-; SSE2-PCLMUL-NEXT:    punpckhdq {{.*#+}} xmm2 = xmm2[2],xmm4[2],xmm2[3],xmm4[3]
+; SSE2-PCLMUL-NEXT:    psrlq $32, %xmm3
+; SSE2-PCLMUL-NEXT:    movdqa %xmm3, %xmm5
+; SSE2-PCLMUL-NEXT:    pclmulqdq $17, %xmm1, %xmm5
+; SSE2-PCLMUL-NEXT:    pclmulqdq $0, %xmm1, %xmm3
+; SSE2-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm3 = xmm3[0],xmm5[0],xmm3[1],xmm5[1]
+; SSE2-PCLMUL-NEXT:    punpckhdq {{.*#+}} xmm2 = xmm2[2],xmm3[2],xmm2[3],xmm3[3]
 ; SSE2-PCLMUL-NEXT:    paddd %xmm2, %xmm2
-; SSE2-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm6 = xmm6[0],xmm7[0],xmm6[1],xmm7[1]
-; SSE2-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm0 = xmm0[0],xmm5[0],xmm0[1],xmm5[1]
-; SSE2-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm0 = xmm0[0],xmm6[0],xmm0[1],xmm6[1]
+; SSE2-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm0 = xmm0[0],xmm4[0],xmm0[1],xmm4[1]
+; SSE2-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm0 = xmm0[0],xmm3[0],xmm0[1],xmm3[1]
 ; SSE2-PCLMUL-NEXT:    psrld $31, %xmm0
 ; SSE2-PCLMUL-NEXT:    por %xmm2, %xmm0
 ; SSE2-PCLMUL-NEXT:    retq
@@ -2088,23 +2088,22 @@ define <4 x i32> @clmulr_v4i32(<4 x i32> %a, <4 x i32> %b) nounwind {
 ; SSE42-PCLMUL-NEXT:    pblendw {{.*#+}} xmm2 = xmm0[0,1],xmm2[2,3],xmm0[4,5],xmm2[6,7]
 ; SSE42-PCLMUL-NEXT:    movdqa %xmm2, %xmm4
 ; SSE42-PCLMUL-NEXT:    pclmulqdq $17, %xmm3, %xmm4
-; SSE42-PCLMUL-NEXT:    movdqa %xmm0, %xmm5
-; SSE42-PCLMUL-NEXT:    movdqa %xmm0, %xmm6
-; SSE42-PCLMUL-NEXT:    pclmulqdq $17, %xmm1, %xmm6
+; SSE42-PCLMUL-NEXT:    pclmulqdq $0, %xmm3, %xmm2
+; SSE42-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm2 = xmm2[0],xmm4[0],xmm2[1],xmm4[1]
+; SSE42-PCLMUL-NEXT:    movdqa %xmm0, %xmm3
+; SSE42-PCLMUL-NEXT:    movdqa %xmm0, %xmm4
+; SSE42-PCLMUL-NEXT:    pclmulqdq $17, %xmm1, %xmm4
 ; SSE42-PCLMUL-NEXT:    pclmulqdq $0, %xmm1, %xmm0
 ; SSE42-PCLMUL-NEXT:    psrlq $32, %xmm1
-; SSE42-PCLMUL-NEXT:    psrlq $32, %xmm5
-; SSE42-PCLMUL-NEXT:    movdqa %xmm5, %xmm7
-; SSE42-PCLMUL-NEXT:    pclmulqdq $17, %xmm1, %xmm7
-; SSE42-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm4 = xmm4[0],xmm7[0],xmm4[1],xmm7[1]
-; SSE42-PCLMUL-NEXT:    pclmulqdq $0, %xmm3, %xmm2
-; SSE42-PCLMUL-NEXT:    pclmulqdq $0, %xmm1, %xmm5
-; SSE42-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm2 = xmm2[0],xmm5[0],xmm2[1],xmm5[1]
-; SSE42-PCLMUL-NEXT:    punpckhdq {{.*#+}} xmm2 = xmm2[2],xmm4[2],xmm2[3],xmm4[3]
+; SSE42-PCLMUL-NEXT:    psrlq $32, %xmm3
+; SSE42-PCLMUL-NEXT:    movdqa %xmm3, %xmm5
+; SSE42-PCLMUL-NEXT:    pclmulqdq $17, %xmm1, %xmm5
+; SSE42-PCLMUL-NEXT:    pclmulqdq $0, %xmm1, %xmm3
+; SSE42-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm3 = xmm3[0],xmm5[0],xmm3[1],xmm5[1]
+; SSE42-PCLMUL-NEXT:    punpckhdq {{.*#+}} xmm2 = xmm2[2],xmm3[2],xmm2[3],xmm3[3]
 ; SSE42-PCLMUL-NEXT:    paddd %xmm2, %xmm2
-; SSE42-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm6 = xmm6[0],xmm7[0],xmm6[1],xmm7[1]
-; SSE42-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm0 = xmm0[0],xmm5[0],xmm0[1],xmm5[1]
-; SSE42-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm0 = xmm0[0],xmm6[0],xmm0[1],xmm6[1]
+; SSE42-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm0 = xmm0[0],xmm4[0],xmm0[1],xmm4[1]
+; SSE42-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm0 = xmm0[0],xmm3[0],xmm0[1],xmm3[1]
 ; SSE42-PCLMUL-NEXT:    psrld $31, %xmm0
 ; SSE42-PCLMUL-NEXT:    por %xmm2, %xmm0
 ; SSE42-PCLMUL-NEXT:    retq
@@ -2115,20 +2114,19 @@ define <4 x i32> @clmulr_v4i32(<4 x i32> %a, <4 x i32> %b) nounwind {
 ; AVX2-NEXT:    vpblendd {{.*#+}} xmm3 = xmm1[0],xmm2[1],xmm1[2],xmm2[3]
 ; AVX2-NEXT:    vpblendd {{.*#+}} xmm2 = xmm0[0],xmm2[1],xmm0[2],xmm2[3]
 ; AVX2-NEXT:    vpclmulqdq $17, %xmm3, %xmm2, %xmm4
-; AVX2-NEXT:    vpsrlq $32, %xmm1, %xmm5
-; AVX2-NEXT:    vpsrlq $32, %xmm0, %xmm6
-; AVX2-NEXT:    vpclmulqdq $17, %xmm5, %xmm6, %xmm7
-; AVX2-NEXT:    vpunpckldq {{.*#+}} xmm4 = xmm4[0],xmm7[0],xmm4[1],xmm7[1]
 ; AVX2-NEXT:    vpclmulqdq $0, %xmm3, %xmm2, %xmm2
-; AVX2-NEXT:    vpclmulqdq $0, %xmm5, %xmm6, %xmm3
-; AVX2-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm3[0],xmm2[1],xmm3[1]
-; AVX2-NEXT:    vpunpckhdq {{.*#+}} xmm2 = xmm2[2],xmm4[2],xmm2[3],xmm4[3]
+; AVX2-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm4[0],xmm2[1],xmm4[1]
+; AVX2-NEXT:    vpsrlq $32, %xmm1, %xmm3
+; AVX2-NEXT:    vpsrlq $32, %xmm0, %xmm4
+; AVX2-NEXT:    vpclmulqdq $17, %xmm3, %xmm4, %xmm5
+; AVX2-NEXT:    vpclmulqdq $0, %xmm3, %xmm4, %xmm3
+; AVX2-NEXT:    vpunpckldq {{.*#+}} xmm3 = xmm3[0],xmm5[0],xmm3[1],xmm5[1]
+; AVX2-NEXT:    vpunpckhdq {{.*#+}} xmm2 = xmm2[2],xmm3[2],xmm2[3],xmm3[3]
 ; AVX2-NEXT:    vpaddd %xmm2, %xmm2, %xmm2
 ; AVX2-NEXT:    vpclmulqdq $17, %xmm1, %xmm0, %xmm4
-; AVX2-NEXT:    vpunpckldq {{.*#+}} xmm4 = xmm4[0],xmm7[0],xmm4[1],xmm7[1]
 ; AVX2-NEXT:    vpclmulqdq $0, %xmm1, %xmm0, %xmm0
-; AVX2-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm0[0],xmm3[0],xmm0[1],xmm3[1]
 ; AVX2-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm0[0],xmm4[0],xmm0[1],xmm4[1]
+; AVX2-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm0[0],xmm3[0],xmm0[1],xmm3[1]
 ; AVX2-NEXT:    vpsrld $31, %xmm0, %xmm0
 ; AVX2-NEXT:    vpor %xmm2, %xmm0, %xmm0
 ; AVX2-NEXT:    retq
@@ -2139,20 +2137,19 @@ define <4 x i32> @clmulr_v4i32(<4 x i32> %a, <4 x i32> %b) nounwind {
 ; AVX512-NEXT:    vpblendd {{.*#+}} xmm3 = xmm1[0],xmm2[1],xmm1[2],xmm2[3]
 ; AVX512-NEXT:    vpblendd {{.*#+}} xmm2 = xmm0[0],xmm2[1],xmm0[2],xmm2[3]
 ; AVX512-NEXT:    vpclmulqdq $17, %xmm3, %xmm2, %xmm4
-; AVX512-NEXT:    vpsrlq $32, %xmm1, %xmm5
-; AVX512-NEXT:    vpsrlq $32, %xmm0, %xmm6
-; AVX512-NEXT:    vpclmulqdq $17, %xmm5, %xmm6, %xmm7
-; AVX512-NEXT:    vpunpckldq {{.*#+}} xmm4 = xmm4[0],xmm7[0],xmm4[1],xmm7[1]
 ; AVX512-NEXT:    vpclmulqdq $0, %xmm3, %xmm2, %xmm2
-; AVX512-NEXT:    vpclmulqdq $0, %xmm5, %xmm6, %xmm3
-; AVX512-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm3[0],xmm2[1],xmm3[1]
-; AVX512-NEXT:    vpunpckhdq {{.*#+}} xmm2 = xmm2[2],xmm4[2],xmm2[3],xmm4[3]
+; AVX512-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm4[0],xmm2[1],xmm4[1]
+; AVX512-NEXT:    vpsrlq $32, %xmm1, %xmm3
+; AVX512-NEXT:    vpsrlq $32, %xmm0, %xmm4
+; AVX512-NEXT:    vpclmulqdq $17, %xmm3, %xmm4, %xmm5
+; AVX512-NEXT:    vpclmulqdq $0, %xmm3, %xmm4, %xmm3
+; AVX512-NEXT:    vpunpckldq {{.*#+}} xmm3 = xmm3[0],xmm5[0],xmm3[1],xmm5[1]
+; AVX512-NEXT:    vpunpckhdq {{.*#+}} xmm2 = xmm2[2],xmm3[2],xmm2[3],xmm3[3]
 ; AVX512-NEXT:    vpaddd %xmm2, %xmm2, %xmm2
 ; AVX512-NEXT:    vpclmulqdq $17, %xmm1, %xmm0, %xmm4
-; AVX512-NEXT:    vpunpckldq {{.*#+}} xmm4 = xmm4[0],xmm7[0],xmm4[1],xmm7[1]
 ; AVX512-NEXT:    vpclmulqdq $0, %xmm1, %xmm0, %xmm0
-; AVX512-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm0[0],xmm3[0],xmm0[1],xmm3[1]
 ; AVX512-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm0[0],xmm4[0],xmm0[1],xmm4[1]
+; AVX512-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm0[0],xmm3[0],xmm0[1],xmm3[1]
 ; AVX512-NEXT:    vpsrld $31, %xmm0, %xmm0
 ; AVX512-NEXT:    vpor %xmm2, %xmm0, %xmm0
 ; AVX512-NEXT:    retq
@@ -3362,23 +3359,23 @@ define <8 x i16> @clmulh_v8i16(<8 x i16> %a, <8 x i16> %b) nounwind {
 ; AVX2-PCLMUL-NEXT:    vpmovzxwd {{.*#+}} ymm0 = xmm0[0],zero,xmm0[1],zero,xmm0[2],zero,xmm0[3],zero,xmm0[4],zero,xmm0[5],zero,xmm0[6],zero,xmm0[7],zero
 ; AVX2-PCLMUL-NEXT:    vextracti128 $1, %ymm0, %xmm3
 ; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm2, %xmm3, %xmm4
-; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm2, %xmm5
-; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm3, %xmm6
-; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm5, %xmm6, %xmm7
-; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm4 = xmm4[0],xmm7[0],xmm4[1],xmm7[1]
+; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm2, %xmm3, %xmm5
+; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm4 = xmm5[0],xmm4[0],xmm5[1],xmm4[1]
+; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm2, %xmm2
+; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm3, %xmm3
+; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm2, %xmm3, %xmm5
 ; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm2, %xmm3, %xmm2
-; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm5, %xmm6, %xmm3
-; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm3[0],xmm2[1],xmm3[1]
-; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm4[0],xmm2[1],xmm4[1]
+; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm5[0],xmm2[1],xmm5[1]
+; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm4[0],xmm2[0],xmm4[1],xmm2[1]
 ; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm1, %xmm0, %xmm3
-; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm1, %xmm4
-; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm0, %xmm5
-; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm4, %xmm5, %xmm6
-; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm3 = xmm3[0],xmm6[0],xmm3[1],xmm6[1]
+; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm1, %xmm0, %xmm4
+; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm3 = xmm4[0],xmm3[0],xmm4[1],xmm3[1]
+; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm1, %xmm1
+; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm0, %xmm0
+; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm1, %xmm0, %xmm4
 ; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm1, %xmm0, %xmm0
-; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm4, %xmm5, %xmm1
-; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm0[0],xmm1[0],xmm0[1],xmm1[1]
-; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm0[0],xmm3[0],xmm0[1],xmm3[1]
+; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm0[0],xmm4[0],xmm0[1],xmm4[1]
+; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm3[0],xmm0[0],xmm3[1],xmm0[1]
 ; AVX2-PCLMUL-NEXT:    vinserti128 $1, %xmm2, %ymm0, %ymm0
 ; AVX2-PCLMUL-NEXT:    vpsrld $16, %ymm0, %ymm0
 ; AVX2-PCLMUL-NEXT:    vextracti128 $1, %ymm0, %xmm1
@@ -3391,14 +3388,14 @@ define <8 x i16> @clmulh_v8i16(<8 x i16> %a, <8 x i16> %b) nounwind {
 ; AVX2-VPCLMULQDQ-NEXT:    vpmovzxwd {{.*#+}} ymm1 = xmm1[0],zero,xmm1[1],zero,xmm1[2],zero,xmm1[3],zero,xmm1[4],zero,xmm1[5],zero,xmm1[6],zero,xmm1[7],zero
 ; AVX2-VPCLMULQDQ-NEXT:    vpmovzxwd {{.*#+}} ymm0 = xmm0[0],zero,xmm0[1],zero,xmm0[2],zero,xmm0[3],zero,xmm0[4],zero,xmm0[5],zero,xmm0[6],zero,xmm0[7],zero
 ; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $17, %ymm1, %ymm0, %ymm2
-; AVX2-VPCLMULQDQ-NEXT:    vpsrlq $32, %ymm1, %ymm3
-; AVX2-VPCLMULQDQ-NEXT:    vpsrlq $32, %ymm0, %ymm4
-; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $17, %ymm3, %ymm4, %ymm5
-; AVX2-VPCLMULQDQ-NEXT:    vpunpckldq {{.*#+}} ymm2 = ymm2[0],ymm5[0],ymm2[1],ymm5[1],ymm2[4],ymm5[4],ymm2[5],ymm5[5]
+; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $0, %ymm1, %ymm0, %ymm3
+; AVX2-VPCLMULQDQ-NEXT:    vpunpckldq {{.*#+}} ymm2 = ymm3[0],ymm2[0],ymm3[1],ymm2[1],ymm3[4],ymm2[4],ymm3[5],ymm2[5]
+; AVX2-VPCLMULQDQ-NEXT:    vpsrlq $32, %ymm1, %ymm1
+; AVX2-VPCLMULQDQ-NEXT:    vpsrlq $32, %ymm0, %ymm0
+; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $17, %ymm1, %ymm0, %ymm3
 ; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $0, %ymm1, %ymm0, %ymm0
-; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $0, %ymm3, %ymm4, %ymm1
-; AVX2-VPCLMULQDQ-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm0[0],ymm1[0],ymm0[1],ymm1[1],ymm0[4],ymm1[4],ymm0[5],ymm1[5]
-; AVX2-VPCLMULQDQ-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm0[0],ymm2[0],ymm0[1],ymm2[1],ymm0[4],ymm2[4],ymm0[5],ymm2[5]
+; AVX2-VPCLMULQDQ-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm0[0],ymm3[0],ymm0[1],ymm3[1],ymm0[4],ymm3[4],ymm0[5],ymm3[5]
+; AVX2-VPCLMULQDQ-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm2[0],ymm0[0],ymm2[1],ymm0[1],ymm2[4],ymm0[4],ymm2[5],ymm0[5]
 ; AVX2-VPCLMULQDQ-NEXT:    vpsrld $16, %ymm0, %ymm0
 ; AVX2-VPCLMULQDQ-NEXT:    vextracti128 $1, %ymm0, %xmm1
 ; AVX2-VPCLMULQDQ-NEXT:    vpackusdw %xmm1, %xmm0, %xmm0
@@ -3410,14 +3407,14 @@ define <8 x i16> @clmulh_v8i16(<8 x i16> %a, <8 x i16> %b) nounwind {
 ; AVX512-NEXT:    vpmovzxwd {{.*#+}} ymm1 = xmm1[0],zero,xmm1[1],zero,xmm1[2],zero,xmm1[3],zero,xmm1[4],zero,xmm1[5],zero,xmm1[6],zero,xmm1[7],zero
 ; AVX512-NEXT:    vpmovzxwd {{.*#+}} ymm0 = xmm0[0],zero,xmm0[1],zero,xmm0[2],zero,xmm0[3],zero,xmm0[4],zero,xmm0[5],zero,xmm0[6],zero,xmm0[7],zero
 ; AVX512-NEXT:    vpclmulqdq $17, %ymm1, %ymm0, %ymm2
-; AVX512-NEXT:    vpsrlq $32, %ymm1, %ymm3
-; AVX512-NEXT:    vpsrlq $32, %ymm0, %ymm4
-; AVX512-NEXT:    vpclmulqdq $17, %ymm3, %ymm4, %ymm5
-; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm2 = ymm2[0],ymm5[0],ymm2[1],ymm5[1],ymm2[4],ymm5[4],ymm2[5],ymm5[5]
+; AVX512-NEXT:    vpclmulqdq $0, %ymm1, %ymm0, %ymm3
+; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm2 = ymm3[0],ymm2[0],ymm3[1],ymm2[1],ymm3[4],ymm2[4],ymm3[5],ymm2[5]
+; AVX512-NEXT:    vpsrlq $32, %ymm1, %ymm1
+; AVX512-NEXT:    vpsrlq $32, %ymm0, %ymm0
+; AVX512-NEXT:    vpclmulqdq $17, %ymm1, %ymm0, %ymm3
 ; AVX512-NEXT:    vpclmulqdq $0, %ymm1, %ymm0, %ymm0
-; AVX512-NEXT:    vpclmulqdq $0, %ymm3, %ymm4, %ymm1
-; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm0[0],ymm1[0],ymm0[1],ymm1[1],ymm0[4],ymm1[4],ymm0[5],ymm1[5]
-; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm0[0],ymm2[0],ymm0[1],ymm2[1],ymm0[4],ymm2[4],ymm0[5],ymm2[5]
+; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm0[0],ymm3[0],ymm0[1],ymm3[1],ymm0[4],ymm3[4],ymm0[5],ymm3[5]
+; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm2[0],ymm0[0],ymm2[1],ymm0[1],ymm2[4],ymm0[4],ymm2[5],ymm0[5]
 ; AVX512-NEXT:    vpsrld $16, %ymm0, %ymm0
 ; AVX512-NEXT:    vpmovdw %ymm0, %xmm0
 ; AVX512-NEXT:    vzeroupper
@@ -3801,15 +3798,15 @@ define <4 x i32> @clmulh_v4i32(<4 x i32> %a, <4 x i32> %b) nounwind {
 ; SSE2-PCLMUL-NEXT:    pand %xmm0, %xmm2
 ; SSE2-PCLMUL-NEXT:    movdqa %xmm2, %xmm4
 ; SSE2-PCLMUL-NEXT:    pclmulqdq $17, %xmm3, %xmm4
+; SSE2-PCLMUL-NEXT:    pclmulqdq $0, %xmm3, %xmm2
+; SSE2-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm2 = xmm2[0],xmm4[0],xmm2[1],xmm4[1]
 ; SSE2-PCLMUL-NEXT:    psrlq $32, %xmm1
 ; SSE2-PCLMUL-NEXT:    psrlq $32, %xmm0
-; SSE2-PCLMUL-NEXT:    movdqa %xmm0, %xmm5
-; SSE2-PCLMUL-NEXT:    pclmulqdq $17, %xmm1, %xmm5
-; SSE2-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm4 = xmm4[0],xmm5[0],xmm4[1],xmm5[1]
-; SSE2-PCLMUL-NEXT:    pclmulqdq $0, %xmm3, %xmm2
+; SSE2-PCLMUL-NEXT:    movdqa %xmm0, %xmm3
+; SSE2-PCLMUL-NEXT:    pclmulqdq $17, %xmm1, %xmm3
 ; SSE2-PCLMUL-NEXT:    pclmulqdq $0, %xmm1, %xmm0
-; SSE2-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm2 = xmm2[0],xmm0[0],xmm2[1],xmm0[1]
-; SSE2-PCLMUL-NEXT:    punpckhdq {{.*#+}} xmm2 = xmm2[2],xmm4[2],xmm2[3],xmm4[3]
+; SSE2-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm0 = xmm0[0],xmm3[0],xmm0[1],xmm3[1]
+; SSE2-PCLMUL-NEXT:    punpckhdq {{.*#+}} xmm2 = xmm2[2],xmm0[2],xmm2[3],xmm0[3]
 ; SSE2-PCLMUL-NEXT:    movdqa %xmm2, %xmm0
 ; SSE2-PCLMUL-NEXT:    retq
 ;
@@ -3821,15 +3818,15 @@ define <4 x i32> @clmulh_v4i32(<4 x i32> %a, <4 x i32> %b) nounwind {
 ; SSE42-PCLMUL-NEXT:    pblendw {{.*#+}} xmm2 = xmm0[0,1],xmm2[2,3],xmm0[4,5],xmm2[6,7]
 ; SSE42-PCLMUL-NEXT:    movdqa %xmm2, %xmm4
 ; SSE42-PCLMUL-NEXT:    pclmulqdq $17, %xmm3, %xmm4
+; SSE42-PCLMUL-NEXT:    pclmulqdq $0, %xmm3, %xmm2
+; SSE42-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm2 = xmm2[0],xmm4[0],xmm2[1],xmm4[1]
 ; SSE42-PCLMUL-NEXT:    psrlq $32, %xmm1
 ; SSE42-PCLMUL-NEXT:    psrlq $32, %xmm0
-; SSE42-PCLMUL-NEXT:    movdqa %xmm0, %xmm5
-; SSE42-PCLMUL-NEXT:    pclmulqdq $17, %xmm1, %xmm5
-; SSE42-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm4 = xmm4[0],xmm5[0],xmm4[1],xmm5[1]
-; SSE42-PCLMUL-NEXT:    pclmulqdq $0, %xmm3, %xmm2
+; SSE42-PCLMUL-NEXT:    movdqa %xmm0, %xmm3
+; SSE42-PCLMUL-NEXT:    pclmulqdq $17, %xmm1, %xmm3
 ; SSE42-PCLMUL-NEXT:    pclmulqdq $0, %xmm1, %xmm0
-; SSE42-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm2 = xmm2[0],xmm0[0],xmm2[1],xmm0[1]
-; SSE42-PCLMUL-NEXT:    punpckhdq {{.*#+}} xmm2 = xmm2[2],xmm4[2],xmm2[3],xmm4[3]
+; SSE42-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm0 = xmm0[0],xmm3[0],xmm0[1],xmm3[1]
+; SSE42-PCLMUL-NEXT:    punpckhdq {{.*#+}} xmm2 = xmm2[2],xmm0[2],xmm2[3],xmm0[3]
 ; SSE42-PCLMUL-NEXT:    movdqa %xmm2, %xmm0
 ; SSE42-PCLMUL-NEXT:    retq
 ;
@@ -3839,14 +3836,14 @@ define <4 x i32> @clmulh_v4i32(<4 x i32> %a, <4 x i32> %b) nounwind {
 ; AVX2-NEXT:    vpblendd {{.*#+}} xmm3 = xmm1[0],xmm2[1],xmm1[2],xmm2[3]
 ; AVX2-NEXT:    vpblendd {{.*#+}} xmm2 = xmm0[0],xmm2[1],xmm0[2],xmm2[3]
 ; AVX2-NEXT:    vpclmulqdq $17, %xmm3, %xmm2, %xmm4
+; AVX2-NEXT:    vpclmulqdq $0, %xmm3, %xmm2, %xmm2
+; AVX2-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm4[0],xmm2[1],xmm4[1]
 ; AVX2-NEXT:    vpsrlq $32, %xmm1, %xmm1
 ; AVX2-NEXT:    vpsrlq $32, %xmm0, %xmm0
-; AVX2-NEXT:    vpclmulqdq $17, %xmm1, %xmm0, %xmm5
-; AVX2-NEXT:    vpunpckldq {{.*#+}} xmm4 = xmm4[0],xmm5[0],xmm4[1],xmm5[1]
-; AVX2-NEXT:    vpclmulqdq $0, %xmm3, %xmm2, %xmm2
+; AVX2-NEXT:    vpclmulqdq $17, %xmm1, %xmm0, %xmm3
 ; AVX2-NEXT:    vpclmulqdq $0, %xmm1, %xmm0, %xmm0
-; AVX2-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm2[0],xmm0[0],xmm2[1],xmm0[1]
-; AVX2-NEXT:    vpunpckhdq {{.*#+}} xmm0 = xmm0[2],xmm4[2],xmm0[3],xmm4[3]
+; AVX2-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm0[0],xmm3[0],xmm0[1],xmm3[1]
+; AVX2-NEXT:    vpunpckhdq {{.*#+}} xmm0 = xmm2[2],xmm0[2],xmm2[3],xmm0[3]
 ; AVX2-NEXT:    retq
 ;
 ; AVX512-LABEL: clmulh_v4i32:
@@ -3855,14 +3852,14 @@ define <4 x i32> @clmulh_v4i32(<4 x i32> %a, <4 x i32> %b) nounwind {
 ; AVX512-NEXT:    vpblendd {{.*#+}} xmm3 = xmm1[0],xmm2[1],xmm1[2],xmm2[3]
 ; AVX512-NEXT:    vpblendd {{.*#+}} xmm2 = xmm0[0],xmm2[1],xmm0[2],xmm2[3]
 ; AVX512-NEXT:    vpclmulqdq $17, %xmm3, %xmm2, %xmm4
+; AVX512-NEXT:    vpclmulqdq $0, %xmm3, %xmm2, %xmm2
+; AVX512-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm4[0],xmm2[1],xmm4[1]
 ; AVX512-NEXT:    vpsrlq $32, %xmm1, %xmm1
 ; AVX512-NEXT:    vpsrlq $32, %xmm0, %xmm0
-; AVX512-NEXT:    vpclmulqdq $17, %xmm1, %xmm0, %xmm5
-; AVX512-NEXT:    vpunpckldq {{.*#+}} xmm4 = xmm4[0],xmm5[0],xmm4[1],xmm5[1]
-; AVX512-NEXT:    vpclmulqdq $0, %xmm3, %xmm2, %xmm2
+; AVX512-NEXT:    vpclmulqdq $17, %xmm1, %xmm0, %xmm3
 ; AVX512-NEXT:    vpclmulqdq $0, %xmm1, %xmm0, %xmm0
-; AVX512-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm2[0],xmm0[0],xmm2[1],xmm0[1]
-; AVX512-NEXT:    vpunpckhdq {{.*#+}} xmm0 = xmm0[2],xmm4[2],xmm0[3],xmm4[3]
+; AVX512-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm0[0],xmm3[0],xmm0[1],xmm3[1]
+; AVX512-NEXT:    vpunpckhdq {{.*#+}} xmm0 = xmm2[2],xmm0[2],xmm2[3],xmm0[3]
 ; AVX512-NEXT:    retq
   %a.ext = zext <4 x i32> %a to <4 x i64>
   %b.ext = zext <4 x i32> %b to <4 x i64>
@@ -6310,22 +6307,22 @@ define <8 x i16> @clmul_v8i16_allones(<8 x i16> %x) nounwind {
 ; AVX2-PCLMUL-NEXT:    vextracti128 $1, %ymm0, %xmm1
 ; AVX2-PCLMUL-NEXT:    vpbroadcastd {{.*#+}} xmm2 = [65535,65535,65535,65535]
 ; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm2, %xmm1, %xmm3
-; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm1, %xmm4
-; AVX2-PCLMUL-NEXT:    vpbroadcastq {{.*#+}} xmm5 = [255,255,0,0,0,0,0,0,255,255,0,0,0,0,0,0]
-; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm5, %xmm4, %xmm6
-; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm3 = xmm3[0],xmm6[0],xmm3[1],xmm6[1]
-; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm2, %xmm1, %xmm1
-; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm5, %xmm4, %xmm4
-; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm1 = xmm1[0],xmm4[0],xmm1[1],xmm4[1]
-; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm1 = xmm1[0],xmm3[0],xmm1[1],xmm3[1]
+; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm2, %xmm1, %xmm4
+; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm3 = xmm4[0],xmm3[0],xmm4[1],xmm3[1]
+; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm1, %xmm1
+; AVX2-PCLMUL-NEXT:    vpbroadcastq {{.*#+}} xmm4 = [255,255,0,0,0,0,0,0,255,255,0,0,0,0,0,0]
+; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm4, %xmm1, %xmm5
+; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm4, %xmm1, %xmm1
+; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm1 = xmm1[0],xmm5[0],xmm1[1],xmm5[1]
+; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm1 = xmm3[0],xmm1[0],xmm3[1],xmm1[1]
 ; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm2, %xmm0, %xmm3
-; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm0, %xmm4
-; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm5, %xmm4, %xmm6
-; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm3 = xmm3[0],xmm6[0],xmm3[1],xmm6[1]
-; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm2, %xmm0, %xmm0
-; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm5, %xmm4, %xmm2
-; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm0[0],xmm2[0],xmm0[1],xmm2[1]
+; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm2, %xmm0, %xmm2
+; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm3[0],xmm2[1],xmm3[1]
+; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm0, %xmm0
+; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm4, %xmm0, %xmm3
+; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm4, %xmm0, %xmm0
 ; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm0[0],xmm3[0],xmm0[1],xmm3[1]
+; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm2[0],xmm0[0],xmm2[1],xmm0[1]
 ; AVX2-PCLMUL-NEXT:    vinserti128 $1, %xmm1, %ymm0, %ymm0
 ; AVX2-PCLMUL-NEXT:    vpshufb {{.*#+}} ymm0 = ymm0[0,1,4,5,8,9,12,13,u,u,u,u,u,u,u,u,16,17,20,21,24,25,28,29,u,u,u,u,u,u,u,u]
 ; AVX2-PCLMUL-NEXT:    vpermq {{.*#+}} ymm0 = ymm0[0,2,2,3]
@@ -6338,14 +6335,14 @@ define <8 x i16> @clmul_v8i16_allones(<8 x i16> %x) nounwind {
 ; AVX2-VPCLMULQDQ-NEXT:    vpmovzxwd {{.*#+}} ymm0 = xmm0[0],zero,xmm0[1],zero,xmm0[2],zero,xmm0[3],zero,xmm0[4],zero,xmm0[5],zero,xmm0[6],zero,xmm0[7],zero
 ; AVX2-VPCLMULQDQ-NEXT:    vpbroadcastd {{.*#+}} ymm1 = [65535,65535,65535,65535,65535,65535,65535,65535]
 ; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $17, %ymm1, %ymm0, %ymm2
-; AVX2-VPCLMULQDQ-NEXT:    vpsrlq $32, %ymm0, %ymm3
-; AVX2-VPCLMULQDQ-NEXT:    vpbroadcastq {{.*#+}} ymm4 = [255,255,0,0,0,0,0,0,255,255,0,0,0,0,0,0,255,255,0,0,0,0,0,0,255,255,0,0,0,0,0,0]
-; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $17, %ymm4, %ymm3, %ymm5
-; AVX2-VPCLMULQDQ-NEXT:    vpunpckldq {{.*#+}} ymm2 = ymm2[0],ymm5[0],ymm2[1],ymm5[1],ymm2[4],ymm5[4],ymm2[5],ymm5[5]
-; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $0, %ymm1, %ymm0, %ymm0
-; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $0, %ymm4, %ymm3, %ymm1
-; AVX2-VPCLMULQDQ-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm0[0],ymm1[0],ymm0[1],ymm1[1],ymm0[4],ymm1[4],ymm0[5],ymm1[5]
-; AVX2-VPCLMULQDQ-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm0[0],ymm2[0],ymm0[1],ymm2[1],ymm0[4],ymm2[4],ymm0[5],ymm2[5]
+; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $0, %ymm1, %ymm0, %ymm1
+; AVX2-VPCLMULQDQ-NEXT:    vpunpckldq {{.*#+}} ymm1 = ymm1[0],ymm2[0],ymm1[1],ymm2[1],ymm1[4],ymm2[4],ymm1[5],ymm2[5]
+; AVX2-VPCLMULQDQ-NEXT:    vpsrlq $32, %ymm0, %ymm0
+; AVX2-VPCLMULQDQ-NEXT:    vpbroadcastq {{.*#+}} ymm2 = [255,255,0,0,0,0,0,0,255,255,0,0,0,0,0,0,255,255,0,0,0,0,0,0,255,255,0,0,0,0,0,0]
+; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $17, %ymm2, %ymm0, %ymm3
+; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $0, %ymm2, %ymm0, %ymm0
+; AVX2-VPCLMULQDQ-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm0[0],ymm3[0],ymm0[1],ymm3[1],ymm0[4],ymm3[4],ymm0[5],ymm3[5]
+; AVX2-VPCLMULQDQ-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm1[0],ymm0[0],ymm1[1],ymm0[1],ymm1[4],ymm0[4],ymm1[5],ymm0[5]
 ; AVX2-VPCLMULQDQ-NEXT:    vpshufb {{.*#+}} ymm0 = ymm0[0,1,4,5,8,9,12,13,u,u,u,u,u,u,u,u,16,17,20,21,24,25,28,29,u,u,u,u,u,u,u,u]
 ; AVX2-VPCLMULQDQ-NEXT:    vpermq {{.*#+}} ymm0 = ymm0[0,2,2,3]
 ; AVX2-VPCLMULQDQ-NEXT:    # kill: def $xmm0 killed $xmm0 killed $ymm0
@@ -6357,14 +6354,14 @@ define <8 x i16> @clmul_v8i16_allones(<8 x i16> %x) nounwind {
 ; AVX512-NEXT:    vpmovzxwd {{.*#+}} ymm0 = xmm0[0],zero,xmm0[1],zero,xmm0[2],zero,xmm0[3],zero,xmm0[4],zero,xmm0[5],zero,xmm0[6],zero,xmm0[7],zero
 ; AVX512-NEXT:    vpbroadcastd {{.*#+}} ymm1 = [65535,65535,65535,65535,65535,65535,65535,65535]
 ; AVX512-NEXT:    vpclmulqdq $17, %ymm1, %ymm0, %ymm2
-; AVX512-NEXT:    vpsrlq $32, %ymm0, %ymm3
-; AVX512-NEXT:    vpbroadcastq {{.*#+}} ymm4 = [255,255,0,0,0,0,0,0,255,255,0,0,0,0,0,0,255,255,0,0,0,0,0,0,255,255,0,0,0,0,0,0]
-; AVX512-NEXT:    vpclmulqdq $17, %ymm4, %ymm3, %ymm5
-; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm2 = ymm2[0],ymm5[0],ymm2[1],ymm5[1],ymm2[4],ymm5[4],ymm2[5],ymm5[5]
-; AVX512-NEXT:    vpclmulqdq $0, %ymm1, %ymm0, %ymm0
-; AVX512-NEXT:    vpclmulqdq $0, %ymm4, %ymm3, %ymm1
-; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm0[0],ymm1[0],ymm0[1],ymm1[1],ymm0[4],ymm1[4],ymm0[5],ymm1[5]
-; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm0[0],ymm2[0],ymm0[1],ymm2[1],ymm0[4],ymm2[4],ymm0[5],ymm2[5]
+; AVX512-NEXT:    vpclmulqdq $0, %ymm1, %ymm0, %ymm1
+; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm1 = ymm1[0],ymm2[0],ymm1[1],ymm2[1],ymm1[4],ymm2[4],ymm1[5],ymm2[5]
+; AVX512-NEXT:    vpsrlq $32, %ymm0, %ymm0
+; AVX512-NEXT:    vpbroadcastq {{.*#+}} ymm2 = [255,255,0,0,0,0,0,0,255,255,0,0,0,0,0,0,255,255,0,0,0,0,0,0,255,255,0,0,0,0,0,0]
+; AVX512-NEXT:    vpclmulqdq $17, %ymm2, %ymm0, %ymm3
+; AVX512-NEXT:    vpclmulqdq $0, %ymm2, %ymm0, %ymm0
+; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm0[0],ymm3[0],ymm0[1],ymm3[1],ymm0[4],ymm3[4],ymm0[5],ymm3[5]
+; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm1[0],ymm0[0],ymm1[1],ymm0[1],ymm1[4],ymm0[4],ymm1[5],ymm0[5]
 ; AVX512-NEXT:    vpmovdw %ymm0, %xmm0
 ; AVX512-NEXT:    vzeroupper
 ; AVX512-NEXT:    retq
@@ -6397,16 +6394,16 @@ define <4 x i32> @clmul_v4i32_allones(<4 x i32> %x) nounwind {
 ; SSE2-PCLMUL-NEXT:    pcmpeqd %xmm1, %xmm1
 ; SSE2-PCLMUL-NEXT:    movdqa %xmm0, %xmm2
 ; SSE2-PCLMUL-NEXT:    pclmulqdq $17, %xmm1, %xmm2
+; SSE2-PCLMUL-NEXT:    pclmulqdq $0, %xmm0, %xmm1
+; SSE2-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm1 = xmm1[0],xmm2[0],xmm1[1],xmm2[1]
+; SSE2-PCLMUL-NEXT:    psrlq $32, %xmm0
+; SSE2-PCLMUL-NEXT:    movdqa {{.*#+}} xmm2 = [255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0]
 ; SSE2-PCLMUL-NEXT:    movdqa %xmm0, %xmm3
-; SSE2-PCLMUL-NEXT:    psrlq $32, %xmm3
-; SSE2-PCLMUL-NEXT:    movdqa {{.*#+}} xmm4 = [255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0]
-; SSE2-PCLMUL-NEXT:    movdqa %xmm3, %xmm5
-; SSE2-PCLMUL-NEXT:    pclmulqdq $17, %xmm4, %xmm5
-; SSE2-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm2 = xmm2[0],xmm5[0],xmm2[1],xmm5[1]
-; SSE2-PCLMUL-NEXT:    pclmulqdq $0, %xmm1, %xmm0
-; SSE2-PCLMUL-NEXT:    pclmulqdq $0, %xmm4, %xmm3
+; SSE2-PCLMUL-NEXT:    pclmulqdq $17, %xmm2, %xmm3
+; SSE2-PCLMUL-NEXT:    pclmulqdq $0, %xmm2, %xmm0
 ; SSE2-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm0 = xmm0[0],xmm3[0],xmm0[1],xmm3[1]
-; SSE2-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm0 = xmm0[0],xmm2[0],xmm0[1],xmm2[1]
+; SSE2-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm1 = xmm1[0],xmm0[0],xmm1[1],xmm0[1]
+; SSE2-PCLMUL-NEXT:    movdqa %xmm1, %xmm0
 ; SSE2-PCLMUL-NEXT:    retq
 ;
 ; SSE42-PCLMUL-LABEL: clmul_v4i32_allones:
@@ -6414,44 +6411,44 @@ define <4 x i32> @clmul_v4i32_allones(<4 x i32> %x) nounwind {
 ; SSE42-PCLMUL-NEXT:    pcmpeqd %xmm1, %xmm1
 ; SSE42-PCLMUL-NEXT:    movdqa %xmm0, %xmm2
 ; SSE42-PCLMUL-NEXT:    pclmulqdq $17, %xmm1, %xmm2
+; SSE42-PCLMUL-NEXT:    pclmulqdq $0, %xmm0, %xmm1
+; SSE42-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm1 = xmm1[0],xmm2[0],xmm1[1],xmm2[1]
+; SSE42-PCLMUL-NEXT:    psrlq $32, %xmm0
+; SSE42-PCLMUL-NEXT:    pmovsxbd {{.*#+}} xmm2 = [4294967295,0,4294967295,0]
 ; SSE42-PCLMUL-NEXT:    movdqa %xmm0, %xmm3
-; SSE42-PCLMUL-NEXT:    psrlq $32, %xmm3
-; SSE42-PCLMUL-NEXT:    pmovsxbd {{.*#+}} xmm4 = [4294967295,0,4294967295,0]
-; SSE42-PCLMUL-NEXT:    movdqa %xmm3, %xmm5
-; SSE42-PCLMUL-NEXT:    pclmulqdq $17, %xmm4, %xmm5
-; SSE42-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm2 = xmm2[0],xmm5[0],xmm2[1],xmm5[1]
-; SSE42-PCLMUL-NEXT:    pclmulqdq $0, %xmm1, %xmm0
-; SSE42-PCLMUL-NEXT:    pclmulqdq $0, %xmm4, %xmm3
+; SSE42-PCLMUL-NEXT:    pclmulqdq $17, %xmm2, %xmm3
+; SSE42-PCLMUL-NEXT:    pclmulqdq $0, %xmm2, %xmm0
 ; SSE42-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm0 = xmm0[0],xmm3[0],xmm0[1],xmm3[1]
-; SSE42-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm0 = xmm0[0],xmm2[0],xmm0[1],xmm2[1]
+; SSE42-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm1 = xmm1[0],xmm0[0],xmm1[1],xmm0[1]
+; SSE42-PCLMUL-NEXT:    movdqa %xmm1, %xmm0
 ; SSE42-PCLMUL-NEXT:    retq
 ;
 ; AVX2-LABEL: clmul_v4i32_allones:
 ; AVX2:       # %bb.0:
 ; AVX2-NEXT:    vpcmpeqd %xmm1, %xmm1, %xmm1
 ; AVX2-NEXT:    vpclmulqdq $17, %xmm1, %xmm0, %xmm2
-; AVX2-NEXT:    vpsrlq $32, %xmm0, %xmm3
-; AVX2-NEXT:    vpbroadcastq {{.*#+}} xmm4 = [255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0]
-; AVX2-NEXT:    vpclmulqdq $17, %xmm4, %xmm3, %xmm5
-; AVX2-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm5[0],xmm2[1],xmm5[1]
-; AVX2-NEXT:    vpclmulqdq $0, %xmm1, %xmm0, %xmm0
-; AVX2-NEXT:    vpclmulqdq $0, %xmm4, %xmm3, %xmm1
-; AVX2-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm0[0],xmm1[0],xmm0[1],xmm1[1]
-; AVX2-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm0[0],xmm2[0],xmm0[1],xmm2[1]
+; AVX2-NEXT:    vpclmulqdq $0, %xmm1, %xmm0, %xmm1
+; AVX2-NEXT:    vpunpckldq {{.*#+}} xmm1 = xmm1[0],xmm2[0],xmm1[1],xmm2[1]
+; AVX2-NEXT:    vpsrlq $32, %xmm0, %xmm0
+; AVX2-NEXT:    vpbroadcastq {{.*#+}} xmm2 = [255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0]
+; AVX2-NEXT:    vpclmulqdq $17, %xmm2, %xmm0, %xmm3
+; AVX2-NEXT:    vpclmulqdq $0, %xmm2, %xmm0, %xmm0
+; AVX2-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm0[0],xmm3[0],xmm0[1],xmm3[1]
+; AVX2-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm1[0],xmm0[0],xmm1[1],xmm0[1]
 ; AVX2-NEXT:    retq
 ;
 ; AVX512-LABEL: clmul_v4i32_allones:
 ; AVX512:       # %bb.0:
 ; AVX512-NEXT:    vpcmpeqd %xmm1, %xmm1, %xmm1
 ; AVX512-NEXT:    vpclmulqdq $17, %xmm1, %xmm0, %xmm2
-; AVX512-NEXT:    vpsrlq $32, %xmm0, %xmm3
-; AVX512-NEXT:    vpbroadcastq {{.*#+}} xmm4 = [255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0]
-; AVX512-NEXT:    vpclmulqdq $17, %xmm4, %xmm3, %xmm5
-; AVX512-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm5[0],xmm2[1],xmm5[1]
-; AVX512-NEXT:    vpclmulqdq $0, %xmm1, %xmm0, %xmm0
-; AVX512-NEXT:    vpclmulqdq $0, %xmm4, %xmm3, %xmm1
-; AVX512-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm0[0],xmm1[0],xmm0[1],xmm1[1]
-; AVX512-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm0[0],xmm2[0],xmm0[1],xmm2[1]
+; AVX512-NEXT:    vpclmulqdq $0, %xmm1, %xmm0, %xmm1
+; AVX512-NEXT:    vpunpckldq {{.*#+}} xmm1 = xmm1[0],xmm2[0],xmm1[1],xmm2[1]
+; AVX512-NEXT:    vpsrlq $32, %xmm0, %xmm0
+; AVX512-NEXT:    vpbroadcastq {{.*#+}} xmm2 = [255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0]
+; AVX512-NEXT:    vpclmulqdq $17, %xmm2, %xmm0, %xmm3
+; AVX512-NEXT:    vpclmulqdq $0, %xmm2, %xmm0, %xmm0
+; AVX512-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm0[0],xmm3[0],xmm0[1],xmm3[1]
+; AVX512-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm1[0],xmm0[0],xmm1[1],xmm0[1]
 ; AVX512-NEXT:    retq
   %r = call <4 x i32> @llvm.clmul.v4i32(<4 x i32> %x, <4 x i32> <i32 -1, i32 -1, i32 -1, i32 -1>)
   ret <4 x i32> %r
@@ -6500,34 +6497,33 @@ define <4 x i32> @clmul_v4i32_zext_allones(<4 x i16> %x) nounwind {
 ; SSE2-PCLMUL-NEXT:    movdqa {{.*#+}} xmm1 = [65535,65535,65535,65535]
 ; SSE2-PCLMUL-NEXT:    movdqa %xmm0, %xmm2
 ; SSE2-PCLMUL-NEXT:    pclmulqdq $17, %xmm1, %xmm2
+; SSE2-PCLMUL-NEXT:    pclmulqdq $0, %xmm0, %xmm1
+; SSE2-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm1 = xmm1[0],xmm2[0],xmm1[1],xmm2[1]
+; SSE2-PCLMUL-NEXT:    psrlq $32, %xmm0
+; SSE2-PCLMUL-NEXT:    movdqa {{.*#+}} xmm2 = [255,255,0,0,0,0,0,0,255,255,0,0,0,0,0,0]
 ; SSE2-PCLMUL-NEXT:    movdqa %xmm0, %xmm3
-; SSE2-PCLMUL-NEXT:    psrlq $32, %xmm3
-; SSE2-PCLMUL-NEXT:    movdqa {{.*#+}} xmm4 = [255,255,0,0,0,0,0,0,255,255,0,0,0,0,0,0]
-; SSE2-PCLMUL-NEXT:    movdqa %xmm3, %xmm5
-; SSE2-PCLMUL-NEXT:    pclmulqdq $17, %xmm4, %xmm5
-; SSE2-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm2 = xmm2[0],xmm5[0],xmm2[1],xmm5[1]
-; SSE2-PCLMUL-NEXT:    pclmulqdq $0, %xmm1, %xmm0
-; SSE2-PCLMUL-NEXT:    pclmulqdq $0, %xmm4, %xmm3
+; SSE2-PCLMUL-NEXT:    pclmulqdq $17, %xmm2, %xmm3
+; SSE2-PCLMUL-NEXT:    pclmulqdq $0, %xmm2, %xmm0
 ; SSE2-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm0 = xmm0[0],xmm3[0],xmm0[1],xmm3[1]
-; SSE2-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm0 = xmm0[0],xmm2[0],xmm0[1],xmm2[1]
+; SSE2-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm1 = xmm1[0],xmm0[0],xmm1[1],xmm0[1]
+; SSE2-PCLMUL-NEXT:    movdqa %xmm1, %xmm0
 ; SSE2-PCLMUL-NEXT:    retq
 ;
 ; SSE42-PCLMUL-LABEL: clmul_v4i32_zext_allones:
 ; SSE42-PCLMUL:       # %bb.0:
-; SSE42-PCLMUL-NEXT:    pmovzxwd {{.*#+}} xmm0 = xmm0[0],zero,xmm0[1],zero,xmm0[2],zero,xmm0[3],zero
-; SSE42-PCLMUL-NEXT:    pmovsxbw {{.*#+}} xmm1 = [65535,0,65535,0,65535,0,65535,0]
-; SSE42-PCLMUL-NEXT:    movdqa %xmm0, %xmm2
-; SSE42-PCLMUL-NEXT:    pclmulqdq $17, %xmm1, %xmm2
-; SSE42-PCLMUL-NEXT:    movdqa %xmm0, %xmm3
-; SSE42-PCLMUL-NEXT:    psrlq $32, %xmm3
-; SSE42-PCLMUL-NEXT:    pmovzxwq {{.*#+}} xmm4 = [65535,65535]
-; SSE42-PCLMUL-NEXT:    movdqa %xmm3, %xmm5
-; SSE42-PCLMUL-NEXT:    pclmulqdq $17, %xmm4, %xmm5
-; SSE42-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm2 = xmm2[0],xmm5[0],xmm2[1],xmm5[1]
+; SSE42-PCLMUL-NEXT:    pmovzxwd {{.*#+}} xmm1 = xmm0[0],zero,xmm0[1],zero,xmm0[2],zero,xmm0[3],zero
+; SSE42-PCLMUL-NEXT:    pmovsxbw {{.*#+}} xmm0 = [65535,0,65535,0,65535,0,65535,0]
+; SSE42-PCLMUL-NEXT:    movdqa %xmm1, %xmm2
+; SSE42-PCLMUL-NEXT:    pclmulqdq $17, %xmm0, %xmm2
 ; SSE42-PCLMUL-NEXT:    pclmulqdq $0, %xmm1, %xmm0
-; SSE42-PCLMUL-NEXT:    pclmulqdq $0, %xmm4, %xmm3
-; SSE42-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm0 = xmm0[0],xmm3[0],xmm0[1],xmm3[1]
 ; SSE42-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm0 = xmm0[0],xmm2[0],xmm0[1],xmm2[1]
+; SSE42-PCLMUL-NEXT:    psrlq $32, %xmm1
+; SSE42-PCLMUL-NEXT:    pmovzxwq {{.*#+}} xmm2 = [65535,65535]
+; SSE42-PCLMUL-NEXT:    movdqa %xmm1, %xmm3
+; SSE42-PCLMUL-NEXT:    pclmulqdq $17, %xmm2, %xmm3
+; SSE42-PCLMUL-NEXT:    pclmulqdq $0, %xmm2, %xmm1
+; SSE42-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm1 = xmm1[0],xmm3[0],xmm1[1],xmm3[1]
+; SSE42-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm0 = xmm0[0],xmm1[0],xmm0[1],xmm1[1]
 ; SSE42-PCLMUL-NEXT:    retq
 ;
 ; AVX2-LABEL: clmul_v4i32_zext_allones:
@@ -6535,14 +6531,14 @@ define <4 x i32> @clmul_v4i32_zext_allones(<4 x i16> %x) nounwind {
 ; AVX2-NEXT:    vpmovzxwd {{.*#+}} xmm0 = xmm0[0],zero,xmm0[1],zero,xmm0[2],zero,xmm0[3],zero
 ; AVX2-NEXT:    vpbroadcastd {{.*#+}} xmm1 = [65535,65535,65535,65535]
 ; AVX2-NEXT:    vpclmulqdq $17, %xmm1, %xmm0, %xmm2
-; AVX2-NEXT:    vpsrlq $32, %xmm0, %xmm3
-; AVX2-NEXT:    vpbroadcastq {{.*#+}} xmm4 = [255,255,0,0,0,0,0,0,255,255,0,0,0,0,0,0]
-; AVX2-NEXT:    vpclmulqdq $17, %xmm4, %xmm3, %xmm5
-; AVX2-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm5[0],xmm2[1],xmm5[1]
-; AVX2-NEXT:    vpclmulqdq $0, %xmm1, %xmm0, %xmm0
-; AVX2-NEXT:    vpclmulqdq $0, %xmm4, %xmm3, %xmm1
-; AVX2-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm0[0],xmm1[0],xmm0[1],xmm1[1]
-; AVX2-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm0[0],xmm2[0],xmm0[1],xmm2[1]
+; AVX2-NEXT:    vpclmulqdq $0, %xmm1, %xmm0, %xmm1
+; AVX2-NEXT:    vpunpckldq {{.*#+}} xmm1 = xmm1[0],xmm2[0],xmm1[1],xmm2[1]
+; AVX2-NEXT:    vpsrlq $32, %xmm0, %xmm0
+; AVX2-NEXT:    vpbroadcastq {{.*#+}} xmm2 = [255,255,0,0,0,0,0,0,255,255,0,0,0,0,0,0]
+; AVX2-NEXT:    vpclmulqdq $17, %xmm2, %xmm0, %xmm3
+; AVX2-NEXT:    vpclmulqdq $0, %xmm2, %xmm0, %xmm0
+; AVX2-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm0[0],xmm3[0],xmm0[1],xmm3[1]
+; AVX2-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm1[0],xmm0[0],xmm1[1],xmm0[1]
 ; AVX2-NEXT:    retq
 ;
 ; AVX512-LABEL: clmul_v4i32_zext_allones:
@@ -6550,14 +6546,14 @@ define <4 x i32> @clmul_v4i32_zext_allones(<4 x i16> %x) nounwind {
 ; AVX512-NEXT:    vpmovzxwd {{.*#+}} xmm0 = xmm0[0],zero,xmm0[1],zero,xmm0[2],zero,xmm0[3],zero
 ; AVX512-NEXT:    vpbroadcastd {{.*#+}} xmm1 = [65535,65535,65535,65535]
 ; AVX512-NEXT:    vpclmulqdq $17, %xmm1, %xmm0, %xmm2
-; AVX512-NEXT:    vpsrlq $32, %xmm0, %xmm3
-; AVX512-NEXT:    vpbroadcastq {{.*#+}} xmm4 = [255,255,0,0,0,0,0,0,255,255,0,0,0,0,0,0]
-; AVX512-NEXT:    vpclmulqdq $17, %xmm4, %xmm3, %xmm5
-; AVX512-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm5[0],xmm2[1],xmm5[1]
-; AVX512-NEXT:    vpclmulqdq $0, %xmm1, %xmm0, %xmm0
-; AVX512-NEXT:    vpclmulqdq $0, %xmm4, %xmm3, %xmm1
-; AVX512-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm0[0],xmm1[0],xmm0[1],xmm1[1]
-; AVX512-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm0[0],xmm2[0],xmm0[1],xmm2[1]
+; AVX512-NEXT:    vpclmulqdq $0, %xmm1, %xmm0, %xmm1
+; AVX512-NEXT:    vpunpckldq {{.*#+}} xmm1 = xmm1[0],xmm2[0],xmm1[1],xmm2[1]
+; AVX512-NEXT:    vpsrlq $32, %xmm0, %xmm0
+; AVX512-NEXT:    vpbroadcastq {{.*#+}} xmm2 = [255,255,0,0,0,0,0,0,255,255,0,0,0,0,0,0]
+; AVX512-NEXT:    vpclmulqdq $17, %xmm2, %xmm0, %xmm3
+; AVX512-NEXT:    vpclmulqdq $0, %xmm2, %xmm0, %xmm0
+; AVX512-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm0[0],xmm3[0],xmm0[1],xmm3[1]
+; AVX512-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm1[0],xmm0[0],xmm1[1],xmm0[1]
 ; AVX512-NEXT:    retq
   %x32 = zext <4 x i16> %x to <4 x i32>
   %r = call <4 x i32> @llvm.clmul.v4i32(<4 x i32> %x32, <4 x i32> <i32 65535, i32 65535, i32 65535, i32 65535>)
@@ -6823,76 +6819,75 @@ define <8 x i16> @clmulr_v8i16_allones(<8 x i16> %x) nounwind {
 ;
 ; SSE2-PCLMUL-LABEL: clmulr_v8i16_allones:
 ; SSE2-PCLMUL:       # %bb.0:
-; SSE2-PCLMUL-NEXT:    pxor %xmm2, %xmm2
 ; SSE2-PCLMUL-NEXT:    movdqa %xmm0, %xmm1
-; SSE2-PCLMUL-NEXT:    punpckhwd {{.*#+}} xmm1 = xmm1[4],xmm2[4],xmm1[5],xmm2[5],xmm1[6],xmm2[6],xmm1[7],xmm2[7]
-; SSE2-PCLMUL-NEXT:    punpcklwd {{.*#+}} xmm0 = xmm0[0],xmm2[0],xmm0[1],xmm2[1],xmm0[2],xmm2[2],xmm0[3],xmm2[3]
-; SSE2-PCLMUL-NEXT:    pcmpeqd %xmm2, %xmm2
-; SSE2-PCLMUL-NEXT:    movdqa %xmm0, %xmm3
-; SSE2-PCLMUL-NEXT:    pclmulqdq $17, %xmm2, %xmm3
-; SSE2-PCLMUL-NEXT:    movdqa %xmm0, %xmm4
-; SSE2-PCLMUL-NEXT:    psrlq $32, %xmm4
-; SSE2-PCLMUL-NEXT:    movdqa {{.*#+}} xmm5 = [255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0]
-; SSE2-PCLMUL-NEXT:    movdqa %xmm4, %xmm6
-; SSE2-PCLMUL-NEXT:    pclmulqdq $17, %xmm5, %xmm6
-; SSE2-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm3 = xmm3[0],xmm6[0],xmm3[1],xmm6[1]
-; SSE2-PCLMUL-NEXT:    pclmulqdq $0, %xmm2, %xmm0
-; SSE2-PCLMUL-NEXT:    pclmulqdq $0, %xmm5, %xmm4
-; SSE2-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm0 = xmm0[0],xmm4[0],xmm0[1],xmm4[1]
-; SSE2-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm0 = xmm0[0],xmm3[0],xmm0[1],xmm3[1]
+; SSE2-PCLMUL-NEXT:    pxor %xmm0, %xmm0
 ; SSE2-PCLMUL-NEXT:    movdqa %xmm1, %xmm3
-; SSE2-PCLMUL-NEXT:    pclmulqdq $17, %xmm2, %xmm3
+; SSE2-PCLMUL-NEXT:    punpckhwd {{.*#+}} xmm3 = xmm3[4],xmm0[4],xmm3[5],xmm0[5],xmm3[6],xmm0[6],xmm3[7],xmm0[7]
+; SSE2-PCLMUL-NEXT:    punpcklwd {{.*#+}} xmm1 = xmm1[0],xmm0[0],xmm1[1],xmm0[1],xmm1[2],xmm0[2],xmm1[3],xmm0[3]
+; SSE2-PCLMUL-NEXT:    pcmpeqd %xmm2, %xmm2
 ; SSE2-PCLMUL-NEXT:    movdqa %xmm1, %xmm4
-; SSE2-PCLMUL-NEXT:    psrlq $32, %xmm4
-; SSE2-PCLMUL-NEXT:    movdqa %xmm4, %xmm6
-; SSE2-PCLMUL-NEXT:    pclmulqdq $17, %xmm5, %xmm6
-; SSE2-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm3 = xmm3[0],xmm6[0],xmm3[1],xmm6[1]
-; SSE2-PCLMUL-NEXT:    pclmulqdq $0, %xmm2, %xmm1
-; SSE2-PCLMUL-NEXT:    pclmulqdq $0, %xmm5, %xmm4
-; SSE2-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm1 = xmm1[0],xmm4[0],xmm1[1],xmm4[1]
-; SSE2-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm1 = xmm1[0],xmm3[0],xmm1[1],xmm3[1]
-; SSE2-PCLMUL-NEXT:    paddd %xmm1, %xmm1
-; SSE2-PCLMUL-NEXT:    psrad $16, %xmm1
+; SSE2-PCLMUL-NEXT:    pclmulqdq $17, %xmm2, %xmm4
+; SSE2-PCLMUL-NEXT:    movdqa %xmm1, %xmm0
+; SSE2-PCLMUL-NEXT:    pclmulqdq $0, %xmm2, %xmm0
+; SSE2-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm0 = xmm0[0],xmm4[0],xmm0[1],xmm4[1]
+; SSE2-PCLMUL-NEXT:    psrlq $32, %xmm1
+; SSE2-PCLMUL-NEXT:    movdqa {{.*#+}} xmm4 = [255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0]
+; SSE2-PCLMUL-NEXT:    movdqa %xmm1, %xmm5
+; SSE2-PCLMUL-NEXT:    pclmulqdq $17, %xmm4, %xmm5
+; SSE2-PCLMUL-NEXT:    pclmulqdq $0, %xmm4, %xmm1
+; SSE2-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm1 = xmm1[0],xmm5[0],xmm1[1],xmm5[1]
+; SSE2-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm0 = xmm0[0],xmm1[0],xmm0[1],xmm1[1]
+; SSE2-PCLMUL-NEXT:    movdqa %xmm3, %xmm1
+; SSE2-PCLMUL-NEXT:    pclmulqdq $17, %xmm2, %xmm1
+; SSE2-PCLMUL-NEXT:    pclmulqdq $0, %xmm3, %xmm2
+; SSE2-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm2 = xmm2[0],xmm1[0],xmm2[1],xmm1[1]
+; SSE2-PCLMUL-NEXT:    psrlq $32, %xmm3
+; SSE2-PCLMUL-NEXT:    movdqa %xmm3, %xmm1
+; SSE2-PCLMUL-NEXT:    pclmulqdq $17, %xmm4, %xmm1
+; SSE2-PCLMUL-NEXT:    pclmulqdq $0, %xmm4, %xmm3
+; SSE2-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm3 = xmm3[0],xmm1[0],xmm3[1],xmm1[1]
+; SSE2-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm2 = xmm2[0],xmm3[0],xmm2[1],xmm3[1]
+; SSE2-PCLMUL-NEXT:    paddd %xmm2, %xmm2
+; SSE2-PCLMUL-NEXT:    psrad $16, %xmm2
 ; SSE2-PCLMUL-NEXT:    paddd %xmm0, %xmm0
 ; SSE2-PCLMUL-NEXT:    psrad $16, %xmm0
-; SSE2-PCLMUL-NEXT:    packssdw %xmm1, %xmm0
+; SSE2-PCLMUL-NEXT:    packssdw %xmm2, %xmm0
 ; SSE2-PCLMUL-NEXT:    retq
 ;
 ; SSE42-PCLMUL-LABEL: clmulr_v8i16_allones:
 ; SSE42-PCLMUL:       # %bb.0:
+; SSE42-PCLMUL-NEXT:    movdqa %xmm0, %xmm1
 ; SSE42-PCLMUL-NEXT:    pxor %xmm2, %xmm2
-; SSE42-PCLMUL-NEXT:    pmovzxwd {{.*#+}} xmm1 = xmm0[0],zero,xmm0[1],zero,xmm0[2],zero,xmm0[3],zero
-; SSE42-PCLMUL-NEXT:    punpckhwd {{.*#+}} xmm0 = xmm0[4],xmm2[4],xmm0[5],xmm2[5],xmm0[6],xmm2[6],xmm0[7],xmm2[7]
-; SSE42-PCLMUL-NEXT:    pcmpeqd %xmm3, %xmm3
-; SSE42-PCLMUL-NEXT:    movdqa %xmm0, %xmm4
-; SSE42-PCLMUL-NEXT:    pclmulqdq $17, %xmm3, %xmm4
-; SSE42-PCLMUL-NEXT:    movdqa %xmm0, %xmm5
-; SSE42-PCLMUL-NEXT:    psrlq $32, %xmm5
-; SSE42-PCLMUL-NEXT:    pmovsxbd {{.*#+}} xmm6 = [4294967295,0,4294967295,0]
-; SSE42-PCLMUL-NEXT:    movdqa %xmm5, %xmm7
-; SSE42-PCLMUL-NEXT:    pclmulqdq $17, %xmm6, %xmm7
-; SSE42-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm4 = xmm4[0],xmm7[0],xmm4[1],xmm7[1]
-; SSE42-PCLMUL-NEXT:    pclmulqdq $0, %xmm3, %xmm0
-; SSE42-PCLMUL-NEXT:    pclmulqdq $0, %xmm6, %xmm5
-; SSE42-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm0 = xmm0[0],xmm5[0],xmm0[1],xmm5[1]
-; SSE42-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm0 = xmm0[0],xmm4[0],xmm0[1],xmm4[1]
-; SSE42-PCLMUL-NEXT:    movdqa %xmm1, %xmm4
-; SSE42-PCLMUL-NEXT:    pclmulqdq $17, %xmm3, %xmm4
+; SSE42-PCLMUL-NEXT:    pmovzxwd {{.*#+}} xmm4 = xmm0[0],zero,xmm0[1],zero,xmm0[2],zero,xmm0[3],zero
+; SSE42-PCLMUL-NEXT:    punpckhwd {{.*#+}} xmm1 = xmm1[4],xmm2[4],xmm1[5],xmm2[5],xmm1[6],xmm2[6],xmm1[7],xmm2[7]
+; SSE42-PCLMUL-NEXT:    pcmpeqd %xmm0, %xmm0
 ; SSE42-PCLMUL-NEXT:    movdqa %xmm1, %xmm5
-; SSE42-PCLMUL-NEXT:    psrlq $32, %xmm5
-; SSE42-PCLMUL-NEXT:    movdqa %xmm5, %xmm7
-; SSE42-PCLMUL-NEXT:    pclmulqdq $17, %xmm6, %xmm7
-; SSE42-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm4 = xmm4[0],xmm7[0],xmm4[1],xmm7[1]
-; SSE42-PCLMUL-NEXT:    pclmulqdq $0, %xmm3, %xmm1
-; SSE42-PCLMUL-NEXT:    pclmulqdq $0, %xmm6, %xmm5
-; SSE42-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm1 = xmm1[0],xmm5[0],xmm1[1],xmm5[1]
-; SSE42-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm1 = xmm1[0],xmm4[0],xmm1[1],xmm4[1]
-; SSE42-PCLMUL-NEXT:    psrld $15, %xmm1
+; SSE42-PCLMUL-NEXT:    pclmulqdq $17, %xmm0, %xmm5
+; SSE42-PCLMUL-NEXT:    movdqa %xmm1, %xmm3
+; SSE42-PCLMUL-NEXT:    pclmulqdq $0, %xmm0, %xmm3
+; SSE42-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm3 = xmm3[0],xmm5[0],xmm3[1],xmm5[1]
+; SSE42-PCLMUL-NEXT:    psrlq $32, %xmm1
+; SSE42-PCLMUL-NEXT:    pmovsxbd {{.*#+}} xmm5 = [4294967295,0,4294967295,0]
+; SSE42-PCLMUL-NEXT:    movdqa %xmm1, %xmm6
+; SSE42-PCLMUL-NEXT:    pclmulqdq $17, %xmm5, %xmm6
+; SSE42-PCLMUL-NEXT:    pclmulqdq $0, %xmm5, %xmm1
+; SSE42-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm1 = xmm1[0],xmm6[0],xmm1[1],xmm6[1]
+; SSE42-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm3 = xmm3[0],xmm1[0],xmm3[1],xmm1[1]
+; SSE42-PCLMUL-NEXT:    movdqa %xmm4, %xmm1
+; SSE42-PCLMUL-NEXT:    pclmulqdq $17, %xmm0, %xmm1
+; SSE42-PCLMUL-NEXT:    pclmulqdq $0, %xmm4, %xmm0
+; SSE42-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm0 = xmm0[0],xmm1[0],xmm0[1],xmm1[1]
+; SSE42-PCLMUL-NEXT:    psrlq $32, %xmm4
+; SSE42-PCLMUL-NEXT:    movdqa %xmm4, %xmm1
+; SSE42-PCLMUL-NEXT:    pclmulqdq $17, %xmm5, %xmm1
+; SSE42-PCLMUL-NEXT:    pclmulqdq $0, %xmm5, %xmm4
+; SSE42-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm4 = xmm4[0],xmm1[0],xmm4[1],xmm1[1]
+; SSE42-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm0 = xmm0[0],xmm4[0],xmm0[1],xmm4[1]
 ; SSE42-PCLMUL-NEXT:    psrld $15, %xmm0
+; SSE42-PCLMUL-NEXT:    psrld $15, %xmm3
+; SSE42-PCLMUL-NEXT:    pblendw {{.*#+}} xmm3 = xmm3[0],xmm2[1],xmm3[2],xmm2[3],xmm3[4],xmm2[5],xmm3[6],xmm2[7]
 ; SSE42-PCLMUL-NEXT:    pblendw {{.*#+}} xmm0 = xmm0[0],xmm2[1],xmm0[2],xmm2[3],xmm0[4],xmm2[5],xmm0[6],xmm2[7]
-; SSE42-PCLMUL-NEXT:    pblendw {{.*#+}} xmm1 = xmm1[0],xmm2[1],xmm1[2],xmm2[3],xmm1[4],xmm2[5],xmm1[6],xmm2[7]
-; SSE42-PCLMUL-NEXT:    packusdw %xmm0, %xmm1
-; SSE42-PCLMUL-NEXT:    movdqa %xmm1, %xmm0
+; SSE42-PCLMUL-NEXT:    packusdw %xmm3, %xmm0
 ; SSE42-PCLMUL-NEXT:    retq
 ;
 ; AVX2-PCLMUL-LABEL: clmulr_v8i16_allones:
@@ -6901,22 +6896,22 @@ define <8 x i16> @clmulr_v8i16_allones(<8 x i16> %x) nounwind {
 ; AVX2-PCLMUL-NEXT:    vextracti128 $1, %ymm0, %xmm1
 ; AVX2-PCLMUL-NEXT:    vpcmpeqd %xmm2, %xmm2, %xmm2
 ; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm2, %xmm1, %xmm3
-; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm1, %xmm4
-; AVX2-PCLMUL-NEXT:    vpbroadcastq {{.*#+}} xmm5 = [255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0]
-; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm5, %xmm4, %xmm6
-; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm3 = xmm3[0],xmm6[0],xmm3[1],xmm6[1]
-; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm2, %xmm1, %xmm1
-; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm5, %xmm4, %xmm4
-; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm1 = xmm1[0],xmm4[0],xmm1[1],xmm4[1]
-; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm1 = xmm1[0],xmm3[0],xmm1[1],xmm3[1]
+; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm2, %xmm1, %xmm4
+; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm3 = xmm4[0],xmm3[0],xmm4[1],xmm3[1]
+; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm1, %xmm1
+; AVX2-PCLMUL-NEXT:    vpbroadcastq {{.*#+}} xmm4 = [255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0]
+; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm4, %xmm1, %xmm5
+; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm4, %xmm1, %xmm1
+; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm1 = xmm1[0],xmm5[0],xmm1[1],xmm5[1]
+; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm1 = xmm3[0],xmm1[0],xmm3[1],xmm1[1]
 ; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm2, %xmm0, %xmm3
-; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm0, %xmm4
-; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm5, %xmm4, %xmm6
-; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm3 = xmm3[0],xmm6[0],xmm3[1],xmm6[1]
-; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm2, %xmm0, %xmm0
-; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm5, %xmm4, %xmm2
-; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm0[0],xmm2[0],xmm0[1],xmm2[1]
+; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm2, %xmm0, %xmm2
+; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm3[0],xmm2[1],xmm3[1]
+; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm0, %xmm0
+; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm4, %xmm0, %xmm3
+; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm4, %xmm0, %xmm0
 ; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm0[0],xmm3[0],xmm0[1],xmm3[1]
+; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm2[0],xmm0[0],xmm2[1],xmm0[1]
 ; AVX2-PCLMUL-NEXT:    vinserti128 $1, %xmm1, %ymm0, %ymm0
 ; AVX2-PCLMUL-NEXT:    vpsrld $15, %ymm0, %ymm0
 ; AVX2-PCLMUL-NEXT:    vpshufb {{.*#+}} ymm0 = ymm0[0,1,4,5,8,9,12,13,u,u,u,u,u,u,u,u,16,17,20,21,24,25,28,29,u,u,u,u,u,u,u,u]
@@ -6930,14 +6925,14 @@ define <8 x i16> @clmulr_v8i16_allones(<8 x i16> %x) nounwind {
 ; AVX2-VPCLMULQDQ-NEXT:    vpmovzxwd {{.*#+}} ymm0 = xmm0[0],zero,xmm0[1],zero,xmm0[2],zero,xmm0[3],zero,xmm0[4],zero,xmm0[5],zero,xmm0[6],zero,xmm0[7],zero
 ; AVX2-VPCLMULQDQ-NEXT:    vpcmpeqd %ymm1, %ymm1, %ymm1
 ; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $17, %ymm1, %ymm0, %ymm2
-; AVX2-VPCLMULQDQ-NEXT:    vpsrlq $32, %ymm0, %ymm3
-; AVX2-VPCLMULQDQ-NEXT:    vpbroadcastq {{.*#+}} ymm4 = [255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0]
-; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $17, %ymm4, %ymm3, %ymm5
-; AVX2-VPCLMULQDQ-NEXT:    vpunpckldq {{.*#+}} ymm2 = ymm2[0],ymm5[0],ymm2[1],ymm5[1],ymm2[4],ymm5[4],ymm2[5],ymm5[5]
-; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $0, %ymm1, %ymm0, %ymm0
-; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $0, %ymm4, %ymm3, %ymm1
-; AVX2-VPCLMULQDQ-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm0[0],ymm1[0],ymm0[1],ymm1[1],ymm0[4],ymm1[4],ymm0[5],ymm1[5]
-; AVX2-VPCLMULQDQ-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm0[0],ymm2[0],ymm0[1],ymm2[1],ymm0[4],ymm2[4],ymm0[5],ymm2[5]
+; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $0, %ymm1, %ymm0, %ymm1
+; AVX2-VPCLMULQDQ-NEXT:    vpunpckldq {{.*#+}} ymm1 = ymm1[0],ymm2[0],ymm1[1],ymm2[1],ymm1[4],ymm2[4],ymm1[5],ymm2[5]
+; AVX2-VPCLMULQDQ-NEXT:    vpsrlq $32, %ymm0, %ymm0
+; AVX2-VPCLMULQDQ-NEXT:    vpbroadcastq {{.*#+}} ymm2 = [255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0]
+; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $17, %ymm2, %ymm0, %ymm3
+; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $0, %ymm2, %ymm0, %ymm0
+; AVX2-VPCLMULQDQ-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm0[0],ymm3[0],ymm0[1],ymm3[1],ymm0[4],ymm3[4],ymm0[5],ymm3[5]
+; AVX2-VPCLMULQDQ-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm1[0],ymm0[0],ymm1[1],ymm0[1],ymm1[4],ymm0[4],ymm1[5],ymm0[5]
 ; AVX2-VPCLMULQDQ-NEXT:    vpsrld $15, %ymm0, %ymm0
 ; AVX2-VPCLMULQDQ-NEXT:    vpshufb {{.*#+}} ymm0 = ymm0[0,1,4,5,8,9,12,13,u,u,u,u,u,u,u,u,16,17,20,21,24,25,28,29,u,u,u,u,u,u,u,u]
 ; AVX2-VPCLMULQDQ-NEXT:    vpermq {{.*#+}} ymm0 = ymm0[0,2,2,3]
@@ -6950,14 +6945,14 @@ define <8 x i16> @clmulr_v8i16_allones(<8 x i16> %x) nounwind {
 ; AVX512-NEXT:    vpmovzxwd {{.*#+}} ymm0 = xmm0[0],zero,xmm0[1],zero,xmm0[2],zero,xmm0[3],zero,xmm0[4],zero,xmm0[5],zero,xmm0[6],zero,xmm0[7],zero
 ; AVX512-NEXT:    vpcmpeqd %ymm1, %ymm1, %ymm1
 ; AVX512-NEXT:    vpclmulqdq $17, %ymm1, %ymm0, %ymm2
-; AVX512-NEXT:    vpsrlq $32, %ymm0, %ymm3
-; AVX512-NEXT:    vpbroadcastq {{.*#+}} ymm4 = [255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0]
-; AVX512-NEXT:    vpclmulqdq $17, %ymm4, %ymm3, %ymm5
-; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm2 = ymm2[0],ymm5[0],ymm2[1],ymm5[1],ymm2[4],ymm5[4],ymm2[5],ymm5[5]
-; AVX512-NEXT:    vpclmulqdq $0, %ymm1, %ymm0, %ymm0
-; AVX512-NEXT:    vpclmulqdq $0, %ymm4, %ymm3, %ymm1
-; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm0[0],ymm1[0],ymm0[1],ymm1[1],ymm0[4],ymm1[4],ymm0[5],ymm1[5]
-; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm0[0],ymm2[0],ymm0[1],ymm2[1],ymm0[4],ymm2[4],ymm0[5],ymm2[5]
+; AVX512-NEXT:    vpclmulqdq $0, %ymm1, %ymm0, %ymm1
+; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm1 = ymm1[0],ymm2[0],ymm1[1],ymm2[1],ymm1[4],ymm2[4],ymm1[5],ymm2[5]
+; AVX512-NEXT:    vpsrlq $32, %ymm0, %ymm0
+; AVX512-NEXT:    vpbroadcastq {{.*#+}} ymm2 = [255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0]
+; AVX512-NEXT:    vpclmulqdq $17, %ymm2, %ymm0, %ymm3
+; AVX512-NEXT:    vpclmulqdq $0, %ymm2, %ymm0, %ymm0
+; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm0[0],ymm3[0],ymm0[1],ymm3[1],ymm0[4],ymm3[4],ymm0[5],ymm3[5]
+; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm1[0],ymm0[0],ymm1[1],ymm0[1],ymm1[4],ymm0[4],ymm1[5],ymm0[5]
 ; AVX512-NEXT:    vpsrld $15, %ymm0, %ymm0
 ; AVX512-NEXT:    vpmovdw %ymm0, %xmm0
 ; AVX512-NEXT:    vzeroupper
@@ -7744,71 +7739,70 @@ define <8 x i16> @clmulh_v8i16_allones(<8 x i16> %x) nounwind {
 ;
 ; SSE2-PCLMUL-LABEL: clmulh_v8i16_allones:
 ; SSE2-PCLMUL:       # %bb.0:
-; SSE2-PCLMUL-NEXT:    pxor %xmm2, %xmm2
 ; SSE2-PCLMUL-NEXT:    movdqa %xmm0, %xmm1
-; SSE2-PCLMUL-NEXT:    punpckhwd {{.*#+}} xmm1 = xmm1[4],xmm2[4],xmm1[5],xmm2[5],xmm1[6],xmm2[6],xmm1[7],xmm2[7]
-; SSE2-PCLMUL-NEXT:    punpcklwd {{.*#+}} xmm0 = xmm0[0],xmm2[0],xmm0[1],xmm2[1],xmm0[2],xmm2[2],xmm0[3],xmm2[3]
-; SSE2-PCLMUL-NEXT:    pcmpeqd %xmm2, %xmm2
-; SSE2-PCLMUL-NEXT:    movdqa %xmm0, %xmm3
-; SSE2-PCLMUL-NEXT:    pclmulqdq $17, %xmm2, %xmm3
-; SSE2-PCLMUL-NEXT:    movdqa %xmm0, %xmm4
-; SSE2-PCLMUL-NEXT:    psrlq $32, %xmm4
-; SSE2-PCLMUL-NEXT:    movdqa {{.*#+}} xmm5 = [255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0]
-; SSE2-PCLMUL-NEXT:    movdqa %xmm4, %xmm6
-; SSE2-PCLMUL-NEXT:    pclmulqdq $17, %xmm5, %xmm6
-; SSE2-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm3 = xmm3[0],xmm6[0],xmm3[1],xmm6[1]
-; SSE2-PCLMUL-NEXT:    pclmulqdq $0, %xmm2, %xmm0
-; SSE2-PCLMUL-NEXT:    pclmulqdq $0, %xmm5, %xmm4
-; SSE2-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm0 = xmm0[0],xmm4[0],xmm0[1],xmm4[1]
-; SSE2-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm0 = xmm0[0],xmm3[0],xmm0[1],xmm3[1]
+; SSE2-PCLMUL-NEXT:    pxor %xmm0, %xmm0
 ; SSE2-PCLMUL-NEXT:    movdqa %xmm1, %xmm3
-; SSE2-PCLMUL-NEXT:    pclmulqdq $17, %xmm2, %xmm3
+; SSE2-PCLMUL-NEXT:    punpckhwd {{.*#+}} xmm3 = xmm3[4],xmm0[4],xmm3[5],xmm0[5],xmm3[6],xmm0[6],xmm3[7],xmm0[7]
+; SSE2-PCLMUL-NEXT:    punpcklwd {{.*#+}} xmm1 = xmm1[0],xmm0[0],xmm1[1],xmm0[1],xmm1[2],xmm0[2],xmm1[3],xmm0[3]
+; SSE2-PCLMUL-NEXT:    pcmpeqd %xmm2, %xmm2
 ; SSE2-PCLMUL-NEXT:    movdqa %xmm1, %xmm4
-; SSE2-PCLMUL-NEXT:    psrlq $32, %xmm4
-; SSE2-PCLMUL-NEXT:    movdqa %xmm4, %xmm6
-; SSE2-PCLMUL-NEXT:    pclmulqdq $17, %xmm5, %xmm6
-; SSE2-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm3 = xmm3[0],xmm6[0],xmm3[1],xmm6[1]
-; SSE2-PCLMUL-NEXT:    pclmulqdq $0, %xmm2, %xmm1
-; SSE2-PCLMUL-NEXT:    pclmulqdq $0, %xmm5, %xmm4
-; SSE2-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm1 = xmm1[0],xmm4[0],xmm1[1],xmm4[1]
-; SSE2-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm1 = xmm1[0],xmm3[0],xmm1[1],xmm3[1]
-; SSE2-PCLMUL-NEXT:    psrad $16, %xmm1
+; SSE2-PCLMUL-NEXT:    pclmulqdq $17, %xmm2, %xmm4
+; SSE2-PCLMUL-NEXT:    movdqa %xmm1, %xmm0
+; SSE2-PCLMUL-NEXT:    pclmulqdq $0, %xmm2, %xmm0
+; SSE2-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm0 = xmm0[0],xmm4[0],xmm0[1],xmm4[1]
+; SSE2-PCLMUL-NEXT:    psrlq $32, %xmm1
+; SSE2-PCLMUL-NEXT:    movdqa {{.*#+}} xmm4 = [255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0]
+; SSE2-PCLMUL-NEXT:    movdqa %xmm1, %xmm5
+; SSE2-PCLMUL-NEXT:    pclmulqdq $17, %xmm4, %xmm5
+; SSE2-PCLMUL-NEXT:    pclmulqdq $0, %xmm4, %xmm1
+; SSE2-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm1 = xmm1[0],xmm5[0],xmm1[1],xmm5[1]
+; SSE2-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm0 = xmm0[0],xmm1[0],xmm0[1],xmm1[1]
+; SSE2-PCLMUL-NEXT:    movdqa %xmm3, %xmm1
+; SSE2-PCLMUL-NEXT:    pclmulqdq $17, %xmm2, %xmm1
+; SSE2-PCLMUL-NEXT:    pclmulqdq $0, %xmm3, %xmm2
+; SSE2-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm2 = xmm2[0],xmm1[0],xmm2[1],xmm1[1]
+; SSE2-PCLMUL-NEXT:    psrlq $32, %xmm3
+; SSE2-PCLMUL-NEXT:    movdqa %xmm3, %xmm1
+; SSE2-PCLMUL-NEXT:    pclmulqdq $17, %xmm4, %xmm1
+; SSE2-PCLMUL-NEXT:    pclmulqdq $0, %xmm4, %xmm3
+; SSE2-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm3 = xmm3[0],xmm1[0],xmm3[1],xmm1[1]
+; SSE2-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm2 = xmm2[0],xmm3[0],xmm2[1],xmm3[1]
+; SSE2-PCLMUL-NEXT:    psrad $16, %xmm2
 ; SSE2-PCLMUL-NEXT:    psrad $16, %xmm0
-; SSE2-PCLMUL-NEXT:    packssdw %xmm1, %xmm0
+; SSE2-PCLMUL-NEXT:    packssdw %xmm2, %xmm0
 ; SSE2-PCLMUL-NEXT:    retq
 ;
 ; SSE42-PCLMUL-LABEL: clmulh_v8i16_allones:
 ; SSE42-PCLMUL:       # %bb.0:
-; SSE42-PCLMUL-NEXT:    pxor %xmm2, %xmm2
-; SSE42-PCLMUL-NEXT:    pmovzxwd {{.*#+}} xmm1 = xmm0[0],zero,xmm0[1],zero,xmm0[2],zero,xmm0[3],zero
-; SSE42-PCLMUL-NEXT:    punpckhwd {{.*#+}} xmm0 = xmm0[4],xmm2[4],xmm0[5],xmm2[5],xmm0[6],xmm2[6],xmm0[7],xmm2[7]
+; SSE42-PCLMUL-NEXT:    pxor %xmm1, %xmm1
+; SSE42-PCLMUL-NEXT:    pmovzxwd {{.*#+}} xmm3 = xmm0[0],zero,xmm0[1],zero,xmm0[2],zero,xmm0[3],zero
+; SSE42-PCLMUL-NEXT:    punpckhwd {{.*#+}} xmm0 = xmm0[4],xmm1[4],xmm0[5],xmm1[5],xmm0[6],xmm1[6],xmm0[7],xmm1[7]
 ; SSE42-PCLMUL-NEXT:    pcmpeqd %xmm2, %xmm2
-; SSE42-PCLMUL-NEXT:    movdqa %xmm1, %xmm3
-; SSE42-PCLMUL-NEXT:    pclmulqdq $17, %xmm2, %xmm3
-; SSE42-PCLMUL-NEXT:    movdqa %xmm1, %xmm4
-; SSE42-PCLMUL-NEXT:    psrlq $32, %xmm4
-; SSE42-PCLMUL-NEXT:    pmovsxbd {{.*#+}} xmm5 = [4294967295,0,4294967295,0]
-; SSE42-PCLMUL-NEXT:    movdqa %xmm4, %xmm6
-; SSE42-PCLMUL-NEXT:    pclmulqdq $17, %xmm5, %xmm6
-; SSE42-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm3 = xmm3[0],xmm6[0],xmm3[1],xmm6[1]
+; SSE42-PCLMUL-NEXT:    movdqa %xmm3, %xmm4
+; SSE42-PCLMUL-NEXT:    pclmulqdq $17, %xmm2, %xmm4
+; SSE42-PCLMUL-NEXT:    movdqa %xmm3, %xmm1
 ; SSE42-PCLMUL-NEXT:    pclmulqdq $0, %xmm2, %xmm1
-; SSE42-PCLMUL-NEXT:    pclmulqdq $0, %xmm5, %xmm4
 ; SSE42-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm1 = xmm1[0],xmm4[0],xmm1[1],xmm4[1]
+; SSE42-PCLMUL-NEXT:    psrlq $32, %xmm3
+; SSE42-PCLMUL-NEXT:    pmovsxbd {{.*#+}} xmm4 = [4294967295,0,4294967295,0]
+; SSE42-PCLMUL-NEXT:    movdqa %xmm3, %xmm5
+; SSE42-PCLMUL-NEXT:    pclmulqdq $17, %xmm4, %xmm5
+; SSE42-PCLMUL-NEXT:    pclmulqdq $0, %xmm4, %xmm3
+; SSE42-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm3 = xmm3[0],xmm5[0],xmm3[1],xmm5[1]
 ; SSE42-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm1 = xmm1[0],xmm3[0],xmm1[1],xmm3[1]
 ; SSE42-PCLMUL-NEXT:    movdqa %xmm0, %xmm3
 ; SSE42-PCLMUL-NEXT:    pclmulqdq $17, %xmm2, %xmm3
-; SSE42-PCLMUL-NEXT:    movdqa %xmm0, %xmm4
-; SSE42-PCLMUL-NEXT:    psrlq $32, %xmm4
-; SSE42-PCLMUL-NEXT:    movdqa %xmm4, %xmm6
-; SSE42-PCLMUL-NEXT:    pclmulqdq $17, %xmm5, %xmm6
-; SSE42-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm3 = xmm3[0],xmm6[0],xmm3[1],xmm6[1]
-; SSE42-PCLMUL-NEXT:    pclmulqdq $0, %xmm2, %xmm0
-; SSE42-PCLMUL-NEXT:    pclmulqdq $0, %xmm5, %xmm4
-; SSE42-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm0 = xmm0[0],xmm4[0],xmm0[1],xmm4[1]
+; SSE42-PCLMUL-NEXT:    pclmulqdq $0, %xmm0, %xmm2
+; SSE42-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm2 = xmm2[0],xmm3[0],xmm2[1],xmm3[1]
+; SSE42-PCLMUL-NEXT:    psrlq $32, %xmm0
+; SSE42-PCLMUL-NEXT:    movdqa %xmm0, %xmm3
+; SSE42-PCLMUL-NEXT:    pclmulqdq $17, %xmm4, %xmm3
+; SSE42-PCLMUL-NEXT:    pclmulqdq $0, %xmm4, %xmm0
 ; SSE42-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm0 = xmm0[0],xmm3[0],xmm0[1],xmm3[1]
-; SSE42-PCLMUL-NEXT:    psrld $16, %xmm0
+; SSE42-PCLMUL-NEXT:    punpckldq {{.*#+}} xmm2 = xmm2[0],xmm0[0],xmm2[1],xmm0[1]
+; SSE42-PCLMUL-NEXT:    psrld $16, %xmm2
 ; SSE42-PCLMUL-NEXT:    psrld $16, %xmm1
-; SSE42-PCLMUL-NEXT:    packusdw %xmm0, %xmm1
+; SSE42-PCLMUL-NEXT:    packusdw %xmm2, %xmm1
 ; SSE42-PCLMUL-NEXT:    movdqa %xmm1, %xmm0
 ; SSE42-PCLMUL-NEXT:    retq
 ;
@@ -7818,22 +7812,22 @@ define <8 x i16> @clmulh_v8i16_allones(<8 x i16> %x) nounwind {
 ; AVX2-PCLMUL-NEXT:    vextracti128 $1, %ymm0, %xmm1
 ; AVX2-PCLMUL-NEXT:    vpcmpeqd %xmm2, %xmm2, %xmm2
 ; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm2, %xmm1, %xmm3
-; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm1, %xmm4
-; AVX2-PCLMUL-NEXT:    vpbroadcastq {{.*#+}} xmm5 = [255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0]
-; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm5, %xmm4, %xmm6
-; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm3 = xmm3[0],xmm6[0],xmm3[1],xmm6[1]
-; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm2, %xmm1, %xmm1
-; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm5, %xmm4, %xmm4
-; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm1 = xmm1[0],xmm4[0],xmm1[1],xmm4[1]
-; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm1 = xmm1[0],xmm3[0],xmm1[1],xmm3[1]
+; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm2, %xmm1, %xmm4
+; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm3 = xmm4[0],xmm3[0],xmm4[1],xmm3[1]
+; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm1, %xmm1
+; AVX2-PCLMUL-NEXT:    vpbroadcastq {{.*#+}} xmm4 = [255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0]
+; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm4, %xmm1, %xmm5
+; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm4, %xmm1, %xmm1
+; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm1 = xmm1[0],xmm5[0],xmm1[1],xmm5[1]
+; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm1 = xmm3[0],xmm1[0],xmm3[1],xmm1[1]
 ; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm2, %xmm0, %xmm3
-; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm0, %xmm4
-; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm5, %xmm4, %xmm6
-; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm3 = xmm3[0],xmm6[0],xmm3[1],xmm6[1]
-; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm2, %xmm0, %xmm0
-; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm5, %xmm4, %xmm2
-; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm0[0],xmm2[0],xmm0[1],xmm2[1]
+; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm2, %xmm0, %xmm2
+; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm3[0],xmm2[1],xmm3[1]
+; AVX2-PCLMUL-NEXT:    vpsrlq $32, %xmm0, %xmm0
+; AVX2-PCLMUL-NEXT:    vpclmulqdq $17, %xmm4, %xmm0, %xmm3
+; AVX2-PCLMUL-NEXT:    vpclmulqdq $0, %xmm4, %xmm0, %xmm0
 ; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm0[0],xmm3[0],xmm0[1],xmm3[1]
+; AVX2-PCLMUL-NEXT:    vpunpckldq {{.*#+}} xmm0 = xmm2[0],xmm0[0],xmm2[1],xmm0[1]
 ; AVX2-PCLMUL-NEXT:    vinserti128 $1, %xmm1, %ymm0, %ymm0
 ; AVX2-PCLMUL-NEXT:    vpsrld $16, %ymm0, %ymm0
 ; AVX2-PCLMUL-NEXT:    vextracti128 $1, %ymm0, %xmm1
@@ -7846,14 +7840,14 @@ define <8 x i16> @clmulh_v8i16_allones(<8 x i16> %x) nounwind {
 ; AVX2-VPCLMULQDQ-NEXT:    vpmovzxwd {{.*#+}} ymm0 = xmm0[0],zero,xmm0[1],zero,xmm0[2],zero,xmm0[3],zero,xmm0[4],zero,xmm0[5],zero,xmm0[6],zero,xmm0[7],zero
 ; AVX2-VPCLMULQDQ-NEXT:    vpcmpeqd %ymm1, %ymm1, %ymm1
 ; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $17, %ymm1, %ymm0, %ymm2
-; AVX2-VPCLMULQDQ-NEXT:    vpsrlq $32, %ymm0, %ymm3
-; AVX2-VPCLMULQDQ-NEXT:    vpbroadcastq {{.*#+}} ymm4 = [255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0]
-; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $17, %ymm4, %ymm3, %ymm5
-; AVX2-VPCLMULQDQ-NEXT:    vpunpckldq {{.*#+}} ymm2 = ymm2[0],ymm5[0],ymm2[1],ymm5[1],ymm2[4],ymm5[4],ymm2[5],ymm5[5]
-; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $0, %ymm1, %ymm0, %ymm0
-; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $0, %ymm4, %ymm3, %ymm1
-; AVX2-VPCLMULQDQ-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm0[0],ymm1[0],ymm0[1],ymm1[1],ymm0[4],ymm1[4],ymm0[5],ymm1[5]
-; AVX2-VPCLMULQDQ-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm0[0],ymm2[0],ymm0[1],ymm2[1],ymm0[4],ymm2[4],ymm0[5],ymm2[5]
+; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $0, %ymm1, %ymm0, %ymm1
+; AVX2-VPCLMULQDQ-NEXT:    vpunpckldq {{.*#+}} ymm1 = ymm1[0],ymm2[0],ymm1[1],ymm2[1],ymm1[4],ymm2[4],ymm1[5],ymm2[5]
+; AVX2-VPCLMULQDQ-NEXT:    vpsrlq $32, %ymm0, %ymm0
+; AVX2-VPCLMULQDQ-NEXT:    vpbroadcastq {{.*#+}} ymm2 = [255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0]
+; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $17, %ymm2, %ymm0, %ymm3
+; AVX2-VPCLMULQDQ-NEXT:    vpclmulqdq $0, %ymm2, %ymm0, %ymm0
+; AVX2-VPCLMULQDQ-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm0[0],ymm3[0],ymm0[1],ymm3[1],ymm0[4],ymm3[4],ymm0[5],ymm3[5]
+; AVX2-VPCLMULQDQ-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm1[0],ymm0[0],ymm1[1],ymm0[1],ymm1[4],ymm0[4],ymm1[5],ymm0[5]
 ; AVX2-VPCLMULQDQ-NEXT:    vpsrld $16, %ymm0, %ymm0
 ; AVX2-VPCLMULQDQ-NEXT:    vextracti128 $1, %ymm0, %xmm1
 ; AVX2-VPCLMULQDQ-NEXT:    vpackusdw %xmm1, %xmm0, %xmm0
@@ -7865,14 +7859,14 @@ define <8 x i16> @clmulh_v8i16_allones(<8 x i16> %x) nounwind {
 ; AVX512-NEXT:    vpmovzxwd {{.*#+}} ymm0 = xmm0[0],zero,xmm0[1],zero,xmm0[2],zero,xmm0[3],zero,xmm0[4],zero,xmm0[5],zero,xmm0[6],zero,xmm0[7],zero
 ; AVX512-NEXT:    vpcmpeqd %ymm1, %ymm1, %ymm1
 ; AVX512-NEXT:    vpclmulqdq $17, %ymm1, %ymm0, %ymm2
-; AVX512-NEXT:    vpsrlq $32, %ymm0, %ymm3
-; AVX512-NEXT:    vpbroadcastq {{.*#+}} ymm4 = [255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0]
-; AVX512-NEXT:    vpclmulqdq $17, %ymm4, %ymm3, %ymm5
-; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm2 = ymm2[0],ymm5[0],ymm2[1],ymm5[1],ymm2[4],ymm5[4],ymm2[5],ymm5[5]
-; AVX512-NEXT:    vpclmulqdq $0, %ymm1, %ymm0, %ymm0
-; AVX512-NEXT:    vpclmulqdq $0, %ymm4, %ymm3, %ymm1
-; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm0[0],ymm1[0],ymm0[1],ymm1[1],ymm0[4],ymm1[4],ymm0[5],ymm1[5]
-; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm0[0],ymm2[0],ymm0[1],ymm2[1],ymm0[4],ymm2[4],ymm0[5],ymm2[5]
+; AVX512-NEXT:    vpclmulqdq $0, %ymm1, %ymm0, %ymm1
+; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm1 = ymm1[0],ymm2[0],ymm1[1],ymm2[1],ymm1[4],ymm2[4],ymm1[5],ymm2[5]
+; AVX512-NEXT:    vpsrlq $32, %ymm0, %ymm0
+; AVX512-NEXT:    vpbroadcastq {{.*#+}} ymm2 = [255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0]
+; AVX512-NEXT:    vpclmulqdq $17, %ymm2, %ymm0, %ymm3
+; AVX512-NEXT:    vpclmulqdq $0, %ymm2, %ymm0, %ymm0
+; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm0[0],ymm3[0],ymm0[1],ymm3[1],ymm0[4],ymm3[4],ymm0[5],ymm3[5]
+; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm0 = ymm1[0],ymm0[0],ymm1[1],ymm0[1],ymm1[4],ymm0[4],ymm1[5],ymm0[5]
 ; AVX512-NEXT:    vpsrld $16, %ymm0, %ymm0
 ; AVX512-NEXT:    vpmovdw %ymm0, %xmm0
 ; AVX512-NEXT:    vzeroupper

--- a/llvm/test/CodeGen/X86/pdep-vector-128.ll
+++ b/llvm/test/CodeGen/X86/pdep-vector-128.ll
@@ -311,16 +311,16 @@ define <8 x i16> @pdep_v8i16(<8 x i16> %val, <8 x i16> %mask) nounwind {
 ; AVX2-NEXT:    vpcmpeqd %xmm2, %xmm2, %xmm2
 ; AVX2-NEXT:    vpxor %xmm2, %xmm1, %xmm2
 ; AVX2-NEXT:    vpaddw %xmm2, %xmm2, %xmm6
-; AVX2-NEXT:    vpmovzxwd {{.*#+}} ymm4 = xmm6[0],zero,xmm6[1],zero,xmm6[2],zero,xmm6[3],zero,xmm6[4],zero,xmm6[5],zero,xmm6[6],zero,xmm6[7],zero
+; AVX2-NEXT:    vpmovzxwd {{.*#+}} ymm3 = xmm6[0],zero,xmm6[1],zero,xmm6[2],zero,xmm6[3],zero,xmm6[4],zero,xmm6[5],zero,xmm6[6],zero,xmm6[7],zero
 ; AVX2-NEXT:    vpbroadcastd {{.*#+}} ymm2 = [65535,65535,65535,65535,65535,65535,65535,65535]
-; AVX2-NEXT:    vpclmulqdq $17, %ymm2, %ymm4, %ymm5
-; AVX2-NEXT:    vpsrlq $32, %ymm4, %ymm7
+; AVX2-NEXT:    vpclmulqdq $17, %ymm2, %ymm3, %ymm4
+; AVX2-NEXT:    vpclmulqdq $0, %ymm2, %ymm3, %ymm5
+; AVX2-NEXT:    vpsrlq $32, %ymm3, %ymm7
 ; AVX2-NEXT:    vpbroadcastq {{.*#+}} ymm3 = [255,255,0,0,0,0,0,0,255,255,0,0,0,0,0,0,255,255,0,0,0,0,0,0,255,255,0,0,0,0,0,0]
 ; AVX2-NEXT:    vpclmulqdq $17, %ymm3, %ymm7, %ymm8
-; AVX2-NEXT:    vpclmulqdq $0, %ymm2, %ymm4, %ymm4
 ; AVX2-NEXT:    vpclmulqdq $0, %ymm3, %ymm7, %ymm7
-; AVX2-NEXT:    vpunpckldq {{.*#+}} ymm5 = ymm5[0],ymm8[0],ymm5[1],ymm8[1],ymm5[4],ymm8[4],ymm5[5],ymm8[5]
-; AVX2-NEXT:    vpunpckldq {{.*#+}} ymm4 = ymm4[0],ymm7[0],ymm4[1],ymm7[1],ymm4[4],ymm7[4],ymm4[5],ymm7[5]
+; AVX2-NEXT:    vpunpckldq {{.*#+}} ymm4 = ymm5[0],ymm4[0],ymm5[1],ymm4[1],ymm5[4],ymm4[4],ymm5[5],ymm4[5]
+; AVX2-NEXT:    vpunpckldq {{.*#+}} ymm5 = ymm7[0],ymm8[0],ymm7[1],ymm8[1],ymm7[4],ymm8[4],ymm7[5],ymm8[5]
 ; AVX2-NEXT:    vpunpckldq {{.*#+}} ymm4 = ymm4[0],ymm5[0],ymm4[1],ymm5[1],ymm4[4],ymm5[4],ymm4[5],ymm5[5]
 ; AVX2-NEXT:    vmovdqa {{.*#+}} ymm5 = [0,1,4,5,8,9,12,13,8,9,12,13,12,13,14,15,16,17,20,21,24,25,28,29,24,25,28,29,28,29,30,31]
 ; AVX2-NEXT:    vpshufb %ymm5, %ymm4, %ymm4
@@ -328,37 +328,37 @@ define <8 x i16> @pdep_v8i16(<8 x i16> %val, <8 x i16> %mask) nounwind {
 ; AVX2-NEXT:    vpandn %xmm6, %xmm4, %xmm7
 ; AVX2-NEXT:    vpmovzxwd {{.*#+}} ymm6 = xmm7[0],zero,xmm7[1],zero,xmm7[2],zero,xmm7[3],zero,xmm7[4],zero,xmm7[5],zero,xmm7[6],zero,xmm7[7],zero
 ; AVX2-NEXT:    vpclmulqdq $17, %ymm2, %ymm6, %ymm8
-; AVX2-NEXT:    vpsrlq $32, %ymm6, %ymm9
-; AVX2-NEXT:    vpclmulqdq $17, %ymm3, %ymm9, %ymm10
-; AVX2-NEXT:    vpunpckldq {{.*#+}} ymm8 = ymm8[0],ymm10[0],ymm8[1],ymm10[1],ymm8[4],ymm10[4],ymm8[5],ymm10[5]
-; AVX2-NEXT:    vpclmulqdq $0, %ymm2, %ymm6, %ymm6
-; AVX2-NEXT:    vpclmulqdq $0, %ymm3, %ymm9, %ymm9
+; AVX2-NEXT:    vpclmulqdq $0, %ymm2, %ymm6, %ymm9
+; AVX2-NEXT:    vpunpckldq {{.*#+}} ymm8 = ymm9[0],ymm8[0],ymm9[1],ymm8[1],ymm9[4],ymm8[4],ymm9[5],ymm8[5]
+; AVX2-NEXT:    vpsrlq $32, %ymm6, %ymm6
+; AVX2-NEXT:    vpclmulqdq $17, %ymm3, %ymm6, %ymm9
+; AVX2-NEXT:    vpclmulqdq $0, %ymm3, %ymm6, %ymm6
 ; AVX2-NEXT:    vpunpckldq {{.*#+}} ymm6 = ymm6[0],ymm9[0],ymm6[1],ymm9[1],ymm6[4],ymm9[4],ymm6[5],ymm9[5]
-; AVX2-NEXT:    vpunpckldq {{.*#+}} ymm6 = ymm6[0],ymm8[0],ymm6[1],ymm8[1],ymm6[4],ymm8[4],ymm6[5],ymm8[5]
+; AVX2-NEXT:    vpunpckldq {{.*#+}} ymm6 = ymm8[0],ymm6[0],ymm8[1],ymm6[1],ymm8[4],ymm6[4],ymm8[5],ymm6[5]
 ; AVX2-NEXT:    vpshufb %ymm5, %ymm6, %ymm6
 ; AVX2-NEXT:    vpermq {{.*#+}} ymm6 = ymm6[0,2,2,3]
 ; AVX2-NEXT:    vpandn %xmm7, %xmm6, %xmm7
 ; AVX2-NEXT:    vpmovzxwd {{.*#+}} ymm8 = xmm7[0],zero,xmm7[1],zero,xmm7[2],zero,xmm7[3],zero,xmm7[4],zero,xmm7[5],zero,xmm7[6],zero,xmm7[7],zero
 ; AVX2-NEXT:    vpclmulqdq $17, %ymm2, %ymm8, %ymm9
-; AVX2-NEXT:    vpsrlq $32, %ymm8, %ymm10
-; AVX2-NEXT:    vpclmulqdq $17, %ymm3, %ymm10, %ymm11
-; AVX2-NEXT:    vpunpckldq {{.*#+}} ymm9 = ymm9[0],ymm11[0],ymm9[1],ymm11[1],ymm9[4],ymm11[4],ymm9[5],ymm11[5]
-; AVX2-NEXT:    vpclmulqdq $0, %ymm2, %ymm8, %ymm8
-; AVX2-NEXT:    vpclmulqdq $0, %ymm3, %ymm10, %ymm10
+; AVX2-NEXT:    vpclmulqdq $0, %ymm2, %ymm8, %ymm10
+; AVX2-NEXT:    vpunpckldq {{.*#+}} ymm9 = ymm10[0],ymm9[0],ymm10[1],ymm9[1],ymm10[4],ymm9[4],ymm10[5],ymm9[5]
+; AVX2-NEXT:    vpsrlq $32, %ymm8, %ymm8
+; AVX2-NEXT:    vpclmulqdq $17, %ymm3, %ymm8, %ymm10
+; AVX2-NEXT:    vpclmulqdq $0, %ymm3, %ymm8, %ymm8
 ; AVX2-NEXT:    vpunpckldq {{.*#+}} ymm8 = ymm8[0],ymm10[0],ymm8[1],ymm10[1],ymm8[4],ymm10[4],ymm8[5],ymm10[5]
-; AVX2-NEXT:    vpunpckldq {{.*#+}} ymm8 = ymm8[0],ymm9[0],ymm8[1],ymm9[1],ymm8[4],ymm9[4],ymm8[5],ymm9[5]
+; AVX2-NEXT:    vpunpckldq {{.*#+}} ymm8 = ymm9[0],ymm8[0],ymm9[1],ymm8[1],ymm9[4],ymm8[4],ymm9[5],ymm8[5]
 ; AVX2-NEXT:    vpshufb %ymm5, %ymm8, %ymm8
 ; AVX2-NEXT:    vpermq {{.*#+}} ymm8 = ymm8[0,2,2,3]
 ; AVX2-NEXT:    vpandn %xmm7, %xmm8, %xmm7
 ; AVX2-NEXT:    vpmovzxwd {{.*#+}} ymm7 = xmm7[0],zero,xmm7[1],zero,xmm7[2],zero,xmm7[3],zero,xmm7[4],zero,xmm7[5],zero,xmm7[6],zero,xmm7[7],zero
 ; AVX2-NEXT:    vpclmulqdq $17, %ymm2, %ymm7, %ymm9
-; AVX2-NEXT:    vpsrlq $32, %ymm7, %ymm10
-; AVX2-NEXT:    vpclmulqdq $17, %ymm3, %ymm10, %ymm11
 ; AVX2-NEXT:    vpclmulqdq $0, %ymm2, %ymm7, %ymm2
-; AVX2-NEXT:    vpclmulqdq $0, %ymm3, %ymm10, %ymm3
-; AVX2-NEXT:    vpunpckldq {{.*#+}} ymm7 = ymm9[0],ymm11[0],ymm9[1],ymm11[1],ymm9[4],ymm11[4],ymm9[5],ymm11[5]
+; AVX2-NEXT:    vpsrlq $32, %ymm7, %ymm7
+; AVX2-NEXT:    vpclmulqdq $17, %ymm3, %ymm7, %ymm10
+; AVX2-NEXT:    vpclmulqdq $0, %ymm3, %ymm7, %ymm3
+; AVX2-NEXT:    vpunpckldq {{.*#+}} ymm2 = ymm2[0],ymm9[0],ymm2[1],ymm9[1],ymm2[4],ymm9[4],ymm2[5],ymm9[5]
+; AVX2-NEXT:    vpunpckldq {{.*#+}} ymm3 = ymm3[0],ymm10[0],ymm3[1],ymm10[1],ymm3[4],ymm10[4],ymm3[5],ymm10[5]
 ; AVX2-NEXT:    vpunpckldq {{.*#+}} ymm2 = ymm2[0],ymm3[0],ymm2[1],ymm3[1],ymm2[4],ymm3[4],ymm2[5],ymm3[5]
-; AVX2-NEXT:    vpunpckldq {{.*#+}} ymm2 = ymm2[0],ymm7[0],ymm2[1],ymm7[1],ymm2[4],ymm7[4],ymm2[5],ymm7[5]
 ; AVX2-NEXT:    vpshufb %ymm5, %ymm2, %ymm2
 ; AVX2-NEXT:    vpermq {{.*#+}} ymm2 = ymm2[0,2,2,3]
 ; AVX2-NEXT:    vpand %xmm1, %xmm4, %xmm3
@@ -402,56 +402,56 @@ define <8 x i16> @pdep_v8i16(<8 x i16> %val, <8 x i16> %mask) nounwind {
 ; AVX512-NEXT:    vpmovzxwd {{.*#+}} ymm3 = xmm2[0],zero,xmm2[1],zero,xmm2[2],zero,xmm2[3],zero,xmm2[4],zero,xmm2[5],zero,xmm2[6],zero,xmm2[7],zero
 ; AVX512-NEXT:    vpbroadcastd {{.*#+}} ymm4 = [65535,65535,65535,65535,65535,65535,65535,65535]
 ; AVX512-NEXT:    vpclmulqdq $17, %ymm4, %ymm3, %ymm5
-; AVX512-NEXT:    vpsrlq $32, %ymm3, %ymm6
-; AVX512-NEXT:    vpbroadcastq {{.*#+}} ymm7 = [255,255,0,0,0,0,0,0,255,255,0,0,0,0,0,0,255,255,0,0,0,0,0,0,255,255,0,0,0,0,0,0]
-; AVX512-NEXT:    vpclmulqdq $17, %ymm7, %ymm6, %ymm8
-; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm5 = ymm5[0],ymm8[0],ymm5[1],ymm8[1],ymm5[4],ymm8[4],ymm5[5],ymm8[5]
-; AVX512-NEXT:    vpclmulqdq $0, %ymm4, %ymm3, %ymm3
-; AVX512-NEXT:    vpclmulqdq $0, %ymm7, %ymm6, %ymm6
-; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm3 = ymm3[0],ymm6[0],ymm3[1],ymm6[1],ymm3[4],ymm6[4],ymm3[5],ymm6[5]
-; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm3 = ymm3[0],ymm5[0],ymm3[1],ymm5[1],ymm3[4],ymm5[4],ymm3[5],ymm5[5]
+; AVX512-NEXT:    vpclmulqdq $0, %ymm4, %ymm3, %ymm6
+; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm5 = ymm6[0],ymm5[0],ymm6[1],ymm5[1],ymm6[4],ymm5[4],ymm6[5],ymm5[5]
+; AVX512-NEXT:    vpsrlq $32, %ymm3, %ymm3
+; AVX512-NEXT:    vpbroadcastq {{.*#+}} ymm6 = [255,255,0,0,0,0,0,0,255,255,0,0,0,0,0,0,255,255,0,0,0,0,0,0,255,255,0,0,0,0,0,0]
+; AVX512-NEXT:    vpclmulqdq $17, %ymm6, %ymm3, %ymm7
+; AVX512-NEXT:    vpclmulqdq $0, %ymm6, %ymm3, %ymm3
+; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm3 = ymm3[0],ymm7[0],ymm3[1],ymm7[1],ymm3[4],ymm7[4],ymm3[5],ymm7[5]
+; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm3 = ymm5[0],ymm3[0],ymm5[1],ymm3[1],ymm5[4],ymm3[4],ymm5[5],ymm3[5]
 ; AVX512-NEXT:    vpmovdw %ymm3, %xmm3
 ; AVX512-NEXT:    vpandn %xmm2, %xmm3, %xmm2
 ; AVX512-NEXT:    vpmovzxwd {{.*#+}} ymm5 = xmm2[0],zero,xmm2[1],zero,xmm2[2],zero,xmm2[3],zero,xmm2[4],zero,xmm2[5],zero,xmm2[6],zero,xmm2[7],zero
-; AVX512-NEXT:    vpclmulqdq $17, %ymm4, %ymm5, %ymm6
-; AVX512-NEXT:    vpsrlq $32, %ymm5, %ymm8
-; AVX512-NEXT:    vpclmulqdq $17, %ymm7, %ymm8, %ymm9
-; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm6 = ymm6[0],ymm9[0],ymm6[1],ymm9[1],ymm6[4],ymm9[4],ymm6[5],ymm9[5]
-; AVX512-NEXT:    vpclmulqdq $0, %ymm4, %ymm5, %ymm5
-; AVX512-NEXT:    vpclmulqdq $0, %ymm7, %ymm8, %ymm8
+; AVX512-NEXT:    vpclmulqdq $17, %ymm4, %ymm5, %ymm7
+; AVX512-NEXT:    vpclmulqdq $0, %ymm4, %ymm5, %ymm8
+; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm7 = ymm8[0],ymm7[0],ymm8[1],ymm7[1],ymm8[4],ymm7[4],ymm8[5],ymm7[5]
+; AVX512-NEXT:    vpsrlq $32, %ymm5, %ymm5
+; AVX512-NEXT:    vpclmulqdq $17, %ymm6, %ymm5, %ymm8
+; AVX512-NEXT:    vpclmulqdq $0, %ymm6, %ymm5, %ymm5
 ; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm5 = ymm5[0],ymm8[0],ymm5[1],ymm8[1],ymm5[4],ymm8[4],ymm5[5],ymm8[5]
-; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm5 = ymm5[0],ymm6[0],ymm5[1],ymm6[1],ymm5[4],ymm6[4],ymm5[5],ymm6[5]
+; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm5 = ymm7[0],ymm5[0],ymm7[1],ymm5[1],ymm7[4],ymm5[4],ymm7[5],ymm5[5]
 ; AVX512-NEXT:    vpmovdw %ymm5, %xmm5
 ; AVX512-NEXT:    vpandn %xmm2, %xmm5, %xmm2
-; AVX512-NEXT:    vpmovzxwd {{.*#+}} ymm6 = xmm2[0],zero,xmm2[1],zero,xmm2[2],zero,xmm2[3],zero,xmm2[4],zero,xmm2[5],zero,xmm2[6],zero,xmm2[7],zero
-; AVX512-NEXT:    vpclmulqdq $17, %ymm4, %ymm6, %ymm8
-; AVX512-NEXT:    vpsrlq $32, %ymm6, %ymm9
-; AVX512-NEXT:    vpclmulqdq $17, %ymm7, %ymm9, %ymm10
-; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm8 = ymm8[0],ymm10[0],ymm8[1],ymm10[1],ymm8[4],ymm10[4],ymm8[5],ymm10[5]
-; AVX512-NEXT:    vpclmulqdq $0, %ymm4, %ymm6, %ymm6
-; AVX512-NEXT:    vpclmulqdq $0, %ymm7, %ymm9, %ymm9
-; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm6 = ymm6[0],ymm9[0],ymm6[1],ymm9[1],ymm6[4],ymm9[4],ymm6[5],ymm9[5]
-; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm6 = ymm6[0],ymm8[0],ymm6[1],ymm8[1],ymm6[4],ymm8[4],ymm6[5],ymm8[5]
-; AVX512-NEXT:    vpmovdw %ymm6, %xmm6
-; AVX512-NEXT:    vpandn %xmm2, %xmm6, %xmm2
+; AVX512-NEXT:    vpmovzxwd {{.*#+}} ymm7 = xmm2[0],zero,xmm2[1],zero,xmm2[2],zero,xmm2[3],zero,xmm2[4],zero,xmm2[5],zero,xmm2[6],zero,xmm2[7],zero
+; AVX512-NEXT:    vpclmulqdq $17, %ymm4, %ymm7, %ymm8
+; AVX512-NEXT:    vpclmulqdq $0, %ymm4, %ymm7, %ymm9
+; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm8 = ymm9[0],ymm8[0],ymm9[1],ymm8[1],ymm9[4],ymm8[4],ymm9[5],ymm8[5]
+; AVX512-NEXT:    vpsrlq $32, %ymm7, %ymm7
+; AVX512-NEXT:    vpclmulqdq $17, %ymm6, %ymm7, %ymm9
+; AVX512-NEXT:    vpclmulqdq $0, %ymm6, %ymm7, %ymm7
+; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm7 = ymm7[0],ymm9[0],ymm7[1],ymm9[1],ymm7[4],ymm9[4],ymm7[5],ymm9[5]
+; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm7 = ymm8[0],ymm7[0],ymm8[1],ymm7[1],ymm8[4],ymm7[4],ymm8[5],ymm7[5]
+; AVX512-NEXT:    vpmovdw %ymm7, %xmm7
+; AVX512-NEXT:    vpandn %xmm2, %xmm7, %xmm2
 ; AVX512-NEXT:    vpmovzxwd {{.*#+}} ymm2 = xmm2[0],zero,xmm2[1],zero,xmm2[2],zero,xmm2[3],zero,xmm2[4],zero,xmm2[5],zero,xmm2[6],zero,xmm2[7],zero
 ; AVX512-NEXT:    vpclmulqdq $17, %ymm4, %ymm2, %ymm8
-; AVX512-NEXT:    vpsrlq $32, %ymm2, %ymm9
-; AVX512-NEXT:    vpclmulqdq $17, %ymm7, %ymm9, %ymm10
-; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm8 = ymm8[0],ymm10[0],ymm8[1],ymm10[1],ymm8[4],ymm10[4],ymm8[5],ymm10[5]
-; AVX512-NEXT:    vpclmulqdq $0, %ymm4, %ymm2, %ymm2
-; AVX512-NEXT:    vpclmulqdq $0, %ymm7, %ymm9, %ymm4
-; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm2 = ymm2[0],ymm4[0],ymm2[1],ymm4[1],ymm2[4],ymm4[4],ymm2[5],ymm4[5]
+; AVX512-NEXT:    vpclmulqdq $0, %ymm4, %ymm2, %ymm4
+; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm4 = ymm4[0],ymm8[0],ymm4[1],ymm8[1],ymm4[4],ymm8[4],ymm4[5],ymm8[5]
+; AVX512-NEXT:    vpsrlq $32, %ymm2, %ymm2
+; AVX512-NEXT:    vpclmulqdq $17, %ymm6, %ymm2, %ymm8
+; AVX512-NEXT:    vpclmulqdq $0, %ymm6, %ymm2, %ymm2
 ; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm2 = ymm2[0],ymm8[0],ymm2[1],ymm8[1],ymm2[4],ymm8[4],ymm2[5],ymm8[5]
+; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm2 = ymm4[0],ymm2[0],ymm4[1],ymm2[1],ymm4[4],ymm2[4],ymm4[5],ymm2[5]
 ; AVX512-NEXT:    vpmovdw %ymm2, %xmm2
 ; AVX512-NEXT:    vpand %xmm1, %xmm3, %xmm3
 ; AVX512-NEXT:    vpsrlw $1, %xmm3, %xmm4
 ; AVX512-NEXT:    vpternlogq {{.*#+}} xmm4 = xmm4 | (xmm1 ^ xmm3)
 ; AVX512-NEXT:    vpand %xmm4, %xmm5, %xmm5
-; AVX512-NEXT:    vpsrlw $2, %xmm5, %xmm7
-; AVX512-NEXT:    vpternlogq {{.*#+}} xmm7 = xmm7 | (xmm4 ^ xmm5)
-; AVX512-NEXT:    vpand %xmm7, %xmm6, %xmm4
-; AVX512-NEXT:    vpxor %xmm4, %xmm7, %xmm6
+; AVX512-NEXT:    vpsrlw $2, %xmm5, %xmm6
+; AVX512-NEXT:    vpternlogq {{.*#+}} xmm6 = xmm6 | (xmm4 ^ xmm5)
+; AVX512-NEXT:    vpand %xmm6, %xmm7, %xmm4
+; AVX512-NEXT:    vpxor %xmm4, %xmm6, %xmm6
 ; AVX512-NEXT:    vpsrlw $4, %xmm4, %xmm7
 ; AVX512-NEXT:    vpternlogq {{.*#+}} xmm7 = xmm2 & (xmm7 | xmm6)
 ; AVX512-NEXT:    vpsllw $8, %xmm0, %xmm2
@@ -612,114 +612,113 @@ define <4 x i32> @pdep_v4i32(<4 x i32> %val, <4 x i32> %mask) nounwind {
 ;
 ; PCLMUL-LABEL: pdep_v4i32:
 ; PCLMUL:       # %bb.0:
-; PCLMUL-NEXT:    pcmpeqd %xmm2, %xmm2
+; PCLMUL-NEXT:    pcmpeqd %xmm5, %xmm5
 ; PCLMUL-NEXT:    movdqa %xmm1, %xmm4
-; PCLMUL-NEXT:    pxor %xmm2, %xmm4
+; PCLMUL-NEXT:    pxor %xmm5, %xmm4
 ; PCLMUL-NEXT:    paddd %xmm4, %xmm4
-; PCLMUL-NEXT:    movdqa %xmm4, %xmm5
-; PCLMUL-NEXT:    pclmulqdq $17, %xmm2, %xmm5
-; PCLMUL-NEXT:    movdqa %xmm4, %xmm7
-; PCLMUL-NEXT:    psrlq $32, %xmm7
-; PCLMUL-NEXT:    movdqa {{.*#+}} xmm6 = [255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0]
-; PCLMUL-NEXT:    movdqa %xmm7, %xmm3
-; PCLMUL-NEXT:    pclmulqdq $17, %xmm6, %xmm3
-; PCLMUL-NEXT:    punpckldq {{.*#+}} xmm5 = xmm5[0],xmm3[0],xmm5[1],xmm3[1]
+; PCLMUL-NEXT:    movdqa %xmm4, %xmm2
+; PCLMUL-NEXT:    pclmulqdq $17, %xmm5, %xmm2
 ; PCLMUL-NEXT:    movdqa %xmm4, %xmm3
-; PCLMUL-NEXT:    pclmulqdq $0, %xmm2, %xmm3
-; PCLMUL-NEXT:    pclmulqdq $0, %xmm6, %xmm7
-; PCLMUL-NEXT:    punpckldq {{.*#+}} xmm3 = xmm3[0],xmm7[0],xmm3[1],xmm7[1]
-; PCLMUL-NEXT:    punpckldq {{.*#+}} xmm3 = xmm3[0],xmm5[0],xmm3[1],xmm5[1]
-; PCLMUL-NEXT:    movdqa %xmm3, %xmm5
-; PCLMUL-NEXT:    pandn %xmm4, %xmm5
-; PCLMUL-NEXT:    movdqa %xmm5, %xmm7
+; PCLMUL-NEXT:    pclmulqdq $0, %xmm5, %xmm3
+; PCLMUL-NEXT:    punpckldq {{.*#+}} xmm3 = xmm3[0],xmm2[0],xmm3[1],xmm2[1]
+; PCLMUL-NEXT:    movdqa %xmm4, %xmm6
+; PCLMUL-NEXT:    psrlq $32, %xmm6
+; PCLMUL-NEXT:    movdqa {{.*#+}} xmm2 = [255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0]
+; PCLMUL-NEXT:    movdqa %xmm6, %xmm7
 ; PCLMUL-NEXT:    pclmulqdq $17, %xmm2, %xmm7
-; PCLMUL-NEXT:    movdqa %xmm5, %xmm8
-; PCLMUL-NEXT:    psrlq $32, %xmm8
-; PCLMUL-NEXT:    movdqa %xmm8, %xmm4
-; PCLMUL-NEXT:    pclmulqdq $17, %xmm6, %xmm4
-; PCLMUL-NEXT:    punpckldq {{.*#+}} xmm7 = xmm7[0],xmm4[0],xmm7[1],xmm4[1]
-; PCLMUL-NEXT:    movdqa %xmm5, %xmm4
-; PCLMUL-NEXT:    pclmulqdq $0, %xmm2, %xmm4
-; PCLMUL-NEXT:    pclmulqdq $0, %xmm6, %xmm8
-; PCLMUL-NEXT:    punpckldq {{.*#+}} xmm4 = xmm4[0],xmm8[0],xmm4[1],xmm8[1]
+; PCLMUL-NEXT:    pclmulqdq $0, %xmm2, %xmm6
+; PCLMUL-NEXT:    punpckldq {{.*#+}} xmm6 = xmm6[0],xmm7[0],xmm6[1],xmm7[1]
+; PCLMUL-NEXT:    punpckldq {{.*#+}} xmm3 = xmm3[0],xmm6[0],xmm3[1],xmm6[1]
+; PCLMUL-NEXT:    movdqa %xmm3, %xmm6
+; PCLMUL-NEXT:    pandn %xmm4, %xmm6
+; PCLMUL-NEXT:    movdqa %xmm6, %xmm7
+; PCLMUL-NEXT:    pclmulqdq $17, %xmm5, %xmm7
+; PCLMUL-NEXT:    movdqa %xmm6, %xmm4
+; PCLMUL-NEXT:    pclmulqdq $0, %xmm5, %xmm4
+; PCLMUL-NEXT:    punpckldq {{.*#+}} xmm4 = xmm4[0],xmm7[0],xmm4[1],xmm7[1]
+; PCLMUL-NEXT:    movdqa %xmm6, %xmm7
+; PCLMUL-NEXT:    psrlq $32, %xmm7
+; PCLMUL-NEXT:    movdqa %xmm7, %xmm8
+; PCLMUL-NEXT:    pclmulqdq $17, %xmm2, %xmm8
+; PCLMUL-NEXT:    pclmulqdq $0, %xmm2, %xmm7
+; PCLMUL-NEXT:    punpckldq {{.*#+}} xmm7 = xmm7[0],xmm8[0],xmm7[1],xmm8[1]
 ; PCLMUL-NEXT:    punpckldq {{.*#+}} xmm4 = xmm4[0],xmm7[0],xmm4[1],xmm7[1]
 ; PCLMUL-NEXT:    movdqa %xmm4, %xmm7
-; PCLMUL-NEXT:    pandn %xmm5, %xmm7
+; PCLMUL-NEXT:    pandn %xmm6, %xmm7
 ; PCLMUL-NEXT:    movdqa %xmm7, %xmm8
-; PCLMUL-NEXT:    pclmulqdq $17, %xmm2, %xmm8
-; PCLMUL-NEXT:    movdqa %xmm7, %xmm9
-; PCLMUL-NEXT:    psrlq $32, %xmm9
-; PCLMUL-NEXT:    movdqa %xmm9, %xmm5
-; PCLMUL-NEXT:    pclmulqdq $17, %xmm6, %xmm5
-; PCLMUL-NEXT:    punpckldq {{.*#+}} xmm8 = xmm8[0],xmm5[0],xmm8[1],xmm5[1]
-; PCLMUL-NEXT:    movdqa %xmm7, %xmm5
-; PCLMUL-NEXT:    pclmulqdq $0, %xmm2, %xmm5
-; PCLMUL-NEXT:    pclmulqdq $0, %xmm6, %xmm9
-; PCLMUL-NEXT:    punpckldq {{.*#+}} xmm5 = xmm5[0],xmm9[0],xmm5[1],xmm9[1]
-; PCLMUL-NEXT:    punpckldq {{.*#+}} xmm5 = xmm5[0],xmm8[0],xmm5[1],xmm8[1]
-; PCLMUL-NEXT:    movdqa %xmm5, %xmm9
-; PCLMUL-NEXT:    pandn %xmm7, %xmm9
-; PCLMUL-NEXT:    movdqa %xmm9, %xmm8
-; PCLMUL-NEXT:    pclmulqdq $17, %xmm2, %xmm8
-; PCLMUL-NEXT:    movdqa %xmm9, %xmm10
-; PCLMUL-NEXT:    psrlq $32, %xmm10
-; PCLMUL-NEXT:    movdqa %xmm10, %xmm7
-; PCLMUL-NEXT:    pclmulqdq $17, %xmm6, %xmm7
-; PCLMUL-NEXT:    punpckldq {{.*#+}} xmm8 = xmm8[0],xmm7[0],xmm8[1],xmm7[1]
-; PCLMUL-NEXT:    movdqa %xmm9, %xmm7
-; PCLMUL-NEXT:    pclmulqdq $0, %xmm2, %xmm7
-; PCLMUL-NEXT:    pclmulqdq $0, %xmm6, %xmm10
-; PCLMUL-NEXT:    punpckldq {{.*#+}} xmm7 = xmm7[0],xmm10[0],xmm7[1],xmm10[1]
-; PCLMUL-NEXT:    punpckldq {{.*#+}} xmm7 = xmm7[0],xmm8[0],xmm7[1],xmm8[1]
+; PCLMUL-NEXT:    pclmulqdq $17, %xmm5, %xmm8
+; PCLMUL-NEXT:    movdqa %xmm7, %xmm6
+; PCLMUL-NEXT:    pclmulqdq $0, %xmm5, %xmm6
+; PCLMUL-NEXT:    punpckldq {{.*#+}} xmm6 = xmm6[0],xmm8[0],xmm6[1],xmm8[1]
 ; PCLMUL-NEXT:    movdqa %xmm7, %xmm8
-; PCLMUL-NEXT:    pandn %xmm9, %xmm8
+; PCLMUL-NEXT:    psrlq $32, %xmm8
 ; PCLMUL-NEXT:    movdqa %xmm8, %xmm9
 ; PCLMUL-NEXT:    pclmulqdq $17, %xmm2, %xmm9
-; PCLMUL-NEXT:    movdqa %xmm8, %xmm10
-; PCLMUL-NEXT:    psrlq $32, %xmm10
-; PCLMUL-NEXT:    movdqa %xmm10, %xmm11
-; PCLMUL-NEXT:    pclmulqdq $17, %xmm6, %xmm11
-; PCLMUL-NEXT:    punpckldq {{.*#+}} xmm9 = xmm9[0],xmm11[0],xmm9[1],xmm11[1]
 ; PCLMUL-NEXT:    pclmulqdq $0, %xmm2, %xmm8
-; PCLMUL-NEXT:    pclmulqdq $0, %xmm6, %xmm10
-; PCLMUL-NEXT:    punpckldq {{.*#+}} xmm8 = xmm8[0],xmm10[0],xmm8[1],xmm10[1]
 ; PCLMUL-NEXT:    punpckldq {{.*#+}} xmm8 = xmm8[0],xmm9[0],xmm8[1],xmm9[1]
+; PCLMUL-NEXT:    punpckldq {{.*#+}} xmm6 = xmm6[0],xmm8[0],xmm6[1],xmm8[1]
+; PCLMUL-NEXT:    movdqa %xmm6, %xmm8
+; PCLMUL-NEXT:    pandn %xmm7, %xmm8
+; PCLMUL-NEXT:    movdqa %xmm8, %xmm9
+; PCLMUL-NEXT:    pclmulqdq $17, %xmm5, %xmm9
+; PCLMUL-NEXT:    movdqa %xmm8, %xmm7
+; PCLMUL-NEXT:    pclmulqdq $0, %xmm5, %xmm7
+; PCLMUL-NEXT:    punpckldq {{.*#+}} xmm7 = xmm7[0],xmm9[0],xmm7[1],xmm9[1]
+; PCLMUL-NEXT:    movdqa %xmm8, %xmm9
+; PCLMUL-NEXT:    psrlq $32, %xmm9
+; PCLMUL-NEXT:    movdqa %xmm9, %xmm10
+; PCLMUL-NEXT:    pclmulqdq $17, %xmm2, %xmm10
+; PCLMUL-NEXT:    pclmulqdq $0, %xmm2, %xmm9
+; PCLMUL-NEXT:    punpckldq {{.*#+}} xmm9 = xmm9[0],xmm10[0],xmm9[1],xmm10[1]
+; PCLMUL-NEXT:    punpckldq {{.*#+}} xmm7 = xmm7[0],xmm9[0],xmm7[1],xmm9[1]
+; PCLMUL-NEXT:    movdqa %xmm7, %xmm9
+; PCLMUL-NEXT:    pandn %xmm8, %xmm9
+; PCLMUL-NEXT:    movdqa %xmm9, %xmm8
+; PCLMUL-NEXT:    pclmulqdq $17, %xmm5, %xmm8
+; PCLMUL-NEXT:    pclmulqdq $0, %xmm9, %xmm5
+; PCLMUL-NEXT:    punpckldq {{.*#+}} xmm5 = xmm5[0],xmm8[0],xmm5[1],xmm8[1]
+; PCLMUL-NEXT:    psrlq $32, %xmm9
+; PCLMUL-NEXT:    movdqa %xmm9, %xmm8
+; PCLMUL-NEXT:    pclmulqdq $17, %xmm2, %xmm8
+; PCLMUL-NEXT:    pclmulqdq $0, %xmm2, %xmm9
+; PCLMUL-NEXT:    punpckldq {{.*#+}} xmm9 = xmm9[0],xmm8[0],xmm9[1],xmm8[1]
+; PCLMUL-NEXT:    punpckldq {{.*#+}} xmm5 = xmm5[0],xmm9[0],xmm5[1],xmm9[1]
 ; PCLMUL-NEXT:    pand %xmm1, %xmm3
 ; PCLMUL-NEXT:    movdqa %xmm1, %xmm2
 ; PCLMUL-NEXT:    pxor %xmm3, %xmm2
-; PCLMUL-NEXT:    movdqa %xmm3, %xmm6
-; PCLMUL-NEXT:    psrld $1, %xmm6
-; PCLMUL-NEXT:    por %xmm2, %xmm6
-; PCLMUL-NEXT:    pand %xmm6, %xmm4
-; PCLMUL-NEXT:    pxor %xmm4, %xmm6
+; PCLMUL-NEXT:    movdqa %xmm3, %xmm8
+; PCLMUL-NEXT:    psrld $1, %xmm8
+; PCLMUL-NEXT:    por %xmm2, %xmm8
+; PCLMUL-NEXT:    pand %xmm8, %xmm4
+; PCLMUL-NEXT:    pxor %xmm4, %xmm8
 ; PCLMUL-NEXT:    movdqa %xmm4, %xmm2
 ; PCLMUL-NEXT:    psrld $2, %xmm2
-; PCLMUL-NEXT:    por %xmm6, %xmm2
-; PCLMUL-NEXT:    pand %xmm2, %xmm5
-; PCLMUL-NEXT:    pxor %xmm5, %xmm2
-; PCLMUL-NEXT:    movdqa %xmm5, %xmm6
-; PCLMUL-NEXT:    psrld $4, %xmm6
-; PCLMUL-NEXT:    por %xmm2, %xmm6
-; PCLMUL-NEXT:    pand %xmm6, %xmm7
-; PCLMUL-NEXT:    pxor %xmm7, %xmm6
+; PCLMUL-NEXT:    por %xmm8, %xmm2
+; PCLMUL-NEXT:    pand %xmm2, %xmm6
+; PCLMUL-NEXT:    pxor %xmm6, %xmm2
+; PCLMUL-NEXT:    movdqa %xmm6, %xmm8
+; PCLMUL-NEXT:    psrld $4, %xmm8
+; PCLMUL-NEXT:    por %xmm2, %xmm8
+; PCLMUL-NEXT:    pand %xmm8, %xmm7
+; PCLMUL-NEXT:    pxor %xmm7, %xmm8
 ; PCLMUL-NEXT:    movdqa %xmm7, %xmm2
 ; PCLMUL-NEXT:    psrld $8, %xmm2
-; PCLMUL-NEXT:    por %xmm6, %xmm2
-; PCLMUL-NEXT:    pand %xmm8, %xmm2
-; PCLMUL-NEXT:    movdqa %xmm0, %xmm6
-; PCLMUL-NEXT:    pslld $16, %xmm6
-; PCLMUL-NEXT:    pand %xmm2, %xmm6
+; PCLMUL-NEXT:    por %xmm8, %xmm2
+; PCLMUL-NEXT:    pand %xmm5, %xmm2
+; PCLMUL-NEXT:    movdqa %xmm0, %xmm5
+; PCLMUL-NEXT:    pslld $16, %xmm5
+; PCLMUL-NEXT:    pand %xmm2, %xmm5
 ; PCLMUL-NEXT:    pandn %xmm0, %xmm2
-; PCLMUL-NEXT:    por %xmm6, %xmm2
+; PCLMUL-NEXT:    por %xmm5, %xmm2
 ; PCLMUL-NEXT:    movdqa %xmm7, %xmm0
 ; PCLMUL-NEXT:    pandn %xmm2, %xmm0
 ; PCLMUL-NEXT:    pslld $8, %xmm2
 ; PCLMUL-NEXT:    pand %xmm7, %xmm2
 ; PCLMUL-NEXT:    por %xmm0, %xmm2
-; PCLMUL-NEXT:    movdqa %xmm5, %xmm0
+; PCLMUL-NEXT:    movdqa %xmm6, %xmm0
 ; PCLMUL-NEXT:    pandn %xmm2, %xmm0
 ; PCLMUL-NEXT:    pslld $4, %xmm2
-; PCLMUL-NEXT:    pand %xmm5, %xmm2
+; PCLMUL-NEXT:    pand %xmm6, %xmm2
 ; PCLMUL-NEXT:    por %xmm0, %xmm2
 ; PCLMUL-NEXT:    movdqa %xmm4, %xmm0
 ; PCLMUL-NEXT:    pandn %xmm2, %xmm0
@@ -761,50 +760,50 @@ define <4 x i32> @pdep_v4i32(<4 x i32> %val, <4 x i32> %mask) nounwind {
 ; AVX2-SLOW-NEXT:    vpxor %xmm2, %xmm1, %xmm3
 ; AVX2-SLOW-NEXT:    vpaddd %xmm3, %xmm3, %xmm5
 ; AVX2-SLOW-NEXT:    vpclmulqdq $17, %xmm2, %xmm5, %xmm4
-; AVX2-SLOW-NEXT:    vpsrlq $32, %xmm5, %xmm6
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %xmm2, %xmm5, %xmm6
+; AVX2-SLOW-NEXT:    vpsrlq $32, %xmm5, %xmm7
 ; AVX2-SLOW-NEXT:    vpbroadcastq {{.*#+}} xmm3 = [255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0]
-; AVX2-SLOW-NEXT:    vpclmulqdq $17, %xmm3, %xmm6, %xmm7
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %xmm2, %xmm5, %xmm8
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %xmm3, %xmm6, %xmm6
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm4 = xmm4[0],xmm7[0],xmm4[1],xmm7[1]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm6 = xmm8[0],xmm6[0],xmm8[1],xmm6[1]
+; AVX2-SLOW-NEXT:    vpclmulqdq $17, %xmm3, %xmm7, %xmm8
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %xmm3, %xmm7, %xmm7
 ; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm4 = xmm6[0],xmm4[0],xmm6[1],xmm4[1]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm6 = xmm7[0],xmm8[0],xmm7[1],xmm8[1]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm4 = xmm4[0],xmm6[0],xmm4[1],xmm6[1]
 ; AVX2-SLOW-NEXT:    vpandn %xmm5, %xmm4, %xmm6
 ; AVX2-SLOW-NEXT:    vpclmulqdq $17, %xmm2, %xmm6, %xmm5
-; AVX2-SLOW-NEXT:    vpsrlq $32, %xmm6, %xmm7
-; AVX2-SLOW-NEXT:    vpclmulqdq $17, %xmm3, %xmm7, %xmm8
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %xmm2, %xmm6, %xmm9
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %xmm3, %xmm7, %xmm7
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm5 = xmm5[0],xmm8[0],xmm5[1],xmm8[1]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm9[0],xmm7[0],xmm9[1],xmm7[1]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm5 = xmm7[0],xmm5[0],xmm7[1],xmm5[1]
-; AVX2-SLOW-NEXT:    vpandn %xmm6, %xmm5, %xmm6
-; AVX2-SLOW-NEXT:    vpclmulqdq $17, %xmm2, %xmm6, %xmm7
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %xmm2, %xmm6, %xmm7
 ; AVX2-SLOW-NEXT:    vpsrlq $32, %xmm6, %xmm8
 ; AVX2-SLOW-NEXT:    vpclmulqdq $17, %xmm3, %xmm8, %xmm9
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %xmm2, %xmm6, %xmm10
 ; AVX2-SLOW-NEXT:    vpclmulqdq $0, %xmm3, %xmm8, %xmm8
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm7[0],xmm9[0],xmm7[1],xmm9[1]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm8 = xmm10[0],xmm8[0],xmm10[1],xmm8[1]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm8[0],xmm7[0],xmm8[1],xmm7[1]
-; AVX2-SLOW-NEXT:    vpandn %xmm6, %xmm7, %xmm6
-; AVX2-SLOW-NEXT:    vpclmulqdq $17, %xmm2, %xmm6, %xmm8
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm5 = xmm7[0],xmm5[0],xmm7[1],xmm5[1]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm8[0],xmm9[0],xmm8[1],xmm9[1]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm5 = xmm5[0],xmm7[0],xmm5[1],xmm7[1]
+; AVX2-SLOW-NEXT:    vpandn %xmm6, %xmm5, %xmm6
+; AVX2-SLOW-NEXT:    vpclmulqdq $17, %xmm2, %xmm6, %xmm7
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %xmm2, %xmm6, %xmm8
 ; AVX2-SLOW-NEXT:    vpsrlq $32, %xmm6, %xmm9
 ; AVX2-SLOW-NEXT:    vpclmulqdq $17, %xmm3, %xmm9, %xmm10
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %xmm2, %xmm6, %xmm11
 ; AVX2-SLOW-NEXT:    vpclmulqdq $0, %xmm3, %xmm9, %xmm9
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm8 = xmm8[0],xmm10[0],xmm8[1],xmm10[1]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm9 = xmm11[0],xmm9[0],xmm11[1],xmm9[1]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm8 = xmm9[0],xmm8[0],xmm9[1],xmm8[1]
-; AVX2-SLOW-NEXT:    vpandn %xmm6, %xmm8, %xmm6
-; AVX2-SLOW-NEXT:    vpclmulqdq $17, %xmm2, %xmm6, %xmm9
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm8[0],xmm7[0],xmm8[1],xmm7[1]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm8 = xmm9[0],xmm10[0],xmm9[1],xmm10[1]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm7[0],xmm8[0],xmm7[1],xmm8[1]
+; AVX2-SLOW-NEXT:    vpandn %xmm6, %xmm7, %xmm6
+; AVX2-SLOW-NEXT:    vpclmulqdq $17, %xmm2, %xmm6, %xmm8
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %xmm2, %xmm6, %xmm9
 ; AVX2-SLOW-NEXT:    vpsrlq $32, %xmm6, %xmm10
 ; AVX2-SLOW-NEXT:    vpclmulqdq $17, %xmm3, %xmm10, %xmm11
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %xmm3, %xmm10, %xmm10
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm8 = xmm9[0],xmm8[0],xmm9[1],xmm8[1]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm9 = xmm10[0],xmm11[0],xmm10[1],xmm11[1]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm8 = xmm8[0],xmm9[0],xmm8[1],xmm9[1]
+; AVX2-SLOW-NEXT:    vpandn %xmm6, %xmm8, %xmm6
+; AVX2-SLOW-NEXT:    vpclmulqdq $17, %xmm2, %xmm6, %xmm9
 ; AVX2-SLOW-NEXT:    vpclmulqdq $0, %xmm2, %xmm6, %xmm2
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm6 = xmm9[0],xmm11[0],xmm9[1],xmm11[1]
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %xmm3, %xmm10, %xmm3
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm3[0],xmm2[1],xmm3[1]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm3 = xmm2[0],xmm6[0],xmm2[1],xmm6[1]
+; AVX2-SLOW-NEXT:    vpsrlq $32, %xmm6, %xmm6
+; AVX2-SLOW-NEXT:    vpclmulqdq $17, %xmm3, %xmm6, %xmm10
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm9[0],xmm2[1],xmm9[1]
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %xmm3, %xmm6, %xmm3
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm3 = xmm3[0],xmm10[0],xmm3[1],xmm10[1]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm3 = xmm2[0],xmm3[0],xmm2[1],xmm3[1]
 ; AVX2-SLOW-NEXT:    vpand %xmm1, %xmm4, %xmm2
 ; AVX2-SLOW-NEXT:    vpxor %xmm2, %xmm1, %xmm4
 ; AVX2-SLOW-NEXT:    vpsrld $1, %xmm2, %xmm6

--- a/llvm/test/CodeGen/X86/pdep-vector-256.ll
+++ b/llvm/test/CodeGen/X86/pdep-vector-256.ll
@@ -305,50 +305,50 @@ define <8 x i32> @pdep_v8i32(<8 x i32> %val, <8 x i32> %mask) nounwind {
 ; AVX2-SLOW-NEXT:    vpxor %ymm2, %ymm1, %ymm3
 ; AVX2-SLOW-NEXT:    vpaddd %ymm3, %ymm3, %ymm5
 ; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm2, %ymm5, %ymm4
-; AVX2-SLOW-NEXT:    vpsrlq $32, %ymm5, %ymm6
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm2, %ymm5, %ymm6
+; AVX2-SLOW-NEXT:    vpsrlq $32, %ymm5, %ymm7
 ; AVX2-SLOW-NEXT:    vpbroadcastq {{.*#+}} ymm3 = [255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0]
-; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm3, %ymm6, %ymm7
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm2, %ymm5, %ymm8
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm3, %ymm6, %ymm6
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm4 = ymm4[0],ymm7[0],ymm4[1],ymm7[1],ymm4[4],ymm7[4],ymm4[5],ymm7[5]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm6 = ymm8[0],ymm6[0],ymm8[1],ymm6[1],ymm8[4],ymm6[4],ymm8[5],ymm6[5]
+; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm3, %ymm7, %ymm8
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm3, %ymm7, %ymm7
 ; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm4 = ymm6[0],ymm4[0],ymm6[1],ymm4[1],ymm6[4],ymm4[4],ymm6[5],ymm4[5]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm6 = ymm7[0],ymm8[0],ymm7[1],ymm8[1],ymm7[4],ymm8[4],ymm7[5],ymm8[5]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm4 = ymm4[0],ymm6[0],ymm4[1],ymm6[1],ymm4[4],ymm6[4],ymm4[5],ymm6[5]
 ; AVX2-SLOW-NEXT:    vpandn %ymm5, %ymm4, %ymm6
 ; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm2, %ymm6, %ymm5
-; AVX2-SLOW-NEXT:    vpsrlq $32, %ymm6, %ymm7
-; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm3, %ymm7, %ymm8
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm2, %ymm6, %ymm9
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm3, %ymm7, %ymm7
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm5 = ymm5[0],ymm8[0],ymm5[1],ymm8[1],ymm5[4],ymm8[4],ymm5[5],ymm8[5]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm7 = ymm9[0],ymm7[0],ymm9[1],ymm7[1],ymm9[4],ymm7[4],ymm9[5],ymm7[5]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm5 = ymm7[0],ymm5[0],ymm7[1],ymm5[1],ymm7[4],ymm5[4],ymm7[5],ymm5[5]
-; AVX2-SLOW-NEXT:    vpandn %ymm6, %ymm5, %ymm6
-; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm2, %ymm6, %ymm7
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm2, %ymm6, %ymm7
 ; AVX2-SLOW-NEXT:    vpsrlq $32, %ymm6, %ymm8
 ; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm3, %ymm8, %ymm9
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm2, %ymm6, %ymm10
 ; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm3, %ymm8, %ymm8
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm7 = ymm7[0],ymm9[0],ymm7[1],ymm9[1],ymm7[4],ymm9[4],ymm7[5],ymm9[5]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm8 = ymm10[0],ymm8[0],ymm10[1],ymm8[1],ymm10[4],ymm8[4],ymm10[5],ymm8[5]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm7 = ymm8[0],ymm7[0],ymm8[1],ymm7[1],ymm8[4],ymm7[4],ymm8[5],ymm7[5]
-; AVX2-SLOW-NEXT:    vpandn %ymm6, %ymm7, %ymm6
-; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm2, %ymm6, %ymm8
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm5 = ymm7[0],ymm5[0],ymm7[1],ymm5[1],ymm7[4],ymm5[4],ymm7[5],ymm5[5]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm7 = ymm8[0],ymm9[0],ymm8[1],ymm9[1],ymm8[4],ymm9[4],ymm8[5],ymm9[5]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm5 = ymm5[0],ymm7[0],ymm5[1],ymm7[1],ymm5[4],ymm7[4],ymm5[5],ymm7[5]
+; AVX2-SLOW-NEXT:    vpandn %ymm6, %ymm5, %ymm6
+; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm2, %ymm6, %ymm7
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm2, %ymm6, %ymm8
 ; AVX2-SLOW-NEXT:    vpsrlq $32, %ymm6, %ymm9
 ; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm3, %ymm9, %ymm10
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm2, %ymm6, %ymm11
 ; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm3, %ymm9, %ymm9
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm8 = ymm8[0],ymm10[0],ymm8[1],ymm10[1],ymm8[4],ymm10[4],ymm8[5],ymm10[5]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm9 = ymm11[0],ymm9[0],ymm11[1],ymm9[1],ymm11[4],ymm9[4],ymm11[5],ymm9[5]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm8 = ymm9[0],ymm8[0],ymm9[1],ymm8[1],ymm9[4],ymm8[4],ymm9[5],ymm8[5]
-; AVX2-SLOW-NEXT:    vpandn %ymm6, %ymm8, %ymm6
-; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm2, %ymm6, %ymm9
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm7 = ymm8[0],ymm7[0],ymm8[1],ymm7[1],ymm8[4],ymm7[4],ymm8[5],ymm7[5]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm8 = ymm9[0],ymm10[0],ymm9[1],ymm10[1],ymm9[4],ymm10[4],ymm9[5],ymm10[5]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm7 = ymm7[0],ymm8[0],ymm7[1],ymm8[1],ymm7[4],ymm8[4],ymm7[5],ymm8[5]
+; AVX2-SLOW-NEXT:    vpandn %ymm6, %ymm7, %ymm6
+; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm2, %ymm6, %ymm8
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm2, %ymm6, %ymm9
 ; AVX2-SLOW-NEXT:    vpsrlq $32, %ymm6, %ymm10
 ; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm3, %ymm10, %ymm11
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm3, %ymm10, %ymm10
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm8 = ymm9[0],ymm8[0],ymm9[1],ymm8[1],ymm9[4],ymm8[4],ymm9[5],ymm8[5]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm9 = ymm10[0],ymm11[0],ymm10[1],ymm11[1],ymm10[4],ymm11[4],ymm10[5],ymm11[5]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm8 = ymm8[0],ymm9[0],ymm8[1],ymm9[1],ymm8[4],ymm9[4],ymm8[5],ymm9[5]
+; AVX2-SLOW-NEXT:    vpandn %ymm6, %ymm8, %ymm6
+; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm2, %ymm6, %ymm9
 ; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm2, %ymm6, %ymm2
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm6 = ymm9[0],ymm11[0],ymm9[1],ymm11[1],ymm9[4],ymm11[4],ymm9[5],ymm11[5]
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm3, %ymm10, %ymm3
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm2 = ymm2[0],ymm3[0],ymm2[1],ymm3[1],ymm2[4],ymm3[4],ymm2[5],ymm3[5]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm3 = ymm2[0],ymm6[0],ymm2[1],ymm6[1],ymm2[4],ymm6[4],ymm2[5],ymm6[5]
+; AVX2-SLOW-NEXT:    vpsrlq $32, %ymm6, %ymm6
+; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm3, %ymm6, %ymm10
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm2 = ymm2[0],ymm9[0],ymm2[1],ymm9[1],ymm2[4],ymm9[4],ymm2[5],ymm9[5]
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm3, %ymm6, %ymm3
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm3 = ymm3[0],ymm10[0],ymm3[1],ymm10[1],ymm3[4],ymm10[4],ymm3[5],ymm10[5]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm3 = ymm2[0],ymm3[0],ymm2[1],ymm3[1],ymm2[4],ymm3[4],ymm2[5],ymm3[5]
 ; AVX2-SLOW-NEXT:    vpand %ymm1, %ymm4, %ymm2
 ; AVX2-SLOW-NEXT:    vpxor %ymm2, %ymm1, %ymm4
 ; AVX2-SLOW-NEXT:    vpsrld $1, %ymm2, %ymm6

--- a/llvm/test/CodeGen/X86/pdep-vector-512.ll
+++ b/llvm/test/CodeGen/X86/pdep-vector-512.ll
@@ -466,50 +466,50 @@ define <16 x i32> @pdep_v16i32(<16 x i32> %val, <16 x i32> %mask) nounwind {
 ; AVX2-SLOW-NEXT:    vpxor %ymm4, %ymm2, %ymm5
 ; AVX2-SLOW-NEXT:    vpaddd %ymm5, %ymm5, %ymm7
 ; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm4, %ymm7, %ymm6
-; AVX2-SLOW-NEXT:    vpsrlq $32, %ymm7, %ymm8
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm4, %ymm7, %ymm8
+; AVX2-SLOW-NEXT:    vpsrlq $32, %ymm7, %ymm9
 ; AVX2-SLOW-NEXT:    vpbroadcastq {{.*#+}} ymm5 = [255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0]
-; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm5, %ymm8, %ymm9
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm4, %ymm7, %ymm10
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm5, %ymm8, %ymm8
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm6 = ymm6[0],ymm9[0],ymm6[1],ymm9[1],ymm6[4],ymm9[4],ymm6[5],ymm9[5]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm8 = ymm10[0],ymm8[0],ymm10[1],ymm8[1],ymm10[4],ymm8[4],ymm10[5],ymm8[5]
+; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm5, %ymm9, %ymm10
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm5, %ymm9, %ymm9
 ; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm6 = ymm8[0],ymm6[0],ymm8[1],ymm6[1],ymm8[4],ymm6[4],ymm8[5],ymm6[5]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm8 = ymm9[0],ymm10[0],ymm9[1],ymm10[1],ymm9[4],ymm10[4],ymm9[5],ymm10[5]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm6 = ymm6[0],ymm8[0],ymm6[1],ymm8[1],ymm6[4],ymm8[4],ymm6[5],ymm8[5]
 ; AVX2-SLOW-NEXT:    vpandn %ymm7, %ymm6, %ymm8
 ; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm4, %ymm8, %ymm7
-; AVX2-SLOW-NEXT:    vpsrlq $32, %ymm8, %ymm9
-; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm5, %ymm9, %ymm10
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm4, %ymm8, %ymm11
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm5, %ymm9, %ymm9
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm7 = ymm7[0],ymm10[0],ymm7[1],ymm10[1],ymm7[4],ymm10[4],ymm7[5],ymm10[5]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm9 = ymm11[0],ymm9[0],ymm11[1],ymm9[1],ymm11[4],ymm9[4],ymm11[5],ymm9[5]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm7 = ymm9[0],ymm7[0],ymm9[1],ymm7[1],ymm9[4],ymm7[4],ymm9[5],ymm7[5]
-; AVX2-SLOW-NEXT:    vpandn %ymm8, %ymm7, %ymm8
-; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm4, %ymm8, %ymm9
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm4, %ymm8, %ymm9
 ; AVX2-SLOW-NEXT:    vpsrlq $32, %ymm8, %ymm10
 ; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm5, %ymm10, %ymm11
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm4, %ymm8, %ymm12
 ; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm5, %ymm10, %ymm10
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm9 = ymm9[0],ymm11[0],ymm9[1],ymm11[1],ymm9[4],ymm11[4],ymm9[5],ymm11[5]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm10 = ymm12[0],ymm10[0],ymm12[1],ymm10[1],ymm12[4],ymm10[4],ymm12[5],ymm10[5]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm9 = ymm10[0],ymm9[0],ymm10[1],ymm9[1],ymm10[4],ymm9[4],ymm10[5],ymm9[5]
-; AVX2-SLOW-NEXT:    vpandn %ymm8, %ymm9, %ymm8
-; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm4, %ymm8, %ymm10
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm7 = ymm9[0],ymm7[0],ymm9[1],ymm7[1],ymm9[4],ymm7[4],ymm9[5],ymm7[5]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm9 = ymm10[0],ymm11[0],ymm10[1],ymm11[1],ymm10[4],ymm11[4],ymm10[5],ymm11[5]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm7 = ymm7[0],ymm9[0],ymm7[1],ymm9[1],ymm7[4],ymm9[4],ymm7[5],ymm9[5]
+; AVX2-SLOW-NEXT:    vpandn %ymm8, %ymm7, %ymm8
+; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm4, %ymm8, %ymm9
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm4, %ymm8, %ymm10
 ; AVX2-SLOW-NEXT:    vpsrlq $32, %ymm8, %ymm11
 ; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm5, %ymm11, %ymm12
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm4, %ymm8, %ymm13
 ; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm5, %ymm11, %ymm11
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm10 = ymm10[0],ymm12[0],ymm10[1],ymm12[1],ymm10[4],ymm12[4],ymm10[5],ymm12[5]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm11 = ymm13[0],ymm11[0],ymm13[1],ymm11[1],ymm13[4],ymm11[4],ymm13[5],ymm11[5]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm10 = ymm11[0],ymm10[0],ymm11[1],ymm10[1],ymm11[4],ymm10[4],ymm11[5],ymm10[5]
-; AVX2-SLOW-NEXT:    vpandn %ymm8, %ymm10, %ymm8
-; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm4, %ymm8, %ymm11
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm9 = ymm10[0],ymm9[0],ymm10[1],ymm9[1],ymm10[4],ymm9[4],ymm10[5],ymm9[5]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm10 = ymm11[0],ymm12[0],ymm11[1],ymm12[1],ymm11[4],ymm12[4],ymm11[5],ymm12[5]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm9 = ymm9[0],ymm10[0],ymm9[1],ymm10[1],ymm9[4],ymm10[4],ymm9[5],ymm10[5]
+; AVX2-SLOW-NEXT:    vpandn %ymm8, %ymm9, %ymm8
+; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm4, %ymm8, %ymm10
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm4, %ymm8, %ymm11
 ; AVX2-SLOW-NEXT:    vpsrlq $32, %ymm8, %ymm12
 ; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm5, %ymm12, %ymm13
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm4, %ymm8, %ymm8
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm11 = ymm11[0],ymm13[0],ymm11[1],ymm13[1],ymm11[4],ymm13[4],ymm11[5],ymm13[5]
 ; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm5, %ymm12, %ymm12
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm8 = ymm8[0],ymm12[0],ymm8[1],ymm12[1],ymm8[4],ymm12[4],ymm8[5],ymm12[5]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm11 = ymm8[0],ymm11[0],ymm8[1],ymm11[1],ymm8[4],ymm11[4],ymm8[5],ymm11[5]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm10 = ymm11[0],ymm10[0],ymm11[1],ymm10[1],ymm11[4],ymm10[4],ymm11[5],ymm10[5]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm11 = ymm12[0],ymm13[0],ymm12[1],ymm13[1],ymm12[4],ymm13[4],ymm12[5],ymm13[5]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm10 = ymm10[0],ymm11[0],ymm10[1],ymm11[1],ymm10[4],ymm11[4],ymm10[5],ymm11[5]
+; AVX2-SLOW-NEXT:    vpandn %ymm8, %ymm10, %ymm8
+; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm4, %ymm8, %ymm11
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm4, %ymm8, %ymm12
+; AVX2-SLOW-NEXT:    vpsrlq $32, %ymm8, %ymm8
+; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm5, %ymm8, %ymm13
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm11 = ymm12[0],ymm11[0],ymm12[1],ymm11[1],ymm12[4],ymm11[4],ymm12[5],ymm11[5]
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm5, %ymm8, %ymm8
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm8 = ymm8[0],ymm13[0],ymm8[1],ymm13[1],ymm8[4],ymm13[4],ymm8[5],ymm13[5]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm11 = ymm11[0],ymm8[0],ymm11[1],ymm8[1],ymm11[4],ymm8[4],ymm11[5],ymm8[5]
 ; AVX2-SLOW-NEXT:    vpand %ymm2, %ymm6, %ymm6
 ; AVX2-SLOW-NEXT:    vpxor %ymm6, %ymm2, %ymm8
 ; AVX2-SLOW-NEXT:    vpsrld $1, %ymm6, %ymm12
@@ -538,61 +538,61 @@ define <16 x i32> @pdep_v16i32(<16 x i32> %val, <16 x i32> %mask) nounwind {
 ; AVX2-SLOW-NEXT:    vpxor %ymm4, %ymm3, %ymm9
 ; AVX2-SLOW-NEXT:    vpaddd %ymm9, %ymm9, %ymm9
 ; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm4, %ymm9, %ymm10
-; AVX2-SLOW-NEXT:    vpsrlq $32, %ymm9, %ymm11
-; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm5, %ymm11, %ymm12
-; AVX2-SLOW-NEXT:    vpandn %ymm0, %ymm8, %ymm13
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm4, %ymm9, %ymm14
+; AVX2-SLOW-NEXT:    vpandn %ymm0, %ymm8, %ymm11
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm4, %ymm9, %ymm12
+; AVX2-SLOW-NEXT:    vpsrlq $32, %ymm9, %ymm13
+; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm5, %ymm13, %ymm14
 ; AVX2-SLOW-NEXT:    vpslld $4, %ymm0, %ymm0
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm5, %ymm11, %ymm11
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm5, %ymm13, %ymm13
 ; AVX2-SLOW-NEXT:    vpand %ymm0, %ymm8, %ymm0
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm8 = ymm10[0],ymm12[0],ymm10[1],ymm12[1],ymm10[4],ymm12[4],ymm10[5],ymm12[5]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm10 = ymm14[0],ymm11[0],ymm14[1],ymm11[1],ymm14[4],ymm11[4],ymm14[5],ymm11[5]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm8 = ymm10[0],ymm8[0],ymm10[1],ymm8[1],ymm10[4],ymm8[4],ymm10[5],ymm8[5]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm8 = ymm12[0],ymm10[0],ymm12[1],ymm10[1],ymm12[4],ymm10[4],ymm12[5],ymm10[5]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm10 = ymm13[0],ymm14[0],ymm13[1],ymm14[1],ymm13[4],ymm14[4],ymm13[5],ymm14[5]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm8 = ymm8[0],ymm10[0],ymm8[1],ymm10[1],ymm8[4],ymm10[4],ymm8[5],ymm10[5]
 ; AVX2-SLOW-NEXT:    vpandn %ymm9, %ymm8, %ymm10
 ; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm4, %ymm10, %ymm9
-; AVX2-SLOW-NEXT:    vpsrlq $32, %ymm10, %ymm11
-; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm5, %ymm11, %ymm12
-; AVX2-SLOW-NEXT:    vpor %ymm0, %ymm13, %ymm0
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm4, %ymm10, %ymm13
-; AVX2-SLOW-NEXT:    vpandn %ymm0, %ymm7, %ymm14
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm5, %ymm11, %ymm11
-; AVX2-SLOW-NEXT:    vpslld $2, %ymm0, %ymm0
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm9 = ymm9[0],ymm12[0],ymm9[1],ymm12[1],ymm9[4],ymm12[4],ymm9[5],ymm12[5]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm11 = ymm13[0],ymm11[0],ymm13[1],ymm11[1],ymm13[4],ymm11[4],ymm13[5],ymm11[5]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm9 = ymm11[0],ymm9[0],ymm11[1],ymm9[1],ymm11[4],ymm9[4],ymm11[5],ymm9[5]
-; AVX2-SLOW-NEXT:    vpandn %ymm10, %ymm9, %ymm10
-; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm4, %ymm10, %ymm11
+; AVX2-SLOW-NEXT:    vpor %ymm0, %ymm11, %ymm0
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm4, %ymm10, %ymm11
 ; AVX2-SLOW-NEXT:    vpsrlq $32, %ymm10, %ymm12
 ; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm5, %ymm12, %ymm13
+; AVX2-SLOW-NEXT:    vpandn %ymm0, %ymm7, %ymm14
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm5, %ymm12, %ymm12
+; AVX2-SLOW-NEXT:    vpslld $2, %ymm0, %ymm0
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm9 = ymm11[0],ymm9[0],ymm11[1],ymm9[1],ymm11[4],ymm9[4],ymm11[5],ymm9[5]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm11 = ymm12[0],ymm13[0],ymm12[1],ymm13[1],ymm12[4],ymm13[4],ymm12[5],ymm13[5]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm9 = ymm9[0],ymm11[0],ymm9[1],ymm11[1],ymm9[4],ymm11[4],ymm9[5],ymm11[5]
+; AVX2-SLOW-NEXT:    vpandn %ymm10, %ymm9, %ymm10
+; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm4, %ymm10, %ymm11
 ; AVX2-SLOW-NEXT:    vpand %ymm7, %ymm0, %ymm0
 ; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm4, %ymm10, %ymm7
+; AVX2-SLOW-NEXT:    vpsrlq $32, %ymm10, %ymm12
+; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm5, %ymm12, %ymm13
 ; AVX2-SLOW-NEXT:    vpor %ymm0, %ymm14, %ymm0
 ; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm5, %ymm12, %ymm12
 ; AVX2-SLOW-NEXT:    vpandn %ymm0, %ymm6, %ymm14
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm11 = ymm11[0],ymm13[0],ymm11[1],ymm13[1],ymm11[4],ymm13[4],ymm11[5],ymm13[5]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm7 = ymm7[0],ymm12[0],ymm7[1],ymm12[1],ymm7[4],ymm12[4],ymm7[5],ymm12[5]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm7 = ymm7[0],ymm11[0],ymm7[1],ymm11[1],ymm7[4],ymm11[4],ymm7[5],ymm11[5]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm11 = ymm12[0],ymm13[0],ymm12[1],ymm13[1],ymm12[4],ymm13[4],ymm12[5],ymm13[5]
 ; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm7 = ymm7[0],ymm11[0],ymm7[1],ymm11[1],ymm7[4],ymm11[4],ymm7[5],ymm11[5]
 ; AVX2-SLOW-NEXT:    vpandn %ymm10, %ymm7, %ymm10
 ; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm4, %ymm10, %ymm11
-; AVX2-SLOW-NEXT:    vpsrlq $32, %ymm10, %ymm12
-; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm5, %ymm12, %ymm13
 ; AVX2-SLOW-NEXT:    vpaddd %ymm0, %ymm0, %ymm0
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm4, %ymm10, %ymm15
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm4, %ymm10, %ymm12
+; AVX2-SLOW-NEXT:    vpsrlq $32, %ymm10, %ymm13
+; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm5, %ymm13, %ymm15
 ; AVX2-SLOW-NEXT:    vpand %ymm6, %ymm0, %ymm0
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm5, %ymm12, %ymm6
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm5, %ymm13, %ymm6
 ; AVX2-SLOW-NEXT:    vpor %ymm0, %ymm14, %ymm0
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm11 = ymm11[0],ymm13[0],ymm11[1],ymm13[1],ymm11[4],ymm13[4],ymm11[5],ymm13[5]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm6 = ymm15[0],ymm6[0],ymm15[1],ymm6[1],ymm15[4],ymm6[4],ymm15[5],ymm6[5]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm6 = ymm6[0],ymm11[0],ymm6[1],ymm11[1],ymm6[4],ymm11[4],ymm6[5],ymm11[5]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm11 = ymm12[0],ymm11[0],ymm12[1],ymm11[1],ymm12[4],ymm11[4],ymm12[5],ymm11[5]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm6 = ymm6[0],ymm15[0],ymm6[1],ymm15[1],ymm6[4],ymm15[4],ymm6[5],ymm15[5]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm6 = ymm11[0],ymm6[0],ymm11[1],ymm6[1],ymm11[4],ymm6[4],ymm11[5],ymm6[5]
 ; AVX2-SLOW-NEXT:    vpandn %ymm10, %ymm6, %ymm10
 ; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm4, %ymm10, %ymm11
-; AVX2-SLOW-NEXT:    vpsrlq $32, %ymm10, %ymm12
-; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm5, %ymm12, %ymm13
 ; AVX2-SLOW-NEXT:    vpand %ymm2, %ymm0, %ymm0
 ; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm4, %ymm10, %ymm2
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm4 = ymm11[0],ymm13[0],ymm11[1],ymm13[1],ymm11[4],ymm13[4],ymm11[5],ymm13[5]
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm5, %ymm12, %ymm5
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm2 = ymm2[0],ymm5[0],ymm2[1],ymm5[1],ymm2[4],ymm5[4],ymm2[5],ymm5[5]
+; AVX2-SLOW-NEXT:    vpsrlq $32, %ymm10, %ymm4
+; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm5, %ymm4, %ymm10
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm2 = ymm2[0],ymm11[0],ymm2[1],ymm11[1],ymm2[4],ymm11[4],ymm2[5],ymm11[5]
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm5, %ymm4, %ymm4
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm4 = ymm4[0],ymm10[0],ymm4[1],ymm10[1],ymm4[4],ymm10[4],ymm4[5],ymm10[5]
 ; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm4 = ymm2[0],ymm4[0],ymm2[1],ymm4[1],ymm2[4],ymm4[4],ymm2[5],ymm4[5]
 ; AVX2-SLOW-NEXT:    vpand %ymm3, %ymm8, %ymm2
 ; AVX2-SLOW-NEXT:    vpxor %ymm2, %ymm3, %ymm5

--- a/llvm/test/CodeGen/X86/pext-vector-128.ll
+++ b/llvm/test/CodeGen/X86/pext-vector-128.ll
@@ -310,16 +310,16 @@ define <8 x i16> @pext_v8i16(<8 x i16> %val, <8 x i16> %mask) nounwind {
 ; AVX2-NEXT:    vpcmpeqd %xmm2, %xmm2, %xmm2
 ; AVX2-NEXT:    vpxor %xmm2, %xmm1, %xmm2
 ; AVX2-NEXT:    vpaddw %xmm2, %xmm2, %xmm6
-; AVX2-NEXT:    vpmovzxwd {{.*#+}} ymm4 = xmm6[0],zero,xmm6[1],zero,xmm6[2],zero,xmm6[3],zero,xmm6[4],zero,xmm6[5],zero,xmm6[6],zero,xmm6[7],zero
+; AVX2-NEXT:    vpmovzxwd {{.*#+}} ymm3 = xmm6[0],zero,xmm6[1],zero,xmm6[2],zero,xmm6[3],zero,xmm6[4],zero,xmm6[5],zero,xmm6[6],zero,xmm6[7],zero
 ; AVX2-NEXT:    vpbroadcastd {{.*#+}} ymm2 = [65535,65535,65535,65535,65535,65535,65535,65535]
-; AVX2-NEXT:    vpclmulqdq $17, %ymm2, %ymm4, %ymm5
-; AVX2-NEXT:    vpsrlq $32, %ymm4, %ymm7
+; AVX2-NEXT:    vpclmulqdq $17, %ymm2, %ymm3, %ymm4
+; AVX2-NEXT:    vpclmulqdq $0, %ymm2, %ymm3, %ymm5
+; AVX2-NEXT:    vpsrlq $32, %ymm3, %ymm7
 ; AVX2-NEXT:    vpbroadcastq {{.*#+}} ymm3 = [255,255,0,0,0,0,0,0,255,255,0,0,0,0,0,0,255,255,0,0,0,0,0,0,255,255,0,0,0,0,0,0]
 ; AVX2-NEXT:    vpclmulqdq $17, %ymm3, %ymm7, %ymm8
-; AVX2-NEXT:    vpclmulqdq $0, %ymm2, %ymm4, %ymm4
 ; AVX2-NEXT:    vpclmulqdq $0, %ymm3, %ymm7, %ymm7
-; AVX2-NEXT:    vpunpckldq {{.*#+}} ymm5 = ymm5[0],ymm8[0],ymm5[1],ymm8[1],ymm5[4],ymm8[4],ymm5[5],ymm8[5]
-; AVX2-NEXT:    vpunpckldq {{.*#+}} ymm4 = ymm4[0],ymm7[0],ymm4[1],ymm7[1],ymm4[4],ymm7[4],ymm4[5],ymm7[5]
+; AVX2-NEXT:    vpunpckldq {{.*#+}} ymm4 = ymm5[0],ymm4[0],ymm5[1],ymm4[1],ymm5[4],ymm4[4],ymm5[5],ymm4[5]
+; AVX2-NEXT:    vpunpckldq {{.*#+}} ymm5 = ymm7[0],ymm8[0],ymm7[1],ymm8[1],ymm7[4],ymm8[4],ymm7[5],ymm8[5]
 ; AVX2-NEXT:    vpunpckldq {{.*#+}} ymm4 = ymm4[0],ymm5[0],ymm4[1],ymm5[1],ymm4[4],ymm5[4],ymm4[5],ymm5[5]
 ; AVX2-NEXT:    vmovdqa {{.*#+}} ymm5 = [0,1,4,5,8,9,12,13,8,9,12,13,12,13,14,15,16,17,20,21,24,25,28,29,24,25,28,29,28,29,30,31]
 ; AVX2-NEXT:    vpshufb %ymm5, %ymm4, %ymm4
@@ -327,37 +327,37 @@ define <8 x i16> @pext_v8i16(<8 x i16> %val, <8 x i16> %mask) nounwind {
 ; AVX2-NEXT:    vpandn %xmm6, %xmm4, %xmm7
 ; AVX2-NEXT:    vpmovzxwd {{.*#+}} ymm6 = xmm7[0],zero,xmm7[1],zero,xmm7[2],zero,xmm7[3],zero,xmm7[4],zero,xmm7[5],zero,xmm7[6],zero,xmm7[7],zero
 ; AVX2-NEXT:    vpclmulqdq $17, %ymm2, %ymm6, %ymm8
-; AVX2-NEXT:    vpsrlq $32, %ymm6, %ymm9
-; AVX2-NEXT:    vpclmulqdq $17, %ymm3, %ymm9, %ymm10
-; AVX2-NEXT:    vpunpckldq {{.*#+}} ymm8 = ymm8[0],ymm10[0],ymm8[1],ymm10[1],ymm8[4],ymm10[4],ymm8[5],ymm10[5]
-; AVX2-NEXT:    vpclmulqdq $0, %ymm2, %ymm6, %ymm6
-; AVX2-NEXT:    vpclmulqdq $0, %ymm3, %ymm9, %ymm9
+; AVX2-NEXT:    vpclmulqdq $0, %ymm2, %ymm6, %ymm9
+; AVX2-NEXT:    vpunpckldq {{.*#+}} ymm8 = ymm9[0],ymm8[0],ymm9[1],ymm8[1],ymm9[4],ymm8[4],ymm9[5],ymm8[5]
+; AVX2-NEXT:    vpsrlq $32, %ymm6, %ymm6
+; AVX2-NEXT:    vpclmulqdq $17, %ymm3, %ymm6, %ymm9
+; AVX2-NEXT:    vpclmulqdq $0, %ymm3, %ymm6, %ymm6
 ; AVX2-NEXT:    vpunpckldq {{.*#+}} ymm6 = ymm6[0],ymm9[0],ymm6[1],ymm9[1],ymm6[4],ymm9[4],ymm6[5],ymm9[5]
-; AVX2-NEXT:    vpunpckldq {{.*#+}} ymm6 = ymm6[0],ymm8[0],ymm6[1],ymm8[1],ymm6[4],ymm8[4],ymm6[5],ymm8[5]
+; AVX2-NEXT:    vpunpckldq {{.*#+}} ymm6 = ymm8[0],ymm6[0],ymm8[1],ymm6[1],ymm8[4],ymm6[4],ymm8[5],ymm6[5]
 ; AVX2-NEXT:    vpshufb %ymm5, %ymm6, %ymm6
 ; AVX2-NEXT:    vpermq {{.*#+}} ymm6 = ymm6[0,2,2,3]
 ; AVX2-NEXT:    vpandn %xmm7, %xmm6, %xmm7
 ; AVX2-NEXT:    vpmovzxwd {{.*#+}} ymm8 = xmm7[0],zero,xmm7[1],zero,xmm7[2],zero,xmm7[3],zero,xmm7[4],zero,xmm7[5],zero,xmm7[6],zero,xmm7[7],zero
 ; AVX2-NEXT:    vpclmulqdq $17, %ymm2, %ymm8, %ymm9
-; AVX2-NEXT:    vpsrlq $32, %ymm8, %ymm10
-; AVX2-NEXT:    vpclmulqdq $17, %ymm3, %ymm10, %ymm11
-; AVX2-NEXT:    vpunpckldq {{.*#+}} ymm9 = ymm9[0],ymm11[0],ymm9[1],ymm11[1],ymm9[4],ymm11[4],ymm9[5],ymm11[5]
-; AVX2-NEXT:    vpclmulqdq $0, %ymm2, %ymm8, %ymm8
-; AVX2-NEXT:    vpclmulqdq $0, %ymm3, %ymm10, %ymm10
+; AVX2-NEXT:    vpclmulqdq $0, %ymm2, %ymm8, %ymm10
+; AVX2-NEXT:    vpunpckldq {{.*#+}} ymm9 = ymm10[0],ymm9[0],ymm10[1],ymm9[1],ymm10[4],ymm9[4],ymm10[5],ymm9[5]
+; AVX2-NEXT:    vpsrlq $32, %ymm8, %ymm8
+; AVX2-NEXT:    vpclmulqdq $17, %ymm3, %ymm8, %ymm10
+; AVX2-NEXT:    vpclmulqdq $0, %ymm3, %ymm8, %ymm8
 ; AVX2-NEXT:    vpunpckldq {{.*#+}} ymm8 = ymm8[0],ymm10[0],ymm8[1],ymm10[1],ymm8[4],ymm10[4],ymm8[5],ymm10[5]
-; AVX2-NEXT:    vpunpckldq {{.*#+}} ymm8 = ymm8[0],ymm9[0],ymm8[1],ymm9[1],ymm8[4],ymm9[4],ymm8[5],ymm9[5]
+; AVX2-NEXT:    vpunpckldq {{.*#+}} ymm8 = ymm9[0],ymm8[0],ymm9[1],ymm8[1],ymm9[4],ymm8[4],ymm9[5],ymm8[5]
 ; AVX2-NEXT:    vpshufb %ymm5, %ymm8, %ymm8
 ; AVX2-NEXT:    vpermq {{.*#+}} ymm8 = ymm8[0,2,2,3]
 ; AVX2-NEXT:    vpandn %xmm7, %xmm8, %xmm7
 ; AVX2-NEXT:    vpmovzxwd {{.*#+}} ymm7 = xmm7[0],zero,xmm7[1],zero,xmm7[2],zero,xmm7[3],zero,xmm7[4],zero,xmm7[5],zero,xmm7[6],zero,xmm7[7],zero
 ; AVX2-NEXT:    vpclmulqdq $17, %ymm2, %ymm7, %ymm9
-; AVX2-NEXT:    vpsrlq $32, %ymm7, %ymm10
-; AVX2-NEXT:    vpclmulqdq $17, %ymm3, %ymm10, %ymm11
 ; AVX2-NEXT:    vpclmulqdq $0, %ymm2, %ymm7, %ymm2
-; AVX2-NEXT:    vpclmulqdq $0, %ymm3, %ymm10, %ymm3
-; AVX2-NEXT:    vpunpckldq {{.*#+}} ymm7 = ymm9[0],ymm11[0],ymm9[1],ymm11[1],ymm9[4],ymm11[4],ymm9[5],ymm11[5]
+; AVX2-NEXT:    vpsrlq $32, %ymm7, %ymm7
+; AVX2-NEXT:    vpclmulqdq $17, %ymm3, %ymm7, %ymm10
+; AVX2-NEXT:    vpclmulqdq $0, %ymm3, %ymm7, %ymm3
+; AVX2-NEXT:    vpunpckldq {{.*#+}} ymm2 = ymm2[0],ymm9[0],ymm2[1],ymm9[1],ymm2[4],ymm9[4],ymm2[5],ymm9[5]
+; AVX2-NEXT:    vpunpckldq {{.*#+}} ymm3 = ymm3[0],ymm10[0],ymm3[1],ymm10[1],ymm3[4],ymm10[4],ymm3[5],ymm10[5]
 ; AVX2-NEXT:    vpunpckldq {{.*#+}} ymm2 = ymm2[0],ymm3[0],ymm2[1],ymm3[1],ymm2[4],ymm3[4],ymm2[5],ymm3[5]
-; AVX2-NEXT:    vpunpckldq {{.*#+}} ymm2 = ymm2[0],ymm7[0],ymm2[1],ymm7[1],ymm2[4],ymm7[4],ymm2[5],ymm7[5]
 ; AVX2-NEXT:    vpshufb %ymm5, %ymm2, %ymm2
 ; AVX2-NEXT:    vpermq {{.*#+}} ymm2 = ymm2[0,2,2,3]
 ; AVX2-NEXT:    vpand %xmm1, %xmm4, %xmm3
@@ -401,57 +401,57 @@ define <8 x i16> @pext_v8i16(<8 x i16> %val, <8 x i16> %mask) nounwind {
 ; AVX512-NEXT:    vpmovzxwd {{.*#+}} ymm3 = xmm2[0],zero,xmm2[1],zero,xmm2[2],zero,xmm2[3],zero,xmm2[4],zero,xmm2[5],zero,xmm2[6],zero,xmm2[7],zero
 ; AVX512-NEXT:    vpbroadcastd {{.*#+}} ymm4 = [65535,65535,65535,65535,65535,65535,65535,65535]
 ; AVX512-NEXT:    vpclmulqdq $17, %ymm4, %ymm3, %ymm5
-; AVX512-NEXT:    vpsrlq $32, %ymm3, %ymm6
-; AVX512-NEXT:    vpbroadcastq {{.*#+}} ymm7 = [255,255,0,0,0,0,0,0,255,255,0,0,0,0,0,0,255,255,0,0,0,0,0,0,255,255,0,0,0,0,0,0]
-; AVX512-NEXT:    vpclmulqdq $17, %ymm7, %ymm6, %ymm8
-; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm5 = ymm5[0],ymm8[0],ymm5[1],ymm8[1],ymm5[4],ymm8[4],ymm5[5],ymm8[5]
-; AVX512-NEXT:    vpclmulqdq $0, %ymm4, %ymm3, %ymm3
-; AVX512-NEXT:    vpclmulqdq $0, %ymm7, %ymm6, %ymm6
-; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm3 = ymm3[0],ymm6[0],ymm3[1],ymm6[1],ymm3[4],ymm6[4],ymm3[5],ymm6[5]
-; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm3 = ymm3[0],ymm5[0],ymm3[1],ymm5[1],ymm3[4],ymm5[4],ymm3[5],ymm5[5]
+; AVX512-NEXT:    vpclmulqdq $0, %ymm4, %ymm3, %ymm6
+; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm5 = ymm6[0],ymm5[0],ymm6[1],ymm5[1],ymm6[4],ymm5[4],ymm6[5],ymm5[5]
+; AVX512-NEXT:    vpsrlq $32, %ymm3, %ymm3
+; AVX512-NEXT:    vpbroadcastq {{.*#+}} ymm6 = [255,255,0,0,0,0,0,0,255,255,0,0,0,0,0,0,255,255,0,0,0,0,0,0,255,255,0,0,0,0,0,0]
+; AVX512-NEXT:    vpclmulqdq $17, %ymm6, %ymm3, %ymm7
+; AVX512-NEXT:    vpclmulqdq $0, %ymm6, %ymm3, %ymm3
+; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm3 = ymm3[0],ymm7[0],ymm3[1],ymm7[1],ymm3[4],ymm7[4],ymm3[5],ymm7[5]
+; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm3 = ymm5[0],ymm3[0],ymm5[1],ymm3[1],ymm5[4],ymm3[4],ymm5[5],ymm3[5]
 ; AVX512-NEXT:    vpmovdw %ymm3, %xmm3
 ; AVX512-NEXT:    vpandn %xmm2, %xmm3, %xmm2
 ; AVX512-NEXT:    vpmovzxwd {{.*#+}} ymm5 = xmm2[0],zero,xmm2[1],zero,xmm2[2],zero,xmm2[3],zero,xmm2[4],zero,xmm2[5],zero,xmm2[6],zero,xmm2[7],zero
-; AVX512-NEXT:    vpclmulqdq $17, %ymm4, %ymm5, %ymm6
-; AVX512-NEXT:    vpsrlq $32, %ymm5, %ymm8
-; AVX512-NEXT:    vpclmulqdq $17, %ymm7, %ymm8, %ymm9
-; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm6 = ymm6[0],ymm9[0],ymm6[1],ymm9[1],ymm6[4],ymm9[4],ymm6[5],ymm9[5]
-; AVX512-NEXT:    vpclmulqdq $0, %ymm4, %ymm5, %ymm5
-; AVX512-NEXT:    vpclmulqdq $0, %ymm7, %ymm8, %ymm8
+; AVX512-NEXT:    vpclmulqdq $17, %ymm4, %ymm5, %ymm7
+; AVX512-NEXT:    vpclmulqdq $0, %ymm4, %ymm5, %ymm8
+; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm7 = ymm8[0],ymm7[0],ymm8[1],ymm7[1],ymm8[4],ymm7[4],ymm8[5],ymm7[5]
+; AVX512-NEXT:    vpsrlq $32, %ymm5, %ymm5
+; AVX512-NEXT:    vpclmulqdq $17, %ymm6, %ymm5, %ymm8
+; AVX512-NEXT:    vpclmulqdq $0, %ymm6, %ymm5, %ymm5
 ; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm5 = ymm5[0],ymm8[0],ymm5[1],ymm8[1],ymm5[4],ymm8[4],ymm5[5],ymm8[5]
-; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm5 = ymm5[0],ymm6[0],ymm5[1],ymm6[1],ymm5[4],ymm6[4],ymm5[5],ymm6[5]
+; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm5 = ymm7[0],ymm5[0],ymm7[1],ymm5[1],ymm7[4],ymm5[4],ymm7[5],ymm5[5]
 ; AVX512-NEXT:    vpmovdw %ymm5, %xmm5
 ; AVX512-NEXT:    vpandn %xmm2, %xmm5, %xmm2
-; AVX512-NEXT:    vpmovzxwd {{.*#+}} ymm6 = xmm2[0],zero,xmm2[1],zero,xmm2[2],zero,xmm2[3],zero,xmm2[4],zero,xmm2[5],zero,xmm2[6],zero,xmm2[7],zero
-; AVX512-NEXT:    vpclmulqdq $17, %ymm4, %ymm6, %ymm8
-; AVX512-NEXT:    vpsrlq $32, %ymm6, %ymm9
-; AVX512-NEXT:    vpclmulqdq $17, %ymm7, %ymm9, %ymm10
-; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm8 = ymm8[0],ymm10[0],ymm8[1],ymm10[1],ymm8[4],ymm10[4],ymm8[5],ymm10[5]
-; AVX512-NEXT:    vpclmulqdq $0, %ymm4, %ymm6, %ymm6
-; AVX512-NEXT:    vpclmulqdq $0, %ymm7, %ymm9, %ymm9
-; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm6 = ymm6[0],ymm9[0],ymm6[1],ymm9[1],ymm6[4],ymm9[4],ymm6[5],ymm9[5]
-; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm6 = ymm6[0],ymm8[0],ymm6[1],ymm8[1],ymm6[4],ymm8[4],ymm6[5],ymm8[5]
-; AVX512-NEXT:    vpmovdw %ymm6, %xmm6
-; AVX512-NEXT:    vpandn %xmm2, %xmm6, %xmm2
+; AVX512-NEXT:    vpmovzxwd {{.*#+}} ymm7 = xmm2[0],zero,xmm2[1],zero,xmm2[2],zero,xmm2[3],zero,xmm2[4],zero,xmm2[5],zero,xmm2[6],zero,xmm2[7],zero
+; AVX512-NEXT:    vpclmulqdq $17, %ymm4, %ymm7, %ymm8
+; AVX512-NEXT:    vpclmulqdq $0, %ymm4, %ymm7, %ymm9
+; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm8 = ymm9[0],ymm8[0],ymm9[1],ymm8[1],ymm9[4],ymm8[4],ymm9[5],ymm8[5]
+; AVX512-NEXT:    vpsrlq $32, %ymm7, %ymm7
+; AVX512-NEXT:    vpclmulqdq $17, %ymm6, %ymm7, %ymm9
+; AVX512-NEXT:    vpclmulqdq $0, %ymm6, %ymm7, %ymm7
+; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm7 = ymm7[0],ymm9[0],ymm7[1],ymm9[1],ymm7[4],ymm9[4],ymm7[5],ymm9[5]
+; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm7 = ymm8[0],ymm7[0],ymm8[1],ymm7[1],ymm8[4],ymm7[4],ymm8[5],ymm7[5]
+; AVX512-NEXT:    vpmovdw %ymm7, %xmm7
+; AVX512-NEXT:    vpandn %xmm2, %xmm7, %xmm2
 ; AVX512-NEXT:    vpmovzxwd {{.*#+}} ymm2 = xmm2[0],zero,xmm2[1],zero,xmm2[2],zero,xmm2[3],zero,xmm2[4],zero,xmm2[5],zero,xmm2[6],zero,xmm2[7],zero
 ; AVX512-NEXT:    vpclmulqdq $17, %ymm4, %ymm2, %ymm8
-; AVX512-NEXT:    vpsrlq $32, %ymm2, %ymm9
-; AVX512-NEXT:    vpclmulqdq $17, %ymm7, %ymm9, %ymm10
-; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm8 = ymm8[0],ymm10[0],ymm8[1],ymm10[1],ymm8[4],ymm10[4],ymm8[5],ymm10[5]
-; AVX512-NEXT:    vpclmulqdq $0, %ymm4, %ymm2, %ymm2
-; AVX512-NEXT:    vpclmulqdq $0, %ymm7, %ymm9, %ymm4
-; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm2 = ymm2[0],ymm4[0],ymm2[1],ymm4[1],ymm2[4],ymm4[4],ymm2[5],ymm4[5]
+; AVX512-NEXT:    vpclmulqdq $0, %ymm4, %ymm2, %ymm4
+; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm4 = ymm4[0],ymm8[0],ymm4[1],ymm8[1],ymm4[4],ymm8[4],ymm4[5],ymm8[5]
+; AVX512-NEXT:    vpsrlq $32, %ymm2, %ymm2
+; AVX512-NEXT:    vpclmulqdq $17, %ymm6, %ymm2, %ymm8
+; AVX512-NEXT:    vpclmulqdq $0, %ymm6, %ymm2, %ymm2
 ; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm2 = ymm2[0],ymm8[0],ymm2[1],ymm8[1],ymm2[4],ymm8[4],ymm2[5],ymm8[5]
+; AVX512-NEXT:    vpunpckldq {{.*#+}} ymm2 = ymm4[0],ymm2[0],ymm4[1],ymm2[1],ymm4[4],ymm2[4],ymm4[5],ymm2[5]
 ; AVX512-NEXT:    vpmovdw %ymm2, %xmm2
 ; AVX512-NEXT:    vpand %xmm1, %xmm3, %xmm3
 ; AVX512-NEXT:    vpsrlw $1, %xmm3, %xmm4
 ; AVX512-NEXT:    vpternlogq {{.*#+}} xmm4 = xmm4 | (xmm1 ^ xmm3)
 ; AVX512-NEXT:    vpand %xmm4, %xmm5, %xmm5
-; AVX512-NEXT:    vpsrlw $2, %xmm5, %xmm7
-; AVX512-NEXT:    vpternlogq {{.*#+}} xmm7 = xmm7 | (xmm4 ^ xmm5)
-; AVX512-NEXT:    vpand %xmm7, %xmm6, %xmm4
-; AVX512-NEXT:    vpsrlw $4, %xmm4, %xmm6
-; AVX512-NEXT:    vpternlogq {{.*#+}} xmm6 = xmm6 | (xmm7 ^ xmm4)
+; AVX512-NEXT:    vpsrlw $2, %xmm5, %xmm6
+; AVX512-NEXT:    vpternlogq {{.*#+}} xmm6 = xmm6 | (xmm4 ^ xmm5)
+; AVX512-NEXT:    vpand %xmm6, %xmm7, %xmm4
+; AVX512-NEXT:    vpsrlw $4, %xmm4, %xmm7
+; AVX512-NEXT:    vpternlogq {{.*#+}} xmm7 = xmm7 | (xmm6 ^ xmm4)
 ; AVX512-NEXT:    vpand %xmm1, %xmm0, %xmm0
 ; AVX512-NEXT:    vpand %xmm3, %xmm0, %xmm1
 ; AVX512-NEXT:    vpsrlw $1, %xmm1, %xmm3
@@ -462,9 +462,9 @@ define <8 x i16> @pext_v8i16(<8 x i16> %val, <8 x i16> %mask) nounwind {
 ; AVX512-NEXT:    vpand %xmm4, %xmm1, %xmm0
 ; AVX512-NEXT:    vpsrlw $4, %xmm0, %xmm3
 ; AVX512-NEXT:    vpternlogq {{.*#+}} xmm3 = xmm3 | (xmm1 ^ xmm0)
-; AVX512-NEXT:    vpternlogq {{.*#+}} xmm6 = xmm6 & xmm3 & xmm2
-; AVX512-NEXT:    vpsrlw $8, %xmm6, %xmm0
-; AVX512-NEXT:    vpternlogq {{.*#+}} xmm0 = xmm0 | (xmm3 ^ xmm6)
+; AVX512-NEXT:    vpternlogq {{.*#+}} xmm7 = xmm7 & xmm3 & xmm2
+; AVX512-NEXT:    vpsrlw $8, %xmm7, %xmm0
+; AVX512-NEXT:    vpternlogq {{.*#+}} xmm0 = xmm0 | (xmm3 ^ xmm7)
 ; AVX512-NEXT:    vzeroupper
 ; AVX512-NEXT:    retq
   %res = call <8 x i16> @llvm.pext.v8i16(<8 x i16> %val, <8 x i16> %mask)
@@ -606,117 +606,116 @@ define <4 x i32> @pext_v4i32(<4 x i32> %val, <4 x i32> %mask) nounwind {
 ;
 ; PCLMUL-LABEL: pext_v4i32:
 ; PCLMUL:       # %bb.0:
-; PCLMUL-NEXT:    pcmpeqd %xmm7, %xmm7
-; PCLMUL-NEXT:    movdqa %xmm1, %xmm3
-; PCLMUL-NEXT:    pxor %xmm7, %xmm3
-; PCLMUL-NEXT:    paddd %xmm3, %xmm3
-; PCLMUL-NEXT:    movdqa %xmm3, %xmm4
-; PCLMUL-NEXT:    pclmulqdq $17, %xmm7, %xmm4
-; PCLMUL-NEXT:    movdqa %xmm3, %xmm5
-; PCLMUL-NEXT:    psrlq $32, %xmm5
-; PCLMUL-NEXT:    movdqa {{.*#+}} xmm8 = [255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0]
-; PCLMUL-NEXT:    movdqa %xmm5, %xmm2
-; PCLMUL-NEXT:    pclmulqdq $17, %xmm8, %xmm2
-; PCLMUL-NEXT:    punpckldq {{.*#+}} xmm4 = xmm4[0],xmm2[0],xmm4[1],xmm2[1]
-; PCLMUL-NEXT:    movdqa %xmm3, %xmm2
-; PCLMUL-NEXT:    pclmulqdq $0, %xmm7, %xmm2
-; PCLMUL-NEXT:    pclmulqdq $0, %xmm8, %xmm5
-; PCLMUL-NEXT:    punpckldq {{.*#+}} xmm2 = xmm2[0],xmm5[0],xmm2[1],xmm5[1]
-; PCLMUL-NEXT:    punpckldq {{.*#+}} xmm2 = xmm2[0],xmm4[0],xmm2[1],xmm4[1]
-; PCLMUL-NEXT:    movdqa %xmm2, %xmm4
-; PCLMUL-NEXT:    pandn %xmm3, %xmm4
+; PCLMUL-NEXT:    pcmpeqd %xmm2, %xmm2
+; PCLMUL-NEXT:    movdqa %xmm1, %xmm4
+; PCLMUL-NEXT:    pxor %xmm2, %xmm4
+; PCLMUL-NEXT:    paddd %xmm4, %xmm4
 ; PCLMUL-NEXT:    movdqa %xmm4, %xmm5
-; PCLMUL-NEXT:    pclmulqdq $17, %xmm7, %xmm5
-; PCLMUL-NEXT:    movdqa %xmm4, %xmm6
-; PCLMUL-NEXT:    psrlq $32, %xmm6
-; PCLMUL-NEXT:    movdqa %xmm6, %xmm3
-; PCLMUL-NEXT:    pclmulqdq $17, %xmm8, %xmm3
-; PCLMUL-NEXT:    punpckldq {{.*#+}} xmm5 = xmm5[0],xmm3[0],xmm5[1],xmm3[1]
+; PCLMUL-NEXT:    pclmulqdq $17, %xmm2, %xmm5
 ; PCLMUL-NEXT:    movdqa %xmm4, %xmm3
-; PCLMUL-NEXT:    pclmulqdq $0, %xmm7, %xmm3
-; PCLMUL-NEXT:    pclmulqdq $0, %xmm8, %xmm6
-; PCLMUL-NEXT:    punpckldq {{.*#+}} xmm3 = xmm3[0],xmm6[0],xmm3[1],xmm6[1]
+; PCLMUL-NEXT:    pclmulqdq $0, %xmm2, %xmm3
+; PCLMUL-NEXT:    punpckldq {{.*#+}} xmm3 = xmm3[0],xmm5[0],xmm3[1],xmm5[1]
+; PCLMUL-NEXT:    movdqa %xmm4, %xmm5
+; PCLMUL-NEXT:    psrlq $32, %xmm5
+; PCLMUL-NEXT:    movdqa {{.*#+}} xmm7 = [255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0]
+; PCLMUL-NEXT:    movdqa %xmm5, %xmm6
+; PCLMUL-NEXT:    pclmulqdq $17, %xmm7, %xmm6
+; PCLMUL-NEXT:    pclmulqdq $0, %xmm7, %xmm5
+; PCLMUL-NEXT:    punpckldq {{.*#+}} xmm5 = xmm5[0],xmm6[0],xmm5[1],xmm6[1]
 ; PCLMUL-NEXT:    punpckldq {{.*#+}} xmm3 = xmm3[0],xmm5[0],xmm3[1],xmm5[1]
 ; PCLMUL-NEXT:    movdqa %xmm3, %xmm5
 ; PCLMUL-NEXT:    pandn %xmm4, %xmm5
 ; PCLMUL-NEXT:    movdqa %xmm5, %xmm6
-; PCLMUL-NEXT:    pclmulqdq $17, %xmm7, %xmm6
-; PCLMUL-NEXT:    movdqa %xmm5, %xmm9
-; PCLMUL-NEXT:    psrlq $32, %xmm9
-; PCLMUL-NEXT:    movdqa %xmm9, %xmm4
-; PCLMUL-NEXT:    pclmulqdq $17, %xmm8, %xmm4
-; PCLMUL-NEXT:    punpckldq {{.*#+}} xmm6 = xmm6[0],xmm4[0],xmm6[1],xmm4[1]
+; PCLMUL-NEXT:    pclmulqdq $17, %xmm2, %xmm6
 ; PCLMUL-NEXT:    movdqa %xmm5, %xmm4
-; PCLMUL-NEXT:    pclmulqdq $0, %xmm7, %xmm4
-; PCLMUL-NEXT:    pclmulqdq $0, %xmm8, %xmm9
-; PCLMUL-NEXT:    punpckldq {{.*#+}} xmm4 = xmm4[0],xmm9[0],xmm4[1],xmm9[1]
+; PCLMUL-NEXT:    pclmulqdq $0, %xmm2, %xmm4
 ; PCLMUL-NEXT:    punpckldq {{.*#+}} xmm4 = xmm4[0],xmm6[0],xmm4[1],xmm6[1]
-; PCLMUL-NEXT:    movdqa %xmm4, %xmm9
-; PCLMUL-NEXT:    pandn %xmm5, %xmm9
-; PCLMUL-NEXT:    movdqa %xmm9, %xmm6
-; PCLMUL-NEXT:    pclmulqdq $17, %xmm7, %xmm6
-; PCLMUL-NEXT:    movdqa %xmm9, %xmm10
-; PCLMUL-NEXT:    psrlq $32, %xmm10
-; PCLMUL-NEXT:    movdqa %xmm10, %xmm5
-; PCLMUL-NEXT:    pclmulqdq $17, %xmm8, %xmm5
-; PCLMUL-NEXT:    punpckldq {{.*#+}} xmm6 = xmm6[0],xmm5[0],xmm6[1],xmm5[1]
-; PCLMUL-NEXT:    movdqa %xmm9, %xmm5
-; PCLMUL-NEXT:    pclmulqdq $0, %xmm7, %xmm5
-; PCLMUL-NEXT:    pclmulqdq $0, %xmm8, %xmm10
-; PCLMUL-NEXT:    punpckldq {{.*#+}} xmm5 = xmm5[0],xmm10[0],xmm5[1],xmm10[1]
-; PCLMUL-NEXT:    punpckldq {{.*#+}} xmm5 = xmm5[0],xmm6[0],xmm5[1],xmm6[1]
 ; PCLMUL-NEXT:    movdqa %xmm5, %xmm6
-; PCLMUL-NEXT:    pandn %xmm9, %xmm6
-; PCLMUL-NEXT:    movdqa %xmm6, %xmm9
-; PCLMUL-NEXT:    pclmulqdq $17, %xmm7, %xmm9
-; PCLMUL-NEXT:    movdqa %xmm6, %xmm10
-; PCLMUL-NEXT:    psrlq $32, %xmm10
-; PCLMUL-NEXT:    movdqa %xmm10, %xmm11
-; PCLMUL-NEXT:    pclmulqdq $17, %xmm8, %xmm11
-; PCLMUL-NEXT:    punpckldq {{.*#+}} xmm9 = xmm9[0],xmm11[0],xmm9[1],xmm11[1]
+; PCLMUL-NEXT:    psrlq $32, %xmm6
+; PCLMUL-NEXT:    movdqa %xmm6, %xmm8
+; PCLMUL-NEXT:    pclmulqdq $17, %xmm7, %xmm8
 ; PCLMUL-NEXT:    pclmulqdq $0, %xmm7, %xmm6
-; PCLMUL-NEXT:    pclmulqdq $0, %xmm8, %xmm10
-; PCLMUL-NEXT:    punpckldq {{.*#+}} xmm6 = xmm6[0],xmm10[0],xmm6[1],xmm10[1]
+; PCLMUL-NEXT:    punpckldq {{.*#+}} xmm6 = xmm6[0],xmm8[0],xmm6[1],xmm8[1]
+; PCLMUL-NEXT:    punpckldq {{.*#+}} xmm4 = xmm4[0],xmm6[0],xmm4[1],xmm6[1]
+; PCLMUL-NEXT:    movdqa %xmm4, %xmm6
+; PCLMUL-NEXT:    pandn %xmm5, %xmm6
+; PCLMUL-NEXT:    movdqa %xmm6, %xmm8
+; PCLMUL-NEXT:    pclmulqdq $17, %xmm2, %xmm8
+; PCLMUL-NEXT:    movdqa %xmm6, %xmm5
+; PCLMUL-NEXT:    pclmulqdq $0, %xmm2, %xmm5
+; PCLMUL-NEXT:    punpckldq {{.*#+}} xmm5 = xmm5[0],xmm8[0],xmm5[1],xmm8[1]
+; PCLMUL-NEXT:    movdqa %xmm6, %xmm8
+; PCLMUL-NEXT:    psrlq $32, %xmm8
+; PCLMUL-NEXT:    movdqa %xmm8, %xmm9
+; PCLMUL-NEXT:    pclmulqdq $17, %xmm7, %xmm9
+; PCLMUL-NEXT:    pclmulqdq $0, %xmm7, %xmm8
+; PCLMUL-NEXT:    punpckldq {{.*#+}} xmm8 = xmm8[0],xmm9[0],xmm8[1],xmm9[1]
+; PCLMUL-NEXT:    punpckldq {{.*#+}} xmm5 = xmm5[0],xmm8[0],xmm5[1],xmm8[1]
+; PCLMUL-NEXT:    movdqa %xmm5, %xmm8
+; PCLMUL-NEXT:    pandn %xmm6, %xmm8
+; PCLMUL-NEXT:    movdqa %xmm8, %xmm9
+; PCLMUL-NEXT:    pclmulqdq $17, %xmm2, %xmm9
+; PCLMUL-NEXT:    movdqa %xmm8, %xmm6
+; PCLMUL-NEXT:    pclmulqdq $0, %xmm2, %xmm6
 ; PCLMUL-NEXT:    punpckldq {{.*#+}} xmm6 = xmm6[0],xmm9[0],xmm6[1],xmm9[1]
-; PCLMUL-NEXT:    pand %xmm1, %xmm2
+; PCLMUL-NEXT:    movdqa %xmm8, %xmm9
+; PCLMUL-NEXT:    psrlq $32, %xmm9
+; PCLMUL-NEXT:    movdqa %xmm9, %xmm10
+; PCLMUL-NEXT:    pclmulqdq $17, %xmm7, %xmm10
+; PCLMUL-NEXT:    pclmulqdq $0, %xmm7, %xmm9
+; PCLMUL-NEXT:    punpckldq {{.*#+}} xmm9 = xmm9[0],xmm10[0],xmm9[1],xmm10[1]
+; PCLMUL-NEXT:    punpckldq {{.*#+}} xmm6 = xmm6[0],xmm9[0],xmm6[1],xmm9[1]
+; PCLMUL-NEXT:    movdqa %xmm6, %xmm9
+; PCLMUL-NEXT:    pandn %xmm8, %xmm9
+; PCLMUL-NEXT:    movdqa %xmm9, %xmm8
+; PCLMUL-NEXT:    pclmulqdq $17, %xmm2, %xmm8
+; PCLMUL-NEXT:    pclmulqdq $0, %xmm9, %xmm2
+; PCLMUL-NEXT:    punpckldq {{.*#+}} xmm2 = xmm2[0],xmm8[0],xmm2[1],xmm8[1]
+; PCLMUL-NEXT:    psrlq $32, %xmm9
+; PCLMUL-NEXT:    movdqa %xmm9, %xmm8
+; PCLMUL-NEXT:    pclmulqdq $17, %xmm7, %xmm8
+; PCLMUL-NEXT:    pclmulqdq $0, %xmm7, %xmm9
+; PCLMUL-NEXT:    punpckldq {{.*#+}} xmm9 = xmm9[0],xmm8[0],xmm9[1],xmm8[1]
+; PCLMUL-NEXT:    punpckldq {{.*#+}} xmm2 = xmm2[0],xmm9[0],xmm2[1],xmm9[1]
+; PCLMUL-NEXT:    pand %xmm1, %xmm3
 ; PCLMUL-NEXT:    pand %xmm1, %xmm0
-; PCLMUL-NEXT:    pxor %xmm2, %xmm1
-; PCLMUL-NEXT:    movdqa %xmm2, %xmm7
+; PCLMUL-NEXT:    pxor %xmm3, %xmm1
+; PCLMUL-NEXT:    movdqa %xmm3, %xmm7
 ; PCLMUL-NEXT:    psrld $1, %xmm7
 ; PCLMUL-NEXT:    por %xmm1, %xmm7
-; PCLMUL-NEXT:    pand %xmm7, %xmm3
-; PCLMUL-NEXT:    pxor %xmm3, %xmm7
-; PCLMUL-NEXT:    movdqa %xmm3, %xmm1
+; PCLMUL-NEXT:    pand %xmm7, %xmm4
+; PCLMUL-NEXT:    pxor %xmm4, %xmm7
+; PCLMUL-NEXT:    movdqa %xmm4, %xmm1
 ; PCLMUL-NEXT:    psrld $2, %xmm1
 ; PCLMUL-NEXT:    por %xmm7, %xmm1
-; PCLMUL-NEXT:    pand %xmm1, %xmm4
-; PCLMUL-NEXT:    pxor %xmm4, %xmm1
-; PCLMUL-NEXT:    movdqa %xmm4, %xmm7
+; PCLMUL-NEXT:    pand %xmm1, %xmm5
+; PCLMUL-NEXT:    pxor %xmm5, %xmm1
+; PCLMUL-NEXT:    movdqa %xmm5, %xmm7
 ; PCLMUL-NEXT:    psrld $4, %xmm7
 ; PCLMUL-NEXT:    por %xmm1, %xmm7
-; PCLMUL-NEXT:    pand %xmm7, %xmm5
-; PCLMUL-NEXT:    pxor %xmm5, %xmm7
-; PCLMUL-NEXT:    movdqa %xmm5, %xmm1
+; PCLMUL-NEXT:    pand %xmm7, %xmm6
+; PCLMUL-NEXT:    pxor %xmm6, %xmm7
+; PCLMUL-NEXT:    movdqa %xmm6, %xmm1
 ; PCLMUL-NEXT:    psrld $8, %xmm1
 ; PCLMUL-NEXT:    por %xmm7, %xmm1
-; PCLMUL-NEXT:    pand %xmm0, %xmm2
-; PCLMUL-NEXT:    pxor %xmm2, %xmm0
-; PCLMUL-NEXT:    psrld $1, %xmm2
-; PCLMUL-NEXT:    por %xmm2, %xmm0
 ; PCLMUL-NEXT:    pand %xmm0, %xmm3
 ; PCLMUL-NEXT:    pxor %xmm3, %xmm0
-; PCLMUL-NEXT:    psrld $2, %xmm3
+; PCLMUL-NEXT:    psrld $1, %xmm3
 ; PCLMUL-NEXT:    por %xmm3, %xmm0
 ; PCLMUL-NEXT:    pand %xmm0, %xmm4
 ; PCLMUL-NEXT:    pxor %xmm4, %xmm0
-; PCLMUL-NEXT:    psrld $4, %xmm4
+; PCLMUL-NEXT:    psrld $2, %xmm4
 ; PCLMUL-NEXT:    por %xmm4, %xmm0
 ; PCLMUL-NEXT:    pand %xmm0, %xmm5
 ; PCLMUL-NEXT:    pxor %xmm5, %xmm0
-; PCLMUL-NEXT:    psrld $8, %xmm5
+; PCLMUL-NEXT:    psrld $4, %xmm5
 ; PCLMUL-NEXT:    por %xmm5, %xmm0
+; PCLMUL-NEXT:    pand %xmm0, %xmm6
+; PCLMUL-NEXT:    pxor %xmm6, %xmm0
+; PCLMUL-NEXT:    psrld $8, %xmm6
+; PCLMUL-NEXT:    por %xmm6, %xmm0
 ; PCLMUL-NEXT:    pand %xmm0, %xmm1
-; PCLMUL-NEXT:    pand %xmm6, %xmm1
+; PCLMUL-NEXT:    pand %xmm2, %xmm1
 ; PCLMUL-NEXT:    pxor %xmm1, %xmm0
 ; PCLMUL-NEXT:    psrld $16, %xmm1
 ; PCLMUL-NEXT:    por %xmm1, %xmm0
@@ -748,50 +747,50 @@ define <4 x i32> @pext_v4i32(<4 x i32> %val, <4 x i32> %mask) nounwind {
 ; AVX2-SLOW-NEXT:    vpxor %xmm2, %xmm1, %xmm3
 ; AVX2-SLOW-NEXT:    vpaddd %xmm3, %xmm3, %xmm5
 ; AVX2-SLOW-NEXT:    vpclmulqdq $17, %xmm2, %xmm5, %xmm4
-; AVX2-SLOW-NEXT:    vpsrlq $32, %xmm5, %xmm6
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %xmm2, %xmm5, %xmm6
+; AVX2-SLOW-NEXT:    vpsrlq $32, %xmm5, %xmm7
 ; AVX2-SLOW-NEXT:    vpbroadcastq {{.*#+}} xmm3 = [255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0]
-; AVX2-SLOW-NEXT:    vpclmulqdq $17, %xmm3, %xmm6, %xmm7
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %xmm2, %xmm5, %xmm8
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %xmm3, %xmm6, %xmm6
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm4 = xmm4[0],xmm7[0],xmm4[1],xmm7[1]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm6 = xmm8[0],xmm6[0],xmm8[1],xmm6[1]
+; AVX2-SLOW-NEXT:    vpclmulqdq $17, %xmm3, %xmm7, %xmm8
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %xmm3, %xmm7, %xmm7
 ; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm4 = xmm6[0],xmm4[0],xmm6[1],xmm4[1]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm6 = xmm7[0],xmm8[0],xmm7[1],xmm8[1]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm4 = xmm4[0],xmm6[0],xmm4[1],xmm6[1]
 ; AVX2-SLOW-NEXT:    vpandn %xmm5, %xmm4, %xmm6
 ; AVX2-SLOW-NEXT:    vpclmulqdq $17, %xmm2, %xmm6, %xmm5
-; AVX2-SLOW-NEXT:    vpsrlq $32, %xmm6, %xmm7
-; AVX2-SLOW-NEXT:    vpclmulqdq $17, %xmm3, %xmm7, %xmm8
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %xmm2, %xmm6, %xmm9
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %xmm3, %xmm7, %xmm7
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm5 = xmm5[0],xmm8[0],xmm5[1],xmm8[1]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm9[0],xmm7[0],xmm9[1],xmm7[1]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm5 = xmm7[0],xmm5[0],xmm7[1],xmm5[1]
-; AVX2-SLOW-NEXT:    vpandn %xmm6, %xmm5, %xmm6
-; AVX2-SLOW-NEXT:    vpclmulqdq $17, %xmm2, %xmm6, %xmm7
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %xmm2, %xmm6, %xmm7
 ; AVX2-SLOW-NEXT:    vpsrlq $32, %xmm6, %xmm8
 ; AVX2-SLOW-NEXT:    vpclmulqdq $17, %xmm3, %xmm8, %xmm9
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %xmm2, %xmm6, %xmm10
 ; AVX2-SLOW-NEXT:    vpclmulqdq $0, %xmm3, %xmm8, %xmm8
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm7[0],xmm9[0],xmm7[1],xmm9[1]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm8 = xmm10[0],xmm8[0],xmm10[1],xmm8[1]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm8[0],xmm7[0],xmm8[1],xmm7[1]
-; AVX2-SLOW-NEXT:    vpandn %xmm6, %xmm7, %xmm6
-; AVX2-SLOW-NEXT:    vpclmulqdq $17, %xmm2, %xmm6, %xmm8
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm5 = xmm7[0],xmm5[0],xmm7[1],xmm5[1]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm8[0],xmm9[0],xmm8[1],xmm9[1]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm5 = xmm5[0],xmm7[0],xmm5[1],xmm7[1]
+; AVX2-SLOW-NEXT:    vpandn %xmm6, %xmm5, %xmm6
+; AVX2-SLOW-NEXT:    vpclmulqdq $17, %xmm2, %xmm6, %xmm7
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %xmm2, %xmm6, %xmm8
 ; AVX2-SLOW-NEXT:    vpsrlq $32, %xmm6, %xmm9
 ; AVX2-SLOW-NEXT:    vpclmulqdq $17, %xmm3, %xmm9, %xmm10
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %xmm2, %xmm6, %xmm11
 ; AVX2-SLOW-NEXT:    vpclmulqdq $0, %xmm3, %xmm9, %xmm9
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm8 = xmm8[0],xmm10[0],xmm8[1],xmm10[1]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm9 = xmm11[0],xmm9[0],xmm11[1],xmm9[1]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm8 = xmm9[0],xmm8[0],xmm9[1],xmm8[1]
-; AVX2-SLOW-NEXT:    vpandn %xmm6, %xmm8, %xmm6
-; AVX2-SLOW-NEXT:    vpclmulqdq $17, %xmm2, %xmm6, %xmm9
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm8[0],xmm7[0],xmm8[1],xmm7[1]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm8 = xmm9[0],xmm10[0],xmm9[1],xmm10[1]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm7[0],xmm8[0],xmm7[1],xmm8[1]
+; AVX2-SLOW-NEXT:    vpandn %xmm6, %xmm7, %xmm6
+; AVX2-SLOW-NEXT:    vpclmulqdq $17, %xmm2, %xmm6, %xmm8
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %xmm2, %xmm6, %xmm9
 ; AVX2-SLOW-NEXT:    vpsrlq $32, %xmm6, %xmm10
 ; AVX2-SLOW-NEXT:    vpclmulqdq $17, %xmm3, %xmm10, %xmm11
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %xmm3, %xmm10, %xmm10
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm8 = xmm9[0],xmm8[0],xmm9[1],xmm8[1]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm9 = xmm10[0],xmm11[0],xmm10[1],xmm11[1]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm8 = xmm8[0],xmm9[0],xmm8[1],xmm9[1]
+; AVX2-SLOW-NEXT:    vpandn %xmm6, %xmm8, %xmm6
+; AVX2-SLOW-NEXT:    vpclmulqdq $17, %xmm2, %xmm6, %xmm9
 ; AVX2-SLOW-NEXT:    vpclmulqdq $0, %xmm2, %xmm6, %xmm2
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm6 = xmm9[0],xmm11[0],xmm9[1],xmm11[1]
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %xmm3, %xmm10, %xmm3
+; AVX2-SLOW-NEXT:    vpsrlq $32, %xmm6, %xmm6
+; AVX2-SLOW-NEXT:    vpclmulqdq $17, %xmm3, %xmm6, %xmm10
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm9[0],xmm2[1],xmm9[1]
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %xmm3, %xmm6, %xmm3
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm3 = xmm3[0],xmm10[0],xmm3[1],xmm10[1]
 ; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm3[0],xmm2[1],xmm3[1]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm6[0],xmm2[1],xmm6[1]
 ; AVX2-SLOW-NEXT:    vpand %xmm1, %xmm4, %xmm3
 ; AVX2-SLOW-NEXT:    vpxor %xmm3, %xmm1, %xmm4
 ; AVX2-SLOW-NEXT:    vpsrld $1, %xmm3, %xmm6

--- a/llvm/test/CodeGen/X86/pext-vector-256.ll
+++ b/llvm/test/CodeGen/X86/pext-vector-256.ll
@@ -314,50 +314,50 @@ define <8 x i32> @pext_v8i32(<8 x i32> %val, <8 x i32> %mask) nounwind {
 ; AVX2-SLOW-NEXT:    vpxor %ymm2, %ymm1, %ymm3
 ; AVX2-SLOW-NEXT:    vpaddd %ymm3, %ymm3, %ymm5
 ; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm2, %ymm5, %ymm4
-; AVX2-SLOW-NEXT:    vpsrlq $32, %ymm5, %ymm6
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm2, %ymm5, %ymm6
+; AVX2-SLOW-NEXT:    vpsrlq $32, %ymm5, %ymm7
 ; AVX2-SLOW-NEXT:    vpbroadcastq {{.*#+}} ymm3 = [255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0]
-; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm3, %ymm6, %ymm7
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm2, %ymm5, %ymm8
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm3, %ymm6, %ymm6
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm4 = ymm4[0],ymm7[0],ymm4[1],ymm7[1],ymm4[4],ymm7[4],ymm4[5],ymm7[5]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm6 = ymm8[0],ymm6[0],ymm8[1],ymm6[1],ymm8[4],ymm6[4],ymm8[5],ymm6[5]
+; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm3, %ymm7, %ymm8
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm3, %ymm7, %ymm7
 ; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm4 = ymm6[0],ymm4[0],ymm6[1],ymm4[1],ymm6[4],ymm4[4],ymm6[5],ymm4[5]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm6 = ymm7[0],ymm8[0],ymm7[1],ymm8[1],ymm7[4],ymm8[4],ymm7[5],ymm8[5]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm4 = ymm4[0],ymm6[0],ymm4[1],ymm6[1],ymm4[4],ymm6[4],ymm4[5],ymm6[5]
 ; AVX2-SLOW-NEXT:    vpandn %ymm5, %ymm4, %ymm6
 ; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm2, %ymm6, %ymm5
-; AVX2-SLOW-NEXT:    vpsrlq $32, %ymm6, %ymm7
-; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm3, %ymm7, %ymm8
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm2, %ymm6, %ymm9
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm3, %ymm7, %ymm7
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm5 = ymm5[0],ymm8[0],ymm5[1],ymm8[1],ymm5[4],ymm8[4],ymm5[5],ymm8[5]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm7 = ymm9[0],ymm7[0],ymm9[1],ymm7[1],ymm9[4],ymm7[4],ymm9[5],ymm7[5]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm5 = ymm7[0],ymm5[0],ymm7[1],ymm5[1],ymm7[4],ymm5[4],ymm7[5],ymm5[5]
-; AVX2-SLOW-NEXT:    vpandn %ymm6, %ymm5, %ymm6
-; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm2, %ymm6, %ymm7
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm2, %ymm6, %ymm7
 ; AVX2-SLOW-NEXT:    vpsrlq $32, %ymm6, %ymm8
 ; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm3, %ymm8, %ymm9
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm2, %ymm6, %ymm10
 ; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm3, %ymm8, %ymm8
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm7 = ymm7[0],ymm9[0],ymm7[1],ymm9[1],ymm7[4],ymm9[4],ymm7[5],ymm9[5]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm8 = ymm10[0],ymm8[0],ymm10[1],ymm8[1],ymm10[4],ymm8[4],ymm10[5],ymm8[5]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm7 = ymm8[0],ymm7[0],ymm8[1],ymm7[1],ymm8[4],ymm7[4],ymm8[5],ymm7[5]
-; AVX2-SLOW-NEXT:    vpandn %ymm6, %ymm7, %ymm6
-; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm2, %ymm6, %ymm8
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm5 = ymm7[0],ymm5[0],ymm7[1],ymm5[1],ymm7[4],ymm5[4],ymm7[5],ymm5[5]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm7 = ymm8[0],ymm9[0],ymm8[1],ymm9[1],ymm8[4],ymm9[4],ymm8[5],ymm9[5]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm5 = ymm5[0],ymm7[0],ymm5[1],ymm7[1],ymm5[4],ymm7[4],ymm5[5],ymm7[5]
+; AVX2-SLOW-NEXT:    vpandn %ymm6, %ymm5, %ymm6
+; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm2, %ymm6, %ymm7
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm2, %ymm6, %ymm8
 ; AVX2-SLOW-NEXT:    vpsrlq $32, %ymm6, %ymm9
 ; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm3, %ymm9, %ymm10
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm2, %ymm6, %ymm11
 ; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm3, %ymm9, %ymm9
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm8 = ymm8[0],ymm10[0],ymm8[1],ymm10[1],ymm8[4],ymm10[4],ymm8[5],ymm10[5]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm9 = ymm11[0],ymm9[0],ymm11[1],ymm9[1],ymm11[4],ymm9[4],ymm11[5],ymm9[5]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm8 = ymm9[0],ymm8[0],ymm9[1],ymm8[1],ymm9[4],ymm8[4],ymm9[5],ymm8[5]
-; AVX2-SLOW-NEXT:    vpandn %ymm6, %ymm8, %ymm6
-; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm2, %ymm6, %ymm9
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm7 = ymm8[0],ymm7[0],ymm8[1],ymm7[1],ymm8[4],ymm7[4],ymm8[5],ymm7[5]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm8 = ymm9[0],ymm10[0],ymm9[1],ymm10[1],ymm9[4],ymm10[4],ymm9[5],ymm10[5]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm7 = ymm7[0],ymm8[0],ymm7[1],ymm8[1],ymm7[4],ymm8[4],ymm7[5],ymm8[5]
+; AVX2-SLOW-NEXT:    vpandn %ymm6, %ymm7, %ymm6
+; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm2, %ymm6, %ymm8
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm2, %ymm6, %ymm9
 ; AVX2-SLOW-NEXT:    vpsrlq $32, %ymm6, %ymm10
 ; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm3, %ymm10, %ymm11
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm3, %ymm10, %ymm10
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm8 = ymm9[0],ymm8[0],ymm9[1],ymm8[1],ymm9[4],ymm8[4],ymm9[5],ymm8[5]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm9 = ymm10[0],ymm11[0],ymm10[1],ymm11[1],ymm10[4],ymm11[4],ymm10[5],ymm11[5]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm8 = ymm8[0],ymm9[0],ymm8[1],ymm9[1],ymm8[4],ymm9[4],ymm8[5],ymm9[5]
+; AVX2-SLOW-NEXT:    vpandn %ymm6, %ymm8, %ymm6
+; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm2, %ymm6, %ymm9
 ; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm2, %ymm6, %ymm2
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm6 = ymm9[0],ymm11[0],ymm9[1],ymm11[1],ymm9[4],ymm11[4],ymm9[5],ymm11[5]
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm3, %ymm10, %ymm3
+; AVX2-SLOW-NEXT:    vpsrlq $32, %ymm6, %ymm6
+; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm3, %ymm6, %ymm10
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm2 = ymm2[0],ymm9[0],ymm2[1],ymm9[1],ymm2[4],ymm9[4],ymm2[5],ymm9[5]
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm3, %ymm6, %ymm3
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm3 = ymm3[0],ymm10[0],ymm3[1],ymm10[1],ymm3[4],ymm10[4],ymm3[5],ymm10[5]
 ; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm2 = ymm2[0],ymm3[0],ymm2[1],ymm3[1],ymm2[4],ymm3[4],ymm2[5],ymm3[5]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm2 = ymm2[0],ymm6[0],ymm2[1],ymm6[1],ymm2[4],ymm6[4],ymm2[5],ymm6[5]
 ; AVX2-SLOW-NEXT:    vpand %ymm1, %ymm4, %ymm3
 ; AVX2-SLOW-NEXT:    vpxor %ymm3, %ymm1, %ymm4
 ; AVX2-SLOW-NEXT:    vpsrld $1, %ymm3, %ymm6

--- a/llvm/test/CodeGen/X86/pext-vector-512.ll
+++ b/llvm/test/CodeGen/X86/pext-vector-512.ll
@@ -474,50 +474,50 @@ define <16 x i32> @pext_v16i32(<16 x i32> %val, <16 x i32> %mask) nounwind {
 ; AVX2-SLOW-NEXT:    vpxor %ymm4, %ymm2, %ymm5
 ; AVX2-SLOW-NEXT:    vpaddd %ymm5, %ymm5, %ymm6
 ; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm4, %ymm6, %ymm7
-; AVX2-SLOW-NEXT:    vpsrlq $32, %ymm6, %ymm8
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm4, %ymm6, %ymm8
+; AVX2-SLOW-NEXT:    vpsrlq $32, %ymm6, %ymm9
 ; AVX2-SLOW-NEXT:    vpbroadcastq {{.*#+}} ymm5 = [255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0]
-; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm5, %ymm8, %ymm9
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm4, %ymm6, %ymm10
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm5, %ymm8, %ymm8
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm7 = ymm7[0],ymm9[0],ymm7[1],ymm9[1],ymm7[4],ymm9[4],ymm7[5],ymm9[5]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm8 = ymm10[0],ymm8[0],ymm10[1],ymm8[1],ymm10[4],ymm8[4],ymm10[5],ymm8[5]
+; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm5, %ymm9, %ymm10
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm5, %ymm9, %ymm9
 ; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm7 = ymm8[0],ymm7[0],ymm8[1],ymm7[1],ymm8[4],ymm7[4],ymm8[5],ymm7[5]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm8 = ymm9[0],ymm10[0],ymm9[1],ymm10[1],ymm9[4],ymm10[4],ymm9[5],ymm10[5]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm7 = ymm7[0],ymm8[0],ymm7[1],ymm8[1],ymm7[4],ymm8[4],ymm7[5],ymm8[5]
 ; AVX2-SLOW-NEXT:    vpandn %ymm6, %ymm7, %ymm6
 ; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm4, %ymm6, %ymm8
-; AVX2-SLOW-NEXT:    vpsrlq $32, %ymm6, %ymm9
-; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm5, %ymm9, %ymm10
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm4, %ymm6, %ymm11
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm5, %ymm9, %ymm9
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm8 = ymm8[0],ymm10[0],ymm8[1],ymm10[1],ymm8[4],ymm10[4],ymm8[5],ymm10[5]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm9 = ymm11[0],ymm9[0],ymm11[1],ymm9[1],ymm11[4],ymm9[4],ymm11[5],ymm9[5]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm8 = ymm9[0],ymm8[0],ymm9[1],ymm8[1],ymm9[4],ymm8[4],ymm9[5],ymm8[5]
-; AVX2-SLOW-NEXT:    vpandn %ymm6, %ymm8, %ymm6
-; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm4, %ymm6, %ymm9
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm4, %ymm6, %ymm9
 ; AVX2-SLOW-NEXT:    vpsrlq $32, %ymm6, %ymm10
 ; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm5, %ymm10, %ymm11
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm4, %ymm6, %ymm12
 ; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm5, %ymm10, %ymm10
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm9 = ymm9[0],ymm11[0],ymm9[1],ymm11[1],ymm9[4],ymm11[4],ymm9[5],ymm11[5]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm10 = ymm12[0],ymm10[0],ymm12[1],ymm10[1],ymm12[4],ymm10[4],ymm12[5],ymm10[5]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm9 = ymm10[0],ymm9[0],ymm10[1],ymm9[1],ymm10[4],ymm9[4],ymm10[5],ymm9[5]
-; AVX2-SLOW-NEXT:    vpandn %ymm6, %ymm9, %ymm6
-; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm4, %ymm6, %ymm10
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm8 = ymm9[0],ymm8[0],ymm9[1],ymm8[1],ymm9[4],ymm8[4],ymm9[5],ymm8[5]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm9 = ymm10[0],ymm11[0],ymm10[1],ymm11[1],ymm10[4],ymm11[4],ymm10[5],ymm11[5]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm8 = ymm8[0],ymm9[0],ymm8[1],ymm9[1],ymm8[4],ymm9[4],ymm8[5],ymm9[5]
+; AVX2-SLOW-NEXT:    vpandn %ymm6, %ymm8, %ymm6
+; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm4, %ymm6, %ymm9
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm4, %ymm6, %ymm10
 ; AVX2-SLOW-NEXT:    vpsrlq $32, %ymm6, %ymm11
 ; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm5, %ymm11, %ymm12
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm4, %ymm6, %ymm13
 ; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm5, %ymm11, %ymm11
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm10 = ymm10[0],ymm12[0],ymm10[1],ymm12[1],ymm10[4],ymm12[4],ymm10[5],ymm12[5]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm11 = ymm13[0],ymm11[0],ymm13[1],ymm11[1],ymm13[4],ymm11[4],ymm13[5],ymm11[5]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm10 = ymm11[0],ymm10[0],ymm11[1],ymm10[1],ymm11[4],ymm10[4],ymm11[5],ymm10[5]
-; AVX2-SLOW-NEXT:    vpandn %ymm6, %ymm10, %ymm6
-; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm4, %ymm6, %ymm11
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm9 = ymm10[0],ymm9[0],ymm10[1],ymm9[1],ymm10[4],ymm9[4],ymm10[5],ymm9[5]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm10 = ymm11[0],ymm12[0],ymm11[1],ymm12[1],ymm11[4],ymm12[4],ymm11[5],ymm12[5]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm9 = ymm9[0],ymm10[0],ymm9[1],ymm10[1],ymm9[4],ymm10[4],ymm9[5],ymm10[5]
+; AVX2-SLOW-NEXT:    vpandn %ymm6, %ymm9, %ymm6
+; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm4, %ymm6, %ymm10
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm4, %ymm6, %ymm11
 ; AVX2-SLOW-NEXT:    vpsrlq $32, %ymm6, %ymm12
 ; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm5, %ymm12, %ymm13
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm4, %ymm6, %ymm6
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm11 = ymm11[0],ymm13[0],ymm11[1],ymm13[1],ymm11[4],ymm13[4],ymm11[5],ymm13[5]
 ; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm5, %ymm12, %ymm12
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm6 = ymm6[0],ymm12[0],ymm6[1],ymm12[1],ymm6[4],ymm12[4],ymm6[5],ymm12[5]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm6 = ymm6[0],ymm11[0],ymm6[1],ymm11[1],ymm6[4],ymm11[4],ymm6[5],ymm11[5]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm10 = ymm11[0],ymm10[0],ymm11[1],ymm10[1],ymm11[4],ymm10[4],ymm11[5],ymm10[5]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm11 = ymm12[0],ymm13[0],ymm12[1],ymm13[1],ymm12[4],ymm13[4],ymm12[5],ymm13[5]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm10 = ymm10[0],ymm11[0],ymm10[1],ymm11[1],ymm10[4],ymm11[4],ymm10[5],ymm11[5]
+; AVX2-SLOW-NEXT:    vpandn %ymm6, %ymm10, %ymm6
+; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm4, %ymm6, %ymm11
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm4, %ymm6, %ymm12
+; AVX2-SLOW-NEXT:    vpsrlq $32, %ymm6, %ymm6
+; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm5, %ymm6, %ymm13
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm11 = ymm12[0],ymm11[0],ymm12[1],ymm11[1],ymm12[4],ymm11[4],ymm12[5],ymm11[5]
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm5, %ymm6, %ymm6
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm6 = ymm6[0],ymm13[0],ymm6[1],ymm13[1],ymm6[4],ymm13[4],ymm6[5],ymm13[5]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm6 = ymm11[0],ymm6[0],ymm11[1],ymm6[1],ymm11[4],ymm6[4],ymm11[5],ymm6[5]
 ; AVX2-SLOW-NEXT:    vpand %ymm2, %ymm7, %ymm11
 ; AVX2-SLOW-NEXT:    vpxor %ymm2, %ymm11, %ymm7
 ; AVX2-SLOW-NEXT:    vpsrld $1, %ymm11, %ymm12
@@ -546,62 +546,62 @@ define <16 x i32> @pext_v16i32(<16 x i32> %val, <16 x i32> %mask) nounwind {
 ; AVX2-SLOW-NEXT:    vpxor %ymm4, %ymm3, %ymm2
 ; AVX2-SLOW-NEXT:    vpaddd %ymm2, %ymm2, %ymm10
 ; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm4, %ymm10, %ymm2
-; AVX2-SLOW-NEXT:    vpsrlq $32, %ymm10, %ymm11
-; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm5, %ymm11, %ymm12
 ; AVX2-SLOW-NEXT:    vpand %ymm0, %ymm9, %ymm9
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm4, %ymm10, %ymm13
-; AVX2-SLOW-NEXT:    vpxor %ymm0, %ymm9, %ymm0
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm5, %ymm11, %ymm11
-; AVX2-SLOW-NEXT:    vpsrld $4, %ymm9, %ymm9
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm2 = ymm2[0],ymm12[0],ymm2[1],ymm12[1],ymm2[4],ymm12[4],ymm2[5],ymm12[5]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm11 = ymm13[0],ymm11[0],ymm13[1],ymm11[1],ymm13[4],ymm11[4],ymm13[5],ymm11[5]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm2 = ymm11[0],ymm2[0],ymm11[1],ymm2[1],ymm11[4],ymm2[4],ymm11[5],ymm2[5]
-; AVX2-SLOW-NEXT:    vpandn %ymm10, %ymm2, %ymm10
-; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm4, %ymm10, %ymm11
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm4, %ymm10, %ymm11
 ; AVX2-SLOW-NEXT:    vpsrlq $32, %ymm10, %ymm12
 ; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm5, %ymm12, %ymm13
+; AVX2-SLOW-NEXT:    vpxor %ymm0, %ymm9, %ymm0
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm5, %ymm12, %ymm12
+; AVX2-SLOW-NEXT:    vpsrld $4, %ymm9, %ymm9
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm2 = ymm11[0],ymm2[0],ymm11[1],ymm2[1],ymm11[4],ymm2[4],ymm11[5],ymm2[5]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm11 = ymm12[0],ymm13[0],ymm12[1],ymm13[1],ymm12[4],ymm13[4],ymm12[5],ymm13[5]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm2 = ymm2[0],ymm11[0],ymm2[1],ymm11[1],ymm2[4],ymm11[4],ymm2[5],ymm11[5]
+; AVX2-SLOW-NEXT:    vpandn %ymm10, %ymm2, %ymm10
+; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm4, %ymm10, %ymm11
 ; AVX2-SLOW-NEXT:    vpor %ymm0, %ymm9, %ymm0
 ; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm4, %ymm10, %ymm9
+; AVX2-SLOW-NEXT:    vpsrlq $32, %ymm10, %ymm12
+; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm5, %ymm12, %ymm13
 ; AVX2-SLOW-NEXT:    vpand %ymm0, %ymm8, %ymm14
 ; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm5, %ymm12, %ymm8
 ; AVX2-SLOW-NEXT:    vpxor %ymm0, %ymm14, %ymm0
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm11 = ymm11[0],ymm13[0],ymm11[1],ymm13[1],ymm11[4],ymm13[4],ymm11[5],ymm13[5]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm9 = ymm9[0],ymm11[0],ymm9[1],ymm11[1],ymm9[4],ymm11[4],ymm9[5],ymm11[5]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm8 = ymm8[0],ymm13[0],ymm8[1],ymm13[1],ymm8[4],ymm13[4],ymm8[5],ymm13[5]
 ; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm8 = ymm9[0],ymm8[0],ymm9[1],ymm8[1],ymm9[4],ymm8[4],ymm9[5],ymm8[5]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm8 = ymm8[0],ymm11[0],ymm8[1],ymm11[1],ymm8[4],ymm11[4],ymm8[5],ymm11[5]
 ; AVX2-SLOW-NEXT:    vpandn %ymm10, %ymm8, %ymm9
 ; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm4, %ymm9, %ymm10
-; AVX2-SLOW-NEXT:    vpsrlq $32, %ymm9, %ymm11
-; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm5, %ymm11, %ymm12
-; AVX2-SLOW-NEXT:    vpsrld $8, %ymm14, %ymm13
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm4, %ymm9, %ymm14
-; AVX2-SLOW-NEXT:    vpor %ymm0, %ymm13, %ymm0
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm5, %ymm11, %ymm11
+; AVX2-SLOW-NEXT:    vpsrld $8, %ymm14, %ymm11
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm4, %ymm9, %ymm12
+; AVX2-SLOW-NEXT:    vpsrlq $32, %ymm9, %ymm13
+; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm5, %ymm13, %ymm14
+; AVX2-SLOW-NEXT:    vpor %ymm0, %ymm11, %ymm0
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm5, %ymm13, %ymm11
 ; AVX2-SLOW-NEXT:    vpand %ymm7, %ymm0, %ymm13
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm7 = ymm10[0],ymm12[0],ymm10[1],ymm12[1],ymm10[4],ymm12[4],ymm10[5],ymm12[5]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm10 = ymm14[0],ymm11[0],ymm14[1],ymm11[1],ymm14[4],ymm11[4],ymm14[5],ymm11[5]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm7 = ymm10[0],ymm7[0],ymm10[1],ymm7[1],ymm10[4],ymm7[4],ymm10[5],ymm7[5]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm7 = ymm12[0],ymm10[0],ymm12[1],ymm10[1],ymm12[4],ymm10[4],ymm12[5],ymm10[5]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm10 = ymm11[0],ymm14[0],ymm11[1],ymm14[1],ymm11[4],ymm14[4],ymm11[5],ymm14[5]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm7 = ymm7[0],ymm10[0],ymm7[1],ymm10[1],ymm7[4],ymm10[4],ymm7[5],ymm10[5]
 ; AVX2-SLOW-NEXT:    vpandn %ymm9, %ymm7, %ymm9
 ; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm4, %ymm9, %ymm10
-; AVX2-SLOW-NEXT:    vpsrlq $32, %ymm9, %ymm11
-; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm5, %ymm11, %ymm12
 ; AVX2-SLOW-NEXT:    vpand %ymm6, %ymm13, %ymm6
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm4, %ymm9, %ymm13
-; AVX2-SLOW-NEXT:    vpxor %ymm6, %ymm0, %ymm0
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm5, %ymm11, %ymm11
-; AVX2-SLOW-NEXT:    vpsrld $16, %ymm6, %ymm6
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm10 = ymm10[0],ymm12[0],ymm10[1],ymm12[1],ymm10[4],ymm12[4],ymm10[5],ymm12[5]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm11 = ymm13[0],ymm11[0],ymm13[1],ymm11[1],ymm13[4],ymm11[4],ymm13[5],ymm11[5]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm10 = ymm11[0],ymm10[0],ymm11[1],ymm10[1],ymm11[4],ymm10[4],ymm11[5],ymm10[5]
-; AVX2-SLOW-NEXT:    vpandn %ymm9, %ymm10, %ymm9
-; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm4, %ymm9, %ymm11
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm4, %ymm9, %ymm11
 ; AVX2-SLOW-NEXT:    vpsrlq $32, %ymm9, %ymm12
 ; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm5, %ymm12, %ymm13
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm10 = ymm11[0],ymm10[0],ymm11[1],ymm10[1],ymm11[4],ymm10[4],ymm11[5],ymm10[5]
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm5, %ymm12, %ymm11
+; AVX2-SLOW-NEXT:    vpxor %ymm6, %ymm0, %ymm0
+; AVX2-SLOW-NEXT:    vpsrld $16, %ymm6, %ymm6
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm11 = ymm11[0],ymm13[0],ymm11[1],ymm13[1],ymm11[4],ymm13[4],ymm11[5],ymm13[5]
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm10 = ymm10[0],ymm11[0],ymm10[1],ymm11[1],ymm10[4],ymm11[4],ymm10[5],ymm11[5]
+; AVX2-SLOW-NEXT:    vpandn %ymm9, %ymm10, %ymm9
+; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm4, %ymm9, %ymm11
 ; AVX2-SLOW-NEXT:    vpor %ymm6, %ymm0, %ymm0
 ; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm4, %ymm9, %ymm4
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm6 = ymm11[0],ymm13[0],ymm11[1],ymm13[1],ymm11[4],ymm13[4],ymm11[5],ymm13[5]
-; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm5, %ymm12, %ymm5
+; AVX2-SLOW-NEXT:    vpsrlq $32, %ymm9, %ymm6
+; AVX2-SLOW-NEXT:    vpclmulqdq $17, %ymm5, %ymm6, %ymm9
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm4 = ymm4[0],ymm11[0],ymm4[1],ymm11[1],ymm4[4],ymm11[4],ymm4[5],ymm11[5]
+; AVX2-SLOW-NEXT:    vpclmulqdq $0, %ymm5, %ymm6, %ymm5
+; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm5 = ymm5[0],ymm9[0],ymm5[1],ymm9[1],ymm5[4],ymm9[4],ymm5[5],ymm9[5]
 ; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm4 = ymm4[0],ymm5[0],ymm4[1],ymm5[1],ymm4[4],ymm5[4],ymm4[5],ymm5[5]
-; AVX2-SLOW-NEXT:    vpunpckldq {{.*#+}} ymm4 = ymm4[0],ymm6[0],ymm4[1],ymm6[1],ymm4[4],ymm6[4],ymm4[5],ymm6[5]
 ; AVX2-SLOW-NEXT:    vpand %ymm3, %ymm2, %ymm2
 ; AVX2-SLOW-NEXT:    vpxor %ymm2, %ymm3, %ymm5
 ; AVX2-SLOW-NEXT:    vpsrld $1, %ymm2, %ymm6

--- a/llvm/test/CodeGen/X86/znver-pdep.ll
+++ b/llvm/test/CodeGen/X86/znver-pdep.ll
@@ -11,54 +11,54 @@ define <4 x i32> @pdep_v4i32(<4 x i32> %val, <4 x i32> %mask) nounwind {
 ; SLOW-ZNVER-NEXT:    vpcmpeqd %xmm2, %xmm2, %xmm2
 ; SLOW-ZNVER-NEXT:    vpxor %xmm2, %xmm1, %xmm3
 ; SLOW-ZNVER-NEXT:    vpaddd %xmm3, %xmm3, %xmm5
-; SLOW-ZNVER-NEXT:    vpbroadcastq {{.*#+}} xmm3 = [255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0]
+; SLOW-ZNVER-NEXT:    vpclmulqdq $17, %xmm2, %xmm5, %xmm3
+; SLOW-ZNVER-NEXT:    vpclmulqdq $0, %xmm2, %xmm5, %xmm4
 ; SLOW-ZNVER-NEXT:    vpsrlq $32, %xmm5, %xmm6
-; SLOW-ZNVER-NEXT:    vpclmulqdq $17, %xmm2, %xmm5, %xmm4
+; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm4 = xmm4[0],xmm3[0],xmm4[1],xmm3[1]
+; SLOW-ZNVER-NEXT:    vpbroadcastq {{.*#+}} xmm3 = [255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0]
 ; SLOW-ZNVER-NEXT:    vpclmulqdq $17, %xmm3, %xmm6, %xmm7
 ; SLOW-ZNVER-NEXT:    vpclmulqdq $0, %xmm3, %xmm6, %xmm6
-; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm4 = xmm4[0],xmm7[0],xmm4[1],xmm7[1]
+; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm6 = xmm6[0],xmm7[0],xmm6[1],xmm7[1]
+; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm4 = xmm4[0],xmm6[0],xmm4[1],xmm6[1]
+; SLOW-ZNVER-NEXT:    vpandn %xmm5, %xmm4, %xmm5
+; SLOW-ZNVER-NEXT:    vpclmulqdq $17, %xmm2, %xmm5, %xmm6
 ; SLOW-ZNVER-NEXT:    vpclmulqdq $0, %xmm2, %xmm5, %xmm7
 ; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm6 = xmm7[0],xmm6[0],xmm7[1],xmm6[1]
-; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm4 = xmm6[0],xmm4[0],xmm6[1],xmm4[1]
-; SLOW-ZNVER-NEXT:    vpandn %xmm5, %xmm4, %xmm5
 ; SLOW-ZNVER-NEXT:    vpsrlq $32, %xmm5, %xmm7
-; SLOW-ZNVER-NEXT:    vpclmulqdq $17, %xmm2, %xmm5, %xmm6
 ; SLOW-ZNVER-NEXT:    vpclmulqdq $17, %xmm3, %xmm7, %xmm8
 ; SLOW-ZNVER-NEXT:    vpclmulqdq $0, %xmm3, %xmm7, %xmm7
-; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm6 = xmm6[0],xmm8[0],xmm6[1],xmm8[1]
+; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm7[0],xmm8[0],xmm7[1],xmm8[1]
+; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm6 = xmm6[0],xmm7[0],xmm6[1],xmm7[1]
+; SLOW-ZNVER-NEXT:    vpandn %xmm5, %xmm6, %xmm5
+; SLOW-ZNVER-NEXT:    vpclmulqdq $17, %xmm2, %xmm5, %xmm7
 ; SLOW-ZNVER-NEXT:    vpclmulqdq $0, %xmm2, %xmm5, %xmm8
 ; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm8[0],xmm7[0],xmm8[1],xmm7[1]
-; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm6 = xmm7[0],xmm6[0],xmm7[1],xmm6[1]
-; SLOW-ZNVER-NEXT:    vpandn %xmm5, %xmm6, %xmm5
 ; SLOW-ZNVER-NEXT:    vpsrlq $32, %xmm5, %xmm8
-; SLOW-ZNVER-NEXT:    vpclmulqdq $17, %xmm2, %xmm5, %xmm7
 ; SLOW-ZNVER-NEXT:    vpclmulqdq $17, %xmm3, %xmm8, %xmm9
 ; SLOW-ZNVER-NEXT:    vpclmulqdq $0, %xmm3, %xmm8, %xmm8
-; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm7[0],xmm9[0],xmm7[1],xmm9[1]
+; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm8 = xmm8[0],xmm9[0],xmm8[1],xmm9[1]
+; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm7[0],xmm8[0],xmm7[1],xmm8[1]
+; SLOW-ZNVER-NEXT:    vpandn %xmm5, %xmm7, %xmm5
+; SLOW-ZNVER-NEXT:    vpclmulqdq $17, %xmm2, %xmm5, %xmm8
 ; SLOW-ZNVER-NEXT:    vpclmulqdq $0, %xmm2, %xmm5, %xmm9
 ; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm8 = xmm9[0],xmm8[0],xmm9[1],xmm8[1]
-; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm8[0],xmm7[0],xmm8[1],xmm7[1]
-; SLOW-ZNVER-NEXT:    vpandn %xmm5, %xmm7, %xmm5
 ; SLOW-ZNVER-NEXT:    vpsrlq $32, %xmm5, %xmm9
-; SLOW-ZNVER-NEXT:    vpclmulqdq $17, %xmm2, %xmm5, %xmm8
 ; SLOW-ZNVER-NEXT:    vpclmulqdq $17, %xmm3, %xmm9, %xmm10
 ; SLOW-ZNVER-NEXT:    vpclmulqdq $0, %xmm3, %xmm9, %xmm9
-; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm8 = xmm8[0],xmm10[0],xmm8[1],xmm10[1]
-; SLOW-ZNVER-NEXT:    vpclmulqdq $0, %xmm2, %xmm5, %xmm10
-; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm9 = xmm10[0],xmm9[0],xmm10[1],xmm9[1]
-; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm8 = xmm9[0],xmm8[0],xmm9[1],xmm8[1]
+; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm9 = xmm9[0],xmm10[0],xmm9[1],xmm10[1]
+; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm8 = xmm8[0],xmm9[0],xmm8[1],xmm9[1]
 ; SLOW-ZNVER-NEXT:    vpandn %xmm5, %xmm8, %xmm5
-; SLOW-ZNVER-NEXT:    vpsrlq $32, %xmm5, %xmm10
 ; SLOW-ZNVER-NEXT:    vpclmulqdq $17, %xmm2, %xmm5, %xmm9
 ; SLOW-ZNVER-NEXT:    vpclmulqdq $0, %xmm2, %xmm5, %xmm2
-; SLOW-ZNVER-NEXT:    vpclmulqdq $17, %xmm3, %xmm10, %xmm11
-; SLOW-ZNVER-NEXT:    vpclmulqdq $0, %xmm3, %xmm10, %xmm3
-; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm9 = xmm9[0],xmm11[0],xmm9[1],xmm11[1]
-; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm3[0],xmm2[1],xmm3[1]
-; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm3 = xmm2[0],xmm9[0],xmm2[1],xmm9[1]
+; SLOW-ZNVER-NEXT:    vpsrlq $32, %xmm5, %xmm5
+; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm9[0],xmm2[1],xmm9[1]
+; SLOW-ZNVER-NEXT:    vpclmulqdq $17, %xmm3, %xmm5, %xmm9
+; SLOW-ZNVER-NEXT:    vpclmulqdq $0, %xmm3, %xmm5, %xmm3
+; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm3 = xmm3[0],xmm9[0],xmm3[1],xmm9[1]
 ; SLOW-ZNVER-NEXT:    vpand %xmm1, %xmm4, %xmm9
 ; SLOW-ZNVER-NEXT:    vpxor %xmm1, %xmm9, %xmm4
 ; SLOW-ZNVER-NEXT:    vpsrld $1, %xmm9, %xmm5
+; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm3 = xmm2[0],xmm3[0],xmm2[1],xmm3[1]
 ; SLOW-ZNVER-NEXT:    vpor %xmm5, %xmm4, %xmm4
 ; SLOW-ZNVER-NEXT:    vpand %xmm4, %xmm6, %xmm5
 ; SLOW-ZNVER-NEXT:    vpxor %xmm5, %xmm4, %xmm4
@@ -101,54 +101,54 @@ define <4 x i32> @pdep_v4i32(<4 x i32> %val, <4 x i32> %mask) nounwind {
 ; SLOW-BDVER4-NEXT:    vpcmpeqd %xmm2, %xmm2, %xmm2
 ; SLOW-BDVER4-NEXT:    vpxor %xmm2, %xmm1, %xmm3
 ; SLOW-BDVER4-NEXT:    vpaddd %xmm3, %xmm3, %xmm5
-; SLOW-BDVER4-NEXT:    vpbroadcastq {{.*#+}} xmm3 = [255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0]
+; SLOW-BDVER4-NEXT:    vpclmulqdq $17, %xmm2, %xmm5, %xmm3
+; SLOW-BDVER4-NEXT:    vpclmulqdq $0, %xmm2, %xmm5, %xmm4
 ; SLOW-BDVER4-NEXT:    vpsrlq $32, %xmm5, %xmm6
-; SLOW-BDVER4-NEXT:    vpclmulqdq $17, %xmm2, %xmm5, %xmm4
+; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm4 = xmm4[0],xmm3[0],xmm4[1],xmm3[1]
+; SLOW-BDVER4-NEXT:    vpbroadcastq {{.*#+}} xmm3 = [255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0]
 ; SLOW-BDVER4-NEXT:    vpclmulqdq $17, %xmm3, %xmm6, %xmm7
 ; SLOW-BDVER4-NEXT:    vpclmulqdq $0, %xmm3, %xmm6, %xmm6
-; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm4 = xmm4[0],xmm7[0],xmm4[1],xmm7[1]
+; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm6 = xmm6[0],xmm7[0],xmm6[1],xmm7[1]
+; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm4 = xmm4[0],xmm6[0],xmm4[1],xmm6[1]
+; SLOW-BDVER4-NEXT:    vpandn %xmm5, %xmm4, %xmm5
+; SLOW-BDVER4-NEXT:    vpclmulqdq $17, %xmm2, %xmm5, %xmm6
 ; SLOW-BDVER4-NEXT:    vpclmulqdq $0, %xmm2, %xmm5, %xmm7
 ; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm6 = xmm7[0],xmm6[0],xmm7[1],xmm6[1]
-; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm4 = xmm6[0],xmm4[0],xmm6[1],xmm4[1]
-; SLOW-BDVER4-NEXT:    vpandn %xmm5, %xmm4, %xmm5
 ; SLOW-BDVER4-NEXT:    vpsrlq $32, %xmm5, %xmm7
-; SLOW-BDVER4-NEXT:    vpclmulqdq $17, %xmm2, %xmm5, %xmm6
 ; SLOW-BDVER4-NEXT:    vpclmulqdq $17, %xmm3, %xmm7, %xmm8
 ; SLOW-BDVER4-NEXT:    vpclmulqdq $0, %xmm3, %xmm7, %xmm7
-; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm6 = xmm6[0],xmm8[0],xmm6[1],xmm8[1]
+; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm7[0],xmm8[0],xmm7[1],xmm8[1]
+; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm6 = xmm6[0],xmm7[0],xmm6[1],xmm7[1]
+; SLOW-BDVER4-NEXT:    vpandn %xmm5, %xmm6, %xmm5
+; SLOW-BDVER4-NEXT:    vpclmulqdq $17, %xmm2, %xmm5, %xmm7
 ; SLOW-BDVER4-NEXT:    vpclmulqdq $0, %xmm2, %xmm5, %xmm8
 ; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm8[0],xmm7[0],xmm8[1],xmm7[1]
-; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm6 = xmm7[0],xmm6[0],xmm7[1],xmm6[1]
-; SLOW-BDVER4-NEXT:    vpandn %xmm5, %xmm6, %xmm5
 ; SLOW-BDVER4-NEXT:    vpsrlq $32, %xmm5, %xmm8
-; SLOW-BDVER4-NEXT:    vpclmulqdq $17, %xmm2, %xmm5, %xmm7
 ; SLOW-BDVER4-NEXT:    vpclmulqdq $17, %xmm3, %xmm8, %xmm9
 ; SLOW-BDVER4-NEXT:    vpclmulqdq $0, %xmm3, %xmm8, %xmm8
-; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm7[0],xmm9[0],xmm7[1],xmm9[1]
+; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm8 = xmm8[0],xmm9[0],xmm8[1],xmm9[1]
+; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm7[0],xmm8[0],xmm7[1],xmm8[1]
+; SLOW-BDVER4-NEXT:    vpandn %xmm5, %xmm7, %xmm5
+; SLOW-BDVER4-NEXT:    vpclmulqdq $17, %xmm2, %xmm5, %xmm8
 ; SLOW-BDVER4-NEXT:    vpclmulqdq $0, %xmm2, %xmm5, %xmm9
 ; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm8 = xmm9[0],xmm8[0],xmm9[1],xmm8[1]
-; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm8[0],xmm7[0],xmm8[1],xmm7[1]
-; SLOW-BDVER4-NEXT:    vpandn %xmm5, %xmm7, %xmm5
 ; SLOW-BDVER4-NEXT:    vpsrlq $32, %xmm5, %xmm9
-; SLOW-BDVER4-NEXT:    vpclmulqdq $17, %xmm2, %xmm5, %xmm8
 ; SLOW-BDVER4-NEXT:    vpclmulqdq $17, %xmm3, %xmm9, %xmm10
 ; SLOW-BDVER4-NEXT:    vpclmulqdq $0, %xmm3, %xmm9, %xmm9
-; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm8 = xmm8[0],xmm10[0],xmm8[1],xmm10[1]
-; SLOW-BDVER4-NEXT:    vpclmulqdq $0, %xmm2, %xmm5, %xmm10
-; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm9 = xmm10[0],xmm9[0],xmm10[1],xmm9[1]
-; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm8 = xmm9[0],xmm8[0],xmm9[1],xmm8[1]
+; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm9 = xmm9[0],xmm10[0],xmm9[1],xmm10[1]
+; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm8 = xmm8[0],xmm9[0],xmm8[1],xmm9[1]
 ; SLOW-BDVER4-NEXT:    vpandn %xmm5, %xmm8, %xmm5
-; SLOW-BDVER4-NEXT:    vpsrlq $32, %xmm5, %xmm10
 ; SLOW-BDVER4-NEXT:    vpclmulqdq $17, %xmm2, %xmm5, %xmm9
 ; SLOW-BDVER4-NEXT:    vpclmulqdq $0, %xmm2, %xmm5, %xmm2
-; SLOW-BDVER4-NEXT:    vpclmulqdq $17, %xmm3, %xmm10, %xmm11
-; SLOW-BDVER4-NEXT:    vpclmulqdq $0, %xmm3, %xmm10, %xmm3
-; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm9 = xmm9[0],xmm11[0],xmm9[1],xmm11[1]
-; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm3[0],xmm2[1],xmm3[1]
+; SLOW-BDVER4-NEXT:    vpsrlq $32, %xmm5, %xmm5
 ; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm9[0],xmm2[1],xmm9[1]
+; SLOW-BDVER4-NEXT:    vpclmulqdq $17, %xmm3, %xmm5, %xmm9
+; SLOW-BDVER4-NEXT:    vpclmulqdq $0, %xmm3, %xmm5, %xmm3
+; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm3 = xmm3[0],xmm9[0],xmm3[1],xmm9[1]
 ; SLOW-BDVER4-NEXT:    vpand %xmm1, %xmm4, %xmm9
 ; SLOW-BDVER4-NEXT:    vpxor %xmm1, %xmm9, %xmm4
 ; SLOW-BDVER4-NEXT:    vpsrld $1, %xmm9, %xmm5
+; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm3[0],xmm2[1],xmm3[1]
 ; SLOW-BDVER4-NEXT:    vpor %xmm5, %xmm4, %xmm4
 ; SLOW-BDVER4-NEXT:    vpand %xmm4, %xmm6, %xmm5
 ; SLOW-BDVER4-NEXT:    vpxor %xmm5, %xmm4, %xmm4
@@ -202,104 +202,104 @@ define <4 x i32> @pdep_v4i32(<4 x i32> %val, <4 x i32> %mask) nounwind {
 define <8 x i32> @pdep_v8i32(<8 x i32> %val, <8 x i32> %mask) nounwind {
 ; SLOW-ZNVER-LABEL: pdep_v8i32:
 ; SLOW-ZNVER:       # %bb.0:
-; SLOW-ZNVER-NEXT:    vpbroadcastq {{.*#+}} xmm3 = [255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0]
 ; SLOW-ZNVER-NEXT:    vpcmpeqd %ymm2, %ymm2, %ymm2
 ; SLOW-ZNVER-NEXT:    vpxor %ymm2, %ymm1, %ymm2
 ; SLOW-ZNVER-NEXT:    vpaddd %ymm2, %ymm2, %ymm5
 ; SLOW-ZNVER-NEXT:    vpcmpeqd %xmm2, %xmm2, %xmm2
-; SLOW-ZNVER-NEXT:    vextracti128 $1, %ymm5, %xmm4
-; SLOW-ZNVER-NEXT:    vpsrlq $32, %xmm4, %xmm7
-; SLOW-ZNVER-NEXT:    vpclmulqdq $17, %xmm2, %xmm4, %xmm6
-; SLOW-ZNVER-NEXT:    vpclmulqdq $0, %xmm2, %xmm4, %xmm4
-; SLOW-ZNVER-NEXT:    vpclmulqdq $17, %xmm3, %xmm7, %xmm8
-; SLOW-ZNVER-NEXT:    vpclmulqdq $0, %xmm3, %xmm7, %xmm7
-; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm4 = xmm4[0],xmm7[0],xmm4[1],xmm7[1]
-; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm6 = xmm6[0],xmm8[0],xmm6[1],xmm8[1]
-; SLOW-ZNVER-NEXT:    vpsrlq $32, %xmm5, %xmm7
+; SLOW-ZNVER-NEXT:    vextracti128 $1, %ymm5, %xmm3
+; SLOW-ZNVER-NEXT:    vpclmulqdq $17, %xmm2, %xmm3, %xmm4
+; SLOW-ZNVER-NEXT:    vpclmulqdq $0, %xmm2, %xmm3, %xmm6
+; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm4 = xmm6[0],xmm4[0],xmm6[1],xmm4[1]
+; SLOW-ZNVER-NEXT:    vpsrlq $32, %xmm3, %xmm6
+; SLOW-ZNVER-NEXT:    vpbroadcastq {{.*#+}} xmm3 = [255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0]
+; SLOW-ZNVER-NEXT:    vpclmulqdq $17, %xmm3, %xmm6, %xmm7
+; SLOW-ZNVER-NEXT:    vpclmulqdq $0, %xmm3, %xmm6, %xmm6
+; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm6 = xmm6[0],xmm7[0],xmm6[1],xmm7[1]
+; SLOW-ZNVER-NEXT:    vpclmulqdq $0, %xmm2, %xmm5, %xmm7
 ; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm4 = xmm4[0],xmm6[0],xmm4[1],xmm6[1]
-; SLOW-ZNVER-NEXT:    vpclmulqdq $17, %xmm3, %xmm7, %xmm8
 ; SLOW-ZNVER-NEXT:    vpclmulqdq $17, %xmm2, %xmm5, %xmm6
-; SLOW-ZNVER-NEXT:    vpclmulqdq $0, %xmm3, %xmm7, %xmm7
-; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm6 = xmm6[0],xmm8[0],xmm6[1],xmm8[1]
-; SLOW-ZNVER-NEXT:    vpclmulqdq $0, %xmm2, %xmm5, %xmm8
-; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm8[0],xmm7[0],xmm8[1],xmm7[1]
 ; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm6 = xmm7[0],xmm6[0],xmm7[1],xmm6[1]
+; SLOW-ZNVER-NEXT:    vpsrlq $32, %xmm5, %xmm7
+; SLOW-ZNVER-NEXT:    vpclmulqdq $17, %xmm3, %xmm7, %xmm8
+; SLOW-ZNVER-NEXT:    vpclmulqdq $0, %xmm3, %xmm7, %xmm7
+; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm7[0],xmm8[0],xmm7[1],xmm8[1]
+; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm6 = xmm6[0],xmm7[0],xmm6[1],xmm7[1]
 ; SLOW-ZNVER-NEXT:    vinserti128 $1, %xmm4, %ymm6, %ymm4
 ; SLOW-ZNVER-NEXT:    vpandn %ymm5, %ymm4, %ymm6
 ; SLOW-ZNVER-NEXT:    vextracti128 $1, %ymm6, %xmm5
-; SLOW-ZNVER-NEXT:    vpsrlq $32, %xmm5, %xmm8
 ; SLOW-ZNVER-NEXT:    vpclmulqdq $17, %xmm2, %xmm5, %xmm7
-; SLOW-ZNVER-NEXT:    vpclmulqdq $0, %xmm2, %xmm5, %xmm5
-; SLOW-ZNVER-NEXT:    vpclmulqdq $17, %xmm3, %xmm8, %xmm9
-; SLOW-ZNVER-NEXT:    vpclmulqdq $0, %xmm3, %xmm8, %xmm8
-; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm5 = xmm5[0],xmm8[0],xmm5[1],xmm8[1]
-; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm7[0],xmm9[0],xmm7[1],xmm9[1]
-; SLOW-ZNVER-NEXT:    vpsrlq $32, %xmm6, %xmm8
-; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm5 = xmm5[0],xmm7[0],xmm5[1],xmm7[1]
-; SLOW-ZNVER-NEXT:    vpclmulqdq $17, %xmm3, %xmm8, %xmm9
-; SLOW-ZNVER-NEXT:    vpclmulqdq $17, %xmm2, %xmm6, %xmm7
-; SLOW-ZNVER-NEXT:    vpclmulqdq $0, %xmm3, %xmm8, %xmm8
-; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm7[0],xmm9[0],xmm7[1],xmm9[1]
-; SLOW-ZNVER-NEXT:    vpclmulqdq $0, %xmm2, %xmm6, %xmm9
-; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm8 = xmm9[0],xmm8[0],xmm9[1],xmm8[1]
+; SLOW-ZNVER-NEXT:    vpclmulqdq $0, %xmm2, %xmm5, %xmm8
+; SLOW-ZNVER-NEXT:    vpsrlq $32, %xmm5, %xmm5
 ; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm8[0],xmm7[0],xmm8[1],xmm7[1]
+; SLOW-ZNVER-NEXT:    vpclmulqdq $17, %xmm3, %xmm5, %xmm8
+; SLOW-ZNVER-NEXT:    vpclmulqdq $0, %xmm3, %xmm5, %xmm5
+; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm5 = xmm5[0],xmm8[0],xmm5[1],xmm8[1]
+; SLOW-ZNVER-NEXT:    vpclmulqdq $0, %xmm2, %xmm6, %xmm8
+; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm5 = xmm7[0],xmm5[0],xmm7[1],xmm5[1]
+; SLOW-ZNVER-NEXT:    vpclmulqdq $17, %xmm2, %xmm6, %xmm7
+; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm8[0],xmm7[0],xmm8[1],xmm7[1]
+; SLOW-ZNVER-NEXT:    vpsrlq $32, %xmm6, %xmm8
+; SLOW-ZNVER-NEXT:    vpclmulqdq $17, %xmm3, %xmm8, %xmm9
+; SLOW-ZNVER-NEXT:    vpclmulqdq $0, %xmm3, %xmm8, %xmm8
+; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm8 = xmm8[0],xmm9[0],xmm8[1],xmm9[1]
+; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm7[0],xmm8[0],xmm7[1],xmm8[1]
 ; SLOW-ZNVER-NEXT:    vinserti128 $1, %xmm5, %ymm7, %ymm5
 ; SLOW-ZNVER-NEXT:    vpandn %ymm6, %ymm5, %ymm7
 ; SLOW-ZNVER-NEXT:    vextracti128 $1, %ymm7, %xmm6
-; SLOW-ZNVER-NEXT:    vpsrlq $32, %xmm6, %xmm9
 ; SLOW-ZNVER-NEXT:    vpclmulqdq $17, %xmm2, %xmm6, %xmm8
-; SLOW-ZNVER-NEXT:    vpclmulqdq $0, %xmm2, %xmm6, %xmm6
-; SLOW-ZNVER-NEXT:    vpclmulqdq $17, %xmm3, %xmm9, %xmm10
-; SLOW-ZNVER-NEXT:    vpclmulqdq $0, %xmm3, %xmm9, %xmm9
-; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm6 = xmm6[0],xmm9[0],xmm6[1],xmm9[1]
-; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm8 = xmm8[0],xmm10[0],xmm8[1],xmm10[1]
-; SLOW-ZNVER-NEXT:    vpsrlq $32, %xmm7, %xmm9
-; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm6 = xmm6[0],xmm8[0],xmm6[1],xmm8[1]
-; SLOW-ZNVER-NEXT:    vpclmulqdq $17, %xmm3, %xmm9, %xmm10
-; SLOW-ZNVER-NEXT:    vpclmulqdq $17, %xmm2, %xmm7, %xmm8
-; SLOW-ZNVER-NEXT:    vpclmulqdq $0, %xmm3, %xmm9, %xmm9
-; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm8 = xmm8[0],xmm10[0],xmm8[1],xmm10[1]
-; SLOW-ZNVER-NEXT:    vpclmulqdq $0, %xmm2, %xmm7, %xmm10
-; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm9 = xmm10[0],xmm9[0],xmm10[1],xmm9[1]
+; SLOW-ZNVER-NEXT:    vpclmulqdq $0, %xmm2, %xmm6, %xmm9
+; SLOW-ZNVER-NEXT:    vpsrlq $32, %xmm6, %xmm6
 ; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm8 = xmm9[0],xmm8[0],xmm9[1],xmm8[1]
+; SLOW-ZNVER-NEXT:    vpclmulqdq $17, %xmm3, %xmm6, %xmm9
+; SLOW-ZNVER-NEXT:    vpclmulqdq $0, %xmm3, %xmm6, %xmm6
+; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm6 = xmm6[0],xmm9[0],xmm6[1],xmm9[1]
+; SLOW-ZNVER-NEXT:    vpclmulqdq $0, %xmm2, %xmm7, %xmm9
+; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm6 = xmm8[0],xmm6[0],xmm8[1],xmm6[1]
+; SLOW-ZNVER-NEXT:    vpclmulqdq $17, %xmm2, %xmm7, %xmm8
+; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm8 = xmm9[0],xmm8[0],xmm9[1],xmm8[1]
+; SLOW-ZNVER-NEXT:    vpsrlq $32, %xmm7, %xmm9
+; SLOW-ZNVER-NEXT:    vpclmulqdq $17, %xmm3, %xmm9, %xmm10
+; SLOW-ZNVER-NEXT:    vpclmulqdq $0, %xmm3, %xmm9, %xmm9
+; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm9 = xmm9[0],xmm10[0],xmm9[1],xmm10[1]
+; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm8 = xmm8[0],xmm9[0],xmm8[1],xmm9[1]
 ; SLOW-ZNVER-NEXT:    vinserti128 $1, %xmm6, %ymm8, %ymm6
 ; SLOW-ZNVER-NEXT:    vpandn %ymm7, %ymm6, %ymm8
 ; SLOW-ZNVER-NEXT:    vextracti128 $1, %ymm8, %xmm7
-; SLOW-ZNVER-NEXT:    vpsrlq $32, %xmm7, %xmm10
 ; SLOW-ZNVER-NEXT:    vpclmulqdq $17, %xmm2, %xmm7, %xmm9
-; SLOW-ZNVER-NEXT:    vpclmulqdq $0, %xmm2, %xmm7, %xmm7
-; SLOW-ZNVER-NEXT:    vpclmulqdq $17, %xmm3, %xmm10, %xmm11
-; SLOW-ZNVER-NEXT:    vpclmulqdq $0, %xmm3, %xmm10, %xmm10
-; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm7[0],xmm10[0],xmm7[1],xmm10[1]
-; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm9 = xmm9[0],xmm11[0],xmm9[1],xmm11[1]
-; SLOW-ZNVER-NEXT:    vpsrlq $32, %xmm8, %xmm10
-; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm7[0],xmm9[0],xmm7[1],xmm9[1]
-; SLOW-ZNVER-NEXT:    vpclmulqdq $17, %xmm3, %xmm10, %xmm11
-; SLOW-ZNVER-NEXT:    vpclmulqdq $17, %xmm2, %xmm8, %xmm9
-; SLOW-ZNVER-NEXT:    vpclmulqdq $0, %xmm3, %xmm10, %xmm10
-; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm9 = xmm9[0],xmm11[0],xmm9[1],xmm11[1]
-; SLOW-ZNVER-NEXT:    vpclmulqdq $0, %xmm2, %xmm8, %xmm11
-; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm10 = xmm11[0],xmm10[0],xmm11[1],xmm10[1]
+; SLOW-ZNVER-NEXT:    vpclmulqdq $0, %xmm2, %xmm7, %xmm10
+; SLOW-ZNVER-NEXT:    vpsrlq $32, %xmm7, %xmm7
 ; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm9 = xmm10[0],xmm9[0],xmm10[1],xmm9[1]
+; SLOW-ZNVER-NEXT:    vpclmulqdq $17, %xmm3, %xmm7, %xmm10
+; SLOW-ZNVER-NEXT:    vpclmulqdq $0, %xmm3, %xmm7, %xmm7
+; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm7[0],xmm10[0],xmm7[1],xmm10[1]
+; SLOW-ZNVER-NEXT:    vpclmulqdq $0, %xmm2, %xmm8, %xmm10
+; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm9[0],xmm7[0],xmm9[1],xmm7[1]
+; SLOW-ZNVER-NEXT:    vpclmulqdq $17, %xmm2, %xmm8, %xmm9
+; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm9 = xmm10[0],xmm9[0],xmm10[1],xmm9[1]
+; SLOW-ZNVER-NEXT:    vpsrlq $32, %xmm8, %xmm10
+; SLOW-ZNVER-NEXT:    vpclmulqdq $17, %xmm3, %xmm10, %xmm11
+; SLOW-ZNVER-NEXT:    vpclmulqdq $0, %xmm3, %xmm10, %xmm10
+; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm10 = xmm10[0],xmm11[0],xmm10[1],xmm11[1]
+; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm9 = xmm9[0],xmm10[0],xmm9[1],xmm10[1]
 ; SLOW-ZNVER-NEXT:    vinserti128 $1, %xmm7, %ymm9, %ymm7
 ; SLOW-ZNVER-NEXT:    vpandn %ymm8, %ymm7, %ymm8
 ; SLOW-ZNVER-NEXT:    vextracti128 $1, %ymm8, %xmm9
-; SLOW-ZNVER-NEXT:    vpsrlq $32, %xmm8, %xmm13
-; SLOW-ZNVER-NEXT:    vpsrlq $32, %xmm9, %xmm11
+; SLOW-ZNVER-NEXT:    vpclmulqdq $17, %xmm2, %xmm8, %xmm12
 ; SLOW-ZNVER-NEXT:    vpclmulqdq $17, %xmm2, %xmm9, %xmm10
-; SLOW-ZNVER-NEXT:    vpclmulqdq $0, %xmm2, %xmm9, %xmm9
-; SLOW-ZNVER-NEXT:    vpclmulqdq $17, %xmm3, %xmm11, %xmm12
-; SLOW-ZNVER-NEXT:    vpclmulqdq $0, %xmm3, %xmm11, %xmm11
-; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm10 = xmm10[0],xmm12[0],xmm10[1],xmm12[1]
-; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm9 = xmm9[0],xmm11[0],xmm9[1],xmm11[1]
-; SLOW-ZNVER-NEXT:    vpclmulqdq $17, %xmm3, %xmm13, %xmm12
-; SLOW-ZNVER-NEXT:    vpclmulqdq $0, %xmm3, %xmm13, %xmm3
-; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm9 = xmm9[0],xmm10[0],xmm9[1],xmm10[1]
-; SLOW-ZNVER-NEXT:    vpclmulqdq $17, %xmm2, %xmm8, %xmm10
+; SLOW-ZNVER-NEXT:    vpclmulqdq $0, %xmm2, %xmm9, %xmm11
+; SLOW-ZNVER-NEXT:    vpsrlq $32, %xmm9, %xmm9
 ; SLOW-ZNVER-NEXT:    vpclmulqdq $0, %xmm2, %xmm8, %xmm2
-; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm10 = xmm10[0],xmm12[0],xmm10[1],xmm12[1]
+; SLOW-ZNVER-NEXT:    vpsrlq $32, %xmm8, %xmm8
+; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm10 = xmm11[0],xmm10[0],xmm11[1],xmm10[1]
+; SLOW-ZNVER-NEXT:    vpclmulqdq $17, %xmm3, %xmm9, %xmm11
+; SLOW-ZNVER-NEXT:    vpclmulqdq $0, %xmm3, %xmm9, %xmm9
+; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm12[0],xmm2[1],xmm12[1]
+; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm9 = xmm9[0],xmm11[0],xmm9[1],xmm11[1]
+; SLOW-ZNVER-NEXT:    vpclmulqdq $17, %xmm3, %xmm8, %xmm11
+; SLOW-ZNVER-NEXT:    vpclmulqdq $0, %xmm3, %xmm8, %xmm3
+; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm9 = xmm10[0],xmm9[0],xmm10[1],xmm9[1]
+; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm3 = xmm3[0],xmm11[0],xmm3[1],xmm11[1]
 ; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm3[0],xmm2[1],xmm3[1]
-; SLOW-ZNVER-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm10[0],xmm2[1],xmm10[1]
 ; SLOW-ZNVER-NEXT:    vinserti128 $1, %xmm9, %ymm2, %ymm3
 ; SLOW-ZNVER-NEXT:    vpand %ymm1, %ymm4, %ymm9
 ; SLOW-ZNVER-NEXT:    vpxor %ymm1, %ymm9, %ymm4
@@ -343,104 +343,104 @@ define <8 x i32> @pdep_v8i32(<8 x i32> %val, <8 x i32> %mask) nounwind {
 ;
 ; SLOW-BDVER4-LABEL: pdep_v8i32:
 ; SLOW-BDVER4:       # %bb.0:
-; SLOW-BDVER4-NEXT:    vpbroadcastq {{.*#+}} xmm3 = [255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0]
 ; SLOW-BDVER4-NEXT:    vpcmpeqd %ymm2, %ymm2, %ymm2
 ; SLOW-BDVER4-NEXT:    vpxor %ymm2, %ymm1, %ymm2
 ; SLOW-BDVER4-NEXT:    vpaddd %ymm2, %ymm2, %ymm5
 ; SLOW-BDVER4-NEXT:    vpcmpeqd %xmm2, %xmm2, %xmm2
-; SLOW-BDVER4-NEXT:    vextracti128 $1, %ymm5, %xmm4
-; SLOW-BDVER4-NEXT:    vpsrlq $32, %xmm4, %xmm7
-; SLOW-BDVER4-NEXT:    vpclmulqdq $17, %xmm2, %xmm4, %xmm6
-; SLOW-BDVER4-NEXT:    vpclmulqdq $0, %xmm2, %xmm4, %xmm4
-; SLOW-BDVER4-NEXT:    vpclmulqdq $17, %xmm3, %xmm7, %xmm8
-; SLOW-BDVER4-NEXT:    vpclmulqdq $0, %xmm3, %xmm7, %xmm7
-; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm4 = xmm4[0],xmm7[0],xmm4[1],xmm7[1]
-; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm6 = xmm6[0],xmm8[0],xmm6[1],xmm8[1]
-; SLOW-BDVER4-NEXT:    vpsrlq $32, %xmm5, %xmm7
+; SLOW-BDVER4-NEXT:    vextracti128 $1, %ymm5, %xmm3
+; SLOW-BDVER4-NEXT:    vpclmulqdq $17, %xmm2, %xmm3, %xmm4
+; SLOW-BDVER4-NEXT:    vpclmulqdq $0, %xmm2, %xmm3, %xmm6
+; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm4 = xmm6[0],xmm4[0],xmm6[1],xmm4[1]
+; SLOW-BDVER4-NEXT:    vpsrlq $32, %xmm3, %xmm6
+; SLOW-BDVER4-NEXT:    vpbroadcastq {{.*#+}} xmm3 = [255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0]
+; SLOW-BDVER4-NEXT:    vpclmulqdq $17, %xmm3, %xmm6, %xmm7
+; SLOW-BDVER4-NEXT:    vpclmulqdq $0, %xmm3, %xmm6, %xmm6
+; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm6 = xmm6[0],xmm7[0],xmm6[1],xmm7[1]
+; SLOW-BDVER4-NEXT:    vpclmulqdq $0, %xmm2, %xmm5, %xmm7
 ; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm4 = xmm4[0],xmm6[0],xmm4[1],xmm6[1]
-; SLOW-BDVER4-NEXT:    vpclmulqdq $17, %xmm3, %xmm7, %xmm8
 ; SLOW-BDVER4-NEXT:    vpclmulqdq $17, %xmm2, %xmm5, %xmm6
-; SLOW-BDVER4-NEXT:    vpclmulqdq $0, %xmm3, %xmm7, %xmm7
-; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm6 = xmm6[0],xmm8[0],xmm6[1],xmm8[1]
-; SLOW-BDVER4-NEXT:    vpclmulqdq $0, %xmm2, %xmm5, %xmm8
-; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm8[0],xmm7[0],xmm8[1],xmm7[1]
 ; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm6 = xmm7[0],xmm6[0],xmm7[1],xmm6[1]
+; SLOW-BDVER4-NEXT:    vpsrlq $32, %xmm5, %xmm7
+; SLOW-BDVER4-NEXT:    vpclmulqdq $17, %xmm3, %xmm7, %xmm8
+; SLOW-BDVER4-NEXT:    vpclmulqdq $0, %xmm3, %xmm7, %xmm7
+; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm7[0],xmm8[0],xmm7[1],xmm8[1]
+; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm6 = xmm6[0],xmm7[0],xmm6[1],xmm7[1]
 ; SLOW-BDVER4-NEXT:    vinserti128 $1, %xmm4, %ymm6, %ymm4
 ; SLOW-BDVER4-NEXT:    vpandn %ymm5, %ymm4, %ymm6
 ; SLOW-BDVER4-NEXT:    vextracti128 $1, %ymm6, %xmm5
-; SLOW-BDVER4-NEXT:    vpsrlq $32, %xmm5, %xmm8
 ; SLOW-BDVER4-NEXT:    vpclmulqdq $17, %xmm2, %xmm5, %xmm7
-; SLOW-BDVER4-NEXT:    vpclmulqdq $0, %xmm2, %xmm5, %xmm5
-; SLOW-BDVER4-NEXT:    vpclmulqdq $17, %xmm3, %xmm8, %xmm9
-; SLOW-BDVER4-NEXT:    vpclmulqdq $0, %xmm3, %xmm8, %xmm8
-; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm5 = xmm5[0],xmm8[0],xmm5[1],xmm8[1]
-; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm7[0],xmm9[0],xmm7[1],xmm9[1]
-; SLOW-BDVER4-NEXT:    vpsrlq $32, %xmm6, %xmm8
-; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm5 = xmm5[0],xmm7[0],xmm5[1],xmm7[1]
-; SLOW-BDVER4-NEXT:    vpclmulqdq $17, %xmm3, %xmm8, %xmm9
-; SLOW-BDVER4-NEXT:    vpclmulqdq $17, %xmm2, %xmm6, %xmm7
-; SLOW-BDVER4-NEXT:    vpclmulqdq $0, %xmm3, %xmm8, %xmm8
-; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm7[0],xmm9[0],xmm7[1],xmm9[1]
-; SLOW-BDVER4-NEXT:    vpclmulqdq $0, %xmm2, %xmm6, %xmm9
-; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm8 = xmm9[0],xmm8[0],xmm9[1],xmm8[1]
+; SLOW-BDVER4-NEXT:    vpclmulqdq $0, %xmm2, %xmm5, %xmm8
+; SLOW-BDVER4-NEXT:    vpsrlq $32, %xmm5, %xmm5
 ; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm8[0],xmm7[0],xmm8[1],xmm7[1]
+; SLOW-BDVER4-NEXT:    vpclmulqdq $17, %xmm3, %xmm5, %xmm8
+; SLOW-BDVER4-NEXT:    vpclmulqdq $0, %xmm3, %xmm5, %xmm5
+; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm5 = xmm5[0],xmm8[0],xmm5[1],xmm8[1]
+; SLOW-BDVER4-NEXT:    vpclmulqdq $0, %xmm2, %xmm6, %xmm8
+; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm5 = xmm7[0],xmm5[0],xmm7[1],xmm5[1]
+; SLOW-BDVER4-NEXT:    vpclmulqdq $17, %xmm2, %xmm6, %xmm7
+; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm8[0],xmm7[0],xmm8[1],xmm7[1]
+; SLOW-BDVER4-NEXT:    vpsrlq $32, %xmm6, %xmm8
+; SLOW-BDVER4-NEXT:    vpclmulqdq $17, %xmm3, %xmm8, %xmm9
+; SLOW-BDVER4-NEXT:    vpclmulqdq $0, %xmm3, %xmm8, %xmm8
+; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm8 = xmm8[0],xmm9[0],xmm8[1],xmm9[1]
+; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm7[0],xmm8[0],xmm7[1],xmm8[1]
 ; SLOW-BDVER4-NEXT:    vinserti128 $1, %xmm5, %ymm7, %ymm5
 ; SLOW-BDVER4-NEXT:    vpandn %ymm6, %ymm5, %ymm7
 ; SLOW-BDVER4-NEXT:    vextracti128 $1, %ymm7, %xmm6
-; SLOW-BDVER4-NEXT:    vpsrlq $32, %xmm6, %xmm9
 ; SLOW-BDVER4-NEXT:    vpclmulqdq $17, %xmm2, %xmm6, %xmm8
-; SLOW-BDVER4-NEXT:    vpclmulqdq $0, %xmm2, %xmm6, %xmm6
-; SLOW-BDVER4-NEXT:    vpclmulqdq $17, %xmm3, %xmm9, %xmm10
-; SLOW-BDVER4-NEXT:    vpclmulqdq $0, %xmm3, %xmm9, %xmm9
-; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm6 = xmm6[0],xmm9[0],xmm6[1],xmm9[1]
-; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm8 = xmm8[0],xmm10[0],xmm8[1],xmm10[1]
-; SLOW-BDVER4-NEXT:    vpsrlq $32, %xmm7, %xmm9
-; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm6 = xmm6[0],xmm8[0],xmm6[1],xmm8[1]
-; SLOW-BDVER4-NEXT:    vpclmulqdq $17, %xmm3, %xmm9, %xmm10
-; SLOW-BDVER4-NEXT:    vpclmulqdq $17, %xmm2, %xmm7, %xmm8
-; SLOW-BDVER4-NEXT:    vpclmulqdq $0, %xmm3, %xmm9, %xmm9
-; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm8 = xmm8[0],xmm10[0],xmm8[1],xmm10[1]
-; SLOW-BDVER4-NEXT:    vpclmulqdq $0, %xmm2, %xmm7, %xmm10
-; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm9 = xmm10[0],xmm9[0],xmm10[1],xmm9[1]
+; SLOW-BDVER4-NEXT:    vpclmulqdq $0, %xmm2, %xmm6, %xmm9
+; SLOW-BDVER4-NEXT:    vpsrlq $32, %xmm6, %xmm6
 ; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm8 = xmm9[0],xmm8[0],xmm9[1],xmm8[1]
+; SLOW-BDVER4-NEXT:    vpclmulqdq $17, %xmm3, %xmm6, %xmm9
+; SLOW-BDVER4-NEXT:    vpclmulqdq $0, %xmm3, %xmm6, %xmm6
+; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm6 = xmm6[0],xmm9[0],xmm6[1],xmm9[1]
+; SLOW-BDVER4-NEXT:    vpclmulqdq $0, %xmm2, %xmm7, %xmm9
+; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm6 = xmm8[0],xmm6[0],xmm8[1],xmm6[1]
+; SLOW-BDVER4-NEXT:    vpclmulqdq $17, %xmm2, %xmm7, %xmm8
+; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm8 = xmm9[0],xmm8[0],xmm9[1],xmm8[1]
+; SLOW-BDVER4-NEXT:    vpsrlq $32, %xmm7, %xmm9
+; SLOW-BDVER4-NEXT:    vpclmulqdq $17, %xmm3, %xmm9, %xmm10
+; SLOW-BDVER4-NEXT:    vpclmulqdq $0, %xmm3, %xmm9, %xmm9
+; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm9 = xmm9[0],xmm10[0],xmm9[1],xmm10[1]
+; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm8 = xmm8[0],xmm9[0],xmm8[1],xmm9[1]
 ; SLOW-BDVER4-NEXT:    vinserti128 $1, %xmm6, %ymm8, %ymm6
 ; SLOW-BDVER4-NEXT:    vpandn %ymm7, %ymm6, %ymm8
 ; SLOW-BDVER4-NEXT:    vextracti128 $1, %ymm8, %xmm7
-; SLOW-BDVER4-NEXT:    vpsrlq $32, %xmm7, %xmm10
 ; SLOW-BDVER4-NEXT:    vpclmulqdq $17, %xmm2, %xmm7, %xmm9
-; SLOW-BDVER4-NEXT:    vpclmulqdq $0, %xmm2, %xmm7, %xmm7
-; SLOW-BDVER4-NEXT:    vpclmulqdq $17, %xmm3, %xmm10, %xmm11
-; SLOW-BDVER4-NEXT:    vpclmulqdq $0, %xmm3, %xmm10, %xmm10
-; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm7[0],xmm10[0],xmm7[1],xmm10[1]
-; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm9 = xmm9[0],xmm11[0],xmm9[1],xmm11[1]
-; SLOW-BDVER4-NEXT:    vpsrlq $32, %xmm8, %xmm10
-; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm7[0],xmm9[0],xmm7[1],xmm9[1]
-; SLOW-BDVER4-NEXT:    vpclmulqdq $17, %xmm3, %xmm10, %xmm11
-; SLOW-BDVER4-NEXT:    vpclmulqdq $17, %xmm2, %xmm8, %xmm9
-; SLOW-BDVER4-NEXT:    vpclmulqdq $0, %xmm3, %xmm10, %xmm10
-; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm9 = xmm9[0],xmm11[0],xmm9[1],xmm11[1]
-; SLOW-BDVER4-NEXT:    vpclmulqdq $0, %xmm2, %xmm8, %xmm11
-; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm10 = xmm11[0],xmm10[0],xmm11[1],xmm10[1]
+; SLOW-BDVER4-NEXT:    vpclmulqdq $0, %xmm2, %xmm7, %xmm10
+; SLOW-BDVER4-NEXT:    vpsrlq $32, %xmm7, %xmm7
 ; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm9 = xmm10[0],xmm9[0],xmm10[1],xmm9[1]
+; SLOW-BDVER4-NEXT:    vpclmulqdq $17, %xmm3, %xmm7, %xmm10
+; SLOW-BDVER4-NEXT:    vpclmulqdq $0, %xmm3, %xmm7, %xmm7
+; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm7[0],xmm10[0],xmm7[1],xmm10[1]
+; SLOW-BDVER4-NEXT:    vpclmulqdq $0, %xmm2, %xmm8, %xmm10
+; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm9[0],xmm7[0],xmm9[1],xmm7[1]
+; SLOW-BDVER4-NEXT:    vpclmulqdq $17, %xmm2, %xmm8, %xmm9
+; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm9 = xmm10[0],xmm9[0],xmm10[1],xmm9[1]
+; SLOW-BDVER4-NEXT:    vpsrlq $32, %xmm8, %xmm10
+; SLOW-BDVER4-NEXT:    vpclmulqdq $17, %xmm3, %xmm10, %xmm11
+; SLOW-BDVER4-NEXT:    vpclmulqdq $0, %xmm3, %xmm10, %xmm10
+; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm10 = xmm10[0],xmm11[0],xmm10[1],xmm11[1]
+; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm9 = xmm9[0],xmm10[0],xmm9[1],xmm10[1]
 ; SLOW-BDVER4-NEXT:    vinserti128 $1, %xmm7, %ymm9, %ymm7
 ; SLOW-BDVER4-NEXT:    vpandn %ymm8, %ymm7, %ymm8
 ; SLOW-BDVER4-NEXT:    vextracti128 $1, %ymm8, %xmm9
-; SLOW-BDVER4-NEXT:    vpsrlq $32, %xmm8, %xmm13
-; SLOW-BDVER4-NEXT:    vpsrlq $32, %xmm9, %xmm11
+; SLOW-BDVER4-NEXT:    vpclmulqdq $17, %xmm2, %xmm8, %xmm12
 ; SLOW-BDVER4-NEXT:    vpclmulqdq $17, %xmm2, %xmm9, %xmm10
-; SLOW-BDVER4-NEXT:    vpclmulqdq $0, %xmm2, %xmm9, %xmm9
-; SLOW-BDVER4-NEXT:    vpclmulqdq $17, %xmm3, %xmm11, %xmm12
-; SLOW-BDVER4-NEXT:    vpclmulqdq $0, %xmm3, %xmm11, %xmm11
-; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm10 = xmm10[0],xmm12[0],xmm10[1],xmm12[1]
-; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm9 = xmm9[0],xmm11[0],xmm9[1],xmm11[1]
-; SLOW-BDVER4-NEXT:    vpclmulqdq $17, %xmm3, %xmm13, %xmm12
-; SLOW-BDVER4-NEXT:    vpclmulqdq $0, %xmm3, %xmm13, %xmm3
-; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm9 = xmm9[0],xmm10[0],xmm9[1],xmm10[1]
-; SLOW-BDVER4-NEXT:    vpclmulqdq $17, %xmm2, %xmm8, %xmm10
+; SLOW-BDVER4-NEXT:    vpclmulqdq $0, %xmm2, %xmm9, %xmm11
+; SLOW-BDVER4-NEXT:    vpsrlq $32, %xmm9, %xmm9
 ; SLOW-BDVER4-NEXT:    vpclmulqdq $0, %xmm2, %xmm8, %xmm2
-; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm10 = xmm10[0],xmm12[0],xmm10[1],xmm12[1]
+; SLOW-BDVER4-NEXT:    vpsrlq $32, %xmm8, %xmm8
+; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm10 = xmm11[0],xmm10[0],xmm11[1],xmm10[1]
+; SLOW-BDVER4-NEXT:    vpclmulqdq $17, %xmm3, %xmm9, %xmm11
+; SLOW-BDVER4-NEXT:    vpclmulqdq $0, %xmm3, %xmm9, %xmm9
+; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm12[0],xmm2[1],xmm12[1]
+; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm9 = xmm9[0],xmm11[0],xmm9[1],xmm11[1]
+; SLOW-BDVER4-NEXT:    vpclmulqdq $17, %xmm3, %xmm8, %xmm11
+; SLOW-BDVER4-NEXT:    vpclmulqdq $0, %xmm3, %xmm8, %xmm3
+; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm9 = xmm10[0],xmm9[0],xmm10[1],xmm9[1]
+; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm3 = xmm3[0],xmm11[0],xmm3[1],xmm11[1]
 ; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm3[0],xmm2[1],xmm3[1]
-; SLOW-BDVER4-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm10[0],xmm2[1],xmm10[1]
 ; SLOW-BDVER4-NEXT:    vinserti128 $1, %xmm9, %ymm2, %ymm2
 ; SLOW-BDVER4-NEXT:    vpand %ymm1, %ymm4, %ymm9
 ; SLOW-BDVER4-NEXT:    vpxor %ymm1, %ymm9, %ymm4

--- a/llvm/test/CodeGen/X86/znver-pext.ll
+++ b/llvm/test/CodeGen/X86/znver-pext.ll
@@ -12,55 +12,55 @@ define <4 x i32> @pext_v4i32(<4 x i32> %val, <4 x i32> %mask) nounwind {
 ; SLOW-NEXT:    vpand %xmm1, %xmm0, %xmm0
 ; SLOW-NEXT:    vpxor %xmm2, %xmm1, %xmm3
 ; SLOW-NEXT:    vpaddd %xmm3, %xmm3, %xmm5
-; SLOW-NEXT:    vpbroadcastq {{.*#+}} xmm3 = [255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0]
+; SLOW-NEXT:    vpclmulqdq $17, %xmm2, %xmm5, %xmm3
+; SLOW-NEXT:    vpclmulqdq $0, %xmm2, %xmm5, %xmm4
 ; SLOW-NEXT:    vpsrlq $32, %xmm5, %xmm6
-; SLOW-NEXT:    vpclmulqdq $17, %xmm2, %xmm5, %xmm4
+; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm4 = xmm4[0],xmm3[0],xmm4[1],xmm3[1]
+; SLOW-NEXT:    vpbroadcastq {{.*#+}} xmm3 = [255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0]
 ; SLOW-NEXT:    vpclmulqdq $17, %xmm3, %xmm6, %xmm7
 ; SLOW-NEXT:    vpclmulqdq $0, %xmm3, %xmm6, %xmm6
-; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm4 = xmm4[0],xmm7[0],xmm4[1],xmm7[1]
+; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm6 = xmm6[0],xmm7[0],xmm6[1],xmm7[1]
+; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm4 = xmm4[0],xmm6[0],xmm4[1],xmm6[1]
+; SLOW-NEXT:    vpandn %xmm5, %xmm4, %xmm5
+; SLOW-NEXT:    vpclmulqdq $17, %xmm2, %xmm5, %xmm6
 ; SLOW-NEXT:    vpclmulqdq $0, %xmm2, %xmm5, %xmm7
 ; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm6 = xmm7[0],xmm6[0],xmm7[1],xmm6[1]
-; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm4 = xmm6[0],xmm4[0],xmm6[1],xmm4[1]
-; SLOW-NEXT:    vpandn %xmm5, %xmm4, %xmm5
 ; SLOW-NEXT:    vpsrlq $32, %xmm5, %xmm7
-; SLOW-NEXT:    vpclmulqdq $17, %xmm2, %xmm5, %xmm6
 ; SLOW-NEXT:    vpclmulqdq $17, %xmm3, %xmm7, %xmm8
 ; SLOW-NEXT:    vpclmulqdq $0, %xmm3, %xmm7, %xmm7
-; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm6 = xmm6[0],xmm8[0],xmm6[1],xmm8[1]
+; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm7[0],xmm8[0],xmm7[1],xmm8[1]
+; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm6 = xmm6[0],xmm7[0],xmm6[1],xmm7[1]
+; SLOW-NEXT:    vpandn %xmm5, %xmm6, %xmm5
+; SLOW-NEXT:    vpclmulqdq $17, %xmm2, %xmm5, %xmm7
 ; SLOW-NEXT:    vpclmulqdq $0, %xmm2, %xmm5, %xmm8
 ; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm8[0],xmm7[0],xmm8[1],xmm7[1]
-; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm6 = xmm7[0],xmm6[0],xmm7[1],xmm6[1]
-; SLOW-NEXT:    vpandn %xmm5, %xmm6, %xmm5
 ; SLOW-NEXT:    vpsrlq $32, %xmm5, %xmm8
-; SLOW-NEXT:    vpclmulqdq $17, %xmm2, %xmm5, %xmm7
 ; SLOW-NEXT:    vpclmulqdq $17, %xmm3, %xmm8, %xmm9
 ; SLOW-NEXT:    vpclmulqdq $0, %xmm3, %xmm8, %xmm8
-; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm7[0],xmm9[0],xmm7[1],xmm9[1]
+; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm8 = xmm8[0],xmm9[0],xmm8[1],xmm9[1]
+; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm7[0],xmm8[0],xmm7[1],xmm8[1]
+; SLOW-NEXT:    vpandn %xmm5, %xmm7, %xmm5
+; SLOW-NEXT:    vpclmulqdq $17, %xmm2, %xmm5, %xmm8
 ; SLOW-NEXT:    vpclmulqdq $0, %xmm2, %xmm5, %xmm9
 ; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm8 = xmm9[0],xmm8[0],xmm9[1],xmm8[1]
-; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm8[0],xmm7[0],xmm8[1],xmm7[1]
-; SLOW-NEXT:    vpandn %xmm5, %xmm7, %xmm5
 ; SLOW-NEXT:    vpsrlq $32, %xmm5, %xmm9
-; SLOW-NEXT:    vpclmulqdq $17, %xmm2, %xmm5, %xmm8
 ; SLOW-NEXT:    vpclmulqdq $17, %xmm3, %xmm9, %xmm10
 ; SLOW-NEXT:    vpclmulqdq $0, %xmm3, %xmm9, %xmm9
-; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm8 = xmm8[0],xmm10[0],xmm8[1],xmm10[1]
-; SLOW-NEXT:    vpclmulqdq $0, %xmm2, %xmm5, %xmm10
-; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm9 = xmm10[0],xmm9[0],xmm10[1],xmm9[1]
-; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm8 = xmm9[0],xmm8[0],xmm9[1],xmm8[1]
+; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm9 = xmm9[0],xmm10[0],xmm9[1],xmm10[1]
+; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm8 = xmm8[0],xmm9[0],xmm8[1],xmm9[1]
 ; SLOW-NEXT:    vpandn %xmm5, %xmm8, %xmm5
-; SLOW-NEXT:    vpsrlq $32, %xmm5, %xmm10
 ; SLOW-NEXT:    vpclmulqdq $17, %xmm2, %xmm5, %xmm9
 ; SLOW-NEXT:    vpclmulqdq $0, %xmm2, %xmm5, %xmm2
-; SLOW-NEXT:    vpclmulqdq $17, %xmm3, %xmm10, %xmm11
-; SLOW-NEXT:    vpclmulqdq $0, %xmm3, %xmm10, %xmm3
-; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm9 = xmm9[0],xmm11[0],xmm9[1],xmm11[1]
-; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm3[0],xmm2[1],xmm3[1]
+; SLOW-NEXT:    vpsrlq $32, %xmm5, %xmm5
 ; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm9[0],xmm2[1],xmm9[1]
+; SLOW-NEXT:    vpclmulqdq $17, %xmm3, %xmm5, %xmm9
+; SLOW-NEXT:    vpclmulqdq $0, %xmm3, %xmm5, %xmm3
+; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm3 = xmm3[0],xmm9[0],xmm3[1],xmm9[1]
 ; SLOW-NEXT:    vpand %xmm1, %xmm4, %xmm9
 ; SLOW-NEXT:    vpxor %xmm1, %xmm9, %xmm4
 ; SLOW-NEXT:    vpand %xmm0, %xmm9, %xmm1
 ; SLOW-NEXT:    vpsrld $1, %xmm9, %xmm5
+; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm3[0],xmm2[1],xmm3[1]
 ; SLOW-NEXT:    vpor %xmm5, %xmm4, %xmm4
 ; SLOW-NEXT:    vpxor %xmm1, %xmm0, %xmm0
 ; SLOW-NEXT:    vpsrld $1, %xmm1, %xmm1
@@ -122,105 +122,105 @@ define <4 x i32> @pext_v4i32(<4 x i32> %val, <4 x i32> %mask) nounwind {
 define <8 x i32> @pext_v8i32(<8 x i32> %val, <8 x i32> %mask) nounwind {
 ; SLOW-LABEL: pext_v8i32:
 ; SLOW:       # %bb.0:
-; SLOW-NEXT:    vpbroadcastq {{.*#+}} xmm3 = [255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0]
 ; SLOW-NEXT:    vpcmpeqd %ymm2, %ymm2, %ymm2
 ; SLOW-NEXT:    vpand %ymm1, %ymm0, %ymm0
 ; SLOW-NEXT:    vpxor %ymm2, %ymm1, %ymm2
 ; SLOW-NEXT:    vpaddd %ymm2, %ymm2, %ymm5
 ; SLOW-NEXT:    vpcmpeqd %xmm2, %xmm2, %xmm2
-; SLOW-NEXT:    vextracti128 $1, %ymm5, %xmm4
-; SLOW-NEXT:    vpsrlq $32, %xmm4, %xmm7
-; SLOW-NEXT:    vpclmulqdq $17, %xmm2, %xmm4, %xmm6
-; SLOW-NEXT:    vpclmulqdq $0, %xmm2, %xmm4, %xmm4
-; SLOW-NEXT:    vpclmulqdq $17, %xmm3, %xmm7, %xmm8
-; SLOW-NEXT:    vpclmulqdq $0, %xmm3, %xmm7, %xmm7
-; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm4 = xmm4[0],xmm7[0],xmm4[1],xmm7[1]
-; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm6 = xmm6[0],xmm8[0],xmm6[1],xmm8[1]
-; SLOW-NEXT:    vpsrlq $32, %xmm5, %xmm7
+; SLOW-NEXT:    vextracti128 $1, %ymm5, %xmm3
+; SLOW-NEXT:    vpclmulqdq $17, %xmm2, %xmm3, %xmm4
+; SLOW-NEXT:    vpclmulqdq $0, %xmm2, %xmm3, %xmm6
+; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm4 = xmm6[0],xmm4[0],xmm6[1],xmm4[1]
+; SLOW-NEXT:    vpsrlq $32, %xmm3, %xmm6
+; SLOW-NEXT:    vpbroadcastq {{.*#+}} xmm3 = [255,255,255,255,0,0,0,0,255,255,255,255,0,0,0,0]
+; SLOW-NEXT:    vpclmulqdq $17, %xmm3, %xmm6, %xmm7
+; SLOW-NEXT:    vpclmulqdq $0, %xmm3, %xmm6, %xmm6
+; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm6 = xmm6[0],xmm7[0],xmm6[1],xmm7[1]
+; SLOW-NEXT:    vpclmulqdq $0, %xmm2, %xmm5, %xmm7
 ; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm4 = xmm4[0],xmm6[0],xmm4[1],xmm6[1]
-; SLOW-NEXT:    vpclmulqdq $17, %xmm3, %xmm7, %xmm8
 ; SLOW-NEXT:    vpclmulqdq $17, %xmm2, %xmm5, %xmm6
-; SLOW-NEXT:    vpclmulqdq $0, %xmm3, %xmm7, %xmm7
-; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm6 = xmm6[0],xmm8[0],xmm6[1],xmm8[1]
-; SLOW-NEXT:    vpclmulqdq $0, %xmm2, %xmm5, %xmm8
-; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm8[0],xmm7[0],xmm8[1],xmm7[1]
 ; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm6 = xmm7[0],xmm6[0],xmm7[1],xmm6[1]
+; SLOW-NEXT:    vpsrlq $32, %xmm5, %xmm7
+; SLOW-NEXT:    vpclmulqdq $17, %xmm3, %xmm7, %xmm8
+; SLOW-NEXT:    vpclmulqdq $0, %xmm3, %xmm7, %xmm7
+; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm7[0],xmm8[0],xmm7[1],xmm8[1]
+; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm6 = xmm6[0],xmm7[0],xmm6[1],xmm7[1]
 ; SLOW-NEXT:    vinserti128 $1, %xmm4, %ymm6, %ymm4
 ; SLOW-NEXT:    vpandn %ymm5, %ymm4, %ymm6
 ; SLOW-NEXT:    vextracti128 $1, %ymm6, %xmm5
-; SLOW-NEXT:    vpsrlq $32, %xmm5, %xmm8
 ; SLOW-NEXT:    vpclmulqdq $17, %xmm2, %xmm5, %xmm7
-; SLOW-NEXT:    vpclmulqdq $0, %xmm2, %xmm5, %xmm5
-; SLOW-NEXT:    vpclmulqdq $17, %xmm3, %xmm8, %xmm9
-; SLOW-NEXT:    vpclmulqdq $0, %xmm3, %xmm8, %xmm8
-; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm5 = xmm5[0],xmm8[0],xmm5[1],xmm8[1]
-; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm7[0],xmm9[0],xmm7[1],xmm9[1]
-; SLOW-NEXT:    vpsrlq $32, %xmm6, %xmm8
-; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm5 = xmm5[0],xmm7[0],xmm5[1],xmm7[1]
-; SLOW-NEXT:    vpclmulqdq $17, %xmm3, %xmm8, %xmm9
-; SLOW-NEXT:    vpclmulqdq $17, %xmm2, %xmm6, %xmm7
-; SLOW-NEXT:    vpclmulqdq $0, %xmm3, %xmm8, %xmm8
-; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm7[0],xmm9[0],xmm7[1],xmm9[1]
-; SLOW-NEXT:    vpclmulqdq $0, %xmm2, %xmm6, %xmm9
-; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm8 = xmm9[0],xmm8[0],xmm9[1],xmm8[1]
+; SLOW-NEXT:    vpclmulqdq $0, %xmm2, %xmm5, %xmm8
+; SLOW-NEXT:    vpsrlq $32, %xmm5, %xmm5
 ; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm8[0],xmm7[0],xmm8[1],xmm7[1]
+; SLOW-NEXT:    vpclmulqdq $17, %xmm3, %xmm5, %xmm8
+; SLOW-NEXT:    vpclmulqdq $0, %xmm3, %xmm5, %xmm5
+; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm5 = xmm5[0],xmm8[0],xmm5[1],xmm8[1]
+; SLOW-NEXT:    vpclmulqdq $0, %xmm2, %xmm6, %xmm8
+; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm5 = xmm7[0],xmm5[0],xmm7[1],xmm5[1]
+; SLOW-NEXT:    vpclmulqdq $17, %xmm2, %xmm6, %xmm7
+; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm8[0],xmm7[0],xmm8[1],xmm7[1]
+; SLOW-NEXT:    vpsrlq $32, %xmm6, %xmm8
+; SLOW-NEXT:    vpclmulqdq $17, %xmm3, %xmm8, %xmm9
+; SLOW-NEXT:    vpclmulqdq $0, %xmm3, %xmm8, %xmm8
+; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm8 = xmm8[0],xmm9[0],xmm8[1],xmm9[1]
+; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm7[0],xmm8[0],xmm7[1],xmm8[1]
 ; SLOW-NEXT:    vinserti128 $1, %xmm5, %ymm7, %ymm5
 ; SLOW-NEXT:    vpandn %ymm6, %ymm5, %ymm7
 ; SLOW-NEXT:    vextracti128 $1, %ymm7, %xmm6
-; SLOW-NEXT:    vpsrlq $32, %xmm6, %xmm9
 ; SLOW-NEXT:    vpclmulqdq $17, %xmm2, %xmm6, %xmm8
-; SLOW-NEXT:    vpclmulqdq $0, %xmm2, %xmm6, %xmm6
-; SLOW-NEXT:    vpclmulqdq $17, %xmm3, %xmm9, %xmm10
-; SLOW-NEXT:    vpclmulqdq $0, %xmm3, %xmm9, %xmm9
-; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm6 = xmm6[0],xmm9[0],xmm6[1],xmm9[1]
-; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm8 = xmm8[0],xmm10[0],xmm8[1],xmm10[1]
-; SLOW-NEXT:    vpsrlq $32, %xmm7, %xmm9
-; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm6 = xmm6[0],xmm8[0],xmm6[1],xmm8[1]
-; SLOW-NEXT:    vpclmulqdq $17, %xmm3, %xmm9, %xmm10
-; SLOW-NEXT:    vpclmulqdq $17, %xmm2, %xmm7, %xmm8
-; SLOW-NEXT:    vpclmulqdq $0, %xmm3, %xmm9, %xmm9
-; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm8 = xmm8[0],xmm10[0],xmm8[1],xmm10[1]
-; SLOW-NEXT:    vpclmulqdq $0, %xmm2, %xmm7, %xmm10
-; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm9 = xmm10[0],xmm9[0],xmm10[1],xmm9[1]
+; SLOW-NEXT:    vpclmulqdq $0, %xmm2, %xmm6, %xmm9
+; SLOW-NEXT:    vpsrlq $32, %xmm6, %xmm6
 ; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm8 = xmm9[0],xmm8[0],xmm9[1],xmm8[1]
+; SLOW-NEXT:    vpclmulqdq $17, %xmm3, %xmm6, %xmm9
+; SLOW-NEXT:    vpclmulqdq $0, %xmm3, %xmm6, %xmm6
+; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm6 = xmm6[0],xmm9[0],xmm6[1],xmm9[1]
+; SLOW-NEXT:    vpclmulqdq $0, %xmm2, %xmm7, %xmm9
+; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm6 = xmm8[0],xmm6[0],xmm8[1],xmm6[1]
+; SLOW-NEXT:    vpclmulqdq $17, %xmm2, %xmm7, %xmm8
+; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm8 = xmm9[0],xmm8[0],xmm9[1],xmm8[1]
+; SLOW-NEXT:    vpsrlq $32, %xmm7, %xmm9
+; SLOW-NEXT:    vpclmulqdq $17, %xmm3, %xmm9, %xmm10
+; SLOW-NEXT:    vpclmulqdq $0, %xmm3, %xmm9, %xmm9
+; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm9 = xmm9[0],xmm10[0],xmm9[1],xmm10[1]
+; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm8 = xmm8[0],xmm9[0],xmm8[1],xmm9[1]
 ; SLOW-NEXT:    vinserti128 $1, %xmm6, %ymm8, %ymm6
 ; SLOW-NEXT:    vpandn %ymm7, %ymm6, %ymm8
 ; SLOW-NEXT:    vextracti128 $1, %ymm8, %xmm7
-; SLOW-NEXT:    vpsrlq $32, %xmm7, %xmm10
 ; SLOW-NEXT:    vpclmulqdq $17, %xmm2, %xmm7, %xmm9
-; SLOW-NEXT:    vpclmulqdq $0, %xmm2, %xmm7, %xmm7
-; SLOW-NEXT:    vpclmulqdq $17, %xmm3, %xmm10, %xmm11
-; SLOW-NEXT:    vpclmulqdq $0, %xmm3, %xmm10, %xmm10
-; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm7[0],xmm10[0],xmm7[1],xmm10[1]
-; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm9 = xmm9[0],xmm11[0],xmm9[1],xmm11[1]
-; SLOW-NEXT:    vpsrlq $32, %xmm8, %xmm10
-; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm7[0],xmm9[0],xmm7[1],xmm9[1]
-; SLOW-NEXT:    vpclmulqdq $17, %xmm3, %xmm10, %xmm11
-; SLOW-NEXT:    vpclmulqdq $17, %xmm2, %xmm8, %xmm9
-; SLOW-NEXT:    vpclmulqdq $0, %xmm3, %xmm10, %xmm10
-; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm9 = xmm9[0],xmm11[0],xmm9[1],xmm11[1]
-; SLOW-NEXT:    vpclmulqdq $0, %xmm2, %xmm8, %xmm11
-; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm10 = xmm11[0],xmm10[0],xmm11[1],xmm10[1]
+; SLOW-NEXT:    vpclmulqdq $0, %xmm2, %xmm7, %xmm10
+; SLOW-NEXT:    vpsrlq $32, %xmm7, %xmm7
 ; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm9 = xmm10[0],xmm9[0],xmm10[1],xmm9[1]
+; SLOW-NEXT:    vpclmulqdq $17, %xmm3, %xmm7, %xmm10
+; SLOW-NEXT:    vpclmulqdq $0, %xmm3, %xmm7, %xmm7
+; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm7[0],xmm10[0],xmm7[1],xmm10[1]
+; SLOW-NEXT:    vpclmulqdq $0, %xmm2, %xmm8, %xmm10
+; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm7 = xmm9[0],xmm7[0],xmm9[1],xmm7[1]
+; SLOW-NEXT:    vpclmulqdq $17, %xmm2, %xmm8, %xmm9
+; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm9 = xmm10[0],xmm9[0],xmm10[1],xmm9[1]
+; SLOW-NEXT:    vpsrlq $32, %xmm8, %xmm10
+; SLOW-NEXT:    vpclmulqdq $17, %xmm3, %xmm10, %xmm11
+; SLOW-NEXT:    vpclmulqdq $0, %xmm3, %xmm10, %xmm10
+; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm10 = xmm10[0],xmm11[0],xmm10[1],xmm11[1]
+; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm9 = xmm9[0],xmm10[0],xmm9[1],xmm10[1]
 ; SLOW-NEXT:    vinserti128 $1, %xmm7, %ymm9, %ymm7
 ; SLOW-NEXT:    vpandn %ymm8, %ymm7, %ymm8
 ; SLOW-NEXT:    vextracti128 $1, %ymm8, %xmm9
-; SLOW-NEXT:    vpsrlq $32, %xmm8, %xmm13
-; SLOW-NEXT:    vpsrlq $32, %xmm9, %xmm11
+; SLOW-NEXT:    vpclmulqdq $17, %xmm2, %xmm8, %xmm12
 ; SLOW-NEXT:    vpclmulqdq $17, %xmm2, %xmm9, %xmm10
-; SLOW-NEXT:    vpclmulqdq $0, %xmm2, %xmm9, %xmm9
-; SLOW-NEXT:    vpclmulqdq $17, %xmm3, %xmm11, %xmm12
-; SLOW-NEXT:    vpclmulqdq $0, %xmm3, %xmm11, %xmm11
-; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm10 = xmm10[0],xmm12[0],xmm10[1],xmm12[1]
-; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm9 = xmm9[0],xmm11[0],xmm9[1],xmm11[1]
-; SLOW-NEXT:    vpclmulqdq $17, %xmm3, %xmm13, %xmm12
-; SLOW-NEXT:    vpclmulqdq $0, %xmm3, %xmm13, %xmm3
-; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm9 = xmm9[0],xmm10[0],xmm9[1],xmm10[1]
-; SLOW-NEXT:    vpclmulqdq $17, %xmm2, %xmm8, %xmm10
+; SLOW-NEXT:    vpclmulqdq $0, %xmm2, %xmm9, %xmm11
+; SLOW-NEXT:    vpsrlq $32, %xmm9, %xmm9
 ; SLOW-NEXT:    vpclmulqdq $0, %xmm2, %xmm8, %xmm2
-; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm10 = xmm10[0],xmm12[0],xmm10[1],xmm12[1]
+; SLOW-NEXT:    vpsrlq $32, %xmm8, %xmm8
+; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm10 = xmm11[0],xmm10[0],xmm11[1],xmm10[1]
+; SLOW-NEXT:    vpclmulqdq $17, %xmm3, %xmm9, %xmm11
+; SLOW-NEXT:    vpclmulqdq $0, %xmm3, %xmm9, %xmm9
+; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm12[0],xmm2[1],xmm12[1]
+; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm9 = xmm9[0],xmm11[0],xmm9[1],xmm11[1]
+; SLOW-NEXT:    vpclmulqdq $17, %xmm3, %xmm8, %xmm11
+; SLOW-NEXT:    vpclmulqdq $0, %xmm3, %xmm8, %xmm3
+; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm9 = xmm10[0],xmm9[0],xmm10[1],xmm9[1]
+; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm3 = xmm3[0],xmm11[0],xmm3[1],xmm11[1]
 ; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm3[0],xmm2[1],xmm3[1]
-; SLOW-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm2[0],xmm10[0],xmm2[1],xmm10[1]
 ; SLOW-NEXT:    vinserti128 $1, %xmm9, %ymm2, %ymm2
 ; SLOW-NEXT:    vpand %ymm1, %ymm4, %ymm9
 ; SLOW-NEXT:    vpxor %ymm1, %ymm9, %ymm4


### PR DESCRIPTION
Fix typo in the unpack order for vXi32 CLMUL/CLMULH codegen from #221289 and #221668 - I'd gotten the variable names right, but failed to actually use the right variables!

Fixes #221964