### PR TITLE
[clang][Sema] Don't warn about non-virtual destructors on destroying delete

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -485,6 +485,11 @@ features cannot lower the translation-unit ABI level;
 - Fixed a missing `-Wconstant-conversion` diagnostic for signed `char` arrays.
   (#GH181730)
 
+- `-Wdelete-abstract-non-virtual-dtor` and `-Wdelete-non-abstract-non-virtual-dtor`
+  no longer warn when the selected deallocation function is a destroying
+  `operator delete`, since such a delete expression never invokes the
+  destructor. (#GH65524)
+
 ### Improvements to Clang's time-trace
 
 ### Improvements to Coverage Mapping

--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -4289,10 +4289,16 @@ Sema::ActOnCXXDelete(SourceLocation StartLoc, bool UseGlobal,
         }
       }
 
-      CheckVirtualDtorCall(PointeeRD->getDestructor(), StartLoc,
-                           /*IsDelete=*/true, /*CallCanBeVirtual=*/true,
-                           /*WarnOnNonAbstractTypes=*/!ArrayForm,
-                           SourceLocation());
+      // C++20 [expr.delete]p3: deleting through a static type whose
+      // destructor is not virtual is only undefined behavior when the
+      // selected deallocation function is not a destroying operator delete.
+      // A destroying operator delete takes over destruction of the object,
+      // so the delete expression never calls the destructor itself.
+      if (!OperatorDelete || !OperatorDelete->isDestroyingOperatorDelete())
+        CheckVirtualDtorCall(PointeeRD->getDestructor(), StartLoc,
+                             /*IsDelete=*/true, /*CallCanBeVirtual=*/true,
+                             /*WarnOnNonAbstractTypes=*/!ArrayForm,
+                             SourceLocation());
     }
 
     if (!OperatorDelete) {

--- a/clang/test/SemaCXX/delete-non-virtual-dtor.cpp
+++ b/clang/test/SemaCXX/delete-non-virtual-dtor.cpp
@@ -28,3 +28,46 @@ void f2(S2 *s2) { delete s2; }
 #ifdef DIAG2
 // expected-warning@-2 {{delete called on non-final 'S2' that has virtual functions but non-virtual destructor}}
 #endif
+
+namespace std {
+struct destroying_delete_t {
+  explicit destroying_delete_t() = default;
+};
+} // namespace std
+
+// GH65524: a destroying operator delete takes over destruction, so the delete
+// expression never calls the destructor and there is nothing to warn about.
+struct S3 {
+  virtual void abs() = 0;
+  void operator delete(S3 *, std::destroying_delete_t);
+};
+void f3(S3 *s3) { delete s3; }
+
+struct S4 {
+  ~S4() {}
+  virtual void abs() = 0;
+  void operator delete(S4 *, std::destroying_delete_t);
+};
+void f4(S4 *s4) { delete s4; }
+
+struct S5 : S3 {
+  void abs() override;
+};
+void f5(S5 *s5) { delete s5; }
+
+struct S6 {
+  virtual void real() {}
+  void operator delete(S6 *, std::destroying_delete_t);
+};
+void f6(S6 *s6) { delete s6; }
+
+// The global operator delete and operator delete[] are never destroying, so
+// the destructor is still invoked and the warning must stay.
+void f7(S3 *s3) { ::delete s3; }
+#ifdef DIAG1
+// expected-warning@-2 {{delete called on 'S3' that is abstract but has non-virtual destructor}}
+#endif
+void f8(S3 *s3) { delete[] s3; }
+#ifdef DIAG1
+// expected-warning@-2 {{delete called on 'S3' that is abstract but has non-virtual destructor}}
+#endif


### PR DESCRIPTION
A destroying `operator delete `takes over destruction, so the delete expression never invokes the destructor and [[expr.delete]p3](https://eel.is/c++draft/expr.delete#3) carves it out. Skip `CheckVirtualDtorCall` when the selected deallocation function is destroying. `::delete` and `delete[]` keep warning.

Fixes #65524