### PR TITLE
[mlir][gpu] Lower gpu.subgroup_id and gpu.subgroup_size to NVVM

### DIFF
--- a/mlir/lib/Conversion/GPUToNVVM/LowerGpuOpsToNVVMOps.cpp
+++ b/mlir/lib/Conversion/GPUToNVVM/LowerGpuOpsToNVVMOps.cpp
@@ -281,6 +281,37 @@ struct GPULaneIdOpToNVVM : ConvertOpToLLVMPattern<gpu::LaneIdOp> {
   }
 };
 
+struct GPUSubgroupSizeOpToNVVM : ConvertOpToLLVMPattern<gpu::SubgroupSizeOp> {
+  using ConvertOpToLLVMPattern<gpu::SubgroupSizeOp>::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(gpu::SubgroupSizeOp op, gpu::SubgroupSizeOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = op->getLoc();
+    MLIRContext *context = rewriter.getContext();
+    // A warp is exactly kWarpSize lanes wide on every NVIDIA target, so the
+    // range is known precisely. An `upper_bound` on the op cannot make it
+    // narrower: an execution with more lanes than the bound is undefined
+    // behaviour, so we are free to keep the exact hardware range.
+    LLVM::ConstantRangeAttr bounds = rewriter.getAttr<LLVM::ConstantRangeAttr>(
+        /*bitWidth=*/32, /*lower=*/kWarpSize, /*upper=*/kWarpSize + 1);
+    Value newOp =
+        NVVM::WarpSizeOp::create(rewriter, loc, rewriter.getI32Type(), bounds);
+    // Truncate or extend the result depending on the index bitwidth specified
+    // by the LLVMTypeConverter options.
+    const unsigned indexBitwidth = getTypeConverter()->getIndexTypeBitwidth();
+    if (indexBitwidth > 32) {
+      newOp = LLVM::SExtOp::create(
+          rewriter, loc, IntegerType::get(context, indexBitwidth), newOp);
+    } else if (indexBitwidth < 32) {
+      newOp = LLVM::TruncOp::create(
+          rewriter, loc, IntegerType::get(context, indexBitwidth), newOp);
+    }
+    rewriter.replaceOp(op, {newOp});
+    return success();
+  }
+};
+
 struct GPUBallotOpToNVVM : public ConvertOpToLLVMPattern<gpu::BallotOp> {
   using ConvertOpToLLVMPattern<gpu::BallotOp>::ConvertOpToLLVMPattern;
 
@@ -536,6 +567,9 @@ struct LowerGpuOpsToNVVMOpsPass final
     {
       RewritePatternSet patterns(m.getContext());
       populateGpuRewritePatterns(patterns);
+      // NVVM has no register holding the subgroup index, so expand the op into
+      // a division of the linearized thread id by the subgroup size.
+      populateGpuSubgroupIdPatterns(patterns);
       // Transform N-D vector.from_elements to 1-D vector.from_elements before
       // conversion.
       vector::populateVectorFromElementsUnrollPatterns(patterns);
@@ -671,8 +705,8 @@ void mlir::populateGpuToNVVMConversionPatterns(
   patterns.add<gpu::index_lowering::OpLowering<
       gpu::GridDimOp, NVVM::GridDimXOp, NVVM::GridDimYOp, NVVM::GridDimZOp>>(
       converter, IndexKind::Grid, IntrType::Dim, benefit);
-  patterns.add<GPULaneIdOpToNVVM, GPUBallotOpToNVVM, GPUShuffleOpLowering,
-               GPUReturnOpLowering>(converter, benefit);
+  patterns.add<GPULaneIdOpToNVVM, GPUSubgroupSizeOpToNVVM, GPUBallotOpToNVVM,
+               GPUShuffleOpLowering, GPUReturnOpLowering>(converter, benefit);
 
   patterns.add<GPUDynamicSharedMemoryOpLowering>(
       converter, NVVM::kSharedMemoryAlignmentBit, benefit);

--- a/mlir/test/Conversion/GPUToNVVM/gpu-to-nvvm-subgroup-id.mlir
+++ b/mlir/test/Conversion/GPUToNVVM/gpu-to-nvvm-subgroup-id.mlir
@@ -1,0 +1,34 @@
+// RUN: mlir-opt %s -convert-gpu-to-nvvm -split-input-file | FileCheck %s
+
+gpu.module @test_module {
+// CHECK-LABEL: func @subgroup_id()
+func.func @subgroup_id() -> index {
+  // CHECK-DAG: = nvvm.read.ptx.sreg.ntid.x : i32
+  // CHECK-DAG: = nvvm.read.ptx.sreg.ntid.y : i32
+  // CHECK-DAG: = nvvm.read.ptx.sreg.tid.x : i32
+  // CHECK-DAG: = nvvm.read.ptx.sreg.tid.y : i32
+  // CHECK-DAG: = nvvm.read.ptx.sreg.tid.z : i32
+  // CHECK: = nvvm.read.ptx.sreg.warpsize range <i32, 32, 33> : i32
+  // CHECK: = llvm.udiv %{{.*}}, %{{.*}} : i64
+  %subgroupId = gpu.subgroup_id : index
+  func.return %subgroupId : index
+}
+}
+
+// -----
+
+// The block sizes are known here, so the linearization folds them to constants
+// and the thread ids come out carrying the matching ranges.
+gpu.module @test_module {
+// CHECK-LABEL: func @subgroup_id_with_workgroup_sizes()
+func.func @subgroup_id_with_workgroup_sizes() -> index
+    attributes {gpu.known_block_size = array<i32: 32, 4, 2>} {
+  // CHECK-DAG: = nvvm.read.ptx.sreg.tid.x range <i32, 0, 32> : i32
+  // CHECK-DAG: = nvvm.read.ptx.sreg.tid.y range <i32, 0, 4> : i32
+  // CHECK-DAG: = nvvm.read.ptx.sreg.tid.z range <i32, 0, 2> : i32
+  // CHECK: = nvvm.read.ptx.sreg.warpsize range <i32, 32, 33> : i32
+  // CHECK: = llvm.udiv %{{.*}}, %{{.*}} : i64
+  %subgroupId = gpu.subgroup_id : index
+  func.return %subgroupId : index
+}
+}

--- a/mlir/test/Conversion/GPUToNVVM/gpu-to-nvvm.mlir
+++ b/mlir/test/Conversion/GPUToNVVM/gpu-to-nvvm.mlir
@@ -1266,3 +1266,21 @@ module attributes {gpu.container_module} {
     }
   }
 }
+
+// -----
+
+gpu.module @test_module_57 {
+  // CHECK-LABEL: func @gpu_subgroup_size
+  func.func @gpu_subgroup_size() -> (index, index) {
+    // CHECK: = nvvm.read.ptx.sreg.warpsize range <i32, 32, 33> : i32
+    // CHECK: = llvm.sext %{{.*}} : i32 to i64
+    %subgroupSize = gpu.subgroup_size : index
+
+    // A bound on the op does not narrow the exact hardware range.
+    // CHECK: = nvvm.read.ptx.sreg.warpsize range <i32, 32, 33> : i32
+    // CHECK: = llvm.sext %{{.*}} : i32 to i64
+    %subgroupSize2 = gpu.subgroup_size upper_bound 32 : index
+
+    func.return %subgroupSize, %subgroupSize2 : index, index
+  }
+}


### PR DESCRIPTION
The NVVM path has no lowering for gpu.subgroup_id: populateGpuSubgroupIdPatterns exists in the GPU dialect but its only caller is the test-gpu-rewrite pass, and populateGpuToNVVMConversionPatterns handles neither gpu.subgroup_id nor gpu.subgroup_size, so both ops survive the in-dialect prepass and then fail the partial conversion against an illegal gpu dialect. This runs the existing rewriter from the in-dialect lowering step of convert-gpu-to-nvvm and adds a conversion for gpu.subgroup_size, the value the rewriter divides by, to nvvm.read.ptx.sreg.warpsize carrying the exact range a warp has on NVIDIA hardware. The ROCDL path already lowers both ops with patterns of its own, so the shared populateGpuRewritePatterns helper is left alone and the rocdl.wave.id lowering on gfx12 keeps winning.

Two things worth knowing for review. The range on the warpsize read is what lets the backend fold the rewriter's division into a shift and the subgroup size into the literal 32 in the PTX; the verifier rejects lower == upper, so <i32, 32, 33> is the form that says exactly 32. And convert-to-llvm through the dialect interface, as well as the transform-dialect path, do not run the in-dialect prepass, so a gpu.subgroup_id reaching them is still left standing; this change covers convert-gpu-to-nvvm and gpu-lower-to-nvvm-pipeline.

Assisted-by: Claude Code
