### PR TITLE
[clang] Fix target-dependent default for -mincremental-linker-compatible

### DIFF
--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -6279,9 +6279,9 @@ defm incremental_linker_compatible : BoolMOption<"incremental-linker-compatible"
   CodeGenOpts<"IncrementalLinkerCompatible">,
   Default<"T.isDefaultIncrementalLinkerCompatibleByDefault()">,
   PosFlag<SetTrue, [], [],
-          "Emit an object file which can be used with an incremental linker">,
+          "(integrated-as) Emit an object file which can be used with an incremental linker">,
   NegFlag<SetFalse, [], [],
-          "Emit an object file which cannot be used with an incremental linker">,
+          "(integrated-as) Emit an object file which cannot be used with an incremental linker">,
   BothFlags<[], [ClangOption, CC1Option, CC1AsOption]>>;
 def mrtd : Flag<["-"], "mrtd">, Group<m_Group>,
   Visibility<[ClangOption, CC1Option]>,

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -6275,15 +6275,14 @@ def mrelax_all : Flag<["-"], "mrelax-all">, Group<m_Group>,
   Visibility<[ClangOption, CC1Option, CC1AsOption]>,
   HelpText<"(integrated-as) Relax all machine instructions">,
   MarshallingInfoFlag<CodeGenOpts<"RelaxAll">>;
-def mincremental_linker_compatible : Flag<["-"], "mincremental-linker-compatible">, Group<m_Group>,
-  Visibility<[ClangOption, CC1Option, CC1AsOption]>,
+defm incremental_linker_compatible : BoolMOption<"incremental-linker-compatible",
+  CodeGenOpts<"IncrementalLinkerCompatible">,
   Default<"T.isDefaultIncrementalLinkerCompatibleByDefault()">,
-  HelpText<"(integrated-as) Emit an object file which can be used with an incremental linker">,
-  MarshallingInfoFlag<CodeGenOpts<"IncrementalLinkerCompatible">>;
-def mno_incremental_linker_compatible : Flag<["-"], "mno-incremental-linker-compatible">, Group<m_Group>,
-  Visibility<[ClangOption, CC1Option, CC1AsOption]>,
-  HelpText<"(integrated-as) Emit an object file which cannot be used with an incremental linker">,
-  MarshallingInfoNegativeFlag<CodeGenOpts<"IncrementalLinkerCompatible">>;
+  PosFlag<SetTrue, [], [],
+          "Emit an object file which can be used with an incremental linker">,
+  NegFlag<SetFalse, [], [],
+          "Emit an object file which cannot be used with an incremental linker">,
+  BothFlags<[], [ClangOption, CC1Option, CC1AsOption]>>;
 def mrtd : Flag<["-"], "mrtd">, Group<m_Group>,
   Visibility<[ClangOption, CC1Option]>,
   HelpText<"Make StdCall calling convention the default">;

--- a/clang/test/CodeGen/coff-default-timestamp.c
+++ b/clang/test/CodeGen/coff-default-timestamp.c
@@ -15,6 +15,14 @@
 // MSVC-DEFAULT:   TimeDateStamp:
 // MSVC-DEFAULT-NOT: 1970-01-01 00:00:00 (0x0)
 
