### PR TITLE
[offload][omp] Add own Error class to libomptarget

### DIFF
--- a/offload/include/OmpAccError.h
+++ b/offload/include/OmpAccError.h
@@ -1,0 +1,64 @@
+//===- OmpAccError.h - Error class for the OpenMP offload RTL -------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef OMPTARGET_OMPACCERROR_H
+#define OMPTARGET_OMPACCERROR_H
+
+#include "llvm/Support/Error.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace llvm::omp::target {
+
+enum class ErrorCode {
+  Unknown,
+  InvalidBinary,
+  InvalidValue,
+  BackendFailure,
+};
+
+} // namespace llvm::omp::target
+
+namespace std {
+template <>
+struct is_error_code_enum<llvm::omp::target::ErrorCode> : std::true_type {};
+} // namespace std
+
+namespace llvm::omp::target {
+
+const std::error_category &OmpAccErrCategory();
+
+inline std::error_code make_error_code(ErrorCode E) {
+  return std::error_code(static_cast<int>(E), OmpAccErrCategory());
+}
+
+/// Error class used by the OpenMP offload runtime (libomptarget).
+class OmpAccError : public llvm::ErrorInfo<OmpAccError, llvm::StringError> {
+public:
+  using ErrorInfo<OmpAccError, StringError>::ErrorInfo;
+
+  OmpAccError(const llvm::Twine &S) : ErrorInfo(S, ErrorCode::Unknown) {}
+
+  static char ID;
+};
+
+/// Create an offload runtime error.
+template <typename... ArgsTy>
+[[maybe_unused]] static llvm::Error
+createError(ErrorCode Code, const char *ErrFmt, ArgsTy... Args) {
+  std::string Buffer;
+  llvm::raw_string_ostream(Buffer) << llvm::format(ErrFmt, Args...);
+  return llvm::make_error<OmpAccError>(Code, Buffer);
+}
+
+inline llvm::Error createError(ErrorCode Code, const char *S) {
+  return llvm::make_error<OmpAccError>(Code, S);
+}
+
+} // namespace llvm::omp::target
+
+#endif

