### PR TITLE
[libc++] Backport resolution of LWG2187 to C++11

### DIFF
--- a/libcxx/include/__vector/vector_bool.h
+++ b/libcxx/include/__vector/vector_bool.h
@@ -322,20 +322,19 @@ public:
   }
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void push_back(const value_type& __x);
-#if _LIBCPP_STD_VER >= 14
+
   template <class... _Args>
-#  if _LIBCPP_STD_VER >= 17
+#if _LIBCPP_STD_VER >= 17
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 reference emplace_back(_Args&&... __args)
-#  else
+#else
   _LIBCPP_HIDE_FROM_ABI void emplace_back(_Args&&... __args)
-#  endif
+#endif
   {
     push_back(value_type(std::forward<_Args>(__args)...));
-#  if _LIBCPP_STD_VER >= 17
+#if _LIBCPP_STD_VER >= 17
     return this->back();
-#  endif
-  }
 #endif
+  }
 
 #if _LIBCPP_STD_VER >= 23
   template <_ContainerCompatibleRange<bool> _Range>
@@ -349,12 +348,10 @@ public:
     --__size_;
   }
 
-#if _LIBCPP_STD_VER >= 14
   template <class... _Args>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 iterator emplace(const_iterator __position, _Args&&... __args) {
     return insert(__position, value_type(std::forward<_Args>(__args)...));
   }
-#endif
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 iterator insert(const_iterator __position, const value_type& __x);
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 iterator

--- a/libcxx/include/__vector/vector_bool.h
+++ b/libcxx/include/__vector/vector_bool.h
@@ -322,19 +322,20 @@ public:
   }
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void push_back(const value_type& __x);
-
+#if _LIBCPP_STD_VER >= 11
   template <class... _Args>
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 reference emplace_back(_Args&&... __args)
-#else
+#  else
   _LIBCPP_HIDE_FROM_ABI void emplace_back(_Args&&... __args)
-#endif
+#  endif
   {
     push_back(value_type(std::forward<_Args>(__args)...));
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
     return this->back();
-#endif
+#  endif
   }
+#endif
 
 #if _LIBCPP_STD_VER >= 23
   template <_ContainerCompatibleRange<bool> _Range>
@@ -348,10 +349,12 @@ public:
     --__size_;
   }
 
+#if _LIBCPP_STD_VER >= 11
   template <class... _Args>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 iterator emplace(const_iterator __position, _Args&&... __args) {
     return insert(__position, value_type(std::forward<_Args>(__args)...));
   }
+#endif
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 iterator insert(const_iterator __position, const value_type& __x);
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 iterator

--- a/libcxx/include/__vector/vector_bool.h
+++ b/libcxx/include/__vector/vector_bool.h
@@ -322,7 +322,7 @@ public:
   }
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void push_back(const value_type& __x);
-#if _LIBCPP_STD_VER >= 11
+#ifndef _LIBCPP_CXX03_LANG
   template <class... _Args>
 #  if _LIBCPP_STD_VER >= 17
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 reference emplace_back(_Args&&... __args)
@@ -349,7 +349,7 @@ public:
     --__size_;
   }
 
