### PR TITLE
[AMDGPU][SIInstrInfo] Materialise t16 PHI subreg operands

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
@@ -8107,16 +8107,26 @@ void SIInstrInfo::legalizeOperandsVALUt16(MachineInstr &MI, unsigned OpIdx,
   if (!RI.isVGPRClass(CurrRC))
     return;
 
-  const TargetRegisterClass *ExpectedRC;
-  if (MI.isPHI()) {
-    // A PHI is generic, so it carries no operand register classes.
-    ExpectedRC = MRI.getRegClass(MI.getOperand(0).getReg());
-  } else {
-    if (OpIdx >= get(Opcode).getNumOperands() ||
-        get(Opcode).operands()[OpIdx].RegClass == -1)
-      return;
-    ExpectedRC = RI.getRegClass(getOpRegClassID(get(Opcode).operands()[OpIdx]));
-  }
+  const TargetRegisterClass *ExpectedRC = [&]() -> const TargetRegisterClass * {
+    if (MI.isPHI()) {
+      // The expected register class of the PHI node operands is determined by
+      // its target operand.
+      return getOpRegClass(MI, 0);
+    }
+
+    if (OpIdx >= get(Opcode).getNumOperands())
+      return nullptr;
+
+    const MCOperandInfo &Operand = get(Opcode).operands()[OpIdx];
+    if (Operand.RegClass == -1)
+      return nullptr;
+
+    return RI.getRegClass(getOpRegClassID(Operand));
+  }();
+
+  if (!ExpectedRC)
+    return;
+
   if (RI.getMatchingSuperRegClass(CurrRC, ExpectedRC, AMDGPU::lo16)) {
     // Default to the lo16 only if the subregister is not specified.
     if (Op.getSubReg() == AMDGPU::NoSubRegister)

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
@@ -8096,9 +8096,7 @@ void SIInstrInfo::legalizeOperandsVALUt16(MachineInstr &MI, unsigned OpIdx,
   unsigned Opcode = MI.getOpcode();
   MachineBasicBlock *MBB = MI.getParent();
   // Legalize operands and check for size mismatch
-  if (OpIdx >= MI.getNumExplicitOperands() ||
-      OpIdx >= get(Opcode).getNumOperands() ||
-      get(Opcode).operands()[OpIdx].RegClass == -1)
+  if (OpIdx >= MI.getNumExplicitOperands())
     return;
 
   MachineOperand &Op = MI.getOperand(OpIdx);
@@ -8109,8 +8107,16 @@ void SIInstrInfo::legalizeOperandsVALUt16(MachineInstr &MI, unsigned OpIdx,
   if (!RI.isVGPRClass(CurrRC))
     return;
 
-  int16_t RCID = getOpRegClassID(get(Opcode).operands()[OpIdx]);
-  const TargetRegisterClass *ExpectedRC = RI.getRegClass(RCID);
+  const TargetRegisterClass *ExpectedRC;
+  if (MI.isPHI()) {
+    // A PHI is generic, so it carries no operand register classes.
+    ExpectedRC = MRI.getRegClass(MI.getOperand(0).getReg());
+  } else {
+    if (OpIdx >= get(Opcode).getNumOperands() ||
+        get(Opcode).operands()[OpIdx].RegClass == -1)
+      return;
+    ExpectedRC = RI.getRegClass(getOpRegClassID(get(Opcode).operands()[OpIdx]));
+  }
   if (RI.getMatchingSuperRegClass(CurrRC, ExpectedRC, AMDGPU::lo16)) {
     // Default to the lo16 only if the subregister is not specified.
     if (Op.getSubReg() == AMDGPU::NoSubRegister)
@@ -8122,10 +8128,15 @@ void SIInstrInfo::legalizeOperandsVALUt16(MachineInstr &MI, unsigned OpIdx,
       RI.getSubRegisterClass(CurrRC, Op.getSubReg());
   if (RI.getMatchingSuperRegClass(ExpectedRC, CurrSRC, AMDGPU::lo16)) {
     const DebugLoc &DL = MI.getDebugLoc();
+    MachineBasicBlock::iterator I = MI;
+    if (MI.isPHI()) {
+      MBB = MI.getOperand(OpIdx + 1).getMBB();
+      I = MBB->getFirstTerminator();
+    }
     Register NewDstReg = MRI.createVirtualRegister(&AMDGPU::VGPR_32RegClass);
     Register Undef = MRI.createVirtualRegister(&AMDGPU::VGPR_16RegClass);
-    BuildMI(*MBB, MI, DL, get(AMDGPU::IMPLICIT_DEF), Undef);
-    BuildMI(*MBB, MI, DL, get(AMDGPU::REG_SEQUENCE), NewDstReg)
+    BuildMI(*MBB, I, DL, get(AMDGPU::IMPLICIT_DEF), Undef);
+    BuildMI(*MBB, I, DL, get(AMDGPU::REG_SEQUENCE), NewDstReg)
         .addReg(Op.getReg(), {}, Op.getSubReg())
         .addImm(AMDGPU::lo16)
         .addReg(Undef)

--- a/llvm/test/CodeGen/AMDGPU/fix-sgpr-copies-f16-true16.mir
+++ b/llvm/test/CodeGen/AMDGPU/fix-sgpr-copies-f16-true16.mir
@@ -273,8 +273,11 @@ body:             |
   ; GCN-NEXT: bb.1:
   ; GCN-NEXT:   successors: %bb.2(0x80000000)
   ; GCN-NEXT: {{  $}}
+  ; GCN-NEXT:   [[DEF2:%[0-9]+]]:vgpr_16 = IMPLICIT_DEF
+  ; GCN-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vgpr_32 = REG_SEQUENCE [[DEF]].lo16, %subreg.lo16, [[DEF2]], %subreg.hi16
+  ; GCN-NEXT: {{  $}}
   ; GCN-NEXT: bb.2:
-  ; GCN-NEXT:   [[PHI:%[0-9]+]]:vgpr_32 = PHI [[COPY]], %bb.0, [[DEF]].lo16, %bb.1
+  ; GCN-NEXT:   [[PHI:%[0-9]+]]:vgpr_32 = PHI [[COPY]], %bb.0, [[REG_SEQUENCE]], %bb.1
   ; GCN-NEXT:   S_ENDPGM 0, implicit [[PHI]]
   bb.0:
     liveins: $scc
@@ -307,8 +310,11 @@ body:             |
   ; GCN-NEXT: bb.1:
   ; GCN-NEXT:   successors: %bb.2(0x80000000)
   ; GCN-NEXT: {{  $}}
+  ; GCN-NEXT:   [[DEF2:%[0-9]+]]:vgpr_16 = IMPLICIT_DEF
+  ; GCN-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vgpr_32 = REG_SEQUENCE [[DEF]].hi16, %subreg.lo16, [[DEF2]], %subreg.hi16
+  ; GCN-NEXT: {{  $}}
   ; GCN-NEXT: bb.2:
-  ; GCN-NEXT:   [[PHI:%[0-9]+]]:vgpr_32 = PHI [[COPY]], %bb.0, [[DEF]].hi16, %bb.1
+  ; GCN-NEXT:   [[PHI:%[0-9]+]]:vgpr_32 = PHI [[COPY]], %bb.0, [[REG_SEQUENCE]], %bb.1
   ; GCN-NEXT:   S_ENDPGM 0, implicit [[PHI]]
   bb.0:
     liveins: $scc

--- a/llvm/test/CodeGen/AMDGPU/frem.ll
+++ b/llvm/test/CodeGen/AMDGPU/frem.ll
@@ -529,23 +529,24 @@ define amdgpu_kernel void @frem_f16(ptr addrspace(1) %out, ptr addrspace(1) %in1
 ; GFX11-TRUE16-NEXT:    s_clause 0x1
 ; GFX11-TRUE16-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24
 ; GFX11-TRUE16-NEXT:    s_load_b64 s[4:5], s[4:5], 0x34
-; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v1, 0
+; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v0, 0
 ; GFX11-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX11-TRUE16-NEXT:    s_clause 0x1
-; GFX11-TRUE16-NEXT:    global_load_d16_b16 v0, v1, s[2:3]
-; GFX11-TRUE16-NEXT:    global_load_d16_hi_b16 v0, v1, s[4:5] offset:8
+; GFX11-TRUE16-NEXT:    global_load_d16_b16 v1, v0, s[2:3]
+; GFX11-TRUE16-NEXT:    global_load_d16_b16 v0, v0, s[4:5] offset:8
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(1)
+; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e64 v4, |v1.l|
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e64 v1, |v0.l|
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e64 v2, |v0.h|
+; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e64 v2, |v0.l|
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_cmp_ngt_f32_e32 vcc_lo, v1, v2
+; GFX11-TRUE16-NEXT:    v_cmp_ngt_f32_e32 vcc_lo, v4, v2
 ; GFX11-TRUE16-NEXT:    s_cbranch_vccz .LBB0_2
 ; GFX11-TRUE16-NEXT:  ; %bb.1: ; %frem.else
-; GFX11-TRUE16-NEXT:    v_and_b16 v3.l, 0x8000, v0.l
-; GFX11-TRUE16-NEXT:    v_cmp_eq_f32_e32 vcc_lo, v1, v2
+; GFX11-TRUE16-NEXT:    v_and_b16 v0.h, 0x8000, v1.l
+; GFX11-TRUE16-NEXT:    v_cmp_eq_f32_e32 vcc_lo, v4, v2
 ; GFX11-TRUE16-NEXT:    s_mov_b32 s2, 0
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX11-TRUE16-NEXT:    v_cndmask_b16 v3.l, v0.l, v3.l, vcc_lo
+; GFX11-TRUE16-NEXT:    v_cndmask_b16 v3.l, v1.l, v0.h, vcc_lo
 ; GFX11-TRUE16-NEXT:    s_branch .LBB0_3
 ; GFX11-TRUE16-NEXT:  .LBB0_2:
 ; GFX11-TRUE16-NEXT:    s_mov_b32 s2, -1
@@ -555,41 +556,43 @@ define amdgpu_kernel void @frem_f16(ptr addrspace(1) %out, ptr addrspace(1) %in1
 ; GFX11-TRUE16-NEXT:    s_and_b32 s2, s2, exec_lo
 ; GFX11-TRUE16-NEXT:    s_cselect_b32 s2, 1, 0
 ; GFX11-TRUE16-NEXT:    s_cmp_lg_u32 s2, 1
-; GFX11-TRUE16-NEXT:    s_cbranch_scc1 .LBB0_8
+; GFX11-TRUE16-NEXT:    s_cbranch_scc1 .LBB0_9
 ; GFX11-TRUE16-NEXT:  ; %bb.4: ; %frem.compute
-; GFX11-TRUE16-NEXT:    v_frexp_mant_f32_e32 v4, v2
+; GFX11-TRUE16-NEXT:    v_frexp_mant_f32_e32 v3, v4
+; GFX11-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v5, v4
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_2) | instid1(VALU_DEP_4)
+; GFX11-TRUE16-NEXT:    v_ldexp_f32 v4, v3, 11
+; GFX11-TRUE16-NEXT:    v_frexp_mant_f32_e32 v3, v2
 ; GFX11-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v2, v2
-; GFX11-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v3, v1
-; GFX11-TRUE16-NEXT:    v_frexp_mant_f32_e32 v1, v1
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_4) | instid1(VALU_DEP_4)
+; GFX11-TRUE16-NEXT:    v_readfirstlane_b32 s2, v5
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX11-TRUE16-NEXT:    v_ldexp_f32 v3, v3, 1
 ; GFX11-TRUE16-NEXT:    v_readfirstlane_b32 s3, v2
-; GFX11-TRUE16-NEXT:    v_add_nc_u32_e32 v5, -1, v2
-; GFX11-TRUE16-NEXT:    v_ldexp_f32 v2, v4, 1
-; GFX11-TRUE16-NEXT:    v_readfirstlane_b32 s2, v3
-; GFX11-TRUE16-NEXT:    v_ldexp_f32 v1, v1, 11
-; GFX11-TRUE16-NEXT:    v_not_b32_e32 v4, v5
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX11-TRUE16-NEXT:    v_div_scale_f32 v5, null, v2, v2, 1.0
-; GFX11-TRUE16-NEXT:    v_add_nc_u32_e32 v4, v4, v3
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_4) | instid1(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_rcp_f32_e32 v6, v5
-; GFX11-TRUE16-NEXT:    v_div_scale_f32 v3, vcc_lo, 1.0, v2, 1.0
+; GFX11-TRUE16-NEXT:    v_add_nc_u32_e32 v2, -1, v2
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX11-TRUE16-NEXT:    v_div_scale_f32 v7, null, v3, v3, 1.0
+; GFX11-TRUE16-NEXT:    v_not_b32_e32 v6, v2
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_rcp_f32_e32 v8, v7
+; GFX11-TRUE16-NEXT:    v_add_nc_u32_e32 v6, v6, v5
+; GFX11-TRUE16-NEXT:    v_div_scale_f32 v5, vcc_lo, 1.0, v3, 1.0
 ; GFX11-TRUE16-NEXT:    s_denorm_mode 15
 ; GFX11-TRUE16-NEXT:    s_waitcnt_depctr depctr_va_vdst(0)
-; GFX11-TRUE16-NEXT:    v_fma_f32 v7, -v5, v6, 1.0
-; GFX11-TRUE16-NEXT:    v_fmac_f32_e32 v6, v7, v6
+; GFX11-TRUE16-NEXT:    v_fma_f32 v9, -v7, v8, 1.0
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_mul_f32_e32 v7, v3, v6
-; GFX11-TRUE16-NEXT:    v_fma_f32 v8, -v5, v7, v3
+; GFX11-TRUE16-NEXT:    v_fmac_f32_e32 v8, v9, v8
+; GFX11-TRUE16-NEXT:    v_mul_f32_e32 v9, v5, v8
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_fmac_f32_e32 v7, v8, v6
-; GFX11-TRUE16-NEXT:    v_fma_f32 v3, -v5, v7, v3
+; GFX11-TRUE16-NEXT:    v_fma_f32 v10, -v7, v9, v5
+; GFX11-TRUE16-NEXT:    v_fmac_f32_e32 v9, v10, v8
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_fma_f32 v5, -v7, v9, v5
 ; GFX11-TRUE16-NEXT:    s_denorm_mode 12
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GFX11-TRUE16-NEXT:    v_div_fmas_f32 v3, v3, v6, v7
-; GFX11-TRUE16-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 12, v4
-; GFX11-TRUE16-NEXT:    v_div_fixup_f32 v3, v3, v2, 1.0
-; GFX11-TRUE16-NEXT:    s_cbranch_vccnz .LBB0_7
+; GFX11-TRUE16-NEXT:    v_div_fmas_f32 v5, v5, v8, v9
+; GFX11-TRUE16-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 12, v6
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX11-TRUE16-NEXT:    v_div_fixup_f32 v5, v5, v3, 1.0
+; GFX11-TRUE16-NEXT:    s_cbranch_vccnz .LBB0_8
 ; GFX11-TRUE16-NEXT:  ; %bb.5: ; %frem.loop_body.preheader
 ; GFX11-TRUE16-NEXT:    s_sub_i32 s2, s2, s3
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
@@ -597,29 +600,49 @@ define amdgpu_kernel void @frem_f16(ptr addrspace(1) %out, ptr addrspace(1) %in1
 ; GFX11-TRUE16-NEXT:  .LBB0_6: ; %frem.loop_body
 ; GFX11-TRUE16-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
-; GFX11-TRUE16-NEXT:    v_mul_f32_e32 v4, v1, v3
+; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v7, v4
 ; GFX11-TRUE16-NEXT:    s_add_i32 s2, s2, -11
 ; GFX11-TRUE16-NEXT:    s_cmp_gt_i32 s2, 11
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_mul_f32_e32 v4, v7, v5
 ; GFX11-TRUE16-NEXT:    v_rndne_f32_e32 v4, v4
-; GFX11-TRUE16-NEXT:    v_fma_f32 v1, -v4, v2, v1
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v1
-; GFX11-TRUE16-NEXT:    v_add_f32_e32 v4, v1, v2
-; GFX11-TRUE16-NEXT:    v_cndmask_b32_e32 v1, v1, v4, vcc_lo
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_ldexp_f32 v1, v1, 11
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_fma_f32 v4, -v4, v3, v7
+; GFX11-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v4
+; GFX11-TRUE16-NEXT:    v_add_f32_e32 v6, v4, v3
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_cndmask_b32_e32 v4, v4, v6, vcc_lo
+; GFX11-TRUE16-NEXT:    v_ldexp_f32 v4, v4, 11
 ; GFX11-TRUE16-NEXT:    s_cbranch_scc1 .LBB0_6
-; GFX11-TRUE16-NEXT:  .LBB0_7: ; %frem.loop_exit
-; GFX11-TRUE16-NEXT:    ; implicit-def: $vgpr3
-; GFX11-TRUE16-NEXT:  .LBB0_8: ; %Flow19
-; GFX11-TRUE16-NEXT:    v_cmp_lg_f16_e32 vcc_lo, 0, v0.h
-; GFX11-TRUE16-NEXT:    v_cmp_nle_f16_e64 s2, 0x7c00, |v0.l|
-; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v1, 0
+; GFX11-TRUE16-NEXT:  ; %bb.7: ; %Flow
+; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v6, s2
+; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v4, v7
+; GFX11-TRUE16-NEXT:  .LBB0_8: ; %frem.loop_exit
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_add_nc_u32_e32 v6, -10, v6
+; GFX11-TRUE16-NEXT:    v_ldexp_f32 v4, v4, v6
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_mul_f32_e32 v5, v4, v5
+; GFX11-TRUE16-NEXT:    v_rndne_f32_e32 v5, v5
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_fma_f32 v4, -v5, v3, v4
+; GFX11-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v4
+; GFX11-TRUE16-NEXT:    v_add_f32_e32 v3, v4, v3
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_cndmask_b32_e32 v3, v4, v3, vcc_lo
+; GFX11-TRUE16-NEXT:    v_ldexp_f32 v2, v3, v2
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v3.l, v1.l
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_cvt_f16_f32_e32 v2.l, v2
+; GFX11-TRUE16-NEXT:    v_bfi_b32 v3, 0x7fff, v2, v3
+; GFX11-TRUE16-NEXT:  .LBB0_9: ; %Flow19
+; GFX11-TRUE16-NEXT:    v_cmp_lg_f16_e32 vcc_lo, 0, v0.l
+; GFX11-TRUE16-NEXT:    v_cmp_nle_f16_e64 s2, 0x7c00, |v1.l|
+; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX11-TRUE16-NEXT:    s_and_b32 s2, s2, vcc_lo
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
 ; GFX11-TRUE16-NEXT:    v_cndmask_b16 v0.l, 0x7e00, v3.l, s2
-; GFX11-TRUE16-NEXT:    global_store_b16 v1, v0, s[0:1]
+; GFX11-TRUE16-NEXT:    global_store_b16 v2, v0, s[0:1]
 ; GFX11-TRUE16-NEXT:    s_endpgm
 ;
 ; GFX11-FAKE16-LABEL: frem_f16:
@@ -778,41 +801,42 @@ define amdgpu_kernel void @frem_f16(ptr addrspace(1) %out, ptr addrspace(1) %in1
 ; GFX1150-TRUE16-NEXT:    s_and_b32 s2, s2, exec_lo
 ; GFX1150-TRUE16-NEXT:    s_cselect_b32 s2, 1, 0
 ; GFX1150-TRUE16-NEXT:    s_cmp_lg_u32 s2, 1
-; GFX1150-TRUE16-NEXT:    s_cbranch_scc1 .LBB0_8
+; GFX1150-TRUE16-NEXT:    s_cbranch_scc1 .LBB0_9
 ; GFX1150-TRUE16-NEXT:  ; %bb.4: ; %frem.compute
 ; GFX1150-TRUE16-NEXT:    v_frexp_mant_f32_e32 v3, s0
-; GFX1150-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v5, s0
-; GFX1150-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v4, s1
 ; GFX1150-TRUE16-NEXT:    v_frexp_mant_f32_e32 v2, s1
-; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX1150-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v5, s1
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
 ; GFX1150-TRUE16-NEXT:    v_ldexp_f32 v3, v3, 1
-; GFX1150-TRUE16-NEXT:    v_readfirstlane_b32 s0, v5
-; GFX1150-TRUE16-NEXT:    v_add_nc_u32_e32 v5, -1, v5
-; GFX1150-TRUE16-NEXT:    v_readfirstlane_b32 s1, v4
-; GFX1150-TRUE16-NEXT:    v_ldexp_f32 v2, v2, 11
-; GFX1150-TRUE16-NEXT:    v_div_scale_f32 v6, null, v3, v3, 1.0
-; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX1150-TRUE16-NEXT:    v_not_b32_e32 v5, v5
-; GFX1150-TRUE16-NEXT:    v_rcp_f32_e32 v7, v6
-; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_2) | instid1(TRANS32_DEP_1)
-; GFX1150-TRUE16-NEXT:    v_add_nc_u32_e32 v5, v5, v4
-; GFX1150-TRUE16-NEXT:    v_div_scale_f32 v4, vcc_lo, 1.0, v3, 1.0
+; GFX1150-TRUE16-NEXT:    v_ldexp_f32 v4, v2, 11
+; GFX1150-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v2, s0
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX1150-TRUE16-NEXT:    v_readfirstlane_b32 s1, v5
+; GFX1150-TRUE16-NEXT:    v_div_scale_f32 v7, null, v3, v3, 1.0
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_3)
+; GFX1150-TRUE16-NEXT:    v_readfirstlane_b32 s0, v2
+; GFX1150-TRUE16-NEXT:    v_add_nc_u32_e32 v2, -1, v2
+; GFX1150-TRUE16-NEXT:    v_rcp_f32_e32 v8, v7
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_not_b32_e32 v6, v2
+; GFX1150-TRUE16-NEXT:    v_add_nc_u32_e32 v6, v6, v5
+; GFX1150-TRUE16-NEXT:    v_div_scale_f32 v5, vcc_lo, 1.0, v3, 1.0
 ; GFX1150-TRUE16-NEXT:    s_denorm_mode 15
-; GFX1150-TRUE16-NEXT:    v_fma_f32 v8, -v6, v7, 1.0
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(TRANS32_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_fma_f32 v9, -v7, v8, 1.0
+; GFX1150-TRUE16-NEXT:    v_fmac_f32_e32 v8, v9, v8
 ; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1150-TRUE16-NEXT:    v_fmac_f32_e32 v7, v8, v7
-; GFX1150-TRUE16-NEXT:    v_mul_f32_e32 v8, v4, v7
+; GFX1150-TRUE16-NEXT:    v_mul_f32_e32 v9, v5, v8
+; GFX1150-TRUE16-NEXT:    v_fma_f32 v10, -v7, v9, v5
 ; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1150-TRUE16-NEXT:    v_fma_f32 v9, -v6, v8, v4
-; GFX1150-TRUE16-NEXT:    v_fmac_f32_e32 v8, v9, v7
-; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
-; GFX1150-TRUE16-NEXT:    v_fma_f32 v4, -v6, v8, v4
+; GFX1150-TRUE16-NEXT:    v_fmac_f32_e32 v9, v10, v8
+; GFX1150-TRUE16-NEXT:    v_fma_f32 v5, -v7, v9, v5
 ; GFX1150-TRUE16-NEXT:    s_denorm_mode 12
-; GFX1150-TRUE16-NEXT:    v_div_fmas_f32 v4, v4, v7, v8
-; GFX1150-TRUE16-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 12, v5
-; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX1150-TRUE16-NEXT:    v_div_fixup_f32 v4, v4, v3, 1.0
-; GFX1150-TRUE16-NEXT:    s_cbranch_vccnz .LBB0_7
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1150-TRUE16-NEXT:    v_div_fmas_f32 v5, v5, v8, v9
+; GFX1150-TRUE16-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 12, v6
+; GFX1150-TRUE16-NEXT:    v_div_fixup_f32 v5, v5, v3, 1.0
+; GFX1150-TRUE16-NEXT:    s_cbranch_vccnz .LBB0_8
 ; GFX1150-TRUE16-NEXT:  ; %bb.5: ; %frem.loop_body.preheader
 ; GFX1150-TRUE16-NEXT:    s_sub_i32 s0, s1, s0
 ; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
@@ -820,23 +844,46 @@ define amdgpu_kernel void @frem_f16(ptr addrspace(1) %out, ptr addrspace(1) %in1
 ; GFX1150-TRUE16-NEXT:  .LBB0_6: ; %frem.loop_body
 ; GFX1150-TRUE16-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
-; GFX1150-TRUE16-NEXT:    v_mul_f32_e32 v5, v2, v4
+; GFX1150-TRUE16-NEXT:    v_mov_b32_e32 v7, v4
 ; GFX1150-TRUE16-NEXT:    s_add_i32 s0, s0, -11
 ; GFX1150-TRUE16-NEXT:    s_cmp_gt_i32 s0, 11
 ; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1150-TRUE16-NEXT:    v_rndne_f32_e32 v5, v5
-; GFX1150-TRUE16-NEXT:    v_xor_b32_e32 v5, 0x80000000, v5
+; GFX1150-TRUE16-NEXT:    v_mul_f32_e32 v4, v7, v5
+; GFX1150-TRUE16-NEXT:    v_rndne_f32_e32 v4, v4
 ; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1150-TRUE16-NEXT:    v_fmac_f32_e32 v2, v5, v3
-; GFX1150-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v2
-; GFX1150-TRUE16-NEXT:    v_add_f32_e32 v5, v2, v3
-; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1150-TRUE16-NEXT:    v_cndmask_b32_e32 v2, v2, v5, vcc_lo
-; GFX1150-TRUE16-NEXT:    v_ldexp_f32 v2, v2, 11
+; GFX1150-TRUE16-NEXT:    v_xor_b32_e32 v4, 0x80000000, v4
+; GFX1150-TRUE16-NEXT:    v_fma_f32 v4, v4, v3, v7
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v4
+; GFX1150-TRUE16-NEXT:    v_add_f32_e32 v6, v4, v3
+; GFX1150-TRUE16-NEXT:    v_cndmask_b32_e32 v4, v4, v6, vcc_lo
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_ldexp_f32 v4, v4, 11
 ; GFX1150-TRUE16-NEXT:    s_cbranch_scc1 .LBB0_6
-; GFX1150-TRUE16-NEXT:  .LBB0_7: ; %frem.loop_exit
-; GFX1150-TRUE16-NEXT:    ; implicit-def: $vgpr2
-; GFX1150-TRUE16-NEXT:  .LBB0_8: ; %Flow19
+; GFX1150-TRUE16-NEXT:  ; %bb.7: ; %Flow
+; GFX1150-TRUE16-NEXT:    v_mov_b32_e32 v6, s0
+; GFX1150-TRUE16-NEXT:    v_mov_b32_e32 v4, v7
+; GFX1150-TRUE16-NEXT:  .LBB0_8: ; %frem.loop_exit
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_add_nc_u32_e32 v6, -10, v6
+; GFX1150-TRUE16-NEXT:    v_ldexp_f32 v4, v4, v6
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_mul_f32_e32 v5, v4, v5
+; GFX1150-TRUE16-NEXT:    v_rndne_f32_e32 v5, v5
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_xor_b32_e32 v5, 0x80000000, v5
+; GFX1150-TRUE16-NEXT:    v_fmac_f32_e32 v4, v5, v3
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v4
+; GFX1150-TRUE16-NEXT:    v_add_f32_e32 v3, v4, v3
+; GFX1150-TRUE16-NEXT:    v_cndmask_b32_e32 v3, v4, v3, vcc_lo
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1150-TRUE16-NEXT:    v_ldexp_f32 v2, v3, v2
+; GFX1150-TRUE16-NEXT:    v_mov_b16_e32 v3.l, v0.l
+; GFX1150-TRUE16-NEXT:    v_cvt_f16_f32_e32 v2.l, v2
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_bfi_b32 v2, 0x7fff, v2, v3
+; GFX1150-TRUE16-NEXT:  .LBB0_9: ; %Flow19
 ; GFX1150-TRUE16-NEXT:    v_dual_mov_b32 v3, 0 :: v_dual_and_b32 v0, 0x7fff, v0
 ; GFX1150-TRUE16-NEXT:    v_cmp_lg_f16_e32 vcc_lo, 0, v1.l
 ; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
@@ -1012,41 +1059,42 @@ define amdgpu_kernel void @frem_f16(ptr addrspace(1) %out, ptr addrspace(1) %in1
 ; GFX1200-TRUE16-NEXT:    s_cselect_b32 s2, 1, 0
 ; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX1200-TRUE16-NEXT:    s_cmp_lg_u32 s2, 1
-; GFX1200-TRUE16-NEXT:    s_cbranch_scc1 .LBB0_8
+; GFX1200-TRUE16-NEXT:    s_cbranch_scc1 .LBB0_9
 ; GFX1200-TRUE16-NEXT:  ; %bb.4: ; %frem.compute
 ; GFX1200-TRUE16-NEXT:    v_frexp_mant_f32_e32 v3, s0
-; GFX1200-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v5, s0
-; GFX1200-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v4, s1
 ; GFX1200-TRUE16-NEXT:    v_frexp_mant_f32_e32 v2, s1
-; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX1200-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v5, s1
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
 ; GFX1200-TRUE16-NEXT:    v_ldexp_f32 v3, v3, 1
-; GFX1200-TRUE16-NEXT:    v_readfirstlane_b32 s0, v5
-; GFX1200-TRUE16-NEXT:    v_add_nc_u32_e32 v5, -1, v5
-; GFX1200-TRUE16-NEXT:    v_readfirstlane_b32 s1, v4
-; GFX1200-TRUE16-NEXT:    v_ldexp_f32 v2, v2, 11
-; GFX1200-TRUE16-NEXT:    v_div_scale_f32 v6, null, v3, v3, 1.0
-; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX1200-TRUE16-NEXT:    v_not_b32_e32 v5, v5
-; GFX1200-TRUE16-NEXT:    v_rcp_f32_e32 v7, v6
-; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_2) | instid1(TRANS32_DEP_1)
-; GFX1200-TRUE16-NEXT:    v_add_nc_u32_e32 v5, v5, v4
-; GFX1200-TRUE16-NEXT:    v_div_scale_f32 v4, vcc_lo, 1.0, v3, 1.0
+; GFX1200-TRUE16-NEXT:    v_ldexp_f32 v4, v2, 11
+; GFX1200-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v2, s0
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX1200-TRUE16-NEXT:    v_readfirstlane_b32 s1, v5
+; GFX1200-TRUE16-NEXT:    v_div_scale_f32 v7, null, v3, v3, 1.0
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_3)
+; GFX1200-TRUE16-NEXT:    v_readfirstlane_b32 s0, v2
+; GFX1200-TRUE16-NEXT:    v_add_nc_u32_e32 v2, -1, v2
+; GFX1200-TRUE16-NEXT:    v_rcp_f32_e32 v8, v7
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1200-TRUE16-NEXT:    v_not_b32_e32 v6, v2
+; GFX1200-TRUE16-NEXT:    v_add_nc_u32_e32 v6, v6, v5
+; GFX1200-TRUE16-NEXT:    v_div_scale_f32 v5, vcc_lo, 1.0, v3, 1.0
 ; GFX1200-TRUE16-NEXT:    s_denorm_mode 15
-; GFX1200-TRUE16-NEXT:    v_fma_f32 v8, -v6, v7, 1.0
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(TRANS32_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1200-TRUE16-NEXT:    v_fma_f32 v9, -v7, v8, 1.0
+; GFX1200-TRUE16-NEXT:    v_fmac_f32_e32 v8, v9, v8
 ; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1200-TRUE16-NEXT:    v_fmac_f32_e32 v7, v8, v7
-; GFX1200-TRUE16-NEXT:    v_mul_f32_e32 v8, v4, v7
+; GFX1200-TRUE16-NEXT:    v_mul_f32_e32 v9, v5, v8
+; GFX1200-TRUE16-NEXT:    v_fma_f32 v10, -v7, v9, v5
 ; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1200-TRUE16-NEXT:    v_fma_f32 v9, -v6, v8, v4
-; GFX1200-TRUE16-NEXT:    v_fmac_f32_e32 v8, v9, v7
-; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
-; GFX1200-TRUE16-NEXT:    v_fma_f32 v4, -v6, v8, v4
+; GFX1200-TRUE16-NEXT:    v_fmac_f32_e32 v9, v10, v8
+; GFX1200-TRUE16-NEXT:    v_fma_f32 v5, -v7, v9, v5
 ; GFX1200-TRUE16-NEXT:    s_denorm_mode 12
-; GFX1200-TRUE16-NEXT:    v_div_fmas_f32 v4, v4, v7, v8
-; GFX1200-TRUE16-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 12, v5
-; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX1200-TRUE16-NEXT:    v_div_fixup_f32 v4, v4, v3, 1.0
-; GFX1200-TRUE16-NEXT:    s_cbranch_vccnz .LBB0_7
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1200-TRUE16-NEXT:    v_div_fmas_f32 v5, v5, v8, v9
+; GFX1200-TRUE16-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 12, v6
+; GFX1200-TRUE16-NEXT:    v_div_fixup_f32 v5, v5, v3, 1.0
+; GFX1200-TRUE16-NEXT:    s_cbranch_vccnz .LBB0_8
 ; GFX1200-TRUE16-NEXT:  ; %bb.5: ; %frem.loop_body.preheader
 ; GFX1200-TRUE16-NEXT:    s_sub_co_i32 s0, s1, s0
 ; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
@@ -1054,26 +1102,49 @@ define amdgpu_kernel void @frem_f16(ptr addrspace(1) %out, ptr addrspace(1) %in1
 ; GFX1200-TRUE16-NEXT:  .LBB0_6: ; %frem.loop_body
 ; GFX1200-TRUE16-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1200-TRUE16-NEXT:    v_mul_f32_e32 v5, v2, v4
+; GFX1200-TRUE16-NEXT:    v_mov_b32_e32 v7, v4
 ; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX1200-TRUE16-NEXT:    s_add_co_i32 s0, s0, -11
 ; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX1200-TRUE16-NEXT:    s_cmp_gt_i32 s0, 11
+; GFX1200-TRUE16-NEXT:    v_mul_f32_e32 v4, v7, v5
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1200-TRUE16-NEXT:    v_rndne_f32_e32 v4, v4
+; GFX1200-TRUE16-NEXT:    v_xor_b32_e32 v4, 0x80000000, v4
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1200-TRUE16-NEXT:    v_fma_f32 v4, v4, v3, v7
+; GFX1200-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v4
+; GFX1200-TRUE16-NEXT:    v_add_f32_e32 v6, v4, v3
+; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1200-TRUE16-NEXT:    v_cndmask_b32_e32 v4, v4, v6, vcc_lo
+; GFX1200-TRUE16-NEXT:    v_ldexp_f32 v4, v4, 11
+; GFX1200-TRUE16-NEXT:    s_cbranch_scc1 .LBB0_6
+; GFX1200-TRUE16-NEXT:  ; %bb.7: ; %Flow
+; GFX1200-TRUE16-NEXT:    v_mov_b32_e32 v6, s0
+; GFX1200-TRUE16-NEXT:    v_mov_b32_e32 v4, v7
+; GFX1200-TRUE16-NEXT:  .LBB0_8: ; %frem.loop_exit
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1200-TRUE16-NEXT:    v_add_nc_u32_e32 v6, -10, v6
+; GFX1200-TRUE16-NEXT:    v_ldexp_f32 v4, v4, v6
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1200-TRUE16-NEXT:    v_mul_f32_e32 v5, v4, v5
 ; GFX1200-TRUE16-NEXT:    v_rndne_f32_e32 v5, v5
 ; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX1200-TRUE16-NEXT:    v_xor_b32_e32 v5, 0x80000000, v5
-; GFX1200-TRUE16-NEXT:    v_fmac_f32_e32 v2, v5, v3
+; GFX1200-TRUE16-NEXT:    v_fmac_f32_e32 v4, v5, v3
 ; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_2) | instid1(VALU_DEP_1)
-; GFX1200-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v2
-; GFX1200-TRUE16-NEXT:    v_add_f32_e32 v5, v2, v3
+; GFX1200-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v4
+; GFX1200-TRUE16-NEXT:    v_add_f32_e32 v3, v4, v3
 ; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_va_vcc(0)
-; GFX1200-TRUE16-NEXT:    v_cndmask_b32_e32 v2, v2, v5, vcc_lo
+; GFX1200-TRUE16-NEXT:    v_cndmask_b32_e32 v3, v4, v3, vcc_lo
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1200-TRUE16-NEXT:    v_ldexp_f32 v2, v3, v2
+; GFX1200-TRUE16-NEXT:    v_mov_b16_e32 v3.l, v0.l
+; GFX1200-TRUE16-NEXT:    v_cvt_f16_f32_e32 v2.l, v2
 ; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1200-TRUE16-NEXT:    v_ldexp_f32 v2, v2, 11
-; GFX1200-TRUE16-NEXT:    s_cbranch_scc1 .LBB0_6
-; GFX1200-TRUE16-NEXT:  .LBB0_7: ; %frem.loop_exit
-; GFX1200-TRUE16-NEXT:    ; implicit-def: $vgpr2
-; GFX1200-TRUE16-NEXT:  .LBB0_8: ; %Flow19
+; GFX1200-TRUE16-NEXT:    v_bfi_b32 v2, 0x7fff, v2, v3
+; GFX1200-TRUE16-NEXT:  .LBB0_9: ; %Flow19
 ; GFX1200-TRUE16-NEXT:    v_dual_mov_b32 v3, 0 :: v_dual_and_b32 v0, 0x7fff, v0
 ; GFX1200-TRUE16-NEXT:    v_cmp_lg_f16_e32 vcc_lo, 0, v1.l
 ; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
@@ -6045,42 +6116,43 @@ define amdgpu_kernel void @frem_v2f16(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; GFX11-TRUE16-NEXT:    s_and_b32 s2, s2, exec_lo
 ; GFX11-TRUE16-NEXT:    s_cselect_b32 s2, 1, 0
 ; GFX11-TRUE16-NEXT:    s_cmp_lg_u32 s2, 1
-; GFX11-TRUE16-NEXT:    s_cbranch_scc1 .LBB9_8
+; GFX11-TRUE16-NEXT:    s_cbranch_scc1 .LBB9_9
 ; GFX11-TRUE16-NEXT:  ; %bb.4: ; %frem.compute19
-; GFX11-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v5, v4
 ; GFX11-TRUE16-NEXT:    v_frexp_mant_f32_e32 v2, v4
-; GFX11-TRUE16-NEXT:    v_frexp_mant_f32_e32 v4, v3
-; GFX11-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v3, v3
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX11-TRUE16-NEXT:    v_frexp_mant_f32_e32 v6, v3
+; GFX11-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v5, v4
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_4)
+; GFX11-TRUE16-NEXT:    v_ldexp_f32 v4, v2, 11
+; GFX11-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v2, v3
+; GFX11-TRUE16-NEXT:    v_ldexp_f32 v3, v6, 1
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_3)
 ; GFX11-TRUE16-NEXT:    v_readfirstlane_b32 s2, v5
-; GFX11-TRUE16-NEXT:    v_ldexp_f32 v2, v2, 11
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_2) | instid1(VALU_DEP_2)
-; GFX11-TRUE16-NEXT:    v_readfirstlane_b32 s3, v3
-; GFX11-TRUE16-NEXT:    v_add_nc_u32_e32 v6, -1, v3
-; GFX11-TRUE16-NEXT:    v_ldexp_f32 v3, v4, 1
-; GFX11-TRUE16-NEXT:    v_not_b32_e32 v4, v6
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX11-TRUE16-NEXT:    v_div_scale_f32 v6, null, v3, v3, 1.0
-; GFX11-TRUE16-NEXT:    v_add_nc_u32_e32 v5, v4, v5
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_4) | instid1(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_rcp_f32_e32 v7, v6
-; GFX11-TRUE16-NEXT:    v_div_scale_f32 v4, vcc_lo, 1.0, v3, 1.0
+; GFX11-TRUE16-NEXT:    v_readfirstlane_b32 s3, v2
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX11-TRUE16-NEXT:    v_div_scale_f32 v7, null, v3, v3, 1.0
+; GFX11-TRUE16-NEXT:    v_add_nc_u32_e32 v2, -1, v2
+; GFX11-TRUE16-NEXT:    v_rcp_f32_e32 v8, v7
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_not_b32_e32 v6, v2
+; GFX11-TRUE16-NEXT:    v_add_nc_u32_e32 v6, v6, v5
+; GFX11-TRUE16-NEXT:    v_div_scale_f32 v5, vcc_lo, 1.0, v3, 1.0
 ; GFX11-TRUE16-NEXT:    s_denorm_mode 15
 ; GFX11-TRUE16-NEXT:    s_waitcnt_depctr depctr_va_vdst(0)
-; GFX11-TRUE16-NEXT:    v_fma_f32 v8, -v6, v7, 1.0
-; GFX11-TRUE16-NEXT:    v_fmac_f32_e32 v7, v8, v7
+; GFX11-TRUE16-NEXT:    v_fma_f32 v9, -v7, v8, 1.0
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_mul_f32_e32 v8, v4, v7
-; GFX11-TRUE16-NEXT:    v_fma_f32 v9, -v6, v8, v4
+; GFX11-TRUE16-NEXT:    v_fmac_f32_e32 v8, v9, v8
+; GFX11-TRUE16-NEXT:    v_mul_f32_e32 v9, v5, v8
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_fmac_f32_e32 v8, v9, v7
-; GFX11-TRUE16-NEXT:    v_fma_f32 v4, -v6, v8, v4
+; GFX11-TRUE16-NEXT:    v_fma_f32 v10, -v7, v9, v5
+; GFX11-TRUE16-NEXT:    v_fmac_f32_e32 v9, v10, v8
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_fma_f32 v5, -v7, v9, v5
 ; GFX11-TRUE16-NEXT:    s_denorm_mode 12
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GFX11-TRUE16-NEXT:    v_div_fmas_f32 v4, v4, v7, v8
-; GFX11-TRUE16-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 12, v5
-; GFX11-TRUE16-NEXT:    v_div_fixup_f32 v4, v4, v3, 1.0
-; GFX11-TRUE16-NEXT:    s_cbranch_vccnz .LBB9_7
+; GFX11-TRUE16-NEXT:    v_div_fmas_f32 v5, v5, v8, v9
+; GFX11-TRUE16-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 12, v6
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX11-TRUE16-NEXT:    v_div_fixup_f32 v5, v5, v3, 1.0
+; GFX11-TRUE16-NEXT:    s_cbranch_vccnz .LBB9_8
 ; GFX11-TRUE16-NEXT:  ; %bb.5: ; %frem.loop_body27.preheader
 ; GFX11-TRUE16-NEXT:    s_sub_i32 s2, s2, s3
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
@@ -6088,22 +6160,42 @@ define amdgpu_kernel void @frem_v2f16(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; GFX11-TRUE16-NEXT:  .LBB9_6: ; %frem.loop_body27
 ; GFX11-TRUE16-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
-; GFX11-TRUE16-NEXT:    v_mul_f32_e32 v5, v2, v4
+; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v7, v4
 ; GFX11-TRUE16-NEXT:    s_add_i32 s2, s2, -11
 ; GFX11-TRUE16-NEXT:    s_cmp_gt_i32 s2, 11
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_rndne_f32_e32 v5, v5
-; GFX11-TRUE16-NEXT:    v_fma_f32 v2, -v5, v3, v2
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v2
-; GFX11-TRUE16-NEXT:    v_add_f32_e32 v5, v2, v3
-; GFX11-TRUE16-NEXT:    v_cndmask_b32_e32 v2, v2, v5, vcc_lo
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_ldexp_f32 v2, v2, 11
+; GFX11-TRUE16-NEXT:    v_mul_f32_e32 v4, v7, v5
+; GFX11-TRUE16-NEXT:    v_rndne_f32_e32 v4, v4
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_fma_f32 v4, -v4, v3, v7
+; GFX11-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v4
+; GFX11-TRUE16-NEXT:    v_add_f32_e32 v6, v4, v3
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_cndmask_b32_e32 v4, v4, v6, vcc_lo
+; GFX11-TRUE16-NEXT:    v_ldexp_f32 v4, v4, 11
 ; GFX11-TRUE16-NEXT:    s_cbranch_scc1 .LBB9_6
-; GFX11-TRUE16-NEXT:  .LBB9_7: ; %frem.loop_exit28
-; GFX11-TRUE16-NEXT:    ; implicit-def: $vgpr2
-; GFX11-TRUE16-NEXT:  .LBB9_8:
+; GFX11-TRUE16-NEXT:  ; %bb.7: ; %Flow55
+; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v6, s2
+; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v4, v7
+; GFX11-TRUE16-NEXT:  .LBB9_8: ; %frem.loop_exit28
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_add_nc_u32_e32 v6, -10, v6
+; GFX11-TRUE16-NEXT:    v_ldexp_f32 v4, v4, v6
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_mul_f32_e32 v5, v4, v5
+; GFX11-TRUE16-NEXT:    v_rndne_f32_e32 v5, v5
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_fma_f32 v4, -v5, v3, v4
+; GFX11-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v4
+; GFX11-TRUE16-NEXT:    v_add_f32_e32 v3, v4, v3
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_cndmask_b32_e32 v3, v4, v3, vcc_lo
+; GFX11-TRUE16-NEXT:    v_ldexp_f32 v2, v3, v2
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v3.l, v0.l
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_cvt_f16_f32_e32 v2.l, v2
+; GFX11-TRUE16-NEXT:    v_bfi_b32 v2, 0x7fff, v2, v3
+; GFX11-TRUE16-NEXT:  .LBB9_9:
 ; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v3, 16, v0
 ; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v4, 16, v1
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
@@ -6111,81 +6203,102 @@ define amdgpu_kernel void @frem_v2f16(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e64 v6, |v4.l|
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX11-TRUE16-NEXT:    v_cmp_ngt_f32_e32 vcc_lo, v7, v6
-; GFX11-TRUE16-NEXT:    s_cbranch_vccz .LBB9_10
-; GFX11-TRUE16-NEXT:  ; %bb.9: ; %frem.else
+; GFX11-TRUE16-NEXT:    s_cbranch_vccz .LBB9_11
+; GFX11-TRUE16-NEXT:  ; %bb.10: ; %frem.else
 ; GFX11-TRUE16-NEXT:    v_and_b16 v0.h, 0x8000, v3.l
 ; GFX11-TRUE16-NEXT:    v_cmp_eq_f32_e32 vcc_lo, v7, v6
 ; GFX11-TRUE16-NEXT:    s_mov_b32 s2, 0
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX11-TRUE16-NEXT:    v_cndmask_b16 v5.l, v3.l, v0.h, vcc_lo
-; GFX11-TRUE16-NEXT:    s_branch .LBB9_11
-; GFX11-TRUE16-NEXT:  .LBB9_10:
+; GFX11-TRUE16-NEXT:    s_branch .LBB9_12
+; GFX11-TRUE16-NEXT:  .LBB9_11:
 ; GFX11-TRUE16-NEXT:    s_mov_b32 s2, -1
 ; GFX11-TRUE16-NEXT:    ; implicit-def: $vgpr5
-; GFX11-TRUE16-NEXT:  .LBB9_11: ; %Flow53
+; GFX11-TRUE16-NEXT:  .LBB9_12: ; %Flow53
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX11-TRUE16-NEXT:    s_and_b32 s2, s2, exec_lo
 ; GFX11-TRUE16-NEXT:    s_cselect_b32 s2, 1, 0
 ; GFX11-TRUE16-NEXT:    s_cmp_lg_u32 s2, 1
-; GFX11-TRUE16-NEXT:    s_cbranch_scc1 .LBB9_16
-; GFX11-TRUE16-NEXT:  ; %bb.12: ; %frem.compute
-; GFX11-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v8, v7
+; GFX11-TRUE16-NEXT:    s_cbranch_scc1 .LBB9_18
+; GFX11-TRUE16-NEXT:  ; %bb.13: ; %frem.compute
 ; GFX11-TRUE16-NEXT:    v_frexp_mant_f32_e32 v5, v7
-; GFX11-TRUE16-NEXT:    v_frexp_mant_f32_e32 v7, v6
-; GFX11-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v6, v6
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX11-TRUE16-NEXT:    v_frexp_mant_f32_e32 v9, v6
+; GFX11-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v8, v7
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_4)
+; GFX11-TRUE16-NEXT:    v_ldexp_f32 v7, v5, 11
+; GFX11-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v5, v6
+; GFX11-TRUE16-NEXT:    v_ldexp_f32 v6, v9, 1
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_3)
 ; GFX11-TRUE16-NEXT:    v_readfirstlane_b32 s2, v8
-; GFX11-TRUE16-NEXT:    v_ldexp_f32 v5, v5, 11
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_2) | instid1(VALU_DEP_2)
-; GFX11-TRUE16-NEXT:    v_readfirstlane_b32 s3, v6
-; GFX11-TRUE16-NEXT:    v_add_nc_u32_e32 v9, -1, v6
-; GFX11-TRUE16-NEXT:    v_ldexp_f32 v6, v7, 1
-; GFX11-TRUE16-NEXT:    v_not_b32_e32 v7, v9
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX11-TRUE16-NEXT:    v_div_scale_f32 v9, null, v6, v6, 1.0
-; GFX11-TRUE16-NEXT:    v_add_nc_u32_e32 v8, v7, v8
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_4) | instid1(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_rcp_f32_e32 v10, v9
-; GFX11-TRUE16-NEXT:    v_div_scale_f32 v7, vcc_lo, 1.0, v6, 1.0
+; GFX11-TRUE16-NEXT:    v_readfirstlane_b32 s3, v5
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX11-TRUE16-NEXT:    v_div_scale_f32 v10, null, v6, v6, 1.0
+; GFX11-TRUE16-NEXT:    v_add_nc_u32_e32 v5, -1, v5
+; GFX11-TRUE16-NEXT:    v_rcp_f32_e32 v11, v10
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_not_b32_e32 v9, v5
+; GFX11-TRUE16-NEXT:    v_add_nc_u32_e32 v9, v9, v8
+; GFX11-TRUE16-NEXT:    v_div_scale_f32 v8, vcc_lo, 1.0, v6, 1.0
 ; GFX11-TRUE16-NEXT:    s_denorm_mode 15
 ; GFX11-TRUE16-NEXT:    s_waitcnt_depctr depctr_va_vdst(0)
-; GFX11-TRUE16-NEXT:    v_fma_f32 v11, -v9, v10, 1.0
-; GFX11-TRUE16-NEXT:    v_fmac_f32_e32 v10, v11, v10
+; GFX11-TRUE16-NEXT:    v_fma_f32 v12, -v10, v11, 1.0
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_mul_f32_e32 v11, v7, v10
-; GFX11-TRUE16-NEXT:    v_fma_f32 v12, -v9, v11, v7
+; GFX11-TRUE16-NEXT:    v_fmac_f32_e32 v11, v12, v11
+; GFX11-TRUE16-NEXT:    v_mul_f32_e32 v12, v8, v11
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_fmac_f32_e32 v11, v12, v10
-; GFX11-TRUE16-NEXT:    v_fma_f32 v7, -v9, v11, v7
+; GFX11-TRUE16-NEXT:    v_fma_f32 v13, -v10, v12, v8
+; GFX11-TRUE16-NEXT:    v_fmac_f32_e32 v12, v13, v11
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_fma_f32 v8, -v10, v12, v8
 ; GFX11-TRUE16-NEXT:    s_denorm_mode 12
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GFX11-TRUE16-NEXT:    v_div_fmas_f32 v7, v7, v10, v11
-; GFX11-TRUE16-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 12, v8
-; GFX11-TRUE16-NEXT:    v_div_fixup_f32 v7, v7, v6, 1.0
-; GFX11-TRUE16-NEXT:    s_cbranch_vccnz .LBB9_15
-; GFX11-TRUE16-NEXT:  ; %bb.13: ; %frem.loop_body.preheader
+; GFX11-TRUE16-NEXT:    v_div_fmas_f32 v8, v8, v11, v12
+; GFX11-TRUE16-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 12, v9
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX11-TRUE16-NEXT:    v_div_fixup_f32 v8, v8, v6, 1.0
+; GFX11-TRUE16-NEXT:    s_cbranch_vccnz .LBB9_17
+; GFX11-TRUE16-NEXT:  ; %bb.14: ; %frem.loop_body.preheader
 ; GFX11-TRUE16-NEXT:    s_sub_i32 s2, s2, s3
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
 ; GFX11-TRUE16-NEXT:    s_add_i32 s2, s2, 11
-; GFX11-TRUE16-NEXT:  .LBB9_14: ; %frem.loop_body
+; GFX11-TRUE16-NEXT:  .LBB9_15: ; %frem.loop_body
 ; GFX11-TRUE16-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
-; GFX11-TRUE16-NEXT:    v_mul_f32_e32 v8, v5, v7
+; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v10, v7
 ; GFX11-TRUE16-NEXT:    s_add_i32 s2, s2, -11
 ; GFX11-TRUE16-NEXT:    s_cmp_gt_i32 s2, 11
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_mul_f32_e32 v7, v10, v8
+; GFX11-TRUE16-NEXT:    v_rndne_f32_e32 v7, v7
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_fma_f32 v7, -v7, v6, v10
+; GFX11-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v7
+; GFX11-TRUE16-NEXT:    v_add_f32_e32 v9, v7, v6
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_cndmask_b32_e32 v7, v7, v9, vcc_lo
+; GFX11-TRUE16-NEXT:    v_ldexp_f32 v7, v7, 11
+; GFX11-TRUE16-NEXT:    s_cbranch_scc1 .LBB9_15
+; GFX11-TRUE16-NEXT:  ; %bb.16: ; %Flow
+; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v9, s2
+; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v7, v10
+; GFX11-TRUE16-NEXT:  .LBB9_17: ; %frem.loop_exit
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_add_nc_u32_e32 v9, -10, v9
+; GFX11-TRUE16-NEXT:    v_ldexp_f32 v7, v7, v9
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_mul_f32_e32 v8, v7, v8
 ; GFX11-TRUE16-NEXT:    v_rndne_f32_e32 v8, v8
-; GFX11-TRUE16-NEXT:    v_fma_f32 v5, -v8, v6, v5
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v5
-; GFX11-TRUE16-NEXT:    v_add_f32_e32 v8, v5, v6
-; GFX11-TRUE16-NEXT:    v_cndmask_b32_e32 v5, v5, v8, vcc_lo
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_ldexp_f32 v5, v5, 11
-; GFX11-TRUE16-NEXT:    s_cbranch_scc1 .LBB9_14
-; GFX11-TRUE16-NEXT:  .LBB9_15: ; %frem.loop_exit
-; GFX11-TRUE16-NEXT:    ; implicit-def: $vgpr5
-; GFX11-TRUE16-NEXT:  .LBB9_16: ; %Flow54
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_fma_f32 v7, -v8, v6, v7
+; GFX11-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v7
+; GFX11-TRUE16-NEXT:    v_add_f32_e32 v6, v7, v6
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_cndmask_b32_e32 v6, v7, v6, vcc_lo
+; GFX11-TRUE16-NEXT:    v_ldexp_f32 v5, v6, v5
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v6.l, v3.l
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_cvt_f16_f32_e32 v5.l, v5
+; GFX11-TRUE16-NEXT:    v_bfi_b32 v5, 0x7fff, v5, v6
+; GFX11-TRUE16-NEXT:  .LBB9_18: ; %Flow54
 ; GFX11-TRUE16-NEXT:    v_cmp_lg_f16_e32 vcc_lo, 0, v1.l
 ; GFX11-TRUE16-NEXT:    v_cmp_nle_f16_e64 s2, 0x7c00, |v0.l|
 ; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v1, 0
@@ -6464,41 +6577,42 @@ define amdgpu_kernel void @frem_v2f16(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; GFX1150-TRUE16-NEXT:    s_and_b32 s7, s7, exec_lo
 ; GFX1150-TRUE16-NEXT:    s_cselect_b32 s7, 1, 0
 ; GFX1150-TRUE16-NEXT:    s_cmp_lg_u32 s7, 1
-; GFX1150-TRUE16-NEXT:    s_cbranch_scc1 .LBB9_8
+; GFX1150-TRUE16-NEXT:    s_cbranch_scc1 .LBB9_9
 ; GFX1150-TRUE16-NEXT:  ; %bb.4: ; %frem.compute19
 ; GFX1150-TRUE16-NEXT:    v_frexp_mant_f32_e32 v1, s5
-; GFX1150-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v3, s5
-; GFX1150-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v2, s6
 ; GFX1150-TRUE16-NEXT:    v_frexp_mant_f32_e32 v0, s6
-; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX1150-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v3, s6
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
 ; GFX1150-TRUE16-NEXT:    v_ldexp_f32 v1, v1, 1
-; GFX1150-TRUE16-NEXT:    v_readfirstlane_b32 s5, v3
-; GFX1150-TRUE16-NEXT:    v_add_nc_u32_e32 v3, -1, v3
-; GFX1150-TRUE16-NEXT:    v_readfirstlane_b32 s6, v2
-; GFX1150-TRUE16-NEXT:    v_ldexp_f32 v0, v0, 11
-; GFX1150-TRUE16-NEXT:    v_div_scale_f32 v4, null, v1, v1, 1.0
-; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX1150-TRUE16-NEXT:    v_not_b32_e32 v3, v3
-; GFX1150-TRUE16-NEXT:    v_rcp_f32_e32 v5, v4
-; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_2) | instid1(TRANS32_DEP_1)
-; GFX1150-TRUE16-NEXT:    v_add_nc_u32_e32 v3, v3, v2
-; GFX1150-TRUE16-NEXT:    v_div_scale_f32 v2, vcc_lo, 1.0, v1, 1.0
+; GFX1150-TRUE16-NEXT:    v_ldexp_f32 v2, v0, 11
+; GFX1150-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v0, s5
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX1150-TRUE16-NEXT:    v_readfirstlane_b32 s6, v3
+; GFX1150-TRUE16-NEXT:    v_div_scale_f32 v5, null, v1, v1, 1.0
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_3)
+; GFX1150-TRUE16-NEXT:    v_readfirstlane_b32 s5, v0
+; GFX1150-TRUE16-NEXT:    v_add_nc_u32_e32 v0, -1, v0
+; GFX1150-TRUE16-NEXT:    v_rcp_f32_e32 v6, v5
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_not_b32_e32 v4, v0
+; GFX1150-TRUE16-NEXT:    v_add_nc_u32_e32 v4, v4, v3
+; GFX1150-TRUE16-NEXT:    v_div_scale_f32 v3, vcc_lo, 1.0, v1, 1.0
 ; GFX1150-TRUE16-NEXT:    s_denorm_mode 15
-; GFX1150-TRUE16-NEXT:    v_fma_f32 v6, -v4, v5, 1.0
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(TRANS32_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_fma_f32 v7, -v5, v6, 1.0
+; GFX1150-TRUE16-NEXT:    v_fmac_f32_e32 v6, v7, v6
 ; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1150-TRUE16-NEXT:    v_fmac_f32_e32 v5, v6, v5
-; GFX1150-TRUE16-NEXT:    v_mul_f32_e32 v6, v2, v5
+; GFX1150-TRUE16-NEXT:    v_mul_f32_e32 v7, v3, v6
+; GFX1150-TRUE16-NEXT:    v_fma_f32 v8, -v5, v7, v3
 ; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1150-TRUE16-NEXT:    v_fma_f32 v7, -v4, v6, v2
-; GFX1150-TRUE16-NEXT:    v_fmac_f32_e32 v6, v7, v5
-; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
-; GFX1150-TRUE16-NEXT:    v_fma_f32 v2, -v4, v6, v2
+; GFX1150-TRUE16-NEXT:    v_fmac_f32_e32 v7, v8, v6
+; GFX1150-TRUE16-NEXT:    v_fma_f32 v3, -v5, v7, v3
 ; GFX1150-TRUE16-NEXT:    s_denorm_mode 12
-; GFX1150-TRUE16-NEXT:    v_div_fmas_f32 v2, v2, v5, v6
-; GFX1150-TRUE16-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 12, v3
-; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX1150-TRUE16-NEXT:    v_div_fixup_f32 v2, v2, v1, 1.0
-; GFX1150-TRUE16-NEXT:    s_cbranch_vccnz .LBB9_7
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1150-TRUE16-NEXT:    v_div_fmas_f32 v3, v3, v6, v7
+; GFX1150-TRUE16-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 12, v4
+; GFX1150-TRUE16-NEXT:    v_div_fixup_f32 v3, v3, v1, 1.0
+; GFX1150-TRUE16-NEXT:    s_cbranch_vccnz .LBB9_8
 ; GFX1150-TRUE16-NEXT:  ; %bb.5: ; %frem.loop_body27.preheader
 ; GFX1150-TRUE16-NEXT:    s_sub_i32 s5, s6, s5
 ; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
@@ -6506,107 +6620,154 @@ define amdgpu_kernel void @frem_v2f16(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; GFX1150-TRUE16-NEXT:  .LBB9_6: ; %frem.loop_body27
 ; GFX1150-TRUE16-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
-; GFX1150-TRUE16-NEXT:    v_mul_f32_e32 v3, v0, v2
+; GFX1150-TRUE16-NEXT:    v_mov_b32_e32 v5, v2
 ; GFX1150-TRUE16-NEXT:    s_add_i32 s5, s5, -11
 ; GFX1150-TRUE16-NEXT:    s_cmp_gt_i32 s5, 11
 ; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1150-TRUE16-NEXT:    v_rndne_f32_e32 v3, v3
-; GFX1150-TRUE16-NEXT:    v_xor_b32_e32 v3, 0x80000000, v3
+; GFX1150-TRUE16-NEXT:    v_mul_f32_e32 v2, v5, v3
+; GFX1150-TRUE16-NEXT:    v_rndne_f32_e32 v2, v2
 ; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1150-TRUE16-NEXT:    v_fmac_f32_e32 v0, v3, v1
-; GFX1150-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v0
-; GFX1150-TRUE16-NEXT:    v_add_f32_e32 v3, v0, v1
-; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1150-TRUE16-NEXT:    v_cndmask_b32_e32 v0, v0, v3, vcc_lo
-; GFX1150-TRUE16-NEXT:    v_ldexp_f32 v0, v0, 11
+; GFX1150-TRUE16-NEXT:    v_xor_b32_e32 v2, 0x80000000, v2
+; GFX1150-TRUE16-NEXT:    v_fma_f32 v2, v2, v1, v5
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v2
+; GFX1150-TRUE16-NEXT:    v_add_f32_e32 v4, v2, v1
+; GFX1150-TRUE16-NEXT:    v_cndmask_b32_e32 v2, v2, v4, vcc_lo
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_ldexp_f32 v2, v2, 11
 ; GFX1150-TRUE16-NEXT:    s_cbranch_scc1 .LBB9_6
-; GFX1150-TRUE16-NEXT:  .LBB9_7: ; %frem.loop_exit28
-; GFX1150-TRUE16-NEXT:    ; implicit-def: $vgpr0
-; GFX1150-TRUE16-NEXT:  .LBB9_8:
-; GFX1150-TRUE16-NEXT:    s_lshr_b32 s8, s4, 16
+; GFX1150-TRUE16-NEXT:  ; %bb.7: ; %Flow55
+; GFX1150-TRUE16-NEXT:    v_mov_b32_e32 v4, s5
+; GFX1150-TRUE16-NEXT:    v_mov_b32_e32 v2, v5
+; GFX1150-TRUE16-NEXT:  .LBB9_8: ; %frem.loop_exit28
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_add_nc_u32_e32 v4, -10, v4
+; GFX1150-TRUE16-NEXT:    v_ldexp_f32 v2, v2, v4
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_mul_f32_e32 v3, v2, v3
+; GFX1150-TRUE16-NEXT:    v_rndne_f32_e32 v3, v3
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_xor_b32_e32 v3, 0x80000000, v3
+; GFX1150-TRUE16-NEXT:    v_fmac_f32_e32 v2, v3, v1
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v2
+; GFX1150-TRUE16-NEXT:    v_add_f32_e32 v1, v2, v1
+; GFX1150-TRUE16-NEXT:    v_cndmask_b32_e32 v1, v2, v1, vcc_lo
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1150-TRUE16-NEXT:    v_ldexp_f32 v0, v1, v0
+; GFX1150-TRUE16-NEXT:    v_mov_b16_e32 v1.l, s4
+; GFX1150-TRUE16-NEXT:    v_cvt_f16_f32_e32 v0.l, v0
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_bfi_b32 v0, 0x7fff, v0, v1
+; GFX1150-TRUE16-NEXT:  .LBB9_9:
+; GFX1150-TRUE16-NEXT:    s_lshr_b32 s6, s4, 16
 ; GFX1150-TRUE16-NEXT:    s_lshr_b32 s5, s3, 16
-; GFX1150-TRUE16-NEXT:    s_and_b32 s4, s8, 0x7fff
-; GFX1150-TRUE16-NEXT:    s_and_b32 s6, s5, 0x7fff
-; GFX1150-TRUE16-NEXT:    s_cvt_f32_f16 s7, s4
-; GFX1150-TRUE16-NEXT:    s_cvt_f32_f16 s6, s6
+; GFX1150-TRUE16-NEXT:    s_and_b32 s4, s6, 0x7fff
+; GFX1150-TRUE16-NEXT:    s_and_b32 s7, s5, 0x7fff
+; GFX1150-TRUE16-NEXT:    s_cvt_f32_f16 s8, s4
+; GFX1150-TRUE16-NEXT:    s_cvt_f32_f16 s7, s7
 ; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_3)
-; GFX1150-TRUE16-NEXT:    s_cmp_ngt_f32 s7, s6
-; GFX1150-TRUE16-NEXT:    s_cbranch_scc0 .LBB9_10
-; GFX1150-TRUE16-NEXT:  ; %bb.9: ; %frem.else
-; GFX1150-TRUE16-NEXT:    s_cmp_eq_f32 s7, s6
-; GFX1150-TRUE16-NEXT:    v_and_b16 v0.h, 0x8000, s8
+; GFX1150-TRUE16-NEXT:    s_cmp_ngt_f32 s8, s7
+; GFX1150-TRUE16-NEXT:    s_cbranch_scc0 .LBB9_11
+; GFX1150-TRUE16-NEXT:  ; %bb.10: ; %frem.else
+; GFX1150-TRUE16-NEXT:    s_cmp_eq_f32 s8, s7
+; GFX1150-TRUE16-NEXT:    v_and_b16 v0.h, 0x8000, s6
 ; GFX1150-TRUE16-NEXT:    s_cselect_b32 s9, -1, 0
 ; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
-; GFX1150-TRUE16-NEXT:    v_cndmask_b16 v1.l, s8, v0.h, s9
-; GFX1150-TRUE16-NEXT:    s_mov_b32 s8, 0
-; GFX1150-TRUE16-NEXT:    s_branch .LBB9_11
-; GFX1150-TRUE16-NEXT:  .LBB9_10:
-; GFX1150-TRUE16-NEXT:    s_mov_b32 s8, -1
+; GFX1150-TRUE16-NEXT:    v_cndmask_b16 v1.l, s6, v0.h, s9
+; GFX1150-TRUE16-NEXT:    s_mov_b32 s9, 0
+; GFX1150-TRUE16-NEXT:    s_branch .LBB9_12
+; GFX1150-TRUE16-NEXT:  .LBB9_11:
+; GFX1150-TRUE16-NEXT:    s_mov_b32 s9, -1
 ; GFX1150-TRUE16-NEXT:    ; implicit-def: $vgpr1
-; GFX1150-TRUE16-NEXT:  .LBB9_11: ; %Flow53
+; GFX1150-TRUE16-NEXT:  .LBB9_12: ; %Flow53
 ; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
-; GFX1150-TRUE16-NEXT:    s_and_b32 s8, s8, exec_lo
-; GFX1150-TRUE16-NEXT:    s_cselect_b32 s8, 1, 0
-; GFX1150-TRUE16-NEXT:    s_cmp_lg_u32 s8, 1
-; GFX1150-TRUE16-NEXT:    s_cbranch_scc1 .LBB9_16
-; GFX1150-TRUE16-NEXT:  ; %bb.12: ; %frem.compute
-; GFX1150-TRUE16-NEXT:    v_frexp_mant_f32_e32 v2, s6
-; GFX1150-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v4, s6
-; GFX1150-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v3, s7
-; GFX1150-TRUE16-NEXT:    v_frexp_mant_f32_e32 v1, s7
-; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX1150-TRUE16-NEXT:    s_and_b32 s9, s9, exec_lo
+; GFX1150-TRUE16-NEXT:    s_cselect_b32 s9, 1, 0
+; GFX1150-TRUE16-NEXT:    s_cmp_lg_u32 s9, 1
+; GFX1150-TRUE16-NEXT:    s_cbranch_scc1 .LBB9_18
+; GFX1150-TRUE16-NEXT:  ; %bb.13: ; %frem.compute
+; GFX1150-TRUE16-NEXT:    v_frexp_mant_f32_e32 v2, s7
+; GFX1150-TRUE16-NEXT:    v_frexp_mant_f32_e32 v1, s8
+; GFX1150-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v4, s8
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
 ; GFX1150-TRUE16-NEXT:    v_ldexp_f32 v2, v2, 1
-; GFX1150-TRUE16-NEXT:    v_readfirstlane_b32 s6, v4
-; GFX1150-TRUE16-NEXT:    v_add_nc_u32_e32 v4, -1, v4
-; GFX1150-TRUE16-NEXT:    v_readfirstlane_b32 s7, v3
-; GFX1150-TRUE16-NEXT:    v_ldexp_f32 v1, v1, 11
-; GFX1150-TRUE16-NEXT:    v_div_scale_f32 v5, null, v2, v2, 1.0
-; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX1150-TRUE16-NEXT:    v_not_b32_e32 v4, v4
-; GFX1150-TRUE16-NEXT:    v_rcp_f32_e32 v6, v5
-; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_2) | instid1(TRANS32_DEP_1)
-; GFX1150-TRUE16-NEXT:    v_add_nc_u32_e32 v4, v4, v3
-; GFX1150-TRUE16-NEXT:    v_div_scale_f32 v3, vcc_lo, 1.0, v2, 1.0
+; GFX1150-TRUE16-NEXT:    v_ldexp_f32 v3, v1, 11
+; GFX1150-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v1, s7
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX1150-TRUE16-NEXT:    v_readfirstlane_b32 s8, v4
+; GFX1150-TRUE16-NEXT:    v_div_scale_f32 v6, null, v2, v2, 1.0
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_3)
+; GFX1150-TRUE16-NEXT:    v_readfirstlane_b32 s7, v1
+; GFX1150-TRUE16-NEXT:    v_add_nc_u32_e32 v1, -1, v1
+; GFX1150-TRUE16-NEXT:    v_rcp_f32_e32 v7, v6
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_not_b32_e32 v5, v1
+; GFX1150-TRUE16-NEXT:    v_add_nc_u32_e32 v5, v5, v4
+; GFX1150-TRUE16-NEXT:    v_div_scale_f32 v4, vcc_lo, 1.0, v2, 1.0
 ; GFX1150-TRUE16-NEXT:    s_denorm_mode 15
-; GFX1150-TRUE16-NEXT:    v_fma_f32 v7, -v5, v6, 1.0
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(TRANS32_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_fma_f32 v8, -v6, v7, 1.0
+; GFX1150-TRUE16-NEXT:    v_fmac_f32_e32 v7, v8, v7
 ; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1150-TRUE16-NEXT:    v_fmac_f32_e32 v6, v7, v6
-; GFX1150-TRUE16-NEXT:    v_mul_f32_e32 v7, v3, v6
+; GFX1150-TRUE16-NEXT:    v_mul_f32_e32 v8, v4, v7
+; GFX1150-TRUE16-NEXT:    v_fma_f32 v9, -v6, v8, v4
 ; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1150-TRUE16-NEXT:    v_fma_f32 v8, -v5, v7, v3
-; GFX1150-TRUE16-NEXT:    v_fmac_f32_e32 v7, v8, v6
-; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
-; GFX1150-TRUE16-NEXT:    v_fma_f32 v3, -v5, v7, v3
+; GFX1150-TRUE16-NEXT:    v_fmac_f32_e32 v8, v9, v7
+; GFX1150-TRUE16-NEXT:    v_fma_f32 v4, -v6, v8, v4
 ; GFX1150-TRUE16-NEXT:    s_denorm_mode 12
-; GFX1150-TRUE16-NEXT:    v_div_fmas_f32 v3, v3, v6, v7
-; GFX1150-TRUE16-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 12, v4
-; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX1150-TRUE16-NEXT:    v_div_fixup_f32 v3, v3, v2, 1.0
-; GFX1150-TRUE16-NEXT:    s_cbranch_vccnz .LBB9_15
-; GFX1150-TRUE16-NEXT:  ; %bb.13: ; %frem.loop_body.preheader
-; GFX1150-TRUE16-NEXT:    s_sub_i32 s6, s7, s6
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1150-TRUE16-NEXT:    v_div_fmas_f32 v4, v4, v7, v8
+; GFX1150-TRUE16-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 12, v5
+; GFX1150-TRUE16-NEXT:    v_div_fixup_f32 v4, v4, v2, 1.0
+; GFX1150-TRUE16-NEXT:    s_cbranch_vccnz .LBB9_17
+; GFX1150-TRUE16-NEXT:  ; %bb.14: ; %frem.loop_body.preheader
+; GFX1150-TRUE16-NEXT:    s_sub_i32 s7, s8, s7
 ; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX1150-TRUE16-NEXT:    s_add_i32 s6, s6, 11
-; GFX1150-TRUE16-NEXT:  .LBB9_14: ; %frem.loop_body
+; GFX1150-TRUE16-NEXT:    s_add_i32 s7, s7, 11
+; GFX1150-TRUE16-NEXT:  .LBB9_15: ; %frem.loop_body
 ; GFX1150-TRUE16-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
-; GFX1150-TRUE16-NEXT:    v_mul_f32_e32 v4, v1, v3
-; GFX1150-TRUE16-NEXT:    s_add_i32 s6, s6, -11
-; GFX1150-TRUE16-NEXT:    s_cmp_gt_i32 s6, 11
+; GFX1150-TRUE16-NEXT:    v_mov_b32_e32 v6, v3
+; GFX1150-TRUE16-NEXT:    s_add_i32 s7, s7, -11
+; GFX1150-TRUE16-NEXT:    s_cmp_gt_i32 s7, 11
 ; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_mul_f32_e32 v3, v6, v4
+; GFX1150-TRUE16-NEXT:    v_rndne_f32_e32 v3, v3
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_xor_b32_e32 v3, 0x80000000, v3
+; GFX1150-TRUE16-NEXT:    v_fma_f32 v3, v3, v2, v6
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v3
+; GFX1150-TRUE16-NEXT:    v_add_f32_e32 v5, v3, v2
+; GFX1150-TRUE16-NEXT:    v_cndmask_b32_e32 v3, v3, v5, vcc_lo
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_ldexp_f32 v3, v3, 11
+; GFX1150-TRUE16-NEXT:    s_cbranch_scc1 .LBB9_15
+; GFX1150-TRUE16-NEXT:  ; %bb.16: ; %Flow
+; GFX1150-TRUE16-NEXT:    v_mov_b32_e32 v5, s7
+; GFX1150-TRUE16-NEXT:    v_mov_b32_e32 v3, v6
+; GFX1150-TRUE16-NEXT:  .LBB9_17: ; %frem.loop_exit
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_add_nc_u32_e32 v5, -10, v5
+; GFX1150-TRUE16-NEXT:    v_ldexp_f32 v3, v3, v5
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_mul_f32_e32 v4, v3, v4
 ; GFX1150-TRUE16-NEXT:    v_rndne_f32_e32 v4, v4
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX1150-TRUE16-NEXT:    v_xor_b32_e32 v4, 0x80000000, v4
-; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1150-TRUE16-NEXT:    v_fmac_f32_e32 v1, v4, v2
-; GFX1150-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v1
-; GFX1150-TRUE16-NEXT:    v_add_f32_e32 v4, v1, v2
-; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1150-TRUE16-NEXT:    v_cndmask_b32_e32 v1, v1, v4, vcc_lo
-; GFX1150-TRUE16-NEXT:    v_ldexp_f32 v1, v1, 11
-; GFX1150-TRUE16-NEXT:    s_cbranch_scc1 .LBB9_14
-; GFX1150-TRUE16-NEXT:  .LBB9_15: ; %frem.loop_exit
-; GFX1150-TRUE16-NEXT:    ; implicit-def: $vgpr1
-; GFX1150-TRUE16-NEXT:  .LBB9_16: ; %Flow54
+; GFX1150-TRUE16-NEXT:    v_fmac_f32_e32 v3, v4, v2
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v3
+; GFX1150-TRUE16-NEXT:    v_add_f32_e32 v2, v3, v2
+; GFX1150-TRUE16-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc_lo
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1150-TRUE16-NEXT:    v_ldexp_f32 v1, v2, v1
+; GFX1150-TRUE16-NEXT:    v_mov_b16_e32 v2.l, s6
+; GFX1150-TRUE16-NEXT:    v_cvt_f16_f32_e32 v1.l, v1
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_bfi_b32 v1, 0x7fff, v1, v2
+; GFX1150-TRUE16-NEXT:  .LBB9_18: ; %Flow54
 ; GFX1150-TRUE16-NEXT:    s_cmp_lg_f16 s3, 0
 ; GFX1150-TRUE16-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX1150-TRUE16-NEXT:    s_cselect_b32 s3, -1, 0
@@ -6911,41 +7072,42 @@ define amdgpu_kernel void @frem_v2f16(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; GFX1200-TRUE16-NEXT:    s_cselect_b32 s7, 1, 0
 ; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX1200-TRUE16-NEXT:    s_cmp_lg_u32 s7, 1
-; GFX1200-TRUE16-NEXT:    s_cbranch_scc1 .LBB9_8
+; GFX1200-TRUE16-NEXT:    s_cbranch_scc1 .LBB9_9
 ; GFX1200-TRUE16-NEXT:  ; %bb.4: ; %frem.compute19
 ; GFX1200-TRUE16-NEXT:    v_frexp_mant_f32_e32 v1, s5
-; GFX1200-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v3, s5
-; GFX1200-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v2, s6
 ; GFX1200-TRUE16-NEXT:    v_frexp_mant_f32_e32 v0, s6
-; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX1200-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v3, s6
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
 ; GFX1200-TRUE16-NEXT:    v_ldexp_f32 v1, v1, 1
-; GFX1200-TRUE16-NEXT:    v_readfirstlane_b32 s5, v3
-; GFX1200-TRUE16-NEXT:    v_add_nc_u32_e32 v3, -1, v3
-; GFX1200-TRUE16-NEXT:    v_readfirstlane_b32 s6, v2
-; GFX1200-TRUE16-NEXT:    v_ldexp_f32 v0, v0, 11
-; GFX1200-TRUE16-NEXT:    v_div_scale_f32 v4, null, v1, v1, 1.0
-; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX1200-TRUE16-NEXT:    v_not_b32_e32 v3, v3
-; GFX1200-TRUE16-NEXT:    v_rcp_f32_e32 v5, v4
-; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_2) | instid1(TRANS32_DEP_1)
-; GFX1200-TRUE16-NEXT:    v_add_nc_u32_e32 v3, v3, v2
-; GFX1200-TRUE16-NEXT:    v_div_scale_f32 v2, vcc_lo, 1.0, v1, 1.0
+; GFX1200-TRUE16-NEXT:    v_ldexp_f32 v2, v0, 11
+; GFX1200-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v0, s5
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX1200-TRUE16-NEXT:    v_readfirstlane_b32 s6, v3
+; GFX1200-TRUE16-NEXT:    v_div_scale_f32 v5, null, v1, v1, 1.0
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_3)
+; GFX1200-TRUE16-NEXT:    v_readfirstlane_b32 s5, v0
+; GFX1200-TRUE16-NEXT:    v_add_nc_u32_e32 v0, -1, v0
+; GFX1200-TRUE16-NEXT:    v_rcp_f32_e32 v6, v5
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1200-TRUE16-NEXT:    v_not_b32_e32 v4, v0
+; GFX1200-TRUE16-NEXT:    v_add_nc_u32_e32 v4, v4, v3
+; GFX1200-TRUE16-NEXT:    v_div_scale_f32 v3, vcc_lo, 1.0, v1, 1.0
 ; GFX1200-TRUE16-NEXT:    s_denorm_mode 15
-; GFX1200-TRUE16-NEXT:    v_fma_f32 v6, -v4, v5, 1.0
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(TRANS32_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1200-TRUE16-NEXT:    v_fma_f32 v7, -v5, v6, 1.0
+; GFX1200-TRUE16-NEXT:    v_fmac_f32_e32 v6, v7, v6
 ; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1200-TRUE16-NEXT:    v_fmac_f32_e32 v5, v6, v5
-; GFX1200-TRUE16-NEXT:    v_mul_f32_e32 v6, v2, v5
+; GFX1200-TRUE16-NEXT:    v_mul_f32_e32 v7, v3, v6
+; GFX1200-TRUE16-NEXT:    v_fma_f32 v8, -v5, v7, v3
 ; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1200-TRUE16-NEXT:    v_fma_f32 v7, -v4, v6, v2
-; GFX1200-TRUE16-NEXT:    v_fmac_f32_e32 v6, v7, v5
-; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
-; GFX1200-TRUE16-NEXT:    v_fma_f32 v2, -v4, v6, v2
+; GFX1200-TRUE16-NEXT:    v_fmac_f32_e32 v7, v8, v6
+; GFX1200-TRUE16-NEXT:    v_fma_f32 v3, -v5, v7, v3
 ; GFX1200-TRUE16-NEXT:    s_denorm_mode 12
-; GFX1200-TRUE16-NEXT:    v_div_fmas_f32 v2, v2, v5, v6
-; GFX1200-TRUE16-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 12, v3
-; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX1200-TRUE16-NEXT:    v_div_fixup_f32 v2, v2, v1, 1.0
-; GFX1200-TRUE16-NEXT:    s_cbranch_vccnz .LBB9_7
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1200-TRUE16-NEXT:    v_div_fmas_f32 v3, v3, v6, v7
+; GFX1200-TRUE16-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 12, v4
+; GFX1200-TRUE16-NEXT:    v_div_fixup_f32 v3, v3, v1, 1.0
+; GFX1200-TRUE16-NEXT:    s_cbranch_vccnz .LBB9_8
 ; GFX1200-TRUE16-NEXT:  ; %bb.5: ; %frem.loop_body27.preheader
 ; GFX1200-TRUE16-NEXT:    s_sub_co_i32 s5, s6, s5
 ; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
@@ -6953,119 +7115,165 @@ define amdgpu_kernel void @frem_v2f16(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; GFX1200-TRUE16-NEXT:  .LBB9_6: ; %frem.loop_body27
 ; GFX1200-TRUE16-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1200-TRUE16-NEXT:    v_mul_f32_e32 v3, v0, v2
+; GFX1200-TRUE16-NEXT:    v_mov_b32_e32 v5, v2
 ; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX1200-TRUE16-NEXT:    s_add_co_i32 s5, s5, -11
 ; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX1200-TRUE16-NEXT:    s_cmp_gt_i32 s5, 11
+; GFX1200-TRUE16-NEXT:    v_mul_f32_e32 v2, v5, v3
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1200-TRUE16-NEXT:    v_rndne_f32_e32 v2, v2
+; GFX1200-TRUE16-NEXT:    v_xor_b32_e32 v2, 0x80000000, v2
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1200-TRUE16-NEXT:    v_fma_f32 v2, v2, v1, v5
+; GFX1200-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v2
+; GFX1200-TRUE16-NEXT:    v_add_f32_e32 v4, v2, v1
+; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1200-TRUE16-NEXT:    v_cndmask_b32_e32 v2, v2, v4, vcc_lo
+; GFX1200-TRUE16-NEXT:    v_ldexp_f32 v2, v2, 11
+; GFX1200-TRUE16-NEXT:    s_cbranch_scc1 .LBB9_6
+; GFX1200-TRUE16-NEXT:  ; %bb.7: ; %Flow55
+; GFX1200-TRUE16-NEXT:    v_mov_b32_e32 v4, s5
+; GFX1200-TRUE16-NEXT:    v_mov_b32_e32 v2, v5
+; GFX1200-TRUE16-NEXT:  .LBB9_8: ; %frem.loop_exit28
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1200-TRUE16-NEXT:    v_add_nc_u32_e32 v4, -10, v4
+; GFX1200-TRUE16-NEXT:    v_ldexp_f32 v2, v2, v4
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1200-TRUE16-NEXT:    v_mul_f32_e32 v3, v2, v3
 ; GFX1200-TRUE16-NEXT:    v_rndne_f32_e32 v3, v3
 ; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX1200-TRUE16-NEXT:    v_xor_b32_e32 v3, 0x80000000, v3
-; GFX1200-TRUE16-NEXT:    v_fmac_f32_e32 v0, v3, v1
+; GFX1200-TRUE16-NEXT:    v_fmac_f32_e32 v2, v3, v1
 ; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_2) | instid1(VALU_DEP_1)
-; GFX1200-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v0
-; GFX1200-TRUE16-NEXT:    v_add_f32_e32 v3, v0, v1
+; GFX1200-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v2
+; GFX1200-TRUE16-NEXT:    v_add_f32_e32 v1, v2, v1
 ; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_va_vcc(0)
-; GFX1200-TRUE16-NEXT:    v_cndmask_b32_e32 v0, v0, v3, vcc_lo
+; GFX1200-TRUE16-NEXT:    v_cndmask_b32_e32 v1, v2, v1, vcc_lo
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1200-TRUE16-NEXT:    v_ldexp_f32 v0, v1, v0
+; GFX1200-TRUE16-NEXT:    v_mov_b16_e32 v1.l, s4
+; GFX1200-TRUE16-NEXT:    v_cvt_f16_f32_e32 v0.l, v0
 ; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1200-TRUE16-NEXT:    v_ldexp_f32 v0, v0, 11
-; GFX1200-TRUE16-NEXT:    s_cbranch_scc1 .LBB9_6
-; GFX1200-TRUE16-NEXT:  .LBB9_7: ; %frem.loop_exit28
-; GFX1200-TRUE16-NEXT:    ; implicit-def: $vgpr0
-; GFX1200-TRUE16-NEXT:  .LBB9_8:
-; GFX1200-TRUE16-NEXT:    s_lshr_b32 s8, s4, 16
+; GFX1200-TRUE16-NEXT:    v_bfi_b32 v0, 0x7fff, v0, v1
+; GFX1200-TRUE16-NEXT:  .LBB9_9:
+; GFX1200-TRUE16-NEXT:    s_lshr_b32 s6, s4, 16
 ; GFX1200-TRUE16-NEXT:    s_lshr_b32 s5, s3, 16
-; GFX1200-TRUE16-NEXT:    s_and_b32 s4, s8, 0x7fff
 ; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX1200-TRUE16-NEXT:    s_and_b32 s6, s5, 0x7fff
-; GFX1200-TRUE16-NEXT:    s_cvt_f32_f16 s7, s4
+; GFX1200-TRUE16-NEXT:    s_and_b32 s4, s6, 0x7fff
+; GFX1200-TRUE16-NEXT:    s_and_b32 s7, s5, 0x7fff
 ; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX1200-TRUE16-NEXT:    s_cvt_f32_f16 s6, s6
+; GFX1200-TRUE16-NEXT:    s_cvt_f32_f16 s8, s4
+; GFX1200-TRUE16-NEXT:    s_cvt_f32_f16 s7, s7
 ; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_2)
-; GFX1200-TRUE16-NEXT:    s_cmp_ngt_f32 s7, s6
-; GFX1200-TRUE16-NEXT:    s_cbranch_scc0 .LBB9_10
-; GFX1200-TRUE16-NEXT:  ; %bb.9: ; %frem.else
-; GFX1200-TRUE16-NEXT:    s_cmp_eq_f32 s7, s6
-; GFX1200-TRUE16-NEXT:    v_and_b16 v0.h, 0x8000, s8
+; GFX1200-TRUE16-NEXT:    s_cmp_ngt_f32 s8, s7
+; GFX1200-TRUE16-NEXT:    s_cbranch_scc0 .LBB9_11
+; GFX1200-TRUE16-NEXT:  ; %bb.10: ; %frem.else
+; GFX1200-TRUE16-NEXT:    s_cmp_eq_f32 s8, s7
+; GFX1200-TRUE16-NEXT:    v_and_b16 v0.h, 0x8000, s6
 ; GFX1200-TRUE16-NEXT:    s_cselect_b32 s9, -1, 0
-; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1200-TRUE16-NEXT:    v_cndmask_b16 v1.l, s8, v0.h, s9
-; GFX1200-TRUE16-NEXT:    s_mov_b32 s8, 0
-; GFX1200-TRUE16-NEXT:    s_branch .LBB9_11
-; GFX1200-TRUE16-NEXT:  .LBB9_10:
-; GFX1200-TRUE16-NEXT:    s_mov_b32 s8, -1
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1200-TRUE16-NEXT:    v_cndmask_b16 v1.l, s6, v0.h, s9
+; GFX1200-TRUE16-NEXT:    s_mov_b32 s9, 0
+; GFX1200-TRUE16-NEXT:    s_branch .LBB9_12
+; GFX1200-TRUE16-NEXT:  .LBB9_11:
+; GFX1200-TRUE16-NEXT:    s_mov_b32 s9, -1
 ; GFX1200-TRUE16-NEXT:    ; implicit-def: $vgpr1
-; GFX1200-TRUE16-NEXT:  .LBB9_11: ; %Flow53
+; GFX1200-TRUE16-NEXT:  .LBB9_12: ; %Flow53
 ; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX1200-TRUE16-NEXT:    s_and_b32 s8, s8, exec_lo
-; GFX1200-TRUE16-NEXT:    s_cselect_b32 s8, 1, 0
+; GFX1200-TRUE16-NEXT:    s_and_b32 s9, s9, exec_lo
+; GFX1200-TRUE16-NEXT:    s_cselect_b32 s9, 1, 0
 ; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX1200-TRUE16-NEXT:    s_cmp_lg_u32 s8, 1
-; GFX1200-TRUE16-NEXT:    s_cbranch_scc1 .LBB9_16
-; GFX1200-TRUE16-NEXT:  ; %bb.12: ; %frem.compute
-; GFX1200-TRUE16-NEXT:    v_frexp_mant_f32_e32 v2, s6
-; GFX1200-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v4, s6
-; GFX1200-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v3, s7
-; GFX1200-TRUE16-NEXT:    v_frexp_mant_f32_e32 v1, s7
-; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX1200-TRUE16-NEXT:    s_cmp_lg_u32 s9, 1
+; GFX1200-TRUE16-NEXT:    s_cbranch_scc1 .LBB9_18
+; GFX1200-TRUE16-NEXT:  ; %bb.13: ; %frem.compute
+; GFX1200-TRUE16-NEXT:    v_frexp_mant_f32_e32 v2, s7
+; GFX1200-TRUE16-NEXT:    v_frexp_mant_f32_e32 v1, s8
+; GFX1200-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v4, s8
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
 ; GFX1200-TRUE16-NEXT:    v_ldexp_f32 v2, v2, 1
-; GFX1200-TRUE16-NEXT:    v_readfirstlane_b32 s6, v4
-; GFX1200-TRUE16-NEXT:    v_add_nc_u32_e32 v4, -1, v4
-; GFX1200-TRUE16-NEXT:    v_readfirstlane_b32 s7, v3
-; GFX1200-TRUE16-NEXT:    v_ldexp_f32 v1, v1, 11
-; GFX1200-TRUE16-NEXT:    v_div_scale_f32 v5, null, v2, v2, 1.0
-; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX1200-TRUE16-NEXT:    v_not_b32_e32 v4, v4
-; GFX1200-TRUE16-NEXT:    v_rcp_f32_e32 v6, v5
-; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_2) | instid1(TRANS32_DEP_1)
-; GFX1200-TRUE16-NEXT:    v_add_nc_u32_e32 v4, v4, v3
-; GFX1200-TRUE16-NEXT:    v_div_scale_f32 v3, vcc_lo, 1.0, v2, 1.0
+; GFX1200-TRUE16-NEXT:    v_ldexp_f32 v3, v1, 11
+; GFX1200-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v1, s7
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX1200-TRUE16-NEXT:    v_readfirstlane_b32 s8, v4
+; GFX1200-TRUE16-NEXT:    v_div_scale_f32 v6, null, v2, v2, 1.0
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_3)
+; GFX1200-TRUE16-NEXT:    v_readfirstlane_b32 s7, v1
+; GFX1200-TRUE16-NEXT:    v_add_nc_u32_e32 v1, -1, v1
+; GFX1200-TRUE16-NEXT:    v_rcp_f32_e32 v7, v6
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1200-TRUE16-NEXT:    v_not_b32_e32 v5, v1
+; GFX1200-TRUE16-NEXT:    v_add_nc_u32_e32 v5, v5, v4
+; GFX1200-TRUE16-NEXT:    v_div_scale_f32 v4, vcc_lo, 1.0, v2, 1.0
 ; GFX1200-TRUE16-NEXT:    s_denorm_mode 15
-; GFX1200-TRUE16-NEXT:    v_fma_f32 v7, -v5, v6, 1.0
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(TRANS32_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1200-TRUE16-NEXT:    v_fma_f32 v8, -v6, v7, 1.0
+; GFX1200-TRUE16-NEXT:    v_fmac_f32_e32 v7, v8, v7
 ; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1200-TRUE16-NEXT:    v_fmac_f32_e32 v6, v7, v6
-; GFX1200-TRUE16-NEXT:    v_mul_f32_e32 v7, v3, v6
+; GFX1200-TRUE16-NEXT:    v_mul_f32_e32 v8, v4, v7
+; GFX1200-TRUE16-NEXT:    v_fma_f32 v9, -v6, v8, v4
 ; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1200-TRUE16-NEXT:    v_fma_f32 v8, -v5, v7, v3
-; GFX1200-TRUE16-NEXT:    v_fmac_f32_e32 v7, v8, v6
-; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_2) | instid1(VALU_DEP_1)
-; GFX1200-TRUE16-NEXT:    v_fma_f32 v3, -v5, v7, v3
+; GFX1200-TRUE16-NEXT:    v_fmac_f32_e32 v8, v9, v7
+; GFX1200-TRUE16-NEXT:    v_fma_f32 v4, -v6, v8, v4
 ; GFX1200-TRUE16-NEXT:    s_denorm_mode 12
 ; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_va_vcc(0)
-; GFX1200-TRUE16-NEXT:    v_div_fmas_f32 v3, v3, v6, v7
-; GFX1200-TRUE16-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 12, v4
-; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX1200-TRUE16-NEXT:    v_div_fixup_f32 v3, v3, v2, 1.0
-; GFX1200-TRUE16-NEXT:    s_cbranch_vccnz .LBB9_15
-; GFX1200-TRUE16-NEXT:  ; %bb.13: ; %frem.loop_body.preheader
-; GFX1200-TRUE16-NEXT:    s_sub_co_i32 s6, s7, s6
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1200-TRUE16-NEXT:    v_div_fmas_f32 v4, v4, v7, v8
+; GFX1200-TRUE16-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 12, v5
+; GFX1200-TRUE16-NEXT:    v_div_fixup_f32 v4, v4, v2, 1.0
+; GFX1200-TRUE16-NEXT:    s_cbranch_vccnz .LBB9_17
+; GFX1200-TRUE16-NEXT:  ; %bb.14: ; %frem.loop_body.preheader
+; GFX1200-TRUE16-NEXT:    s_sub_co_i32 s7, s8, s7
 ; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX1200-TRUE16-NEXT:    s_add_co_i32 s6, s6, 11
-; GFX1200-TRUE16-NEXT:  .LBB9_14: ; %frem.loop_body
+; GFX1200-TRUE16-NEXT:    s_add_co_i32 s7, s7, 11
+; GFX1200-TRUE16-NEXT:  .LBB9_15: ; %frem.loop_body
 ; GFX1200-TRUE16-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1200-TRUE16-NEXT:    v_mul_f32_e32 v4, v1, v3
+; GFX1200-TRUE16-NEXT:    v_mov_b32_e32 v6, v3
 ; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX1200-TRUE16-NEXT:    s_add_co_i32 s6, s6, -11
+; GFX1200-TRUE16-NEXT:    s_add_co_i32 s7, s7, -11
 ; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX1200-TRUE16-NEXT:    s_cmp_gt_i32 s6, 11
+; GFX1200-TRUE16-NEXT:    s_cmp_gt_i32 s7, 11
+; GFX1200-TRUE16-NEXT:    v_mul_f32_e32 v3, v6, v4
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1200-TRUE16-NEXT:    v_rndne_f32_e32 v3, v3
+; GFX1200-TRUE16-NEXT:    v_xor_b32_e32 v3, 0x80000000, v3
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1200-TRUE16-NEXT:    v_fma_f32 v3, v3, v2, v6
+; GFX1200-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v3
+; GFX1200-TRUE16-NEXT:    v_add_f32_e32 v5, v3, v2
+; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1200-TRUE16-NEXT:    v_cndmask_b32_e32 v3, v3, v5, vcc_lo
+; GFX1200-TRUE16-NEXT:    v_ldexp_f32 v3, v3, 11
+; GFX1200-TRUE16-NEXT:    s_cbranch_scc1 .LBB9_15
+; GFX1200-TRUE16-NEXT:  ; %bb.16: ; %Flow
+; GFX1200-TRUE16-NEXT:    v_mov_b32_e32 v5, s7
+; GFX1200-TRUE16-NEXT:    v_mov_b32_e32 v3, v6
+; GFX1200-TRUE16-NEXT:  .LBB9_17: ; %frem.loop_exit
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1200-TRUE16-NEXT:    v_add_nc_u32_e32 v5, -10, v5
+; GFX1200-TRUE16-NEXT:    v_ldexp_f32 v3, v3, v5
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1200-TRUE16-NEXT:    v_mul_f32_e32 v4, v3, v4
 ; GFX1200-TRUE16-NEXT:    v_rndne_f32_e32 v4, v4
 ; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX1200-TRUE16-NEXT:    v_xor_b32_e32 v4, 0x80000000, v4
-; GFX1200-TRUE16-NEXT:    v_fmac_f32_e32 v1, v4, v2
+; GFX1200-TRUE16-NEXT:    v_fmac_f32_e32 v3, v4, v2
 ; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_2) | instid1(VALU_DEP_1)
-; GFX1200-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v1
-; GFX1200-TRUE16-NEXT:    v_add_f32_e32 v4, v1, v2
+; GFX1200-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v3
+; GFX1200-TRUE16-NEXT:    v_add_f32_e32 v2, v3, v2
 ; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_va_vcc(0)
-; GFX1200-TRUE16-NEXT:    v_cndmask_b32_e32 v1, v1, v4, vcc_lo
+; GFX1200-TRUE16-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc_lo
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1200-TRUE16-NEXT:    v_ldexp_f32 v1, v2, v1
+; GFX1200-TRUE16-NEXT:    v_mov_b16_e32 v2.l, s6
+; GFX1200-TRUE16-NEXT:    v_cvt_f16_f32_e32 v1.l, v1
 ; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1200-TRUE16-NEXT:    v_ldexp_f32 v1, v1, 11
-; GFX1200-TRUE16-NEXT:    s_cbranch_scc1 .LBB9_14
-; GFX1200-TRUE16-NEXT:  .LBB9_15: ; %frem.loop_exit
-; GFX1200-TRUE16-NEXT:    ; implicit-def: $vgpr1
-; GFX1200-TRUE16-NEXT:  .LBB9_16: ; %Flow54
+; GFX1200-TRUE16-NEXT:    v_bfi_b32 v1, 0x7fff, v1, v2
+; GFX1200-TRUE16-NEXT:  .LBB9_18: ; %Flow54
 ; GFX1200-TRUE16-NEXT:    s_cmp_lg_f16 s3, 0
 ; GFX1200-TRUE16-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX1200-TRUE16-NEXT:    s_cselect_b32 s3, -1, 0
@@ -9217,42 +9425,43 @@ define amdgpu_kernel void @frem_v4f16(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; GFX11-TRUE16-NEXT:    s_and_b32 s2, s2, exec_lo
 ; GFX11-TRUE16-NEXT:    s_cselect_b32 s2, 1, 0
 ; GFX11-TRUE16-NEXT:    s_cmp_lg_u32 s2, 1
-; GFX11-TRUE16-NEXT:    s_cbranch_scc1 .LBB10_8
+; GFX11-TRUE16-NEXT:    s_cbranch_scc1 .LBB10_9
 ; GFX11-TRUE16-NEXT:  ; %bb.4: ; %frem.compute85
-; GFX11-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v7, v6
 ; GFX11-TRUE16-NEXT:    v_frexp_mant_f32_e32 v4, v6
-; GFX11-TRUE16-NEXT:    v_frexp_mant_f32_e32 v6, v5
-; GFX11-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v5, v5
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX11-TRUE16-NEXT:    v_frexp_mant_f32_e32 v8, v5
+; GFX11-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v7, v6
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_4)
+; GFX11-TRUE16-NEXT:    v_ldexp_f32 v6, v4, 11
+; GFX11-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v4, v5
+; GFX11-TRUE16-NEXT:    v_ldexp_f32 v5, v8, 1
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_3)
 ; GFX11-TRUE16-NEXT:    v_readfirstlane_b32 s2, v7
