### PR TITLE
[SandboxVec][Scheduler] Reinsert deferred ready nodes to the ready list

### DIFF
--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Scheduler.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Scheduler.h
@@ -410,6 +410,9 @@ public:
                                           ArrayRef<Instruction *> Instrs) {
     return Sched.getBndlSchedState(Instrs);
   }
+  static const ReadyListContainer &getReadyList(const Scheduler &Sched) {
+    return Sched.ReadyList;
+  }
 };
 
 } // namespace llvm::sandboxir

--- a/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Scheduler.cpp
+++ b/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Scheduler.cpp
@@ -216,11 +216,11 @@ bool Scheduler::tryScheduleUntil(ArrayRef<Instruction *> Instrs) {
       auto Res = TryScheduleBndl(ReadyN);
       switch (Res) {
       case TryScheduleRes::Success:
-        // We successfully scheduled ReadyN, keep scheduling.
+        // We successfully scheduled ReadyN's bundle, keep scheduling.
         continue;
       case TryScheduleRes::Failure:
-        // We failed to schedule ReadyN, defer it to later and keep scheduling
-        // other ready instructions.
+        // We failed to schedule ReadyN's bundle, defer it to later and keep
+        // scheduling other ready instructions.
         Retry.push_back(ReadyN);
         continue;
       case TryScheduleRes::Finished:
@@ -239,6 +239,12 @@ bool Scheduler::tryScheduleUntil(ArrayRef<Instruction *> Instrs) {
       }
     }
   }
+
+  // The Retry vector contains the ready nodes that were removed from the ready
+  // list but we could not schedule them (along with their parent bundle).
+  // Insert them back in.
+  for (auto *RetryN : Retry)
+    ReadyList.insert(RetryN);
 
   eraseBundle(InstrsSB);
   return false;
@@ -432,10 +438,7 @@ bool Scheduler::trySchedule(ArrayRef<Instruction *> Instrs) {
     // Extend the DAG to include Instrs.
     Interval<Instruction> Extension = DAG.extend(Instrs);
     // Add nodes from the new interval to ready list if they are ready.
-    Interval<Instruction> InstrsInterval(Instrs);
-    Interval<Instruction> ScanForReady =
-        InstrsInterval.getUnionInterval(Extension);
-    for (auto &I : ScanForReady) {
+    for (auto &I : Extension) {
       auto *N = DAG.getNode(&I);
       if (N->scheduled())
         continue;

--- a/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/SchedulerTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/SchedulerTest.cpp
@@ -1054,6 +1054,44 @@ bb1:
   EXPECT_EQ(ReadyList.pop(), RetN);
 }
 
+TEST_F(SchedulerTest, ReadyListStateAfterTryScheduleFailure) {
+  parseIR(C, R"IR(
+define void @foo(i8 %v0, i8 %v1) {
+  %add0 = add i8 %v0, 0
+  %add1 = add i8 %add0, 1
+  %add2 = add i8 %add0, 2
+  ret void
+}
+)IR");
+  llvm::Function *LLVMF = &*M->getFunction("foo");
+  sandboxir::Context Ctx(C);
+  auto *F = Ctx.createFunction(LLVMF);
+  auto *BB = &*F->begin();
+  auto It = BB->begin();
+  auto *Add0 = &*It++;
+  auto *Add1 = &*It++;
+  auto *Add2 = &*It++;
+
+  sandboxir::Scheduler Sched(getAA(*LLVMF), Ctx,
+                             sandboxir::SchedDirection::BottomUp);
+  auto &DAG = sandboxir::SchedulerInternalsAttorney::getDAG(Sched);
+  EXPECT_TRUE(Sched.trySchedule(Add2));
+  // After a failing trySchedule({Add0, Add1}) we should have Add1 in the ready
+  // list.
+  EXPECT_FALSE(Sched.trySchedule({Add0, Add1}));
+  auto &ReadyList = sandboxir::SchedulerInternalsAttorney::getReadyList(Sched);
+  EXPECT_TRUE(ReadyList.contains(DAG.getNode(Add1)));
+  EXPECT_FALSE(ReadyList.contains(DAG.getNode(Add0)));
+
+  // After the failed trySchedule() the DAG should contain all nodes from Add0
+  // to Add2.
+  EXPECT_NE(DAG.getNode(Add1), nullptr);
+  EXPECT_NE(DAG.getNode(Add0), nullptr);
+  // Scheduling Add1 should succeed and should make Add0 ready.
+  EXPECT_TRUE(Sched.trySchedule({Add1}));
+  EXPECT_TRUE(ReadyList.contains(DAG.getNode(Add0)));
+}
+
 TEST_F(SchedulerTest, SchedulingPoint) {
   parseIR(C, R"IR(
 define void @foo(ptr %ptr, i8 %v0) {


### PR DESCRIPTION
Up until now if trySchedule() failed, the ready instructions would be removed from the ready list for no good reason.
This patch fixes this and reinserts the deferred nodes to the ready list.

This also helps reduce the scan for ready instructions in trySchedule().