### PR TITLE
[Clang] Reject overflow behavior types on _Atomic

### DIFF
--- a/clang/docs/OverflowBehaviorTypes.md
+++ b/clang/docs/OverflowBehaviorTypes.md
@@ -773,3 +773,42 @@ typedef float __attribute__((overflow_behavior(wrap))) wrapping_float;
 typedef struct S { int i; } __attribute__((overflow_behavior(wrap))) S_t;
 // error: 'overflow_behavior' attribute cannot be applied to non-integer type 'struct S'
 ```
+
+### Incompatibility With `_Atomic`
+
+Overflow behavior types do not compose with `_Atomic`. An error is issued for
+any spelling of the combination.
+
+```c++
+typedef int __ob_trap trapping_int;
+
+_Atomic trapping_int a;
+// error: _Atomic cannot be applied to overflow behavior type '__ob_trap int'
+
+_Atomic __ob_trap int b;
+// error: __ob_trap specifier cannot be applied to atomic type '_Atomic(int)'
+```
+
+The reason is that atomic read-modify-write operations cannot carry the
+guarantee. A compound assignment or increment on an `_Atomic` object lowers to
+a single `atomicrmw` instruction, which is never instrumented — this is true of
+plain atomic types under `-fsanitize=signed-integer-overflow` as well. A
+`trap` type is defined as being checked regardless of the global flags in
+effect, so permitting `_Atomic __ob_trap int` would mean silently honoring that
+contract for some expressions and not others:
+
+```c++
+_Atomic trapping_int counter;
+int x = counter + 1;  // checked
+counter++;            // would NOT be checked: lowers to a bare atomicrmw
+```
+
+Rather than provide a guarantee that holds only for some uses of a type, the
+combination is rejected outright. `wrap` is rejected as well, so that the rule
+is a single one that does not depend on the behavior kind.
+
+Instrumenting checked atomic read-modify-write operations would require
+lowering them to a compare-exchange loop, which changes both the performance
+characteristics and the memory-ordering story of the operation. That may be
+revisited if a concrete use case appears; relaxing this error later is a
+backwards-compatible change.

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -4211,6 +4211,9 @@ def err_overflow_behavior_unknown_ident
 def err_overflow_behavior_non_integer_type
     : Error<"%0 %select{attribute|specifier}2 cannot be applied to "
             "non-integer type '%1'">;
+def err_overflow_behavior_atomic_type
+    : Error<"%0 %select{attribute|specifier}2 cannot be applied to atomic type "
+            "'%1'">;
 def err_conflicting_overflow_behaviors
     : Error<"conflicting %select{'overflow_behavior' attributes|overflow "
             "behavior specification; specifier specifies '%1' but attribute "
@@ -7520,8 +7523,8 @@ def err_func_def_incomplete_result : Error<
 def err_atomic_specifier_bad_type
     : Error<"_Atomic cannot be applied to "
             "%select{incomplete |array |function |reference |atomic |qualified "
-            "|sizeless ||integer |}0type "
-            "%1 %select{|||||||which is not trivially copyable||in C23}0">;
+            "|sizeless ||integer ||overflow behavior }0type "
+            "%1 %select{|||||||which is not trivially copyable||in C23|}0">;
 def warn_atomic_member_access : Warning<
   "accessing a member of an atomic structure or union is undefined behavior">,
   InGroup<DiagGroup<"atomic-access">>, DefaultError;

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -1581,7 +1581,13 @@ static QualType ConvertDeclSpecToType(TypeProcessingState &state) {
   // Check for __ob_wrap and __ob_trap
   if (DS.isOverflowBehaviorSpecified() &&
       S.getLangOpts().OverflowBehaviorTypes) {
-    if (!Result->isIntegerType()) {
+    if (Result->isAtomicType()) {
+      SourceLocation Loc = DS.getOverflowBehaviorLoc();
+      StringRef SpecifierName =
+          DeclSpec::getSpecifierName(DS.getOverflowBehaviorState());
+      S.Diag(Loc, diag::err_overflow_behavior_atomic_type)
+          << SpecifierName << Result.getAsString() << 1;
+    } else if (!Result->isIntegerType()) {
       SourceLocation Loc = DS.getOverflowBehaviorLoc();
       StringRef SpecifierName =
           DeclSpec::getSpecifierName(DS.getOverflowBehaviorState());
@@ -6735,6 +6741,14 @@ static void HandleOverflowBehaviorAttr(QualType &Type, const ParsedAttr &Attr,
     return;
   }
 
+  // Verify we aren't dealing with an atomic type
+  if (Type->isAtomicType()) {
+    S.Diag(Attr.getLoc(), diag::err_overflow_behavior_atomic_type)
+        << Attr << Type.getAsString() << 0; // 0 for attribute
+    Attr.setInvalid();
+    return;
+  }
+
   // Check that the underlying type is an integer type
   if (!Type->isIntegerType()) {
     S.Diag(Attr.getLoc(), diag::err_overflow_behavior_non_integer_type)
@@ -10419,6 +10433,9 @@ QualType Sema::BuildAtomicType(QualType T, SourceLocation Loc) {
     else if (getLangOpts().C23 && T->isUndeducedAutoType())
       // _Atomic auto is prohibited in C23
       DisallowedKind = 9;
+    else if (T->isOverflowBehaviorType())
+      // Overflow behavior types do not compose with _Atomic
+      DisallowedKind = 10;
 
     if (DisallowedKind != -1) {
       Diag(Loc, diag::err_atomic_specifier_bad_type) << DisallowedKind << T;

--- a/clang/test/Sema/overflow-behavior-atomic.c
+++ b/clang/test/Sema/overflow-behavior-atomic.c
@@ -1,0 +1,47 @@
+// RUN: %clang_cc1 %s -fexperimental-overflow-behavior-types -verify -fsyntax-only -std=c11
+
+// Overflow behavior types do not compose with _Atomic. Atomic
+// read-modify-write operations lower to a single atomicrmw and are never
+// instrumented, so an '__ob_trap' type would silently lose the overflow
+// checking it promises. Reject the combination in every spelling.
+
+typedef int __ob_trap tint;
+typedef int __ob_wrap wint;
+typedef _Atomic int aint;
+
+// _Atomic applied over an overflow behavior type.
+_Atomic tint a1;    // expected-error {{_Atomic cannot be applied to overflow behavior type 'tint' (aka '__ob_trap int')}}
+_Atomic wint a2;    // expected-error {{_Atomic cannot be applied to overflow behavior type 'wint' (aka '__ob_wrap int')}}
+_Atomic(tint) a3;   // expected-error {{_Atomic cannot be applied to overflow behavior type 'tint' (aka '__ob_trap int')}}
+_Atomic(wint) a4;   // expected-error {{_Atomic cannot be applied to overflow behavior type 'wint' (aka '__ob_wrap int')}}
+
+// Same, via the attribute spelling on the declarator.
+_Atomic int __attribute__((overflow_behavior(trap))) a5;  // expected-error {{_Atomic cannot be applied to overflow behavior type '__ob_trap int'}}
+_Atomic int __attribute__((overflow_behavior(wrap))) a6;  // expected-error {{_Atomic cannot be applied to overflow behavior type '__ob_wrap int'}}
+
+// Pointers and members must be rejected too, not just plain declarations.
+_Atomic tint *a7;             // expected-error {{_Atomic cannot be applied to overflow behavior type 'tint' (aka '__ob_trap int')}}
+struct S { _Atomic tint m; }; // expected-error {{_Atomic cannot be applied to overflow behavior type 'tint' (aka '__ob_trap int')}}
+
+// An overflow behavior specifier applied over an atomic type.
+_Atomic __ob_trap int b1;   // expected-error {{__ob_trap specifier cannot be applied to atomic type '_Atomic(int)'}}
+__ob_trap _Atomic int b2;   // expected-error {{__ob_trap specifier cannot be applied to atomic type '_Atomic(int)'}}
+_Atomic __ob_wrap int b3;   // expected-error {{__ob_wrap specifier cannot be applied to atomic type '_Atomic(int)'}}
+aint __ob_trap b4;          // expected-error {{__ob_trap specifier cannot be applied to atomic type 'aint'}}
+
+// Same, via the attribute spelling.
+aint __attribute__((overflow_behavior(trap))) b5; // expected-error {{'overflow_behavior' attribute cannot be applied to atomic type 'aint'}}
+aint __attribute__((overflow_behavior(wrap))) b6; // expected-error {{'overflow_behavior' attribute cannot be applied to atomic type 'aint'}}
+
+// Neither feature is disturbed on its own.
+_Atomic int ok_atomic;
+tint ok_trap;
+wint ok_wrap;
+_Atomic int *ok_atomic_ptr;
+struct T { _Atomic int m; tint n; };
+
+void uses(void) {
+  ok_atomic++;
+  ok_trap++;
+  ok_wrap++;
+}


### PR DESCRIPTION
I'm pretty sure atomic read-modify-write operations aren't instrumented for overflow. `counter++` on an `_Atomic` object lowers to a single `atomicrmw`, and this is true for plain atomic types under `-fsanitize=signed-integer-overflow` too.

That's a problem for `__ob_trap`, which is supposed to be checked no matter what the global flags say:

```c
  typedef int __ob_trap trapping_int;
  _Atomic trapping_int counter;
  int x = counter + 1; // checked
  counter++;           // not checked
```

A guarantee that only holds for some expressions is worse than none, so reject the combination outriht. Let's also reject `__ob_wrap` too so the rule doesn't depend on the behavior kind... wrap has minimal use here anyways.

Applying an OBT specifier over an atomic type was already an error, though it unhelpfully reported `_Atomic(int)` as a non-integer type even though it is. Applying `_Atomic` over an existing OBT was accepted, which is where the unchecked read-modify-write came from... this was a bug that is now fixed because we are no longer trying to apply OBT on top of `_Atomic`. This is all made more clear by better diagnostics too :)

We can relax this later if someone needs it. I think instrumenting checked atomic rmws would mean lowering to a cmpxchg/CAS loop.

Assisted-by: claude
^^^ he wrote the tests, i looked them over. :)