### PR TITLE
[mlir][ABI] Add the nofreeobj param attr to the LLVM dialect

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMDialect.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMDialect.td
@@ -54,6 +54,7 @@ def LLVM_Dialect : Dialect {
     static StringRef getNoAliasAttrName() { return "llvm.noalias"; }
     static StringRef getNoCaptureAttrName() { return "llvm.nocapture"; }
     static StringRef getNoFreeAttrName() { return "llvm.nofree"; }
+    static StringRef getNoFreeObjAttrName() { return "llvm.nofreeobj"; }
     static StringRef getNonNullAttrName() { return "llvm.nonnull"; }
     static StringRef getPreallocatedAttrName() { return "llvm.preallocated"; }
     static StringRef getRangeAttrName() { return "llvm.range"; }

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
@@ -4736,6 +4736,7 @@ LogicalResult LLVMDialect::verifyParameterAttribute(Operation *op,
       name == LLVMDialect::getNestAttrName() ||
       name == LLVMDialect::getNoCaptureAttrName() ||
       name == LLVMDialect::getNoFreeAttrName() ||
+      name == LLVMDialect::getNoFreeObjAttrName() ||
       name == LLVMDialect::getNonNullAttrName()) {
     if (failed(checkUnitAttrType()))
       return failure();

--- a/mlir/lib/Target/LLVMIR/AttrKindDetail.h
+++ b/mlir/lib/Target/LLVMIR/AttrKindDetail.h
@@ -44,6 +44,8 @@ getAttrKindToNameMapping() {
       {llvm::Attribute::AttrKind::Captures,
        LLVMDialect::getNoCaptureAttrName()},
       {llvm::Attribute::AttrKind::NoFree, LLVMDialect::getNoFreeAttrName()},
+      {llvm::Attribute::AttrKind::NoFreeObj,
+       LLVMDialect::getNoFreeObjAttrName()},
       {llvm::Attribute::AttrKind::NonNull, LLVMDialect::getNonNullAttrName()},
       {llvm::Attribute::AttrKind::Preallocated,
        LLVMDialect::getPreallocatedAttrName()},

--- a/mlir/test/Dialect/LLVMIR/parameter-attrs-invalid.mlir
+++ b/mlir/test/Dialect/LLVMIR/parameter-attrs-invalid.mlir
@@ -132,6 +132,16 @@ llvm.func @invalid_nofree_attr_type(%0 : !llvm.ptr {llvm.nofree = f32})
 
 // -----
 
+// expected-error@below {{"llvm.nofreeobj" attribute attached to non-pointer LLVM type}}
+llvm.func @invalid_nofreeobj_arg_type(%0 : f32 {llvm.nofreeobj})
+
+// -----
+
+// expected-error@below {{"llvm.nofreeobj" should be a unit attribute}}
+llvm.func @invalid_nofreeobj_attr_type(%0 : !llvm.ptr {llvm.nofreeobj = f32})
+
+// -----
+
 // expected-error@below {{"llvm.nonnull" attribute attached to non-pointer LLVM type}}
 llvm.func @invalid_nonnull_arg_type(%0 : f32 {llvm.nonnull})
 

--- a/mlir/test/Target/LLVMIR/Import/function-attributes.ll
+++ b/mlir/test/Target/LLVMIR/Import/function-attributes.ll
@@ -58,6 +58,7 @@ attributes #0 = { readnone }
 ; CHECK-SAME:  !llvm.ptr {llvm.dead_on_return = 8 : i64}
 ; CHECK-SAME:  f32 {llvm.nofpclass = 519 : i64}
 ; CHECK-SAME:  i64 {llvm.range = #llvm.constant_range<i64, 0, 4097>}
+; CHECK-SAME:  !llvm.ptr {llvm.nofreeobj}
 define ptr @func_arg_attrs(
     ptr byval(i64) %arg0,
     ptr byref(i64) %arg1,
@@ -80,7 +81,8 @@ define ptr @func_arg_attrs(
     ptr dead_on_unwind %arg20,
     ptr dead_on_return(8) %arg21,
     float nofpclass(nan inf) %arg22,
-    i64 range(i64 0, 4097) %arg23) {
+    i64 range(i64 0, 4097) %arg23,
+    ptr nofreeobj %arg24) {
   ret ptr %arg17
 }
 
@@ -106,6 +108,12 @@ declare ptr @allocator(i64 allocalign, ptr allocptr)
 ; CHECK-LABEL: @func_res_attr_noalias
 ; CHECK-SAME:  !llvm.ptr {llvm.noalias}
 declare noalias ptr @func_res_attr_noalias()
+
+; // -----
+
+; CHECK-LABEL: @func_res_attr_nofreeobj
+; CHECK-SAME:  !llvm.ptr {llvm.nofreeobj}
+declare nofreeobj ptr @func_res_attr_nofreeobj()
 
 ; // -----
 

--- a/mlir/test/Target/LLVMIR/llvmir.mlir
+++ b/mlir/test/Target/LLVMIR/llvmir.mlir
@@ -1251,6 +1251,12 @@ llvm.func @nocaptureattr_decl(!llvm.ptr {llvm.nocapture})
 // CHECK-LABEL: declare void @nofreeattr_decl(ptr nofree)
 llvm.func @nofreeattr_decl(!llvm.ptr {llvm.nofree})
 
+// CHECK-LABEL: declare void @nofreeobjattr_decl(ptr nofreeobj)
+llvm.func @nofreeobjattr_decl(!llvm.ptr {llvm.nofreeobj})
+
+// CHECK-LABEL: declare nofreeobj ptr @nofreeobjattr_ret_decl()
+llvm.func @nofreeobjattr_ret_decl() -> (!llvm.ptr {llvm.nofreeobj})
+
 // CHECK-LABEL: declare void @nonnullattr_decl(ptr nonnull)
 llvm.func @nonnullattr_decl(!llvm.ptr {llvm.nonnull})
 


### PR DESCRIPTION
Since #218404 clang marks every indirect argument nofreeobj rather than nofree.  LLVM allows it on returns too.

Assisted-by: Cursor / claude-opus-5
