### PR TITLE
[lldb] Add requireClang decorator

### DIFF
--- a/lldb/docs/resources/test.md
+++ b/lldb/docs/resources/test.md
@@ -159,12 +159,15 @@ decorator you pick says which:
 The `require*` decorators mirror the `skip*` ones one-for-one:
 `requireDarwin` / `requireNotDarwin`, `requireLinux` / `requireNotLinux`,
 `requireWindows` / `requireNotWindows`, plus `requirePOSIX`, `requireSignals`,
-`requireNotWasm`, `requireDarwinHost`, and the general
+`requireNotWasm`, `requireDarwinHost`, `requireClang`, and the general
 `requirePlatform(oslist)` / `requireNotPlatform(oslist)`.
 
 Reach for `require*` when the test is tied to a platform-specific file format,
-API, or OS feature. If the test is merely untested or broken somewhere, keep
-`skipIf*` so nobody mistakes a bug for a design decision.
+API, or OS feature, or to a specific compiler. If the test is merely untested
+or broken somewhere, keep `skipIf*` so nobody mistakes a bug for a design
+decision. For example, a test that only uses Clang-specific debug info
+options belongs behind `@requireClang` rather than
+`@skipIf(compiler=no_match("clang"))`.
 
 In addition to providing a lot more flexibility when it comes to writing the
 test, the API test also allow for much more complex scenarios when it comes to

--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -1313,6 +1313,15 @@ def requireSocketPermission(func):
     return unittest.skipIf(error is not None, UnsupportedReason(error or ""))(func)
 
 
+def requireClang(func):
+    """Mark the item as inherently Clang-only (Clang-specific debug info,
+    diagnostics, or command-line flags)."""
+    compiler = os.path.basename(lldbplatformutil.getCompiler())
+    return unittest.skipUnless(
+        compiler.startswith("clang"), UnsupportedReason("requires clang")
+    )(func)
+
+
 def skipIfTargetDoesNotSupportSharedLibraries():
     """Skip tests that require shared library (dylib/so) support."""
     platform = lldbplatformutil.getPlatform()
@@ -1410,19 +1419,6 @@ def skipUnlessHasCallSiteInfo(func):
             return None
 
     return skipTestIfFn(is_compiler_clang_with_call_site_info)(func)
-
-
-def skipUnlessCompilerIsClang(func):
-    """Decorate the item to skip test unless the compiler is clang."""
-
-    def is_compiler_clang():
-        compiler_path = lldbplatformutil.getCompiler()
-        compiler = os.path.basename(compiler_path)
-        if not compiler.startswith("clang"):
-            return "Test requires clang as compiler"
-        return None
-
-    return skipTestIfFn(is_compiler_clang)(func)
 
 
 def skipUnlessMSVC(func):

--- a/lldb/test/API/commands/expression/import-std-module/array/TestArrayFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/array/TestArrayFromStdModule.py
@@ -9,7 +9,7 @@ from lldbsuite.test import lldbutil
 
 class TestCase(TestBase):
     @add_test_categories(["libc++"])
-    @skipIf(compiler=no_match("clang"))
+    @requireClang
     @skipIf(macos_version=["<", "15.0"])
     @skipIf(
         bugnumber="ASTImport of lambdas not supported: https://github.com/llvm/llvm-project/issues/149477"

--- a/lldb/test/API/commands/expression/import-std-module/basic/TestImportStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/basic/TestImportStdModule.py
@@ -9,7 +9,7 @@ from lldbsuite.test import lldbutil
 
 class ImportStdModule(TestBase):
     @add_test_categories(["libc++"])
-    @skipIf(compiler=no_match("clang"))
+    @requireClang
     @skipIf(macos_version=["<", "15.0"])
     @skipIf(macos_sdk_version=["<", "16.0"])
     def test(self):
@@ -39,7 +39,7 @@ class ImportStdModule(TestBase):
         )
 
     @add_test_categories(["libc++"])
