### PR TITLE
[HLSL] Fix float type promotion to double of the select intrinsic

### DIFF
--- a/clang/lib/Headers/hlsl/hlsl_alias_intrinsics.h
+++ b/clang/lib/Headers/hlsl/hlsl_alias_intrinsics.h
@@ -148,9 +148,8 @@ T select(bool, T, T);
 template <typename T, int N>
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_select)
 vector<T, N> select(
-  __detail::enable_if_t<(N > 1),
-              __detail::type_identity_t<vector<bool, N>>>,
-  vector<T, N>, vector<T, N>);
+    __detail::enable_if_t<(N > 1), __detail::type_identity_t<vector<bool, N>>>,
+    vector<T, N>, vector<T, N>);
 
 /// \fn vector<T,Sz> select(vector<bool,Sz> Conds, T TrueVal,
 ///                         vector<T,Sz> FalseVals)
@@ -163,9 +162,8 @@ vector<T, N> select(
 template <typename T, int N>
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_select)
 vector<T, N> select(
-  __detail::enable_if_t<(N > 1),
-              __detail::type_identity_t<vector<bool, N>>>,
-  T, vector<T, N>);
+    __detail::enable_if_t<(N > 1), __detail::type_identity_t<vector<bool, N>>>,
+    T, vector<T, N>);
 
 /// \fn vector<T,Sz> select(vector<bool,Sz> Conds, vector<T,Sz> TrueVals,
 ///                         T FalseVal)
@@ -177,9 +175,8 @@ vector<T, N> select(
 template <typename T, int N>
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_select)
 vector<T, N> select(
-  __detail::enable_if_t<(N > 1),
-              __detail::type_identity_t<vector<bool, N>>>,
-  vector<T, N>, T);
+    __detail::enable_if_t<(N > 1), __detail::type_identity_t<vector<bool, N>>>,
+    vector<T, N>, T);
 
 /// \fn vector<T,Sz> select(vector<bool,Sz> Conds, T TrueVals,
 ///                         T FalseVal)

--- a/clang/lib/Headers/hlsl/hlsl_alias_intrinsics.h
+++ b/clang/lib/Headers/hlsl/hlsl_alias_intrinsics.h
@@ -147,8 +147,10 @@ T select(bool, T, T);
 
 template <typename T, int N>
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_select)
-vector<T, N> select(__detail::type_identity_t<vector<bool, N>>, vector<T, N>,
-                    vector<T, N>);
+vector<T, N> select(
+  __detail::enable_if_t<(N > 1),
+              __detail::type_identity_t<vector<bool, N>>>,
+  vector<T, N>, vector<T, N>);
 
 /// \fn vector<T,Sz> select(vector<bool,Sz> Conds, T TrueVal,
 ///                         vector<T,Sz> FalseVals)
@@ -160,8 +162,10 @@ vector<T, N> select(__detail::type_identity_t<vector<bool, N>>, vector<T, N>,
 
 template <typename T, int N>
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_select)
-vector<T, N> select(__detail::type_identity_t<vector<bool, N>>, T,
-                    vector<T, N>);
+vector<T, N> select(
+  __detail::enable_if_t<(N > 1),
+              __detail::type_identity_t<vector<bool, N>>>,
+  T, vector<T, N>);
 
 /// \fn vector<T,Sz> select(vector<bool,Sz> Conds, vector<T,Sz> TrueVals,
 ///                         T FalseVal)
@@ -172,8 +176,10 @@ vector<T, N> select(__detail::type_identity_t<vector<bool, N>>, T,
 
 template <typename T, int N>
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_select)
-vector<T, N> select(__detail::type_identity_t<vector<bool, N>>, vector<T, N>,
-                    T);
+vector<T, N> select(
+  __detail::enable_if_t<(N > 1),
+              __detail::type_identity_t<vector<bool, N>>>,
+  vector<T, N>, T);
 
 /// \fn vector<T,Sz> select(vector<bool,Sz> Conds, T TrueVals,
 ///                         T FalseVal)

--- a/clang/test/CodeGenHLSL/builtins/select.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/select.hlsl
@@ -28,9 +28,23 @@ int2 test_select_bool_vector(bool cond0, int2 tVal, int2 fVal) {
 }
 
 // CHECK-LABEL: test_select_vector_1