--- a/offload/liboffload/exports
+++ b/offload/liboffload/exports
@@ -5,8 +5,6 @@ global:
   # they become replaced by calls to the liboffload API.
   # No new symbols should be added here.
   extern "C++" {
-    error::OffloadError::ID;
-    "error::OffloadErrCategory()";
     "llvm::omp::target::plugin::GenericPluginTy::async_barrier(omp_interop_val_t*)";
     "llvm::omp::target::plugin::GenericPluginTy::create_interop(int, int, interop_spec_t*)";
     "llvm::omp::target::plugin::GenericPluginTy::data_alloc(int, long, void*, int)";

--- a/offload/libompaccsupport/OmpAccError.cpp
+++ b/offload/libompaccsupport/OmpAccError.cpp
@@ -1,0 +1,43 @@
+//===- OmpAccError.cpp - Error class for the OpenMP offload RTL -----===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "OmpAccError.h"
+#include "llvm/Support/ErrorHandling.h"
+
+using namespace llvm;
+using namespace llvm::omp::target;
+
+namespace {
+// OmpAccError inherits from llvm::StringError which requires a
+// std::error_code. Once/if that requirement is removed, then this
+// std::error_code machinery can be removed.
+class OmpAccErrorCategory : public std::error_category {
+public:
+  const char *name() const noexcept override { return "llvm.omptarget"; }
+  std::string message(int Condition) const override {
+    switch (static_cast<ErrorCode>(Condition)) {
+    case ErrorCode::Unknown:
+      return "unknown error";
+    case ErrorCode::InvalidBinary:
+      return "invalid binary";
+    case ErrorCode::InvalidValue:
+      return "invalid value";
+    case ErrorCode::BackendFailure:
+      return "backend failure";
+    }
+    llvm_unreachable("Unrecognized offload RTL ErrorCode");
+  }
+};
+} // namespace
+
+const std::error_category &llvm::omp::target::OmpAccErrCategory() {
+  static OmpAccErrorCategory Category;
+  return Category;
+}
+
+char OmpAccError::ID;

--- a/offload/libompaccsupport/PluginManager.cpp
+++ b/offload/libompaccsupport/PluginManager.cpp
@@ -12,6 +12,7 @@
 
 #include "PluginManager.h"
 #include "OffloadPolicy.h"
+#include "OmpAccError.h"
 #include "Shared/Debug.h"
 #include "Shared/Profile.h"
 #include "device.h"
@@ -22,6 +23,7 @@
 
 using namespace llvm;
 using namespace llvm::sys;
+using namespace llvm::omp::target;
 using namespace llvm::omp::target::debug;
 
 PluginManager *PM = nullptr;
@@ -618,8 +620,8 @@ Expected<DeviceTy &> PluginManager::getDevice(uint32_t DeviceNo) {
   {
     auto ExclusiveDevicesAccessor = getExclusiveDevicesAccessor();
     if (DeviceNo >= ExclusiveDevicesAccessor->size())
-      return error::createOffloadError(
-          error::ErrorCode::INVALID_VALUE,
+      return createError(
+          ErrorCode::InvalidValue,
           "device number '%i' out of range, only %i devices available",
           DeviceNo, ExclusiveDevicesAccessor->size());
 
@@ -629,8 +631,7 @@ Expected<DeviceTy &> PluginManager::getDevice(uint32_t DeviceNo) {
   // Check whether global data has been mapped for this device
   if (DevicePtr->hasPendingImages())
     if (loadImagesOntoDevice(*DevicePtr) != OFFLOAD_SUCCESS)
-      return error::createOffloadError(error::ErrorCode::BACKEND_FAILURE,
-                                       "failed to load images on device '%i'",
-                                       DeviceNo);
+      return createError(ErrorCode::BackendFailure,
+                         "failed to load images on device '%i'", DeviceNo);
   return *DevicePtr;
 }

--- a/offload/libompaccsupport/Program.cpp
+++ b/offload/libompaccsupport/Program.cpp
@@ -7,11 +7,12 @@
 //===----------------------------------------------------------------------===//
 
 #include "Program.h"
-#include "OffloadError.h"
+#include "OmpAccError.h"
 
 #include <cstdint>
 
 using namespace llvm;
+using namespace llvm::omp::target;
 
 // Temporary helper to help transition of libomptarget to liboffload: returns
 // the opaque plugin kernel handle backing a kernel symbol, for use with the
@@ -27,9 +28,8 @@ Expected<ProgramTy> ProgramTy::create(ol_context_handle_t Context,
                      reinterpret_cast<uintptr_t>(Img->ImageStart);
   if (auto Res =
           olCreateProgram(Context, Device, Img->ImageStart, ImageSize, &Handle))
-    return error::createOffloadError(error::ErrorCode::INVALID_BINARY,
-                                     "failed to load binary %p: %s", Img,
-                                     Res->Details);
+    return createError(ErrorCode::InvalidBinary, "failed to load binary %p: %s",
+                       Img, Res->Details);
 
   return ProgramTy(Handle);
 }
@@ -39,17 +39,16 @@ Expected<void *> ProgramTy::getGlobalAddress(const char *Name,
   ol_symbol_handle_t Symbol;
   if (auto Res =
           olGetSymbol(Handle, Name, OL_SYMBOL_KIND_GLOBAL_VARIABLE, &Symbol))
-    return error::createOffloadError(error::ErrorCode::INVALID_BINARY,
-                                     "failed to find global symbol %s: %s",
-                                     Name, Res->Details);
+    return createError(ErrorCode::InvalidBinary,
+                       "failed to find global symbol %s: %s", Name,
+                       Res->Details);
 
   void *Address = nullptr;
   if (auto Res = olGetSymbolInfo(Symbol, OL_SYMBOL_INFO_GLOBAL_VARIABLE_ADDRESS,
                                  sizeof(Address), &Address))
-    return error::createOffloadError(
-        error::ErrorCode::INVALID_BINARY,
-        "failed to get device address of global symbol %s: %s", Name,
-        Res->Details);
+    return createError(ErrorCode::InvalidBinary,
+                       "failed to get device address of global symbol %s: %s",
+                       Name, Res->Details);
 
   if (Size && olGetSymbolInfo(Symbol, OL_SYMBOL_INFO_GLOBAL_VARIABLE_SIZE,
                               sizeof(*Size), Size))
@@ -61,9 +60,9 @@ Expected<void *> ProgramTy::getGlobalAddress(const char *Name,
 Expected<void *> ProgramTy::getKernelAddress(const char *Name) const {
   ol_symbol_handle_t Symbol;
   if (auto Res = olGetSymbol(Handle, Name, OL_SYMBOL_KIND_KERNEL, &Symbol))
-    return error::createOffloadError(error::ErrorCode::INVALID_BINARY,
-                                     "failed to find kernel symbol %s: %s",
-                                     Name, Res->Details);
+    return createError(ErrorCode::InvalidBinary,
+                       "failed to find kernel symbol %s: %s", Name,
+                       Res->Details);
 
   return __ol_tgt_GetKernelFromSymbol(Symbol);
 }

--- a/offload/libompaccsupport/device.cpp
+++ b/offload/libompaccsupport/device.cpp
@@ -12,6 +12,7 @@
 
 #include "device.h"
 #include "OffloadEntry.h"
+#include "OmpAccError.h"
 #include "OpenMP/Mapping.h"
 #include "OpenMP/OMPT/Callback.h"
 #include "OpenMP/OMPT/Interface.h"
@@ -38,6 +39,7 @@
 using namespace llvm::omp::target::ompt;
 #endif
 
+using namespace llvm::omp::target;
 using namespace llvm::omp::target::plugin;
 using namespace llvm::omp::target::debug;
 
@@ -76,9 +78,8 @@ DeviceTy::~DeviceTy() {
 
 llvm::Error DeviceTy::init() {
   if (olCreateContext(1, &DeviceHandle, &Context)) {
-    return error::createOffloadError(error::ErrorCode::BACKEND_FAILURE,
-                                     "failed to create context for device %d\n",
-                                     DeviceID);
+    return createError(ErrorCode::BackendFailure,
+                       "failed to create context for device %d\n", DeviceID);
   }
 
   // Envar that indicates whether mapped host buffers should be locked
@@ -131,9 +132,8 @@ llvm::Error DeviceTy::init() {
         OMPX_RecordReportFilename.get().c_str(),
         OMPX_RecordOutputDir.get().c_str());
     if (Ret != OFFLOAD_SUCCESS)
-      return error::createOffloadError(error::ErrorCode::BACKEND_FAILURE,
-                                       "failed to initialize RR in device %d\n",
-                                       DeviceID);
+      return createError(ErrorCode::BackendFailure,
+                         "failed to initialize RR in device %d\n", DeviceID);
   }
 
   return llvm::Error::success();
@@ -141,9 +141,8 @@ llvm::Error DeviceTy::init() {
 
 llvm::Error DeviceTy::deinit() {
   if (olDestroyContext(Context)) {
-    return error::createOffloadError(
-        error::ErrorCode::BACKEND_FAILURE,
-        "failed to destroy context for device %d\n", DeviceID);
+    return createError(ErrorCode::BackendFailure,
+                       "failed to destroy context for device %d\n", DeviceID);
   }
   return llvm::Error::success();
 }
@@ -199,12 +198,12 @@ setupIndirectCallTable(DeviceTy &Device, __tgt_device_image *Image,
 
       // HstPtr = Entry.Address;
       if (Device.retrieveData(&res, Vtable, PtrSize, AsyncInfo))
-        return error::createOffloadError(error::ErrorCode::INVALID_BINARY,
-                                         "failed to load %s", Entry.SymbolName);
+        return createError(ErrorCode::InvalidBinary, "failed to load %s",
+                           Entry.SymbolName);
       if (Device.synchronize(AsyncInfo))
-        return error::createOffloadError(
-            error::ErrorCode::INVALID_BINARY,
-            "failed to synchronize after retrieving %s", Entry.SymbolName);
+        return createError(ErrorCode::InvalidBinary,
+                           "failed to synchronize after retrieving %s",
+                           Entry.SymbolName);
       // Calculate and emplace entire Vtable from first Vtable byte
       for (uint64_t i = 0; i < Entry.Size / PtrSize; ++i) {
         auto &[HstPtr, DevPtr] = IndirectCallTable.emplace_back();
@@ -226,13 +225,13 @@ setupIndirectCallTable(DeviceTy &Device, __tgt_device_image *Image,
 
       HstPtr = Entry.Address;
       if (Device.retrieveData(&DevPtr, Ptr, Entry.Size, AsyncInfo))
-        return error::createOffloadError(error::ErrorCode::INVALID_BINARY,
-                                         "failed to load %s", Entry.SymbolName);
+        return createError(ErrorCode::InvalidBinary, "failed to load %s",
+                           Entry.SymbolName);
     }
     if (Device.synchronize(AsyncInfo))
-      return error::createOffloadError(
-          error::ErrorCode::INVALID_BINARY,
-          "failed to synchronize after retrieving %s", Entry.SymbolName);
+      return createError(ErrorCode::InvalidBinary,
+                         "failed to synchronize after retrieving %s",
+                         Entry.SymbolName);
   }
 
   // If we do not have any indirect globals we exit early.
@@ -248,14 +247,12 @@ setupIndirectCallTable(DeviceTy &Device, __tgt_device_image *Image,
   void *DevicePtr = Device.allocData(TableSize, nullptr, TARGET_ALLOC_DEVICE);
   if (Device.submitData(DevicePtr, IndirectCallTable.data(), TableSize,
                         AsyncInfo))
-    return error::createOffloadError(error::ErrorCode::INVALID_BINARY,
-                                     "failed to copy data");
+    return createError(ErrorCode::InvalidBinary, "failed to copy data");
   // The IndirectCallTable is on the stack, so we must synchronize to ensure
   // the data is copied before we return.
   if (Device.synchronize(AsyncInfo))
-    return error::createOffloadError(
-        error::ErrorCode::INVALID_BINARY,
-        "failed to synchronize after copying data");
+    return createError(ErrorCode::InvalidBinary,
+                       "failed to synchronize after copying data");
 
   return std::pair<void *, uint64_t>(DevicePtr, IndirectCallTable.size());
 }
@@ -298,8 +295,7 @@ llvm::Expected<ProgramTy> DeviceTy::loadBinary(__tgt_device_image *Img) {
   AsyncInfoTy AsyncInfo(*this);
   if (submitData(DeviceEnvironmentPtr, &DeviceEnvironment,
                  sizeof(DeviceEnvironment), AsyncInfo))
-    return error::createOffloadError(error::ErrorCode::INVALID_BINARY,
-                                     "failed to copy data");
+    return createError(ErrorCode::InvalidBinary, "failed to copy data");
 
   return std::move(Program);
 }
@@ -419,9 +415,8 @@ llvm::Expected<void *> DeviceTy::registerMemory(void *HstPtr, int64_t Size,
   ol_memory_register_flags_t Flags =
       LockMemory ? OL_MEMORY_REGISTER_FLAG_LOCK_MEMORY : 0;
   if (auto Res = olMemRegister(DeviceHandle, HstPtr, Size, Flags, &LockedPtr))
-    return error::createOffloadError(error::ErrorCode::UNKNOWN,
-                                     "failed to lock memory %p: %s", HstPtr,
-                                     Res->Details);
+    return createError(ErrorCode::Unknown, "failed to lock memory %p: %s",
+                       HstPtr, Res->Details);
   return LockedPtr;
 }
 
@@ -429,9 +424,8 @@ llvm::Error DeviceTy::unregisterMemory(void *HstPtr, bool UnlockMemory) {
   ol_memory_register_flags_t Flags =
       UnlockMemory ? OL_MEMORY_REGISTER_FLAG_UNLOCK_MEMORY : 0;
   if (auto Res = olMemUnregister(DeviceHandle, HstPtr, Flags))
-    return error::createOffloadError(error::ErrorCode::UNKNOWN,
-                                     "failed to unlock memory %p: %s", HstPtr,
-                                     Res->Details);
+    return createError(ErrorCode::Unknown, "failed to unlock memory %p: %s",
+                       HstPtr, Res->Details);
   return llvm::Error::success();
 }
 

--- a/offload/libomptarget/CMakeLists.txt
+++ b/offload/libomptarget/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(omptarget SHARED
   ../libompaccsupport/DeviceImage.cpp
   ../libompaccsupport/Mapping.cpp
   ../libompaccsupport/Program.cpp
+  ../libompaccsupport/OmpAccError.cpp
 
   KernelLanguage/API.cpp
 )


### PR DESCRIPTION
Add a new class for Errors generated within libomptarget to break the dependence with the Error class defined inside the plugins.

Assisted by Claude.