### PR TITLE
[MLIR][CMake] Order compilation after generated headers of link dependencies

### DIFF
--- a/clang/lib/CIR/Dialect/IR/CMakeLists.txt
+++ b/clang/lib/CIR/Dialect/IR/CMakeLists.txt
@@ -20,6 +20,6 @@ add_clang_library(MLIRCIR
   MLIRDataLayoutInterfaces
   MLIRFuncDialect
   MLIRLoopLikeInterface
-  MLIRCIRInterfaces
+  MLIRPtrMemorySpaceInterfaces
   clangAST
   )

--- a/clang/lib/CIR/Interfaces/CMakeLists.txt
+++ b/clang/lib/CIR/Interfaces/CMakeLists.txt
@@ -13,8 +13,10 @@ add_clang_library(MLIRCIRInterfaces
   MLIRCIRTypeInterfacesIncGen
   MLIRCIRLoopOpInterfaceIncGen
   MLIRCIROpInterfacesIncGen
+  MLIRCIRTypeConstraintsIncGen
 
   LINK_LIBS
   MLIRIR
+  MLIRPtrMemorySpaceInterfaces
   MLIRSupport
  )

--- a/llvm/cmake/modules/AddLLVM.cmake
+++ b/llvm/cmake/modules/AddLLVM.cmake
@@ -554,6 +554,48 @@ function(set_windows_version_resource_properties name resource_file)
                "RC_PRODUCT_VERSION=\"${ARG_VERSION_STRING}\"")
 endfunction(set_windows_version_resource_properties)
 
+# Collect the targets named by a LINK_LIBS item. Generator expressions cannot
+# be evaluated at configure time, so every token that names a target is
+# returned; ordering on all arms of a conditional expression is harmless.
+function(_llvm_link_item_targets output item)
+  if(item MATCHES "\\$<")
+    string(REGEX MATCHALL "[A-Za-z_][A-Za-z0-9_.+-]*(::[A-Za-z0-9_.+-]+)*"
+      candidates "${item}")
+  else()
+    set(candidates "${item}")
+  endif()
+  set(result)
+  foreach(candidate ${candidates})
+    if(TARGET "${candidate}")
+      get_target_property(aliased "${candidate}" ALIASED_TARGET)
+      if(aliased)
+        set(candidate "${aliased}")
+      endif()
+      list(APPEND result "${candidate}")
+    endif()
+  endforeach()
+  set(${output} ${result} PARENT_SCOPE)
+endfunction()
+
+# Order every object library after the targets in its LINK_LIBS, so that the
+# generated headers of a dependency exist before the objects compile. Ninja
+# follows target-level dependencies transitively without waiting for the
+# archives to be linked. This runs once the whole target graph exists, so
+# LINK_LIBS may name targets declared later, generator expressions, or plain
+# libraries such as -lpthread that are not targets at all.
+function(_llvm_add_object_link_dependencies)
+  get_property(object_libraries GLOBAL PROPERTY LLVM_OBJECT_LIBRARIES_WITH_LINK_LIBS)
+  foreach(object_library ${object_libraries})
+    get_target_property(items ${object_library} LLVM_OBJECT_LINK_LIBS)
+    foreach(item ${items})
+      _llvm_link_item_targets(targets "${item}")
+      if(targets)
+        add_dependencies(${object_library} ${targets})
+      endif()
+    endforeach()
+  endforeach()
+endfunction()
+
 # llvm_add_library(name sources...
 #   SHARED;STATIC
 #     STATIC by default w/o BUILD_SHARED_LIBS.
@@ -674,25 +716,24 @@ function(llvm_add_library name)
     if(ARG_DEPENDS)
       add_dependencies(${obj_name} ${ARG_DEPENDS})
     endif()
-    # Treat link libraries like PUBLIC dependencies.  LINK_LIBS might
-    # result in generating header files.  Add a dependendency so that
-    # the generated header is created before this object library.
+    # Order compilation after the LINK_LIBS targets; see
+    # _llvm_add_object_link_dependencies.
     if(ARG_LINK_LIBS)
