### PR TITLE
[SystemZ][z/OS] Correctly align the constant pool and the PPA1

### DIFF
--- a/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZTargetStreamer.cpp
+++ b/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZTargetStreamer.cpp
@@ -157,6 +157,7 @@ void SystemZTargetzOSStreamer::emitPPA1(PPA1Info &Info) {
   assert(PPA2Sym != nullptr && "PPA2 Symbol not defined");
   MCStreamer &OutStreamer = getStreamer();
   MCContext &OutContext = OutStreamer.getContext();
+  getStreamer().emitValueToAlignment(Align(2));
 
   // Optional Argument Area Length.
   // Note: This represents the length of the argument area that we reserve
@@ -283,6 +284,7 @@ void SystemZTargetzOSStreamer::emitPPA1(PPA1Info &Info) {
 
 void SystemZTargetzOSStreamer::emitConstantPools() {
   // Emit EXRL target instructions (base class prolog).
+  getStreamer().emitValueToAlignment(Align(2));
   SystemZTargetStreamer::emitConstantPools();
 
   // Emit deferred PPA1 blocks into the text section.

--- a/llvm/test/CodeGen/SystemZ/zos-align-constpool.ll
+++ b/llvm/test/CodeGen/SystemZ/zos-align-constpool.ll
@@ -1,0 +1,20 @@
+; RUN: llc < %s -mtriple=s390x-ibm-zos -mcpu=z10 | FileCheck %s
+; Checks that the instruction is half-word aligned, even if there is a
+; string constant with odd length.
+
+@.str.5 = constant [13 x i8] c"\82\81\A2\89\83m\A2\A3\99\89\95\87\00"
+
+define [1 x i64] @foo(i64 %0) {
+  call void @llvm.memset.p0.i64(ptr null, i8 0, i64 %0, i1 false)
+  ret [1 x i64] zeroinitializer
+}
+
+declare void @llvm.memset.p0.i64(ptr writeonly captures(none), i8, i64, i1 immarg)
+
+; CHECK:       ENTRY .str.5
+; CHECK-NEXT: .str.5 XATTR LINKAGE(XPLINK),REFERENCE(DATA),SCOPE(EXPORT)
+; CHECK-NEXT: .str.5 DS 0H
+; CHECK-NEXT:  DC XL13'8281A289836DA2A39989958700'
+; CHECK-NEXT:  DS 0B
+; CHECK-NEXT: L#tmp0 DS 0H
+; CHECK-NEXT:  xc 0(1,2),0(2)

--- a/llvm/test/CodeGen/SystemZ/zos-ppa1.ll
+++ b/llvm/test/CodeGen/SystemZ/zos-ppa1.ll
@@ -123,7 +123,7 @@ declare i32 @other(ptr, i32)
 ; CHECK-NEXT: * Name of Function
 ; CHECK-NEXT:  DC XL4'93858186'
 ; CHECK-NEXT:  DC AD(L#EPM_leaf_0-L#PPA1_leaf_0)
-
+; CHECK-NEXT:  DS 0B
 ; CHECK-NEXT: * PPA1
 ; CHECK-NEXT: L#PPA1_nonleaf_0 DS 0H
 ; CHECK-NEXT: * Version
@@ -163,7 +163,7 @@ declare i32 @other(ptr, i32)
 ; CHECK-NEXT: * Name of Function
 ; CHECK-NEXT:  DC XL7'95969593858186'
 ; CHECK-NEXT:  DC AD(L#EPM_nonleaf_0-L#PPA1_nonleaf_0)
-
+; CHECK-NEXT:  DS 0B
 ; CHECK-NEXT: * PPA1
 ; CHECK-NEXT: L#PPA1_withalloca_0 DS 0H
 ; CHECK-NEXT: * Version


### PR DESCRIPTION
Both should be half-word aligned. However, testing revealed that both can end up on odd addresses, which leads to relocation errors. Fix is to change the alignment.