### PR TITLE
[MLIR][Linalg] Update transform tests for strict properties

### DIFF
--- a/mlir/test/Dialect/Linalg/vectorization/contraction-interface.mlir
+++ b/mlir/test/Dialect/Linalg/vectorization/contraction-interface.mlir
@@ -375,7 +375,7 @@ func.func @matmul_mixed_precision_unsigned(
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
     %0 = transform.structured.match ops{["linalg.matmul"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-    transform.structured.vectorize %0 {create_named_contraction} : !transform.any_op
+    transform.structured.vectorize %0 create_named_contraction : !transform.any_op
     transform.yield
   }
 }
@@ -404,7 +404,7 @@ func.func @matmul_float_to_unsigned_integer(
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
     %0 = transform.structured.match ops{["linalg.matmul"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-    transform.structured.vectorize %0 {create_named_contraction} : !transform.any_op
+    transform.structured.vectorize %0 create_named_contraction : !transform.any_op
     transform.yield
   }
 }
@@ -433,7 +433,7 @@ func.func @matmul_float_to_signed_integer(
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
     %0 = transform.structured.match ops{["linalg.matmul"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-    transform.structured.vectorize %0 {create_named_contraction} : !transform.any_op
+    transform.structured.vectorize %0 create_named_contraction : !transform.any_op
     transform.yield
   }
 }
@@ -463,7 +463,7 @@ func.func @matmul_mixed_precision_signed(
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
     %0 = transform.structured.match ops{["linalg.matmul"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-    transform.structured.vectorize %0 {create_named_contraction} : !transform.any_op
+    transform.structured.vectorize %0 create_named_contraction : !transform.any_op
     transform.yield
   }
 }
@@ -490,7 +490,7 @@ func.func @matmul_same_precision_unsigned(
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
     %0 = transform.structured.match ops{["linalg.matmul"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-    transform.structured.vectorize %0 {create_named_contraction} : !transform.any_op
+    transform.structured.vectorize %0 create_named_contraction : !transform.any_op
     transform.yield
   }
 }
@@ -521,7 +521,7 @@ module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
     %0 = transform.structured.match ops{["linalg.matmul"]} in %arg1 : (!transform.any_op) -> !transform.any_op
     transform.structured.vectorize %0 vector_sizes [4, 4, 16]
-      {create_named_contraction} : !transform.any_op
+      create_named_contraction : !transform.any_op
     transform.yield
   }
 }
@@ -661,7 +661,7 @@ func.func @contract_mixed_precision_unsigned(
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
     %0 = transform.structured.match ops{["linalg.contract"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-    transform.structured.vectorize %0 {create_named_contraction} : !transform.any_op
+    transform.structured.vectorize %0 create_named_contraction : !transform.any_op
     transform.yield
   }
 }

--- a/mlir/test/Dialect/Linalg/vectorization/convolution-with-patterns.mlir
+++ b/mlir/test/Dialect/Linalg/vectorization/convolution-with-patterns.mlir
@@ -938,7 +938,7 @@ func.func @generic_conv_1d_nwc_wcf_unsigned_input_memref(%input: memref<1x2x3xi8
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
     %0 = transform.structured.match ops{["linalg.generic"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-    %1 = transform.get_parent_op %0 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
+    %1 = transform.get_parent_op %0 <isolated_from_above> : (!transform.any_op) -> !transform.any_op
     %2 = transform.structured.vectorize_children_and_apply_patterns %1 : (!transform.any_op) -> !transform.any_op
     transform.yield
   }


### PR DESCRIPTION
Update recently added vectorization tests to use the custom assembly syntax.

Strict Transform dialect properties no longer parse inherent attributes from the generic attribute dictionary.

These tests landed concurrently with the strict-properties migration.

Assisted-by: Codex