-; GFX11-TRUE16-NEXT:    v_ldexp_f32 v4, v4, 11
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_2) | instid1(VALU_DEP_2)
-; GFX11-TRUE16-NEXT:    v_readfirstlane_b32 s3, v5
-; GFX11-TRUE16-NEXT:    v_add_nc_u32_e32 v8, -1, v5
-; GFX11-TRUE16-NEXT:    v_ldexp_f32 v5, v6, 1
-; GFX11-TRUE16-NEXT:    v_not_b32_e32 v6, v8
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX11-TRUE16-NEXT:    v_div_scale_f32 v8, null, v5, v5, 1.0
-; GFX11-TRUE16-NEXT:    v_add_nc_u32_e32 v7, v6, v7
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_4) | instid1(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_rcp_f32_e32 v9, v8
-; GFX11-TRUE16-NEXT:    v_div_scale_f32 v6, vcc_lo, 1.0, v5, 1.0
+; GFX11-TRUE16-NEXT:    v_readfirstlane_b32 s3, v4
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX11-TRUE16-NEXT:    v_div_scale_f32 v9, null, v5, v5, 1.0
+; GFX11-TRUE16-NEXT:    v_add_nc_u32_e32 v4, -1, v4
+; GFX11-TRUE16-NEXT:    v_rcp_f32_e32 v10, v9
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_not_b32_e32 v8, v4
+; GFX11-TRUE16-NEXT:    v_add_nc_u32_e32 v8, v8, v7
+; GFX11-TRUE16-NEXT:    v_div_scale_f32 v7, vcc_lo, 1.0, v5, 1.0
 ; GFX11-TRUE16-NEXT:    s_denorm_mode 15
 ; GFX11-TRUE16-NEXT:    s_waitcnt_depctr depctr_va_vdst(0)
-; GFX11-TRUE16-NEXT:    v_fma_f32 v10, -v8, v9, 1.0
-; GFX11-TRUE16-NEXT:    v_fmac_f32_e32 v9, v10, v9
+; GFX11-TRUE16-NEXT:    v_fma_f32 v11, -v9, v10, 1.0
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_mul_f32_e32 v10, v6, v9
-; GFX11-TRUE16-NEXT:    v_fma_f32 v11, -v8, v10, v6
+; GFX11-TRUE16-NEXT:    v_fmac_f32_e32 v10, v11, v10
+; GFX11-TRUE16-NEXT:    v_mul_f32_e32 v11, v7, v10
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_fmac_f32_e32 v10, v11, v9
-; GFX11-TRUE16-NEXT:    v_fma_f32 v6, -v8, v10, v6
+; GFX11-TRUE16-NEXT:    v_fma_f32 v12, -v9, v11, v7
+; GFX11-TRUE16-NEXT:    v_fmac_f32_e32 v11, v12, v10
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_fma_f32 v7, -v9, v11, v7
 ; GFX11-TRUE16-NEXT:    s_denorm_mode 12
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GFX11-TRUE16-NEXT:    v_div_fmas_f32 v6, v6, v9, v10
-; GFX11-TRUE16-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 12, v7
-; GFX11-TRUE16-NEXT:    v_div_fixup_f32 v6, v6, v5, 1.0
-; GFX11-TRUE16-NEXT:    s_cbranch_vccnz .LBB10_7
+; GFX11-TRUE16-NEXT:    v_div_fmas_f32 v7, v7, v10, v11
+; GFX11-TRUE16-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 12, v8
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX11-TRUE16-NEXT:    v_div_fixup_f32 v7, v7, v5, 1.0
+; GFX11-TRUE16-NEXT:    s_cbranch_vccnz .LBB10_8
 ; GFX11-TRUE16-NEXT:  ; %bb.5: ; %frem.loop_body93.preheader
 ; GFX11-TRUE16-NEXT:    s_sub_i32 s2, s2, s3
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
@@ -9260,22 +9469,42 @@ define amdgpu_kernel void @frem_v4f16(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; GFX11-TRUE16-NEXT:  .LBB10_6: ; %frem.loop_body93
 ; GFX11-TRUE16-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
-; GFX11-TRUE16-NEXT:    v_mul_f32_e32 v7, v4, v6
+; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v9, v6
 ; GFX11-TRUE16-NEXT:    s_add_i32 s2, s2, -11
 ; GFX11-TRUE16-NEXT:    s_cmp_gt_i32 s2, 11
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_rndne_f32_e32 v7, v7
-; GFX11-TRUE16-NEXT:    v_fma_f32 v4, -v7, v5, v4
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v4
-; GFX11-TRUE16-NEXT:    v_add_f32_e32 v7, v4, v5
-; GFX11-TRUE16-NEXT:    v_cndmask_b32_e32 v4, v4, v7, vcc_lo
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_ldexp_f32 v4, v4, 11
+; GFX11-TRUE16-NEXT:    v_mul_f32_e32 v6, v9, v7
+; GFX11-TRUE16-NEXT:    v_rndne_f32_e32 v6, v6
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_fma_f32 v6, -v6, v5, v9
+; GFX11-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v6
+; GFX11-TRUE16-NEXT:    v_add_f32_e32 v8, v6, v5
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_cndmask_b32_e32 v6, v6, v8, vcc_lo
+; GFX11-TRUE16-NEXT:    v_ldexp_f32 v6, v6, 11
 ; GFX11-TRUE16-NEXT:    s_cbranch_scc1 .LBB10_6
-; GFX11-TRUE16-NEXT:  .LBB10_7: ; %frem.loop_exit94
-; GFX11-TRUE16-NEXT:    ; implicit-def: $vgpr4
-; GFX11-TRUE16-NEXT:  .LBB10_8:
+; GFX11-TRUE16-NEXT:  ; %bb.7: ; %Flow133
+; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v8, s2
+; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v6, v9
+; GFX11-TRUE16-NEXT:  .LBB10_8: ; %frem.loop_exit94
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_add_nc_u32_e32 v8, -10, v8
+; GFX11-TRUE16-NEXT:    v_ldexp_f32 v6, v6, v8
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_mul_f32_e32 v7, v6, v7
+; GFX11-TRUE16-NEXT:    v_rndne_f32_e32 v7, v7
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_fma_f32 v6, -v7, v5, v6
+; GFX11-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v6
+; GFX11-TRUE16-NEXT:    v_add_f32_e32 v5, v6, v5
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_cndmask_b32_e32 v5, v6, v5, vcc_lo
+; GFX11-TRUE16-NEXT:    v_ldexp_f32 v4, v5, v4
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v5.l, v0.l
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_cvt_f16_f32_e32 v4.l, v4
+; GFX11-TRUE16-NEXT:    v_bfi_b32 v4, 0x7fff, v4, v5
+; GFX11-TRUE16-NEXT:  .LBB10_9:
 ; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v5, 16, v0
 ; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v6, 16, v2
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
@@ -9283,160 +9512,202 @@ define amdgpu_kernel void @frem_v4f16(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e64 v8, |v6.l|
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX11-TRUE16-NEXT:    v_cmp_ngt_f32_e32 vcc_lo, v9, v8
-; GFX11-TRUE16-NEXT:    s_cbranch_vccz .LBB10_10
-; GFX11-TRUE16-NEXT:  ; %bb.9: ; %frem.else53
+; GFX11-TRUE16-NEXT:    s_cbranch_vccz .LBB10_11
+; GFX11-TRUE16-NEXT:  ; %bb.10: ; %frem.else53
 ; GFX11-TRUE16-NEXT:    v_and_b16 v0.h, 0x8000, v5.l
 ; GFX11-TRUE16-NEXT:    v_cmp_eq_f32_e32 vcc_lo, v9, v8
 ; GFX11-TRUE16-NEXT:    s_mov_b32 s2, 0
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX11-TRUE16-NEXT:    v_cndmask_b16 v7.l, v5.l, v0.h, vcc_lo
-; GFX11-TRUE16-NEXT:    s_branch .LBB10_11
-; GFX11-TRUE16-NEXT:  .LBB10_10:
+; GFX11-TRUE16-NEXT:    s_branch .LBB10_12
+; GFX11-TRUE16-NEXT:  .LBB10_11:
 ; GFX11-TRUE16-NEXT:    s_mov_b32 s2, -1
 ; GFX11-TRUE16-NEXT:    ; implicit-def: $vgpr7
-; GFX11-TRUE16-NEXT:  .LBB10_11: ; %Flow131
+; GFX11-TRUE16-NEXT:  .LBB10_12: ; %Flow131
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX11-TRUE16-NEXT:    s_and_b32 s2, s2, exec_lo
 ; GFX11-TRUE16-NEXT:    s_cselect_b32 s2, 1, 0
 ; GFX11-TRUE16-NEXT:    s_cmp_lg_u32 s2, 1
-; GFX11-TRUE16-NEXT:    s_cbranch_scc1 .LBB10_16
-; GFX11-TRUE16-NEXT:  ; %bb.12: ; %frem.compute52
-; GFX11-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v10, v9
+; GFX11-TRUE16-NEXT:    s_cbranch_scc1 .LBB10_18
+; GFX11-TRUE16-NEXT:  ; %bb.13: ; %frem.compute52
 ; GFX11-TRUE16-NEXT:    v_frexp_mant_f32_e32 v7, v9
-; GFX11-TRUE16-NEXT:    v_frexp_mant_f32_e32 v9, v8
-; GFX11-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v8, v8
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX11-TRUE16-NEXT:    v_frexp_mant_f32_e32 v11, v8
+; GFX11-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v10, v9
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_4)
+; GFX11-TRUE16-NEXT:    v_ldexp_f32 v9, v7, 11
+; GFX11-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v7, v8
+; GFX11-TRUE16-NEXT:    v_ldexp_f32 v8, v11, 1
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_3)
 ; GFX11-TRUE16-NEXT:    v_readfirstlane_b32 s2, v10
-; GFX11-TRUE16-NEXT:    v_ldexp_f32 v7, v7, 11
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_2) | instid1(VALU_DEP_2)
-; GFX11-TRUE16-NEXT:    v_readfirstlane_b32 s3, v8
-; GFX11-TRUE16-NEXT:    v_add_nc_u32_e32 v11, -1, v8
-; GFX11-TRUE16-NEXT:    v_ldexp_f32 v8, v9, 1
-; GFX11-TRUE16-NEXT:    v_not_b32_e32 v9, v11
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX11-TRUE16-NEXT:    v_div_scale_f32 v11, null, v8, v8, 1.0
-; GFX11-TRUE16-NEXT:    v_add_nc_u32_e32 v10, v9, v10
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_4) | instid1(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_rcp_f32_e32 v12, v11
-; GFX11-TRUE16-NEXT:    v_div_scale_f32 v9, vcc_lo, 1.0, v8, 1.0
+; GFX11-TRUE16-NEXT:    v_readfirstlane_b32 s3, v7
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX11-TRUE16-NEXT:    v_div_scale_f32 v12, null, v8, v8, 1.0
+; GFX11-TRUE16-NEXT:    v_add_nc_u32_e32 v7, -1, v7
+; GFX11-TRUE16-NEXT:    v_rcp_f32_e32 v13, v12
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_not_b32_e32 v11, v7
+; GFX11-TRUE16-NEXT:    v_add_nc_u32_e32 v11, v11, v10
+; GFX11-TRUE16-NEXT:    v_div_scale_f32 v10, vcc_lo, 1.0, v8, 1.0
 ; GFX11-TRUE16-NEXT:    s_denorm_mode 15
 ; GFX11-TRUE16-NEXT:    s_waitcnt_depctr depctr_va_vdst(0)
-; GFX11-TRUE16-NEXT:    v_fma_f32 v13, -v11, v12, 1.0
-; GFX11-TRUE16-NEXT:    v_fmac_f32_e32 v12, v13, v12
+; GFX11-TRUE16-NEXT:    v_fma_f32 v14, -v12, v13, 1.0
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_mul_f32_e32 v13, v9, v12
-; GFX11-TRUE16-NEXT:    v_fma_f32 v14, -v11, v13, v9
+; GFX11-TRUE16-NEXT:    v_fmac_f32_e32 v13, v14, v13
+; GFX11-TRUE16-NEXT:    v_mul_f32_e32 v14, v10, v13
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_fmac_f32_e32 v13, v14, v12
-; GFX11-TRUE16-NEXT:    v_fma_f32 v9, -v11, v13, v9
+; GFX11-TRUE16-NEXT:    v_fma_f32 v15, -v12, v14, v10
+; GFX11-TRUE16-NEXT:    v_fmac_f32_e32 v14, v15, v13
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_fma_f32 v10, -v12, v14, v10
 ; GFX11-TRUE16-NEXT:    s_denorm_mode 12
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GFX11-TRUE16-NEXT:    v_div_fmas_f32 v9, v9, v12, v13
-; GFX11-TRUE16-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 12, v10
-; GFX11-TRUE16-NEXT:    v_div_fixup_f32 v9, v9, v8, 1.0
-; GFX11-TRUE16-NEXT:    s_cbranch_vccnz .LBB10_15
-; GFX11-TRUE16-NEXT:  ; %bb.13: ; %frem.loop_body60.preheader
+; GFX11-TRUE16-NEXT:    v_div_fmas_f32 v10, v10, v13, v14
+; GFX11-TRUE16-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 12, v11
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX11-TRUE16-NEXT:    v_div_fixup_f32 v10, v10, v8, 1.0
+; GFX11-TRUE16-NEXT:    s_cbranch_vccnz .LBB10_17
+; GFX11-TRUE16-NEXT:  ; %bb.14: ; %frem.loop_body60.preheader
 ; GFX11-TRUE16-NEXT:    s_sub_i32 s2, s2, s3
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
 ; GFX11-TRUE16-NEXT:    s_add_i32 s2, s2, 11
-; GFX11-TRUE16-NEXT:  .LBB10_14: ; %frem.loop_body60
+; GFX11-TRUE16-NEXT:  .LBB10_15: ; %frem.loop_body60
 ; GFX11-TRUE16-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
-; GFX11-TRUE16-NEXT:    v_mul_f32_e32 v10, v7, v9
+; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v12, v9
 ; GFX11-TRUE16-NEXT:    s_add_i32 s2, s2, -11
 ; GFX11-TRUE16-NEXT:    s_cmp_gt_i32 s2, 11
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_mul_f32_e32 v9, v12, v10
+; GFX11-TRUE16-NEXT:    v_rndne_f32_e32 v9, v9
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_fma_f32 v9, -v9, v8, v12
+; GFX11-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v9
+; GFX11-TRUE16-NEXT:    v_add_f32_e32 v11, v9, v8
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_cndmask_b32_e32 v9, v9, v11, vcc_lo
+; GFX11-TRUE16-NEXT:    v_ldexp_f32 v9, v9, 11
+; GFX11-TRUE16-NEXT:    s_cbranch_scc1 .LBB10_15
+; GFX11-TRUE16-NEXT:  ; %bb.16: ; %Flow129
+; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v11, s2
+; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v9, v12
+; GFX11-TRUE16-NEXT:  .LBB10_17: ; %frem.loop_exit61
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_add_nc_u32_e32 v11, -10, v11
+; GFX11-TRUE16-NEXT:    v_ldexp_f32 v9, v9, v11
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_mul_f32_e32 v10, v9, v10
 ; GFX11-TRUE16-NEXT:    v_rndne_f32_e32 v10, v10
-; GFX11-TRUE16-NEXT:    v_fma_f32 v7, -v10, v8, v7
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v7
-; GFX11-TRUE16-NEXT:    v_add_f32_e32 v10, v7, v8
-; GFX11-TRUE16-NEXT:    v_cndmask_b32_e32 v7, v7, v10, vcc_lo
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_ldexp_f32 v7, v7, 11
-; GFX11-TRUE16-NEXT:    s_cbranch_scc1 .LBB10_14
-; GFX11-TRUE16-NEXT:  .LBB10_15: ; %frem.loop_exit61
-; GFX11-TRUE16-NEXT:    ; implicit-def: $vgpr7
-; GFX11-TRUE16-NEXT:  .LBB10_16:
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_fma_f32 v9, -v10, v8, v9
+; GFX11-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v9
+; GFX11-TRUE16-NEXT:    v_add_f32_e32 v8, v9, v8
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_cndmask_b32_e32 v8, v9, v8, vcc_lo
+; GFX11-TRUE16-NEXT:    v_ldexp_f32 v7, v8, v7
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v8.l, v5.l
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_cvt_f16_f32_e32 v7.l, v7
+; GFX11-TRUE16-NEXT:    v_bfi_b32 v7, 0x7fff, v7, v8
+; GFX11-TRUE16-NEXT:  .LBB10_18:
 ; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e64 v10, |v1.l|
 ; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e64 v9, |v3.l|
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX11-TRUE16-NEXT:    v_cmp_ngt_f32_e32 vcc_lo, v10, v9
-; GFX11-TRUE16-NEXT:    s_cbranch_vccz .LBB10_18
-; GFX11-TRUE16-NEXT:  ; %bb.17: ; %frem.else20
+; GFX11-TRUE16-NEXT:    s_cbranch_vccz .LBB10_20
+; GFX11-TRUE16-NEXT:  ; %bb.19: ; %frem.else20
 ; GFX11-TRUE16-NEXT:    v_and_b16 v0.h, 0x8000, v1.l
 ; GFX11-TRUE16-NEXT:    v_cmp_eq_f32_e32 vcc_lo, v10, v9
 ; GFX11-TRUE16-NEXT:    s_mov_b32 s2, 0
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX11-TRUE16-NEXT:    v_cndmask_b16 v8.l, v1.l, v0.h, vcc_lo
-; GFX11-TRUE16-NEXT:    s_branch .LBB10_19
-; GFX11-TRUE16-NEXT:  .LBB10_18:
+; GFX11-TRUE16-NEXT:    s_branch .LBB10_21
+; GFX11-TRUE16-NEXT:  .LBB10_20:
 ; GFX11-TRUE16-NEXT:    s_mov_b32 s2, -1
 ; GFX11-TRUE16-NEXT:    ; implicit-def: $vgpr8
-; GFX11-TRUE16-NEXT:  .LBB10_19: ; %Flow127
+; GFX11-TRUE16-NEXT:  .LBB10_21: ; %Flow127
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX11-TRUE16-NEXT:    s_and_b32 s2, s2, exec_lo
 ; GFX11-TRUE16-NEXT:    s_cselect_b32 s2, 1, 0
 ; GFX11-TRUE16-NEXT:    s_cmp_lg_u32 s2, 1
-; GFX11-TRUE16-NEXT:    s_cbranch_scc1 .LBB10_24
-; GFX11-TRUE16-NEXT:  ; %bb.20: ; %frem.compute19
-; GFX11-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v11, v10
+; GFX11-TRUE16-NEXT:    s_cbranch_scc1 .LBB10_27
+; GFX11-TRUE16-NEXT:  ; %bb.22: ; %frem.compute19
 ; GFX11-TRUE16-NEXT:    v_frexp_mant_f32_e32 v8, v10
-; GFX11-TRUE16-NEXT:    v_frexp_mant_f32_e32 v10, v9
-; GFX11-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v9, v9
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX11-TRUE16-NEXT:    v_frexp_mant_f32_e32 v12, v9
+; GFX11-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v11, v10
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_4)
+; GFX11-TRUE16-NEXT:    v_ldexp_f32 v10, v8, 11
+; GFX11-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v8, v9
+; GFX11-TRUE16-NEXT:    v_ldexp_f32 v9, v12, 1
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_3)
 ; GFX11-TRUE16-NEXT:    v_readfirstlane_b32 s2, v11
