### PR TITLE
[CodeGen] Don't derive MODereferenceable from !dereferenceable metadata

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/FastISel.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/FastISel.cpp
@@ -2355,7 +2355,6 @@ FastISel::createMachineMemOperandFor(const Instruction *I) const {
 
   bool IsNonTemporal = I->hasMetadata(LLVMContext::MD_nontemporal);
   bool IsInvariant = I->hasMetadata(LLVMContext::MD_invariant_load);
-  bool IsDereferenceable = I->hasMetadata(LLVMContext::MD_dereferenceable);
   const MDNode *Ranges = I->getMetadata(LLVMContext::MD_range);
 
   AAMDNodes AAInfo = I->getAAMetadata();
@@ -2369,8 +2368,6 @@ FastISel::createMachineMemOperandFor(const Instruction *I) const {
     Flags |= MachineMemOperand::MOVolatile;
   if (IsNonTemporal)
     Flags |= MachineMemOperand::MONonTemporal;
-  if (IsDereferenceable)
-    Flags |= MachineMemOperand::MODereferenceable;
   if (IsInvariant)
     Flags |= MachineMemOperand::MOInvariant;
 

--- a/llvm/lib/CodeGen/TargetLoweringBase.cpp
+++ b/llvm/lib/CodeGen/TargetLoweringBase.cpp
@@ -2524,11 +2524,8 @@ MachineMemOperand::Flags TargetLoweringBase::getLoadMemOperandFlags(
   if (OptLevel != CodeGenOptLevel::None &&
       isDereferenceableAndAlignedPointer(
           LI.getPointerOperand(), LI.getType(), LI.getAlign(),
-          SimplifyQuery(DL, LibInfo, /*DT=*/nullptr, AC, &LI))) {
+          SimplifyQuery(DL, LibInfo, /*DT=*/nullptr, AC, &LI)))
     Flags |= MachineMemOperand::MODereferenceable;
-  } else if (LI.hasMetadata(LLVMContext::MD_dereferenceable)) {
-    Flags |= MachineMemOperand::MODereferenceable;
-  }
 
   Flags |= getTargetMMOFlags(LI);
   return Flags;

--- a/llvm/test/CodeGen/AArch64/dereferenceable-metadata-mmo.ll
+++ b/llvm/test/CodeGen/AArch64/dereferenceable-metadata-mmo.ll
@@ -19,8 +19,8 @@ define ptr @load_dereferenceable_md(ptr %p) {
 
 define ptr @load_dereferenceable_invariant_md(ptr %p) {
   ; CHECK-LABEL: name: load_dereferenceable_invariant_md
-  ; CHECK: invariant load
   ; CHECK-NOT: dereferenceable
+  ; CHECK: invariant load
   %v = load ptr, ptr %p, align 8, !dereferenceable !0, !invariant.load !1
   ret ptr %v
 }

--- a/llvm/test/CodeGen/AArch64/dereferenceable-metadata-mmo.ll
+++ b/llvm/test/CodeGen/AArch64/dereferenceable-metadata-mmo.ll
@@ -1,0 +1,29 @@
+; RUN: llc -mtriple=aarch64 -O0 -global-isel -stop-after=irtranslator -o - %s | FileCheck %s
+; RUN: llc -mtriple=aarch64 -O0 -fast-isel -stop-after=finalize-isel -o - %s | FileCheck %s
+; RUN: llc -mtriple=aarch64 -O2 -stop-after=finalize-isel -o - %s | FileCheck %s
+
+; !dereferenceable on a load describes the value the load produces, not the
+; address it reads from, so it must not set the dereferenceable MMO flag.
+; %p carries no dereferenceability of its own, so there is nothing else for the
+; flag to come from.
+
+define ptr @load_dereferenceable_md(ptr %p) {
+  ; CHECK-LABEL: name: load_dereferenceable_md
+  ; CHECK-NOT: dereferenceable
+  %v = load ptr, ptr %p, align 8, !dereferenceable !0
+  ret ptr %v
+}
+
+; With !invariant.load as well, a spurious dereferenceable flag would make
+; MachineInstr::isDereferenceableInvariantLoad() -- "will never trap" -- true.
+
+define ptr @load_dereferenceable_invariant_md(ptr %p) {
+  ; CHECK-LABEL: name: load_dereferenceable_invariant_md
+  ; CHECK: invariant load
+  ; CHECK-NOT: dereferenceable
+  %v = load ptr, ptr %p, align 8, !dereferenceable !0, !invariant.load !1
+  ret ptr %v
+}
+
+!0 = !{i64 8}
+!1 = !{}


### PR DESCRIPTION
The two facts are about different pointers. `!dereferenceable` on a load "tells the optimizer that the value loaded is known to be dereferenceable" while `MachineMemOperand::MODereferenceable` says the access itself doesn't trap.