### PR TITLE
[NFC][Attributor] Drop the comment on the indirect-call address space cast

### DIFF
--- a/llvm/lib/Transforms/IPO/AttributorAttributes.cpp
+++ b/llvm/lib/Transforms/IPO/AttributorAttributes.cpp
@@ -12495,10 +12495,6 @@ struct AAIndirectCallInfoCallSite : public AAIndirectCallInfo {
       return ChangeStatus::UNCHANGED;
 
     ChangeStatus Changed = ChangeStatus::UNCHANGED;
-    // The callees this is compared against below are functions, which live in
-    // the program address space. Normalize to that rather than to zero: they
-    // are only the same address space on a target that leaves it at the
-    // default.
     unsigned ProgramAS = CB->getDataLayout().getProgramAddressSpace();
     Value *FP = CB->getCalledOperand();
     if (FP->getType()->getPointerAddressSpace() != ProgramAS)


### PR DESCRIPTION
Follow-up to #222097, which merged before this was addressed.

@efriedma-quic pointed out that the comment described the change rather than the
code, and that address space zero is not relevant to the fixed code. Removing
it; `getProgramAddressSpace()` and the cast say what is happening.