-; GFX11-TRUE16-NEXT:    v_ldexp_f32 v8, v8, 11
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_2) | instid1(VALU_DEP_2)
-; GFX11-TRUE16-NEXT:    v_readfirstlane_b32 s3, v9
-; GFX11-TRUE16-NEXT:    v_add_nc_u32_e32 v12, -1, v9
-; GFX11-TRUE16-NEXT:    v_ldexp_f32 v9, v10, 1
-; GFX11-TRUE16-NEXT:    v_not_b32_e32 v10, v12
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX11-TRUE16-NEXT:    v_div_scale_f32 v12, null, v9, v9, 1.0
-; GFX11-TRUE16-NEXT:    v_add_nc_u32_e32 v11, v10, v11
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_4) | instid1(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_rcp_f32_e32 v13, v12
-; GFX11-TRUE16-NEXT:    v_div_scale_f32 v10, vcc_lo, 1.0, v9, 1.0
+; GFX11-TRUE16-NEXT:    v_readfirstlane_b32 s3, v8
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX11-TRUE16-NEXT:    v_div_scale_f32 v13, null, v9, v9, 1.0
+; GFX11-TRUE16-NEXT:    v_add_nc_u32_e32 v8, -1, v8
+; GFX11-TRUE16-NEXT:    v_rcp_f32_e32 v14, v13
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_not_b32_e32 v12, v8
+; GFX11-TRUE16-NEXT:    v_add_nc_u32_e32 v12, v12, v11
+; GFX11-TRUE16-NEXT:    v_div_scale_f32 v11, vcc_lo, 1.0, v9, 1.0
 ; GFX11-TRUE16-NEXT:    s_denorm_mode 15
 ; GFX11-TRUE16-NEXT:    s_waitcnt_depctr depctr_va_vdst(0)
-; GFX11-TRUE16-NEXT:    v_fma_f32 v14, -v12, v13, 1.0
-; GFX11-TRUE16-NEXT:    v_fmac_f32_e32 v13, v14, v13
+; GFX11-TRUE16-NEXT:    v_fma_f32 v15, -v13, v14, 1.0
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_mul_f32_e32 v14, v10, v13
-; GFX11-TRUE16-NEXT:    v_fma_f32 v15, -v12, v14, v10
+; GFX11-TRUE16-NEXT:    v_fmac_f32_e32 v14, v15, v14
+; GFX11-TRUE16-NEXT:    v_mul_f32_e32 v15, v11, v14
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_fmac_f32_e32 v14, v15, v13
-; GFX11-TRUE16-NEXT:    v_fma_f32 v10, -v12, v14, v10
+; GFX11-TRUE16-NEXT:    v_fma_f32 v16, -v13, v15, v11
+; GFX11-TRUE16-NEXT:    v_fmac_f32_e32 v15, v16, v14
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_fma_f32 v11, -v13, v15, v11
 ; GFX11-TRUE16-NEXT:    s_denorm_mode 12
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GFX11-TRUE16-NEXT:    v_div_fmas_f32 v10, v10, v13, v14
-; GFX11-TRUE16-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 12, v11
-; GFX11-TRUE16-NEXT:    v_div_fixup_f32 v10, v10, v9, 1.0
-; GFX11-TRUE16-NEXT:    s_cbranch_vccnz .LBB10_23
-; GFX11-TRUE16-NEXT:  ; %bb.21: ; %frem.loop_body27.preheader
+; GFX11-TRUE16-NEXT:    v_div_fmas_f32 v11, v11, v14, v15
+; GFX11-TRUE16-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 12, v12
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX11-TRUE16-NEXT:    v_div_fixup_f32 v11, v11, v9, 1.0
+; GFX11-TRUE16-NEXT:    s_cbranch_vccnz .LBB10_26
+; GFX11-TRUE16-NEXT:  ; %bb.23: ; %frem.loop_body27.preheader
 ; GFX11-TRUE16-NEXT:    s_sub_i32 s2, s2, s3
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
 ; GFX11-TRUE16-NEXT:    s_add_i32 s2, s2, 11
-; GFX11-TRUE16-NEXT:  .LBB10_22: ; %frem.loop_body27
+; GFX11-TRUE16-NEXT:  .LBB10_24: ; %frem.loop_body27
 ; GFX11-TRUE16-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
-; GFX11-TRUE16-NEXT:    v_mul_f32_e32 v11, v8, v10
+; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v13, v10
 ; GFX11-TRUE16-NEXT:    s_add_i32 s2, s2, -11
 ; GFX11-TRUE16-NEXT:    s_cmp_gt_i32 s2, 11
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_mul_f32_e32 v10, v13, v11
+; GFX11-TRUE16-NEXT:    v_rndne_f32_e32 v10, v10
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_fma_f32 v10, -v10, v9, v13
+; GFX11-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v10
+; GFX11-TRUE16-NEXT:    v_add_f32_e32 v12, v10, v9
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_cndmask_b32_e32 v10, v10, v12, vcc_lo
+; GFX11-TRUE16-NEXT:    v_ldexp_f32 v10, v10, 11
+; GFX11-TRUE16-NEXT:    s_cbranch_scc1 .LBB10_24
+; GFX11-TRUE16-NEXT:  ; %bb.25: ; %Flow125
+; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v12, s2
+; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v10, v13
+; GFX11-TRUE16-NEXT:  .LBB10_26: ; %frem.loop_exit28
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_add_nc_u32_e32 v12, -10, v12
+; GFX11-TRUE16-NEXT:    v_ldexp_f32 v10, v10, v12
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_mul_f32_e32 v11, v10, v11
 ; GFX11-TRUE16-NEXT:    v_rndne_f32_e32 v11, v11
-; GFX11-TRUE16-NEXT:    v_fma_f32 v8, -v11, v9, v8
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v8
-; GFX11-TRUE16-NEXT:    v_add_f32_e32 v11, v8, v9
-; GFX11-TRUE16-NEXT:    v_cndmask_b32_e32 v8, v8, v11, vcc_lo
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_ldexp_f32 v8, v8, 11
-; GFX11-TRUE16-NEXT:    s_cbranch_scc1 .LBB10_22
-; GFX11-TRUE16-NEXT:  .LBB10_23: ; %frem.loop_exit28
-; GFX11-TRUE16-NEXT:    ; implicit-def: $vgpr8
-; GFX11-TRUE16-NEXT:  .LBB10_24:
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_fma_f32 v10, -v11, v9, v10
+; GFX11-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v10
+; GFX11-TRUE16-NEXT:    v_add_f32_e32 v9, v10, v9
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_cndmask_b32_e32 v9, v10, v9, vcc_lo
+; GFX11-TRUE16-NEXT:    v_ldexp_f32 v8, v9, v8
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v9.l, v1.l
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_cvt_f16_f32_e32 v8.l, v8
+; GFX11-TRUE16-NEXT:    v_bfi_b32 v8, 0x7fff, v8, v9
+; GFX11-TRUE16-NEXT:  .LBB10_27:
 ; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v9, 16, v1
 ; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v10, 16, v3
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
@@ -9444,81 +9715,102 @@ define amdgpu_kernel void @frem_v4f16(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e64 v12, |v10.l|
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX11-TRUE16-NEXT:    v_cmp_ngt_f32_e32 vcc_lo, v13, v12
-; GFX11-TRUE16-NEXT:    s_cbranch_vccz .LBB10_26
-; GFX11-TRUE16-NEXT:  ; %bb.25: ; %frem.else
+; GFX11-TRUE16-NEXT:    s_cbranch_vccz .LBB10_29
+; GFX11-TRUE16-NEXT:  ; %bb.28: ; %frem.else
 ; GFX11-TRUE16-NEXT:    v_and_b16 v0.h, 0x8000, v9.l
 ; GFX11-TRUE16-NEXT:    v_cmp_eq_f32_e32 vcc_lo, v13, v12
 ; GFX11-TRUE16-NEXT:    s_mov_b32 s2, 0
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX11-TRUE16-NEXT:    v_cndmask_b16 v11.l, v9.l, v0.h, vcc_lo
-; GFX11-TRUE16-NEXT:    s_branch .LBB10_27
-; GFX11-TRUE16-NEXT:  .LBB10_26:
+; GFX11-TRUE16-NEXT:    s_branch .LBB10_30
+; GFX11-TRUE16-NEXT:  .LBB10_29:
 ; GFX11-TRUE16-NEXT:    s_mov_b32 s2, -1
 ; GFX11-TRUE16-NEXT:    ; implicit-def: $vgpr11
-; GFX11-TRUE16-NEXT:  .LBB10_27: ; %Flow123
+; GFX11-TRUE16-NEXT:  .LBB10_30: ; %Flow123
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX11-TRUE16-NEXT:    s_and_b32 s2, s2, exec_lo
 ; GFX11-TRUE16-NEXT:    s_cselect_b32 s2, 1, 0
 ; GFX11-TRUE16-NEXT:    s_cmp_lg_u32 s2, 1
-; GFX11-TRUE16-NEXT:    s_cbranch_scc1 .LBB10_32
-; GFX11-TRUE16-NEXT:  ; %bb.28: ; %frem.compute
-; GFX11-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v14, v13
+; GFX11-TRUE16-NEXT:    s_cbranch_scc1 .LBB10_36
+; GFX11-TRUE16-NEXT:  ; %bb.31: ; %frem.compute
 ; GFX11-TRUE16-NEXT:    v_frexp_mant_f32_e32 v11, v13
-; GFX11-TRUE16-NEXT:    v_frexp_mant_f32_e32 v13, v12
-; GFX11-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v12, v12
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX11-TRUE16-NEXT:    v_frexp_mant_f32_e32 v15, v12
+; GFX11-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v14, v13
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_4)
+; GFX11-TRUE16-NEXT:    v_ldexp_f32 v13, v11, 11
+; GFX11-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v11, v12
+; GFX11-TRUE16-NEXT:    v_ldexp_f32 v12, v15, 1
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_3)
 ; GFX11-TRUE16-NEXT:    v_readfirstlane_b32 s2, v14
