### PR TITLE
[CIR][NFC] Reduce the dialects referenced by cir-lsp-server to minimum

### DIFF
--- a/clang/tools/cir-lsp-server/CMakeLists.txt
+++ b/clang/tools/cir-lsp-server/CMakeLists.txt
@@ -6,16 +6,16 @@ set(LIBS
   clangCIR
   CIRRegisterAllDialects
   clangCIRLoweringDirectToLLVM
-  MLIRAffineAnalysis
   MLIRAnalysis
   MLIRCIR
   MLIRDialect
   MLIRIR
+  MLIRLLVMDialect
   MLIRLspServerLib
+  MLIRFuncDialect
+  MLIRMemRefDialect
   MLIRParser
   MLIRPass
-  MLIRRegisterAllDialects
-  MLIRRegisterAllPasses
   MLIRSupport
   MLIRTransformUtils
   MLIRTransforms

--- a/clang/tools/cir-lsp-server/cir-lsp-server.cpp
+++ b/clang/tools/cir-lsp-server/cir-lsp-server.cpp
@@ -10,6 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/IR/DialectRegistry.h"
 #include "mlir/InitAllDialects.h"
 #include "mlir/Tools/mlir-lsp-server/MlirLspServerMain.h"
@@ -17,7 +20,8 @@
 
 int main(int argc, char **argv) {
   mlir::DialectRegistry registry;
-  mlir::registerAllDialects(registry);
   cir::registerAllDialects(registry);
+  registry.insert<mlir::memref::MemRefDialect, mlir::LLVM::LLVMDialect,
+                  mlir::func::FuncDialect>();
   return failed(mlir::MlirLspServerMain(argc, argv, registry));
 }


### PR DESCRIPTION
This is 1 of 2 patches that build on the work of others, and reduces the list of dialects to just those in CIR + a handful of others. Between this, 1 other commit, and the existing patches proposed by others, we reduce the 'overhead' of the CIR build to +30%.

AI Disclaimer:  Claude came up with this and the list.  I'm not sure it is correct, but we pass all tests.