-#if _LIBCPP_STD_VER >= 11
+#ifndef _LIBCPP_CXX03_LANG
   template <class... _Args>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 iterator emplace(const_iterator __position, _Args&&... __args) {
     return insert(__position, value_type(std::forward<_Args>(__args)...));

--- a/libcxx/include/vector
+++ b/libcxx/include/vector
@@ -230,12 +230,12 @@ public:
     const_reference back() const;
 
     void push_back(const value_type& x);
-    template <class... Args> reference emplace_back(Args&&... args);  // C++14; reference in C++17
+    template <class... Args> reference emplace_back(Args&&... args);  // returns void/reference until/since C++17
     template<container-compatible-range<T> R>
       constexpr void append_range(R&& rg); // C++23
     void pop_back();
 
-    template <class... Args> iterator emplace(const_iterator position, Args&&... args);  // C++14
+    template <class... Args> iterator emplace(const_iterator position, Args&&... args);
     iterator insert(const_iterator position, const value_type& x);
     iterator insert(const_iterator position, size_type n, const value_type& x);
     template <class InputIterator>

--- a/libcxx/include/vector
+++ b/libcxx/include/vector
@@ -235,7 +235,7 @@ public:
       constexpr void append_range(R&& rg); // C++23
     void pop_back();
 
-    template <class... Args> iterator emplace(const_iterator position, Args&&... args); // C++11
+    template <class... Args> iterator emplace(const_iterator position, Args&&... args);  // C++11
     iterator insert(const_iterator position, const value_type& x);
     iterator insert(const_iterator position, size_type n, const value_type& x);
     template <class InputIterator>

--- a/libcxx/include/vector
+++ b/libcxx/include/vector
@@ -230,12 +230,12 @@ public:
     const_reference back() const;
 
     void push_back(const value_type& x);
-    template <class... Args> reference emplace_back(Args&&... args);  // returns void/reference until/since C++17
+    template <class... Args> reference emplace_back(Args&&... args);  // C++11; returns void/reference until/since C++17
     template<container-compatible-range<T> R>
       constexpr void append_range(R&& rg); // C++23
     void pop_back();
 
-    template <class... Args> iterator emplace(const_iterator position, Args&&... args);
+    template <class... Args> iterator emplace(const_iterator position, Args&&... args); // C++11
     iterator insert(const_iterator position, const value_type& x);
     iterator insert(const_iterator position, size_type n, const value_type& x);
     template <class InputIterator>

--- a/libcxx/test/std/containers/sequences/vector.bool/emplace.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/emplace.pass.cpp
@@ -6,7 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11
+// XFAIL: FROZEN-CXX03-HEADERS-FIXME
+
 // <vector>
 //  vector<bool>
 
@@ -41,7 +42,7 @@ TEST_CONSTEXPR_CXX20 bool tests() {
     assert(c.back() == true);
   }
   {
-    typedef std::vector<bool, min_allocator<bool>> C;
+    typedef std::vector<bool, min_allocator<bool> > C;
     C c;
 
     C::iterator i = c.emplace(c.cbegin());

--- a/libcxx/test/std/containers/sequences/vector.bool/emplace.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/emplace.pass.cpp
@@ -42,7 +42,7 @@ TEST_CONSTEXPR_CXX20 bool tests() {
     assert(c.back() == true);
   }
   {
-    typedef std::vector<bool, min_allocator<bool> > C;
+    typedef std::vector<bool, min_allocator<bool>> C;
     C c;
 
     C::iterator i = c.emplace(c.cbegin());

--- a/libcxx/test/std/containers/sequences/vector.bool/emplace.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/emplace.pass.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: FROZEN-CXX03-HEADERS-FIXME
+// REQUIRES: std-at-least-c++11
 
 // <vector>
 //  vector<bool>

--- a/libcxx/test/std/containers/sequences/vector.bool/emplace_back.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/emplace_back.pass.cpp
@@ -6,7 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11
+// XFAIL: FROZEN-CXX03-HEADERS-FIXME
+
 // <vector>
 //  vector.bool
 
@@ -53,7 +54,7 @@ TEST_CONSTEXPR_CXX20 bool tests() {
     assert(c.back() == true);
   }
   {
-    typedef std::vector<bool, min_allocator<bool>> C;
+    typedef std::vector<bool, min_allocator<bool> > C;
     C c;
 
 #if TEST_STD_VER > 14

--- a/libcxx/test/std/containers/sequences/vector.bool/emplace_back.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/emplace_back.pass.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: FROZEN-CXX03-HEADERS-FIXME
+// REQUIRES: std-at-least-c++11
 
 // <vector>
 //  vector.bool

--- a/libcxx/test/std/containers/sequences/vector.bool/emplace_back.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/emplace_back.pass.cpp
@@ -54,7 +54,7 @@ TEST_CONSTEXPR_CXX20 bool tests() {
     assert(c.back() == true);
   }
   {
-    typedef std::vector<bool, min_allocator<bool> > C;
+    typedef std::vector<bool, min_allocator<bool>> C;
     C c;
 
 #if TEST_STD_VER > 14


### PR DESCRIPTION
libc++ has LWG2187 implemented in 2d6e2834a8abcce862ef17c44f62e4de41662748 but only since C++14 mode. Usually, resolution of an LWG issue should be treated as a Defect Report and applied to old modes. In the case of LWG2187, the resolution should be applied to C++11.