-; GFX11-TRUE16-NEXT:    v_ldexp_f32 v11, v11, 11
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_2) | instid1(VALU_DEP_2)
-; GFX11-TRUE16-NEXT:    v_readfirstlane_b32 s3, v12
-; GFX11-TRUE16-NEXT:    v_add_nc_u32_e32 v15, -1, v12
-; GFX11-TRUE16-NEXT:    v_ldexp_f32 v12, v13, 1
-; GFX11-TRUE16-NEXT:    v_not_b32_e32 v13, v15
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX11-TRUE16-NEXT:    v_div_scale_f32 v15, null, v12, v12, 1.0
-; GFX11-TRUE16-NEXT:    v_add_nc_u32_e32 v14, v13, v14
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_4) | instid1(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_rcp_f32_e32 v16, v15
-; GFX11-TRUE16-NEXT:    v_div_scale_f32 v13, vcc_lo, 1.0, v12, 1.0
+; GFX11-TRUE16-NEXT:    v_readfirstlane_b32 s3, v11
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX11-TRUE16-NEXT:    v_div_scale_f32 v16, null, v12, v12, 1.0
+; GFX11-TRUE16-NEXT:    v_add_nc_u32_e32 v11, -1, v11
+; GFX11-TRUE16-NEXT:    v_rcp_f32_e32 v17, v16
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_not_b32_e32 v15, v11
+; GFX11-TRUE16-NEXT:    v_add_nc_u32_e32 v15, v15, v14
+; GFX11-TRUE16-NEXT:    v_div_scale_f32 v14, vcc_lo, 1.0, v12, 1.0
 ; GFX11-TRUE16-NEXT:    s_denorm_mode 15
 ; GFX11-TRUE16-NEXT:    s_waitcnt_depctr depctr_va_vdst(0)
-; GFX11-TRUE16-NEXT:    v_fma_f32 v17, -v15, v16, 1.0
-; GFX11-TRUE16-NEXT:    v_fmac_f32_e32 v16, v17, v16
+; GFX11-TRUE16-NEXT:    v_fma_f32 v18, -v16, v17, 1.0
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_mul_f32_e32 v17, v13, v16
-; GFX11-TRUE16-NEXT:    v_fma_f32 v18, -v15, v17, v13
+; GFX11-TRUE16-NEXT:    v_fmac_f32_e32 v17, v18, v17
+; GFX11-TRUE16-NEXT:    v_mul_f32_e32 v18, v14, v17
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_fmac_f32_e32 v17, v18, v16
-; GFX11-TRUE16-NEXT:    v_fma_f32 v13, -v15, v17, v13
+; GFX11-TRUE16-NEXT:    v_fma_f32 v19, -v16, v18, v14
+; GFX11-TRUE16-NEXT:    v_fmac_f32_e32 v18, v19, v17
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_fma_f32 v14, -v16, v18, v14
 ; GFX11-TRUE16-NEXT:    s_denorm_mode 12
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GFX11-TRUE16-NEXT:    v_div_fmas_f32 v13, v13, v16, v17
-; GFX11-TRUE16-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 12, v14
-; GFX11-TRUE16-NEXT:    v_div_fixup_f32 v13, v13, v12, 1.0
-; GFX11-TRUE16-NEXT:    s_cbranch_vccnz .LBB10_31
-; GFX11-TRUE16-NEXT:  ; %bb.29: ; %frem.loop_body.preheader
+; GFX11-TRUE16-NEXT:    v_div_fmas_f32 v14, v14, v17, v18
+; GFX11-TRUE16-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 12, v15
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX11-TRUE16-NEXT:    v_div_fixup_f32 v14, v14, v12, 1.0
+; GFX11-TRUE16-NEXT:    s_cbranch_vccnz .LBB10_35
+; GFX11-TRUE16-NEXT:  ; %bb.32: ; %frem.loop_body.preheader
 ; GFX11-TRUE16-NEXT:    s_sub_i32 s2, s2, s3
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
 ; GFX11-TRUE16-NEXT:    s_add_i32 s2, s2, 11
-; GFX11-TRUE16-NEXT:  .LBB10_30: ; %frem.loop_body
+; GFX11-TRUE16-NEXT:  .LBB10_33: ; %frem.loop_body
 ; GFX11-TRUE16-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
-; GFX11-TRUE16-NEXT:    v_mul_f32_e32 v14, v11, v13
+; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v16, v13
 ; GFX11-TRUE16-NEXT:    s_add_i32 s2, s2, -11
 ; GFX11-TRUE16-NEXT:    s_cmp_gt_i32 s2, 11
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_mul_f32_e32 v13, v16, v14
+; GFX11-TRUE16-NEXT:    v_rndne_f32_e32 v13, v13
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_fma_f32 v13, -v13, v12, v16
+; GFX11-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v13
+; GFX11-TRUE16-NEXT:    v_add_f32_e32 v15, v13, v12
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_cndmask_b32_e32 v13, v13, v15, vcc_lo
+; GFX11-TRUE16-NEXT:    v_ldexp_f32 v13, v13, 11
+; GFX11-TRUE16-NEXT:    s_cbranch_scc1 .LBB10_33
+; GFX11-TRUE16-NEXT:  ; %bb.34: ; %Flow
+; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v15, s2
+; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v13, v16
+; GFX11-TRUE16-NEXT:  .LBB10_35: ; %frem.loop_exit
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_add_nc_u32_e32 v15, -10, v15
+; GFX11-TRUE16-NEXT:    v_ldexp_f32 v13, v13, v15
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_mul_f32_e32 v14, v13, v14
 ; GFX11-TRUE16-NEXT:    v_rndne_f32_e32 v14, v14
-; GFX11-TRUE16-NEXT:    v_fma_f32 v11, -v14, v12, v11
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v11
-; GFX11-TRUE16-NEXT:    v_add_f32_e32 v14, v11, v12
-; GFX11-TRUE16-NEXT:    v_cndmask_b32_e32 v11, v11, v14, vcc_lo
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_ldexp_f32 v11, v11, 11
-; GFX11-TRUE16-NEXT:    s_cbranch_scc1 .LBB10_30
-; GFX11-TRUE16-NEXT:  .LBB10_31: ; %frem.loop_exit
-; GFX11-TRUE16-NEXT:    ; implicit-def: $vgpr11
-; GFX11-TRUE16-NEXT:  .LBB10_32: ; %Flow124
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_fma_f32 v13, -v14, v12, v13
+; GFX11-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v13
+; GFX11-TRUE16-NEXT:    v_add_f32_e32 v12, v13, v12
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_cndmask_b32_e32 v12, v13, v12, vcc_lo
+; GFX11-TRUE16-NEXT:    v_ldexp_f32 v11, v12, v11
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v12.l, v9.l
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_cvt_f16_f32_e32 v11.l, v11
+; GFX11-TRUE16-NEXT:    v_bfi_b32 v11, 0x7fff, v11, v12
+; GFX11-TRUE16-NEXT:  .LBB10_36: ; %Flow124
 ; GFX11-TRUE16-NEXT:    v_cmp_lg_f16_e32 vcc_lo, 0, v2.l
 ; GFX11-TRUE16-NEXT:    v_cmp_nle_f16_e64 s2, 0x7c00, |v0.l|
 ; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v2, 0
@@ -10017,41 +10309,42 @@ define amdgpu_kernel void @frem_v4f16(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; GFX1150-TRUE16-NEXT:    s_and_b32 s9, s9, exec_lo
 ; GFX1150-TRUE16-NEXT:    s_cselect_b32 s9, 1, 0
 ; GFX1150-TRUE16-NEXT:    s_cmp_lg_u32 s9, 1
-; GFX1150-TRUE16-NEXT:    s_cbranch_scc1 .LBB10_8
+; GFX1150-TRUE16-NEXT:    s_cbranch_scc1 .LBB10_9
 ; GFX1150-TRUE16-NEXT:  ; %bb.4: ; %frem.compute85
 ; GFX1150-TRUE16-NEXT:    v_frexp_mant_f32_e32 v1, s6
-; GFX1150-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v3, s6
-; GFX1150-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v2, s8
 ; GFX1150-TRUE16-NEXT:    v_frexp_mant_f32_e32 v0, s8
-; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX1150-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v3, s8
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
 ; GFX1150-TRUE16-NEXT:    v_ldexp_f32 v1, v1, 1
-; GFX1150-TRUE16-NEXT:    v_readfirstlane_b32 s6, v3
-; GFX1150-TRUE16-NEXT:    v_add_nc_u32_e32 v3, -1, v3
-; GFX1150-TRUE16-NEXT:    v_readfirstlane_b32 s8, v2
-; GFX1150-TRUE16-NEXT:    v_ldexp_f32 v0, v0, 11
-; GFX1150-TRUE16-NEXT:    v_div_scale_f32 v4, null, v1, v1, 1.0
-; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX1150-TRUE16-NEXT:    v_not_b32_e32 v3, v3
-; GFX1150-TRUE16-NEXT:    v_rcp_f32_e32 v5, v4
-; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_2) | instid1(TRANS32_DEP_1)
-; GFX1150-TRUE16-NEXT:    v_add_nc_u32_e32 v3, v3, v2
-; GFX1150-TRUE16-NEXT:    v_div_scale_f32 v2, vcc_lo, 1.0, v1, 1.0
+; GFX1150-TRUE16-NEXT:    v_ldexp_f32 v2, v0, 11
+; GFX1150-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v0, s6
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX1150-TRUE16-NEXT:    v_readfirstlane_b32 s8, v3
+; GFX1150-TRUE16-NEXT:    v_div_scale_f32 v5, null, v1, v1, 1.0
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_3)
+; GFX1150-TRUE16-NEXT:    v_readfirstlane_b32 s6, v0
+; GFX1150-TRUE16-NEXT:    v_add_nc_u32_e32 v0, -1, v0
+; GFX1150-TRUE16-NEXT:    v_rcp_f32_e32 v6, v5
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_not_b32_e32 v4, v0
+; GFX1150-TRUE16-NEXT:    v_add_nc_u32_e32 v4, v4, v3
+; GFX1150-TRUE16-NEXT:    v_div_scale_f32 v3, vcc_lo, 1.0, v1, 1.0
 ; GFX1150-TRUE16-NEXT:    s_denorm_mode 15
