### PR TITLE
[lld-macho] Parallelize ObjFile::sourceFile() during STABS emission.

### DIFF
--- a/lld/MachO/SyntheticSections.cpp
+++ b/lld/MachO/SyntheticSections.cpp
@@ -1268,16 +1268,16 @@ void SymtabSection::emitStabs() {
     if (stabFiles.empty() || stabFiles.back() != file)
       stabFiles.push_back(file);
   }
-  std::vector<std::string> stabSourceFiles(stabFiles.size());
+  std::vector<std::string> stabSourceFiles(
+      stabFiles.empty() ? 0 : stabFiles.back()->id + 1);
   parallelFor(0, stabFiles.size(), [&](size_t i) {
-    stabSourceFiles[i] = stabFiles[i]->sourceFile();
+    stabSourceFiles[stabFiles[i]->id] = stabFiles[i]->sourceFile();
   });
 
   // Emit STABS symbols so that dsymutil and/or the debugger can map address
   // regions in the final binary to the source and object files from which they
   // originated.
   InputFile *lastFile = nullptr;
-  size_t stabFileIdx = 0;
   for (SortingPair &pair : symbolsNeedingStabs) {
     Defined *defined = pair.first;
     // When emitting STABS entries for a symbol, always use the original
@@ -1293,8 +1293,7 @@ void SymtabSection::emitStabs() {
         emitEndSourceStab();
       lastFile = file;
 
-      assert(stabFiles[stabFileIdx] == file);
-      emitBeginSourceStab(stabSourceFiles[stabFileIdx++]);
+      emitBeginSourceStab(stabSourceFiles[file->id]);
       emitObjectFileStab(file);
     }
 

--- a/lld/MachO/SyntheticSections.cpp
+++ b/lld/MachO/SyntheticSections.cpp
@@ -1239,7 +1239,6 @@ void SymtabSection::emitStabs() {
     if (auto *defined = dyn_cast<Defined>(sym)) {
       // Excluded symbols should have been filtered out in finalizeContents().
       assert(defined->includeInSymtab);
-
       if (defined->isAbsolute())
         continue;
 
@@ -1263,10 +1262,22 @@ void SymtabSection::emitStabs() {
 
   llvm::stable_sort(symbolsNeedingStabs, llvm::less_second());
 
+  std::vector<ObjFile *> stabFiles;
+  for (const SortingPair &pair : symbolsNeedingStabs) {
+    ObjFile *file = cast<ObjFile>(pair.first->originalIsec->getFile());
+    if (stabFiles.empty() || stabFiles.back() != file)
+      stabFiles.push_back(file);
+  }
+  std::vector<std::string> stabSourceFiles(stabFiles.size());
+  parallelFor(0, stabFiles.size(), [&](size_t i) {
+    stabSourceFiles[i] = stabFiles[i]->sourceFile();
+  });
+
   // Emit STABS symbols so that dsymutil and/or the debugger can map address
   // regions in the final binary to the source and object files from which they
   // originated.
   InputFile *lastFile = nullptr;
+  size_t stabFileIdx = 0;
   for (SortingPair &pair : symbolsNeedingStabs) {
     Defined *defined = pair.first;
     // When emitting STABS entries for a symbol, always use the original
@@ -1282,7 +1293,8 @@ void SymtabSection::emitStabs() {
         emitEndSourceStab();
       lastFile = file;
 
-      emitBeginSourceStab(file->sourceFile());
+      assert(stabFiles[stabFileIdx] == file);
+      emitBeginSourceStab(stabSourceFiles[stabFileIdx++]);
       emitObjectFileStab(file);
     }
 

--- a/lld/MachO/SyntheticSections.cpp
+++ b/lld/MachO/SyntheticSections.cpp
@@ -1262,17 +1262,13 @@ void SymtabSection::emitStabs() {
 
   llvm::stable_sort(symbolsNeedingStabs, llvm::less_second());
 
-  std::vector<ObjFile *> stabFiles;
-  for (const SortingPair &pair : symbolsNeedingStabs) {
-    ObjFile *file = cast<ObjFile>(pair.first->originalIsec->getFile());
-    if (stabFiles.empty() || stabFiles.back() != file)
-      stabFiles.push_back(file);
+  llvm::MapVector<ObjFile *, std::string> stabFiles;
+  for (const auto &[defined, fileId] : symbolsNeedingStabs) {
+    ObjFile *file = cast<ObjFile>(defined->originalIsec->getFile());
+    stabFiles[file] = "";
   }
-  std::vector<std::string> stabSourceFiles(
-      stabFiles.empty() ? 0 : stabFiles.back()->id + 1);
-  parallelFor(0, stabFiles.size(), [&](size_t i) {
-    stabSourceFiles[stabFiles[i]->id] = stabFiles[i]->sourceFile();
-  });
+  parallelForEach(stabFiles,
+                  [&](auto &it) { it.second = it.first->sourceFile(); });
 
   // Emit STABS symbols so that dsymutil and/or the debugger can map address
   // regions in the final binary to the source and object files from which they
@@ -1293,7 +1289,7 @@ void SymtabSection::emitStabs() {
         emitEndSourceStab();
       lastFile = file;
 
-      emitBeginSourceStab(stabSourceFiles[file->id]);
+      emitBeginSourceStab(stabFiles[file]);
       emitObjectFileStab(file);
     }
 


### PR DESCRIPTION
This is part of the ld64.lld performance improvements tracked by #222068

Currently, SymtabSection::emitStabs() calls emitBeginSourceStab() it passes in file->sourceFile(), which will call
ObjFile::sourceFile(). This method reads the component's root DIE, which is a bottleneck when done serially as at this stage the DWARF sections have not been parsed yet.

This commit parallelizes the calls to ObjFile::sourceFile(), as we already have the file ids stable sorted.

AI tool use: this is one of the commits that was prototyped by AI. I rewrote this commit and ran the benchmarking myself.

**Benchmark for mac_debug_component_sym_2**
LLD Baseline
Time (mean ± σ):      8.630 s ±  0.479 s    [User: 7.170 s, System: 2.012 s]
  Range (min … max):    8.147 s …  9.661 s    20 runs

LLD Optimized
Time (mean ± σ):      8.149 s ±  0.373 s    [User: 7.410 s, System: 2.206 s]
  Range (min … max):    7.804 s …  9.507 s    20 runs

LLD Baseline 2
Time (mean ± σ):      8.365 s ±  0.347 s    [User: 7.097 s, System: 1.922 s]
  Range (min … max):    8.036 s …  9.146 s    20 runs