+// RUN: %clang_cc1 -triple x86_64-unknown-uefi -mno-incremental-linker-compatible -emit-obj %s -o - | llvm-readobj -h - | FileCheck %s --check-prefix=UEFI-NOINC
+// UEFI-NOINC: TimeDateStamp: 1970-01-01 00:00:00 (0x0)
+
+// RUN: %clang_cc1 -triple x86_64-unknown-uefi -emit-obj %s -o - | llvm-readobj -h - | FileCheck %s --check-prefix=UEFI-DEFAULT
+// UEFI-DEFAULT: ImageFileHeader {
+// UEFI-DEFAULT:   TimeDateStamp:
+// UEFI-DEFAULT-NOT: 1970-01-01 00:00:00 (0x0)
+
 
 int main(void) {
   return 0;

--- a/clang/test/CodeGen/coff-default-timestamp.c
+++ b/clang/test/CodeGen/coff-default-timestamp.c
@@ -1,0 +1,21 @@
+// REQUIRES: x86-registered-target
+// RUN: %clang_cc1 -triple x86_64-w64-windows-gnu -emit-obj %s -o - | llvm-readobj -h - | FileCheck %s --check-prefix=GNU-DEFAULT
+// GNU-DEFAULT: TimeDateStamp: 1970-01-01 00:00:00 (0x0)
+
+// RUN: %clang_cc1 -triple x86_64-w64-windows-gnu -mincremental-linker-compatible -emit-obj %s -o - | llvm-readobj -h - | FileCheck %s --check-prefix=GNU-INC
+// GNU-INC: ImageFileHeader {
+// GNU-INC:   TimeDateStamp:
+// GNU-INC-NOT: 1970-01-01 00:00:00 (0x0)
+
+// RUN: %clang_cc1 -triple x86_64-pc-windows-msvc -mno-incremental-linker-compatible -emit-obj %s -o - | llvm-readobj -h - | FileCheck %s --check-prefix=MSVC-NOINC
+// MSVC-NOINC: TimeDateStamp: 1970-01-01 00:00:00 (0x0)
+
+// RUN: %clang_cc1 -triple x86_64-pc-windows-msvc -emit-obj %s -o - | llvm-readobj -h - | FileCheck %s --check-prefix=MSVC-DEFAULT
+// MSVC-DEFAULT: ImageFileHeader {
+// MSVC-DEFAULT:   TimeDateStamp:
+// MSVC-DEFAULT-NOT: 1970-01-01 00:00:00 (0x0)
+
+
+int main(void) {
+  return 0;
+}

--- a/clang/test/Driver/incremental-linker-compatible.c
+++ b/clang/test/Driver/incremental-linker-compatible.c
@@ -27,3 +27,13 @@
 
 // RUN: %clang '-###' %s -c -o tmp.o -target x86_64-uefi -integrated-as -mno-incremental-linker-compatible 2>&1 | FileCheck %s --check-prefix=TEST9
 // TEST9: "-cc1" {{.*}} "-mno-incremental-linker-compatible"
+
+// RUN: %clang '-###' %s -c -o tmp.o -target x86_64-w64-windows-gnu -integrated-as 2>&1 | FileCheck %s --check-prefix=TEST10
+// TEST10-NOT: "-cc1" {{.*}} "-mincremental-linker-compatible"
+// TEST10-NOT: "-cc1" {{.*}} "-mno-incremental-linker-compatible"
+
+// RUN: %clang '-###' %s -c -o tmp.o -target x86_64-w64-windows-gnu -integrated-as -mincremental-linker-compatible 2>&1 | FileCheck %s --check-prefix=TEST11
+// TEST11: "-cc1" {{.*}} "-mincremental-linker-compatible"
+
+// RUN: %clang '-###' %s -c -o tmp.o -target x86_64-w64-windows-gnu -integrated-as -mno-incremental-linker-compatible 2>&1 | FileCheck %s --check-prefix=TEST12
+// TEST12: "-cc1" {{.*}} "-mno-incremental-linker-compatible"

--- a/clang/test/Misc/cc1as-coff-timestamp.s
+++ b/clang/test/Misc/cc1as-coff-timestamp.s
@@ -1,0 +1,19 @@
+// REQUIRES: x86-registered-target
+// RUN: %clang -cc1as -triple x86_64-w64-windows-gnu -filetype obj %s -o - | llvm-readobj -h - | FileCheck %s --check-prefix=GNU-DEFAULT
+// GNU-DEFAULT: TimeDateStamp: 1970-01-01 00:00:00 (0x0)
+
+// RUN: %clang -cc1as -triple x86_64-w64-windows-gnu -mincremental-linker-compatible -filetype obj %s -o - | llvm-readobj -h - | FileCheck %s --check-prefix=GNU-INC
+// GNU-INC: ImageFileHeader {
+// GNU-INC:   TimeDateStamp:
+// GNU-INC-NOT: 1970-01-01 00:00:00 (0x0)
+
+// RUN: %clang -cc1as -triple x86_64-pc-windows-msvc -mno-incremental-linker-compatible -filetype obj %s -o - | llvm-readobj -h - | FileCheck %s --check-prefix=MSVC-NOINC
+// MSVC-NOINC: TimeDateStamp: 1970-01-01 00:00:00 (0x0)
+
+// RUN: %clang -cc1as -triple x86_64-pc-windows-msvc -filetype obj %s -o - | llvm-readobj -h - | FileCheck %s --check-prefix=MSVC-DEFAULT
+// MSVC-DEFAULT: ImageFileHeader {
+// MSVC-DEFAULT:   TimeDateStamp:
+// MSVC-DEFAULT-NOT: 1970-01-01 00:00:00 (0x0)
+
+    .text
+    ret

--- a/clang/test/Misc/cc1as-coff-timestamp.s
+++ b/clang/test/Misc/cc1as-coff-timestamp.s
@@ -15,5 +15,13 @@
 // MSVC-DEFAULT:   TimeDateStamp:
 // MSVC-DEFAULT-NOT: 1970-01-01 00:00:00 (0x0)
 
+// RUN: %clang -cc1as -triple x86_64-unknown-uefi -mno-incremental-linker-compatible -filetype obj %s -o - | llvm-readobj -h - | FileCheck %s --check-prefix=UEFI-NOINC
+// UEFI-NOINC: TimeDateStamp: 1970-01-01 00:00:00 (0x0)
+
+// RUN: %clang -cc1as -triple x86_64-unknown-uefi -filetype obj %s -o - | llvm-readobj -h - | FileCheck %s --check-prefix=UEFI-DEFAULT
+// UEFI-DEFAULT: ImageFileHeader {
+// UEFI-DEFAULT:   TimeDateStamp:
+// UEFI-DEFAULT-NOT: 1970-01-01 00:00:00 (0x0)
+
     .text
     ret

--- a/clang/tools/driver/cc1as_main.cpp
+++ b/clang/tools/driver/cc1as_main.cpp
@@ -370,8 +370,9 @@ bool AssemblerInvocation::CreateFromArgs(AssemblerInvocation &Opts,
   Opts.RelocationModel =
       std::string(Args.getLastArgValue(OPT_mrelocation_model, "pic"));
   Opts.TargetABI = std::string(Args.getLastArgValue(OPT_target_abi));
-  Opts.IncrementalLinkerCompatible =
-      Args.hasArg(OPT_mincremental_linker_compatible);
+  Opts.IncrementalLinkerCompatible = Args.hasFlag(
+      OPT_mincremental_linker_compatible, OPT_mno_incremental_linker_compatible,
+      Opts.Triple.isDefaultIncrementalLinkerCompatibleByDefault());
   Opts.SymbolDefs = Args.getAllArgValues(OPT_defsym);
 
   // EmbedBitcode Option. If -fembed-bitcode is enabled, set the flag.
@@ -465,6 +466,7 @@ static bool ExecuteAssemblerImpl(AssemblerInvocation &Opts,
 
   MCTargetOptions MCOptions;
   MCOptions.MCRelaxAll = Opts.RelaxAll;
+  MCOptions.MCIncrementalLinkerCompatible = Opts.IncrementalLinkerCompatible;
   MCOptions.EmitDwarfUnwind = Opts.EmitDwarfUnwind;
   MCOptions.EmitCompactUnwindNonCanonical = Opts.EmitCompactUnwindNonCanonical;
   MCOptions.EmitSFrameUnwind = Opts.EmitSFrameUnwind;

--- a/clang/unittests/Frontend/CompilerInvocationTest.cpp
+++ b/clang/unittests/Frontend/CompilerInvocationTest.cpp
@@ -427,6 +427,77 @@ TEST_F(CommandLineTest, BoolOptionDefaultArbitraryTwoFlagsPresentReset) {
   ASSERT_THAT(GeneratedArgs, Not(Contains(StrEq("-clear-ast-before-backend"))));
 }
 
+// Boolean option with a keypath that defaults to a target-dependent expression.
+// IncrementalLinkerCompatible defaults to true on MSVC/UEFI, and false on
+// others.
+
+TEST_F(CommandLineTest, BoolOptionDefaultTargetDependentPresentNoneGNU) {
+  const char *Args[] = {"-triple", "x86_64-w64-windows-gnu"};
+
+  ASSERT_TRUE(CompilerInvocation::CreateFromArgs(Invocation, Args, *Diags));
+  ASSERT_FALSE(Invocation.getCodeGenOpts().IncrementalLinkerCompatible);
+
+  Invocation.generateCC1CommandLine(GeneratedArgs, *this);
+  ASSERT_THAT(GeneratedArgs,
+              Not(Contains(StrEq("-mincremental-linker-compatible"))));
+  ASSERT_THAT(GeneratedArgs,
+              Not(Contains(StrEq("-mno-incremental-linker-compatible"))));
+}
+
+TEST_F(CommandLineTest, BoolOptionDefaultTargetDependentPresentNoneMSVC) {
+  const char *Args[] = {"-triple", "x86_64-pc-windows-msvc"};
+
+  ASSERT_TRUE(CompilerInvocation::CreateFromArgs(Invocation, Args, *Diags));
+  ASSERT_TRUE(Invocation.getCodeGenOpts().IncrementalLinkerCompatible);
+
+  Invocation.generateCC1CommandLine(GeneratedArgs, *this);
+  ASSERT_THAT(GeneratedArgs,
+              Not(Contains(StrEq("-mincremental-linker-compatible"))));
+  ASSERT_THAT(GeneratedArgs,
+              Not(Contains(StrEq("-mno-incremental-linker-compatible"))));
+}
+
+TEST_F(CommandLineTest, BoolOptionDefaultTargetDependentPresentNoneUEFI) {
+  const char *Args[] = {"-triple", "x86_64-unknown-uefi"};
+
+  ASSERT_TRUE(CompilerInvocation::CreateFromArgs(Invocation, Args, *Diags));
+  ASSERT_TRUE(Invocation.getCodeGenOpts().IncrementalLinkerCompatible);
+
+  Invocation.generateCC1CommandLine(GeneratedArgs, *this);
+  ASSERT_THAT(GeneratedArgs,
+              Not(Contains(StrEq("-mincremental-linker-compatible"))));
+  ASSERT_THAT(GeneratedArgs,
+              Not(Contains(StrEq("-mno-incremental-linker-compatible"))));
+}
+
+TEST_F(CommandLineTest, BoolOptionDefaultTargetDependentPresentChangeGNU) {
+  const char *Args[] = {"-triple", "x86_64-w64-windows-gnu",
+                        "-mincremental-linker-compatible"};
+
+  ASSERT_TRUE(CompilerInvocation::CreateFromArgs(Invocation, Args, *Diags));
+  ASSERT_TRUE(Invocation.getCodeGenOpts().IncrementalLinkerCompatible);
+
+  Invocation.generateCC1CommandLine(GeneratedArgs, *this);
+  ASSERT_THAT(GeneratedArgs,
+              Contains(StrEq("-mincremental-linker-compatible")));
+  ASSERT_THAT(GeneratedArgs,
+              Not(Contains(StrEq("-mno-incremental-linker-compatible"))));
+}
+
+TEST_F(CommandLineTest, BoolOptionDefaultTargetDependentPresentChangeMSVC) {
+  const char *Args[] = {"-triple", "x86_64-pc-windows-msvc",
+                        "-mno-incremental-linker-compatible"};
+
+  ASSERT_TRUE(CompilerInvocation::CreateFromArgs(Invocation, Args, *Diags));
+  ASSERT_FALSE(Invocation.getCodeGenOpts().IncrementalLinkerCompatible);
+
+  Invocation.generateCC1CommandLine(GeneratedArgs, *this);
+  ASSERT_THAT(GeneratedArgs,
+              Contains(StrEq("-mno-incremental-linker-compatible")));
+  ASSERT_THAT(GeneratedArgs,
+              Not(Contains(StrEq("-mincremental-linker-compatible"))));
+}
+
 // Boolean option that gets the CC1Option flag from a let statement (which
 // is applied **after** the record is defined):
 //


### PR DESCRIPTION
Patch #188800 modified the target specific default for this flag which
resulted in non MSVC, non UEFI targets getting this flag set. This
caused issue https://github.com/llvm/llvm-project/issues/219457 which
this patch should fix.

Assisted-by: Gemini