-; GFX1150-TRUE16-NEXT:    v_fma_f32 v6, -v4, v5, 1.0
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(TRANS32_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_fma_f32 v7, -v5, v6, 1.0
+; GFX1150-TRUE16-NEXT:    v_fmac_f32_e32 v6, v7, v6
 ; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1150-TRUE16-NEXT:    v_fmac_f32_e32 v5, v6, v5
-; GFX1150-TRUE16-NEXT:    v_mul_f32_e32 v6, v2, v5
+; GFX1150-TRUE16-NEXT:    v_mul_f32_e32 v7, v3, v6
+; GFX1150-TRUE16-NEXT:    v_fma_f32 v8, -v5, v7, v3
 ; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1150-TRUE16-NEXT:    v_fma_f32 v7, -v4, v6, v2
-; GFX1150-TRUE16-NEXT:    v_fmac_f32_e32 v6, v7, v5
-; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
-; GFX1150-TRUE16-NEXT:    v_fma_f32 v2, -v4, v6, v2
+; GFX1150-TRUE16-NEXT:    v_fmac_f32_e32 v7, v8, v6
+; GFX1150-TRUE16-NEXT:    v_fma_f32 v3, -v5, v7, v3
 ; GFX1150-TRUE16-NEXT:    s_denorm_mode 12
-; GFX1150-TRUE16-NEXT:    v_div_fmas_f32 v2, v2, v5, v6
-; GFX1150-TRUE16-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 12, v3
-; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX1150-TRUE16-NEXT:    v_div_fixup_f32 v2, v2, v1, 1.0
-; GFX1150-TRUE16-NEXT:    s_cbranch_vccnz .LBB10_7
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1150-TRUE16-NEXT:    v_div_fmas_f32 v3, v3, v6, v7
+; GFX1150-TRUE16-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 12, v4
+; GFX1150-TRUE16-NEXT:    v_div_fixup_f32 v3, v3, v1, 1.0
+; GFX1150-TRUE16-NEXT:    s_cbranch_vccnz .LBB10_8
 ; GFX1150-TRUE16-NEXT:  ; %bb.5: ; %frem.loop_body93.preheader
 ; GFX1150-TRUE16-NEXT:    s_sub_i32 s6, s8, s6
 ; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
@@ -10059,273 +10352,368 @@ define amdgpu_kernel void @frem_v4f16(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; GFX1150-TRUE16-NEXT:  .LBB10_6: ; %frem.loop_body93
 ; GFX1150-TRUE16-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
-; GFX1150-TRUE16-NEXT:    v_mul_f32_e32 v3, v0, v2
+; GFX1150-TRUE16-NEXT:    v_mov_b32_e32 v5, v2
 ; GFX1150-TRUE16-NEXT:    s_add_i32 s6, s6, -11
 ; GFX1150-TRUE16-NEXT:    s_cmp_gt_i32 s6, 11
 ; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1150-TRUE16-NEXT:    v_rndne_f32_e32 v3, v3
-; GFX1150-TRUE16-NEXT:    v_xor_b32_e32 v3, 0x80000000, v3
+; GFX1150-TRUE16-NEXT:    v_mul_f32_e32 v2, v5, v3
+; GFX1150-TRUE16-NEXT:    v_rndne_f32_e32 v2, v2
 ; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1150-TRUE16-NEXT:    v_fmac_f32_e32 v0, v3, v1
-; GFX1150-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v0
-; GFX1150-TRUE16-NEXT:    v_add_f32_e32 v3, v0, v1
-; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1150-TRUE16-NEXT:    v_cndmask_b32_e32 v0, v0, v3, vcc_lo
-; GFX1150-TRUE16-NEXT:    v_ldexp_f32 v0, v0, 11
+; GFX1150-TRUE16-NEXT:    v_xor_b32_e32 v2, 0x80000000, v2
+; GFX1150-TRUE16-NEXT:    v_fma_f32 v2, v2, v1, v5
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v2
+; GFX1150-TRUE16-NEXT:    v_add_f32_e32 v4, v2, v1
+; GFX1150-TRUE16-NEXT:    v_cndmask_b32_e32 v2, v2, v4, vcc_lo
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_ldexp_f32 v2, v2, 11
 ; GFX1150-TRUE16-NEXT:    s_cbranch_scc1 .LBB10_6
-; GFX1150-TRUE16-NEXT:  .LBB10_7: ; %frem.loop_exit94
-; GFX1150-TRUE16-NEXT:    ; implicit-def: $vgpr0
-; GFX1150-TRUE16-NEXT:  .LBB10_8:
-; GFX1150-TRUE16-NEXT:    s_lshr_b32 s10, s5, 16
+; GFX1150-TRUE16-NEXT:  ; %bb.7: ; %Flow133
+; GFX1150-TRUE16-NEXT:    v_mov_b32_e32 v4, s6
+; GFX1150-TRUE16-NEXT:    v_mov_b32_e32 v2, v5
+; GFX1150-TRUE16-NEXT:  .LBB10_8: ; %frem.loop_exit94
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_add_nc_u32_e32 v4, -10, v4
+; GFX1150-TRUE16-NEXT:    v_ldexp_f32 v2, v2, v4
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_mul_f32_e32 v3, v2, v3
+; GFX1150-TRUE16-NEXT:    v_rndne_f32_e32 v3, v3
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_xor_b32_e32 v3, 0x80000000, v3
+; GFX1150-TRUE16-NEXT:    v_fmac_f32_e32 v2, v3, v1
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v2
+; GFX1150-TRUE16-NEXT:    v_add_f32_e32 v1, v2, v1
+; GFX1150-TRUE16-NEXT:    v_cndmask_b32_e32 v1, v2, v1, vcc_lo
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1150-TRUE16-NEXT:    v_ldexp_f32 v0, v1, v0
+; GFX1150-TRUE16-NEXT:    v_mov_b16_e32 v1.l, s5
+; GFX1150-TRUE16-NEXT:    v_cvt_f16_f32_e32 v0.l, v0
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_bfi_b32 v0, 0x7fff, v0, v1
+; GFX1150-TRUE16-NEXT:  .LBB10_9:
+; GFX1150-TRUE16-NEXT:    s_lshr_b32 s8, s5, 16
 ; GFX1150-TRUE16-NEXT:    s_lshr_b32 s6, s4, 16
-; GFX1150-TRUE16-NEXT:    s_and_b32 s5, s10, 0x7fff
-; GFX1150-TRUE16-NEXT:    s_and_b32 s8, s6, 0x7fff
-; GFX1150-TRUE16-NEXT:    s_cvt_f32_f16 s9, s5
-; GFX1150-TRUE16-NEXT:    s_cvt_f32_f16 s8, s8
+; GFX1150-TRUE16-NEXT:    s_and_b32 s5, s8, 0x7fff
+; GFX1150-TRUE16-NEXT:    s_and_b32 s9, s6, 0x7fff
+; GFX1150-TRUE16-NEXT:    s_cvt_f32_f16 s10, s5
+; GFX1150-TRUE16-NEXT:    s_cvt_f32_f16 s9, s9
 ; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_3)
-; GFX1150-TRUE16-NEXT:    s_cmp_ngt_f32 s9, s8
-; GFX1150-TRUE16-NEXT:    s_cbranch_scc0 .LBB10_10
-; GFX1150-TRUE16-NEXT:  ; %bb.9: ; %frem.else53
-; GFX1150-TRUE16-NEXT:    s_cmp_eq_f32 s9, s8
-; GFX1150-TRUE16-NEXT:    v_and_b16 v0.h, 0x8000, s10
+; GFX1150-TRUE16-NEXT:    s_cmp_ngt_f32 s10, s9
+; GFX1150-TRUE16-NEXT:    s_cbranch_scc0 .LBB10_11
+; GFX1150-TRUE16-NEXT:  ; %bb.10: ; %frem.else53
+; GFX1150-TRUE16-NEXT:    s_cmp_eq_f32 s10, s9
+; GFX1150-TRUE16-NEXT:    v_and_b16 v0.h, 0x8000, s8
 ; GFX1150-TRUE16-NEXT:    s_cselect_b32 s11, -1, 0
 ; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
-; GFX1150-TRUE16-NEXT:    v_cndmask_b16 v1.l, s10, v0.h, s11
-; GFX1150-TRUE16-NEXT:    s_mov_b32 s10, 0
-; GFX1150-TRUE16-NEXT:    s_branch .LBB10_11
-; GFX1150-TRUE16-NEXT:  .LBB10_10:
-; GFX1150-TRUE16-NEXT:    s_mov_b32 s10, -1
+; GFX1150-TRUE16-NEXT:    v_cndmask_b16 v1.l, s8, v0.h, s11
+; GFX1150-TRUE16-NEXT:    s_mov_b32 s11, 0
+; GFX1150-TRUE16-NEXT:    s_branch .LBB10_12
+; GFX1150-TRUE16-NEXT:  .LBB10_11:
+; GFX1150-TRUE16-NEXT:    s_mov_b32 s11, -1
 ; GFX1150-TRUE16-NEXT:    ; implicit-def: $vgpr1
-; GFX1150-TRUE16-NEXT:  .LBB10_11: ; %Flow131
+; GFX1150-TRUE16-NEXT:  .LBB10_12: ; %Flow131
 ; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
-; GFX1150-TRUE16-NEXT:    s_and_b32 s10, s10, exec_lo
-; GFX1150-TRUE16-NEXT:    s_cselect_b32 s10, 1, 0
-; GFX1150-TRUE16-NEXT:    s_cmp_lg_u32 s10, 1
-; GFX1150-TRUE16-NEXT:    s_cbranch_scc1 .LBB10_16
-; GFX1150-TRUE16-NEXT:  ; %bb.12: ; %frem.compute52
-; GFX1150-TRUE16-NEXT:    v_frexp_mant_f32_e32 v2, s8
-; GFX1150-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v4, s8
-; GFX1150-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v3, s9
-; GFX1150-TRUE16-NEXT:    v_frexp_mant_f32_e32 v1, s9
-; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX1150-TRUE16-NEXT:    s_and_b32 s11, s11, exec_lo
+; GFX1150-TRUE16-NEXT:    s_cselect_b32 s11, 1, 0
+; GFX1150-TRUE16-NEXT:    s_cmp_lg_u32 s11, 1
+; GFX1150-TRUE16-NEXT:    s_cbranch_scc1 .LBB10_18
+; GFX1150-TRUE16-NEXT:  ; %bb.13: ; %frem.compute52
+; GFX1150-TRUE16-NEXT:    v_frexp_mant_f32_e32 v2, s9
+; GFX1150-TRUE16-NEXT:    v_frexp_mant_f32_e32 v1, s10
+; GFX1150-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v4, s10
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
 ; GFX1150-TRUE16-NEXT:    v_ldexp_f32 v2, v2, 1
-; GFX1150-TRUE16-NEXT:    v_readfirstlane_b32 s8, v4
-; GFX1150-TRUE16-NEXT:    v_add_nc_u32_e32 v4, -1, v4
-; GFX1150-TRUE16-NEXT:    v_readfirstlane_b32 s9, v3
-; GFX1150-TRUE16-NEXT:    v_ldexp_f32 v1, v1, 11
-; GFX1150-TRUE16-NEXT:    v_div_scale_f32 v5, null, v2, v2, 1.0
-; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX1150-TRUE16-NEXT:    v_not_b32_e32 v4, v4
-; GFX1150-TRUE16-NEXT:    v_rcp_f32_e32 v6, v5
-; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_2) | instid1(TRANS32_DEP_1)
-; GFX1150-TRUE16-NEXT:    v_add_nc_u32_e32 v4, v4, v3
-; GFX1150-TRUE16-NEXT:    v_div_scale_f32 v3, vcc_lo, 1.0, v2, 1.0
+; GFX1150-TRUE16-NEXT:    v_ldexp_f32 v3, v1, 11
+; GFX1150-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v1, s9
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX1150-TRUE16-NEXT:    v_readfirstlane_b32 s10, v4
+; GFX1150-TRUE16-NEXT:    v_div_scale_f32 v6, null, v2, v2, 1.0
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_3)
+; GFX1150-TRUE16-NEXT:    v_readfirstlane_b32 s9, v1
+; GFX1150-TRUE16-NEXT:    v_add_nc_u32_e32 v1, -1, v1
+; GFX1150-TRUE16-NEXT:    v_rcp_f32_e32 v7, v6
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_not_b32_e32 v5, v1
+; GFX1150-TRUE16-NEXT:    v_add_nc_u32_e32 v5, v5, v4
+; GFX1150-TRUE16-NEXT:    v_div_scale_f32 v4, vcc_lo, 1.0, v2, 1.0
 ; GFX1150-TRUE16-NEXT:    s_denorm_mode 15
