### PR TITLE
[clang][AST] Value-initialize deserialized concept specialization args

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -686,6 +686,9 @@ features cannot lower the translation-unit ABI level;
   `this` via a member access through a dependent base class.
 - Fixed `DiagnoseUnguardedAvailability::TraverseIfStmt` dereferencing a nullptr
   on `if consteval {}`. (#GH220004)
+- Fixed a non-deterministic crash when a concept specialization is
+  deserialized from a module or precompiled header and its own template
+  arguments are read reentrantly. (#GH191361)
 
 ### OpenACC Specific Changes
 

--- a/clang/lib/AST/DeclTemplate.cpp
+++ b/clang/lib/AST/DeclTemplate.cpp
@@ -33,7 +33,9 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/ErrorHandling.h"
 #include <cassert>
+#include <memory>
 #include <optional>
+#include <type_traits>
 #include <utility>
 
 using namespace clang;
@@ -1130,7 +1132,19 @@ ImplicitConceptSpecializationDecl::ImplicitConceptSpecializationDecl(
 ImplicitConceptSpecializationDecl::ImplicitConceptSpecializationDecl(
     EmptyShell Empty, unsigned NumTemplateArgs)
     : Decl(ImplicitConceptSpecialization, Empty),
-      NumTemplateArgs(NumTemplateArgs) {}
+      NumTemplateArgs(NumTemplateArgs) {
+  // ASTReader registers a decl before ASTDeclReader visits it, so re-entrant
+  // deserialization can reach this one through a ConceptSpecializationExpr and
+  // call getTemplateArguments() before setTemplateArguments() has run. Give
+  // that read a well-defined result rather than raw allocator memory.
+  //
+  // FIXME: well-defined is not the same as correct. Profiling the decl in this
+  // window hashes these value-initialized arguments rather than the real ones,
+  // so a FunctionProtoType uniqued from that profile is filed under a hash it
+  // will never profile to again. A later lookup cannot find that type, and the
+  // next derivation of the same type creates a duplicate. See #191361.
+  std::uninitialized_value_construct_n(getTrailingObjects(), NumTemplateArgs);
+}
 
 ImplicitConceptSpecializationDecl *ImplicitConceptSpecializationDecl::Create(
     const ASTContext &C, DeclContext *DC, SourceLocation SL,
@@ -1150,6 +1164,12 @@ ImplicitConceptSpecializationDecl::CreateDeserialized(
 void ImplicitConceptSpecializationDecl::setTemplateArguments(
     ArrayRef<TemplateArgument> Converted) {
   assert(Converted.size() == NumTemplateArgs);
+  // uninitialized_copy rather than assignment: Create() calls this on genuinely
+  // raw storage. Overwriting the value-initialized objects CreateDeserialized()
+  // leaves behind is sound because TemplateArgument is trivially destructible.
+  static_assert(std::is_trivially_destructible_v<TemplateArgument>,
+                "setTemplateArguments() overwrites any trailing arguments that "
+                "may exist without destroying them");
   llvm::uninitialized_copy(Converted, getTrailingObjects());
 }
 

--- a/clang/test/Modules/concept-specialization-deserialization.cppm
+++ b/clang/test/Modules/concept-specialization-deserialization.cppm
@@ -1,0 +1,152 @@
+// Reading an ImplicitConceptSpecializationDecl's trailing template arguments
+// requires deserializing a FunctionDecl whose FunctionProtoType has a computed
+// noexcept specification. Uniquing that type profiles the noexcept expression,
+// which is a ConceptSpecializationExpr pointing back at the decl currently
+// being read, so StmtProfiler walks the trailing array before
+// setTemplateArguments() has written it.
+//
+// Before the fix that array was raw bump-allocator storage, and this compiled
+// clean, crashed, or silently mis-keyed the type depending on what happened to
+// be in the slab. It is now value-initialized, so the read is well defined.
+//
+// This test does not fail deterministically without the fix -- the window opens
+// on every run, but whether the uninitialized bytes cause a crash does not. It
+// is a regression test in the sense that the read is reachable here, so a
+// sanitizer build catches it.
+
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: split-file %s %t
+//
+// RUN: %clang_cc1 -std=c++23 -emit-module-interface %t/a.cppm -o %t/a.pcm
+// RUN: %clang_cc1 -std=c++23 -fmodule-file=a=%t/a.pcm -fsyntax-only %t/use.cpp
+
+//--- shared.h
+namespace stdexec {
+struct __cp {
+  template <class _Tp> using __f = _Tp;
+};
+template <class> __cp __cpcvr;
+template <class _Tp> using __copy_cvref_fn = decltype(__cpcvr<_Tp>);
+template <class _Fun>
+concept __callable = requires(_Fun __fun) { __fun; };
+template <class _Fun>
+concept __nothrow_callable = requires(_Fun __fun) { __fun; };
+template <class... _As>
+concept constructible_from = __is_constructible(_As...);
+template <class>
+concept move_constructible = constructible_from<>;
+template <class _Ty>
+concept __movable_value = move_constructible<_Ty>;
+template <auto _Value> using __mtypeof = decltype(_Value);
+struct __ignore {
+  template <class _Ts> __ignore(_Ts);
+};
+template <class _Fn, class _Arg> using __mcall1 = _Fn::template __f<_Arg>;
+template <class... _Args>
+concept _Ok = (__is_same(_Args, int) && ...);
+template <int> struct __i {
+  template <template <class> class _Fn, class... _Args>
+  using __g = _Fn<_Args...>;
+  template <class _Fn, class... _Args> using __f = _Fn::template __f<_Args...>;
+};
+template <template <class> class _Fn, class... _Args>
+using __minvoke_q = __i<_Ok<>>::__g<_Fn, _Args...>;
+template <class _Fn, class... _Args>
+using __minvoke = __i<_Ok<>>::__f<_Fn, _Args...>;
+template <template <class> class _Fn> struct __qq {
+  template <class... _Args> using __f = _Fn<_Args...>;
+};
+template <template <class> class _Tp, class... _Args>
+concept __minvocable_q = requires { typename __minvoke_q<_Tp, _Args...>; };
+template <class _Fun, class... _As>
+using __call_result_t = decltype(_Fun()(_As()...));
+struct set_value_t;
+struct just_t;
+extern just_t just;
+namespace __tup {
+template <class...> struct __tuple {};
+template <class _CvRef> struct __impl {
+  template <class... _Ts> using __tuple_t = __mcall1<_CvRef, __tuple<_Ts...>>;
+  template <class... _Ts, __callable _Fn>
+  auto operator()(_Fn, __tuple_t<_Ts...>)
+      -> __call_result_t<_Fn, __mcall1<_CvRef, _Ts>...>;
+};
+template <class _Tuple> using __impl_t = __impl<__copy_cvref_fn<_Tuple>>;
+struct __apply_t {
+  // The noexcept specification here is the ConceptSpecializationExpr that
+  // reaches back into the decl being deserialized.
+  template <class _Fn, class _Tuple>
+  auto operator()(_Fn, _Tuple) noexcept(__nothrow_callable<_Tuple>)
+      -> __call_result_t<__impl_t<_Tuple>, _Fn, _Tuple>;
+};
+} // namespace __tup
+using __tup::__tuple;
+template <class _Fn, class _Tuple>
+using __apply_result_t = __call_result_t<__tup::__apply_t, _Fn, _Tuple>;
+template <class, class, class, class> using __gather_completions_t = int;
+template <class _EnvProvider>
+using __get_env_member_result_t = decltype(_EnvProvider().get_env());
+struct get_env_t {
+  template <class _EnvProvider>
+  auto operator()(_EnvProvider) -> __get_env_member_result_t<_EnvProvider>;
+};
+template <class _EnvProvider>
+concept __environment_provider =
+    __minvocable_q<__call_result_t, get_env_t, _EnvProvider>;
+template <class _Sender>
+concept sender = __environment_provider<_Sender>;
+template <class _Sender, class>
+concept sender_in = sender<_Sender>;
+template <auto> struct __sexpr;
+template <class _Tag, class _Data> struct __desc {
+  using __tag = _Tag;
+  template <class _Fn> using __f = __minvoke<_Fn, _Tag, _Data>;
+};
+template <class _Descriptor> auto __descriptor_fn_v = _Descriptor{};
+template <class> struct __sexpr_impl;
+template <class _Tag, class _Data>
+using __sexpr_t = __sexpr<__descriptor_fn_v<__desc<_Tag, _Data>>>;
+template <auto _DescriptorFn> struct __sexpr {
+  using __desc_t = decltype(_DescriptorFn);
+  using __base_t = __minvoke<__desc_t, __qq<__tuple>>;
+  using __get_attrs_t =
+      __mtypeof<__sexpr_impl<typename __desc_t::__tag>::__get_attrs>;
+  using __attrs_t = __apply_result_t<__get_attrs_t, __base_t>;
+  auto get_env() -> __attrs_t;
+};
+struct __make_sexpr_t {
+  template <class _Data> auto operator()(_Data) {
+    return __sexpr_t<just_t, _Data>{};
+  }
+};
+template <class> __make_sexpr_t __make_sexpr;
+template <class _Sender, class _SetSig>
+concept sender_of =
+    sender_in<_Sender, __gather_completions_t<_SetSig, _Sender, int, int>>;
+struct just_t {
+  template <__movable_value... _Ts> auto operator()(_Ts... __ts) {
+    return __make_sexpr<just_t>(__tuple{__ts...});
+  }
+};
+template <> struct __sexpr_impl<just_t> {
+  static void __get_attrs(__ignore, __ignore);
+};
+using __force = __call_result_t<just_t>;
+} // namespace stdexec
+
+//--- a.cppm
+module;
+#include "shared.h"
+export module a;
+
+export template <stdexec::sender_of<stdexec::set_value_t()> T> void ta(T) {}
+export using stdexec::just;
+export using stdexec::set_value_t;
+
+//--- use.cpp
+import a;
+
+// Calling ta() forces constraint satisfaction, which triggers the lazy
+// specialization lookup that deserializes the ImplicitConceptSpecializationDecl.
+void f() { ta(just()); }

--- a/clang/unittests/AST/DeclTest.cpp
+++ b/clang/unittests/AST/DeclTest.cpp
@@ -15,7 +15,9 @@
 #include "clang/AST/DeclCXX.h"
 #include "clang/AST/DeclObjC.h"
 #include "clang/AST/DeclTemplate.h"
+#include "clang/AST/ExprConcepts.h"
 #include "clang/AST/Mangle.h"
+#include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/TypeBase.h"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 #include "clang/ASTMatchers/ASTMatchers.h"
@@ -1028,4 +1030,73 @@ TEST(Decl, ObjCPropertyDeclNameForDiagnostic) {
   ExtP->getNameForDiagnostic(ExtPQualifiedOS, Ctx.getPrintingPolicy(),
                              /*Qualified=*/true);
   EXPECT_EQ(ExtPQualifiedOS.str(), "-[MyClass extensionProp]");
+}
+
+namespace {
+
+/// Collects every ConceptSpecializationExpr in a translation unit.
+struct ConceptSpecializationExprCollector
+    : RecursiveASTVisitor<ConceptSpecializationExprCollector> {
+  SmallVector<const ConceptSpecializationExpr *, 8> Exprs;
+
+  bool VisitConceptSpecializationExpr(ConceptSpecializationExpr *E) {
+    Exprs.push_back(E);
+    return true;
+  }
+};
+
+} // namespace
+
+// Pins the postcondition of the fix for #191361: CreateDeserialized() publishes
+// NumTemplateArgs, but ASTDeclReader does not write the trailing arguments
+// until setTemplateArguments() runs at the end of
+// VisitImplicitConceptSpecializationDecl(). Re-entrant deserialization can
+// reach the decl in that window -- through a ConceptSpecializationExpr, into
+// StmtProfiler -- so the storage has to be well defined rather than raw
+// bump-allocator memory.
+TEST(ImplicitConceptSpecializationDecl,
+     DeserializedArgumentsAreValueInitialized) {
+  std::unique_ptr<ASTUnit> AST = buildASTFromCodeWithArgs("", {"-std=c++20"});
+  ASSERT_TRUE(AST);
+
+  auto *D = ImplicitConceptSpecializationDecl::CreateDeserialized(
+      AST->getASTContext(), GlobalDeclID(), /*NumTemplateArgs=*/3);
+  ArrayRef<TemplateArgument> Args = D->getTemplateArguments();
+
+  ASSERT_EQ(Args.size(), 3u);
+  for (const TemplateArgument &Arg : Args)
+    EXPECT_TRUE(Arg.isNull())
+        << "trailing arguments must be value-initialized before "
+           "setTemplateArguments() runs";
+}
+
+// The value-initialization must not survive the real write.
+TEST(ImplicitConceptSpecializationDecl, SetTemplateArgumentsOverwritesStorage) {
+  std::unique_ptr<ASTUnit> AST = buildASTFromCodeWithArgs("", {"-std=c++20"});
+  ASSERT_TRUE(AST);
+  ASTContext &Ctx = AST->getASTContext();
+
+  auto *D = ImplicitConceptSpecializationDecl::CreateDeserialized(
+      Ctx, GlobalDeclID(), /*NumTemplateArgs=*/2);
+
+  TemplateArgument Written[] = {TemplateArgument(Ctx.IntTy),
+                                TemplateArgument(Ctx.CharTy)};
+  D->setTemplateArguments(Written);
+
+  ArrayRef<TemplateArgument> Args = D->getTemplateArguments();
+  ASSERT_EQ(Args.size(), 2u);
+  for (const TemplateArgument &Arg : Args)
+    EXPECT_FALSE(Arg.isNull());
+  EXPECT_TRUE(Args[0].getAsType()->isIntegerType());
+}
+
+// The zero-argument case: getTemplateArguments() must be empty and must not
+// touch the trailing storage at all.
+TEST(ImplicitConceptSpecializationDecl, DeserializedWithNoArguments) {
+  std::unique_ptr<ASTUnit> AST = buildASTFromCodeWithArgs("", {"-std=c++20"});
+  ASSERT_TRUE(AST);
+
+  auto *D = ImplicitConceptSpecializationDecl::CreateDeserialized(
+      AST->getASTContext(), GlobalDeclID(), /*NumTemplateArgs=*/0);
+  EXPECT_TRUE(D->getTemplateArguments().empty());
 }


### PR DESCRIPTION
This change fixes a non-deterministic ICE during deserialization of an implicit concept specialization as described in #191361. Not addressed here is the pre-existing possibility of mis-keying `FunctionProtoType`s that happen to be profiled during such a deserialization.

The bug being addressed here is that `ImplicitConceptSpecializationDecl` has an `EmptyShell` constructor (invoked from `CreateDeserialized`) that leaves the resulting decl's trailing template arguments uninitialized. `ASTReader::ReadDeclRecord` registers a decl in `DeclsLoaded` before `ASTDeclReader` visits it so that a reentrant `GetDecl` for the same ID returns the partially-completed decl rather than re-deserializing it, which would lead to infinite recursion. Given that consumers can observe incompletely-deserialized decls, the `EmptyShell` constructors that produce those decls must leave them in a well-defined state. `ImplicitConceptSpecializationDecl`'s `EmptyShell` constructor fails to meet that obligation. Whether the bug manifests as an ICE depends on what the indeterminate values happen to be (all zeroes is never fatal, while some junk values are).

The reentrancy arises when a decl being deserialized holds the converted template arguments of some concept specialization `C<T>` and one of those arguments is the type of a function declared `noexcept(C<T>)`. Uniquing that function type profiles its `noexcept` expression, and profiling a `ConceptSpecializationExpr` walks the trailing arguments of the decl it names; given the named decl is currently being read, its template arguments have not yet been written when the uniquing process reads them. See
`clang/test/Modules/concept-specialization-deserialization.cppm` for a concrete instance.

Only the deserialization path can experience this reentrancy. `Create` receives the converted arguments and passes them to the constructor so Sema never creates an `ImplicitConceptSpecializationDecl` without fully-initialized template arguments. `CreateDeserialized`, on the other hand, must construct decls before they've been deserialized (as explained above). Any AST file read goes through the same path; #191361 shows this affecting both clangd's preambles and compilation of named-module consumers.

The fix is to ensure that an `ImplicitConceptSpecializationDecl`'s trailing objects are always value-initialized, making any observation of a half-built decl deterministically well-defined. Uniquing a `FunctionProtoType` using a hash computed from this transient state is no longer UB, but could, in principle, still lead to duplicate `FunctionProtoType`s, as was already possible whenever the UB was not fatal. Detecting or preventing such mis-keyings is left for future work.

The new `lit` test ensures that the test suite includes a TU that triggers the bug's preconditions although, because of the test TU's small size, it's very unlikely to trigger an ICE in unpatched Clang (the memory backing the problematic decl's trailing objects is highly likely to contain all zeroes during the undefined read window, which isn't fatal in practice).

The new unit tests validate:
 * the new postcondition of `ImplicitConceptSpecializationDecl::CreateDeserialized`;
 * that overwriting the value-initialized trailing objects by invoking `setTemplateArguments` actually overwrites (i.e. the status quo is maintained); and
 * that `getTemplateArguments()` on a zero-length array works on a value-initialized array.

Testing locally confirmed that, with this change, Clang can build NVIDIA's stdexec with modules enabled (which is where the bug was found), repeatedly and without crashing.

Assisted-by: Claude