### PR TITLE
[libc][test] Enforce errno check in test teardown

### DIFF
--- a/libc/test/UnitTest/ErrnoCheckingTest.h
+++ b/libc/test/UnitTest/ErrnoCheckingTest.h
@@ -43,6 +43,10 @@ namespace testing {
 // contained the value pre-set by the system), and confirms it's still zero
 // at the end of the test, forcing the test author to explicitly account for all
 // non-zero values.
+//
+// Uses the Non-Virtual Interface (NVI) pattern: TearDown() is final so that
+// derived fixtures cannot accidentally bypass post-test verification. Derived
+// fixtures may override OnTearDown() for custom cleanup.
 class ErrnoCheckingTest : public Test {
 public:
   void SetUp() override {
@@ -50,10 +54,14 @@ public:
     libc_errno = 0;
   }
 
-  void TearDown() override {
+  void TearDown() override final {
+    OnTearDown();
     ASSERT_ERRNO_SUCCESS();
     Test::TearDown();
   }
+
+protected:
+  virtual void OnTearDown() {}
 };
 
 } // namespace testing

--- a/libc/test/UnitTest/FEnvSafeTest.cpp
+++ b/libc/test/UnitTest/FEnvSafeTest.cpp
@@ -23,14 +23,13 @@ void FEnvSafeTest::PreserveFEnv::check() {
   test.expect_fenv_eq(before, after);
 }
 
-void FEnvSafeTest::TearDown() {
+void FEnvSafeTest::OnTearDown() {
   if (!should_be_unchanged) {
     restore_fenv();
   }
   // TODO (PR 135320): Remove this override once all FEnvSafeTest instances are
   // updated to validate or ignore errno.
   libc_errno = 0;
-  ErrnoCheckingTest::TearDown();
 }
 
 void FEnvSafeTest::get_fenv(fenv_t &fenv) {

--- a/libc/test/UnitTest/FEnvSafeTest.h
+++ b/libc/test/UnitTest/FEnvSafeTest.h
@@ -22,10 +22,8 @@ namespace testing {
 // asserts that each test does not leave the FPU state represented by `fenv_t`
 // (aka `FPState`) perturbed from its initial state.
 class FEnvSafeTest : public ErrnoCheckingTest {
-public:
-  void TearDown() override;
-
 protected:
+  void OnTearDown() override;
   // This is an RAII type where `PreserveFEnv preserve{this};` will sample the
   // `fenv_t` state and restore it when `preserve` goes out of scope.
   class PreserveFEnv {

--- a/libc/test/UnitTest/FPMatcher.h
+++ b/libc/test/UnitTest/FPMatcher.h
@@ -208,11 +208,10 @@ template <typename T> struct FPTest : public ErrnoCheckingTest {
   };
 #endif // LIBC_MATH_HAS_ASSUME_ROUND_NEAREST_ONLY
 
-  void TearDown() override {
+  void OnTearDown() override {
     // TODO (PR 135320): Remove this override once all FPTest instances are
     // updated to validate or ignore errno.
     libc_errno = 0;
-    ErrnoCheckingTest::TearDown();
   }
 };
 

--- a/libc/test/src/net/linux/if_indextoname_test.cpp
+++ b/libc/test/src/net/linux/if_indextoname_test.cpp
@@ -28,7 +28,6 @@ TEST_F(LlvmLibcIfIndexToNameTest, Loopback) {
   char *res = LIBC_NAMESPACE::if_indextoname(lo_idx, buf);
   ASSERT_EQ(res, buf);
   ASSERT_STREQ(buf, "lo");
-  ASSERT_ERRNO_SUCCESS();
 }
 
 TEST_F(LlvmLibcIfIndexToNameTest, InvalidIndex) {

--- a/libc/test/src/net/linux/if_nameindex_test.cpp
+++ b/libc/test/src/net/linux/if_nameindex_test.cpp
@@ -141,7 +141,7 @@ struct LlvmLibcIfNameIndexSocketTest : public LlvmLibcIfNameIndexTest {
     policy_data.socket_results.push_back(FAKE_SOCKET);
   }
 
-  void TearDown() override {
+  void OnTearDown() override {
     ASSERT_EQ(policy_data.socket_calls.size(), size_t(1));
     ASSERT_EQ(get<0>(policy_data.socket_calls[0]), AF_NETLINK);
     ASSERT_EQ(get<1>(policy_data.socket_calls[0]), SOCK_RAW | SOCK_CLOEXEC);
@@ -151,7 +151,6 @@ struct LlvmLibcIfNameIndexSocketTest : public LlvmLibcIfNameIndexTest {
     ASSERT_EQ(policy_data.close_calls[0], FAKE_SOCKET);
     ASSERT_TRUE(policy_data.sendto_results.empty());
     ASSERT_TRUE(policy_data.recv_results.empty());
-    LlvmLibcIfNameIndexTest::TearDown();
   }
 };
 

--- a/libc/test/src/net/linux/if_nametoindex_test.cpp
+++ b/libc/test/src/net/linux/if_nametoindex_test.cpp
@@ -21,7 +21,6 @@ using LlvmLibcIfNameToIndexTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 TEST_F(LlvmLibcIfNameToIndexTest, Loopback) {
   unsigned int idx = LIBC_NAMESPACE::if_nametoindex("lo");
   ASSERT_GT(idx, 0u);
-  ASSERT_ERRNO_SUCCESS();
 }
 
 TEST_F(LlvmLibcIfNameToIndexTest, InvalidName) {

--- a/libc/test/src/sched/sched_getcpu_test.cpp
+++ b/libc/test/src/sched/sched_getcpu_test.cpp
@@ -14,5 +14,4 @@ using LlvmLibcSchedSchedGetCpuTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
 TEST_F(LlvmLibcSchedSchedGetCpuTest, SmokeTest) {
   ASSERT_GE(LIBC_NAMESPACE::sched_getcpu(), 0);
-  ASSERT_ERRNO_SUCCESS();
 }

--- a/libc/test/src/sched/yield_test.cpp
+++ b/libc/test/src/sched/yield_test.cpp
@@ -13,8 +13,6 @@
 using LlvmLibcSchedYieldTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
 TEST_F(LlvmLibcSchedYieldTest, SmokeTest) {
-  // sched_yield() always succeeds, just do a basic test that errno/ret are
-  // properly 0.
+  // sched_yield() always succeeds, just do a basic test that ret is properly 0.
   ASSERT_EQ(LIBC_NAMESPACE::sched_yield(), 0);
-  ASSERT_ERRNO_SUCCESS();
 }

--- a/libc/test/src/signal/pthread_sigmask_test.cpp
+++ b/libc/test/src/signal/pthread_sigmask_test.cpp
@@ -30,9 +30,8 @@ public:
     LIBC_NAMESPACE::pthread_sigmask(0, nullptr, &old_set);
   }
 
-  void TearDown() override {
+  void OnTearDown() override {
     LIBC_NAMESPACE::pthread_sigmask(SIG_SETMASK, &old_set, nullptr);
-    ErrnoCheckingTest::TearDown();
   }
 };
 

--- a/libc/test/src/signal/sigprocmask_test.cpp
+++ b/libc/test/src/signal/sigprocmask_test.cpp
@@ -26,9 +26,8 @@ public:
     LIBC_NAMESPACE::sigprocmask(0, nullptr, &oldSet);
   }
 
-  void TearDown() override {
+  void OnTearDown() override {
     LIBC_NAMESPACE::sigprocmask(SIG_SETMASK, &oldSet, nullptr);
-    ErrnoCheckingTest::TearDown();
   }
 };
 

--- a/libc/test/src/stdlib/realpath_test.cpp
+++ b/libc/test/src/stdlib/realpath_test.cpp
@@ -203,10 +203,8 @@ public:
     ASSERT_ERRNO_SUCCESS();
   }
 
-  void TearDown() override {
+  void OnTearDown() override {
     ASSERT_THAT(LIBC_NAMESPACE::chdir(start_dir), Succeeds());
-
-    ErrnoCheckingTest::TearDown();
   }
 
   char *realpath_buffered(const char *path) {

--- a/libc/test/src/sys/time/gettimeofday_test.cpp
+++ b/libc/test/src/sys/time/gettimeofday_test.cpp
@@ -22,5 +22,4 @@ TEST_F(LlvmLibcGettimeofdayTest, SmokeTest) {
   timeval tv;
   int ret = LIBC_NAMESPACE::gettimeofday(&tv, nullptr);
   ASSERT_EQ(ret, 0);
-  ASSERT_ERRNO_SUCCESS();
 }

--- a/libc/test/src/sys/time/setitimer_test.cpp
+++ b/libc/test/src/sys/time/setitimer_test.cpp
@@ -25,7 +25,6 @@ static bool timer_fired(false);
 extern "C" void handle_sigalrm(int) { timer_fired = true; }
 
 TEST_F(LlvmLibcSysTimeSetitimerTest, SmokeTest) {
-  libc_errno = 0;
   struct sigaction sa;
   sa.sa_handler = handle_sigalrm;
   LIBC_NAMESPACE::sigemptyset(&sa.sa_mask);

--- a/libc/test/src/unistd/syscall_test.cpp
+++ b/libc/test/src/unistd/syscall_test.cpp
@@ -29,7 +29,6 @@ using LlvmLibcSyscallTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 // (__llvm_libc_syscall) which is inside the namespace.
 TEST_F(LlvmLibcSyscallTest, TrivialCall) {
   ASSERT_GE(LIBC_NAMESPACE::syscall(SYS_gettid), 0l);
-  ASSERT_ERRNO_SUCCESS();
 }
 
 TEST_F(LlvmLibcSyscallTest, SymlinkCreateDestroy) {


### PR DESCRIPTION
Make TearDown final in ErrnoCheckingTest to prevent derived fixtures from accidentally overriding and omitting the post-test errno check. Add an OnTearDown protected hook for fixtures requiring custom teardown logic, guaranteeing that errno verification runs on clean exit.

Migrate existing fixtures that previously overrode TearDown to use the new OnTearDown hook:

* realpath_test: migrate working directory restoration to OnTearDown
* sigprocmask_test: migrate signal mask restoration to OnTearDown
* pthread_sigmask_test: migrate pthread signal mask restoration
* if_nameindex_test: migrate socket cleanup to OnTearDown
* FEnvSafeTest and FPMatcher: migrate fixture cleanup to OnTearDown

Clean up a representative sample of existing tests to demonstrate the simplifications now possible, removing redundant manual errno resets and trailing ASSERT_ERRNO_SUCCESS checks that are guaranteed by the base fixture.

Assisted-by: Automated tooling, human reviewed.