### PR TITLE
[Attributor] Compare an indirect call's callee in the program address space

### DIFF
--- a/llvm/lib/Transforms/IPO/AttributorAttributes.cpp
+++ b/llvm/lib/Transforms/IPO/AttributorAttributes.cpp
@@ -12495,10 +12495,16 @@ struct AAIndirectCallInfoCallSite : public AAIndirectCallInfo {
       return ChangeStatus::UNCHANGED;
 
     ChangeStatus Changed = ChangeStatus::UNCHANGED;
+    // The callees this is compared against below are functions, which live in
+    // the program address space. Normalize to that rather than to zero: they
+    // are only the same address space on a target that leaves it at the
+    // default.
+    unsigned ProgramAS = CB->getDataLayout().getProgramAddressSpace();
     Value *FP = CB->getCalledOperand();
-    if (FP->getType()->getPointerAddressSpace())
-      FP = new AddrSpaceCastInst(FP, PointerType::get(FP->getContext(), 0),
-                                 FP->getName() + ".as0", CB->getIterator());
+    if (FP->getType()->getPointerAddressSpace() != ProgramAS)
+      FP = new AddrSpaceCastInst(
+          FP, PointerType::get(FP->getContext(), ProgramAS),
+          FP->getName() + ".as" + Twine(ProgramAS), CB->getIterator());
 
     bool CBIsVoid = CB->getType()->isVoidTy();
     BasicBlock::iterator IP = CB->getIterator();

--- a/llvm/test/Transforms/Attributor/indirect_call_program_address_space.ll
+++ b/llvm/test/Transforms/Attributor/indirect_call_program_address_space.ll
@@ -1,0 +1,54 @@
+; RUN: opt -passes=attributor -S < %s | FileCheck %s
+
+; Specializing an indirect call compares the called operand against each
+; candidate callee. Functions live in the program address space, 9 here, so the
+; comparison has to be made there: normalizing the operand to address space 0
+; gave an icmp whose operands had different types.
+
+target datalayout = "e-i64:64-G1-P9-A0"
+
+@g = external addrspace(1) global i32
+
+define internal void @cb1() {
+; CHECK-LABEL: define internal void @cb1(
+; CHECK-SAME: ) addrspace(9) #[[ATTR0:[0-9]+]] {
+; CHECK-NEXT:    store i32 1, ptr addrspace(1) @g, align 4
+; CHECK-NEXT:    ret void
+;
+  store i32 1, ptr addrspace(1) @g
+  ret void
+}
+
+define internal void @cb2() {
+; CHECK-LABEL: define internal void @cb2(
+; CHECK-SAME: ) addrspace(9) #[[ATTR0]] {
+; CHECK-NEXT:    store i32 2, ptr addrspace(1) @g, align 4
+; CHECK-NEXT:    ret void
+;
+  store i32 2, ptr addrspace(1) @g
+  ret void
+}
+
+define void @caller(i1 %c) {
+; CHECK-LABEL: define void @caller(
+; CHECK-SAME: i1 [[C:%.*]]) addrspace(9) #[[ATTR0]] {
+; CHECK-NEXT:    [[FP:%.*]] = select i1 [[C]], ptr addrspace(9) @cb1, ptr addrspace(9) @cb2
+; CHECK-NEXT:    [[TMP1:%.*]] = icmp eq ptr addrspace(9) [[FP]], @cb2
+; CHECK-NEXT:    br i1 [[TMP1]], label %[[BB2:.*]], label %[[BB3:.*]]
+; CHECK:       [[BB2]]:
+; CHECK-NEXT:    call addrspace(9) void @cb2()
+; CHECK-NEXT:    br label %[[BB6:.*]]
+; CHECK:       [[BB3]]:
+; CHECK-NEXT:    br i1 true, label %[[BB4:.*]], label %[[BB5:.*]]
+; CHECK:       [[BB4]]:
+; CHECK-NEXT:    call addrspace(9) void @cb1()
+; CHECK-NEXT:    br label %[[BB6]]
+; CHECK:       [[BB5]]:
+; CHECK-NEXT:    unreachable
+; CHECK:       [[BB6]]:
+; CHECK-NEXT:    ret void
+;
+  %fp = select i1 %c, ptr addrspace(9) @cb1, ptr addrspace(9) @cb2
+  call addrspace(9) void %fp()
+  ret void
+}


### PR DESCRIPTION
Specializing an indirect call emits, for each candidate callee, an `icmp` between
the call's callee operand and the candidate. The operand was first normalized to
address space 0, but the candidates are functions, and functions live in the
target's program address space. Where that is not 0 the two sides of the
comparison had different types and the `icmp` asserted:

```
Instructions.h:1266: void llvm::ICmpInst::AssertOK(): Assertion
`getOperand(0)->getType() == getOperand(1)->getType() &&
"Both operands to ICmp instruction are not of the same type!"' failed.
```

Normalize to the program address space instead. It is 0 unless a target says
otherwise, so nothing changes for those; for `spirv64`, whose data layout sets
`P9`, it is the difference between comparing a `ptr` with a `ptr addrspace(9)`
and comparing two `ptr addrspace(9)`.

This was found on the `intel-sycl-gpu` builder, which crashed compiling
`offload/test/offloading/nested_parallel_reduction.c` for `spirv64-intel` once
841d4ad6b315 let that call site reach the specialization path: before, it took
the single-callee promotion path, which emits no comparison. The bug it reached
is older than that commit and is not specific to OpenMP, so the test added here
is a plain Attributor one that needs only a data layout with a non-zero program
address space.
