### PR TITLE
[MustExecute] Use the loop predecessor instead of the preheader

### DIFF
--- a/llvm/lib/Analysis/MustExecute.cpp
+++ b/llvm/lib/Analysis/MustExecute.cpp
@@ -144,8 +144,15 @@ static bool CanProveNotTakenFirstIteration(const BasicBlock *ExitBlock,
       return false;
   }
 
+  // The induction variable starts at the value coming into the header from
+  // outside the loop. A loop that is not in simplified form has no preheader,
+  // but the header can still have a single predecessor outside the loop.
+  BasicBlock *Predecessor = CurLoop->getLoopPredecessor();
+  if (!Predecessor)
+    return false;
+
   auto DL = ExitBlock->getModule()->getDataLayout();
-  auto *IVStart = LHS->getIncomingValueForBlock(CurLoop->getLoopPreheader());
+  auto *IVStart = LHS->getIncomingValueForBlock(Predecessor);
   auto *SimpleValOrNull = simplifyCmpInst(
       Pred, IVStart, RHS, {DL, /*TLI*/ nullptr, DT, /*AC*/ nullptr, BI});
   auto *SimpleCst = dyn_cast_or_null<Constant>(SimpleValOrNull);

--- a/llvm/test/Analysis/MustExecute/no-preheader.ll
+++ b/llvm/test/Analysis/MustExecute/no-preheader.ll
@@ -1,0 +1,33 @@
+; RUN: opt -disable-output -passes='print<must-execute>' %s 2>&1 | FileCheck %s
+
+; The loop is not in simplified form: %header is entered from %entry, which
+; ends in a conditional branch, so the loop has no preheader. %entry is still
+; the only predecessor of the header from outside the loop, so the value %iv
+; starts at is known, and %latch is proven to execute on the first iteration.
+
+; CHECK-LABEL: @no_preheader(
+; CHECK:       header:
+; CHECK-NEXT:    %iv = phi i32 [ 0, %latch ], [ 0, %entry ] ; (mustexec in: header)
+; CHECK-NEXT:    %cmp = icmp sgt i32 %iv, 0 ; (mustexec in: header)
+; CHECK-NEXT:    br i1 %cmp, label %loop.exit, label %latch ; (mustexec in: header)
+; CHECK:       latch:
+; CHECK-NEXT:    br label %header ; (mustexec in: header)
+
+define i32 @no_preheader(i1 %c) {
+entry:
+  br i1 %c, label %header, label %exit
+
+header:
+  %iv = phi i32 [ 0, %latch ], [ 0, %entry ]
+  %cmp = icmp sgt i32 %iv, 0
+  br i1 %cmp, label %loop.exit, label %latch
+
+latch:
+  br label %header
+
+loop.exit:
+  ret i32 0
+
+exit:
+  ret i32 0
+}


### PR DESCRIPTION
CanProveNotTakenFirstIteration() gets the IV start value via LHS->getIncomingValueForBlock(CurLoop->getLoopPreheader()). If the loop is not in simplified form, getLoopPreheader() returns null and the lookup asserts. This is reachable from print<must-execute> on IR that is not in LoopSimplify form (see the reproducer in #166488).

Fixed: use getLoopPredecessor() instead: it returns the unique out-of-loop predecessor of the header even when it is not a dedicated preheader, consequently the start value is still known. If there is no such predecessor, bail out.

Fixes #166488.