### PR TITLE
[lldb] Remove internal linkage from roundtripJSON (NFC)

### DIFF
--- a/lldb/unittests/TestingSupport/TestUtilities.h
+++ b/lldb/unittests/TestingSupport/TestUtilities.h
@@ -65,7 +65,7 @@ private:
   std::string Buffer;
 };
 
-template <typename T> static llvm::Expected<T> roundtripJSON(const T &input) {
+template <typename T> llvm::Expected<T> roundtripJSON(const T &input) {
   std::string encoded;
   llvm::raw_string_ostream OS(encoded);
   OS << toJSON(input);


### PR DESCRIPTION
`static` on a namespace-scope function template gives every instantiation internal linkage, so each translation unit including TestingSupport/TestUtilities.h gets its own copy and -Wunused-template fires in any of them that never calls roundtripJSON. That is 52 of the 57 unit test files which include the header:

```
  lldb/unittests/TestingSupport/TestUtilities.h:68:48: error: unused
  function template 'roundtripJSON' [-Werror,-Wunused-template]
```

1529d35adbd6, the reland of #206123, added -Wunused-template to -Wall, which makes this a hard error under -Werror. That change is currently reverted on main by 8710728e0418, so a compiler built from main today does not surface it. It did ship in clang 23.1.0 though, because the revert landed too late to make that tag and only reached the release branch in 23.1.1, so building LLDB with a released 23.1.0 compiler hits this now.

Function templates already have vague linkage, so `static` bought nothing here and only narrowed it. Drop it, matching da6918474bb7 and 1376072719a0 in MLIR.