### PR TITLE
[NFCI][CIR] Add in 2 missing returns-

### DIFF
--- a/clang/include/clang/CIR/Interfaces/CIROpInterfaces.td
+++ b/clang/include/clang/CIR/Interfaces/CIROpInterfaces.td
@@ -55,13 +55,13 @@ let cppNamespace = "::cir" in {
                       "std::optional<cir::InlineKind>", "getInlineKind", 
                       (ins), [{}], 
                       /*defaultImplementation=*/[{
-                        $_op.getInlineKind();
+                        return $_op.getInlineKind();
                       }]>,
       InterfaceMethod<[{"Get the inline-kind attribute name"}], 
                       "mlir::StringAttr", "getInlineKindAttrName",
                       (ins), [{}],
                       /*defaultImplementation=*/[{
-                        $_op.getInlineKindAttrName();
+                        return $_op.getInlineKindAttrName();
                       }]>,
     ];
   }


### PR DESCRIPTION
I discovered these two were missing thanks to a warning diagnostic on a downstream.  It isn't clear why this doesn't cause problems anywhere (we must just not really use these?), but fix it anyway.