-; GFX1150-TRUE16-NEXT:    v_fma_f32 v7, -v5, v6, 1.0
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(TRANS32_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_fma_f32 v8, -v6, v7, 1.0
+; GFX1150-TRUE16-NEXT:    v_fmac_f32_e32 v7, v8, v7
 ; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1150-TRUE16-NEXT:    v_fmac_f32_e32 v6, v7, v6
-; GFX1150-TRUE16-NEXT:    v_mul_f32_e32 v7, v3, v6
+; GFX1150-TRUE16-NEXT:    v_mul_f32_e32 v8, v4, v7
+; GFX1150-TRUE16-NEXT:    v_fma_f32 v9, -v6, v8, v4
 ; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1150-TRUE16-NEXT:    v_fma_f32 v8, -v5, v7, v3
-; GFX1150-TRUE16-NEXT:    v_fmac_f32_e32 v7, v8, v6
-; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
-; GFX1150-TRUE16-NEXT:    v_fma_f32 v3, -v5, v7, v3
+; GFX1150-TRUE16-NEXT:    v_fmac_f32_e32 v8, v9, v7
+; GFX1150-TRUE16-NEXT:    v_fma_f32 v4, -v6, v8, v4
 ; GFX1150-TRUE16-NEXT:    s_denorm_mode 12
-; GFX1150-TRUE16-NEXT:    v_div_fmas_f32 v3, v3, v6, v7
-; GFX1150-TRUE16-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 12, v4
-; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX1150-TRUE16-NEXT:    v_div_fixup_f32 v3, v3, v2, 1.0
-; GFX1150-TRUE16-NEXT:    s_cbranch_vccnz .LBB10_15
-; GFX1150-TRUE16-NEXT:  ; %bb.13: ; %frem.loop_body60.preheader
-; GFX1150-TRUE16-NEXT:    s_sub_i32 s8, s9, s8
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1150-TRUE16-NEXT:    v_div_fmas_f32 v4, v4, v7, v8
+; GFX1150-TRUE16-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 12, v5
+; GFX1150-TRUE16-NEXT:    v_div_fixup_f32 v4, v4, v2, 1.0
+; GFX1150-TRUE16-NEXT:    s_cbranch_vccnz .LBB10_17
+; GFX1150-TRUE16-NEXT:  ; %bb.14: ; %frem.loop_body60.preheader
+; GFX1150-TRUE16-NEXT:    s_sub_i32 s9, s10, s9
 ; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX1150-TRUE16-NEXT:    s_add_i32 s8, s8, 11
-; GFX1150-TRUE16-NEXT:  .LBB10_14: ; %frem.loop_body60
+; GFX1150-TRUE16-NEXT:    s_add_i32 s9, s9, 11
+; GFX1150-TRUE16-NEXT:  .LBB10_15: ; %frem.loop_body60
 ; GFX1150-TRUE16-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
-; GFX1150-TRUE16-NEXT:    v_mul_f32_e32 v4, v1, v3
-; GFX1150-TRUE16-NEXT:    s_add_i32 s8, s8, -11
-; GFX1150-TRUE16-NEXT:    s_cmp_gt_i32 s8, 11
+; GFX1150-TRUE16-NEXT:    v_mov_b32_e32 v6, v3
+; GFX1150-TRUE16-NEXT:    s_add_i32 s9, s9, -11
+; GFX1150-TRUE16-NEXT:    s_cmp_gt_i32 s9, 11
 ; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_mul_f32_e32 v3, v6, v4
+; GFX1150-TRUE16-NEXT:    v_rndne_f32_e32 v3, v3
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_xor_b32_e32 v3, 0x80000000, v3
+; GFX1150-TRUE16-NEXT:    v_fma_f32 v3, v3, v2, v6
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v3
+; GFX1150-TRUE16-NEXT:    v_add_f32_e32 v5, v3, v2
+; GFX1150-TRUE16-NEXT:    v_cndmask_b32_e32 v3, v3, v5, vcc_lo
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_ldexp_f32 v3, v3, 11
+; GFX1150-TRUE16-NEXT:    s_cbranch_scc1 .LBB10_15
+; GFX1150-TRUE16-NEXT:  ; %bb.16: ; %Flow129
+; GFX1150-TRUE16-NEXT:    v_mov_b32_e32 v5, s9
+; GFX1150-TRUE16-NEXT:    v_mov_b32_e32 v3, v6
+; GFX1150-TRUE16-NEXT:  .LBB10_17: ; %frem.loop_exit61
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_add_nc_u32_e32 v5, -10, v5
+; GFX1150-TRUE16-NEXT:    v_ldexp_f32 v3, v3, v5
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_mul_f32_e32 v4, v3, v4
 ; GFX1150-TRUE16-NEXT:    v_rndne_f32_e32 v4, v4
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX1150-TRUE16-NEXT:    v_xor_b32_e32 v4, 0x80000000, v4
-; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1150-TRUE16-NEXT:    v_fmac_f32_e32 v1, v4, v2
-; GFX1150-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v1
-; GFX1150-TRUE16-NEXT:    v_add_f32_e32 v4, v1, v2
-; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1150-TRUE16-NEXT:    v_cndmask_b32_e32 v1, v1, v4, vcc_lo
-; GFX1150-TRUE16-NEXT:    v_ldexp_f32 v1, v1, 11
-; GFX1150-TRUE16-NEXT:    s_cbranch_scc1 .LBB10_14
-; GFX1150-TRUE16-NEXT:  .LBB10_15: ; %frem.loop_exit61
-; GFX1150-TRUE16-NEXT:    ; implicit-def: $vgpr1
-; GFX1150-TRUE16-NEXT:  .LBB10_16:
+; GFX1150-TRUE16-NEXT:    v_fmac_f32_e32 v3, v4, v2
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v3
+; GFX1150-TRUE16-NEXT:    v_add_f32_e32 v2, v3, v2
+; GFX1150-TRUE16-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc_lo
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1150-TRUE16-NEXT:    v_ldexp_f32 v1, v2, v1
+; GFX1150-TRUE16-NEXT:    v_mov_b16_e32 v2.l, s8
+; GFX1150-TRUE16-NEXT:    v_cvt_f16_f32_e32 v1.l, v1
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_bfi_b32 v1, 0x7fff, v1, v2
+; GFX1150-TRUE16-NEXT:  .LBB10_18:
 ; GFX1150-TRUE16-NEXT:    s_and_b32 s8, s7, 0x7fff
 ; GFX1150-TRUE16-NEXT:    s_and_b32 s9, s2, 0x7fff
 ; GFX1150-TRUE16-NEXT:    s_cvt_f32_f16 s10, s8
 ; GFX1150-TRUE16-NEXT:    s_cvt_f32_f16 s9, s9
 ; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_3)
 ; GFX1150-TRUE16-NEXT:    s_cmp_ngt_f32 s10, s9
-; GFX1150-TRUE16-NEXT:    s_cbranch_scc0 .LBB10_18
-; GFX1150-TRUE16-NEXT:  ; %bb.17: ; %frem.else20
+; GFX1150-TRUE16-NEXT:    s_cbranch_scc0 .LBB10_20
+; GFX1150-TRUE16-NEXT:  ; %bb.19: ; %frem.else20
 ; GFX1150-TRUE16-NEXT:    s_cmp_eq_f32 s10, s9
 ; GFX1150-TRUE16-NEXT:    v_and_b16 v0.h, 0x8000, s7
 ; GFX1150-TRUE16-NEXT:    s_cselect_b32 s11, -1, 0
 ; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
 ; GFX1150-TRUE16-NEXT:    v_cndmask_b16 v2.l, s7, v0.h, s11
 ; GFX1150-TRUE16-NEXT:    s_mov_b32 s11, 0
-; GFX1150-TRUE16-NEXT:    s_branch .LBB10_19
-; GFX1150-TRUE16-NEXT:  .LBB10_18:
+; GFX1150-TRUE16-NEXT:    s_branch .LBB10_21
+; GFX1150-TRUE16-NEXT:  .LBB10_20:
 ; GFX1150-TRUE16-NEXT:    s_mov_b32 s11, -1
 ; GFX1150-TRUE16-NEXT:    ; implicit-def: $vgpr2
-; GFX1150-TRUE16-NEXT:  .LBB10_19: ; %Flow127
+; GFX1150-TRUE16-NEXT:  .LBB10_21: ; %Flow127
 ; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX1150-TRUE16-NEXT:    s_and_b32 s11, s11, exec_lo
 ; GFX1150-TRUE16-NEXT:    s_cselect_b32 s11, 1, 0
 ; GFX1150-TRUE16-NEXT:    s_cmp_lg_u32 s11, 1
-; GFX1150-TRUE16-NEXT:    s_cbranch_scc1 .LBB10_24
-; GFX1150-TRUE16-NEXT:  ; %bb.20: ; %frem.compute19
+; GFX1150-TRUE16-NEXT:    s_cbranch_scc1 .LBB10_27
+; GFX1150-TRUE16-NEXT:  ; %bb.22: ; %frem.compute19
 ; GFX1150-TRUE16-NEXT:    v_frexp_mant_f32_e32 v3, s9
-; GFX1150-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v5, s9
-; GFX1150-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v4, s10
 ; GFX1150-TRUE16-NEXT:    v_frexp_mant_f32_e32 v2, s10
-; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX1150-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v5, s10
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
 ; GFX1150-TRUE16-NEXT:    v_ldexp_f32 v3, v3, 1
-; GFX1150-TRUE16-NEXT:    v_readfirstlane_b32 s9, v5
-; GFX1150-TRUE16-NEXT:    v_add_nc_u32_e32 v5, -1, v5
-; GFX1150-TRUE16-NEXT:    v_readfirstlane_b32 s10, v4
-; GFX1150-TRUE16-NEXT:    v_ldexp_f32 v2, v2, 11
-; GFX1150-TRUE16-NEXT:    v_div_scale_f32 v6, null, v3, v3, 1.0
-; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX1150-TRUE16-NEXT:    v_not_b32_e32 v5, v5
-; GFX1150-TRUE16-NEXT:    v_rcp_f32_e32 v7, v6
-; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_2) | instid1(TRANS32_DEP_1)
-; GFX1150-TRUE16-NEXT:    v_add_nc_u32_e32 v5, v5, v4
-; GFX1150-TRUE16-NEXT:    v_div_scale_f32 v4, vcc_lo, 1.0, v3, 1.0
+; GFX1150-TRUE16-NEXT:    v_ldexp_f32 v4, v2, 11
+; GFX1150-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v2, s9
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX1150-TRUE16-NEXT:    v_readfirstlane_b32 s10, v5
+; GFX1150-TRUE16-NEXT:    v_div_scale_f32 v7, null, v3, v3, 1.0
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_3)
+; GFX1150-TRUE16-NEXT:    v_readfirstlane_b32 s9, v2
+; GFX1150-TRUE16-NEXT:    v_add_nc_u32_e32 v2, -1, v2
+; GFX1150-TRUE16-NEXT:    v_rcp_f32_e32 v8, v7
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_not_b32_e32 v6, v2
+; GFX1150-TRUE16-NEXT:    v_add_nc_u32_e32 v6, v6, v5
+; GFX1150-TRUE16-NEXT:    v_div_scale_f32 v5, vcc_lo, 1.0, v3, 1.0
 ; GFX1150-TRUE16-NEXT:    s_denorm_mode 15
-; GFX1150-TRUE16-NEXT:    v_fma_f32 v8, -v6, v7, 1.0
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(TRANS32_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_fma_f32 v9, -v7, v8, 1.0
+; GFX1150-TRUE16-NEXT:    v_fmac_f32_e32 v8, v9, v8
 ; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1150-TRUE16-NEXT:    v_fmac_f32_e32 v7, v8, v7
-; GFX1150-TRUE16-NEXT:    v_mul_f32_e32 v8, v4, v7
+; GFX1150-TRUE16-NEXT:    v_mul_f32_e32 v9, v5, v8
+; GFX1150-TRUE16-NEXT:    v_fma_f32 v10, -v7, v9, v5
 ; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1150-TRUE16-NEXT:    v_fma_f32 v9, -v6, v8, v4
-; GFX1150-TRUE16-NEXT:    v_fmac_f32_e32 v8, v9, v7
-; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
-; GFX1150-TRUE16-NEXT:    v_fma_f32 v4, -v6, v8, v4
+; GFX1150-TRUE16-NEXT:    v_fmac_f32_e32 v9, v10, v8
+; GFX1150-TRUE16-NEXT:    v_fma_f32 v5, -v7, v9, v5
 ; GFX1150-TRUE16-NEXT:    s_denorm_mode 12
-; GFX1150-TRUE16-NEXT:    v_div_fmas_f32 v4, v4, v7, v8
-; GFX1150-TRUE16-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 12, v5
-; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX1150-TRUE16-NEXT:    v_div_fixup_f32 v4, v4, v3, 1.0
-; GFX1150-TRUE16-NEXT:    s_cbranch_vccnz .LBB10_23
-; GFX1150-TRUE16-NEXT:  ; %bb.21: ; %frem.loop_body27.preheader
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1150-TRUE16-NEXT:    v_div_fmas_f32 v5, v5, v8, v9
+; GFX1150-TRUE16-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 12, v6
+; GFX1150-TRUE16-NEXT:    v_div_fixup_f32 v5, v5, v3, 1.0
+; GFX1150-TRUE16-NEXT:    s_cbranch_vccnz .LBB10_26
+; GFX1150-TRUE16-NEXT:  ; %bb.23: ; %frem.loop_body27.preheader
 ; GFX1150-TRUE16-NEXT:    s_sub_i32 s9, s10, s9
 ; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
 ; GFX1150-TRUE16-NEXT:    s_add_i32 s9, s9, 11
-; GFX1150-TRUE16-NEXT:  .LBB10_22: ; %frem.loop_body27
+; GFX1150-TRUE16-NEXT:  .LBB10_24: ; %frem.loop_body27
 ; GFX1150-TRUE16-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
-; GFX1150-TRUE16-NEXT:    v_mul_f32_e32 v5, v2, v4
+; GFX1150-TRUE16-NEXT:    v_mov_b32_e32 v7, v4
 ; GFX1150-TRUE16-NEXT:    s_add_i32 s9, s9, -11
 ; GFX1150-TRUE16-NEXT:    s_cmp_gt_i32 s9, 11
 ; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_mul_f32_e32 v4, v7, v5
+; GFX1150-TRUE16-NEXT:    v_rndne_f32_e32 v4, v4
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_xor_b32_e32 v4, 0x80000000, v4
+; GFX1150-TRUE16-NEXT:    v_fma_f32 v4, v4, v3, v7
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v4
+; GFX1150-TRUE16-NEXT:    v_add_f32_e32 v6, v4, v3
+; GFX1150-TRUE16-NEXT:    v_cndmask_b32_e32 v4, v4, v6, vcc_lo
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_ldexp_f32 v4, v4, 11
+; GFX1150-TRUE16-NEXT:    s_cbranch_scc1 .LBB10_24
+; GFX1150-TRUE16-NEXT:  ; %bb.25: ; %Flow125
+; GFX1150-TRUE16-NEXT:    v_mov_b32_e32 v6, s9
+; GFX1150-TRUE16-NEXT:    v_mov_b32_e32 v4, v7
+; GFX1150-TRUE16-NEXT:  .LBB10_26: ; %frem.loop_exit28
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_add_nc_u32_e32 v6, -10, v6
+; GFX1150-TRUE16-NEXT:    v_ldexp_f32 v4, v4, v6
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_mul_f32_e32 v5, v4, v5
 ; GFX1150-TRUE16-NEXT:    v_rndne_f32_e32 v5, v5
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX1150-TRUE16-NEXT:    v_xor_b32_e32 v5, 0x80000000, v5
-; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1150-TRUE16-NEXT:    v_fmac_f32_e32 v2, v5, v3
-; GFX1150-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v2
-; GFX1150-TRUE16-NEXT:    v_add_f32_e32 v5, v2, v3
-; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1150-TRUE16-NEXT:    v_cndmask_b32_e32 v2, v2, v5, vcc_lo
-; GFX1150-TRUE16-NEXT:    v_ldexp_f32 v2, v2, 11
-; GFX1150-TRUE16-NEXT:    s_cbranch_scc1 .LBB10_22
-; GFX1150-TRUE16-NEXT:  .LBB10_23: ; %frem.loop_exit28
-; GFX1150-TRUE16-NEXT:    ; implicit-def: $vgpr2
-; GFX1150-TRUE16-NEXT:  .LBB10_24:
-; GFX1150-TRUE16-NEXT:    s_lshr_b32 s12, s7, 16
+; GFX1150-TRUE16-NEXT:    v_fmac_f32_e32 v4, v5, v3
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v4
+; GFX1150-TRUE16-NEXT:    v_add_f32_e32 v3, v4, v3
+; GFX1150-TRUE16-NEXT:    v_cndmask_b32_e32 v3, v4, v3, vcc_lo
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1150-TRUE16-NEXT:    v_ldexp_f32 v2, v3, v2
+; GFX1150-TRUE16-NEXT:    v_mov_b16_e32 v3.l, s7
+; GFX1150-TRUE16-NEXT:    v_cvt_f16_f32_e32 v2.l, v2
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_bfi_b32 v2, 0x7fff, v2, v3
+; GFX1150-TRUE16-NEXT:  .LBB10_27:
+; GFX1150-TRUE16-NEXT:    s_lshr_b32 s10, s7, 16
 ; GFX1150-TRUE16-NEXT:    s_lshr_b32 s9, s2, 16
-; GFX1150-TRUE16-NEXT:    s_and_b32 s7, s12, 0x7fff
-; GFX1150-TRUE16-NEXT:    s_and_b32 s10, s9, 0x7fff
-; GFX1150-TRUE16-NEXT:    s_cvt_f32_f16 s11, s7
-; GFX1150-TRUE16-NEXT:    s_cvt_f32_f16 s10, s10
+; GFX1150-TRUE16-NEXT:    s_and_b32 s7, s10, 0x7fff
+; GFX1150-TRUE16-NEXT:    s_and_b32 s11, s9, 0x7fff
+; GFX1150-TRUE16-NEXT:    s_cvt_f32_f16 s12, s7
+; GFX1150-TRUE16-NEXT:    s_cvt_f32_f16 s11, s11
 ; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_3)
-; GFX1150-TRUE16-NEXT:    s_cmp_ngt_f32 s11, s10
-; GFX1150-TRUE16-NEXT:    s_cbranch_scc0 .LBB10_26
-; GFX1150-TRUE16-NEXT:  ; %bb.25: ; %frem.else
-; GFX1150-TRUE16-NEXT:    s_cmp_eq_f32 s11, s10
-; GFX1150-TRUE16-NEXT:    v_and_b16 v0.h, 0x8000, s12
+; GFX1150-TRUE16-NEXT:    s_cmp_ngt_f32 s12, s11
+; GFX1150-TRUE16-NEXT:    s_cbranch_scc0 .LBB10_29
+; GFX1150-TRUE16-NEXT:  ; %bb.28: ; %frem.else
+; GFX1150-TRUE16-NEXT:    s_cmp_eq_f32 s12, s11
+; GFX1150-TRUE16-NEXT:    v_and_b16 v0.h, 0x8000, s10
 ; GFX1150-TRUE16-NEXT:    s_cselect_b32 s13, -1, 0
 ; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
-; GFX1150-TRUE16-NEXT:    v_cndmask_b16 v3.l, s12, v0.h, s13
-; GFX1150-TRUE16-NEXT:    s_mov_b32 s12, 0
-; GFX1150-TRUE16-NEXT:    s_branch .LBB10_27
-; GFX1150-TRUE16-NEXT:  .LBB10_26:
-; GFX1150-TRUE16-NEXT:    s_mov_b32 s12, -1
+; GFX1150-TRUE16-NEXT:    v_cndmask_b16 v3.l, s10, v0.h, s13
+; GFX1150-TRUE16-NEXT:    s_mov_b32 s13, 0
+; GFX1150-TRUE16-NEXT:    s_branch .LBB10_30
+; GFX1150-TRUE16-NEXT:  .LBB10_29:
+; GFX1150-TRUE16-NEXT:    s_mov_b32 s13, -1
 ; GFX1150-TRUE16-NEXT:    ; implicit-def: $vgpr3
-; GFX1150-TRUE16-NEXT:  .LBB10_27: ; %Flow123
+; GFX1150-TRUE16-NEXT:  .LBB10_30: ; %Flow123
 ; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
-; GFX1150-TRUE16-NEXT:    s_and_b32 s12, s12, exec_lo
-; GFX1150-TRUE16-NEXT:    s_cselect_b32 s12, 1, 0
-; GFX1150-TRUE16-NEXT:    s_cmp_lg_u32 s12, 1
-; GFX1150-TRUE16-NEXT:    s_cbranch_scc1 .LBB10_32
-; GFX1150-TRUE16-NEXT:  ; %bb.28: ; %frem.compute
-; GFX1150-TRUE16-NEXT:    v_frexp_mant_f32_e32 v4, s10
-; GFX1150-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v6, s10
-; GFX1150-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v5, s11
-; GFX1150-TRUE16-NEXT:    v_frexp_mant_f32_e32 v3, s11
-; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX1150-TRUE16-NEXT:    s_and_b32 s13, s13, exec_lo
+; GFX1150-TRUE16-NEXT:    s_cselect_b32 s13, 1, 0
+; GFX1150-TRUE16-NEXT:    s_cmp_lg_u32 s13, 1
+; GFX1150-TRUE16-NEXT:    s_cbranch_scc1 .LBB10_36
+; GFX1150-TRUE16-NEXT:  ; %bb.31: ; %frem.compute
+; GFX1150-TRUE16-NEXT:    v_frexp_mant_f32_e32 v4, s11
+; GFX1150-TRUE16-NEXT:    v_frexp_mant_f32_e32 v3, s12
+; GFX1150-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v6, s12
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
 ; GFX1150-TRUE16-NEXT:    v_ldexp_f32 v4, v4, 1
-; GFX1150-TRUE16-NEXT:    v_readfirstlane_b32 s10, v6
-; GFX1150-TRUE16-NEXT:    v_add_nc_u32_e32 v6, -1, v6
-; GFX1150-TRUE16-NEXT:    v_readfirstlane_b32 s11, v5
-; GFX1150-TRUE16-NEXT:    v_ldexp_f32 v3, v3, 11
-; GFX1150-TRUE16-NEXT:    v_div_scale_f32 v7, null, v4, v4, 1.0
-; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX1150-TRUE16-NEXT:    v_not_b32_e32 v6, v6
-; GFX1150-TRUE16-NEXT:    v_rcp_f32_e32 v8, v7
-; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_2) | instid1(TRANS32_DEP_1)
-; GFX1150-TRUE16-NEXT:    v_add_nc_u32_e32 v6, v6, v5
-; GFX1150-TRUE16-NEXT:    v_div_scale_f32 v5, vcc_lo, 1.0, v4, 1.0
+; GFX1150-TRUE16-NEXT:    v_ldexp_f32 v5, v3, 11
+; GFX1150-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v3, s11
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX1150-TRUE16-NEXT:    v_readfirstlane_b32 s12, v6
+; GFX1150-TRUE16-NEXT:    v_div_scale_f32 v8, null, v4, v4, 1.0
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_3)
+; GFX1150-TRUE16-NEXT:    v_readfirstlane_b32 s11, v3
+; GFX1150-TRUE16-NEXT:    v_add_nc_u32_e32 v3, -1, v3
+; GFX1150-TRUE16-NEXT:    v_rcp_f32_e32 v9, v8
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_not_b32_e32 v7, v3
+; GFX1150-TRUE16-NEXT:    v_add_nc_u32_e32 v7, v7, v6
+; GFX1150-TRUE16-NEXT:    v_div_scale_f32 v6, vcc_lo, 1.0, v4, 1.0
 ; GFX1150-TRUE16-NEXT:    s_denorm_mode 15
