### PR TITLE
[libFuzzer] Modify stop-file.test to support remote devices

### DIFF
--- a/compiler-rt/test/fuzzer/stop-file.test
+++ b/compiler-rt/test/fuzzer/stop-file.test
@@ -6,7 +6,5 @@ RUN: %run %t-AccumulateAllocationsTest -seed=1 -runs=100000 -stop_file=%t.stop_f
 CHECK: Done {{[0-9]}} runs
 
 # Fuzzing must not stop when the stop file does not exist.
-RUN: rm -f %t.stop_file
-RUN: %device_rm -f %t.stop_file
-RUN: %run %t-AccumulateAllocationsTest -seed=1 -runs=1000 -stop_file=%t.stop_file 2>&1 | FileCheck %s --check-prefix=NOSTOP
+RUN: %run %t-AccumulateAllocationsTest -seed=1 -runs=1000 -stop_file=%t.nonexistent_stop_file 2>&1 | FileCheck %s --check-prefix=NOSTOP
 NOSTOP: Done 1000 runs

--- a/compiler-rt/test/fuzzer/stop-file.test
+++ b/compiler-rt/test/fuzzer/stop-file.test
@@ -1,12 +1,12 @@
 RUN: %cpp_compiler %S/AccumulateAllocationsTest.cpp -o %t-AccumulateAllocationsTest
 
 # Fuzzing must stop when the stop file exists, even if the file is empty.
-RUN: rm -f %t.stop_file
 RUN: echo -n "" > %t.stop_file
 RUN: %run %t-AccumulateAllocationsTest -seed=1 -runs=100000 -stop_file=%t.stop_file 2>&1 | FileCheck %s
 CHECK: Done {{[0-9]}} runs
 
 # Fuzzing must not stop when the stop file does not exist.
 RUN: rm -f %t.stop_file
+RUN: %device_rm -f %t.stop_file
 RUN: %run %t-AccumulateAllocationsTest -seed=1 -runs=1000 -stop_file=%t.stop_file 2>&1 | FileCheck %s --check-prefix=NOSTOP
 NOSTOP: Done 1000 runs


### PR DESCRIPTION
Currently this test fails when running on remote devices because the 'rm' command only removes the file from the host, and the second part of the test expects the file to have been removed. This patch changes the later run command to point to a non-existent file in order to work around this.

rdar://186683123