### PR TITLE
[WindowsSecureHotPatching] Remove redundant getGetElementPtr() (NFC)

### DIFF
--- a/llvm/lib/CodeGen/WindowsSecureHotPatching.cpp
+++ b/llvm/lib/CodeGen/WindowsSecureHotPatching.cpp
@@ -359,12 +359,9 @@ static GlobalVariable *getOrCreateRefVariable(
 
   auto PtrTy = PointerType::get(M->getContext(), 0);
 
-  Constant *AddrOfOldGV =
-      ConstantExpr::getGetElementPtr(PtrTy, GV, ArrayRef<Value *>{});
-
   GlobalVariable *RefGV =
       new GlobalVariable(*M, PtrTy, false, GlobalValue::LinkOnceAnyLinkage,
-                         AddrOfOldGV, Twine("__ref_").concat(GV->getName()),
+                         GV, Twine("__ref_").concat(GV->getName()),
                          nullptr, GlobalVariable::NotThreadLocal);
 
   // RefGV is created with isConstant = false, but we want to place RefGV into


### PR DESCRIPTION
This was creating a degenerate getelementptr without any indices,
which is equivalent to the base pointer and will fold away.