-; GFX1150-TRUE16-NEXT:    v_fma_f32 v9, -v7, v8, 1.0
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(TRANS32_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_fma_f32 v10, -v8, v9, 1.0
+; GFX1150-TRUE16-NEXT:    v_fmac_f32_e32 v9, v10, v9
 ; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1150-TRUE16-NEXT:    v_fmac_f32_e32 v8, v9, v8
-; GFX1150-TRUE16-NEXT:    v_mul_f32_e32 v9, v5, v8
+; GFX1150-TRUE16-NEXT:    v_mul_f32_e32 v10, v6, v9
+; GFX1150-TRUE16-NEXT:    v_fma_f32 v11, -v8, v10, v6
 ; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1150-TRUE16-NEXT:    v_fma_f32 v10, -v7, v9, v5
-; GFX1150-TRUE16-NEXT:    v_fmac_f32_e32 v9, v10, v8
-; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
-; GFX1150-TRUE16-NEXT:    v_fma_f32 v5, -v7, v9, v5
+; GFX1150-TRUE16-NEXT:    v_fmac_f32_e32 v10, v11, v9
+; GFX1150-TRUE16-NEXT:    v_fma_f32 v6, -v8, v10, v6
 ; GFX1150-TRUE16-NEXT:    s_denorm_mode 12
-; GFX1150-TRUE16-NEXT:    v_div_fmas_f32 v5, v5, v8, v9
-; GFX1150-TRUE16-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 12, v6
-; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX1150-TRUE16-NEXT:    v_div_fixup_f32 v5, v5, v4, 1.0
-; GFX1150-TRUE16-NEXT:    s_cbranch_vccnz .LBB10_31
-; GFX1150-TRUE16-NEXT:  ; %bb.29: ; %frem.loop_body.preheader
-; GFX1150-TRUE16-NEXT:    s_sub_i32 s10, s11, s10
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1150-TRUE16-NEXT:    v_div_fmas_f32 v6, v6, v9, v10
+; GFX1150-TRUE16-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 12, v7
+; GFX1150-TRUE16-NEXT:    v_div_fixup_f32 v6, v6, v4, 1.0
+; GFX1150-TRUE16-NEXT:    s_cbranch_vccnz .LBB10_35
+; GFX1150-TRUE16-NEXT:  ; %bb.32: ; %frem.loop_body.preheader
+; GFX1150-TRUE16-NEXT:    s_sub_i32 s11, s12, s11
 ; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX1150-TRUE16-NEXT:    s_add_i32 s10, s10, 11
-; GFX1150-TRUE16-NEXT:  .LBB10_30: ; %frem.loop_body
+; GFX1150-TRUE16-NEXT:    s_add_i32 s11, s11, 11
+; GFX1150-TRUE16-NEXT:  .LBB10_33: ; %frem.loop_body
 ; GFX1150-TRUE16-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
-; GFX1150-TRUE16-NEXT:    v_mul_f32_e32 v6, v3, v5
-; GFX1150-TRUE16-NEXT:    s_add_i32 s10, s10, -11
-; GFX1150-TRUE16-NEXT:    s_cmp_gt_i32 s10, 11
+; GFX1150-TRUE16-NEXT:    v_mov_b32_e32 v8, v5
+; GFX1150-TRUE16-NEXT:    s_add_i32 s11, s11, -11
+; GFX1150-TRUE16-NEXT:    s_cmp_gt_i32 s11, 11
 ; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_mul_f32_e32 v5, v8, v6
+; GFX1150-TRUE16-NEXT:    v_rndne_f32_e32 v5, v5
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_xor_b32_e32 v5, 0x80000000, v5
+; GFX1150-TRUE16-NEXT:    v_fma_f32 v5, v5, v4, v8
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v5
+; GFX1150-TRUE16-NEXT:    v_add_f32_e32 v7, v5, v4
+; GFX1150-TRUE16-NEXT:    v_cndmask_b32_e32 v5, v5, v7, vcc_lo
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_ldexp_f32 v5, v5, 11
+; GFX1150-TRUE16-NEXT:    s_cbranch_scc1 .LBB10_33
+; GFX1150-TRUE16-NEXT:  ; %bb.34: ; %Flow
+; GFX1150-TRUE16-NEXT:    v_mov_b32_e32 v7, s11
+; GFX1150-TRUE16-NEXT:    v_mov_b32_e32 v5, v8
+; GFX1150-TRUE16-NEXT:  .LBB10_35: ; %frem.loop_exit
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_add_nc_u32_e32 v7, -10, v7
+; GFX1150-TRUE16-NEXT:    v_ldexp_f32 v5, v5, v7
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_mul_f32_e32 v6, v5, v6
 ; GFX1150-TRUE16-NEXT:    v_rndne_f32_e32 v6, v6
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX1150-TRUE16-NEXT:    v_xor_b32_e32 v6, 0x80000000, v6
-; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1150-TRUE16-NEXT:    v_fmac_f32_e32 v3, v6, v4
-; GFX1150-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v3
-; GFX1150-TRUE16-NEXT:    v_add_f32_e32 v6, v3, v4
-; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1150-TRUE16-NEXT:    v_cndmask_b32_e32 v3, v3, v6, vcc_lo
-; GFX1150-TRUE16-NEXT:    v_ldexp_f32 v3, v3, 11
-; GFX1150-TRUE16-NEXT:    s_cbranch_scc1 .LBB10_30
-; GFX1150-TRUE16-NEXT:  .LBB10_31: ; %frem.loop_exit
-; GFX1150-TRUE16-NEXT:    ; implicit-def: $vgpr3
-; GFX1150-TRUE16-NEXT:  .LBB10_32: ; %Flow124
+; GFX1150-TRUE16-NEXT:    v_fmac_f32_e32 v5, v6, v4
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v5
+; GFX1150-TRUE16-NEXT:    v_add_f32_e32 v4, v5, v4
+; GFX1150-TRUE16-NEXT:    v_cndmask_b32_e32 v4, v5, v4, vcc_lo
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1150-TRUE16-NEXT:    v_ldexp_f32 v3, v4, v3
+; GFX1150-TRUE16-NEXT:    v_mov_b16_e32 v4.l, s10
+; GFX1150-TRUE16-NEXT:    v_cvt_f16_f32_e32 v3.l, v3
+; GFX1150-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1150-TRUE16-NEXT:    v_bfi_b32 v3, 0x7fff, v3, v4
+; GFX1150-TRUE16-NEXT:  .LBB10_36: ; %Flow124
 ; GFX1150-TRUE16-NEXT:    s_cmp_lg_f16 s4, 0
 ; GFX1150-TRUE16-NEXT:    s_cselect_b32 s4, -1, 0
 ; GFX1150-TRUE16-NEXT:    s_cmp_nge_f16 s3, 0x7c00
@@ -10878,41 +11266,42 @@ define amdgpu_kernel void @frem_v4f16(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; GFX1200-TRUE16-NEXT:    s_cselect_b32 s9, 1, 0
 ; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX1200-TRUE16-NEXT:    s_cmp_lg_u32 s9, 1
-; GFX1200-TRUE16-NEXT:    s_cbranch_scc1 .LBB10_8
+; GFX1200-TRUE16-NEXT:    s_cbranch_scc1 .LBB10_9
 ; GFX1200-TRUE16-NEXT:  ; %bb.4: ; %frem.compute85
 ; GFX1200-TRUE16-NEXT:    v_frexp_mant_f32_e32 v1, s6
-; GFX1200-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v3, s6
-; GFX1200-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v2, s8
 ; GFX1200-TRUE16-NEXT:    v_frexp_mant_f32_e32 v0, s8
-; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX1200-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v3, s8
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
 ; GFX1200-TRUE16-NEXT:    v_ldexp_f32 v1, v1, 1
-; GFX1200-TRUE16-NEXT:    v_readfirstlane_b32 s6, v3
-; GFX1200-TRUE16-NEXT:    v_add_nc_u32_e32 v3, -1, v3
-; GFX1200-TRUE16-NEXT:    v_readfirstlane_b32 s8, v2
-; GFX1200-TRUE16-NEXT:    v_ldexp_f32 v0, v0, 11
-; GFX1200-TRUE16-NEXT:    v_div_scale_f32 v4, null, v1, v1, 1.0
-; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX1200-TRUE16-NEXT:    v_not_b32_e32 v3, v3
-; GFX1200-TRUE16-NEXT:    v_rcp_f32_e32 v5, v4
-; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_2) | instid1(TRANS32_DEP_1)
-; GFX1200-TRUE16-NEXT:    v_add_nc_u32_e32 v3, v3, v2
-; GFX1200-TRUE16-NEXT:    v_div_scale_f32 v2, vcc_lo, 1.0, v1, 1.0
+; GFX1200-TRUE16-NEXT:    v_ldexp_f32 v2, v0, 11
+; GFX1200-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v0, s6
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX1200-TRUE16-NEXT:    v_readfirstlane_b32 s8, v3
+; GFX1200-TRUE16-NEXT:    v_div_scale_f32 v5, null, v1, v1, 1.0
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_3)
+; GFX1200-TRUE16-NEXT:    v_readfirstlane_b32 s6, v0
+; GFX1200-TRUE16-NEXT:    v_add_nc_u32_e32 v0, -1, v0
+; GFX1200-TRUE16-NEXT:    v_rcp_f32_e32 v6, v5
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1200-TRUE16-NEXT:    v_not_b32_e32 v4, v0
+; GFX1200-TRUE16-NEXT:    v_add_nc_u32_e32 v4, v4, v3
+; GFX1200-TRUE16-NEXT:    v_div_scale_f32 v3, vcc_lo, 1.0, v1, 1.0
 ; GFX1200-TRUE16-NEXT:    s_denorm_mode 15
-; GFX1200-TRUE16-NEXT:    v_fma_f32 v6, -v4, v5, 1.0
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(TRANS32_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1200-TRUE16-NEXT:    v_fma_f32 v7, -v5, v6, 1.0
+; GFX1200-TRUE16-NEXT:    v_fmac_f32_e32 v6, v7, v6
 ; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1200-TRUE16-NEXT:    v_fmac_f32_e32 v5, v6, v5
-; GFX1200-TRUE16-NEXT:    v_mul_f32_e32 v6, v2, v5
+; GFX1200-TRUE16-NEXT:    v_mul_f32_e32 v7, v3, v6
+; GFX1200-TRUE16-NEXT:    v_fma_f32 v8, -v5, v7, v3
 ; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1200-TRUE16-NEXT:    v_fma_f32 v7, -v4, v6, v2
-; GFX1200-TRUE16-NEXT:    v_fmac_f32_e32 v6, v7, v5
-; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
-; GFX1200-TRUE16-NEXT:    v_fma_f32 v2, -v4, v6, v2
+; GFX1200-TRUE16-NEXT:    v_fmac_f32_e32 v7, v8, v6
+; GFX1200-TRUE16-NEXT:    v_fma_f32 v3, -v5, v7, v3
 ; GFX1200-TRUE16-NEXT:    s_denorm_mode 12
-; GFX1200-TRUE16-NEXT:    v_div_fmas_f32 v2, v2, v5, v6
-; GFX1200-TRUE16-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 12, v3
-; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX1200-TRUE16-NEXT:    v_div_fixup_f32 v2, v2, v1, 1.0
-; GFX1200-TRUE16-NEXT:    s_cbranch_vccnz .LBB10_7
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1200-TRUE16-NEXT:    v_div_fmas_f32 v3, v3, v6, v7
+; GFX1200-TRUE16-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 12, v4
+; GFX1200-TRUE16-NEXT:    v_div_fixup_f32 v3, v3, v1, 1.0
+; GFX1200-TRUE16-NEXT:    s_cbranch_vccnz .LBB10_8
 ; GFX1200-TRUE16-NEXT:  ; %bb.5: ; %frem.loop_body93.preheader
 ; GFX1200-TRUE16-NEXT:    s_sub_co_i32 s6, s8, s6
 ; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
@@ -10920,119 +11309,165 @@ define amdgpu_kernel void @frem_v4f16(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; GFX1200-TRUE16-NEXT:  .LBB10_6: ; %frem.loop_body93
 ; GFX1200-TRUE16-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1200-TRUE16-NEXT:    v_mul_f32_e32 v3, v0, v2
+; GFX1200-TRUE16-NEXT:    v_mov_b32_e32 v5, v2
 ; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX1200-TRUE16-NEXT:    s_add_co_i32 s6, s6, -11
 ; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX1200-TRUE16-NEXT:    s_cmp_gt_i32 s6, 11
+; GFX1200-TRUE16-NEXT:    v_mul_f32_e32 v2, v5, v3
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1200-TRUE16-NEXT:    v_rndne_f32_e32 v2, v2
+; GFX1200-TRUE16-NEXT:    v_xor_b32_e32 v2, 0x80000000, v2
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1200-TRUE16-NEXT:    v_fma_f32 v2, v2, v1, v5
+; GFX1200-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v2
+; GFX1200-TRUE16-NEXT:    v_add_f32_e32 v4, v2, v1
+; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1200-TRUE16-NEXT:    v_cndmask_b32_e32 v2, v2, v4, vcc_lo
+; GFX1200-TRUE16-NEXT:    v_ldexp_f32 v2, v2, 11
+; GFX1200-TRUE16-NEXT:    s_cbranch_scc1 .LBB10_6
+; GFX1200-TRUE16-NEXT:  ; %bb.7: ; %Flow133
+; GFX1200-TRUE16-NEXT:    v_mov_b32_e32 v4, s6
+; GFX1200-TRUE16-NEXT:    v_mov_b32_e32 v2, v5
+; GFX1200-TRUE16-NEXT:  .LBB10_8: ; %frem.loop_exit94
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1200-TRUE16-NEXT:    v_add_nc_u32_e32 v4, -10, v4
+; GFX1200-TRUE16-NEXT:    v_ldexp_f32 v2, v2, v4
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1200-TRUE16-NEXT:    v_mul_f32_e32 v3, v2, v3
 ; GFX1200-TRUE16-NEXT:    v_rndne_f32_e32 v3, v3
 ; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX1200-TRUE16-NEXT:    v_xor_b32_e32 v3, 0x80000000, v3
-; GFX1200-TRUE16-NEXT:    v_fmac_f32_e32 v0, v3, v1
+; GFX1200-TRUE16-NEXT:    v_fmac_f32_e32 v2, v3, v1
 ; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_2) | instid1(VALU_DEP_1)
-; GFX1200-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v0
-; GFX1200-TRUE16-NEXT:    v_add_f32_e32 v3, v0, v1
+; GFX1200-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v2
+; GFX1200-TRUE16-NEXT:    v_add_f32_e32 v1, v2, v1
 ; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_va_vcc(0)
-; GFX1200-TRUE16-NEXT:    v_cndmask_b32_e32 v0, v0, v3, vcc_lo
+; GFX1200-TRUE16-NEXT:    v_cndmask_b32_e32 v1, v2, v1, vcc_lo
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1200-TRUE16-NEXT:    v_ldexp_f32 v0, v1, v0
+; GFX1200-TRUE16-NEXT:    v_mov_b16_e32 v1.l, s5
+; GFX1200-TRUE16-NEXT:    v_cvt_f16_f32_e32 v0.l, v0
 ; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1200-TRUE16-NEXT:    v_ldexp_f32 v0, v0, 11
-; GFX1200-TRUE16-NEXT:    s_cbranch_scc1 .LBB10_6
-; GFX1200-TRUE16-NEXT:  .LBB10_7: ; %frem.loop_exit94
-; GFX1200-TRUE16-NEXT:    ; implicit-def: $vgpr0
-; GFX1200-TRUE16-NEXT:  .LBB10_8:
-; GFX1200-TRUE16-NEXT:    s_lshr_b32 s10, s5, 16
+; GFX1200-TRUE16-NEXT:    v_bfi_b32 v0, 0x7fff, v0, v1
+; GFX1200-TRUE16-NEXT:  .LBB10_9:
+; GFX1200-TRUE16-NEXT:    s_lshr_b32 s8, s5, 16
 ; GFX1200-TRUE16-NEXT:    s_lshr_b32 s6, s4, 16
-; GFX1200-TRUE16-NEXT:    s_and_b32 s5, s10, 0x7fff
 ; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX1200-TRUE16-NEXT:    s_and_b32 s8, s6, 0x7fff
-; GFX1200-TRUE16-NEXT:    s_cvt_f32_f16 s9, s5
+; GFX1200-TRUE16-NEXT:    s_and_b32 s5, s8, 0x7fff
+; GFX1200-TRUE16-NEXT:    s_and_b32 s9, s6, 0x7fff
 ; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX1200-TRUE16-NEXT:    s_cvt_f32_f16 s8, s8
+; GFX1200-TRUE16-NEXT:    s_cvt_f32_f16 s10, s5
+; GFX1200-TRUE16-NEXT:    s_cvt_f32_f16 s9, s9
 ; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_2)
-; GFX1200-TRUE16-NEXT:    s_cmp_ngt_f32 s9, s8
-; GFX1200-TRUE16-NEXT:    s_cbranch_scc0 .LBB10_10
-; GFX1200-TRUE16-NEXT:  ; %bb.9: ; %frem.else53
-; GFX1200-TRUE16-NEXT:    s_cmp_eq_f32 s9, s8
-; GFX1200-TRUE16-NEXT:    v_and_b16 v0.h, 0x8000, s10
+; GFX1200-TRUE16-NEXT:    s_cmp_ngt_f32 s10, s9
+; GFX1200-TRUE16-NEXT:    s_cbranch_scc0 .LBB10_11
+; GFX1200-TRUE16-NEXT:  ; %bb.10: ; %frem.else53
+; GFX1200-TRUE16-NEXT:    s_cmp_eq_f32 s10, s9
+; GFX1200-TRUE16-NEXT:    v_and_b16 v0.h, 0x8000, s8
 ; GFX1200-TRUE16-NEXT:    s_cselect_b32 s11, -1, 0
-; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1200-TRUE16-NEXT:    v_cndmask_b16 v1.l, s10, v0.h, s11
-; GFX1200-TRUE16-NEXT:    s_mov_b32 s10, 0
-; GFX1200-TRUE16-NEXT:    s_branch .LBB10_11
-; GFX1200-TRUE16-NEXT:  .LBB10_10:
-; GFX1200-TRUE16-NEXT:    s_mov_b32 s10, -1
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1200-TRUE16-NEXT:    v_cndmask_b16 v1.l, s8, v0.h, s11
+; GFX1200-TRUE16-NEXT:    s_mov_b32 s11, 0
+; GFX1200-TRUE16-NEXT:    s_branch .LBB10_12
+; GFX1200-TRUE16-NEXT:  .LBB10_11:
+; GFX1200-TRUE16-NEXT:    s_mov_b32 s11, -1
 ; GFX1200-TRUE16-NEXT:    ; implicit-def: $vgpr1
-; GFX1200-TRUE16-NEXT:  .LBB10_11: ; %Flow131
+; GFX1200-TRUE16-NEXT:  .LBB10_12: ; %Flow131
 ; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX1200-TRUE16-NEXT:    s_and_b32 s10, s10, exec_lo
-; GFX1200-TRUE16-NEXT:    s_cselect_b32 s10, 1, 0
+; GFX1200-TRUE16-NEXT:    s_and_b32 s11, s11, exec_lo
+; GFX1200-TRUE16-NEXT:    s_cselect_b32 s11, 1, 0
 ; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX1200-TRUE16-NEXT:    s_cmp_lg_u32 s10, 1
-; GFX1200-TRUE16-NEXT:    s_cbranch_scc1 .LBB10_16
-; GFX1200-TRUE16-NEXT:  ; %bb.12: ; %frem.compute52
-; GFX1200-TRUE16-NEXT:    v_frexp_mant_f32_e32 v2, s8
-; GFX1200-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v4, s8
-; GFX1200-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v3, s9
-; GFX1200-TRUE16-NEXT:    v_frexp_mant_f32_e32 v1, s9
-; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX1200-TRUE16-NEXT:    s_cmp_lg_u32 s11, 1
+; GFX1200-TRUE16-NEXT:    s_cbranch_scc1 .LBB10_18
+; GFX1200-TRUE16-NEXT:  ; %bb.13: ; %frem.compute52
+; GFX1200-TRUE16-NEXT:    v_frexp_mant_f32_e32 v2, s9
+; GFX1200-TRUE16-NEXT:    v_frexp_mant_f32_e32 v1, s10
+; GFX1200-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v4, s10
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
 ; GFX1200-TRUE16-NEXT:    v_ldexp_f32 v2, v2, 1
-; GFX1200-TRUE16-NEXT:    v_readfirstlane_b32 s8, v4
-; GFX1200-TRUE16-NEXT:    v_add_nc_u32_e32 v4, -1, v4
-; GFX1200-TRUE16-NEXT:    v_readfirstlane_b32 s9, v3
-; GFX1200-TRUE16-NEXT:    v_ldexp_f32 v1, v1, 11
-; GFX1200-TRUE16-NEXT:    v_div_scale_f32 v5, null, v2, v2, 1.0
-; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX1200-TRUE16-NEXT:    v_not_b32_e32 v4, v4
-; GFX1200-TRUE16-NEXT:    v_rcp_f32_e32 v6, v5
-; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_2) | instid1(TRANS32_DEP_1)
-; GFX1200-TRUE16-NEXT:    v_add_nc_u32_e32 v4, v4, v3
-; GFX1200-TRUE16-NEXT:    v_div_scale_f32 v3, vcc_lo, 1.0, v2, 1.0
+; GFX1200-TRUE16-NEXT:    v_ldexp_f32 v3, v1, 11
+; GFX1200-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v1, s9
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX1200-TRUE16-NEXT:    v_readfirstlane_b32 s10, v4
+; GFX1200-TRUE16-NEXT:    v_div_scale_f32 v6, null, v2, v2, 1.0
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_3)
+; GFX1200-TRUE16-NEXT:    v_readfirstlane_b32 s9, v1
+; GFX1200-TRUE16-NEXT:    v_add_nc_u32_e32 v1, -1, v1
+; GFX1200-TRUE16-NEXT:    v_rcp_f32_e32 v7, v6
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1200-TRUE16-NEXT:    v_not_b32_e32 v5, v1
+; GFX1200-TRUE16-NEXT:    v_add_nc_u32_e32 v5, v5, v4
+; GFX1200-TRUE16-NEXT:    v_div_scale_f32 v4, vcc_lo, 1.0, v2, 1.0
 ; GFX1200-TRUE16-NEXT:    s_denorm_mode 15
-; GFX1200-TRUE16-NEXT:    v_fma_f32 v7, -v5, v6, 1.0
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(TRANS32_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1200-TRUE16-NEXT:    v_fma_f32 v8, -v6, v7, 1.0
+; GFX1200-TRUE16-NEXT:    v_fmac_f32_e32 v7, v8, v7
 ; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1200-TRUE16-NEXT:    v_fmac_f32_e32 v6, v7, v6
-; GFX1200-TRUE16-NEXT:    v_mul_f32_e32 v7, v3, v6
+; GFX1200-TRUE16-NEXT:    v_mul_f32_e32 v8, v4, v7
+; GFX1200-TRUE16-NEXT:    v_fma_f32 v9, -v6, v8, v4
 ; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1200-TRUE16-NEXT:    v_fma_f32 v8, -v5, v7, v3
-; GFX1200-TRUE16-NEXT:    v_fmac_f32_e32 v7, v8, v6
-; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_2) | instid1(VALU_DEP_1)
-; GFX1200-TRUE16-NEXT:    v_fma_f32 v3, -v5, v7, v3
+; GFX1200-TRUE16-NEXT:    v_fmac_f32_e32 v8, v9, v7
+; GFX1200-TRUE16-NEXT:    v_fma_f32 v4, -v6, v8, v4
 ; GFX1200-TRUE16-NEXT:    s_denorm_mode 12
 ; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_va_vcc(0)
-; GFX1200-TRUE16-NEXT:    v_div_fmas_f32 v3, v3, v6, v7
-; GFX1200-TRUE16-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 12, v4
-; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX1200-TRUE16-NEXT:    v_div_fixup_f32 v3, v3, v2, 1.0
-; GFX1200-TRUE16-NEXT:    s_cbranch_vccnz .LBB10_15
-; GFX1200-TRUE16-NEXT:  ; %bb.13: ; %frem.loop_body60.preheader
-; GFX1200-TRUE16-NEXT:    s_sub_co_i32 s8, s9, s8
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1200-TRUE16-NEXT:    v_div_fmas_f32 v4, v4, v7, v8
+; GFX1200-TRUE16-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 12, v5
+; GFX1200-TRUE16-NEXT:    v_div_fixup_f32 v4, v4, v2, 1.0
+; GFX1200-TRUE16-NEXT:    s_cbranch_vccnz .LBB10_17
+; GFX1200-TRUE16-NEXT:  ; %bb.14: ; %frem.loop_body60.preheader
+; GFX1200-TRUE16-NEXT:    s_sub_co_i32 s9, s10, s9
 ; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX1200-TRUE16-NEXT:    s_add_co_i32 s8, s8, 11
-; GFX1200-TRUE16-NEXT:  .LBB10_14: ; %frem.loop_body60
+; GFX1200-TRUE16-NEXT:    s_add_co_i32 s9, s9, 11
+; GFX1200-TRUE16-NEXT:  .LBB10_15: ; %frem.loop_body60
 ; GFX1200-TRUE16-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1200-TRUE16-NEXT:    v_mul_f32_e32 v4, v1, v3
+; GFX1200-TRUE16-NEXT:    v_mov_b32_e32 v6, v3
 ; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX1200-TRUE16-NEXT:    s_add_co_i32 s8, s8, -11
+; GFX1200-TRUE16-NEXT:    s_add_co_i32 s9, s9, -11
 ; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX1200-TRUE16-NEXT:    s_cmp_gt_i32 s8, 11
+; GFX1200-TRUE16-NEXT:    s_cmp_gt_i32 s9, 11
+; GFX1200-TRUE16-NEXT:    v_mul_f32_e32 v3, v6, v4
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1200-TRUE16-NEXT:    v_rndne_f32_e32 v3, v3
+; GFX1200-TRUE16-NEXT:    v_xor_b32_e32 v3, 0x80000000, v3
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1200-TRUE16-NEXT:    v_fma_f32 v3, v3, v2, v6
+; GFX1200-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v3
+; GFX1200-TRUE16-NEXT:    v_add_f32_e32 v5, v3, v2
+; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1200-TRUE16-NEXT:    v_cndmask_b32_e32 v3, v3, v5, vcc_lo
+; GFX1200-TRUE16-NEXT:    v_ldexp_f32 v3, v3, 11
+; GFX1200-TRUE16-NEXT:    s_cbranch_scc1 .LBB10_15
+; GFX1200-TRUE16-NEXT:  ; %bb.16: ; %Flow129
+; GFX1200-TRUE16-NEXT:    v_mov_b32_e32 v5, s9
+; GFX1200-TRUE16-NEXT:    v_mov_b32_e32 v3, v6
+; GFX1200-TRUE16-NEXT:  .LBB10_17: ; %frem.loop_exit61
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1200-TRUE16-NEXT:    v_add_nc_u32_e32 v5, -10, v5
+; GFX1200-TRUE16-NEXT:    v_ldexp_f32 v3, v3, v5
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1200-TRUE16-NEXT:    v_mul_f32_e32 v4, v3, v4
 ; GFX1200-TRUE16-NEXT:    v_rndne_f32_e32 v4, v4
 ; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX1200-TRUE16-NEXT:    v_xor_b32_e32 v4, 0x80000000, v4
-; GFX1200-TRUE16-NEXT:    v_fmac_f32_e32 v1, v4, v2
+; GFX1200-TRUE16-NEXT:    v_fmac_f32_e32 v3, v4, v2
 ; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_2) | instid1(VALU_DEP_1)
-; GFX1200-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v1
-; GFX1200-TRUE16-NEXT:    v_add_f32_e32 v4, v1, v2
+; GFX1200-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v3
+; GFX1200-TRUE16-NEXT:    v_add_f32_e32 v2, v3, v2
 ; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_va_vcc(0)
-; GFX1200-TRUE16-NEXT:    v_cndmask_b32_e32 v1, v1, v4, vcc_lo
+; GFX1200-TRUE16-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc_lo
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1200-TRUE16-NEXT:    v_ldexp_f32 v1, v2, v1
+; GFX1200-TRUE16-NEXT:    v_mov_b16_e32 v2.l, s8
+; GFX1200-TRUE16-NEXT:    v_cvt_f16_f32_e32 v1.l, v1
 ; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1200-TRUE16-NEXT:    v_ldexp_f32 v1, v1, 11
-; GFX1200-TRUE16-NEXT:    s_cbranch_scc1 .LBB10_14
-; GFX1200-TRUE16-NEXT:  .LBB10_15: ; %frem.loop_exit61
-; GFX1200-TRUE16-NEXT:    ; implicit-def: $vgpr1
-; GFX1200-TRUE16-NEXT:  .LBB10_16:
+; GFX1200-TRUE16-NEXT:    v_bfi_b32 v1, 0x7fff, v1, v2
+; GFX1200-TRUE16-NEXT:  .LBB10_18:
 ; GFX1200-TRUE16-NEXT:    s_and_b32 s8, s7, 0x7fff
 ; GFX1200-TRUE16-NEXT:    s_and_b32 s9, s2, 0x7fff
 ; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
@@ -11041,8 +11476,8 @@ define amdgpu_kernel void @frem_v4f16(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_2)
 ; GFX1200-TRUE16-NEXT:    s_cmp_ngt_f32 s10, s9
-; GFX1200-TRUE16-NEXT:    s_cbranch_scc0 .LBB10_18
-; GFX1200-TRUE16-NEXT:  ; %bb.17: ; %frem.else20
+; GFX1200-TRUE16-NEXT:    s_cbranch_scc0 .LBB10_20
+; GFX1200-TRUE16-NEXT:  ; %bb.19: ; %frem.else20
 ; GFX1200-TRUE16-NEXT:    s_cmp_eq_f32 s10, s9
 ; GFX1200-TRUE16-NEXT:    v_and_b16 v0.h, 0x8000, s7
 ; GFX1200-TRUE16-NEXT:    s_cselect_b32 s11, -1, 0
@@ -11050,172 +11485,219 @@ define amdgpu_kernel void @frem_v4f16(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1200-TRUE16-NEXT:    v_cndmask_b16 v2.l, s7, v0.h, s11
 ; GFX1200-TRUE16-NEXT:    s_mov_b32 s11, 0
-; GFX1200-TRUE16-NEXT:    s_branch .LBB10_19
-; GFX1200-TRUE16-NEXT:  .LBB10_18:
+; GFX1200-TRUE16-NEXT:    s_branch .LBB10_21
+; GFX1200-TRUE16-NEXT:  .LBB10_20:
 ; GFX1200-TRUE16-NEXT:    s_mov_b32 s11, -1
 ; GFX1200-TRUE16-NEXT:    ; implicit-def: $vgpr2
-; GFX1200-TRUE16-NEXT:  .LBB10_19: ; %Flow127
+; GFX1200-TRUE16-NEXT:  .LBB10_21: ; %Flow127
 ; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX1200-TRUE16-NEXT:    s_and_b32 s11, s11, exec_lo
 ; GFX1200-TRUE16-NEXT:    s_cselect_b32 s11, 1, 0
 ; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX1200-TRUE16-NEXT:    s_cmp_lg_u32 s11, 1
-; GFX1200-TRUE16-NEXT:    s_cbranch_scc1 .LBB10_24
-; GFX1200-TRUE16-NEXT:  ; %bb.20: ; %frem.compute19
+; GFX1200-TRUE16-NEXT:    s_cbranch_scc1 .LBB10_27
+; GFX1200-TRUE16-NEXT:  ; %bb.22: ; %frem.compute19
 ; GFX1200-TRUE16-NEXT:    v_frexp_mant_f32_e32 v3, s9
-; GFX1200-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v5, s9
-; GFX1200-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v4, s10
 ; GFX1200-TRUE16-NEXT:    v_frexp_mant_f32_e32 v2, s10
-; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX1200-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v5, s10
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
 ; GFX1200-TRUE16-NEXT:    v_ldexp_f32 v3, v3, 1
-; GFX1200-TRUE16-NEXT:    v_readfirstlane_b32 s9, v5
-; GFX1200-TRUE16-NEXT:    v_add_nc_u32_e32 v5, -1, v5
-; GFX1200-TRUE16-NEXT:    v_readfirstlane_b32 s10, v4
-; GFX1200-TRUE16-NEXT:    v_ldexp_f32 v2, v2, 11
-; GFX1200-TRUE16-NEXT:    v_div_scale_f32 v6, null, v3, v3, 1.0
-; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX1200-TRUE16-NEXT:    v_not_b32_e32 v5, v5
-; GFX1200-TRUE16-NEXT:    v_rcp_f32_e32 v7, v6
-; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_2) | instid1(TRANS32_DEP_1)
-; GFX1200-TRUE16-NEXT:    v_add_nc_u32_e32 v5, v5, v4
-; GFX1200-TRUE16-NEXT:    v_div_scale_f32 v4, vcc_lo, 1.0, v3, 1.0
+; GFX1200-TRUE16-NEXT:    v_ldexp_f32 v4, v2, 11
+; GFX1200-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v2, s9
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX1200-TRUE16-NEXT:    v_readfirstlane_b32 s10, v5
+; GFX1200-TRUE16-NEXT:    v_div_scale_f32 v7, null, v3, v3, 1.0
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_3)
+; GFX1200-TRUE16-NEXT:    v_readfirstlane_b32 s9, v2
+; GFX1200-TRUE16-NEXT:    v_add_nc_u32_e32 v2, -1, v2
+; GFX1200-TRUE16-NEXT:    v_rcp_f32_e32 v8, v7
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1200-TRUE16-NEXT:    v_not_b32_e32 v6, v2
+; GFX1200-TRUE16-NEXT:    v_add_nc_u32_e32 v6, v6, v5
+; GFX1200-TRUE16-NEXT:    v_div_scale_f32 v5, vcc_lo, 1.0, v3, 1.0
 ; GFX1200-TRUE16-NEXT:    s_denorm_mode 15
