### PR TITLE
[SLP][AMDGPU] Fix test to actually exercise count-check condition

### DIFF
--- a/llvm/test/Transforms/SLPVectorizer/AMDGPU/inst-count-heuristic.ll
+++ b/llvm/test/Transforms/SLPVectorizer/AMDGPU/inst-count-heuristic.ll
@@ -7,102 +7,113 @@
 ; RUN:     < %s | FileCheck -check-prefix=GFX942 %s
 ; RUN: opt -S -mtriple=amdgpu9.06-amd-amdhsa -passes=slp-vectorizer \
 ; RUN:     < %s | FileCheck -check-prefix=GFX906 %s
+; RUN: opt -S -mtriple=amdgpu9.06-amd-amdhsa -passes=slp-vectorizer \
+; RUN:     -slp-inst-count-check=false < %s | FileCheck -check-prefix=GFX906NOCOUNT %s
 
 define amdgpu_kernel void @phi5_rotate(
 ; GFX950-LABEL: define amdgpu_kernel void @phi5_rotate(
-; GFX950-SAME: ptr addrspace(1) captures(none) [[OUT:%.*]], i32 [[N:%.*]], i32 [[S0:%.*]], i32 [[S1:%.*]], i32 [[S2:%.*]], i32 [[S3:%.*]], i32 [[S4:%.*]]) {
+; GFX950-SAME: ptr addrspace(1) captures(none) [[OUT:%.*]], i32 [[N:%.*]], i16 [[S0:%.*]], i16 [[S1:%.*]], i16 [[S2:%.*]], i16 [[S3:%.*]], i16 [[S4:%.*]]) {
 ; GFX950-NEXT:  [[ENTRY:.*]]:
-; GFX950-NEXT:    [[TMP0:%.*]] = insertelement <2 x i32> poison, i32 [[S0]], i64 0
-; GFX950-NEXT:    [[TMP1:%.*]] = insertelement <2 x i32> [[TMP0]], i32 [[S1]], i64 1
-; GFX950-NEXT:    [[TMP2:%.*]] = insertelement <2 x i32> poison, i32 [[S4]], i64 0
-; GFX950-NEXT:    [[TMP3:%.*]] = insertelement <2 x i32> [[TMP2]], i32 [[S0]], i64 1
-; GFX950-NEXT:    [[TMP4:%.*]] = insertelement <2 x i32> poison, i32 [[S3]], i64 0
-; GFX950-NEXT:    [[TMP5:%.*]] = insertelement <2 x i32> [[TMP4]], i32 [[S4]], i64 1
-; GFX950-NEXT:    [[TMP6:%.*]] = insertelement <2 x i32> poison, i32 [[S2]], i64 0
-; GFX950-NEXT:    [[TMP7:%.*]] = insertelement <2 x i32> [[TMP6]], i32 [[S3]], i64 1
 ; GFX950-NEXT:    br label %[[LOOP:.*]]
 ; GFX950:       [[LOOP]]:
-; GFX950-NEXT:    [[I1:%.*]] = phi i32 [ 0, %[[ENTRY]] ], [ [[I_NEXT:%.*]], %[[LOOP]] ]
-; GFX950-NEXT:    [[TMP8:%.*]] = phi <2 x i32> [ [[TMP1]], %[[ENTRY]] ], [ [[TMP9:%.*]], %[[LOOP]] ]
-; GFX950-NEXT:    [[TMP9]] = phi <2 x i32> [ [[TMP3]], %[[ENTRY]] ], [ [[TMP10:%.*]], %[[LOOP]] ]
-; GFX950-NEXT:    [[TMP10]] = phi <2 x i32> [ [[TMP5]], %[[ENTRY]] ], [ [[TMP11:%.*]], %[[LOOP]] ]
-; GFX950-NEXT:    [[TMP11]] = phi <2 x i32> [ [[TMP7]], %[[ENTRY]] ], [ [[TMP12:%.*]], %[[LOOP]] ]
-; GFX950-NEXT:    [[GEP1:%.*]] = getelementptr i32, ptr addrspace(1) [[OUT]], i32 [[I1]]
-; GFX950-NEXT:    store <2 x i32> [[TMP8]], ptr addrspace(1) [[GEP1]], align 4
-; GFX950-NEXT:    [[I_NEXT]] = add nuw i32 [[I1]], 2
+; GFX950-NEXT:    [[I:%.*]] = phi i32 [ 0, %[[ENTRY]] ], [ [[I_NEXT:%.*]], %[[LOOP]] ]
+; GFX950-NEXT:    [[X0:%.*]] = phi i16 [ [[S0]], %[[ENTRY]] ], [ [[X4:%.*]], %[[LOOP]] ]
+; GFX950-NEXT:    [[X1:%.*]] = phi i16 [ [[S1]], %[[ENTRY]] ], [ [[X0]], %[[LOOP]] ]
+; GFX950-NEXT:    [[X2:%.*]] = phi i16 [ [[S2]], %[[ENTRY]] ], [ [[X1]], %[[LOOP]] ]
+; GFX950-NEXT:    [[X3:%.*]] = phi i16 [ [[S3]], %[[ENTRY]] ], [ [[X2]], %[[LOOP]] ]
+; GFX950-NEXT:    [[X4]] = phi i16 [ [[S4]], %[[ENTRY]] ], [ [[X3]], %[[LOOP]] ]
+; GFX950-NEXT:    [[GEP0:%.*]] = getelementptr i16, ptr addrspace(1) [[OUT]], i32 [[I]]
+; GFX950-NEXT:    [[TMP0:%.*]] = insertelement <2 x i16> poison, i16 [[X0]], i64 0
+; GFX950-NEXT:    [[TMP1:%.*]] = insertelement <2 x i16> [[TMP0]], i16 [[X1]], i64 1
+; GFX950-NEXT:    store <2 x i16> [[TMP1]], ptr addrspace(1) [[GEP0]], align 2
+; GFX950-NEXT:    [[I_NEXT]] = add nuw i32 [[I]], 2
 ; GFX950-NEXT:    [[CMP:%.*]] = icmp ult i32 [[I_NEXT]], [[N]]
-; GFX950-NEXT:    [[TMP12]] = shufflevector <2 x i32> [[TMP8]], <2 x i32> [[TMP11]], <2 x i32> <i32 1, i32 2>
 ; GFX950-NEXT:    br i1 [[CMP]], label %[[LOOP]], label %[[EXIT:.*]]
 ; GFX950:       [[EXIT]]:
 ; GFX950-NEXT:    ret void
 ;
 ; GFX942-LABEL: define amdgpu_kernel void @phi5_rotate(
-; GFX942-SAME: ptr addrspace(1) captures(none) [[OUT:%.*]], i32 [[N:%.*]], i32 [[S0:%.*]], i32 [[S1:%.*]], i32 [[S2:%.*]], i32 [[S3:%.*]], i32 [[S4:%.*]]) {
+; GFX942-SAME: ptr addrspace(1) captures(none) [[OUT:%.*]], i32 [[N:%.*]], i16 [[S0:%.*]], i16 [[S1:%.*]], i16 [[S2:%.*]], i16 [[S3:%.*]], i16 [[S4:%.*]]) {
 ; GFX942-NEXT:  [[ENTRY:.*]]:
-; GFX942-NEXT:    [[TMP0:%.*]] = insertelement <2 x i32> poison, i32 [[S0]], i64 0
-; GFX942-NEXT:    [[TMP1:%.*]] = insertelement <2 x i32> [[TMP0]], i32 [[S1]], i64 1
-; GFX942-NEXT:    [[TMP2:%.*]] = insertelement <2 x i32> poison, i32 [[S4]], i64 0
-; GFX942-NEXT:    [[TMP3:%.*]] = insertelement <2 x i32> [[TMP2]], i32 [[S0]], i64 1
-; GFX942-NEXT:    [[TMP4:%.*]] = insertelement <2 x i32> poison, i32 [[S3]], i64 0
-; GFX942-NEXT:    [[TMP5:%.*]] = insertelement <2 x i32> [[TMP4]], i32 [[S4]], i64 1
-; GFX942-NEXT:    [[TMP6:%.*]] = insertelement <2 x i32> poison, i32 [[S2]], i64 0
-; GFX942-NEXT:    [[TMP7:%.*]] = insertelement <2 x i32> [[TMP6]], i32 [[S3]], i64 1
 ; GFX942-NEXT:    br label %[[LOOP:.*]]
 ; GFX942:       [[LOOP]]:
-; GFX942-NEXT:    [[I1:%.*]] = phi i32 [ 0, %[[ENTRY]] ], [ [[I_NEXT:%.*]], %[[LOOP]] ]
-; GFX942-NEXT:    [[TMP8:%.*]] = phi <2 x i32> [ [[TMP1]], %[[ENTRY]] ], [ [[TMP9:%.*]], %[[LOOP]] ]
-; GFX942-NEXT:    [[TMP9]] = phi <2 x i32> [ [[TMP3]], %[[ENTRY]] ], [ [[TMP10:%.*]], %[[LOOP]] ]
-; GFX942-NEXT:    [[TMP10]] = phi <2 x i32> [ [[TMP5]], %[[ENTRY]] ], [ [[TMP11:%.*]], %[[LOOP]] ]
-; GFX942-NEXT:    [[TMP11]] = phi <2 x i32> [ [[TMP7]], %[[ENTRY]] ], [ [[TMP12:%.*]], %[[LOOP]] ]
-; GFX942-NEXT:    [[GEP1:%.*]] = getelementptr i32, ptr addrspace(1) [[OUT]], i32 [[I1]]
-; GFX942-NEXT:    store <2 x i32> [[TMP8]], ptr addrspace(1) [[GEP1]], align 4
-; GFX942-NEXT:    [[I_NEXT]] = add nuw i32 [[I1]], 2
+; GFX942-NEXT:    [[I:%.*]] = phi i32 [ 0, %[[ENTRY]] ], [ [[I_NEXT:%.*]], %[[LOOP]] ]
+; GFX942-NEXT:    [[X0:%.*]] = phi i16 [ [[S0]], %[[ENTRY]] ], [ [[X4:%.*]], %[[LOOP]] ]
+; GFX942-NEXT:    [[X1:%.*]] = phi i16 [ [[S1]], %[[ENTRY]] ], [ [[X0]], %[[LOOP]] ]
+; GFX942-NEXT:    [[X2:%.*]] = phi i16 [ [[S2]], %[[ENTRY]] ], [ [[X1]], %[[LOOP]] ]
+; GFX942-NEXT:    [[X3:%.*]] = phi i16 [ [[S3]], %[[ENTRY]] ], [ [[X2]], %[[LOOP]] ]
+; GFX942-NEXT:    [[X4]] = phi i16 [ [[S4]], %[[ENTRY]] ], [ [[X3]], %[[LOOP]] ]
+; GFX942-NEXT:    [[GEP0:%.*]] = getelementptr i16, ptr addrspace(1) [[OUT]], i32 [[I]]
+; GFX942-NEXT:    [[TMP0:%.*]] = insertelement <2 x i16> poison, i16 [[X0]], i64 0
+; GFX942-NEXT:    [[TMP1:%.*]] = insertelement <2 x i16> [[TMP0]], i16 [[X1]], i64 1
+; GFX942-NEXT:    store <2 x i16> [[TMP1]], ptr addrspace(1) [[GEP0]], align 2
+; GFX942-NEXT:    [[I_NEXT]] = add nuw i32 [[I]], 2
 ; GFX942-NEXT:    [[CMP:%.*]] = icmp ult i32 [[I_NEXT]], [[N]]
-; GFX942-NEXT:    [[TMP12]] = shufflevector <2 x i32> [[TMP8]], <2 x i32> [[TMP11]], <2 x i32> <i32 1, i32 2>
 ; GFX942-NEXT:    br i1 [[CMP]], label %[[LOOP]], label %[[EXIT:.*]]
 ; GFX942:       [[EXIT]]:
 ; GFX942-NEXT:    ret void
 ;
 ; GFX906-LABEL: define amdgpu_kernel void @phi5_rotate(
-; GFX906-SAME: ptr addrspace(1) captures(none) [[OUT:%.*]], i32 [[N:%.*]], i32 [[S0:%.*]], i32 [[S1:%.*]], i32 [[S2:%.*]], i32 [[S3:%.*]], i32 [[S4:%.*]]) {
+; GFX906-SAME: ptr addrspace(1) captures(none) [[OUT:%.*]], i32 [[N:%.*]], i16 [[S0:%.*]], i16 [[S1:%.*]], i16 [[S2:%.*]], i16 [[S3:%.*]], i16 [[S4:%.*]]) {
 ; GFX906-NEXT:  [[ENTRY:.*]]:
 ; GFX906-NEXT:    br label %[[LOOP:.*]]
 ; GFX906:       [[LOOP]]:
 ; GFX906-NEXT:    [[I:%.*]] = phi i32 [ 0, %[[ENTRY]] ], [ [[I_NEXT:%.*]], %[[LOOP]] ]
-; GFX906-NEXT:    [[X0:%.*]] = phi i32 [ [[S0]], %[[ENTRY]] ], [ [[X4:%.*]], %[[LOOP]] ]
-; GFX906-NEXT:    [[X1:%.*]] = phi i32 [ [[S1]], %[[ENTRY]] ], [ [[X0]], %[[LOOP]] ]
-; GFX906-NEXT:    [[X2:%.*]] = phi i32 [ [[S2]], %[[ENTRY]] ], [ [[X1]], %[[LOOP]] ]
-; GFX906-NEXT:    [[X3:%.*]] = phi i32 [ [[S3]], %[[ENTRY]] ], [ [[X2]], %[[LOOP]] ]
-; GFX906-NEXT:    [[X4]] = phi i32 [ [[S4]], %[[ENTRY]] ], [ [[X3]], %[[LOOP]] ]
-; GFX906-NEXT:    [[GEP0:%.*]] = getelementptr i32, ptr addrspace(1) [[OUT]], i32 [[I]]
-; GFX906-NEXT:    store i32 [[X0]], ptr addrspace(1) [[GEP0]], align 4
+; GFX906-NEXT:    [[X0:%.*]] = phi i16 [ [[S0]], %[[ENTRY]] ], [ [[X4:%.*]], %[[LOOP]] ]
+; GFX906-NEXT:    [[X1:%.*]] = phi i16 [ [[S1]], %[[ENTRY]] ], [ [[X0]], %[[LOOP]] ]
+; GFX906-NEXT:    [[X2:%.*]] = phi i16 [ [[S2]], %[[ENTRY]] ], [ [[X1]], %[[LOOP]] ]
+; GFX906-NEXT:    [[X3:%.*]] = phi i16 [ [[S3]], %[[ENTRY]] ], [ [[X2]], %[[LOOP]] ]
+; GFX906-NEXT:    [[X4]] = phi i16 [ [[S4]], %[[ENTRY]] ], [ [[X3]], %[[LOOP]] ]
+; GFX906-NEXT:    [[GEP0:%.*]] = getelementptr i16, ptr addrspace(1) [[OUT]], i32 [[I]]
+; GFX906-NEXT:    store i16 [[X0]], ptr addrspace(1) [[GEP0]], align 2
 ; GFX906-NEXT:    [[I1:%.*]] = or disjoint i32 [[I]], 1
-; GFX906-NEXT:    [[GEP1:%.*]] = getelementptr i32, ptr addrspace(1) [[OUT]], i32 [[I1]]
-; GFX906-NEXT:    store i32 [[X1]], ptr addrspace(1) [[GEP1]], align 4
+; GFX906-NEXT:    [[GEP1:%.*]] = getelementptr i16, ptr addrspace(1) [[OUT]], i32 [[I1]]
+; GFX906-NEXT:    store i16 [[X1]], ptr addrspace(1) [[GEP1]], align 2
 ; GFX906-NEXT:    [[I_NEXT]] = add nuw i32 [[I]], 2
 ; GFX906-NEXT:    [[CMP:%.*]] = icmp ult i32 [[I_NEXT]], [[N]]
 ; GFX906-NEXT:    br i1 [[CMP]], label %[[LOOP]], label %[[EXIT:.*]]
 ; GFX906:       [[EXIT]]:
 ; GFX906-NEXT:    ret void
 ;
+; GFX906NOCOUNT-LABEL: define amdgpu_kernel void @phi5_rotate(
+; GFX906NOCOUNT-SAME: ptr addrspace(1) captures(none) [[OUT:%.*]], i32 [[N:%.*]], i16 [[S0:%.*]], i16 [[S1:%.*]], i16 [[S2:%.*]], i16 [[S3:%.*]], i16 [[S4:%.*]]) {
+; GFX906NOCOUNT-NEXT:  [[ENTRY:.*]]:
+; GFX906NOCOUNT-NEXT:    br label %[[LOOP:.*]]
+; GFX906NOCOUNT:       [[LOOP]]:
+; GFX906NOCOUNT-NEXT:    [[I:%.*]] = phi i32 [ 0, %[[ENTRY]] ], [ [[I_NEXT:%.*]], %[[LOOP]] ]
+; GFX906NOCOUNT-NEXT:    [[X0:%.*]] = phi i16 [ [[S0]], %[[ENTRY]] ], [ [[X4:%.*]], %[[LOOP]] ]
+; GFX906NOCOUNT-NEXT:    [[X1:%.*]] = phi i16 [ [[S1]], %[[ENTRY]] ], [ [[X0]], %[[LOOP]] ]
+; GFX906NOCOUNT-NEXT:    [[X2:%.*]] = phi i16 [ [[S2]], %[[ENTRY]] ], [ [[X1]], %[[LOOP]] ]
+; GFX906NOCOUNT-NEXT:    [[X3:%.*]] = phi i16 [ [[S3]], %[[ENTRY]] ], [ [[X2]], %[[LOOP]] ]
+; GFX906NOCOUNT-NEXT:    [[X4]] = phi i16 [ [[S4]], %[[ENTRY]] ], [ [[X3]], %[[LOOP]] ]
+; GFX906NOCOUNT-NEXT:    [[GEP0:%.*]] = getelementptr i16, ptr addrspace(1) [[OUT]], i32 [[I]]
+; GFX906NOCOUNT-NEXT:    [[TMP0:%.*]] = insertelement <2 x i16> poison, i16 [[X0]], i64 0
+; GFX906NOCOUNT-NEXT:    [[TMP1:%.*]] = insertelement <2 x i16> [[TMP0]], i16 [[X1]], i64 1
+; GFX906NOCOUNT-NEXT:    store <2 x i16> [[TMP1]], ptr addrspace(1) [[GEP0]], align 2
+; GFX906NOCOUNT-NEXT:    [[I_NEXT]] = add nuw i32 [[I]], 2
+; GFX906NOCOUNT-NEXT:    [[CMP:%.*]] = icmp ult i32 [[I_NEXT]], [[N]]
+; GFX906NOCOUNT-NEXT:    br i1 [[CMP]], label %[[LOOP]], label %[[EXIT:.*]]
+; GFX906NOCOUNT:       [[EXIT]]:
+; GFX906NOCOUNT-NEXT:    ret void
+;
   ptr addrspace(1) nocapture %out,
   i32 %n,
-  i32 %s0, i32 %s1, i32 %s2, i32 %s3, i32 %s4) {
+  i16 %s0, i16 %s1, i16 %s2, i16 %s3, i16 %s4) {
 entry:
   br label %loop
 
 loop:
   %i   = phi i32 [ 0,   %entry ], [ %i.next, %loop ]
-  %x0  = phi i32 [ %s0, %entry ], [ %x4,     %loop ]
-  %x1  = phi i32 [ %s1, %entry ], [ %x0,     %loop ]
-  %x2  = phi i32 [ %s2, %entry ], [ %x1,     %loop ]
-  %x3  = phi i32 [ %s3, %entry ], [ %x2,     %loop ]
-  %x4  = phi i32 [ %s4, %entry ], [ %x3,     %loop ]
-  %gep0 = getelementptr i32, ptr addrspace(1) %out, i32 %i
-  store i32 %x0, ptr addrspace(1) %gep0, align 4
+  %x0  = phi i16 [ %s0, %entry ], [ %x4,     %loop ]
+  %x1  = phi i16 [ %s1, %entry ], [ %x0,     %loop ]
+  %x2  = phi i16 [ %s2, %entry ], [ %x1,     %loop ]
+  %x3  = phi i16 [ %s3, %entry ], [ %x2,     %loop ]
+  %x4  = phi i16 [ %s4, %entry ], [ %x3,     %loop ]
+  %gep0 = getelementptr i16, ptr addrspace(1) %out, i32 %i
+  store i16 %x0, ptr addrspace(1) %gep0, align 2
   %i1   = or disjoint i32 %i, 1
-  %gep1 = getelementptr i32, ptr addrspace(1) %out, i32 %i1
-  store i32 %x1, ptr addrspace(1) %gep1, align 4
+  %gep1 = getelementptr i16, ptr addrspace(1) %out, i32 %i1
+  store i16 %x1, ptr addrspace(1) %gep1, align 2
   %i.next = add nuw i32 %i, 2
   %cmp  = icmp ult i32 %i.next, %n
   br i1 %cmp, label %loop, label %exit


### PR DESCRIPTION
The gfx906 RUN lines in `inst-count-heuristic.ll` never exercised the `SLPInstCountCheck` heuristic they were meant to test.
This patch converts the test kernel from `i32` to `i16` elements so the heuristic's `getVectorFactor() == 2` gate is actually reachable on gfx906, and adds a `-slp-inst-count-check=false` RUN line to cover the non-default behavior.