### PR TITLE
[clang][AST] Implement -Wunsigned-integer-overflow for checking for unsigned integer constants overflow

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -486,6 +486,15 @@ features cannot lower the translation-unit ABI level;
   dimension that is a zero integer constant, as in `struct Empty vla[n]` or
   `int vla[n][0]`. (#GH28328)
 
+- Added `-Wunsigned-integer-overflow` (off by default), which diagnoses `+`
+  and `*` between integer constant expressions whose unsigned result wraps
+  around, for example `4096u * 1024 * 1024` evaluating to `0`. Unsigned
+  wraparound is well-defined, so this is a warning only. Still, this might
+  denote a bug.
+  Wraps that are intended can be expressed with an explicit cast of the widened
+  result, with a type marked `__attribute__((overflow_behavior(wrap)))`, or
+  silenced with `#pragma clang diagnostic`.
+
 ### Improvements to Clang's time-trace
 
 ### Improvements to Coverage Mapping

--- a/clang/include/clang/Basic/DiagnosticASTKinds.td
+++ b/clang/include/clang/Basic/DiagnosticASTKinds.td
@@ -428,6 +428,10 @@ def warn_cxx20_compat_requires_explicit_init_non_aggregate : Warning<
 def warn_integer_constant_overflow : Warning<
   "overflow in expression; result is %0 with type %1">,
   InGroup<DiagGroup<"integer-overflow">>;
+def warn_unsigned_integer_overflow : Warning<
+  "unsigned constant expression wraps around: %0 %1 %2 is %3, which does not "
+  "fit in %4 and becomes %5">,
+  DefaultIgnore, InGroup<DiagGroup<"unsigned-integer-overflow">>;
 def warn_fixedpoint_constant_overflow : Warning<
   "overflow in expression; result is %0 with type %1">,
   InGroup<DiagGroup<"fixed-point-overflow">>;

--- a/clang/lib/AST/ByteCode/Interp.h
+++ b/clang/lib/AST/ByteCode/Interp.h
@@ -331,6 +331,62 @@ PRESERVE_NONE inline bool RetVoid(InterpState &S) {
 // Add, Sub, Mul
 //===----------------------------------------------------------------------===//
 
+/// Mirrors CheckUnsignedIntArithmetic in ExprConstant.cpp
+/// Helper function to check if unsigned integer constant is overflowing.
+template <typename T, template <typename U> class OpAP>
+void checkUnsignedIntArithmetic(InterpState &S, CodePtr OpPC, unsigned Bits,
+                                const T &LHS, const T &RHS, const T &Result) {
+  static_assert(!std::is_same_v<T, FixedPoint>,
+                "Not meant for fixed point numbers");
+  assert(!T::isSigned() && "Left hand side shall be unsigned integer");
+
+  // Verify if the check should be performed
+  // Note: "checkingForUndefinedBehavior" is a misleading name: currently it
+  // checks only for overflows, as the function doc confirms. Should be
+  // changed to checkingForOverflow here and elsewhere.
+  if (!S.checkingForUndefinedBehavior())
+    return;
+
+  const Expr *E = S.Current->getExpr(OpPC);
+  assert(E);
+  // Check for __attribute__((overflow_behavior(wrap))) i.e. wrapping is
+  // intended
+  if (E->getType().isWrapType()) {
+    return;
+  }
+
+  const auto *BO = dyn_cast<BinaryOperator>(E);
+  if (!BO) {
+    return;
+  }
+  const auto Opcode = BO->getOpcode();
+  // Intentionally consider only + and *, to exclude from the diagnostic
+  // things like bit shifts (already covered by shift-count-overflow) and
+  // constructions like (0u - 1) which might be intentional (wrap to max).
+  if (Opcode != BO_Add && Opcode != BO_Mul) {
+    return;
+  }
+
+  if (S.getASTContext().getDiagnostics().isIgnored(
+          diag::warn_unsigned_integer_overflow, E->getExprLoc())) {
+    return;
+  }
+
+  // Check for overflow
+  APSInt Value = OpAP<APSInt>()(LHS.toAPSInt(Bits), RHS.toAPSInt(Bits));
+  if (Result.toAPSInt(Bits) == Value) {
+    // Value didn't overflow
+    return;
+  }
+
+  S.report(E->getExprLoc(), diag::warn_unsigned_integer_overflow)
+      << toString(LHS.toAPSInt(), 10, T::isSigned()) << BO->getOpcodeStr()
+      << toString(RHS.toAPSInt(), 10, T::isSigned())
+      << toString(Value, 10, Value.isSigned()) << E->getType()
+      << toString(Result.toAPSInt(), 10, Result.isSigned())
+      << E->getSourceRange();
+}
+
 template <typename T, bool (*OpFW)(T, T, unsigned, T *),
           template <typename U> class OpAP>
 bool AddSubMulHelper(InterpState &S, CodePtr OpPC, unsigned Bits, const T &LHS,
@@ -346,6 +402,11 @@ bool AddSubMulHelper(InterpState &S, CodePtr OpPC, unsigned Bits, const T &LHS,
     Result = S.allocAP<T>(LHS.bitWidth());
 
   if (!OpFW(LHS, RHS, Bits, &Result)) {
+    if constexpr (!std::is_same_v<T, FixedPoint>) {
+      if (!T::isSigned()) {
+        checkUnsignedIntArithmetic<T, OpAP>(S, OpPC, Bits, LHS, RHS, Result);
+      }
+    }
     S.Stk.push<T>(Result);
     return true;
   }

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -2811,6 +2811,59 @@ static bool truncateBitfieldValue(EvalInfo &Info, const Expr *E,
   return true;
 }
 
+/// Helper function to check if unsigned integer constant is overflowing.
+template <typename Operation>
+static void CheckUnsignedIntArithmetic(EvalInfo &Info, const Expr *E,
+                                       const APSInt &LHS, const APSInt &RHS,
+                                       unsigned BitWidth, Operation Op,
+                                       APSInt &Result) {
+  assert(LHS.isUnsigned() && "Left hand side shall be unsigned integer");
+  // Verify if the check should be performed
+  // Note: "checkingForUndefinedBehavior" is a misleading name: currently it
+  // checks only for overflows, as the function doc confirms. Should be
+  // changed to checkingForOverflow here and elsewhere.
+  if (!Info.checkingForUndefinedBehavior()) {
+    return;
+  }
+  // Check for __attribute__((overflow_behavior(wrap))) i.e. wrapping is
+  // intended
+  if (E->getType().isWrapType()) {
+    return;
+  }
+
+  const auto *BO = dyn_cast<BinaryOperator>(E);
+  if (!BO) {
+    return;
+  }
+  const auto Opcode = BO->getOpcode();
+  // Intentionally consider only + and *, to exclude from the diagnostic
+  // things like bit shifts (already covered by shift-count-overflow) and
+  // constructions like (0u - 1) which might be intentional (wrap to max).
+  if (Opcode != BO_Add && Opcode != BO_Mul) {
+    return;
+  }
+
+  if (Info.Ctx.getDiagnostics().isIgnored(diag::warn_unsigned_integer_overflow,
+                                          E->getExprLoc())) {
+    return;
+  }
+
+  // Check for overflow
+  APSInt Value(Op(LHS.extend(BitWidth), RHS.extend(BitWidth)),
+               /*IsUnsigned=*/true);
+  if (Result.extend(BitWidth) == Value) {
+    // Value didn't overflow
+    return;
+  }
+
+  Info.Ctx.getDiagnostics().Report(E->getExprLoc(),
+                                   diag::warn_unsigned_integer_overflow)
+      << toString(LHS, 10, LHS.isSigned()) << BO->getOpcodeStr()
+      << toString(RHS, 10, RHS.isSigned())
+      << toString(Value, 10, Value.isSigned()) << E->getType()
+      << toString(Result, 10, Result.isSigned()) << E->getSourceRange();
+}
+
 /// Perform the given integer operation, which is known to need at most BitWidth
 /// bits, and check for overflow in the original type (if that type was not an
 /// unsigned type).
@@ -2821,10 +2874,14 @@ static bool CheckedIntArithmetic(EvalInfo &Info, const Expr *E,
                                  APSInt &Result) {
   if (LHS.isUnsigned()) {
     Result = Op(LHS, RHS);
+    CheckUnsignedIntArithmetic(Info, E, LHS, RHS, BitWidth, Op, Result);
+    // Always return true, because overflow on unsigned integers is not
+    // undefined behavior
     return true;
   }
 
-  APSInt Value(Op(LHS.extend(BitWidth), RHS.extend(BitWidth)), false);
+  APSInt Value(Op(LHS.extend(BitWidth), RHS.extend(BitWidth)),
+               /*IsUnsigned=*/false);
   Result = Value.trunc(LHS.getBitWidth());
   if (Result.extend(BitWidth) != Value && !E->getType().isWrapType()) {
     if (Info.checkingForUndefinedBehavior())

--- a/clang/test/Sema/unsigned-integer-overflow.c
+++ b/clang/test/Sema/unsigned-integer-overflow.c
@@ -1,0 +1,42 @@
+// Note: -triple x86_64-pc-linux-gnu is here to ensure the size of "uint32_t"
+// and "uint64_t" are of the expected size. Ideally, we would included stdint.h
+// but it's not available in the tests.
+// RUN: %clang_cc1 %s -verify=on -fsyntax-only -triple x86_64-pc-linux-gnu -Wunsigned-integer-overflow
+// RUN: %clang_cc1 %s -verify=on -fsyntax-only -triple x86_64-pc-linux-gnu -Wunsigned-integer-overflow -fexperimental-new-constant-interpreter
+// RUN: %clang_cc1 %s -verify=off -fsyntax-only -triple x86_64-pc-linux-gnu
+// off-no-diagnostics
+
+typedef unsigned int uint32_t;
+typedef unsigned long long uint64_t;
+
+_Static_assert(sizeof(uint32_t) == 4, "uint32_t should be 4 bytes long");
+_Static_assert(sizeof(uint64_t) == 8, "uint64_t should be 8 bytes long");
+
+uint32_t a = 1024u * (1024 * 1024) * 6; // on-warning{{unsigned constant expression wraps around: 1073741824 * 6 is 6442450944, which does not fit in 'unsigned int' and becomes 2147483648}}
+uint64_t b = 1024u * (1024 * 1024) * 9; // on-warning{{wraps around: 1073741824 * 9 is 9663676416}}
+uint32_t c = 0xFFFFFFFFu + 1u;          // on-warning{{wraps around: 4294967295 + 1 is 4294967296}}
+enum { kMiB = 1024 * 1024 };
+uint32_t d = kMiB * 1024u * 9;          // on-warning{{wraps around: 1073741824 * 9}}
+
+uint32_t ok1 = 1024u * 1024 * 1024;
+uint64_t ok2 = (uint64_t)1024 * 1024 * 1024 * 9;
+uint32_t ok3 = 0u - 1;
+uint32_t ok4 = ~0u;
+uint32_t ok5 = (uint32_t)((uint64_t)0xFFFFFFFFu + 1u);
+uint32_t Runtime(uint32_t v) { return v * 1024u * 1024u; }
+
+// The group name can be used for suppression, and the check is not performed
+// where the warning is ignored.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunsigned-integer-overflow"
+uint32_t suppressed = 0xFFFFFFFFu + 1u;
+#pragma clang diagnostic pop
+uint32_t afterPop = 0xFFFFFFFFu + 1u; // on-warning{{wraps around: 4294967295 + 1}}
+
+// Wide integers use the arbitrary-precision path in both evaluators.
+typedef unsigned _BitInt(128) u128;
+u128 big = ((u128)1 << 127) * 2u; // on-warning{{wraps around: 170141183460469231731687303715884105728 * 2 is 340282366920938463463374607431768211456, which does not fit in 'u128' (aka 'unsigned _BitInt(128)') and becomes 0}}
+
+// Operands narrower than int are promoted to int first, so no unsigned
+// wraparound is involved.
+int promoted = (unsigned char)200 + (unsigned char)100;

--- a/clang/test/SemaCXX/unsigned-integer-overflow.cpp
+++ b/clang/test/SemaCXX/unsigned-integer-overflow.cpp
@@ -1,0 +1,103 @@
+// Note: -triple x86_64-pc-linux-gnu is here to ensure the size of "uint32_t"
+// and "uint64_t" are of the expected size. Ideally, we would included cstdint
+// but it's not available in the tests.
+// RUN: %clang_cc1 %s -verify=on -fsyntax-only -std=gnu++2a -triple x86_64-pc-linux-gnu -Wunsigned-integer-overflow
+// RUN: %clang_cc1 %s -verify=on -fsyntax-only -std=gnu++2a -triple x86_64-pc-linux-gnu -Wunsigned-integer-overflow -fexperimental-new-constant-interpreter
+// RUN: %clang_cc1 %s -verify=on -fsyntax-only -std=gnu++2a -triple x86_64-pc-linux-gnu -Wunsigned-integer-overflow -fexperimental-overflow-behavior-types -DOBT
+// RUN: %clang_cc1 %s -verify=off -fsyntax-only -std=gnu++2a -triple x86_64-pc-linux-gnu
+// off-no-diagnostics
+
+typedef unsigned int uint32_t;
+typedef unsigned long long uint64_t;
+
+static_assert(sizeof(uint32_t) == 4, "uint32_t should be 4 bytes long");
+static_assert(sizeof(uint64_t) == 8, "uint64_t should be 8 bytes long");
+
+uint32_t a = 1024u * (1024 * 1024) * 6; // on-warning{{unsigned constant expression wraps around: 1073741824 * 6 is 6442450944, which does not fit in 'unsigned int' and becomes 2147483648}}
+// Storing into a wider type does not help: the arithmetic is done in
+// 'unsigned int' and only the wrapped result is converted.
+uint64_t b = 1024u * (1024 * 1024) * 9; // on-warning{{wraps around: 1073741824 * 9 is 9663676416}}
+uint32_t c = 0xFFFFFFFFu + 1u;          // on-warning{{wraps around: 4294967295 + 1 is 4294967296, which does not fit in 'unsigned int' and becomes 0}}
+constexpr uint32_t kMiB = 1024u * 1024;
+uint32_t d = kMiB * 1024u * 9;          // on-warning{{wraps around: 1073741824 * 9}}
+uint64_t e = 0xFFFFFFFFFFFFFFFFull * 2u; // on-warning{{wraps around: 18446744073709551615 * 2 is 36893488147419103230, which does not fit in 'unsigned long long' and becomes 18446744073709551614}}
+const uint32_t f = 1024u * 1024 * 1024 * 9;     // on-warning{{wraps around: 1073741824 * 9}}
+static_assert(f == 1073741824u, "");
+
+// Initializers that must be constant expressions (constexpr variables,
+// enumerators, static constexpr members) are evaluated by a different path
+// and are not diagnosed currently.
+constexpr uint32_t notChecked1 = 1024u * 1024 * 1024 * 9;
+enum : uint32_t { notChecked2 = 1024u * 1024 * 1024 * 9 };
+void NotCheckedLocal() {
+  constexpr uint32_t l = 1024u * 1024 * 1024 * 9;
+  (void)l;
+}
+
+uint32_t ok1 = 1024u * 1024 * 1024;
+uint64_t ok2 = uint64_t(1024) * 1024 * 1024 * 9;
+uint64_t ok3 = 9ull * 1024 * 1024 * 1024;
+// Only + and * are checked: wrapping subtraction, negation and shifts are
+// idiomatic ways to build masks and maximum values.
+uint32_t ok4 = 0u - 1;
+uint32_t ok5 = -1u;
+uint32_t ok6 = ~0u;
+uint32_t ok7 = 1u << 31;
+// Widening, then truncating explicitly, is the idiom for an intended wrap.
+uint32_t ok8 = static_cast<uint32_t>(uint64_t(0xFFFFFFFFu) + 1u);
+uint32_t Runtime(uint32_t v) { return v * 1024u * 1024u; }
+
+// Diagnosed per instantiation, at the template's source location.
+template <unsigned N> uint32_t Bytes() {
+  return N * 1024u * 1024u; // on-warning{{wraps around: 5120000 * 1024}}
+}
+uint32_t t1 = Bytes<4>();
+uint32_t t2 = Bytes<5000>();
+template <unsigned N> struct Size {
+  static constexpr uint32_t kBytes = N * 1024u * 1024u; // not diagnosed, see above
+};
+uint32_t t3 = Size<5000>::kBytes;
+
+// Arithmetic inside a constexpr function is diagnosed when the function is
+// evaluated with constants, at the function's own source location.
+constexpr uint32_t Mul(uint32_t x) { return x * 16777619u; } // on-warning{{wraps around: 4294967295 * 16777619}}
+uint32_t g = Mul(0xFFFFFFFFu) + 0u;
+
+// Unlike code that is never instantiated, a branch that is merely unreachable
+// is still evaluated.
+uint32_t DeadBranch() {
+  const int kib = -1;
+  if (kib >= 0) {
+    return uint32_t(kib) * 1024u; // on-warning{{wraps around: 4294967295 * 1024}}
+  }
+  return 0;
+}
+
+#ifdef OBT
+// Annotating the wrapping shall silence the warning
+typedef unsigned int __attribute__((overflow_behavior(wrap))) wrap_u32;
+wrap_u32 w = wrap_u32(0xFFFFFFFFu) + 1u;
+#endif
+
+// The group name can be used for suppression, and the check is not performed
+// where the warning is ignored.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunsigned-integer-overflow"
+uint32_t suppressed = 0xFFFFFFFFu + 1u;
+#pragma clang diagnostic pop
+uint32_t afterPop = 0xFFFFFFFFu + 1u; // on-warning{{wraps around: 4294967295 + 1}}
+
+// Wide integers use the arbitrary-precision path in both evaluators.
+typedef unsigned _BitInt(128) u128;
+u128 big = ((u128)1 << 127) * 2u; // on-warning{{wraps around: 170141183460469231731687303715884105728 * 2 is 340282366920938463463374607431768211456, which does not fit in 'u128' (aka 'unsigned _BitInt(128)') and becomes 0}}
+
+// Operands narrower than int are promoted to int first, so no unsigned
+// wraparound is involved.
+int promoted = (unsigned char)200 + (unsigned char)100;
+
+// Compound assignments are not checked.
+constexpr uint32_t Acc(uint32_t x) {
+  x *= 16777619u;
+  return x;
+}
+uint32_t acc = Acc(0xFFFFFFFFu) + 0u;


### PR DESCRIPTION
Unlike signed integer overflow, which are undefined behavior, unsigned integer overflow (wrapping) is well defined.
Still, it could denote a bug.