### PR TITLE
[flang][acc] Add missing dependencies for ACCMapInfoPrep pass

### DIFF
--- a/flang/lib/Optimizer/OpenACC/Transforms/CMakeLists.txt
+++ b/flang/lib/Optimizer/OpenACC/Transforms/CMakeLists.txt
@@ -13,6 +13,7 @@ add_flang_library(FIROpenACCTransforms
   FIROpenACCPassesIncGen
 
   LINK_LIBS
+  CUFAttrs
   CUFDialect
   FIRAnalysis
   FIRBuilder
@@ -20,6 +21,7 @@ add_flang_library(FIROpenACCTransforms
   FIRDialectSupport
   FIROpenACCAnalysis
   FIROpenACCSupport
+  FIRSupport
   HLFIRDialect
 
   MLIR_LIBS


### PR DESCRIPTION
To resolve linking failures for:
cuf::hasDataAttr and loadRecordTypeSizeFromTypeDesc

after: https://github.com/llvm/llvm-project/pull/221282