-; GFX1200-TRUE16-NEXT:    v_fma_f32 v8, -v6, v7, 1.0
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(TRANS32_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1200-TRUE16-NEXT:    v_fma_f32 v9, -v7, v8, 1.0
+; GFX1200-TRUE16-NEXT:    v_fmac_f32_e32 v8, v9, v8
 ; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1200-TRUE16-NEXT:    v_fmac_f32_e32 v7, v8, v7
-; GFX1200-TRUE16-NEXT:    v_mul_f32_e32 v8, v4, v7
+; GFX1200-TRUE16-NEXT:    v_mul_f32_e32 v9, v5, v8
+; GFX1200-TRUE16-NEXT:    v_fma_f32 v10, -v7, v9, v5
 ; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1200-TRUE16-NEXT:    v_fma_f32 v9, -v6, v8, v4
-; GFX1200-TRUE16-NEXT:    v_fmac_f32_e32 v8, v9, v7
-; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_2) | instid1(VALU_DEP_1)
-; GFX1200-TRUE16-NEXT:    v_fma_f32 v4, -v6, v8, v4
+; GFX1200-TRUE16-NEXT:    v_fmac_f32_e32 v9, v10, v8
+; GFX1200-TRUE16-NEXT:    v_fma_f32 v5, -v7, v9, v5
 ; GFX1200-TRUE16-NEXT:    s_denorm_mode 12
 ; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_va_vcc(0)
-; GFX1200-TRUE16-NEXT:    v_div_fmas_f32 v4, v4, v7, v8
-; GFX1200-TRUE16-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 12, v5
-; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX1200-TRUE16-NEXT:    v_div_fixup_f32 v4, v4, v3, 1.0
-; GFX1200-TRUE16-NEXT:    s_cbranch_vccnz .LBB10_23
-; GFX1200-TRUE16-NEXT:  ; %bb.21: ; %frem.loop_body27.preheader
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1200-TRUE16-NEXT:    v_div_fmas_f32 v5, v5, v8, v9
+; GFX1200-TRUE16-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 12, v6
+; GFX1200-TRUE16-NEXT:    v_div_fixup_f32 v5, v5, v3, 1.0
+; GFX1200-TRUE16-NEXT:    s_cbranch_vccnz .LBB10_26
+; GFX1200-TRUE16-NEXT:  ; %bb.23: ; %frem.loop_body27.preheader
 ; GFX1200-TRUE16-NEXT:    s_sub_co_i32 s9, s10, s9
 ; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX1200-TRUE16-NEXT:    s_add_co_i32 s9, s9, 11
-; GFX1200-TRUE16-NEXT:  .LBB10_22: ; %frem.loop_body27
+; GFX1200-TRUE16-NEXT:  .LBB10_24: ; %frem.loop_body27
 ; GFX1200-TRUE16-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1200-TRUE16-NEXT:    v_mul_f32_e32 v5, v2, v4
+; GFX1200-TRUE16-NEXT:    v_mov_b32_e32 v7, v4
 ; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX1200-TRUE16-NEXT:    s_add_co_i32 s9, s9, -11
 ; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX1200-TRUE16-NEXT:    s_cmp_gt_i32 s9, 11
+; GFX1200-TRUE16-NEXT:    v_mul_f32_e32 v4, v7, v5
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1200-TRUE16-NEXT:    v_rndne_f32_e32 v4, v4
+; GFX1200-TRUE16-NEXT:    v_xor_b32_e32 v4, 0x80000000, v4
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1200-TRUE16-NEXT:    v_fma_f32 v4, v4, v3, v7
+; GFX1200-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v4
+; GFX1200-TRUE16-NEXT:    v_add_f32_e32 v6, v4, v3
+; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1200-TRUE16-NEXT:    v_cndmask_b32_e32 v4, v4, v6, vcc_lo
+; GFX1200-TRUE16-NEXT:    v_ldexp_f32 v4, v4, 11
+; GFX1200-TRUE16-NEXT:    s_cbranch_scc1 .LBB10_24
+; GFX1200-TRUE16-NEXT:  ; %bb.25: ; %Flow125
+; GFX1200-TRUE16-NEXT:    v_mov_b32_e32 v6, s9
+; GFX1200-TRUE16-NEXT:    v_mov_b32_e32 v4, v7
+; GFX1200-TRUE16-NEXT:  .LBB10_26: ; %frem.loop_exit28
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1200-TRUE16-NEXT:    v_add_nc_u32_e32 v6, -10, v6
+; GFX1200-TRUE16-NEXT:    v_ldexp_f32 v4, v4, v6
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1200-TRUE16-NEXT:    v_mul_f32_e32 v5, v4, v5
 ; GFX1200-TRUE16-NEXT:    v_rndne_f32_e32 v5, v5
 ; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX1200-TRUE16-NEXT:    v_xor_b32_e32 v5, 0x80000000, v5
-; GFX1200-TRUE16-NEXT:    v_fmac_f32_e32 v2, v5, v3
+; GFX1200-TRUE16-NEXT:    v_fmac_f32_e32 v4, v5, v3
 ; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_2) | instid1(VALU_DEP_1)
-; GFX1200-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v2
-; GFX1200-TRUE16-NEXT:    v_add_f32_e32 v5, v2, v3
+; GFX1200-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v4
+; GFX1200-TRUE16-NEXT:    v_add_f32_e32 v3, v4, v3
 ; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_va_vcc(0)
-; GFX1200-TRUE16-NEXT:    v_cndmask_b32_e32 v2, v2, v5, vcc_lo
+; GFX1200-TRUE16-NEXT:    v_cndmask_b32_e32 v3, v4, v3, vcc_lo
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1200-TRUE16-NEXT:    v_ldexp_f32 v2, v3, v2
+; GFX1200-TRUE16-NEXT:    v_mov_b16_e32 v3.l, s7
+; GFX1200-TRUE16-NEXT:    v_cvt_f16_f32_e32 v2.l, v2
 ; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1200-TRUE16-NEXT:    v_ldexp_f32 v2, v2, 11
-; GFX1200-TRUE16-NEXT:    s_cbranch_scc1 .LBB10_22
-; GFX1200-TRUE16-NEXT:  .LBB10_23: ; %frem.loop_exit28
-; GFX1200-TRUE16-NEXT:    ; implicit-def: $vgpr2
-; GFX1200-TRUE16-NEXT:  .LBB10_24:
-; GFX1200-TRUE16-NEXT:    s_lshr_b32 s12, s7, 16
+; GFX1200-TRUE16-NEXT:    v_bfi_b32 v2, 0x7fff, v2, v3
+; GFX1200-TRUE16-NEXT:  .LBB10_27:
+; GFX1200-TRUE16-NEXT:    s_lshr_b32 s10, s7, 16
 ; GFX1200-TRUE16-NEXT:    s_lshr_b32 s9, s2, 16
-; GFX1200-TRUE16-NEXT:    s_and_b32 s7, s12, 0x7fff
 ; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX1200-TRUE16-NEXT:    s_and_b32 s10, s9, 0x7fff
-; GFX1200-TRUE16-NEXT:    s_cvt_f32_f16 s11, s7
+; GFX1200-TRUE16-NEXT:    s_and_b32 s7, s10, 0x7fff
+; GFX1200-TRUE16-NEXT:    s_and_b32 s11, s9, 0x7fff
 ; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX1200-TRUE16-NEXT:    s_cvt_f32_f16 s10, s10
+; GFX1200-TRUE16-NEXT:    s_cvt_f32_f16 s12, s7
+; GFX1200-TRUE16-NEXT:    s_cvt_f32_f16 s11, s11
 ; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_2)
-; GFX1200-TRUE16-NEXT:    s_cmp_ngt_f32 s11, s10
-; GFX1200-TRUE16-NEXT:    s_cbranch_scc0 .LBB10_26
-; GFX1200-TRUE16-NEXT:  ; %bb.25: ; %frem.else
-; GFX1200-TRUE16-NEXT:    s_cmp_eq_f32 s11, s10
-; GFX1200-TRUE16-NEXT:    v_and_b16 v0.h, 0x8000, s12
+; GFX1200-TRUE16-NEXT:    s_cmp_ngt_f32 s12, s11
+; GFX1200-TRUE16-NEXT:    s_cbranch_scc0 .LBB10_29
+; GFX1200-TRUE16-NEXT:  ; %bb.28: ; %frem.else
+; GFX1200-TRUE16-NEXT:    s_cmp_eq_f32 s12, s11
+; GFX1200-TRUE16-NEXT:    v_and_b16 v0.h, 0x8000, s10
 ; GFX1200-TRUE16-NEXT:    s_cselect_b32 s13, -1, 0
-; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1200-TRUE16-NEXT:    v_cndmask_b16 v3.l, s12, v0.h, s13
-; GFX1200-TRUE16-NEXT:    s_mov_b32 s12, 0
-; GFX1200-TRUE16-NEXT:    s_branch .LBB10_27
-; GFX1200-TRUE16-NEXT:  .LBB10_26:
-; GFX1200-TRUE16-NEXT:    s_mov_b32 s12, -1
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1200-TRUE16-NEXT:    v_cndmask_b16 v3.l, s10, v0.h, s13
+; GFX1200-TRUE16-NEXT:    s_mov_b32 s13, 0
+; GFX1200-TRUE16-NEXT:    s_branch .LBB10_30
+; GFX1200-TRUE16-NEXT:  .LBB10_29:
+; GFX1200-TRUE16-NEXT:    s_mov_b32 s13, -1
 ; GFX1200-TRUE16-NEXT:    ; implicit-def: $vgpr3
-; GFX1200-TRUE16-NEXT:  .LBB10_27: ; %Flow123
+; GFX1200-TRUE16-NEXT:  .LBB10_30: ; %Flow123
 ; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX1200-TRUE16-NEXT:    s_and_b32 s12, s12, exec_lo
-; GFX1200-TRUE16-NEXT:    s_cselect_b32 s12, 1, 0
+; GFX1200-TRUE16-NEXT:    s_and_b32 s13, s13, exec_lo
+; GFX1200-TRUE16-NEXT:    s_cselect_b32 s13, 1, 0
 ; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX1200-TRUE16-NEXT:    s_cmp_lg_u32 s12, 1
-; GFX1200-TRUE16-NEXT:    s_cbranch_scc1 .LBB10_32
-; GFX1200-TRUE16-NEXT:  ; %bb.28: ; %frem.compute
-; GFX1200-TRUE16-NEXT:    v_frexp_mant_f32_e32 v4, s10
-; GFX1200-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v6, s10
-; GFX1200-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v5, s11
-; GFX1200-TRUE16-NEXT:    v_frexp_mant_f32_e32 v3, s11
-; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX1200-TRUE16-NEXT:    s_cmp_lg_u32 s13, 1
+; GFX1200-TRUE16-NEXT:    s_cbranch_scc1 .LBB10_36
+; GFX1200-TRUE16-NEXT:  ; %bb.31: ; %frem.compute
+; GFX1200-TRUE16-NEXT:    v_frexp_mant_f32_e32 v4, s11
+; GFX1200-TRUE16-NEXT:    v_frexp_mant_f32_e32 v3, s12
+; GFX1200-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v6, s12
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
 ; GFX1200-TRUE16-NEXT:    v_ldexp_f32 v4, v4, 1
-; GFX1200-TRUE16-NEXT:    v_readfirstlane_b32 s10, v6
-; GFX1200-TRUE16-NEXT:    v_add_nc_u32_e32 v6, -1, v6
-; GFX1200-TRUE16-NEXT:    v_readfirstlane_b32 s11, v5
-; GFX1200-TRUE16-NEXT:    v_ldexp_f32 v3, v3, 11
-; GFX1200-TRUE16-NEXT:    v_div_scale_f32 v7, null, v4, v4, 1.0
-; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX1200-TRUE16-NEXT:    v_not_b32_e32 v6, v6
-; GFX1200-TRUE16-NEXT:    v_rcp_f32_e32 v8, v7
-; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_2) | instid1(TRANS32_DEP_1)
-; GFX1200-TRUE16-NEXT:    v_add_nc_u32_e32 v6, v6, v5
-; GFX1200-TRUE16-NEXT:    v_div_scale_f32 v5, vcc_lo, 1.0, v4, 1.0
+; GFX1200-TRUE16-NEXT:    v_ldexp_f32 v5, v3, 11
+; GFX1200-TRUE16-NEXT:    v_frexp_exp_i32_f32_e32 v3, s11
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX1200-TRUE16-NEXT:    v_readfirstlane_b32 s12, v6
+; GFX1200-TRUE16-NEXT:    v_div_scale_f32 v8, null, v4, v4, 1.0
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_3)
+; GFX1200-TRUE16-NEXT:    v_readfirstlane_b32 s11, v3
+; GFX1200-TRUE16-NEXT:    v_add_nc_u32_e32 v3, -1, v3
+; GFX1200-TRUE16-NEXT:    v_rcp_f32_e32 v9, v8
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1200-TRUE16-NEXT:    v_not_b32_e32 v7, v3
+; GFX1200-TRUE16-NEXT:    v_add_nc_u32_e32 v7, v7, v6
+; GFX1200-TRUE16-NEXT:    v_div_scale_f32 v6, vcc_lo, 1.0, v4, 1.0
 ; GFX1200-TRUE16-NEXT:    s_denorm_mode 15
-; GFX1200-TRUE16-NEXT:    v_fma_f32 v9, -v7, v8, 1.0
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(TRANS32_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1200-TRUE16-NEXT:    v_fma_f32 v10, -v8, v9, 1.0
+; GFX1200-TRUE16-NEXT:    v_fmac_f32_e32 v9, v10, v9
 ; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1200-TRUE16-NEXT:    v_fmac_f32_e32 v8, v9, v8
-; GFX1200-TRUE16-NEXT:    v_mul_f32_e32 v9, v5, v8
+; GFX1200-TRUE16-NEXT:    v_mul_f32_e32 v10, v6, v9
+; GFX1200-TRUE16-NEXT:    v_fma_f32 v11, -v8, v10, v6
 ; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1200-TRUE16-NEXT:    v_fma_f32 v10, -v7, v9, v5
-; GFX1200-TRUE16-NEXT:    v_fmac_f32_e32 v9, v10, v8
-; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_2) | instid1(VALU_DEP_1)
-; GFX1200-TRUE16-NEXT:    v_fma_f32 v5, -v7, v9, v5
+; GFX1200-TRUE16-NEXT:    v_fmac_f32_e32 v10, v11, v9
+; GFX1200-TRUE16-NEXT:    v_fma_f32 v6, -v8, v10, v6
 ; GFX1200-TRUE16-NEXT:    s_denorm_mode 12
 ; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_va_vcc(0)
-; GFX1200-TRUE16-NEXT:    v_div_fmas_f32 v5, v5, v8, v9
-; GFX1200-TRUE16-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 12, v6
-; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX1200-TRUE16-NEXT:    v_div_fixup_f32 v5, v5, v4, 1.0
-; GFX1200-TRUE16-NEXT:    s_cbranch_vccnz .LBB10_31
-; GFX1200-TRUE16-NEXT:  ; %bb.29: ; %frem.loop_body.preheader
-; GFX1200-TRUE16-NEXT:    s_sub_co_i32 s10, s11, s10
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1200-TRUE16-NEXT:    v_div_fmas_f32 v6, v6, v9, v10
+; GFX1200-TRUE16-NEXT:    v_cmp_gt_i32_e32 vcc_lo, 12, v7
+; GFX1200-TRUE16-NEXT:    v_div_fixup_f32 v6, v6, v4, 1.0
+; GFX1200-TRUE16-NEXT:    s_cbranch_vccnz .LBB10_35
+; GFX1200-TRUE16-NEXT:  ; %bb.32: ; %frem.loop_body.preheader
+; GFX1200-TRUE16-NEXT:    s_sub_co_i32 s11, s12, s11
 ; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX1200-TRUE16-NEXT:    s_add_co_i32 s10, s10, 11
-; GFX1200-TRUE16-NEXT:  .LBB10_30: ; %frem.loop_body
+; GFX1200-TRUE16-NEXT:    s_add_co_i32 s11, s11, 11
+; GFX1200-TRUE16-NEXT:  .LBB10_33: ; %frem.loop_body
 ; GFX1200-TRUE16-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1200-TRUE16-NEXT:    v_mul_f32_e32 v6, v3, v5
+; GFX1200-TRUE16-NEXT:    v_mov_b32_e32 v8, v5
 ; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX1200-TRUE16-NEXT:    s_add_co_i32 s10, s10, -11
+; GFX1200-TRUE16-NEXT:    s_add_co_i32 s11, s11, -11
 ; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX1200-TRUE16-NEXT:    s_cmp_gt_i32 s10, 11
+; GFX1200-TRUE16-NEXT:    s_cmp_gt_i32 s11, 11
+; GFX1200-TRUE16-NEXT:    v_mul_f32_e32 v5, v8, v6
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1200-TRUE16-NEXT:    v_rndne_f32_e32 v5, v5
+; GFX1200-TRUE16-NEXT:    v_xor_b32_e32 v5, 0x80000000, v5
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1200-TRUE16-NEXT:    v_fma_f32 v5, v5, v4, v8
+; GFX1200-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v5
+; GFX1200-TRUE16-NEXT:    v_add_f32_e32 v7, v5, v4
+; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1200-TRUE16-NEXT:    v_cndmask_b32_e32 v5, v5, v7, vcc_lo
+; GFX1200-TRUE16-NEXT:    v_ldexp_f32 v5, v5, 11
+; GFX1200-TRUE16-NEXT:    s_cbranch_scc1 .LBB10_33
+; GFX1200-TRUE16-NEXT:  ; %bb.34: ; %Flow
+; GFX1200-TRUE16-NEXT:    v_mov_b32_e32 v7, s11
+; GFX1200-TRUE16-NEXT:    v_mov_b32_e32 v5, v8
+; GFX1200-TRUE16-NEXT:  .LBB10_35: ; %frem.loop_exit
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1200-TRUE16-NEXT:    v_add_nc_u32_e32 v7, -10, v7
+; GFX1200-TRUE16-NEXT:    v_ldexp_f32 v5, v5, v7
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1200-TRUE16-NEXT:    v_mul_f32_e32 v6, v5, v6
 ; GFX1200-TRUE16-NEXT:    v_rndne_f32_e32 v6, v6
 ; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX1200-TRUE16-NEXT:    v_xor_b32_e32 v6, 0x80000000, v6
-; GFX1200-TRUE16-NEXT:    v_fmac_f32_e32 v3, v6, v4
+; GFX1200-TRUE16-NEXT:    v_fmac_f32_e32 v5, v6, v4
 ; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_2) | instid1(VALU_DEP_1)
-; GFX1200-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v3
-; GFX1200-TRUE16-NEXT:    v_add_f32_e32 v6, v3, v4
+; GFX1200-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0, v5
+; GFX1200-TRUE16-NEXT:    v_add_f32_e32 v4, v5, v4
 ; GFX1200-TRUE16-NEXT:    s_wait_alu depctr_va_vcc(0)
-; GFX1200-TRUE16-NEXT:    v_cndmask_b32_e32 v3, v3, v6, vcc_lo
+; GFX1200-TRUE16-NEXT:    v_cndmask_b32_e32 v4, v5, v4, vcc_lo
+; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1200-TRUE16-NEXT:    v_ldexp_f32 v3, v4, v3
+; GFX1200-TRUE16-NEXT:    v_mov_b16_e32 v4.l, s10
+; GFX1200-TRUE16-NEXT:    v_cvt_f16_f32_e32 v3.l, v3
 ; GFX1200-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1200-TRUE16-NEXT:    v_ldexp_f32 v3, v3, 11
-; GFX1200-TRUE16-NEXT:    s_cbranch_scc1 .LBB10_30
-; GFX1200-TRUE16-NEXT:  .LBB10_31: ; %frem.loop_exit
-; GFX1200-TRUE16-NEXT:    ; implicit-def: $vgpr3
-; GFX1200-TRUE16-NEXT:  .LBB10_32: ; %Flow124
+; GFX1200-TRUE16-NEXT:    v_bfi_b32 v3, 0x7fff, v3, v4
+; GFX1200-TRUE16-NEXT:  .LBB10_36: ; %Flow124
 ; GFX1200-TRUE16-NEXT:    s_cmp_lg_f16 s4, 0
 ; GFX1200-TRUE16-NEXT:    s_cselect_b32 s4, -1, 0
 ; GFX1200-TRUE16-NEXT:    s_cmp_nge_f16 s3, 0x7c00

--- a/llvm/test/CodeGen/AMDGPU/v_swap_b16.ll
+++ b/llvm/test/CodeGen/AMDGPU/v_swap_b16.ll
@@ -8,22 +8,20 @@ define half @swap(half %a, half %b, i32 %i) {
 ; GFX11-TRUE16-LABEL: swap:
 ; GFX11-TRUE16:       ; %bb.0: ; %entry
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.h, v0.l
-; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.l, v1.l
 ; GFX11-TRUE16-NEXT:    s_mov_b32 s0, 0
 ; GFX11-TRUE16-NEXT:  .LBB0_1: ; %loop
 ; GFX11-TRUE16-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX11-TRUE16-NEXT:    v_add_nc_u32_e32 v2, -1, v2
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_3)
-; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v1.l, v0.l
-; GFX11-TRUE16-NEXT:    v_swap_b16 v0.l, v0.h
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.h, v1.l
+; GFX11-TRUE16-NEXT:    v_swap_b16 v1.l, v0.l
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX11-TRUE16-NEXT:    v_cmp_eq_u32_e32 vcc_lo, 0, v2
 ; GFX11-TRUE16-NEXT:    s_or_b32 s0, vcc_lo, s0
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
 ; GFX11-TRUE16-NEXT:    s_and_not1_b32 exec_lo, exec_lo, s0
 ; GFX11-TRUE16-NEXT:    s_cbranch_execnz .LBB0_1
 ; GFX11-TRUE16-NEXT:  ; %bb.2: ; %ret
 ; GFX11-TRUE16-NEXT:    s_or_b32 exec_lo, exec_lo, s0
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.l, v1.l
 ; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-FAKE16-LABEL: swap:
@@ -52,15 +50,13 @@ define half @swap(half %a, half %b, i32 %i) {
 ; GFX12-TRUE16-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-TRUE16-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-TRUE16-NEXT:    s_wait_kmcnt 0x0
-; GFX12-TRUE16-NEXT:    v_mov_b16_e32 v0.h, v0.l
-; GFX12-TRUE16-NEXT:    v_mov_b16_e32 v0.l, v1.l
 ; GFX12-TRUE16-NEXT:    s_mov_b32 s0, 0
 ; GFX12-TRUE16-NEXT:  .LBB0_1: ; %loop
 ; GFX12-TRUE16-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX12-TRUE16-NEXT:    v_add_nc_u32_e32 v2, -1, v2
-; GFX12-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_3)
-; GFX12-TRUE16-NEXT:    v_mov_b16_e32 v1.l, v0.l
-; GFX12-TRUE16-NEXT:    v_swap_b16 v0.l, v0.h
+; GFX12-TRUE16-NEXT:    v_mov_b16_e32 v0.h, v1.l
+; GFX12-TRUE16-NEXT:    v_swap_b16 v1.l, v0.l
+; GFX12-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3)
 ; GFX12-TRUE16-NEXT:    v_cmp_eq_u32_e32 vcc_lo, 0, v2
 ; GFX12-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12-TRUE16-NEXT:    s_or_b32 s0, vcc_lo, s0
@@ -69,6 +65,7 @@ define half @swap(half %a, half %b, i32 %i) {
 ; GFX12-TRUE16-NEXT:    s_cbranch_execnz .LBB0_1
 ; GFX12-TRUE16-NEXT:  ; %bb.2: ; %ret
 ; GFX12-TRUE16-NEXT:    s_or_b32 exec_lo, exec_lo, s0
+; GFX12-TRUE16-NEXT:    v_mov_b16_e32 v0.l, v1.l
 ; GFX12-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-FAKE16-LABEL: swap:
@@ -116,32 +113,30 @@ define half @swap_B(half %a, half %b, half %c, i32 %i) {
 ; GFX11-TRUE16-LABEL: swap_B:
 ; GFX11-TRUE16:       ; %bb.0: ; %entry
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.h, v1.l
 ; GFX11-TRUE16-NEXT:    s_mov_b32 s0, 0
 ; GFX11-TRUE16-NEXT:  .LBB1_1: ; %loop
 ; GFX11-TRUE16-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX11-TRUE16-NEXT:    v_add_nc_u32_e32 v3, -1, v3
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_2) | instid1(VALU_DEP_3)
-; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v1.l, v0.h
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.h, v1.l
 ; GFX11-TRUE16-NEXT:    ;;#ASMSTART
 ; GFX11-TRUE16-NEXT:    ; use v0.l
 ; GFX11-TRUE16-NEXT:    ;;#ASMEND
-; GFX11-TRUE16-NEXT:    v_swap_b16 v0.h, v0.l
+; GFX11-TRUE16-NEXT:    v_swap_b16 v1.l, v0.l
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_4) | instid1(SALU_CYCLE_1)
 ; GFX11-TRUE16-NEXT:    v_cmp_eq_u32_e32 vcc_lo, 0, v3
 ; GFX11-TRUE16-NEXT:    ;;#ASMSTART
-; GFX11-TRUE16-NEXT:    ; use v1.l
+; GFX11-TRUE16-NEXT:    ; use v0.h
 ; GFX11-TRUE16-NEXT:    ;;#ASMEND
 ; GFX11-TRUE16-NEXT:    ;;#ASMSTART
 ; GFX11-TRUE16-NEXT:    ; use v2.l
 ; GFX11-TRUE16-NEXT:    ;;#ASMEND
-; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v2.l, v1.l
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v2.l, v0.h
 ; GFX11-TRUE16-NEXT:    s_or_b32 s0, vcc_lo, s0
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
 ; GFX11-TRUE16-NEXT:    s_and_not1_b32 exec_lo, exec_lo, s0
 ; GFX11-TRUE16-NEXT:    s_cbranch_execnz .LBB1_1
 ; GFX11-TRUE16-NEXT:  ; %bb.2: ; %ret
 ; GFX11-TRUE16-NEXT:    s_or_b32 exec_lo, exec_lo, s0
-; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.l, v0.h
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.l, v1.l
 ; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-FAKE16-LABEL: swap_B:
@@ -179,25 +174,24 @@ define half @swap_B(half %a, half %b, half %c, i32 %i) {
 ; GFX12-TRUE16-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-TRUE16-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-TRUE16-NEXT:    s_wait_kmcnt 0x0
-; GFX12-TRUE16-NEXT:    v_mov_b16_e32 v0.h, v1.l
 ; GFX12-TRUE16-NEXT:    s_mov_b32 s0, 0
 ; GFX12-TRUE16-NEXT:  .LBB1_1: ; %loop
 ; GFX12-TRUE16-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX12-TRUE16-NEXT:    v_add_nc_u32_e32 v3, -1, v3
-; GFX12-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_2) | instid1(VALU_DEP_3)
-; GFX12-TRUE16-NEXT:    v_mov_b16_e32 v1.l, v0.h
+; GFX12-TRUE16-NEXT:    v_mov_b16_e32 v0.h, v1.l
 ; GFX12-TRUE16-NEXT:    ;;#ASMSTART
 ; GFX12-TRUE16-NEXT:    ; use v0.l
 ; GFX12-TRUE16-NEXT:    ;;#ASMEND
-; GFX12-TRUE16-NEXT:    v_swap_b16 v0.h, v0.l
+; GFX12-TRUE16-NEXT:    v_swap_b16 v1.l, v0.l
+; GFX12-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3)
 ; GFX12-TRUE16-NEXT:    v_cmp_eq_u32_e32 vcc_lo, 0, v3
 ; GFX12-TRUE16-NEXT:    ;;#ASMSTART
-; GFX12-TRUE16-NEXT:    ; use v1.l
+; GFX12-TRUE16-NEXT:    ; use v0.h
 ; GFX12-TRUE16-NEXT:    ;;#ASMEND
 ; GFX12-TRUE16-NEXT:    ;;#ASMSTART
 ; GFX12-TRUE16-NEXT:    ; use v2.l
 ; GFX12-TRUE16-NEXT:    ;;#ASMEND
-; GFX12-TRUE16-NEXT:    v_mov_b16_e32 v2.l, v1.l
+; GFX12-TRUE16-NEXT:    v_mov_b16_e32 v2.l, v0.h
 ; GFX12-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12-TRUE16-NEXT:    s_or_b32 s0, vcc_lo, s0
 ; GFX12-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
@@ -205,7 +199,7 @@ define half @swap_B(half %a, half %b, half %c, i32 %i) {
 ; GFX12-TRUE16-NEXT:    s_cbranch_execnz .LBB1_1
 ; GFX12-TRUE16-NEXT:  ; %bb.2: ; %ret
 ; GFX12-TRUE16-NEXT:    s_or_b32 exec_lo, exec_lo, s0
-; GFX12-TRUE16-NEXT:    v_mov_b16_e32 v0.l, v0.h
+; GFX12-TRUE16-NEXT:    v_mov_b16_e32 v0.l, v1.l
 ; GFX12-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-FAKE16-LABEL: swap_B:


### PR DESCRIPTION
For true16, 16-bit subregister copies would copy the lo16/hi16 subregister index into 32-bit PHI operands, which results in miscompilations.

This patch replaces the subregister copy with a `REG_SEQUENCE` construction to ensure the PHI operands remain proper 32-bit registers.