### PR TITLE
[Fuzzer] Bump rss_limit again.

### DIFF
--- a/compiler-rt/test/fuzzer/fork.test
+++ b/compiler-rt/test/fuzzer/fork.test
@@ -22,4 +22,4 @@ RUN: FileCheck %s --check-prefix=CRASH --input-file=%t-ShallowOOMDeepCrash.log
 
 MAX_TOTAL_TIME: INFO: fuzzed for {{.*}} seconds, wrapping up soon
 MAX_TOTAL_TIME: INFO: exiting: {{.*}} time:
-RUN: not %run %t-ShallowOOMDeepCrash -fork=1 -rss_limit_mb=512 -ignore_crashes=1 -max_total_time=30 2>&1 | FileCheck %s  --check-prefix=MAX_TOTAL_TIME
+RUN: not %run %t-ShallowOOMDeepCrash -fork=1 -rss_limit_mb=768 -ignore_crashes=1 -max_total_time=30 2>&1 | FileCheck %s  --check-prefix=MAX_TOTAL_TIME

--- a/compiler-rt/test/fuzzer/fork_corpus_groups.test
+++ b/compiler-rt/test/fuzzer/fork_corpus_groups.test
@@ -22,4 +22,4 @@ RUN: FileCheck %s --check-prefix=CRASH --input-file=%t-ShallowOOMDeepCrash.log
 
 MAX_TOTAL_TIME: INFO: fuzzed for {{.*}} seconds, wrapping up soon
 MAX_TOTAL_TIME: INFO: exiting: {{.*}} time:
-RUN: not %run %t-ShallowOOMDeepCrash -fork=1 -fork_corpus_groups=1 -rss_limit_mb=512 -ignore_crashes=1 -max_total_time=30 2>&1 | FileCheck %s  --check-prefix=MAX_TOTAL_TIME
+RUN: not %run %t-ShallowOOMDeepCrash -fork=1 -fork_corpus_groups=1 -rss_limit_mb=768 -ignore_crashes=1 -max_total_time=30 2>&1 | FileCheck %s  --check-prefix=MAX_TOTAL_TIME


### PR DESCRIPTION
Two of my gcc based bots (https://lab.llvm.org/buildbot/#/builders/174 and https://lab.llvm.org/buildbot/#/builders/202) are starting again to have random failures in the fork.test and fork_corpus_groups.test tests:

- libFuzzer-x86-64-default-Linux::fork_corpus_groups.test:
  - https://lab.llvm.org/buildbot/#/builders/202/builds/2559
  - https://lab.llvm.org/buildbot/#/builders/202/builds/2580
  - https://lab.llvm.org/buildbot/#/builders/202/builds/2607
  - https://lab.llvm.org/buildbot/#/builders/174/builds/40902
  - https://lab.llvm.org/buildbot/#/builders/174/builds/40907
  - https://lab.llvm.org/buildbot/#/builders/174/builds/40962
  - https://lab.llvm.org/buildbot/#/builders/174/builds/40977

- libFuzzer-x86-64-default-Linux::fork.test:
  - https://lab.llvm.org/buildbot/#/builders/202/builds/2559
  - https://lab.llvm.org/buildbot/#/builders/202/builds/2607
  - https://lab.llvm.org/buildbot/#/builders/174/builds/40959
  - https://lab.llvm.org/buildbot/#/builders/174/builds/40962
  - https://lab.llvm.org/buildbot/#/builders/174/builds/40972
  - https://lab.llvm.org/buildbot/#/builders/174/builds/40977
  - https://lab.llvm.org/buildbot/#/builders/174/builds/40991

Bumping up the rss limit previously helped in #204701, so bump it further to hope it works again.