### PR TITLE
AMDGPU: Remove unused getBaseArchNameAMDGCN

### DIFF
--- a/llvm/include/llvm/TargetParser/AMDGPUTargetParser.h
+++ b/llvm/include/llvm/TargetParser/AMDGPUTargetParser.h
@@ -109,9 +109,6 @@ enum FeatureError : uint32_t {
 
 LLVM_ABI StringRef getArchFamilyNameAMDGCN(GPUKind AK);
 
-/// The canonical GPU name for a variant name.
-LLVM_ABI StringRef getBaseArchNameAMDGCN(GPUKind AK);
-
 LLVM_ABI Triple::SubArchType getSubArch(GPUKind AK);
 
 /// Returns the preferred subarch for a GPU name \p CPU, or NoSubArch if

--- a/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
+++ b/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
@@ -40,7 +40,6 @@ struct GPUInfo {
   AMDGPUFeatureBitset Features;
   IsaVersion Version;
   StringTable::Offset FamilyName;
-  StringTable::Offset BaseName; // The canonical device name for a variant.
   uint8_t MaxWavesPerEU;
   uint32_t MaxHWAddressableLocalMemorySize;
   uint8_t LDSBankCount;
@@ -173,11 +172,6 @@ Triple::SubArchType llvm::AMDGPU::getSubArch(GPUKind AK) {
 
 Triple::SubArchType llvm::AMDGPU::getSubArchFromGPUName(StringRef CPU) {
   return getSubArch(parseArchAMDGCN(CPU));
-}
-
-StringRef llvm::AMDGPU::getBaseArchNameAMDGCN(GPUKind AK) {
-  const GPUInfo *Info = getAMDGPUInfo(AK);
-  return Info ? AMDGPUNameStrTab[Info->BaseName] : "";
 }
 
 AMDGPU::GPUKind

--- a/llvm/test/TableGen/AMDGPUTargetDefSubArchSpelling.td
+++ b/llvm/test/TableGen/AMDGPUTargetDefSubArchSpelling.td
@@ -15,7 +15,7 @@ class AMDGPUGPUInfo<list<int> isa = []> {
 
 def GFX888 : ProcessorModel<"gfx888", NoSchedModel, []>, AMDGPUGPUInfo<[8, 8, 8]>;
 
-// A variant CPU: its subarch, triple name, family, and base name come from the
+// A variant CPU: its subarch, triple name, and family come from the
 // spelling / ISA version, not its own name.
 def GFX888_AMAZING : ProcessorModel<"gfx888-amazing", NoSchedModel, []>,
     AMDGPUGPUInfo<[8, 8, 8]> {
@@ -35,7 +35,7 @@ def GFX88F : ProcessorModel<"gfx88f", NoSchedModel, []>,
 // The variant is its own major subarch, so it produces no override entry.
 // CHECK: AMDGPUMajorSubArchEntry, 0>{{ }}AMDGPUMajorSubArch
 
-// The name pool holds the variant's name, its gfx8 family, and its base name.
+// The name pool holds the variant's name and its gfx8 family.
 // CHECK: "gfx888\0"
 // CHECK: "gfx8\0"
 // CHECK: "gfx888-amazing\0"
@@ -44,11 +44,11 @@ def GFX88F : ProcessorModel<"gfx88f", NoSchedModel, []>,
 // The stepping is spelled as a single lowercase hex digit in the triple name.
 // CHECK: "amdgpu8.8f\0"
 
-// The GPU table: the base GPU has no base name (offset 0); the variant uses
-// AMDGPUSubArch888A and records "gfx888" as its base name.
-// CHECK: {[[#]], Triple::AMDGPUSubArch888, {{.*}}, {8, 8, 8}, [[FAM:[0-9]+]], 0, [[#]], [[#]], [[#]]},
-// CHECK: {[[#]], Triple::AMDGPUSubArch888A, {{.*}}, {8, 8, 8}, [[FAM]], [[#]], [[#]], [[#]], [[#]]},
-// CHECK: {[[#]], Triple::AMDGPUSubArch88F, {{.*}}, {8, 8, 15}, [[#]], 0, [[#]], [[#]], [[#]]},
+// The GPU table: both the base GPU and the variant share the gfx8 family; the
+// variant uses its own AMDGPUSubArch888A from the spelling.
+// CHECK: {[[#]], Triple::AMDGPUSubArch888, {{.*}}, {8, 8, 8}, [[FAM:[0-9]+]], [[#]], [[#]], [[#]]},
+// CHECK: {[[#]], Triple::AMDGPUSubArch888A, {{.*}}, {8, 8, 8}, [[FAM]], [[#]], [[#]], [[#]]},
+// CHECK: {[[#]], Triple::AMDGPUSubArch88F, {{.*}}, {8, 8, 15}, [[#]], [[#]], [[#]], [[#]]},
 
 // The subarch-name table maps the variant's own subarch to its triple name.
 // CHECK: {Triple::AMDGPUSubArch888A, [[#]], [[#]]},

--- a/llvm/utils/TableGen/Basic/AMDGPUTargetDefEmitter.cpp
+++ b/llvm/utils/TableGen/Basic/AMDGPUTargetDefEmitter.cpp
@@ -113,16 +113,6 @@ static void emitArchFamily(raw_ostream &OS, const Record *Rec) {
   OS << "gfx" << Rec->getValueAsListOfInts("IsaVersion")[0];
 }
 
-// Emit the canonical GPU name for a variant (empty for a non-variant GPU). The
-// stepping is the trailing single hex character of the device name (validated
-// by emitIsaVersion).
-static void emitBaseName(raw_ostream &OS, const Record *Rec) {
-  if (!getSubArchSpelling(Rec))
-    return;
-  std::vector<int64_t> V = Rec->getValueAsListOfInts("IsaVersion");
-  OS << "gfx" << V[0] << V[1] << hexdigit(V[2], /*LowerCase=*/true);
-}
-
 // Emit the ISA version tuple as "major, minor, stepping" wrapped in \p Open and
 // \p Close (parens for the AMDGPU_GPU macro's ISAVERSION argument, braces for a
 // struct initializer).
@@ -607,11 +597,7 @@ emitAMDGPUTable(raw_ostream &OS, const RecordKeeper &RK,
     SmallString<16> Family;
     raw_svector_ostream FamilyOS(Family);
     emitArchFamily(FamilyOS, R);
-    OS << ", " << Names.GetOrAddStringOffset(Family) << ", ";
-    SmallString<16> BaseName;
-    raw_svector_ostream BaseNameOS(BaseName);
-    emitBaseName(BaseNameOS, R);
-    OS << Names.GetOrAddStringOffset(BaseName) << ", "
+    OS << ", " << Names.GetOrAddStringOffset(Family) << ", "
        << getFeatureValue(R, "MaxWavesPerEU", 10) << ", "
        << getFeatureValue(R, "AddressableLocalMemorySize", 32768) << ", "
        << getFeatureValue(R, "LDSBankCount", 32) << "},\n";


### PR DESCRIPTION
This ended up unused for gfx1250-strict

Co-authored-by: Claude <noreply@anthropic.com>