### PR TITLE
[InstCombine] restrict InstCombineNegator for sub(y,and(lshr(x,C),1))

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineNegator.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineNegator.cpp
@@ -258,8 +258,15 @@ std::array<Value *, 2> Negator::getSortedOperandsOfBinOp(Instruction *I) {
   }
   case Instruction::And: {
     Constant *ShAmt;
-    // sub(y,and(lshr(x,C),1)) --> add(ashr(shl(x,(BW-1)-C),BW-1),y)
-    if (match(I, m_And(m_OneUse(m_TruncOrSelf(
+    // sub(0,and(lshr(x,C),1)) --> add(ashr(shl(x,(BW-1)-C),BW-1),0)
+    // Only applies when this is a true negation (LHS is zero).  For the
+    // general sub(y,and(lshr(x,C),1)) case the rewrite replaces one 2-insn
+    // sequence with another without reducing instruction count, and the
+    // resulting shl/ashr form prevents later target-specific combines (e.g.
+    // on PowerPC the original lshr+and maps to a single rldicl, while the
+    // shl+ashr form requires sldi+sradi).
+    if (IsTrulyNegation &&
+        match(I, m_And(m_OneUse(m_TruncOrSelf(
                            m_LShr(m_Value(X), m_ImmConstant(ShAmt)))),
                        m_One()))) {
       unsigned BW = X->getType()->getScalarSizeInBits();

--- a/llvm/test/Transforms/InstCombine/negated-bitmask.ll
+++ b/llvm/test/Transforms/InstCombine/negated-bitmask.ll
@@ -18,9 +18,9 @@ define i8 @neg_mask1_lshr(i8 %a0) {
 
 define i8 @sub_mask1_lshr(i8 %a0) {
 ; CHECK-LABEL: @sub_mask1_lshr(
-; CHECK-NEXT:    [[TMP1:%.*]] = shl i8 [[A0:%.*]], 6
-; CHECK-NEXT:    [[TMP2:%.*]] = ashr i8 [[TMP1]], 7
-; CHECK-NEXT:    [[NEG:%.*]] = add nsw i8 [[TMP2]], 10
+; CHECK-NEXT:    [[SHIFT:%.*]] = lshr i8 [[A0:%.*]], 1
+; CHECK-NEXT:    [[MASK:%.*]] = and i8 [[SHIFT]], 1
+; CHECK-NEXT:    [[NEG:%.*]] = sub nuw nsw i8 10, [[MASK]]
 ; CHECK-NEXT:    ret i8 [[NEG]]
 ;
   %shift = lshr i8 %a0, 1
@@ -55,9 +55,9 @@ define <4 x i32> @neg_mask1_lshr_vector_nonuniform(<4 x i32> %a0) {
 
 define <4 x i32> @sub_mask1_lshr_vector_nonuniform(<4 x i32> %a0) {
 ; CHECK-LABEL: @sub_mask1_lshr_vector_nonuniform(
-; CHECK-NEXT:    [[TMP1:%.*]] = shl <4 x i32> [[A0:%.*]], <i32 28, i32 27, i32 26, i32 25>
-; CHECK-NEXT:    [[TMP2:%.*]] = ashr <4 x i32> [[TMP1]], splat (i32 31)
-; CHECK-NEXT:    [[NEG:%.*]] = add nsw <4 x i32> [[TMP2]], <i32 5, i32 0, i32 -1, i32 65556>
+; CHECK-NEXT:    [[SHIFT:%.*]] = lshr <4 x i32> [[A0:%.*]], <i32 3, i32 4, i32 5, i32 6>
+; CHECK-NEXT:    [[MASK:%.*]] = and <4 x i32> [[SHIFT]], splat (i32 1)
+; CHECK-NEXT:    [[NEG:%.*]] = sub nsw <4 x i32> <i32 5, i32 0, i32 -1, i32 65556>, [[MASK]]
 ; CHECK-NEXT:    ret <4 x i32> [[NEG]]
 ;
   %shift = lshr <4 x i32> %a0, <i32 3, i32 4, i32 5, i32 6>
@@ -68,10 +68,10 @@ define <4 x i32> @sub_mask1_lshr_vector_nonuniform(<4 x i32> %a0) {
 
 define i8 @sub_mask1_trunc_lshr(i64 %a0) {
 ; CHECK-LABEL: @sub_mask1_trunc_lshr(
-; CHECK-NEXT:    [[TMP1:%.*]] = shl i64 [[A0:%.*]], 48
-; CHECK-NEXT:    [[TMP2:%.*]] = ashr i64 [[TMP1]], 63
-; CHECK-NEXT:    [[TMP3:%.*]] = trunc nsw i64 [[TMP2]] to i8
-; CHECK-NEXT:    [[NEG:%.*]] = add nsw i8 [[TMP3]], 10
+; CHECK-NEXT:    [[SHIFT:%.*]] = lshr i64 [[A0:%.*]], 15
+; CHECK-NEXT:    [[TRUNC:%.*]] = trunc i64 [[SHIFT]] to i8
+; CHECK-NEXT:    [[MASK:%.*]] = and i8 [[TRUNC]], 1
+; CHECK-NEXT:    [[NEG:%.*]] = sub nuw nsw i8 10, [[MASK]]
 ; CHECK-NEXT:    ret i8 [[NEG]]
 ;
   %shift = lshr i64 %a0, 15
@@ -83,11 +83,11 @@ define i8 @sub_mask1_trunc_lshr(i64 %a0) {
 
 define i32 @sub_sext_mask1_trunc_lshr(i64 %a0) {
 ; CHECK-LABEL: @sub_sext_mask1_trunc_lshr(
-; CHECK-NEXT:    [[TMP1:%.*]] = shl i64 [[A0:%.*]], 48
-; CHECK-NEXT:    [[TMP2:%.*]] = ashr i64 [[TMP1]], 63
-; CHECK-NEXT:    [[TMP3:%.*]] = trunc nsw i64 [[TMP2]] to i8
-; CHECK-NEXT:    [[NARROW:%.*]] = add nsw i8 [[TMP3]], 10
-; CHECK-NEXT:    [[NEG:%.*]] = zext i8 [[NARROW]] to i32
+; CHECK-NEXT:    [[SHIFT:%.*]] = lshr i64 [[A0:%.*]], 15
+; CHECK-NEXT:    [[TRUNC:%.*]] = trunc i64 [[SHIFT]] to i8
+; CHECK-NEXT:    [[MASK:%.*]] = and i8 [[TRUNC]], 1
+; CHECK-NEXT:    [[NARROW:%.*]] = sub nuw nsw i8 10, [[MASK]]
+; CHECK-NEXT:    [[NEG:%.*]] = zext nneg i8 [[NARROW]] to i32
 ; CHECK-NEXT:    ret i32 [[NEG]]
 ;
   %shift = lshr i64 %a0, 15
@@ -101,9 +101,9 @@ define i32 @sub_sext_mask1_trunc_lshr(i64 %a0) {
 define i32 @sub_zext_trunc_lshr(i64 %a0) {
 ; CHECK-LABEL: @sub_zext_trunc_lshr(
 ; CHECK-NEXT:    [[TMP1:%.*]] = trunc i64 [[A0:%.*]] to i32
-; CHECK-NEXT:    [[TMP2:%.*]] = shl i32 [[TMP1]], 16
-; CHECK-NEXT:    [[TMP3:%.*]] = ashr i32 [[TMP2]], 31
-; CHECK-NEXT:    [[NEG:%.*]] = add nsw i32 [[TMP3]], 10
+; CHECK-NEXT:    [[TMP2:%.*]] = lshr i32 [[TMP1]], 15
+; CHECK-NEXT:    [[SEXT:%.*]] = and i32 [[TMP2]], 1
+; CHECK-NEXT:    [[NEG:%.*]] = sub nuw nsw i32 10, [[SEXT]]
 ; CHECK-NEXT:    ret i32 [[NEG]]
 ;
   %shift = lshr i64 %a0, 15


### PR DESCRIPTION
For the general sub(y,and(lshr(x,C),1)) case the rewrite replaces one 2-instructions
sequence with another without reducing instruction count, and the
resulting shl/ashr form prevents later target-specific combines (e.g.
on PowerPC the original lshr+and maps to a single rldicl, while the shl+ashr form requires sldi+sradi).
in the patch, Only applies when this is a true negation (LHS is zero).
sub(0,and(lshr(x,C),1)) --> add(ashr(shl(x,(BW-1)-C),BW-1),0)