-// CHECK: [[SELECT:%.*]] = select <1 x i1> {{%.*}}, <1 x i32> {{%.*}}, <1 x i32> {{%.*}}
+// CHECK: [[SELECT:%.*]] = select i1 {{%.*}}, <1 x i32> {{%.*}}, <1 x i32> {{%.*}}
 // CHECK: ret <1 x i32> [[SELECT]]
 int1 test_select_vector_1(bool1 cond0, int1 tVals, int1 fVals) {
+  return select(cond0, tVals, fVals);
+}
+
+// CHECK-LABEL: test_select_float_vector_1
+// CHECK: [[SELECT:%.*]] = select i1 {{%.*}}, <1 x float> {{%.*}}, <1 x float> {{%.*}}
+// CHECK: ret <1 x float> [[SELECT]]
+float1 test_select_float_vector_1(bool1 cond0, float1 tVals, float1 fVals) {
+  return select(cond0, tVals, fVals);
+}
+
+// CHECK-LABEL: test_select_half_vector_1
+// CHECK: [[SELECT:%.*]] = select i1 {{%.*}}, <1 x half> {{%.*}}, <1 x half> {{%.*}}
+// CHECK: ret <1 x half> [[SELECT]]
+half1 test_select_half_vector_1(bool1 cond0, half1 tVals, half1 fVals) {
   return select(cond0, tVals, fVals);
 }
 

--- a/clang/test/CodeGenHLSL/builtins/select.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/select.hlsl
@@ -1,6 +1,10 @@
 // RUN: %clang_cc1 -finclude-default-header -x hlsl -triple \
 // RUN:   dxil-pc-shadermodel6.3-library %s -emit-llvm -disable-llvm-passes \
-// RUN:   -o - | FileCheck %s --check-prefixes=CHECK
+// RUN:   -o - | FileCheck %s --check-prefixes=CHECK,NO_HALF
+// RUN: %clang_cc1 -finclude-default-header -x hlsl -triple \
+// RUN:   dxil-pc-shadermodel6.3-library %s -fnative-half-type -emit-llvm \
+// RUN:   -disable-llvm-passes -o - | FileCheck %s \
+// RUN:   --check-prefixes=CHECK,NATIVE_HALF
 
 // CHECK-LABEL: test_select_bool_int
 // CHECK: [[SELECT:%.*]] = select i1 {{%.*}}, i32 {{%.*}}, i32 {{%.*}}
@@ -35,15 +39,17 @@ int1 test_select_vector_1(bool1 cond0, int1 tVals, int1 fVals) {
 }
 
 // CHECK-LABEL: test_select_float_vector_1
-// CHECK: [[SELECT:%.*]] = select i1 {{%.*}}, <1 x float> {{%.*}}, <1 x float> {{%.*}}
+// CHECK: [[SELECT:%.*]] = select {{.*}}i1 {{%.*}}, <1 x float> {{%.*}}, <1 x float> {{%.*}}
 // CHECK: ret <1 x float> [[SELECT]]
 float1 test_select_float_vector_1(bool1 cond0, float1 tVals, float1 fVals) {
   return select(cond0, tVals, fVals);
 }
 
 // CHECK-LABEL: test_select_half_vector_1
-// CHECK: [[SELECT:%.*]] = select i1 {{%.*}}, <1 x half> {{%.*}}, <1 x half> {{%.*}}
-// CHECK: ret <1 x half> [[SELECT]]
+// NO_HALF: [[SELECT:%.*]] = select {{.*}}i1 {{%.*}}, <1 x float> {{%.*}}, <1 x float> {{%.*}}
+// NO_HALF: ret <1 x float> [[SELECT]]
+// NATIVE_HALF: [[SELECT:%.*]] = select {{.*}}i1 {{%.*}}, <1 x half> {{%.*}}, <1 x half> {{%.*}}
+// NATIVE_HALF: ret <1 x half> [[SELECT]]
 half1 test_select_half_vector_1(bool1 cond0, half1 tVals, half1 fVals) {
   return select(cond0, tVals, fVals);
 }


### PR DESCRIPTION
fixes #222055

A previous pr replaced per vector 2-4 overloads with an all inclusive vector template overload. These vector overloads needed to be guarded so that vec1s go down the scalar overload path.

Assisted by Copilot MA-code-1.1-flash