### PR TITLE
[libc] Generate a stub for libdl.a

### DIFF
--- a/libc/lib/CMakeLists.txt
+++ b/libc/lib/CMakeLists.txt
@@ -74,7 +74,7 @@ endforeach()
 # bits of libc to be located in separate files (e.g. libpthread).
 set(added_empty_archives "")
 if(LLVM_LIBC_FULL_BUILD AND ${LIBC_TARGET_OS} STREQUAL "linux")
-  list(APPEND libc_empty_archive_names pthread)
+  list(APPEND libc_empty_archive_names pthread dl)
   foreach(archive ${libc_empty_archive_names})
     set(empty_archive_path ${LIBC_LIBRARY_DIR}/lib${archive}.a)
     add_custom_command(


### PR DESCRIPTION
Avoid link errors when build rules explicitly add `-ldl` to the linker invocation -
create an empty `libdl.a` static archive on Linux. It's necessary, for example,
to build Clang (https://github.com/llvm/llvm-project/issues/97191) 

Follow the approach from f88e9de37a52abf9b269a7232bf4d4028bc4ace8
which added a similar stub for `libpthread.a`. Like pthread, dynamic loader
functions (although they are mostly unimplemented in LLVM-libc as of today)
are residing in the main `libc.a` archive instead.