### PR TITLE
[lldb] Match frame recognizers by function when the frame has no symbol

### DIFF
--- a/lldb/source/Target/StackFrameRecognizer.cpp
+++ b/lldb/source/Target/StackFrameRecognizer.cpp
@@ -12,6 +12,7 @@
 #include "lldb/Core/Module.h"
 #include "lldb/Interpreter/Interfaces/ScriptedStackFrameRecognizerInterface.h"
 #include "lldb/Interpreter/ScriptInterpreter.h"
+#include "lldb/Symbol/Function.h"
 #include "lldb/Symbol/Symbol.h"
 #include "lldb/Target/StackFrame.h"
 #include "lldb/Target/Target.h"
@@ -195,10 +196,13 @@ StackFrameRecognizerManager::GetRecognizerForFrame(StackFrameSP frame) {
   if (!module_sp)
     return StackFrameRecognizerSP();
   llvm::StringRef module_name = module_sp->GetFileSpec().GetFilename();
-  const Symbol *symbol = symctx.symbol;
-  if (!symbol)
+  Address start_addr;
+  if (symctx.symbol)
+    start_addr = symctx.symbol->GetAddress();
+  else if (symctx.function)
+    start_addr = symctx.function->GetAddress();
+  else
     return StackFrameRecognizerSP();
-  Address start_addr = symbol->GetAddress();
   Address current_addr = frame->GetFrameCodeAddress();
 
   // The symbol's start address may fall inside a non-executable function

--- a/lldb/test/API/commands/frame/recognizer/step-through/TestFrameRecognizerStepThrough.py
+++ b/lldb/test/API/commands/frame/recognizer/step-through/TestFrameRecognizerStepThrough.py
@@ -14,7 +14,6 @@ import recognizer
 class TestFrameRecognizerStepThrough(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
-    @skipIfWindows
     def test_frame_recognizer_step_through(self):
         """Test that the step through recognizer works"""
         self.build()


### PR DESCRIPTION
A frame can have a function without having a symbol: a PE/COFF image built with DWARF carries no symbol table at all, so `symctx.symbol` is null on Windows while `symctx.function` resolves fine from the debug info. `GetRecognizerForFrame` bailed out on `!symbol`, so no frame recognizer ever matched there.

Fall back to the function's start address when there is no symbol. The symbol still wins when both are present, so this is a no-op on ELF/Mach-O.

This fixes `TestFrameRecognizerStepThrough.py`.