-    @skipIf(compiler=no_match("clang"))
+    @requireClang
     @skipIf(macos_version=["<", "15.0"])
     @skipIf(macos_sdk_version=["<", "16.0"])
     def test_non_cpp_language(self):

--- a/lldb/test/API/commands/expression/import-std-module/conflicts/TestStdModuleWithConflicts.py
+++ b/lldb/test/API/commands/expression/import-std-module/conflicts/TestStdModuleWithConflicts.py
@@ -14,7 +14,7 @@ from lldbsuite.test import lldbutil
 
 class TestImportStdModuleConflicts(TestBase):
     @add_test_categories(["libc++"])
-    @skipIf(compiler=no_match("clang"))
+    @requireClang
     @skipIf(macos_version=["<", "15.0"])
     @skipIf(macos_sdk_version=["<", "16.0"])
     def test(self):

--- a/lldb/test/API/commands/expression/import-std-module/deque-basic/TestDequeFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/deque-basic/TestDequeFromStdModule.py
@@ -9,7 +9,7 @@ from lldbsuite.test import lldbutil
 
 class TestBasicDeque(TestBase):
     @add_test_categories(["libc++"])
-    @skipIf(compiler=no_match("clang"))
+    @requireClang
     @skipIf(macos_version=["<", "15.0"])
     @skipIf(
         bugnumber="ASTImport of lambdas not supported: https://github.com/llvm/llvm-project/issues/149477"

--- a/lldb/test/API/commands/expression/import-std-module/empty-module/TestEmptyStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/empty-module/TestEmptyStdModule.py
@@ -14,7 +14,7 @@ class ImportStdModule(TestBase):
     # test configurations where libc++ is actually supposed to be tested.
     @add_test_categories(["libc++"])
     @skipIfRemote
-    @skipIf(compiler=no_match("clang"))
+    @requireClang
     @skipIf(macos_sdk_version=["<", "16.0"])
     def test(self):
         self.build()

--- a/lldb/test/API/commands/expression/import-std-module/forward_decl_from_module/TestForwardDeclFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/forward_decl_from_module/TestForwardDeclFromStdModule.py
@@ -14,7 +14,7 @@ class TestCase(TestBase):
     # test configurations where libc++ is actually supposed to be tested.
     @add_test_categories(["libc++"])
     @skipIfRemote
-    @skipIf(compiler=no_match("clang"))
+    @requireClang
     @skipIf(macos_sdk_version=["<", "16.0"])
     def test(self):
         self.build()

--- a/lldb/test/API/commands/expression/import-std-module/forward_list-dbg-info-content/TestDbgInfoContentForwardListFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/forward_list-dbg-info-content/TestDbgInfoContentForwardListFromStdModule.py
@@ -9,7 +9,7 @@ from lldbsuite.test import lldbutil
 
 class TestDbgInfoContentForwardList(TestBase):
     @add_test_categories(["libc++"])
-    @skipIf(compiler=no_match("clang"))
+    @requireClang
     @skipIf(macos_version=["<", "15.0"])
     @skipIf(macos_sdk_version=["<", "16.0"])
     def test(self):

--- a/lldb/test/API/commands/expression/import-std-module/forward_list/TestForwardListFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/forward_list/TestForwardListFromStdModule.py
@@ -9,7 +9,7 @@ from lldbsuite.test import lldbutil
 
 class TestBasicForwardList(TestBase):
     @add_test_categories(["libc++"])
-    @skipIf(compiler=no_match("clang"))
+    @requireClang
     @skipIf(macos_version=["<", "15.0"])
     @skipIf(
         bugnumber="ASTImport of lambdas not supported: https://github.com/llvm/llvm-project/issues/149477"

--- a/lldb/test/API/commands/expression/import-std-module/iterator/TestIteratorFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/iterator/TestIteratorFromStdModule.py
@@ -9,7 +9,7 @@ from lldbsuite.test import lldbutil
 
 class TestCase(TestBase):
     @add_test_categories(["libc++"])
-    @skipIf(compiler=no_match("clang"))
+    @requireClang
     @skipIf(macos_version=["<", "15.0"])
     @skipIf(macos_sdk_version=["<", "16.0"])
     def test(self):
@@ -29,7 +29,7 @@ class TestCase(TestBase):
         self.expect_expr("move_begin + 3 == move_end", result_value="true")
 
     @add_test_categories(["libc++"])
-    @skipIf(compiler=no_match("clang"))
+    @requireClang
     @expectedFailureAll(bugnumber="https://github.com/llvm/llvm-project/issues/149477")
     @skipIf(macos_sdk_version=["<", "16.0"])
     def test_xfail(self):

--- a/lldb/test/API/commands/expression/import-std-module/list/TestListFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/list/TestListFromStdModule.py
@@ -9,7 +9,7 @@ from lldbsuite.test import lldbutil
 
 class TestBasicList(TestBase):
     @add_test_categories(["libc++"])
-    @skipIf(compiler=no_match("clang"))
+    @requireClang
     @skipIf(macos_version=["<", "15.0"])
     @skipIf(
         bugnumber="ASTImport of lambdas not supported: https://github.com/llvm/llvm-project/issues/149477"

--- a/lldb/test/API/commands/expression/import-std-module/missing-module-sources/TestStdModuleSourcesMissing.py
+++ b/lldb/test/API/commands/expression/import-std-module/missing-module-sources/TestStdModuleSourcesMissing.py
@@ -14,7 +14,7 @@ class TestCase(TestBase):
     # but we still add the libc++ category so that this test is only run in
     # test configurations where libc++ is actually supposed to be tested.
     @add_test_categories(["libc++"])
-    @skipIf(compiler=no_match("clang"))
+    @requireClang
     @skipIfRemote
     @skipIf(macos_sdk_version=["<", "16.0"])
     def test(self):

--- a/lldb/test/API/commands/expression/import-std-module/module-build-errors/TestStdModuleBuildErrors.py
+++ b/lldb/test/API/commands/expression/import-std-module/module-build-errors/TestStdModuleBuildErrors.py
@@ -18,7 +18,7 @@ class TestCase(TestBase):
     # test configurations where libc++ is actually supposed to be tested.
     @add_test_categories(["libc++"])
     @skipIfRemote
-    @skipIf(compiler=no_match("clang"))
+    @requireClang
     @skipIf(macos_sdk_version=["<", "16.0"])
     def test(self):
         self.build()

--- a/lldb/test/API/commands/expression/import-std-module/no-std-module/TestMissingStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/no-std-module/TestMissingStdModule.py
@@ -15,7 +15,7 @@ from lldbsuite.test import lldbutil
 
 class STLTestCase(TestBase):
     @add_test_categories(["libc++"])
-    @skipIf(compiler=no_match("clang"))
+    @requireClang
     @skipIf(macos_sdk_version=["<", "16.0"])
     def test(self):
         self.build()

--- a/lldb/test/API/commands/expression/import-std-module/non-module-type-separation/TestNonModuleTypeSeparation.py
+++ b/lldb/test/API/commands/expression/import-std-module/non-module-type-separation/TestNonModuleTypeSeparation.py
@@ -10,7 +10,7 @@ from lldbsuite.test import lldbutil
 
 class TestCase(TestBase):
     @add_test_categories(["libc++"])
-    @skipIf(compiler=no_match("clang"))
+    @requireClang
     @skipIf(macos_version=["<", "15.0"])
     @skipIf(macos_sdk_version=["<", "16.0"])
     def test(self):

--- a/lldb/test/API/commands/expression/import-std-module/pair/TestPairFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/pair/TestPairFromStdModule.py
@@ -9,7 +9,7 @@ from lldbsuite.test import lldbutil
 
 class TestCase(TestBase):
     @add_test_categories(["libc++"])
-    @skipIf(compiler=no_match("clang"))
+    @requireClang
     # FIXME: This regressed in 69d5a6662115499198ebfa07a081e98a6ce4b915
     # but needs further investigation for what underlying Clang/LLDB bug can't
     # handle that code change.

--- a/lldb/test/API/commands/expression/import-std-module/queue/TestQueueFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/queue/TestQueueFromStdModule.py
@@ -9,7 +9,7 @@ from lldbsuite.test import lldbutil
 
 class TestQueue(TestBase):
     @add_test_categories(["libc++"])
-    @skipIf(compiler=no_match("clang"))
+    @requireClang
     @skipIf(
         compiler="clang",
         compiler_version=[">", "16.0"],

--- a/lldb/test/API/commands/expression/import-std-module/retry-with-std-module/TestRetryWithStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/retry-with-std-module/TestRetryWithStdModule.py
@@ -5,7 +5,7 @@ from lldbsuite.test import lldbutil
 
 class TestCase(TestBase):
     @add_test_categories(["libc++"])
-    @skipIf(compiler=no_match("clang"))
+    @requireClang
     @skipIf(macos_version=["<", "15.0"])
     @skipIf(macos_sdk_version=["<", "16.0"])
     def test(self):

--- a/lldb/test/API/commands/expression/import-std-module/shared_ptr-dbg-info-content/TestSharedPtrDbgInfoContentFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/shared_ptr-dbg-info-content/TestSharedPtrDbgInfoContentFromStdModule.py
@@ -9,7 +9,7 @@ from lldbsuite.test import lldbutil
 
 class TestSharedPtrDbgInfoContent(TestBase):
     @add_test_categories(["libc++"])
-    @skipIf(compiler=no_match("clang"))
+    @requireClang
     @skipIf(macos_version=["<", "15.0"])
     @skipIf(macos_sdk_version=["<", "16.0"])
     def test(self):

--- a/lldb/test/API/commands/expression/import-std-module/stack/TestStackFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/stack/TestStackFromStdModule.py
@@ -9,7 +9,7 @@ from lldbsuite.test import lldbutil
 
 class TestStack(TestBase):
     @add_test_categories(["libc++"])
-    @skipIf(compiler=no_match("clang"))
+    @requireClang
     @skipIfLinux  # Declaration in some Linux headers causes LLDB to crash.
     @skipIf(bugnumber="rdar://97622854")
     @skipIf(macos_sdk_version=["<", "16.0"])

--- a/lldb/test/API/commands/expression/import-std-module/sysroot/TestStdModuleSysroot.py
+++ b/lldb/test/API/commands/expression/import-std-module/sysroot/TestStdModuleSysroot.py
@@ -13,7 +13,7 @@ class ImportStdModule(TestBase):
     # but we still add the libc++ category so that this test is only run in
     # test configurations where libc++ is actually supposed to be tested.
     @add_test_categories(["libc++"])
-    @skipIf(compiler=no_match("clang"))
+    @requireClang
     @skipIfRemote  # This test messes with the platform, can't be run remotely.
     @skipIf(macos_sdk_version=["<", "16.0"])
     def test(self):

--- a/lldb/test/API/commands/expression/import-std-module/vector-bool/TestVectorBoolFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/vector-bool/TestVectorBoolFromStdModule.py
@@ -9,7 +9,7 @@ from lldbsuite.test import lldbutil
 
 class TestBoolVector(TestBase):
     @add_test_categories(["libc++"])
-    @skipIf(compiler=no_match("clang"))
+    @requireClang
     @skipIf(bugnumber="rdar://100741983")
     @skipIf(macos_sdk_version=["<", "16.0"])
     def test(self):

--- a/lldb/test/API/commands/expression/import-std-module/vector-of-vectors/TestVectorOfVectorsFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/vector-of-vectors/TestVectorOfVectorsFromStdModule.py
@@ -9,7 +9,7 @@ from lldbsuite.test import lldbutil
 
 class TestVectorOfVectors(TestBase):
     @add_test_categories(["libc++"])
-    @skipIf(compiler=no_match("clang"))
+    @requireClang
     @skipIf(macos_version=["<", "15.0"])
     @skipIf(
         bugnumber="ASTImport of lambdas not supported: https://github.com/llvm/llvm-project/issues/149477"

--- a/lldb/test/API/commands/expression/import-std-module/vector/TestVectorFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/vector/TestVectorFromStdModule.py
@@ -9,7 +9,7 @@ from lldbsuite.test import lldbutil
 
 class TestBasicVector(TestBase):
     @add_test_categories(["libc++"])
-    @skipIf(compiler=no_match("clang"))
+    @requireClang
     @skipIf(bugnumber="rdar://100741983")
     @skipIf(macos_sdk_version=["<", "16.0"])
     def test(self):

--- a/lldb/test/API/commands/frame/var/TestFrameVar.py
+++ b/lldb/test/API/commands/frame/var/TestFrameVar.py
@@ -170,7 +170,7 @@ class TestFrameVar(TestBase):
 
     @skipIfRemote
     @skipIfWindows  # Windows can't set breakpoints by name 'main' in this case.
-    @skipIf(compiler=no_match("clang"))
+    @requireClang
     def test_gline_tables_only(self):
         """
         Test that if we build a binary with "-gline-tables-only" that we can

--- a/lldb/test/API/functionalities/breakpoint/jit_loader_rtdyld_elf/TestJitBreakPoint.py
+++ b/lldb/test/API/functionalities/breakpoint/jit_loader_rtdyld_elf/TestJitBreakPoint.py
@@ -10,7 +10,7 @@ from lldbsuite.test import configuration
 
 class TestJitBreakpoint(TestBase):
     @skipUnlessArch("x86_64")
-    @skipUnlessCompilerIsClang
+    @requireClang
     @expectedFailureAll(oslist=["windows"])
     def test_jit_breakpoints(self):
         self.build()

--- a/lldb/test/API/lang/cpp/abi_tag_structors/TestAbiTagStructors.py
+++ b/lldb/test/API/lang/cpp/abi_tag_structors/TestAbiTagStructors.py
@@ -17,7 +17,7 @@ class AbiTagStructorsTestCase(TestBase):
         compiler_version=["<", "22"],
         bugnumber="Required Clang flag not supported",
     )
-    @skipIf(compiler=no_match("clang"))
+    @requireClang
     @expectedFailureAll(oslist=["windows"])
     @requireExpressionEvaluation
     def test_with_structor_linkage_names(self):
@@ -77,7 +77,7 @@ class AbiTagStructorsTestCase(TestBase):
         )
 
     @expectedFailureAll(oslist=["windows"])
-    @skipIf(compiler=no_match("clang"))
+    @requireClang
     def test_no_structor_linkage_names(self):
         """
         Test that without linkage names on structor declarations we can't call
@@ -132,7 +132,7 @@ class AbiTagStructorsTestCase(TestBase):
         self.build(dictionary={"CXXFLAGS_EXTRAS": "-gstructor-decl-linkage-names"})
         self.do_nested_structor_test()
 
-    @skipIf(compiler=no_match("clang"))
+    @requireClang
     @expectedFailureAll(oslist=["windows"])
     @requireExpressionEvaluation
     def test_nested_no_structor_linkage_names(self):

--- a/lldb/test/API/lang/cpp/forward/TestCPPForwardDeclaration.py
+++ b/lldb/test/API/lang/cpp/forward/TestCPPForwardDeclaration.py
@@ -56,7 +56,7 @@ class ForwardDeclarationTestCase(TestBase):
         self.do_test(dict(CFLAGS_EXTRAS="-gdwarf-5 -gpubnames"))
 
     @no_debug_info_test
-    @skipIf(compiler=no_match("clang"))
+    @requireClang
     def test_simple_template_names(self):
         """Test that we are able to find complete types when using DWARF v5
         accelerator tables"""


### PR DESCRIPTION
- Add requireClang, marking Clang-only tests as UNSUPPORTED elsewhere instead of SKIPPED, following the existing require* convention.
- Replace the ~30 standalone @skipIf(compiler=no_match("clang")) uses with @requireClang; leave the cases paired with a compiler_version check as-is, since those are more complex than a simple compiler check.
- Remove the now-unused skipUnlessCompilerIsClang in favor of requireClang.
- Update the testing docs to mention requireClang.

Follow-up to #214197.