### PR TITLE
[lldb] Fix switch case for i386 in COFF GetModuleSpecifications

### DIFF
--- a/lldb/source/Plugins/ObjectFile/COFF/ObjectFileCOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/COFF/ObjectFileCOFF.cpp
@@ -145,6 +145,7 @@ ObjectFileCOFF::GetModuleSpecifications(const FileSpec &file,
       unique_dyn_cast<COFFObjectFile>(std::move(*binary));
   ModuleSpecList specs;
   switch (static_cast<COFF::MachineTypes>(object->getMachine())) {
+  case COFF::IMAGE_FILE_MACHINE_I386:
     specs.Append(ModuleSpec(file, ArchSpec("i686-unknown-windows-msvc")));
     return specs;
   case COFF::IMAGE_FILE_MACHINE_AMD64:


### PR DESCRIPTION
08c94c0ac3b503dd4971da8935001aba01918688 / #188276 accidentally removed the "case:" for i386.