### PR TITLE
[AArch64] Guard against large types in performOrXorChainCombine

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -12767,7 +12767,8 @@ static SDValue performOrXorChainCombine(SDNode *N, SelectionDAG &DAG) {
   SmallVector<std::pair<SDValue, SDValue>, 16> WorkList;
 
   // Only handle integer compares.
-  if (N->getOpcode() != ISD::SETCC)
+  if (N->getOpcode() != ISD::SETCC || LHS.getValueType().isVector() ||
+      LHS.getValueType().getSizeInBits() > 64)
     return SDValue();
 
   ISD::CondCode Cond = cast<CondCodeSDNode>(N->getOperand(2))->get();

--- a/llvm/test/CodeGen/AArch64/bcmp.ll
+++ b/llvm/test/CodeGen/AArch64/bcmp.ll
@@ -493,17 +493,15 @@ define i1 @bcmp_i16(i16 %a0, i16 %b0, i16 %a1, i16 %b1, i16 %a2, i16 %b2) {
 define i1 @bcmp_i128(i128 %a0, i128 %b0, i128 %a1, i128 %b1, i128 %a2, i128 %b2) {
 ; CHECK-LABEL: bcmp_i128:
 ; CHECK:       // %bb.0:
+; CHECK-NEXT:    ldp x10, x8, [sp]
 ; CHECK-NEXT:    cmp x2, x0
-; CHECK-NEXT:    ldp x10, x8, [sp, #8]
-; CHECK-NEXT:    ccmp x3, x1, #0, eq
-; CHECK-NEXT:    ldr x9, [sp]
-; CHECK-NEXT:    ldr x11, [sp, #24]
+; CHECK-NEXT:    ldp x11, x9, [sp, #16]
 ; CHECK-NEXT:    ccmp x6, x4, #0, eq
-; CHECK-NEXT:    ccmp x7, x5, #0, eq
-; CHECK-NEXT:    cset w12, ne
-; CHECK-NEXT:    cmp x8, x9
 ; CHECK-NEXT:    ccmp x11, x10, #0, eq
-; CHECK-NEXT:    csinc w0, w12, wzr, eq
+; CHECK-NEXT:    ccmp x3, x1, #0, eq
+; CHECK-NEXT:    ccmp x7, x5, #0, eq
+; CHECK-NEXT:    ccmp x9, x8, #0, eq
+; CHECK-NEXT:    cset w0, ne
 ; CHECK-NEXT:    ret
   %xor0 = xor i128 %b0, %a0
   %xor1 = xor i128 %b1, %a1

--- a/llvm/test/CodeGen/AArch64/i128-imm-compare-ccmp.ll
+++ b/llvm/test/CodeGen/AArch64/i128-imm-compare-ccmp.ll
@@ -201,3 +201,20 @@ define i1 @uge_imm(i128 %x) {
   %cmp = icmp uge i128 %x, 5
   ret i1 %cmp
 }
+
+define i1 @f1(i65 %loadedv) {
+; CHECK-LABEL: f1:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    mvn w8, w1
+; CHECK-NEXT:    orn w8, w8, w0
+; CHECK-NEXT:    orr x8, x8, #0xfffffffffffffffe
+; CHECK-NEXT:    cmp x8, #0
+; CHECK-NEXT:    cset w0, eq
+; CHECK-NEXT:    ret
+entry:
+  %conv2 = zext i65 %loadedv to i113
+  %not = xor i113 %conv2, -1
+  %conv3 = trunc i113 %not to i96
+  %cmp4 = icmp eq i96 %conv3, 0
+  ret i1 %cmp4
+}


### PR DESCRIPTION
Larger type sizes will be legalized to i64, and will hit a crash in checking constants.

Fixes #222089