-      cmake_parse_arguments(LINK_LIBS_ARG
-        ""
-        ""
-        "PUBLIC;PRIVATE"
+      cmake_parse_arguments(LINK_LIBS_ARG "" "" "PUBLIC;PRIVATE;INTERFACE"
         ${ARG_LINK_LIBS})
-      foreach(link_lib ${LINK_LIBS_ARG_PUBLIC})
-        if(LLVM_PTHREAD_LIB)
-          # Can't specify a dependence on -lpthread
-          if(NOT ${link_lib} STREQUAL ${LLVM_PTHREAD_LIB})
-            add_dependencies(${obj_name} ${link_lib})
-          endif()
-        else()
-          add_dependencies(${obj_name} ${link_lib})
-        endif()
-      endforeach()
+      set_property(TARGET ${obj_name} PROPERTY LLVM_OBJECT_LINK_LIBS
+        ${LINK_LIBS_ARG_PUBLIC} ${LINK_LIBS_ARG_PRIVATE}
+        ${LINK_LIBS_ARG_UNPARSED_ARGUMENTS})
+      set_property(GLOBAL APPEND PROPERTY LLVM_OBJECT_LIBRARIES_WITH_LINK_LIBS
+        ${obj_name})
+      get_property(scheduled GLOBAL PROPERTY
+        LLVM_OBJECT_LINK_DEPENDENCIES_SCHEDULED)
+      if(NOT scheduled)
+        cmake_language(DEFER DIRECTORY "${CMAKE_SOURCE_DIR}"
+          CALL _llvm_add_object_link_dependencies)
+        set_property(GLOBAL PROPERTY LLVM_OBJECT_LINK_DEPENDENCIES_SCHEDULED
+          TRUE)
+      endif()
     endif()
 
     if(ARG_DISABLE_LLVM_LINK_LLVM_DYLIB)

--- a/mlir/cmake/modules/AddMLIR.cmake
+++ b/mlir/cmake/modules/AddMLIR.cmake
@@ -273,6 +273,91 @@ function(_check_llvm_components_usage name)
   endforeach()
 endfunction()
 
+# Record HEADER_LIBS for resolution once every target exists, so providers may
+# be declared later and typos are diagnosed.
+function(_mlir_add_header_libs target)
+  if(NOT ARGN)
+    return()
+  endif()
+  set_property(TARGET ${target} APPEND PROPERTY MLIR_HEADER_LIBS ${ARGN})
+  set_property(GLOBAL APPEND PROPERTY MLIR_HEADER_LIBS_CONSUMERS ${target})
+  get_property(scheduled GLOBAL PROPERTY MLIR_HEADER_LIBS_SCHEDULED)
+  if(NOT scheduled)
+    cmake_language(DEFER DIRECTORY "${CMAKE_SOURCE_DIR}"
+      CALL _mlir_resolve_header_libs)
+    set_property(GLOBAL PROPERTY MLIR_HEADER_LIBS_SCHEDULED TRUE)
+  endif()
+endfunction()
+
+# Order each consumer after the TableGen targets of its HEADER_LIBS and of
+# everything they link or list in HEADER_LIBS, mirroring how a link dependency
+# propagates. Depending on those TableGen targets rather than on the libraries
+# keeps a header-only relationship from forming a dependency cycle when the
+# provider links the consumer.
+function(_mlir_resolve_header_libs)
+  get_property(consumers GLOBAL PROPERTY MLIR_HEADER_LIBS_CONSUMERS)
+  foreach(consumer ${consumers})
+    set(consumer_targets ${consumer})
+    if(TARGET obj.${consumer})
+      list(APPEND consumer_targets obj.${consumer})
+    endif()
+    get_target_property(providers ${consumer} MLIR_HEADER_LIBS)
+    set(queue)
+    foreach(provider ${providers})
+      if(NOT TARGET "${provider}")
+        message(SEND_ERROR
+          "${consumer}: HEADER_LIBS entry '${provider}' is not a target")
+        continue()
+      endif()
+      get_target_property(type ${provider} TYPE)
+      if(type STREQUAL "UTILITY")
+        message(SEND_ERROR
+          "${consumer}: HEADER_LIBS entry '${provider}' is not a library; "
+          "list TableGen targets in DEPENDS instead")
+        continue()
+      endif()
+      _llvm_link_item_targets(targets "${provider}")
+      list(APPEND queue ${targets})
+    endforeach()
+
+    set(visited)
+    set(tablegen_targets)
+    while(queue)
+      list(POP_FRONT queue provider)
+      if(provider IN_LIST visited)
+        continue()
+      endif()
+      list(APPEND visited ${provider})
+      get_target_property(imported ${provider} IMPORTED)
+      if(imported)
+        # Installed headers already exist.
+        continue()
+      endif()
+      get_target_property(dependencies ${provider} MANUALLY_ADDED_DEPENDENCIES)
+      foreach(dependency ${dependencies})
+        if(TARGET "${dependency}")
+          get_target_property(type ${dependency} TYPE)
+          if(type STREQUAL "UTILITY")
+            list(APPEND tablegen_targets ${dependency})
+          endif()
+        endif()
+      endforeach()
+      get_target_property(links ${provider} INTERFACE_LINK_LIBRARIES)
+      get_target_property(header_libs ${provider} MLIR_HEADER_LIBS)
+      foreach(item ${links} ${header_libs})
+        _llvm_link_item_targets(targets "${item}")
+        list(APPEND queue ${targets})
+      endforeach()
+    endwhile()
+    list(REMOVE_DUPLICATES tablegen_targets)
+    if(tablegen_targets)
+      foreach(consumer_target ${consumer_targets})
+        add_dependencies(${consumer_target} ${tablegen_targets})
+      endforeach()
+    endif()
+  endforeach()
+endfunction()
+
 function(add_mlir_example_library name)
   cmake_parse_arguments(ARG
     "SHARED;DISABLE_INSTALL"
@@ -325,11 +410,16 @@ endfunction()
 #   are compatible with building an object library.
 # STANDALONE
 #   Don't link against LLVMSupport.
+# HEADER_LIBS
+#   MLIR libraries whose generated headers this library includes without
+#   linking them; compilation is ordered after the TableGen targets of those
+#   libraries and of the libraries they link. Libraries in LINK_LIBS need no
+#   entry here, and a library's own TableGen targets belong in DEPENDS.
 function(add_mlir_library name)
   cmake_parse_arguments(ARG
     "SHARED;INSTALL_WITH_TOOLCHAIN;EXCLUDE_FROM_LIBMLIR;DISABLE_INSTALL;ENABLE_AGGREGATION;OBJECT;STANDALONE"
     ""
-    "ADDITIONAL_HEADERS;DEPENDS;LINK_COMPONENTS;LINK_LIBS"
+    "ADDITIONAL_HEADERS;DEPENDS;HEADER_LIBS;LINK_COMPONENTS;LINK_LIBS"
     ${ARGN})
   _set_mlir_additional_headers_as_srcs(${ARG_ADDITIONAL_HEADERS})
 
@@ -388,6 +478,7 @@ function(add_mlir_library name)
 
   list(APPEND ARG_DEPENDS mlir-generic-headers)
   llvm_add_library(${name} ${LIBTYPE} ${ARG_UNPARSED_ARGUMENTS} ${srcs} DEPENDS ${ARG_DEPENDS} LINK_COMPONENTS ${ARG_LINK_COMPONENTS} LINK_LIBS ${ARG_LINK_LIBS})
+  _mlir_add_header_libs(${name} ${ARG_HEADER_LIBS})
 
   if(TARGET ${name})
     target_link_libraries(${name} INTERFACE ${LLVM_COMMON_LIBS})
@@ -677,25 +768,25 @@ endfunction()
 # Declare the library associated with a dialect.
 function(add_mlir_dialect_library name)
   set_property(GLOBAL APPEND PROPERTY MLIR_DIALECT_LIBS ${name})
-  add_mlir_library(${ARGV} DEPENDS mlir-headers)
+  add_mlir_library(${ARGV})
 endfunction(add_mlir_dialect_library)
 
 # Declare the library associated with a conversion.
 function(add_mlir_conversion_library name)
   set_property(GLOBAL APPEND PROPERTY MLIR_CONVERSION_LIBS ${name})
-  add_mlir_library(${ARGV} DEPENDS mlir-headers)
+  add_mlir_library(${ARGV})
 endfunction(add_mlir_conversion_library)
 
 # Declare the library associated with an extension.
 function(add_mlir_extension_library name)
   set_property(GLOBAL APPEND PROPERTY MLIR_EXTENSION_LIBS ${name})
-  add_mlir_library(${ARGV} DEPENDS mlir-headers)
+  add_mlir_library(${ARGV})
 endfunction(add_mlir_extension_library)
 
 # Declare the library associated with a translation.
 function(add_mlir_translation_library name)
   set_property(GLOBAL APPEND PROPERTY MLIR_TRANSLATION_LIBS ${name})
-  add_mlir_library(${ARGV} DEPENDS mlir-headers)
+  add_mlir_library(${ARGV})
 endfunction(add_mlir_translation_library)
 
 # Verification tools to aid debugging.

--- a/mlir/docs/CMakeInfrastructure.md
+++ b/mlir/docs/CMakeInfrastructure.md
@@ -1,0 +1,97 @@
+# CMake Infrastructure
+
+[TOC]
+
+MLIR extends LLVM's CMake helpers in
+[`AddMLIR.cmake`](../cmake/modules/AddMLIR.cmake). This document describes how
+MLIR libraries declare their dependencies, in particular on TableGen-generated
+headers. Getting these right matters: a missing dependency does not fail a
+warm build, it only shows up as a race in a clean, parallel build.
+
+## Libraries
+
+`add_mlir_library` and its wrappers (`add_mlir_dialect_library`,
+`add_mlir_conversion_library`, `add_mlir_extension_library`,
+`add_mlir_translation_library`) build on `llvm_add_library` and accept the
+same keywords, plus `HEADER_LIBS`:
+
+~~~cmake
+add_mlir_dialect_library(MLIRFooDialect
+  FooDialect.cpp
+  FooOps.cpp
+
+  ADDITIONAL_HEADER_DIRS
+  ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/Foo
+
+  DEPENDS
+  MLIRFooOpsIncGen
+  MLIRFooInterfacesIncGen
+
+  LINK_LIBS PUBLIC
+  MLIRIR
+  MLIRBarDialect
+  )
+~~~
+
+## TableGen targets
+
+Set `LLVM_TARGET_DEFINITIONS`, call `mlir_tablegen` once per output, then
+create the target:
+
+| Helper | Use for |
+| --- | --- |
+| `add_mlir_dialect` | The standard op, type and dialect declarations of a dialect |
+| `add_mlir_dialect_tablegen_target` | Other dialect-specific headers |
+| `add_mlir_interface`, `add_mlir_generic_tablegen_target` | Dialect-independent headers such as interfaces and pass registries |
+| `add_public_tablegen_target` | Files private to one library, such as rewrite patterns |
+
+Dialect-independent targets are collected in `mlir-generic-headers`, which
+every MLIR library depends on. Dialect-specific targets are collected in
+`mlir-headers`; do not depend on that aggregate, it serializes every dialect
+behind every generator.
+
+## Generated header dependencies
+
+Three rules cover every generated header in MLIR:
+
+1. **A library lists its own TableGen targets in `DEPENDS`.** These are the
+   targets producing the `.inc` files that its sources or public headers
+   include, normally the ones declared in the matching `include/` directory.
+
+2. **Linking a library orders compilation after that library's generated
+   headers.** Every `LINK_LIBS` entry, `PUBLIC` or `PRIVATE`, becomes a
+   target-level ordering dependency of the object library, and Ninja follows
+   those dependencies transitively without waiting for archives to be linked.
+   Never list another library's `*IncGen` target: link the library that owns it.
+
+3. **`HEADER_LIBS` names libraries whose generated headers are included
+   without linking them.** Compilation is ordered after the TableGen targets of
+   that library and of the libraries it links, but not after the libraries
+   themselves, so this cannot create a dependency cycle when the provider links
+   the consumer. Add a comment naming the include that requires the edge:
+
+   ~~~cmake
+   # ArithDialect.cpp includes the generated Bufferization interfaces.
+   HEADER_LIBS
+   MLIRBufferizationDialect
+   ~~~
+
+   A misspelled entry is diagnosed at configure time.
+
+Generated LLVM headers are not covered by these rules; libraries that include
+them still list `intrinsics_gen` or the relevant LLVM target in `DEPENDS`.
+
+## Checking dependencies
+
+A missing dependency is only visible from a clean build. After configuring a
+fresh Ninja build directory, build a few leaf libraries in parallel rather
+than an aggregate target, for example:
+
+~~~sh
+ninja -C <build> MLIRArmNeonDialect MLIRLinalgDialect
+~~~
+
+An aggregate such as `check-mlir` often generates headers incidentally and
+hides the race. After a successful build has populated the compiler depfiles,
+`ninja -C <build> -t missingdeps` lists every generated file that an object
+includes without a path to its generator in the build graph.

--- a/mlir/docs/DefiningDialects/AttributesAndTypes.md
+++ b/mlir/docs/DefiningDialects/AttributesAndTypes.md
@@ -192,7 +192,7 @@ mlir_tablegen(<Your Dialect>AttrDefs.h.inc -gen-attrdef-decls
               -attrdefs-dialect=<Your Dialect>)
 mlir_tablegen(<Your Dialect>AttrDefs.cpp.inc -gen-attrdef-defs 
               -attrdefs-dialect=<Your Dialect>)
-add_public_tablegen_target(<Your Dialect>AttrDefsIncGen)
+add_mlir_dialect_tablegen_target(<Your Dialect>AttrDefsIncGen)
 ```
 
 The generated `<Your Dialect>AttrDefs.h.inc` will need to be included whereever

--- a/mlir/include/mlir/Dialect/OpenACC/CMakeLists.txt
+++ b/mlir/include/mlir/Dialect/OpenACC/CMakeLists.txt
@@ -3,6 +3,8 @@ add_subdirectory(Transforms)
 set(LLVM_TARGET_DEFINITIONS ${LLVM_MAIN_INCLUDE_DIR}/llvm/Frontend/OpenACC/ACC.td)
 mlir_tablegen(AccCommon.td --gen-directive-decl --directives-dialect=OpenACC)
 add_mlir_dialect_tablegen_target(acc_common_td)
+# Subsequent TableGen inputs include the generated AccCommon.td file.
+list(APPEND LLVM_TARGET_DEPENDS acc_common_td)
 
 add_mlir_dialect(OpenACCOps acc)
 
@@ -25,3 +27,4 @@ set(LLVM_TARGET_DEFINITIONS OpenACCTypeInterfaces.td)
 mlir_tablegen(OpenACCTypeInterfaces.h.inc -gen-type-interface-decls)
 mlir_tablegen(OpenACCTypeInterfaces.cpp.inc -gen-type-interface-defs)
 add_mlir_dialect_tablegen_target(MLIROpenACCTypeInterfacesIncGen)
+list(REMOVE_ITEM LLVM_TARGET_DEPENDS acc_common_td)

--- a/mlir/include/mlir/Dialect/OpenMP/CMakeLists.txt
+++ b/mlir/include/mlir/Dialect/OpenMP/CMakeLists.txt
@@ -3,6 +3,8 @@ add_subdirectory(Transforms)
 set(LLVM_TARGET_DEFINITIONS ${LLVM_MAIN_INCLUDE_DIR}/llvm/Frontend/OpenMP/OMP.td)
 mlir_tablegen(OmpCommon.td --gen-directive-decl --directives-dialect=OpenMP)
 add_mlir_dialect_tablegen_target(omp_common_td)
+# Subsequent TableGen inputs include the generated OmpCommon.td file.
+list(APPEND LLVM_TARGET_DEPENDS omp_common_td)
 
 set(LLVM_TARGET_DEFINITIONS OpenMPOps.td)
 
@@ -35,3 +37,4 @@ set(LLVM_TARGET_DEFINITIONS OpenMPTypeInterfaces.td)
 mlir_tablegen(OpenMPTypeInterfaces.h.inc -gen-type-interface-decls)
 mlir_tablegen(OpenMPTypeInterfaces.cpp.inc -gen-type-interface-defs)
 add_mlir_generic_tablegen_target(MLIROpenMPTypeInterfacesIncGen)
+list(REMOVE_ITEM LLVM_TARGET_DEPENDS omp_common_td)

--- a/mlir/lib/Analysis/CMakeLists.txt
+++ b/mlir/lib/Analysis/CMakeLists.txt
@@ -47,9 +47,6 @@ add_mlir_library(MLIRAnalysis
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Analysis
 
-  DEPENDS
-  mlir-headers
-
   LINK_LIBS PUBLIC
   MLIRCallInterfaces
   MLIRControlFlowInterfaces
@@ -65,4 +62,3 @@ add_mlir_library(MLIRAnalysis
   MLIRSideEffectInterfaces
   MLIRViewLikeInterface
   )
-

--- a/mlir/lib/Bytecode/CMakeLists.txt
+++ b/mlir/lib/Bytecode/CMakeLists.txt
@@ -7,6 +7,10 @@ add_mlir_library(MLIRBytecodeOpInterface
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Bytecode
 
+  DEPENDS
+  MLIRBytecodeOpInterfaceIncGen
+  MLIRBytecodeDialectInterfaceIncGen
+
   LINK_LIBS PUBLIC
   MLIRIR
   MLIRSupport

--- a/mlir/lib/CAPI/Conversion/CMakeLists.txt
+++ b/mlir/lib/CAPI/Conversion/CMakeLists.txt
@@ -2,9 +2,6 @@ get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
 add_mlir_upstream_c_api_library(MLIRCAPIConversion
   Passes.cpp
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   ${conversion_libs}
 )

--- a/mlir/lib/CAPI/Dialect/CMakeLists.txt
+++ b/mlir/lib/CAPI/Dialect/CMakeLists.txt
@@ -3,8 +3,6 @@ add_mlir_upstream_c_api_library(MLIRCAPIAffine
   AffinePasses.cpp
 
   PARTIAL_SOURCES_INTENDED
-  DEPENDS
-  MLIRAffinePassIncGen
 
   LINK_LIBS PUBLIC
   MLIRCAPIIR
@@ -17,8 +15,6 @@ add_mlir_upstream_c_api_library(MLIRCAPIAMDGPU
   AMDGPUPasses.cpp
 
   PARTIAL_SOURCES_INTENDED
-  DEPENDS
-  MLIRNVGPUPassIncGen
 
   LINK_LIBS PUBLIC
   MLIRCAPIIR
@@ -63,8 +59,6 @@ add_mlir_upstream_c_api_library(MLIRCAPIArmSVE
   ArmSVEPasses.cpp
 
   PARTIAL_SOURCES_INTENDED
-  DEPENDS
-  MLIRArmSVEPassIncGen
 
   LINK_LIBS PUBLIC
   MLIRCAPIIR
@@ -77,8 +71,6 @@ add_mlir_upstream_c_api_library(MLIRCAPIAsync
   AsyncPasses.cpp
 
   PARTIAL_SOURCES_INTENDED
-  DEPENDS
-  MLIRAsyncPassIncGen
 
   LINK_LIBS PUBLIC
   MLIRCAPIIR
@@ -92,8 +84,6 @@ add_mlir_upstream_c_api_library(MLIRCAPIBufferization
   BufferizationPasses.cpp
 
   PARTIAL_SOURCES_INTENDED
-  DEPENDS
-  MLIRBufferizationPassIncGen
 
   LINK_LIBS PUBLIC
   MLIRCAPIIR
@@ -156,8 +146,6 @@ add_mlir_upstream_c_api_library(MLIRCAPIGPU
   GPUPasses.cpp
 
   PARTIAL_SOURCES_INTENDED
-  DEPENDS
-  MLIRGPUPassIncGen
 
   LINK_LIBS PUBLIC
   MLIRCAPIIR
@@ -188,8 +176,6 @@ add_mlir_upstream_c_api_library(MLIRCAPILinalg
   LinalgPasses.cpp
 
   PARTIAL_SOURCES_INTENDED
-  DEPENDS
-  MLIRLinalgPassIncGen
 
   LINK_LIBS PUBLIC
   MLIRCAPIIR
@@ -226,8 +212,6 @@ add_mlir_upstream_c_api_library(MLIRCAPIMemRef
 
   PARTIAL_SOURCES_INTENDED
   PARTIAL_SOURCES_INTENDED
-  DEPENDS
-  MLIRMemRefPassIncGen
 
   LINK_LIBS PUBLIC
   MLIRCAPIIR
@@ -240,8 +224,6 @@ add_mlir_upstream_c_api_library(MLIRCAPIMLProgram
   MLProgramPasses.cpp
 
   PARTIAL_SOURCES_INTENDED
-  DEPENDS
-  MLIRMLProgramPassIncGen
 
   LINK_LIBS PUBLIC
   MLIRCAPIIR
@@ -263,8 +245,6 @@ add_mlir_upstream_c_api_library(MLIRCAPINVGPU
   NVGPUPasses.cpp
 
   PARTIAL_SOURCES_INTENDED
-  DEPENDS
-  MLIRNVGPUPassIncGen
 
   LINK_LIBS PUBLIC
   MLIRCAPIIR
@@ -286,8 +266,6 @@ add_mlir_upstream_c_api_library(MLIRCAPIOpenACC
   OpenACCPasses.cpp
 
   PARTIAL_SOURCES_INTENDED
-  DEPENDS
-  MLIROpenACCPassIncGen
 
   LINK_LIBS PUBLIC
   MLIRCAPIIR
@@ -354,8 +332,6 @@ add_mlir_upstream_c_api_library(MLIRCAPISCF
   SCFPasses.cpp
 
   PARTIAL_SOURCES_INTENDED
-  DEPENDS
-  MLIRSCFPassIncGen
 
   LINK_LIBS PUBLIC
   MLIRCAPIIR
@@ -379,8 +355,6 @@ add_mlir_upstream_c_api_library(MLIRCAPIShard
   ShardPasses.cpp
 
   PARTIAL_SOURCES_INTENDED
-  DEPENDS
-  MLIRShardPassIncGen
 
   LINK_LIBS PUBLIC
   MLIRCAPIIR
@@ -402,8 +376,6 @@ add_mlir_upstream_c_api_library(MLIRCAPISparseTensor
   SparseTensorPasses.cpp
 
   PARTIAL_SOURCES_INTENDED
-  DEPENDS
-  MLIRSparseTensorPassIncGen
 
   LINK_LIBS PUBLIC
   MLIRCAPIIR
@@ -416,8 +388,6 @@ add_mlir_upstream_c_api_library(MLIRCAPISPIRV
   SPIRVPasses.cpp
 
   PARTIAL_SOURCES_INTENDED
-  DEPENDS
-  MLIRSPIRVPassIncGen
 
   LINK_LIBS PUBLIC
   MLIRCAPIIR
@@ -441,8 +411,6 @@ add_mlir_upstream_c_api_library(MLIRCAPITosa
   TosaPasses.cpp
 
   PARTIAL_SOURCES_INTENDED
-  DEPENDS
-  MLIRTosaPassIncGen
 
   LINK_LIBS PUBLIC
   MLIRCAPIIR

--- a/mlir/lib/Conversion/AMDGPUToROCDL/CMakeLists.txt
+++ b/mlir/lib/Conversion/AMDGPUToROCDL/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRAMDGPUToROCDL
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/AMDGPUToROCDL
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/AffineToStandard/CMakeLists.txt
+++ b/mlir/lib/Conversion/AffineToStandard/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRAffineToStandard
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/AffineToStandard
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRAffineDialect
   MLIRAffineTransforms

--- a/mlir/lib/Conversion/ArithAndMathToAPFloat/CMakeLists.txt
+++ b/mlir/lib/Conversion/ArithAndMathToAPFloat/CMakeLists.txt
@@ -14,9 +14,6 @@ add_mlir_conversion_library(MLIRArithToAPFloat
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/ArithToLLVM
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 
@@ -36,11 +33,12 @@ add_mlir_conversion_library(MLIRMathToAPFloat
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/MathToLLVM
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
+
+  # MathToAPFloat.cpp includes the generated Math transforms pass header.
+  HEADER_LIBS
+  MLIRMathTransforms
 
   LINK_LIBS PUBLIC
   MLIRTransformUtils

--- a/mlir/lib/Conversion/ArithToAMDGPU/CMakeLists.txt
+++ b/mlir/lib/Conversion/ArithToAMDGPU/CMakeLists.txt
@@ -4,11 +4,12 @@ add_mlir_conversion_library(MLIRArithToAMDGPU
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/ArithToAMDGPU
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
+
+  # ArithToAMDGPU.cpp includes VectorRewritePatterns.h.
+  HEADER_LIBS
+  MLIRVectorTransforms
 
   LINK_LIBS PUBLIC
   MLIRAMDGPUDialect

--- a/mlir/lib/Conversion/ArithToArmSME/CMakeLists.txt
+++ b/mlir/lib/Conversion/ArithToArmSME/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRArithToArmSME
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/ArithToArmSME
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/ArithToEmitC/CMakeLists.txt
+++ b/mlir/lib/Conversion/ArithToEmitC/CMakeLists.txt
@@ -5,9 +5,6 @@ add_mlir_conversion_library(MLIRArithToEmitC
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/ArithToEmitC
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRArithDialect
   MLIREmitCCommonConversion

--- a/mlir/lib/Conversion/ArithToLLVM/CMakeLists.txt
+++ b/mlir/lib/Conversion/ArithToLLVM/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRArithToLLVM
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/ArithToLLVM
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/ArithToSPIRV/CMakeLists.txt
+++ b/mlir/lib/Conversion/ArithToSPIRV/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRArithToSPIRV
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/ArithToSPIRV
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/ArmNeon2dToIntr/CMakeLists.txt
+++ b/mlir/lib/Conversion/ArmNeon2dToIntr/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRArmNeon2dToIntr
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/ArmNeon2dToIntr
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/ArmSMEToLLVM/CMakeLists.txt
+++ b/mlir/lib/Conversion/ArmSMEToLLVM/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRArmSMEToLLVM
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/ArmSMEToLLVM
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRArmSMETransforms
   MLIRArmSMEDialect

--- a/mlir/lib/Conversion/ArmSMEToSCF/CMakeLists.txt
+++ b/mlir/lib/Conversion/ArmSMEToSCF/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRArmSMEToSCF
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/ArmSMEToSCF
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRArmSMEDialect
   MLIRTransforms

--- a/mlir/lib/Conversion/AsyncToLLVM/CMakeLists.txt
+++ b/mlir/lib/Conversion/AsyncToLLVM/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRAsyncToLLVM
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/AsyncToLLVM
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/BufferizationToMemRef/CMakeLists.txt
+++ b/mlir/lib/Conversion/BufferizationToMemRef/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRBufferizationToMemRef
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/BufferizationToMemRef
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRBufferizationDialect
   MLIRBufferizationTransforms

--- a/mlir/lib/Conversion/ComplexToLLVM/CMakeLists.txt
+++ b/mlir/lib/Conversion/ComplexToLLVM/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRComplexToLLVM
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/ComplexToLLVM
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/ComplexToLibm/CMakeLists.txt
+++ b/mlir/lib/Conversion/ComplexToLibm/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRComplexToLibm
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/ComplexToLibm
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/ComplexToROCDLLibraryCalls/CMakeLists.txt
+++ b/mlir/lib/Conversion/ComplexToROCDLLibraryCalls/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRComplexToROCDLLibraryCalls
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/ComplexToROCDLLibraryCalls
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/ComplexToSPIRV/CMakeLists.txt
+++ b/mlir/lib/Conversion/ComplexToSPIRV/CMakeLists.txt
@@ -6,9 +6,6 @@ add_mlir_conversion_library(MLIRComplexToSPIRV
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/SPIRV
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/IR
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRComplexDialect
   MLIRIR

--- a/mlir/lib/Conversion/ComplexToStandard/CMakeLists.txt
+++ b/mlir/lib/Conversion/ComplexToStandard/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRComplexToStandard
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/ComplexToStandard
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRArithDialect
   MLIRComplexDivisionConversion

--- a/mlir/lib/Conversion/ControlFlowToLLVM/CMakeLists.txt
+++ b/mlir/lib/Conversion/ControlFlowToLLVM/CMakeLists.txt
@@ -5,7 +5,6 @@ add_mlir_conversion_library(MLIRControlFlowToLLVM
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/ControlFlowToLLVM
 
   DEPENDS
-  MLIRConversionPassIncGen
   intrinsics_gen
 
   LINK_COMPONENTS

--- a/mlir/lib/Conversion/ControlFlowToSCF/CMakeLists.txt
+++ b/mlir/lib/Conversion/ControlFlowToSCF/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRControlFlowToSCF
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/ControlFlowToSCF
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRAnalysis
   MLIRArithDialect

--- a/mlir/lib/Conversion/ControlFlowToSPIRV/CMakeLists.txt
+++ b/mlir/lib/Conversion/ControlFlowToSPIRV/CMakeLists.txt
@@ -6,9 +6,6 @@ add_mlir_conversion_library(MLIRControlFlowToSPIRV
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/SPIRV
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/IR
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRIR
   MLIRControlFlowDialect

--- a/mlir/lib/Conversion/ConvertToEmitC/CMakeLists.txt
+++ b/mlir/lib/Conversion/ConvertToEmitC/CMakeLists.txt
@@ -5,7 +5,6 @@ add_mlir_conversion_library(MLIRConvertToEmitC
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/ConvertToEmitC
 
   DEPENDS
-  MLIRConversionPassIncGen
   MLIRConvertToEmitCPatternInterfaceIncGen
 
   LINK_LIBS PUBLIC

--- a/mlir/lib/Conversion/ConvertToLLVM/CMakeLists.txt
+++ b/mlir/lib/Conversion/ConvertToLLVM/CMakeLists.txt
@@ -17,9 +17,6 @@ add_mlir_conversion_library(MLIRConvertToLLVMInterface
 add_mlir_conversion_library(MLIRConvertToLLVMPass
   ConvertToLLVMPass.cpp
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRIR
   MLIRConvertToLLVMInterface

--- a/mlir/lib/Conversion/FuncToEmitC/CMakeLists.txt
+++ b/mlir/lib/Conversion/FuncToEmitC/CMakeLists.txt
@@ -5,9 +5,6 @@ add_mlir_conversion_library(MLIRFuncToEmitC
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/FuncToEmitC
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIREmitCCommonConversion
   MLIREmitCDialect

--- a/mlir/lib/Conversion/FuncToLLVM/CMakeLists.txt
+++ b/mlir/lib/Conversion/FuncToLLVM/CMakeLists.txt
@@ -5,7 +5,6 @@ add_mlir_conversion_library(MLIRFuncToLLVM
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/FuncToLLVM
 
   DEPENDS
-  MLIRConversionPassIncGen
   intrinsics_gen
 
   LINK_COMPONENTS

--- a/mlir/lib/Conversion/FuncToSPIRV/CMakeLists.txt
+++ b/mlir/lib/Conversion/FuncToSPIRV/CMakeLists.txt
@@ -6,9 +6,6 @@ add_mlir_conversion_library(MLIRFuncToSPIRV
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/SPIRV
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/IR
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRFuncDialect
   MLIRIR

--- a/mlir/lib/Conversion/GPUCommon/CMakeLists.txt
+++ b/mlir/lib/Conversion/GPUCommon/CMakeLists.txt
@@ -21,7 +21,6 @@ add_mlir_conversion_library(MLIRGPUToGPURuntimeTransforms
   IndexIntrinsicsOpLowering.cpp
 
   DEPENDS
-  MLIRConversionPassIncGen
   intrinsics_gen
 
   LINK_COMPONENTS

--- a/mlir/lib/Conversion/GPUToLLVMSPV/CMakeLists.txt
+++ b/mlir/lib/Conversion/GPUToLLVMSPV/CMakeLists.txt
@@ -1,9 +1,6 @@
 add_mlir_conversion_library(MLIRGPUToLLVMSPV
   GPUToLLVMSPV.cpp
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRGPUDialect
   MLIRGPUToGPURuntimeTransforms

--- a/mlir/lib/Conversion/GPUToNVVM/CMakeLists.txt
+++ b/mlir/lib/Conversion/GPUToNVVM/CMakeLists.txt
@@ -2,9 +2,6 @@ add_mlir_conversion_library(MLIRGPUToNVVMTransforms
   LowerGpuOpsToNVVMOps.cpp
   WmmaOpsToNvvm.cpp
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRArithToLLVM
   MLIRFuncToLLVM

--- a/mlir/lib/Conversion/GPUToROCDL/CMakeLists.txt
+++ b/mlir/lib/Conversion/GPUToROCDL/CMakeLists.txt
@@ -6,7 +6,6 @@ add_mlir_conversion_library(MLIRGPUToROCDLTransforms
   LowerGpuOpsToROCDLOps.cpp
 
   DEPENDS
-  MLIRConversionPassIncGen
   MLIRGPUToROCDLIncGen
 
   LINK_LIBS PUBLIC

--- a/mlir/lib/Conversion/GPUToSPIRV/CMakeLists.txt
+++ b/mlir/lib/Conversion/GPUToSPIRV/CMakeLists.txt
@@ -3,9 +3,6 @@ add_mlir_conversion_library(MLIRGPUToSPIRV
   GPUToSPIRVPass.cpp
   WmmaOpsToSPIRV.cpp
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRArithToSPIRV
   MLIRGPUDialect

--- a/mlir/lib/Conversion/IndexToLLVM/CMakeLists.txt
+++ b/mlir/lib/Conversion/IndexToLLVM/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRIndexToLLVM
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/IndexToLLVM
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/IndexToSPIRV/CMakeLists.txt
+++ b/mlir/lib/Conversion/IndexToSPIRV/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRIndexToSPIRV
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/IndexToSPIRV
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/LinalgToStandard/CMakeLists.txt
+++ b/mlir/lib/Conversion/LinalgToStandard/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRLinalgToStandard
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/LinalgToStandard
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/MPIToLLVM/CMakeLists.txt
+++ b/mlir/lib/Conversion/MPIToLLVM/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRMPIToLLVM
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/MPIToLLVM
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/MathToEmitC/CMakeLists.txt
+++ b/mlir/lib/Conversion/MathToEmitC/CMakeLists.txt
@@ -5,9 +5,6 @@ add_mlir_conversion_library(MLIRMathToEmitC
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/MathToEmitC
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/MathToFuncs/CMakeLists.txt
+++ b/mlir/lib/Conversion/MathToFuncs/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRMathToFuncs
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/MathToFuncs
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/MathToLLVM/CMakeLists.txt
+++ b/mlir/lib/Conversion/MathToLLVM/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRMathToLLVM
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/MathToLLVM
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/MathToLibm/CMakeLists.txt
+++ b/mlir/lib/Conversion/MathToLibm/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRMathToLibm
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/MathToLibm
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/MathToNVVM/CMakeLists.txt
+++ b/mlir/lib/Conversion/MathToNVVM/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRMathToNVVM
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/MathToNVVM
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/MathToROCDL/CMakeLists.txt
+++ b/mlir/lib/Conversion/MathToROCDL/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRMathToROCDL
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/MathToROCDL
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/MathToSPIRV/CMakeLists.txt
+++ b/mlir/lib/Conversion/MathToSPIRV/CMakeLists.txt
@@ -6,9 +6,6 @@ add_mlir_conversion_library(MLIRMathToSPIRV
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/SPIRV
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/IR
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRIR
   MLIRMathDialect

--- a/mlir/lib/Conversion/MathToXeVM/CMakeLists.txt
+++ b/mlir/lib/Conversion/MathToXeVM/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRMathToXeVM
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/MathToXeVM
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/MemRefToEmitC/CMakeLists.txt
+++ b/mlir/lib/Conversion/MemRefToEmitC/CMakeLists.txt
@@ -5,9 +5,6 @@ add_mlir_conversion_library(MLIRMemRefToEmitC
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/MemRefToEmitC
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/MemRefToLLVM/CMakeLists.txt
+++ b/mlir/lib/Conversion/MemRefToLLVM/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRMemRefToLLVM
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/MemRefToLLVM
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/MemRefToSPIRV/CMakeLists.txt
+++ b/mlir/lib/Conversion/MemRefToSPIRV/CMakeLists.txt
@@ -7,9 +7,6 @@ add_mlir_conversion_library(MLIRMemRefToSPIRV
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/SPIRV
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/IR
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRFunctionInterfaces
   MLIRIR

--- a/mlir/lib/Conversion/NVGPUToNVVM/CMakeLists.txt
+++ b/mlir/lib/Conversion/NVGPUToNVVM/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRNVGPUToNVVM
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/NVGPUToNVVM
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/NVVMToLLVM/CMakeLists.txt
+++ b/mlir/lib/Conversion/NVVMToLLVM/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRNVVMToLLVM
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/NVVMToLLVM
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/OpenACCToLLVM/CMakeLists.txt
+++ b/mlir/lib/Conversion/OpenACCToLLVM/CMakeLists.txt
@@ -7,9 +7,6 @@ add_mlir_conversion_library(MLIROpenACCToLLVM
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/OpenACCToLLVM
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRArithToLLVM
   MLIRComplexDialect

--- a/mlir/lib/Conversion/OpenACCToSCF/CMakeLists.txt
+++ b/mlir/lib/Conversion/OpenACCToSCF/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIROpenACCToSCF
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/OpenACCToSCF
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRArithDialect
   MLIRIR

--- a/mlir/lib/Conversion/OpenMPToLLVM/CMakeLists.txt
+++ b/mlir/lib/Conversion/OpenMPToLLVM/CMakeLists.txt
@@ -5,7 +5,6 @@ add_mlir_conversion_library(MLIROpenMPToLLVM
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/OpenMPToLLVM
 
   DEPENDS
-  MLIRConversionPassIncGen
   intrinsics_gen
 
   LINK_COMPONENTS

--- a/mlir/lib/Conversion/PDLToPDLInterp/CMakeLists.txt
+++ b/mlir/lib/Conversion/PDLToPDLInterp/CMakeLists.txt
@@ -7,9 +7,6 @@ add_mlir_conversion_library(MLIRPDLToPDLInterp
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/PDLToPDLInterp
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRIR
   MLIRInferTypeOpInterface

--- a/mlir/lib/Conversion/PtrToLLVM/CMakeLists.txt
+++ b/mlir/lib/Conversion/PtrToLLVM/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRPtrToLLVM
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/PtrToLLVM
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/RaiseWasm/CMakeLists.txt
+++ b/mlir/lib/Conversion/RaiseWasm/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRWasmRaise
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/RaiseWasm
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRArithDialect
   MLIRControlFlowDialect

--- a/mlir/lib/Conversion/ReconcileUnrealizedCasts/CMakeLists.txt
+++ b/mlir/lib/Conversion/ReconcileUnrealizedCasts/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRReconcileUnrealizedCasts
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/ReconcileUnrealizedCasts
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/SCFToAffine/CMakeLists.txt
+++ b/mlir/lib/Conversion/SCFToAffine/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRSCFToAffine
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/SCFToAffine
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRAffineDialect
   MLIRArithDialect

--- a/mlir/lib/Conversion/SCFToControlFlow/CMakeLists.txt
+++ b/mlir/lib/Conversion/SCFToControlFlow/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRSCFToControlFlow
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/SCFToControlFlow
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRArithDialect
   MLIRControlFlowDialect

--- a/mlir/lib/Conversion/SCFToEmitC/CMakeLists.txt
+++ b/mlir/lib/Conversion/SCFToEmitC/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRSCFToEmitC
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/SCFToEmitC
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/SCFToGPU/CMakeLists.txt
+++ b/mlir/lib/Conversion/SCFToGPU/CMakeLists.txt
@@ -5,9 +5,6 @@ add_mlir_conversion_library(MLIRSCFToGPU
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/SCFToGPU
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRAffineDialect
   MLIRAffineToStandard

--- a/mlir/lib/Conversion/SCFToOpenMP/CMakeLists.txt
+++ b/mlir/lib/Conversion/SCFToOpenMP/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRSCFToOpenMP
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/SCFToStandard
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/SCFToSPIRV/CMakeLists.txt
+++ b/mlir/lib/Conversion/SCFToSPIRV/CMakeLists.txt
@@ -5,9 +5,6 @@ add_mlir_conversion_library(MLIRSCFToSPIRV
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/SCFToSPIRV
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRArithToSPIRV
   MLIRFuncToSPIRV

--- a/mlir/lib/Conversion/SPIRVCommon/CMakeLists.txt
+++ b/mlir/lib/Conversion/SPIRVCommon/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_mlir_conversion_library(MLIRSPIRVAttrToLLVMConversion
   AttrToLLVMConverter.cpp
 
-  DEPENDS
-  MLIRSPIRVEnumsIncGen
+  # AttrToLLVMConverter.h includes the generated SPIRVEnums.h.
+  HEADER_LIBS
+  MLIRSPIRVDialect
 )

--- a/mlir/lib/Conversion/SPIRVToLLVM/CMakeLists.txt
+++ b/mlir/lib/Conversion/SPIRVToLLVM/CMakeLists.txt
@@ -7,7 +7,6 @@ add_mlir_conversion_library(MLIRSPIRVToLLVM
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/SPIRVToLLVM
 
   DEPENDS
-  MLIRConversionPassIncGen
   intrinsics_gen
 
   LINK_LIBS PUBLIC

--- a/mlir/lib/Conversion/ShapeToStandard/CMakeLists.txt
+++ b/mlir/lib/Conversion/ShapeToStandard/CMakeLists.txt
@@ -10,7 +10,6 @@ add_mlir_conversion_library(MLIRShapeToStandard
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/ShapeToStandard
 
   DEPENDS
-  MLIRConversionPassIncGen
   ShapeToStandardIncGen
 
   LINK_COMPONENTS

--- a/mlir/lib/Conversion/ShardToMPI/CMakeLists.txt
+++ b/mlir/lib/Conversion/ShardToMPI/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRShardToMPI
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/ShardToMPI
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/TensorToLinalg/CMakeLists.txt
+++ b/mlir/lib/Conversion/TensorToLinalg/CMakeLists.txt
@@ -6,9 +6,6 @@ add_mlir_conversion_library(MLIRTensorToLinalg
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/Linalg
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/IR
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRIR
   MLIRPass

--- a/mlir/lib/Conversion/TensorToSPIRV/CMakeLists.txt
+++ b/mlir/lib/Conversion/TensorToSPIRV/CMakeLists.txt
@@ -6,9 +6,6 @@ add_mlir_conversion_library(MLIRTensorToSPIRV
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/SPIRV
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/IR
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRArithToSPIRV
   MLIRFuncToSPIRV

--- a/mlir/lib/Conversion/TosaToArith/CMakeLists.txt
+++ b/mlir/lib/Conversion/TosaToArith/CMakeLists.txt
@@ -6,9 +6,6 @@ add_mlir_conversion_library(MLIRTosaToArith
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/Tosa
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/IR
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRArithDialect
   MLIRIR

--- a/mlir/lib/Conversion/TosaToLinalg/CMakeLists.txt
+++ b/mlir/lib/Conversion/TosaToLinalg/CMakeLists.txt
@@ -8,9 +8,6 @@ add_mlir_conversion_library(MLIRTosaToLinalg
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/Tosa
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/IR
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRArithDialect
   MLIRDialectUtils

--- a/mlir/lib/Conversion/TosaToMLProgram/CMakeLists.txt
+++ b/mlir/lib/Conversion/TosaToMLProgram/CMakeLists.txt
@@ -6,9 +6,6 @@ add_mlir_conversion_library(MLIRTosaToMLProgram
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/Tosa
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/IR
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRIR
   MLIRMLProgramDialect

--- a/mlir/lib/Conversion/TosaToSCF/CMakeLists.txt
+++ b/mlir/lib/Conversion/TosaToSCF/CMakeLists.txt
@@ -6,9 +6,6 @@ add_mlir_conversion_library(MLIRTosaToSCF
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/Tosa
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/IR
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRIR
   MLIRSCFDialect

--- a/mlir/lib/Conversion/TosaToSPIRVTosa/CMakeLists.txt
+++ b/mlir/lib/Conversion/TosaToSPIRVTosa/CMakeLists.txt
@@ -9,9 +9,6 @@ add_mlir_conversion_library(MLIRTosaToSPIRVTosa
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/Tosa
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/IR
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRFuncDialect
   MLIRIR

--- a/mlir/lib/Conversion/TosaToTensor/CMakeLists.txt
+++ b/mlir/lib/Conversion/TosaToTensor/CMakeLists.txt
@@ -6,9 +6,6 @@ add_mlir_conversion_library(MLIRTosaToTensor
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/Tosa
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/IR
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRTensorDialect
   MLIRTensorUtils

--- a/mlir/lib/Conversion/UBToLLVM/CMakeLists.txt
+++ b/mlir/lib/Conversion/UBToLLVM/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRUBToLLVM
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/UBToLLVM
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/UBToSPIRV/CMakeLists.txt
+++ b/mlir/lib/Conversion/UBToSPIRV/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRUBToSPIRV
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/UBToSPIRV
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/VectorToAMX/CMakeLists.txt
+++ b/mlir/lib/Conversion/VectorToAMX/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRVectorToAMX
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/VectorToAMX
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRAffineUtils
   MLIRArithDialect

--- a/mlir/lib/Conversion/VectorToArmSME/CMakeLists.txt
+++ b/mlir/lib/Conversion/VectorToArmSME/CMakeLists.txt
@@ -5,9 +5,6 @@ add_mlir_conversion_library(MLIRVectorToArmSME
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/VectorToArmSME
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRArmSMEDialect
   MLIRArmSVEDialect

--- a/mlir/lib/Conversion/VectorToLLVM/CMakeLists.txt
+++ b/mlir/lib/Conversion/VectorToLLVM/CMakeLists.txt
@@ -6,7 +6,6 @@ add_mlir_conversion_library(MLIRVectorToLLVM
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/VectorToLLVM
 
   DEPENDS
-  MLIRConversionPassIncGen
   intrinsics_gen
 
   LINK_COMPONENTS

--- a/mlir/lib/Conversion/VectorToSPIRV/CMakeLists.txt
+++ b/mlir/lib/Conversion/VectorToSPIRV/CMakeLists.txt
@@ -6,7 +6,6 @@ add_mlir_conversion_library(MLIRVectorToSPIRV
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/VectorToSPIRV
 
   DEPENDS
-  MLIRConversionPassIncGen
   intrinsics_gen
 
   LINK_LIBS PUBLIC

--- a/mlir/lib/Conversion/VectorToXeGPU/CMakeLists.txt
+++ b/mlir/lib/Conversion/VectorToXeGPU/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRVectorToXeGPU
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/VectorToXeGPU
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRArithDialect
   MLIRMemRefDialect

--- a/mlir/lib/Conversion/XeGPUToXeVM/CMakeLists.txt
+++ b/mlir/lib/Conversion/XeGPUToXeVM/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRXeGPUToXeVM
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/XeGPUToXeVM
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/XeVMToLLVM/CMakeLists.txt
+++ b/mlir/lib/Conversion/XeVMToLLVM/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRXeVMToLLVM
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/XeVMToLLVM
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Dialect/AMDGPU/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/AMDGPU/Transforms/CMakeLists.txt
@@ -10,6 +10,10 @@ add_mlir_dialect_library(MLIRAMDGPUTransforms
   DEPENDS
   MLIRAMDGPUTransformsIncGen
 
+  # MaskedloadToLoad.cpp includes VectorTransforms.h.
+  HEADER_LIBS
+  MLIRVectorTransforms
+
   LINK_LIBS PUBLIC
   MLIRAMDGPUDialect
   MLIRAMDGPUUtils

--- a/mlir/lib/Dialect/Affine/Analysis/CMakeLists.txt
+++ b/mlir/lib/Dialect/Affine/Analysis/CMakeLists.txt
@@ -8,9 +8,6 @@ add_mlir_dialect_library(MLIRAffineAnalysis
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/Affine
 
-  DEPENDS
-  MLIRFuncOpsIncGen
-
   LINK_LIBS PUBLIC
   MLIRAffineDialect
   MLIRAnalysis

--- a/mlir/lib/Dialect/Affine/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/Affine/Transforms/CMakeLists.txt
@@ -25,9 +25,7 @@ add_mlir_dialect_library(MLIRAffineTransforms
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/Affine
 
   DEPENDS
-  MLIRAffineOpsIncGen
   MLIRAffinePassIncGen
-  MLIRLoopLikeInterfaceIncGen
 
   LINK_LIBS PUBLIC
   MLIRAffineDialect

--- a/mlir/lib/Dialect/Arith/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/Arith/IR/CMakeLists.txt
@@ -23,6 +23,12 @@ add_mlir_dialect_library(MLIRArithDialect
   MLIRArithOpsIncGen
   MLIRArithOpsInterfacesIncGen
 
+  # ArithDialect.cpp includes generated Bufferization interfaces and
+  # mlir/Transforms/InliningUtils.h.
+  HEADER_LIBS
+  MLIRBufferizationDialect
+  MLIRTransformUtils
+
   LINK_LIBS PUBLIC
   MLIRCastInterfaces
   MLIRDialect

--- a/mlir/lib/Dialect/ArmNeon/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/ArmNeon/IR/CMakeLists.txt
@@ -6,6 +6,13 @@ add_mlir_dialect_library(MLIRArmNeonDialect
 
   DEPENDS
   MLIRArmNeonIncGen
+  MLIRArmNeonConversionsIncGen
+
+  # ArmNeonDialect.cpp includes VectorOps.h, whose generated declarations
+  # expose both Vector and Arith generated headers.
+  HEADER_LIBS
+  MLIRArithDialect
+  MLIRVectorDialect
 
   LINK_LIBS PUBLIC
   MLIRIR

--- a/mlir/lib/Dialect/ArmNeon/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/ArmNeon/Transforms/CMakeLists.txt
@@ -1,9 +1,6 @@
 add_mlir_dialect_library(MLIRArmNeonTransforms
   LowerContractToNeonPatterns.cpp
 
-  DEPENDS
-  MLIRArmNeonIncGen
-
   LINK_LIBS PUBLIC
   MLIRArmNeonDialect
   MLIRFuncDialect

--- a/mlir/lib/Dialect/ArmSME/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/ArmSME/IR/CMakeLists.txt
@@ -8,6 +8,9 @@ add_mlir_dialect_library(MLIRArmSMEDialect
   DEPENDS
   MLIRArmSMEOpsIncGen
   MLIRArmSMEIntrinsicOpsIncGen
+  MLIRArmSMEIncGen
+  MLIRArmSMEConversionsIncGen
+  MLIRArmSMEOpInterfaces
 
   LINK_LIBS PUBLIC
   MLIRIR

--- a/mlir/lib/Dialect/ArmSVE/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/ArmSVE/IR/CMakeLists.txt
@@ -6,6 +6,7 @@ add_mlir_dialect_library(MLIRArmSVEDialect
 
   DEPENDS
   MLIRArmSVEIncGen
+  MLIRArmSVEConversionsIncGen
 
   LINK_LIBS PUBLIC
   MLIRIR

--- a/mlir/lib/Dialect/ArmSVE/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/ArmSVE/Transforms/CMakeLists.txt
@@ -4,7 +4,6 @@ add_mlir_dialect_library(MLIRArmSVETransforms
   LowerContractToSVEPatterns.cpp
 
   DEPENDS
-  MLIRArmSVEConversionsIncGen
   MLIRArmSVEPassIncGen
 
   LINK_LIBS PUBLIC

--- a/mlir/lib/Dialect/Bufferization/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/Bufferization/IR/CMakeLists.txt
@@ -16,6 +16,10 @@ add_mlir_dialect_library(MLIRBufferizationDialect
   MLIRAllocationOpInterfaceIncGen
   MLIRBufferizationOpsIncGen
   MLIRBufferizationEnumsIncGen
+  MLIRBufferDeallocationOpInterfaceIncGen
+  MLIRBufferizableOpInterfaceIncGen
+  MLIRBufferViewFlowOpInterfaceIncGen
+  MLIRBufferizationTypeInterfacesIncGen
 
   LINK_LIBS PUBLIC
   MLIRAffineDialect

--- a/mlir/lib/Dialect/Bufferization/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/Bufferization/Transforms/CMakeLists.txt
@@ -24,7 +24,6 @@ add_mlir_dialect_library(MLIRBufferizationTransforms
 
   DEPENDS
   MLIRBufferizationPassIncGen
-  MLIRBufferizationEnumsIncGen
 
   LINK_LIBS PUBLIC
   MLIRArithDialect

--- a/mlir/lib/Dialect/Complex/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/Complex/IR/CMakeLists.txt
@@ -9,6 +9,10 @@ add_mlir_dialect_library(MLIRComplexDialect
   MLIRComplexOpsIncGen
   MLIRComplexAttributesIncGen
 
+  # ComplexDialect.cpp includes mlir/Transforms/InliningUtils.h.
+  HEADER_LIBS
+  MLIRTransformUtils
+
   LINK_LIBS PUBLIC
   MLIRArithDialect
   MLIRDialect

--- a/mlir/lib/Dialect/ControlFlow/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/ControlFlow/IR/CMakeLists.txt
@@ -7,6 +7,12 @@ add_mlir_dialect_library(MLIRControlFlowDialect
   DEPENDS
   MLIRControlFlowOpsIncGen
 
+  # ControlFlowOps.cpp includes generated Bufferization interfaces and
+  # mlir/Transforms/InliningUtils.h.
+  HEADER_LIBS
+  MLIRBufferizationDialect
+  MLIRTransformUtils
+
   LINK_LIBS PUBLIC
   MLIRArithDialect
   MLIRControlFlowInterfaces

--- a/mlir/lib/Dialect/DLTI/CMakeLists.txt
+++ b/mlir/lib/Dialect/DLTI/CMakeLists.txt
@@ -5,6 +5,7 @@ add_mlir_dialect_library(MLIRDLTIDialect
 
   DEPENDS
   MLIRDLTIIncGen
+  MLIRDLTIAttrsIncGen
 
   LINK_LIBS PUBLIC
   MLIRIR

--- a/mlir/lib/Dialect/DLTI/TransformOps/CMakeLists.txt
+++ b/mlir/lib/Dialect/DLTI/TransformOps/CMakeLists.txt
@@ -6,7 +6,6 @@ add_mlir_dialect_library(MLIRDLTITransformOps
 
   DEPENDS
   MLIRDLTITransformOpsIncGen
-  MLIRDLTIDialect
 
   LINK_LIBS PUBLIC
   MLIRDLTIDialect

--- a/mlir/lib/Dialect/EmitC/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/EmitC/IR/CMakeLists.txt
@@ -7,6 +7,7 @@ add_mlir_dialect_library(MLIREmitCDialect
   DEPENDS
   MLIREmitCIncGen
   MLIREmitCAttributesIncGen
+  MLIREmitCInterfacesIncGen
 
   LINK_LIBS PUBLIC
   MLIRCallInterfaces

--- a/mlir/lib/Dialect/Func/Extensions/CMakeLists.txt
+++ b/mlir/lib/Dialect/Func/Extensions/CMakeLists.txt
@@ -10,6 +10,10 @@ add_mlir_extension_library(MLIRFuncInlinerExtension
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/Func/Extensions
 
+  # InlinerExtension.cpp includes mlir/Transforms/InliningUtils.h.
+  HEADER_LIBS
+  MLIRTransformUtils
+
   LINK_LIBS PUBLIC
   MLIRControlFlowDialect
   MLIRInferTypeOpInterface

--- a/mlir/lib/Dialect/Func/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/Func/IR/CMakeLists.txt
@@ -7,6 +7,11 @@ add_mlir_dialect_library(MLIRFuncDialect
   DEPENDS
   MLIRFuncOpsIncGen
 
+  # FuncOps.cpp includes generated Bufferization interfaces and InliningUtils.
+  HEADER_LIBS
+  MLIRBufferizationDialect
+  MLIRTransformUtils
+
   LINK_LIBS PUBLIC
   MLIRCallInterfaces
   MLIRControlFlowInterfaces

--- a/mlir/lib/Dialect/GPU/CMakeLists.txt
+++ b/mlir/lib/Dialect/GPU/CMakeLists.txt
@@ -12,6 +12,10 @@ add_mlir_dialect_library(MLIRGPUDialect
   MLIRGPUOpsEnumsGen
   MLIRGPUOpInterfacesIncGen
   MLIRGPUCompilationAttrInterfacesIncGen
+  MLIRParallelLoopMapperEnumsGen
+  MLIRGPUDeviceMapperEnumsGen
+  # GPU dialect sources include llvm/IR/Attributes.h.
+  intrinsics_gen
 
   LINK_LIBS PUBLIC
   MLIRArithDialect
@@ -54,7 +58,6 @@ add_mlir_dialect_library(MLIRGPUTransforms
 
   DEPENDS
   MLIRGPUPassIncGen
-  MLIRParallelLoopMapperEnumsGen
 
   LINK_LIBS PUBLIC
   MLIRAMDGPUDialect

--- a/mlir/lib/Dialect/GPU/Pipelines/CMakeLists.txt
+++ b/mlir/lib/Dialect/GPU/Pipelines/CMakeLists.txt
@@ -6,6 +6,13 @@ add_mlir_dialect_library(MLIRGPUPipelines
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/GPU
 
+  # GPUToXeVMPipeline.cpp includes the aggregate Conversion/Passes.h header,
+  # whose declarations include these generated dialect and pass headers.
+  HEADER_LIBS
+  MLIRArmSMETransforms
+  MLIROpenACCDialect
+  MLIRTosaTransforms
+
   LINK_LIBS PUBLIC
   MLIRMemRefTransforms
   MLIRFuncDialect

--- a/mlir/lib/Dialect/GPU/TransformOps/CMakeLists.txt
+++ b/mlir/lib/Dialect/GPU/TransformOps/CMakeLists.txt
@@ -8,8 +8,6 @@ add_mlir_dialect_library(MLIRGPUTransformOps
 
   DEPENDS
   MLIRGPUTransformOpsIncGen
-  MLIRDeviceMappingInterfacesIncGen
-  MLIRGPUDeviceMapperEnumsGen
 
   LINK_LIBS PUBLIC
   MLIRGPUDialect

--- a/mlir/lib/Dialect/GPU/Utils/CMakeLists.txt
+++ b/mlir/lib/Dialect/GPU/Utils/CMakeLists.txt
@@ -5,10 +5,15 @@ add_mlir_dialect_library(MLIRGPUUtils
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/GPU/Utils
 
+  # GPU utility headers include llvm/IR/Attributes.h.
+  DEPENDS
+  intrinsics_gen
+
   LINK_LIBS PUBLIC
   MLIRArithDialect
   MLIRAffineDialect
   MLIRGPUDialect
   MLIRSupport
   MLIRIR
+  MLIRVectorDialect
   )

--- a/mlir/lib/Dialect/IRDL/CMakeLists.txt
+++ b/mlir/lib/Dialect/IRDL/CMakeLists.txt
@@ -9,6 +9,8 @@ add_mlir_dialect_library(MLIRIRDL
   MLIRIRDLIncGen
   MLIRIRDLOpsIncGen
   MLIRIRDLTypesIncGen
+  MLIRIRDLInterfacesIncGen
+  MLIRIRDLAttributesIncGen
 
   LINK_LIBS PUBLIC
   MLIRDialect

--- a/mlir/lib/Dialect/Index/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/Index/IR/CMakeLists.txt
@@ -7,6 +7,10 @@ add_mlir_dialect_library(MLIRIndexDialect
   DEPENDS
   MLIRIndexOpsIncGen
 
+  # IndexDialect.cpp includes mlir/Transforms/InliningUtils.h.
+  HEADER_LIBS
+  MLIRTransformUtils
+
   LINK_LIBS PUBLIC
   MLIRDialect
   MLIRIR

--- a/mlir/lib/Dialect/LLVMIR/CMakeLists.txt
+++ b/mlir/lib/Dialect/LLVMIR/CMakeLists.txt
@@ -35,14 +35,20 @@ add_mlir_dialect_library(MLIRLLVMDialect
   MLIRLLVMAllOpsIncGen
   MLIRLLVMOpsIncGen
   MLIRLLVMOpsShardGen
-  MLIRLLVMTranslationDialectInterfaceIncGen
   MLIRLLVMTypesIncGen
-  MLIROpenMPOpsIncGen
   intrinsics_gen
+  MLIRLLVMConversionsIncGen
+  MLIRLLVMIntrinsicConversionsIncGen
 
   LINK_COMPONENTS
   BinaryFormat
   Core
+
+  HEADER_LIBS
+  # LLVMAttrs.cpp includes mlir/Dialect/Ptr/IR/PtrEnums.h.
+  MLIRPtrDialect
+  # LLVMDialect.cpp includes mlir/Transforms/InliningUtils.h.
+  MLIRTransformUtils
 
   LINK_LIBS PUBLIC
   MLIRCallInterfaces
@@ -67,7 +73,6 @@ add_mlir_dialect_library(MLIRNVVMDialect
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/LLVMIR
 
   DEPENDS
-  MLIRGPUCompilationAttrInterfacesIncGen
   MLIRNVVMOpsIncGen
   MLIRNVVMConversionsIncGen
   MLIRBasicPtxBuilderInterfaceIncGen
@@ -105,7 +110,6 @@ add_mlir_dialect_library(MLIRROCDLDialect
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/LLVMIR
 
   DEPENDS
-  MLIRGPUCompilationAttrInterfacesIncGen
   MLIRROCDLOpsIncGen
   MLIRROCDLOpsShardGen
   MLIRROCDLConversionsIncGen
@@ -114,6 +118,11 @@ add_mlir_dialect_library(MLIRROCDLDialect
   LINK_COMPONENTS
   AsmParser
   Core
+
+  # ROCDLDialect.cpp includes GPU CompilationInterfaces and InliningUtils.
+  HEADER_LIBS
+  MLIRGPUDialect
+  MLIRTransformUtils
 
   LINK_LIBS PUBLIC
   MLIRIR
@@ -128,7 +137,6 @@ add_mlir_dialect_library(MLIRVCIXDialect
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/LLVMIR
 
   DEPENDS
-  MLIRGPUCompilationAttrInterfacesIncGen
   MLIRVCIXOpsIncGen
   MLIRVCIXConversionsIncGen
   intrinsics_gen
@@ -136,6 +144,10 @@ add_mlir_dialect_library(MLIRVCIXDialect
   LINK_COMPONENTS
   AsmParser
   Core
+
+  # VCIXDialect.cpp includes the generated GPU CompilationInterfaces.
+  HEADER_LIBS
+  MLIRGPUDialect
 
   LINK_LIBS PUBLIC
   MLIRIR
@@ -150,7 +162,6 @@ add_mlir_dialect_library(MLIRXeVMDialect
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/LLVMIR
 
   DEPENDS
-  MLIRGPUCompilationAttrInterfacesIncGen
   MLIRXeVMOpsIncGen
   MLIRXeVMConversionsIncGen
   intrinsics_gen
@@ -159,6 +170,10 @@ add_mlir_dialect_library(MLIRXeVMDialect
   AsmParser
   Core
   TargetParser
+
+  # XeVMDialect.cpp includes the generated GPU CompilationInterfaces.
+  HEADER_LIBS
+  MLIRGPUDialect
 
   LINK_LIBS PUBLIC
   MLIRDialectUtils

--- a/mlir/lib/Dialect/Linalg/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/Linalg/IR/CMakeLists.txt
@@ -14,7 +14,11 @@ add_mlir_dialect_library(MLIRLinalgDialect
   MLIRLinalgOpsIncGen
   MLIRLinalgStructuredOpsIncGen
   MLIRLinalgRelayoutOpsIncGen
-  MLIRShardingInterfaceIncGen
+  MLIRRelayoutOpInterfaceIncGen
+
+  # LinalgDialect.cpp includes ShardingInterface.h for promised interfaces.
+  HEADER_LIBS
+  MLIRShardingInterface
 
   LINK_LIBS PUBLIC
   MLIRAffineDialect

--- a/mlir/lib/Dialect/Math/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/Math/IR/CMakeLists.txt
@@ -8,6 +8,10 @@ add_mlir_dialect_library(MLIRMathDialect
   DEPENDS
   MLIRMathOpsIncGen
 
+  # MathDialect.cpp includes mlir/Transforms/InliningUtils.h.
+  HEADER_LIBS
+  MLIRTransformUtils
+
   LINK_LIBS PUBLIC
   MLIRArithDialect
   MLIRDialect

--- a/mlir/lib/Dialect/NVGPU/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/NVGPU/IR/CMakeLists.txt
@@ -9,6 +9,7 @@ add_mlir_dialect_library(MLIRNVGPUDialect
   MLIRNVGPUEnumsIncGen
   MLIRNVGPUAttributesIncGen
   MLIRNVGPUTypesIncGen
+  MLIRNVGPUIncGen
 
   LINK_LIBS PUBLIC
   MLIRGPUDialect

--- a/mlir/lib/Dialect/OpenACC/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/OpenACC/IR/CMakeLists.txt
@@ -9,7 +9,6 @@ add_mlir_dialect_library(MLIROpenACCDialect
   MLIROpenACCOpsIncGen
   MLIROpenACCEnumsIncGen
   MLIROpenACCAttributesIncGen
-  MLIROpenACCMPOpsInterfacesIncGen
   MLIROpenACCOpsInterfacesIncGen
   MLIROpenACCTypeInterfacesIncGen
 

--- a/mlir/lib/Dialect/OpenACC/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/OpenACC/Transforms/CMakeLists.txt
@@ -27,12 +27,6 @@ add_mlir_dialect_library(MLIROpenACCTransforms
 
   DEPENDS
   MLIROpenACCPassIncGen
-  MLIROpenACCOpsIncGen
-  MLIROpenACCEnumsIncGen
-  MLIROpenACCAttributesIncGen
-  MLIROpenACCMPOpsInterfacesIncGen
-  MLIROpenACCOpsInterfacesIncGen
-  MLIROpenACCTypeInterfacesIncGen
 
   LINK_LIBS PUBLIC
   MLIRAnalysis

--- a/mlir/lib/Dialect/OpenACC/Utils/CMakeLists.txt
+++ b/mlir/lib/Dialect/OpenACC/Utils/CMakeLists.txt
@@ -11,15 +11,6 @@ add_mlir_dialect_library(MLIROpenACCUtils
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/OpenACC
 
-  DEPENDS
-  MLIROpenACCPassIncGen
-  MLIROpenACCOpsIncGen
-  MLIROpenACCEnumsIncGen
-  MLIROpenACCAttributesIncGen
-  MLIROpenACCMPOpsInterfacesIncGen
-  MLIROpenACCOpsInterfacesIncGen
-  MLIROpenACCTypeInterfacesIncGen
-
   LINK_LIBS PUBLIC
   MLIRArithDialect
   MLIRArithUtils

--- a/mlir/lib/Dialect/OpenACCMPCommon/Interfaces/CMakeLists.txt
+++ b/mlir/lib/Dialect/OpenACCMPCommon/Interfaces/CMakeLists.txt
@@ -5,8 +5,8 @@ ADDITIONAL_HEADER_DIRS
 ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/OpenACCMPCommon/Interfaces
 
 DEPENDS
-MLIRArithOpsIncGen
 MLIRAtomicInterfacesIncGen
+MLIROpenACCMPOpsInterfacesIncGen
 
 LINK_LIBS PUBLIC
 MLIRArithDialect

--- a/mlir/lib/Dialect/OpenMP/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/OpenMP/IR/CMakeLists.txt
@@ -8,7 +8,6 @@ add_mlir_dialect_library(MLIROpenMPDialect
   omp_gen
   MLIROpenMPOpsIncGen
   MLIROpenMPOpsInterfacesIncGen
-  MLIROpenMPTypeInterfacesIncGen
 
   LINK_COMPONENTS
   TargetParser

--- a/mlir/lib/Dialect/OpenMP/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/OpenMP/Transforms/CMakeLists.txt
@@ -11,9 +11,6 @@ add_mlir_dialect_library(MLIROpenMPTransforms
   DEPENDS
   omp_gen
   MLIROpenMPPassIncGen
-  MLIROpenMPOpsIncGen
-  MLIROpenMPOpsInterfacesIncGen
-  MLIROpenMPTypeInterfacesIncGen
 
   LINK_LIBS PUBLIC
   MLIRFunctionInterfaces

--- a/mlir/lib/Dialect/Ptr/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/Ptr/IR/CMakeLists.txt
@@ -10,8 +10,8 @@ add_mlir_dialect_library(
   MemorySpaceInterfaces.cpp
 
   DEPENDS
-  MLIRPtrOpsEnumsGen
   MLIRPtrMemorySpaceInterfacesIncGen
+
   LINK_LIBS
   PUBLIC
   MLIRIR
@@ -27,7 +27,11 @@ add_mlir_dialect_library(
   MLIRPtrOpsAttributesIncGen
   MLIRPtrOpsIncGen
   MLIRPtrOpsEnumsGen
-  MLIRPtrMemorySpaceInterfacesIncGen
+
+  # PtrDialect.cpp includes mlir/Transforms/InliningUtils.h.
+  HEADER_LIBS
+  MLIRTransformUtils
+
   LINK_LIBS
   PUBLIC
   MLIRIR

--- a/mlir/lib/Dialect/Quant/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/Quant/IR/CMakeLists.txt
@@ -13,6 +13,10 @@ add_mlir_dialect_library(MLIRQuantDialect
   MLIRQuantOpsIncGen
   MLIRQuantDialectBytecodeIncGen
 
+  # QuantOps.cpp includes mlir/Transforms/InliningUtils.h.
+  HEADER_LIBS
+  MLIRTransformUtils
+
   LINK_LIBS PUBLIC
   MLIRIR
   MLIRInferTypeOpInterface

--- a/mlir/lib/Dialect/SCF/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/SCF/IR/CMakeLists.txt
@@ -9,6 +9,7 @@ add_mlir_dialect_library(MLIRSCFDialect
 
   DEPENDS
   MLIRSCFOpsIncGen
+  MLIRDeviceMappingInterfacesIncGen
 
   LINK_LIBS PUBLIC
   MLIRArithDialect

--- a/mlir/lib/Dialect/SMT/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/SMT/IR/CMakeLists.txt
@@ -21,7 +21,3 @@ add_mlir_dialect_library(MLIRSMT
   MLIRSideEffectInterfaces
   MLIRControlFlowInterfaces
 )
-
-add_dependencies(mlir-headers
-  MLIRSMTIncGen
-)

--- a/mlir/lib/Dialect/SPIRV/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/SPIRV/IR/CMakeLists.txt
@@ -44,16 +44,21 @@ add_mlir_dialect_library(MLIRSPIRVDialect
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/SPIRV
 
   DEPENDS
-  MLIRGPUDialect
   MLIRSPIRVAttributeIncGen
   MLIRSPIRVAttrUtilsGen
   MLIRSPIRVAvailabilityIncGen
   MLIRSPIRVCanonicalizationIncGen
   MLIRSPIRVEnumAvailabilityIncGen
   MLIRSPIRVEnumsIncGen
-  MLIRSPIRVImageInterfacesIncGen
   MLIRSPIRVOpsIncGen
   MLIRSPIRVOpsShardGen
+  MLIRSPIRVSerializationGen
+  # SPIRVDialect.cpp includes llvm/IR/Attributes.h.
+  intrinsics_gen
+
+  # SPIRVDialect.cpp includes the generated GPU CompilationInterfaces.
+  HEADER_LIBS
+  MLIRGPUDialect
 
   LINK_LIBS PUBLIC
   MLIRControlFlowInterfaces

--- a/mlir/lib/Dialect/Shape/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/Shape/Transforms/CMakeLists.txt
@@ -9,10 +9,15 @@ add_mlir_dialect_library(MLIRShapeOpsTransforms
 
   DEPENDS
   MLIRShapeTransformsIncGen
-  )
 
-target_link_libraries(MLIRShapeOpsTransforms
-  PUBLIC
+  # The implementations include FuncOps.h and Tensor.h; Tensor.h includes
+  # Dialect/Utils/ReshapeOpsUtils.h.
+  HEADER_LIBS
+  MLIRDialectUtils
+  MLIRFuncDialect
+  MLIRTensorDialect
+
+  LINK_LIBS PUBLIC
   MLIRArithDialect
   MLIRBufferizationDialect
   MLIRBufferizationTransforms

--- a/mlir/lib/Dialect/Shard/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/Shard/IR/CMakeLists.txt
@@ -7,6 +7,10 @@ add_mlir_dialect_library(MLIRShardDialect
   DEPENDS
   MLIRShardIncGen
 
+  # ShardOps.cpp includes mlir/Transforms/InliningUtils.h.
+  HEADER_LIBS
+  MLIRTransformUtils
+
   LINK_LIBS PUBLIC
   MLIRArithDialect
   MLIRDialectUtils

--- a/mlir/lib/Dialect/Shard/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/Shard/Transforms/CMakeLists.txt
@@ -9,6 +9,9 @@ add_mlir_dialect_library(MLIRShardTransforms
 
   DEPENDS
   MLIRShardPassIncGen
+
+  # Partition.cpp and ShardingPropagation.cpp include ShardingInterface.h.
+  HEADER_LIBS
   MLIRShardingInterface
 
   LINK_LIBS PUBLIC

--- a/mlir/lib/Dialect/SparseTensor/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/SparseTensor/IR/CMakeLists.txt
@@ -42,6 +42,11 @@ add_mlir_dialect_library(MLIRSparseTensorDialect
   MLIRSparseTensorAttrDefsIncGen
   MLIRSparseTensorOpsIncGen
   MLIRSparseTensorTypesIncGen
+  MLIRSparseTensorInterfacesIncGen
+
+  # SparseTensorDialect.cpp includes the generated BufferizableOpInterface.
+  HEADER_LIBS
+  MLIRBufferizationDialect
 
   LINK_LIBS PUBLIC
   MLIRArithDialect

--- a/mlir/lib/Dialect/SparseTensor/Pipelines/CMakeLists.txt
+++ b/mlir/lib/Dialect/SparseTensor/Pipelines/CMakeLists.txt
@@ -4,6 +4,13 @@ add_mlir_dialect_library(MLIRSparseTensorPipelines
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/SparseTensor
 
+  # SparseTensorPipelines.cpp includes the aggregate Conversion/Passes.h
+  # header, whose declarations include these generated dialect headers.
+  HEADER_LIBS
+  MLIRArmSMETransforms
+  MLIROpenACCDialect
+  MLIRTosaTransforms
+
   LINK_LIBS PUBLIC
   MLIRArithTransforms
   MLIRAffineToStandard

--- a/mlir/lib/Dialect/Tensor/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/Tensor/IR/CMakeLists.txt
@@ -17,6 +17,10 @@ add_mlir_dialect_library(MLIRTensorDialect
   DEPENDS
   MLIRTensorOpsIncGen
 
+  # TensorDialect.cpp includes TransformInterfaces.h.
+  HEADER_LIBS
+  MLIRTransformDialectInterfaces
+
   LINK_LIBS PUBLIC
   MLIRAffineDialect
   MLIRArithDialect

--- a/mlir/lib/Dialect/Tosa/CMakeLists.txt
+++ b/mlir/lib/Dialect/Tosa/CMakeLists.txt
@@ -14,7 +14,10 @@ add_mlir_dialect_library(MLIRTosaDialect
   MLIRTosaOpsIncGen
   MLIRTosaInterfacesIncGen
   MLIRTosaEnumsIncGen
-  MLIRShardingInterfaceIncGen
+
+  # TosaOps.cpp includes ShardingInterface.h for promised interfaces.
+  HEADER_LIBS
+  MLIRShardingInterface
 
   LINK_LIBS PUBLIC
   MLIRIR

--- a/mlir/lib/Dialect/Transform/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/Transform/IR/CMakeLists.txt
@@ -5,6 +5,13 @@ add_mlir_dialect_library(MLIRTransformDialect
   TransformTypes.cpp
   Utils.cpp
 
+  DEPENDS
+  MLIRTransformDialectIncGen
+  MLIRTransformTypesIncGen
+  MLIRTransformDialectEnumIncGen
+  MLIRTransformDialectAttributesIncGen
+  MLIRTransformOpsIncGen
+
   LINK_LIBS PUBLIC
   MLIRCastInterfaces
   MLIRFunctionInterfaces

--- a/mlir/lib/Dialect/Transform/Interfaces/CMakeLists.txt
+++ b/mlir/lib/Dialect/Transform/Interfaces/CMakeLists.txt
@@ -5,6 +5,8 @@ add_mlir_library(MLIRTransformDialectInterfaces
   DEPENDS
   MLIRMatchInterfacesIncGen
   MLIRTransformInterfacesIncGen
+  MLIRTransformDialectTypeInterfacesIncGen
+  MLIRTransformDialectAttrInterfacesIncGen
 
   LINK_LIBS PUBLIC
   MLIRCastInterfaces

--- a/mlir/lib/Dialect/UB/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/UB/IR/CMakeLists.txt
@@ -8,6 +8,10 @@ add_mlir_dialect_library(MLIRUBDialect
   MLIRUBOpsIncGen
   MLIRUBOpsInterfacesIncGen
 
+  # UBOps.cpp includes mlir/Transforms/InliningUtils.h.
+  HEADER_LIBS
+  MLIRTransformUtils
+
   LINK_LIBS PUBLIC
   MLIRIR
   )

--- a/mlir/lib/Dialect/Utils/CMakeLists.txt
+++ b/mlir/lib/Dialect/Utils/CMakeLists.txt
@@ -7,6 +7,9 @@ add_mlir_library(MLIRDialectUtils
 
   DEPENDS
   MLIRDialectUtilsIncGen
+
+  # ReshapeOpsUtils.h includes the generated Arith operation declarations.
+  HEADER_LIBS
   MLIRArithDialect
 
   LINK_LIBS PUBLIC

--- a/mlir/lib/Dialect/Vector/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/Vector/IR/CMakeLists.txt
@@ -7,10 +7,9 @@ add_mlir_dialect_library(MLIRVectorDialect
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/Vector/IR
 
   DEPENDS
-  MLIRMaskableOpInterfaceIncGen
-  MLIRMaskingOpInterfaceIncGen
   MLIRVectorOpsIncGen
   MLIRVectorAttributesIncGen
+  MLIRVectorIncGen
 
   LINK_LIBS PUBLIC
   MLIRAffineDialect

--- a/mlir/lib/Dialect/X86/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/X86/IR/CMakeLists.txt
@@ -6,6 +6,7 @@ add_mlir_dialect_library(MLIRX86Dialect
 
   DEPENDS
   MLIRX86IncGen
+  MLIRX86InterfacesIncGen
 
   LINK_LIBS PUBLIC
   MLIRIR

--- a/mlir/lib/Dialect/XeGPU/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/XeGPU/IR/CMakeLists.txt
@@ -10,6 +10,7 @@ add_mlir_dialect_library(MLIRXeGPUDialect
   MLIRXeGPUAttrInterfaceIncGen
   MLIRXeGPUAttrsIncGen
   MLIRXeGPUEnumsIncGen
+  MLIRXeGPUOpInterfaceIncGen
 
   LINK_LIBS PUBLIC
   MLIRArithDialect

--- a/mlir/lib/IR/CMakeLists.txt
+++ b/mlir/lib/IR/CMakeLists.txt
@@ -60,14 +60,10 @@ add_mlir_library(MLIRIR
   MLIRBuiltinTypesIncGen
   MLIRBuiltinTypeConstraintsIncGen
   MLIRBuiltinTypeInterfacesIncGen
-  MLIRCallInterfacesIncGen
-  MLIRCastInterfacesIncGen
-  MLIRDataLayoutInterfacesIncGen
   MLIRDialectFoldInterfaceIncGen
   MLIROpAsmInterfaceIncGen
   MLIRQuantStorageTypeInterfaceIncGen
   MLIRRegionKindInterfaceIncGen
-  MLIRSideEffectInterfacesIncGen
   MLIRSymbolInterfacesIncGen
   MLIRTensorEncodingIncGen
   MLIROpAsmDialectInterfaceIncGen

--- a/mlir/lib/Interfaces/CMakeLists.txt
+++ b/mlir/lib/Interfaces/CMakeLists.txt
@@ -115,9 +115,7 @@ add_mlir_library(MLIRSubsetOpInterface
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Interfaces
 
   DEPENDS
-  MLIRDestinationStyleOpInterface
   MLIRSubsetOpInterfaceIncGen
-  MLIRValueBoundsOpInterface
 
   LINK_LIBS PUBLIC
   MLIRDestinationStyleOpInterface
@@ -133,6 +131,9 @@ add_mlir_library(MLIRTilingInterface
 
   DEPENDS
   MLIRTilingInterfaceIncGen
+
+  # TilingInterface.h includes Dialect/Utils/StructuredOpsUtils.h.
+  HEADER_LIBS
   MLIRDialectUtils
 
   LINK_LIBS PUBLIC
@@ -149,8 +150,10 @@ add_mlir_library(MLIRValueBoundsOpInterface
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Interfaces
 
   DEPENDS
-  MLIRDestinationStyleOpInterface
   MLIRValueBoundsOpInterfaceIncGen
+
+  # ValueBoundsOpInterface.cpp includes the generated ViewLike interface.
+  HEADER_LIBS
   MLIRViewLikeInterface
 
   LINK_LIBS PUBLIC

--- a/mlir/lib/Interfaces/Utils/CMakeLists.txt
+++ b/mlir/lib/Interfaces/Utils/CMakeLists.txt
@@ -9,9 +9,6 @@ add_mlir_library(MLIRInferIntRangeCommon
     ADDITIONAL_HEADER_DIRS
     ${MLIR_MAIN_INCLUDE_DIR}/mlir/Interfaces/Utils
 
-    DEPENDS
-    MLIRInferIntRangeInterfaceIncGen
-
     LINK_LIBS PUBLIC
     MLIRShapedOpInterfaces
     MLIRInferIntRangeInterface

--- a/mlir/lib/Reducer/CMakeLists.txt
+++ b/mlir/lib/Reducer/CMakeLists.txt
@@ -4,15 +4,16 @@ add_mlir_library(MLIRReduce
    ReductionTreePass.cpp
    Tester.cpp
 
+   DEPENDS
+   MLIRReducerIncGen
+   MLIRDialectReductionPatternInterfaceIncGen
+
    LINK_LIBS PUBLIC
    MLIRIR
    MLIRPass
    MLIRRewrite
    MLIRTransformUtils
 
-   DEPENDS
-   MLIRReducerIncGen
-   MLIRDialectReductionPatternInterfaceIncGen
 )
 
 mlir_check_all_link_libraries(MLIRReduce)

--- a/mlir/lib/Rewrite/CMakeLists.txt
+++ b/mlir/lib/Rewrite/CMakeLists.txt
@@ -9,7 +9,12 @@ add_mlir_library(MLIRRewrite
 
   DEPENDS
   mlir-generic-headers
-  MLIRConversionPassIncGen
+
+  # ByteCode.cpp and FrozenRewritePatternSet.cpp include generated PDL and
+  # PDLInterp operation declarations.
+  HEADER_LIBS
+  MLIRPDLDialect
+  MLIRPDLInterpDialect
 
   LINK_LIBS PUBLIC
   MLIRIR
@@ -40,4 +45,3 @@ if(MLIR_ENABLE_PDL_IN_PATTERNMATCH)
     MLIRPDLToPDLInterp
     MLIRRewritePDL)
 endif()
-

--- a/mlir/lib/Target/LLVMIR/CMakeLists.txt
+++ b/mlir/lib/Target/LLVMIR/CMakeLists.txt
@@ -29,6 +29,7 @@ add_mlir_translation_library(MLIRTargetLLVMIRExport
 
   DEPENDS
   intrinsics_gen
+  MLIRLLVMTranslationDialectInterfaceIncGen
 
   LINK_COMPONENTS
   Analysis

--- a/mlir/lib/Target/LLVMIR/Dialect/ArmNeon/CMakeLists.txt
+++ b/mlir/lib/Target/LLVMIR/Dialect/ArmNeon/CMakeLists.txt
@@ -1,9 +1,6 @@
 add_mlir_translation_library(MLIRArmNeonToLLVMIRTranslation
   ArmNeonToLLVMIRTranslation.cpp
 
-  DEPENDS
-  MLIRArmNeonConversionsIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Target/LLVMIR/Dialect/ArmSME/CMakeLists.txt
+++ b/mlir/lib/Target/LLVMIR/Dialect/ArmSME/CMakeLists.txt
@@ -1,9 +1,6 @@
 add_mlir_translation_library(MLIRArmSMEToLLVMIRTranslation
   ArmSMEToLLVMIRTranslation.cpp
 
-  DEPENDS
-  MLIRArmSMEConversionsIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Target/LLVMIR/Dialect/ArmSVE/CMakeLists.txt
+++ b/mlir/lib/Target/LLVMIR/Dialect/ArmSVE/CMakeLists.txt
@@ -1,9 +1,6 @@
 add_mlir_translation_library(MLIRArmSVEToLLVMIRTranslation
   ArmSVEToLLVMIRTranslation.cpp
 
-  DEPENDS
-  MLIRArmSVEConversionsIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Target/LLVMIR/Dialect/NVVM/CMakeLists.txt
+++ b/mlir/lib/Target/LLVMIR/Dialect/NVVM/CMakeLists.txt
@@ -19,9 +19,6 @@ add_mlir_translation_library(MLIRLLVMIRToNVVMTranslation
 add_mlir_translation_library(MLIRNVVMToLLVMIRTranslation
   NVVMToLLVMIRTranslation.cpp
 
-  DEPENDS
-  MLIRNVVMConversionsIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Target/LLVMIR/Dialect/ROCDL/CMakeLists.txt
+++ b/mlir/lib/Target/LLVMIR/Dialect/ROCDL/CMakeLists.txt
@@ -1,9 +1,6 @@
 add_mlir_translation_library(MLIRROCDLToLLVMIRTranslation
   ROCDLToLLVMIRTranslation.cpp
 
-  DEPENDS
-  MLIRROCDLConversionsIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Target/LLVMIR/Dialect/VCIX/CMakeLists.txt
+++ b/mlir/lib/Target/LLVMIR/Dialect/VCIX/CMakeLists.txt
@@ -1,9 +1,6 @@
 add_mlir_translation_library(MLIRVCIXToLLVMIRTranslation
   VCIXToLLVMIRTranslation.cpp
 
-  DEPENDS
-  MLIRVCIXConversionsIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Target/LLVMIR/Dialect/XeVM/CMakeLists.txt
+++ b/mlir/lib/Target/LLVMIR/Dialect/XeVM/CMakeLists.txt
@@ -5,9 +5,6 @@ set(LLVM_OPTIONAL_SOURCES
 add_mlir_translation_library(MLIRXeVMToLLVMIRTranslation
   XeVMToLLVMIRTranslation.cpp
 
-  DEPENDS
-  MLIRXeVMConversionsIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Target/SPIRV/CMakeLists.txt
+++ b/mlir/lib/Target/SPIRV/CMakeLists.txt
@@ -10,6 +10,10 @@ set(LLVM_OPTIONAL_SOURCES
 add_mlir_translation_library(MLIRSPIRVBinaryUtils
   SPIRVBinaryUtils.cpp
 
+  # SPIRVBinaryUtils.h includes the generated SPIRVEnums.h.
+  HEADER_LIBS
+  MLIRSPIRVDialect
+
   LINK_LIBS PUBLIC
   MLIRIR
   MLIRSupport
@@ -27,6 +31,10 @@ add_mlir_translation_library(MLIRSPIRVTranslateRegistration
 
 add_mlir_dialect_library(MLIRSPIRVTarget
   Target.cpp
+
+  # Target.cpp includes llvm/IR/Attributes.h.
+  DEPENDS
+  intrinsics_gen
 
   LINK_LIBS PUBLIC
   MLIRIR

--- a/mlir/lib/Target/SPIRV/Deserialization/CMakeLists.txt
+++ b/mlir/lib/Target/SPIRV/Deserialization/CMakeLists.txt
@@ -3,9 +3,6 @@ add_mlir_translation_library(MLIRSPIRVDeserialization
   Deserializer.cpp
   Deserialization.cpp
 
-  DEPENDS
-  MLIRSPIRVSerializationGen
-
   LINK_LIBS PUBLIC
   MLIRIR
   MLIRSPIRVDialect

--- a/mlir/lib/Target/SPIRV/Serialization/CMakeLists.txt
+++ b/mlir/lib/Target/SPIRV/Serialization/CMakeLists.txt
@@ -3,9 +3,6 @@ add_mlir_translation_library(MLIRSPIRVSerialization
   Serializer.cpp
   SerializeOps.cpp
 
-  DEPENDS
-  MLIRSPIRVSerializationGen
-
   LINK_LIBS PUBLIC
   MLIRIR
   MLIRSPIRVDialect

--- a/mlir/lib/Transforms/CMakeLists.txt
+++ b/mlir/lib/Transforms/CMakeLists.txt
@@ -28,7 +28,6 @@ add_mlir_library(MLIRTransforms
 
   DEPENDS
   MLIRTransformsPassIncGen
-  MLIRTransformsDialectInterfaceIncGen
 
   LINK_LIBS PUBLIC
   MLIRAnalysis

--- a/mlir/lib/Transforms/Utils/CMakeLists.txt
+++ b/mlir/lib/Transforms/Utils/CMakeLists.txt
@@ -15,6 +15,9 @@ add_mlir_library(MLIRTransformUtils
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Transforms
 
+  DEPENDS
+  MLIRTransformsDialectInterfaceIncGen
+
   LINK_LIBS PUBLIC
   MLIRAnalysis
   MLIRCallInterfaces

--- a/mlir/test/CMake/header-dependencies.test
+++ b/mlir/test/CMake/header-dependencies.test
@@ -1,0 +1,97 @@
+# RUN: rm -rf %t
+# RUN: split-file %s %t
+# RUN: "%cmake_exe" -S %t/valid -B %t/valid-build -G "%cmake_generator" \
+# RUN:   -DMLIR_DIR=%mlir_cmake_dir -DCMAKE_CXX_COMPILER=%host_cxx 2>&1 \
+# RUN:   | FileCheck %s --check-prefix=VALID
+# RUN: not "%cmake_exe" -S %t/invalid -B %t/invalid-build \
+# RUN:   -G "%cmake_generator" -DMLIR_DIR=%mlir_cmake_dir \
+# RUN:   -DCMAKE_CXX_COMPILER=%host_cxx 2>&1 \
+# RUN:   | FileCheck %s --check-prefix=INVALID
+
+# VALID: -- Generated header dependency checks passed
+# INVALID-DAG: BadConsumer: HEADER_LIBS entry 'MisspelledProvider' is not a target
+# INVALID-DAG: BadConsumer: HEADER_LIBS entry 'ProviderIncGen' is not a library
+
+#--- common.cmake
+find_package(MLIR REQUIRED CONFIG)
+list(APPEND CMAKE_MODULE_PATH "${MLIR_CMAKE_DIR}" "${LLVM_CMAKE_DIR}")
+include(TableGen)
+include(AddLLVM)
+include(AddMLIR)
+include(HandleLLVMOptions)
+set(LLVM_RUNTIME_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/bin)
+set(LLVM_LIBRARY_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/lib)
+
+set(LLVM_TARGET_DEFINITIONS Provider.td)
+mlir_tablegen(Provider.h.inc -gen-op-decls)
+add_public_tablegen_target(ProviderIncGen)
+mlir_tablegen(Base.h.inc -gen-op-decls)
+add_public_tablegen_target(BaseIncGen)
+# Keep the libraries below from depending on every TableGen target declared in
+# this directory, so the checks only see edges added by the helpers under test.
+set(LLVM_COMMON_DEPENDS)
+
+#--- valid/CMakeLists.txt
+cmake_minimum_required(VERSION 3.20)
+project(HeaderDependencies LANGUAGES C CXX)
+include(../common.cmake)
+
+# Consumers are declared before the provider: resolution is deferred.
+add_mlir_library(LinkConsumer empty.cpp DISABLE_INSTALL
+  LINK_LIBS PRIVATE Provider PUBLIC "$<$<BOOL:1>:ProviderAlias>")
+add_mlir_library(HeaderConsumer empty.cpp DISABLE_INSTALL
+  HEADER_LIBS ProviderAlias)
+add_mlir_library(Provider empty.cpp DISABLE_INSTALL
+  DEPENDS ProviderIncGen
+  LINK_LIBS PUBLIC Base
+  HEADER_LIBS HeaderConsumer)
+add_library(ProviderAlias ALIAS Provider)
+add_mlir_library(Base empty.cpp DISABLE_INSTALL
+  DEPENDS BaseIncGen)
+
+function(expect_dependencies target expected)
+  get_target_property(actual ${target} MANUALLY_ADDED_DEPENDENCIES)
+  # Older CMake versions make a library depend on its own object library.
+  list(FILTER actual EXCLUDE REGEX "^obj\\.")
+  list(SORT actual)
+  list(SORT expected)
+  if(NOT "${actual}" STREQUAL "${expected}")
+    message(FATAL_ERROR
+      "${target}: expected dependencies '${expected}', got '${actual}'")
+  endif()
+endfunction()
+
+function(check_dependencies)
+  # PRIVATE and generator-expression LINK_LIBS both order the object library.
+  expect_dependencies(obj.LinkConsumer "Provider;mlir-generic-headers")
+  # HEADER_LIBS resolves to the TableGen targets of the provider and of what it
+  # links, not to the libraries, for both the object library and the library.
+  expect_dependencies(obj.HeaderConsumer
+    "ProviderIncGen;BaseIncGen;mlir-generic-headers")
+  expect_dependencies(HeaderConsumer
+    "ProviderIncGen;BaseIncGen;mlir-generic-headers")
+  # A provider with a header-only dependency on its own consumer gets no cycle.
+  expect_dependencies(obj.Provider
+    "ProviderIncGen;Base;BaseIncGen;mlir-generic-headers")
+  message(STATUS "Generated header dependency checks passed")
+endfunction()
+cmake_language(DEFER CALL check_dependencies)
+
+#--- valid/empty.cpp
+void empty() {}
+
+#--- valid/Provider.td
+// Only configuration is under test.
+
+#--- invalid/CMakeLists.txt
+cmake_minimum_required(VERSION 3.20)
+project(HeaderDependenciesInvalid LANGUAGES C CXX)
+include(../common.cmake)
+add_mlir_library(BadConsumer empty.cpp DISABLE_INSTALL
+  HEADER_LIBS MisspelledProvider ProviderIncGen)
+
+#--- invalid/empty.cpp
+void empty() {}
+
+#--- invalid/Provider.td
+// Only configuration is under test.

--- a/mlir/test/CMake/lit.local.cfg
+++ b/mlir/test/CMake/lit.local.cfg
@@ -1,0 +1,3 @@
+config.substitutions.append(("%cmake_exe", config.host_cmake))
+config.substitutions.append(("%cmake_generator", config.host_cmake_generator))
+config.substitutions.append(("%mlir_cmake_dir", config.mlir_cmake_dir))

--- a/mlir/test/lib/Dialect/NVGPU/CMakeLists.txt
+++ b/mlir/test/lib/Dialect/NVGPU/CMakeLists.txt
@@ -3,6 +3,12 @@ add_mlir_library(MLIRNVGPUTestPasses
   TestNVGPUTransforms.cpp
 
   EXCLUDE_FROM_LIBMLIR
+
+  # TestNVGPUTransforms.cpp includes Linalg and Vector transform headers.
+  HEADER_LIBS
+  MLIRLinalgDialect
+  MLIRLinalgTransforms
+  MLIRVectorTransforms
   )
 mlir_target_link_libraries(MLIRNVGPUTestPasses PUBLIC
   MLIRIR

--- a/mlir/test/lib/Dialect/Shard/CMakeLists.txt
+++ b/mlir/test/lib/Dialect/Shard/CMakeLists.txt
@@ -4,6 +4,10 @@ add_mlir_library(MLIRShardTest
   TestReshardingPartition.cpp
 
   EXCLUDE_FROM_LIBMLIR
+
+  # TestReshardingPartition.cpp includes SPIRVOps.h.
+  HEADER_LIBS
+  MLIRSPIRVDialect
   )
 mlir_target_link_libraries(MLIRShardTest PUBLIC
   MLIRShardDialect

--- a/mlir/test/lib/Dialect/Test/CMakeLists.txt
+++ b/mlir/test/lib/Dialect/Test/CMakeLists.txt
@@ -68,7 +68,10 @@ add_mlir_library(MLIRTestDialect
   MLIRTestOpsIncGen
   MLIRTestOpsSyntaxIncGen
   MLIRTestOpsShardGen
-  MLIRConvertToEmitCPatternInterfaceIncGen
+
+  # TestDialectInterfaces.cpp includes the generated ToEmitCInterface.
+  HEADER_LIBS
+  MLIRConvertToEmitC
   )
 mlir_target_link_libraries(MLIRTestDialect PUBLIC
   MLIRControlFlowInterfaces

--- a/mlir/test/lib/Dialect/Tosa/CMakeLists.txt
+++ b/mlir/test/lib/Dialect/Tosa/CMakeLists.txt
@@ -6,8 +6,9 @@ add_mlir_dialect_library(MLIRTosaTestPasses
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/Tosa/Transforms
 
-  DEPENDS
-  MLIRTosaPassIncGen
+  # TosaTestPasses.cpp includes the generated Tosa transform pass header.
+  HEADER_LIBS
+  MLIRTosaTransforms
   )
 mlir_target_link_libraries(MLIRTosaTestPasses PUBLIC
   MLIRFuncDialect

--- a/mlir/test/lib/Interfaces/TilingInterface/CMakeLists.txt
+++ b/mlir/test/lib/Interfaces/TilingInterface/CMakeLists.txt
@@ -6,10 +6,10 @@ add_public_tablegen_target(MLIRTestTilingInterfaceTransformOpsIncGen)
 add_mlir_library(MLIRTilingInterfaceTestPasses
   TestTilingInterfaceTransformOps.cpp
 
+  EXCLUDE_FROM_LIBMLIR
+
   DEPENDS
   MLIRTestTilingInterfaceTransformOpsIncGen
-
-  EXCLUDE_FROM_LIBMLIR
   )
 mlir_target_link_libraries(MLIRTilingInterfaceTestPasses PUBLIC
   MLIRAffineDialect

--- a/mlir/test/python/lib/CMakeLists.txt
+++ b/mlir/test/python/lib/CMakeLists.txt
@@ -21,9 +21,6 @@ mlir_target_link_libraries(MLIRPythonTestDialect PUBLIC
 add_mlir_public_c_api_library(MLIRCAPIPythonTestDialect
   PythonTestCAPI.cpp
 
-  DEPENDS
-  MLIRPythonTestIncGen
-
   LINK_LIBS PUBLIC
   MLIRCAPIInterfaces
   MLIRCAPIIR

--- a/mlir/unittests/IR/CMakeLists.txt
+++ b/mlir/unittests/IR/CMakeLists.txt
@@ -26,9 +26,6 @@ add_mlir_unittest(MLIRIRTests
   ValueTest.cpp
   VerifierTest.cpp
   BlobManagerTest.cpp
-
-  DEPENDS
-  MLIRTestInterfaceIncGen
 )
 target_include_directories(MLIRIRTests PRIVATE "${MLIR_BINARY_DIR}/test/lib/Dialect/Test")
 mlir_target_link_libraries(MLIRIRTests PRIVATE MLIRIR)

--- a/mlir/unittests/Interfaces/CMakeLists.txt
+++ b/mlir/unittests/Interfaces/CMakeLists.txt
@@ -5,9 +5,6 @@ add_mlir_unittest(MLIRInterfacesTests
   MemorySlotUtilsTest.cpp
   SideEffectInterfacesTest.cpp
   InferTypeOpInterfaceTest.cpp
-
-  DEPENDS
-  MLIRTestInterfaceIncGen
 )
 target_include_directories(MLIRInterfacesTests PRIVATE "${MLIR_BINARY_DIR}/test/lib/Dialect/Test")
 

--- a/mlir/unittests/Parser/CMakeLists.txt
+++ b/mlir/unittests/Parser/CMakeLists.txt
@@ -1,9 +1,6 @@
 add_mlir_unittest(MLIRParserTests
   ParserTest.cpp
   ResourceTest.cpp
-
-  DEPENDS
-  MLIRTestInterfaceIncGen
 )
 target_include_directories(MLIRParserTests PRIVATE "${MLIR_BINARY_DIR}/test/lib/Dialect/Test")
 


### PR DESCRIPTION
MLIR libraries depend on the `mlir-headers` aggregate, which serializes every
dialect library behind every TableGen target, and many of them repeat other
libraries' private `*IncGen` targets in DEPENDS to paper over dependencies that
the link graph should already express. Both hide missing edges: a library that
forgets a dependency still builds, because something else generated the header
first.

Ninja already orders object compilation transitively through the
`cmake_object_order_depends_target_*` phonies of every target-level dependency,
without waiting for archives to be linked. The only gap was that
`llvm_add_library` created such an edge from an object library only to its
PUBLIC LINK_LIBS. Resolve LINK_LIBS once the whole target graph exists and add
the edge for PUBLIC, PRIVATE and unqualified entries alike, resolving aliases,
extracting targets from generator expressions, and skipping non-targets such
as `-lpthread`.

With that in place:

* Every MLIR library lists its own TableGen targets in DEPENDS, and only those.
  Dependencies on other libraries' `*IncGen` targets are removed; the link edge
  covers them.
* `add_mlir_dialect_library` and friends no longer depend on `mlir-headers`.
* Header-only relationships (a library including generated headers of a library
  it does not link) use the new `HEADER_LIBS` keyword of `add_mlir_library`.
  They are resolved in a deferred pass to the TableGen targets of the named
  libraries and of everything they link, never to the libraries themselves, so
  a provider that links the consumer does not create a dependency cycle. Each
  entry carries a comment naming the include that requires it; misspelled
  entries are diagnosed at configure time.
* Fix a few genuinely missing edges found along the way (GPU/SPIRV sources
  including LLVM's generated `Attributes.inc`, generated `.td` inputs for the
  OpenACC and OpenMP dialects, CIR linking `MLIRPtrMemorySpaceInterfaces`).

Add mlir/docs/CMakeInfrastructure.md describing the three rules above and how
to check them, and a configure-time lit test exercising PRIVATE and generator
expression LINK_LIBS, forward references, transitive HEADER_LIBS, and the
diagnostics.

Validated with a fresh mlir+clang+flang configure on CMake 4.3 and 3.22, and
`ninja -t missingdeps` on fully built MLIR trees for both versions, which
reports no missing generated-header dependencies.

Assisted-by: Codex
Assisted-by: Claude Code