### PR TITLE
[MLIR][CIR][NFCI] Split TestAliasAnalysis into its own library

### DIFF
--- a/clang/test/CIR/lib/Analysis/CMakeLists.txt
+++ b/clang/test/CIR/lib/Analysis/CMakeLists.txt
@@ -7,7 +7,7 @@ add_clang_library(CIRTestAnalysis
   MLIRIR
   MLIRAnalysis
   MLIRPass
-  MLIRTestAnalysis
+  MLIRTestAliasAnalysis
 )
 
 target_include_directories(CIRTestAnalysis

--- a/mlir/test/lib/Analysis/CMakeLists.txt
+++ b/mlir/test/lib/Analysis/CMakeLists.txt
@@ -1,6 +1,23 @@
+# TestAliasAnalysis.cpp doesn't depend on the Test dialect (unlike the rest
+# of this directory), so it's split into its own library: downstream users
+# that only want to reuse the generic alias-analysis testing boilerplate
+# (e.g. ClangIR) can link this without pulling in MLIRTestDialect and
+# everything it depends on.
+add_mlir_library(MLIRTestAliasAnalysis
+  TestAliasAnalysis.cpp
+
+  EXCLUDE_FROM_LIBMLIR
+  PARTIAL_SOURCES_INTENDED
+
+  LINK_LIBS PUBLIC
+  MLIRAnalysis
+  MLIRFunctionInterfaces
+  MLIRIR
+  MLIRPass
+  )
+
 # Exclude tests from libMLIR.so
 add_mlir_library(MLIRTestAnalysis
-  TestAliasAnalysis.cpp
   TestCallGraph.cpp
   TestDataFlowFramework.cpp
   TestLiveness.cpp
@@ -21,8 +38,10 @@ add_mlir_library(MLIRTestAnalysis
   DataFlow/TestStridedMetadataRangeAnalysis.cpp
 
   EXCLUDE_FROM_LIBMLIR
+  PARTIAL_SOURCES_INTENDED
 
   LINK_LIBS PUBLIC
+  MLIRTestAliasAnalysis
   MLIRTestDialect
   )
 mlir_target_link_libraries(MLIRTestAnalysis PUBLIC


### PR DESCRIPTION
This is a target for the CIR alias analysis, and bringing in all of the MLIRTestAnalysis is too heavy: it results in a significant increase in CIR test size.  This patch, plus a few little things, gets us ~850 edges removed from the Clang Build (after Medhi's patches).

This also has CIR use it.