### PR TITLE
[mlir][OpenACC] Preserve reduction mappings during materialization.

### DIFF
--- a/flang/test/Transforms/OpenACC/acc-recipe-materialization-parallel.fir
+++ b/flang/test/Transforms/OpenACC/acc-recipe-materialization-parallel.fir
@@ -3,8 +3,10 @@
 // Test that the reduction recipes are correctly inlined when attached to a
 // parallel construct without loop. Verify init and combine materialize in the region.
 // CHECK-LABEL: func.func @par_reduction_clause_
-// CHECK:       acc.parallel {
-// CHECK:       [[PRIVATE:%.*]] = acc.reduction_init {{.*}} <add>
+// CHECK:       [[HOST:%.*]] = fir.declare
+// CHECK:       [[MAPPED:%.*]] = acc.copyin varPtr([[HOST]] : !fir.ref<f64>) dataClause(acc_reduction) implicit(true) name("tmp")
+// CHECK:       acc.parallel dataOperands([[MAPPED]] : !fir.ref<f64>) {
+// CHECK:       [[PRIVATE:%.*]] = acc.reduction_init [[MAPPED]] <add>
 // CHECK-NEXT:  [[ZERO:%.*]] = arith.constant 0.000000e+00 : f64
 // CHECK-NEXT:  [[ALLOCA:%.*]] = fir.alloca f64
 // CHECK-NEXT:  {{.*}} = fir.declare [[ALLOCA]] {{.*}}acc.reduction.init
@@ -13,12 +15,13 @@
 // CHECK:       } {{.*}}acc.var_name = #acc.var_name<"tmp">
 // CHECK:       fir.load [[PRIVATE]]
 // CHECK:       fir.store {{.*}} to [[PRIVATE]]
-// CHECK:       acc.reduction_combine_region [[PRIVATE]] into [[REDUCVAR:%.*]] :
-// CHECK:       [[LOADVAR:%.*]] = fir.load [[REDUCVAR]]
+// CHECK:       acc.reduction_combine_region [[PRIVATE]] into [[MAPPED]] :
+// CHECK:       [[LOADVAR:%.*]] = fir.load [[MAPPED]]
 // CHECK-NEXT:  [[LOADPRIV:%.*]] = fir.load [[PRIVATE]]
 // CHECK-NEXT:  [[COMBINE:%.*]] = arith.addf [[LOADVAR]], [[LOADPRIV]]
-// CHECK-NEXT:  fir.store [[COMBINE]] to [[REDUCVAR]]
+// CHECK-NEXT:  fir.store [[COMBINE]] to [[MAPPED]]
 // CHECK:       acc.yield
+// CHECK:       acc.copyout accPtr([[MAPPED]] : !fir.ref<f64>) to varPtr([[HOST]] : !fir.ref<f64>) dataClause(acc_reduction) implicit(true) name("tmp")
 
 acc.reduction.recipe @reduction_add_ref_f64 : !fir.ref<f64> reduction_operator <add> init {
 ^bb0(%arg0: !fir.ref<f64>):

--- a/flang/test/Transforms/OpenACC/acc-recipe-materialization-reduction.fir
+++ b/flang/test/Transforms/OpenACC/acc-recipe-materialization-reduction.fir
@@ -3,8 +3,10 @@
 // Verify that the reduction init and combine recipes attached to compute
 // ops materialize within the region
 // CHECK-LABEL: func.func @par_reduction_clause_
-// CHECK:       acc.parallel {
-// CHECK:       [[PRIVATE:%.*]] = acc.reduction_init {{.*}} <add>
+// CHECK:       [[HOST:%.*]] = fir.declare
+// CHECK:       [[MAPPED:%.*]] = acc.copyin varPtr([[HOST]] : !fir.ref<f64>) dataClause(acc_reduction) implicit(true) name("tmp")
+// CHECK:       acc.parallel dataOperands([[MAPPED]] : !fir.ref<f64>) {
+// CHECK:       [[PRIVATE:%.*]] = acc.reduction_init [[MAPPED]] <add>
 // CHECK-NEXT:  [[ZERO:%.*]] = arith.constant 0.000000e+00 : f64
 // CHECK-NEXT:  [[ALLOCA:%.*]] = fir.alloca f64
 // CHECK-NEXT:  {{.*}} = fir.declare [[ALLOCA]] {{.*}}acc.reduction.init
@@ -13,12 +15,13 @@
 // CHECK:       } {{.*}}acc.var_name = #acc.var_name<"tmp">
 // CHECK:       fir.load [[PRIVATE]]
 // CHECK:       fir.store {{.*}} to [[PRIVATE]]
-// CHECK:       acc.reduction_combine_region [[PRIVATE]] into [[REDUCVAR:%.*]] :
-// CHECK:       [[LOADVAR:%.*]] = fir.load [[REDUCVAR]]
+// CHECK:       acc.reduction_combine_region [[PRIVATE]] into [[MAPPED]] :
+// CHECK:       [[LOADVAR:%.*]] = fir.load [[MAPPED]]
 // CHECK-NEXT:  [[LOADPRIV:%.*]] = fir.load [[PRIVATE]]
 // CHECK-NEXT:  [[COMBINE:%.*]] = arith.addf [[LOADVAR]], [[LOADPRIV]]
-// CHECK-NEXT:  fir.store [[COMBINE]] to [[REDUCVAR]]
+// CHECK-NEXT:  fir.store [[COMBINE]] to [[MAPPED]]
 // CHECK:       acc.yield
+// CHECK:       acc.copyout accPtr([[MAPPED]] : !fir.ref<f64>) to varPtr([[HOST]] : !fir.ref<f64>) dataClause(acc_reduction) implicit(true) name("tmp")
 
 acc.reduction.recipe @reduction_add_ref_f64 : !fir.ref<f64> reduction_operator <add> init {
 ^bb0(%arg0: !fir.ref<f64>):

--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCRecipeMaterialization.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCRecipeMaterialization.cpp
@@ -31,6 +31,12 @@
 // 3. Reduction: Creates acc.reduction_init (init region inlined) and
 //    acc.reduction_combine_region (combiner region inlined). Uses within
 //    the region are updated to the reduction init result.
+//    In addition, creates appropriate acc.copyin/copyout around
+//    the compute region; the reduction's initial value is taken
+//    from the copied in variable, and the final reduction value
+//    is copied out to the variable. If there are existing
+//    data operations for the reduction variable, no new data
+//    operations are added.
 //
 // Requirements:
 // -------------
@@ -192,7 +198,8 @@ private:
   template <typename OpTy, typename RecipeOpTy, typename AccOpTy>
   LogicalResult materialize(OpTy op, RecipeOpTy recipe, AccOpTy accOp,
                             acc::OpenACCSupport &accSupport,
-                            acc::ACCToGPUMappingPolicy &policy) const;
+                            acc::ACCToGPUMappingPolicy &policy,
+                            Value materializationVar = {}) const;
   template <typename OpTy>
   LogicalResult materializeForACCOp(OpTy accOp, acc::OpenACCSupport &accSupport,
                                     acc::ACCToGPUMappingPolicy &policy) const;
@@ -248,9 +255,9 @@ void ACCRecipeMaterialization::removeRecipe(
 template <typename OpTy, typename RecipeOpTy, typename AccOpTy>
 LogicalResult ACCRecipeMaterialization::materialize(
     OpTy op, RecipeOpTy recipe, AccOpTy accOp, acc::OpenACCSupport &accSupport,
-    acc::ACCToGPUMappingPolicy &policy) const {
+    acc::ACCToGPUMappingPolicy &policy, Value materializationVar) const {
   Region &region = accOp.getRegion();
-  Value origPtr = op.getVar();
+  Value origPtr = materializationVar ? materializationVar : op.getVar();
   Value accPtr = op.getAccVar();
   assert(accPtr && "invalid op: null acc var");
 
@@ -459,6 +466,78 @@ LogicalResult ACCRecipeMaterialization::materializeForACCOp(
     acc::ACCToGPUMappingPolicy &policy) const {
   assert(isa<ACC_COMPUTE_CONSTRUCT_AND_LOOP_OPS>(accOp));
 
+  // Reduction recipes use the original variable both to initialize the
+  // private reduction value and to combine the result. Preserve copy semantics
+  // when materializing reductions on compute constructs, before the
+  // acc.reduction operation carrying that intent is erased. Loop reductions
+  // are excluded: their original variable can be an outer private reduction
+  // value rather than a host variable. Keep acc.reduction referring to its
+  // original host variable and pass the mapped value to materialization
+  // separately.
+  struct ReductionMapping {
+    Value originalVar;
+    Value mappedVar;
+  };
+  SmallVector<ReductionMapping> mappedReductionVars;
+  if constexpr (!std::is_same_v<OpTy, acc::LoopOp>) {
+    for (Value dataOperand : accOp.getDataClauseOperands()) {
+      Operation *dataOp = dataOperand.getDefiningOp();
+      if (dataOp && isa<ACC_DATA_ENTRY_OPS>(dataOp))
+        mappedReductionVars.push_back({acc::getVar(dataOp), dataOperand});
+    }
+  }
+
+  auto getMappedReductionVar = [&](acc::ReductionOp reductionOp) -> Value {
+    if constexpr (std::is_same_v<OpTy, acc::LoopOp>) {
+      return reductionOp.getVar();
+    } else {
+      Value originalVar = reductionOp.getVar();
+      if (isa_and_nonnull<ACC_DATA_ENTRY_OPS>(originalVar.getDefiningOp()))
+        return originalVar;
+
+      // Note that we do not require matching bounds here.
+      // Bounds may be represented by different SSA values while evaluating to
+      // the same values at runtime. Data clauses for the same variable are
+      // expected to specify matching bounds.
+      auto existing = llvm::find_if(mappedReductionVars,
+                                    [&](const ReductionMapping &mapping) {
+                                      return mapping.originalVar == originalVar;
+                                    });
+      if (existing != mappedReductionVars.end())
+        return existing->mappedVar;
+
+      OpBuilder builder(reductionOp);
+      acc::CopyinOp copyinOp;
+      if (std::optional<StringRef> name = reductionOp.getName())
+        copyinOp =
+            acc::CopyinOp::create(builder, reductionOp.getLoc(), originalVar,
+                                  /*structured=*/true, /*implicit=*/true, *name,
+                                  reductionOp.getBounds());
+      else
+        copyinOp = acc::CopyinOp::create(
+            builder, reductionOp.getLoc(), originalVar,
+            /*structured=*/true, /*implicit=*/true, reductionOp.getBounds());
+      copyinOp.setDataClause(acc::DataClause::acc_reduction);
+      accOp.getDataClauseOperandsMutable().append(copyinOp.getAccVar());
+
+      builder.setInsertionPointAfter(accOp);
+      acc::CopyoutOp copyoutOp;
+      if (std::optional<StringRef> name = reductionOp.getName())
+        copyoutOp = acc::CopyoutOp::create(
+            builder, reductionOp.getLoc(), copyinOp.getAccVar(), originalVar,
+            /*structured=*/true, /*implicit=*/true, *name,
+            reductionOp.getBounds());
+      else
+        copyoutOp = acc::CopyoutOp::create(
+            builder, reductionOp.getLoc(), copyinOp.getAccVar(), originalVar,
+            /*structured=*/true, /*implicit=*/true, reductionOp.getBounds());
+      copyoutOp.setDataClause(acc::DataClause::acc_reduction);
+
+      mappedReductionVars.push_back({originalVar, copyinOp.getAccVar()});
+      return copyinOp.getAccVar();
+    }
+  };
+
   if (!accOp.getFirstprivateOperands().empty()) {
     // Clear the firstprivate operands list so there will be no uses after
     // the recipe is materialized.
@@ -510,7 +589,9 @@ LogicalResult ACCRecipeMaterialization::materializeForACCOp(
       auto recipeOp = cast<acc::ReductionRecipeOp>(decl);
       LLVM_DEBUG(llvm::dbgs() << "materializing: " << reductionOp << "\n"
                               << symbolRef << "\n");
-      if (failed(materialize(reductionOp, recipeOp, accOp, accSupport, policy)))
+      Value mappedVar = getMappedReductionVar(reductionOp);
+      if (failed(materialize(reductionOp, recipeOp, accOp, accSupport, policy,
+                             mappedVar)))
         return failure();
     }
   }

--- a/mlir/test/Dialect/OpenACC/acc-recipe-materialization-parallel.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-recipe-materialization-parallel.mlir
@@ -3,8 +3,10 @@
 // Test that the reduction recipes are correctly inlined when attached to a
 // parallel construct without loop. Verify init and combine materialize in the region.
 // CHECK-LABEL: func.func @par_reduction_clause_
-// CHECK:       acc.parallel {
-// CHECK:       [[PRIVATE:%.*]] = acc.reduction_init {{.*}} <add>
+// CHECK-SAME:  (%[[HOST:.*]]: memref<f64>)
+// CHECK:       %[[MAPPED:.*]] = acc.copyin varPtr(%[[HOST]] : memref<f64>) dataClause(acc_reduction) implicit(true) name("tmp")
+// CHECK:       acc.parallel dataOperands(%[[MAPPED]] : memref<f64>) {
+// CHECK:       [[PRIVATE:%.*]] = acc.reduction_init %[[MAPPED]] <add>
 // CHECK-NEXT:  [[ZERO:%.*]] = arith.constant 0.000000e+00 : f64
 // CHECK-NEXT:  [[ALLOCA:%.*]] = memref.alloca() : memref<f64>
 // CHECK-NEXT:  memref.store [[ZERO]], [[ALLOCA]][]
@@ -12,12 +14,13 @@
 // CHECK:       } {{.*}}acc.var_name = #acc.var_name<"tmp">
 // CHECK:       memref.load [[PRIVATE]][]
 // CHECK:       memref.store {{.*}}, [[PRIVATE]][]
-// CHECK:       acc.reduction_combine_region [[PRIVATE]] into [[REDUCVAR:%.*]] :
-// CHECK:       [[LOADVAR:%.*]] = memref.load [[REDUCVAR]][]
+// CHECK:       acc.reduction_combine_region [[PRIVATE]] into %[[MAPPED]] :
+// CHECK:       [[LOADVAR:%.*]] = memref.load %[[MAPPED]][]
 // CHECK-NEXT:  [[LOADPRIV:%.*]] = memref.load [[PRIVATE]][]
 // CHECK-NEXT:  [[COMBINE:%.*]] = arith.addf [[LOADVAR]], [[LOADPRIV]]
-// CHECK-NEXT:  memref.store [[COMBINE]], [[REDUCVAR]][]
+// CHECK-NEXT:  memref.store [[COMBINE]], %[[MAPPED]][]
 // CHECK:       acc.yield
+// CHECK:       acc.copyout accPtr(%[[MAPPED]] : memref<f64>) to varPtr(%[[HOST]] : memref<f64>) dataClause(acc_reduction) implicit(true) name("tmp")
 
 acc.reduction.recipe @reduction_add_memref_f64 : memref<f64> reduction_operator <add> init {
 ^bb0(%arg0: memref<f64>):

--- a/mlir/test/Dialect/OpenACC/acc-recipe-materialization-reduction.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-recipe-materialization-reduction.mlir
@@ -1,4 +1,5 @@
 // RUN: mlir-opt %s -acc-recipe-materialization | FileCheck %s
+// RUN: mlir-opt %s -acc-recipe-materialization -acc-compute-lowering | FileCheck %s --check-prefix=LOWER
 
 acc.reduction.recipe @reduction_add_memref_f64 : memref<f64> reduction_operator <add> init {
 ^bb0(%arg0: memref<f64>):
@@ -22,8 +23,10 @@ acc.reduction.recipe @reduction_add_memref_f64 : memref<f64> reduction_operator 
 // Verify that the reduction init and combine recipes attached to compute
 // ops materialize within the region
 // CHECK-LABEL: func.func @par_reduction_clause_
-// CHECK:       acc.parallel {
-// CHECK:       [[PRIVATE:%.*]] = acc.reduction_init {{.*}} <add>
+// CHECK-SAME:  (%[[HOST:.*]]: memref<f64>)
+// CHECK:       %[[MAPPED:.*]] = acc.copyin varPtr(%[[HOST]] : memref<f64>) dataClause(acc_reduction) implicit(true) name("tmp")
+// CHECK:       acc.parallel dataOperands(%[[MAPPED]] : memref<f64>) {
+// CHECK:       [[PRIVATE:%.*]] = acc.reduction_init %[[MAPPED]] <add>
 // CHECK-NEXT:  [[ZERO:%.*]] = arith.constant 0.000000e+00 : f64
 // CHECK-NEXT:  [[ALLOCA:%.*]] = memref.alloca() : memref<f64>
 // CHECK-NEXT:  memref.store [[ZERO]], [[ALLOCA]][]
@@ -31,14 +34,24 @@ acc.reduction.recipe @reduction_add_memref_f64 : memref<f64> reduction_operator 
 // CHECK:       } {{.*}}acc.par_dims = #acc<par_dims[block_x]>, acc.var_name = #acc.var_name<"tmp">
 // CHECK:       memref.load [[PRIVATE]][]
 // CHECK:       memref.store {{.*}}, [[PRIVATE]][]
-// CHECK:       acc.reduction_combine_region [[PRIVATE]] into [[REDUCVAR:%.*]] : memref<f64> {
-// CHECK:       [[LOADVAR:%.*]] = memref.load [[REDUCVAR]][]
+// CHECK:       acc.reduction_combine_region [[PRIVATE]] into %[[MAPPED]] : memref<f64> {
+// CHECK:       [[LOADVAR:%.*]] = memref.load %[[MAPPED]][]
 // CHECK-NEXT:  [[LOADPRIV:%.*]] = memref.load [[PRIVATE]][]
 // CHECK-NEXT:  [[COMBINE:%.*]] = arith.addf [[LOADVAR]], [[LOADPRIV]]
-// CHECK-NEXT:  memref.store [[COMBINE]], [[REDUCVAR]][]
+// CHECK-NEXT:  memref.store [[COMBINE]], %[[MAPPED]][]
 // CHECK-NEXT:  } {acc.par_dims = #acc<par_dims[block_x]>}
 // CHECK-NEXT:  memref.dealloc [[PRIVATE]] : memref<f64>
 // CHECK:       acc.yield
+// CHECK:       acc.copyout accPtr(%[[MAPPED]] : memref<f64>) to varPtr(%[[HOST]] : memref<f64>) dataClause(acc_reduction) implicit(true) name("tmp")
+
+// LOWER-LABEL: func.func @par_reduction_clause_
+// LOWER-SAME:  (%[[HOST:.*]]: memref<f64>)
+// LOWER:       %[[MAPPED:.*]] = acc.copyin varPtr(%[[HOST]] : memref<f64>) dataClause(acc_reduction) implicit(true) name("tmp")
+// LOWER:       acc.kernel_environment dataOperands(%[[MAPPED]] : memref<f64>) {
+// LOWER:       acc.compute_region ins(%[[SHARED:.*]] = %[[MAPPED]]) : (memref<f64>) {
+// LOWER:       acc.reduction_init %[[SHARED]] <add>
+// LOWER:       acc.reduction_combine_region {{.*}} into %[[SHARED]] : memref<f64>
+// LOWER:       acc.copyout accPtr(%[[MAPPED]] : memref<f64>) to varPtr(%[[HOST]] : memref<f64>) dataClause(acc_reduction) implicit(true) name("tmp")
 
 func.func @par_reduction_clause_(%arg0: memref<f64>) {
   %cst = arith.constant 1.000000e+00 : f64
@@ -53,8 +66,10 @@ func.func @par_reduction_clause_(%arg0: memref<f64>) {
 }
 
 // CHECK-LABEL: func.func @par_reduction_clause_serial
-// CHECK:       acc.parallel {{.*}} {
-// CHECK:       [[PRIVATE:%.*]] = acc.reduction_init {{.*}} <add>
+// CHECK-SAME:  (%[[HOST:.*]]: memref<f64>)
+// CHECK:       %[[MAPPED:.*]] = acc.copyin varPtr(%[[HOST]] : memref<f64>) dataClause(acc_reduction) implicit(true) name("tmp")
+// CHECK:       acc.parallel dataOperands(%[[MAPPED]] : memref<f64>) {{.*}} {
+// CHECK:       [[PRIVATE:%.*]] = acc.reduction_init %[[MAPPED]] <add>
 // CHECK-NEXT:  [[ZERO:%.*]] = arith.constant 0.000000e+00 : f64
 // CHECK-NEXT:  [[ALLOCA:%.*]] = memref.alloca() : memref<f64>
 // CHECK-NEXT:  memref.store [[ZERO]], [[ALLOCA]][]
@@ -62,14 +77,15 @@ func.func @par_reduction_clause_(%arg0: memref<f64>) {
 // CHECK:       } {{.*}}acc.par_dims = #acc<par_dims[sequential]>, acc.var_name = #acc.var_name<"tmp">
 // CHECK:       memref.load [[PRIVATE]][]
 // CHECK:       memref.store {{.*}}, [[PRIVATE]][]
-// CHECK:       acc.reduction_combine_region [[PRIVATE]] into [[REDUCVAR:%.*]] : memref<f64> {
-// CHECK:       [[LOADVAR:%.*]] = memref.load [[REDUCVAR]][]
+// CHECK:       acc.reduction_combine_region [[PRIVATE]] into %[[MAPPED]] : memref<f64> {
+// CHECK:       [[LOADVAR:%.*]] = memref.load %[[MAPPED]][]
 // CHECK-NEXT:  [[LOADPRIV:%.*]] = memref.load [[PRIVATE]][]
 // CHECK-NEXT:  [[COMBINE:%.*]] = arith.addf [[LOADVAR]], [[LOADPRIV]]
-// CHECK-NEXT:  memref.store [[COMBINE]], [[REDUCVAR]][]
+// CHECK-NEXT:  memref.store [[COMBINE]], %[[MAPPED]][]
 // CHECK-NEXT:  } {acc.par_dims = #acc<par_dims[sequential]>}
 // CHECK-NEXT:  memref.dealloc [[PRIVATE]] : memref<f64>
 // CHECK:       acc.yield
+// CHECK:       acc.copyout accPtr(%[[MAPPED]] : memref<f64>) to varPtr(%[[HOST]] : memref<f64>) dataClause(acc_reduction) implicit(true) name("tmp")
 
 func.func @par_reduction_clause_serial(%arg0: memref<f64>) {
   %c1_i32 = arith.constant 1 : i32
@@ -79,6 +95,54 @@ func.func @par_reduction_clause_serial(%arg0: memref<f64>) {
     %3 = memref.load %red[] : memref<f64>
     %4 = arith.addf %3, %cst fastmath<contract> : f64
     memref.store %4, %red[] : memref<f64>
+    acc.yield
+  }
+  return
+}
+
+// A reduction whose original variable is already mapped must reuse that
+// mapping rather than create another copy pair.
+// CHECK-LABEL: func.func @par_reduction_already_mapped
+// CHECK:       %[[MAPPED:.*]] = acc.copyin
+// CHECK-NOT:   acc.copyin
+// CHECK:       acc.parallel dataOperands(%[[MAPPED]] : memref<f64>) {
+// CHECK:       acc.reduction_init %[[MAPPED]] <add>
+// CHECK:       acc.reduction_combine_region {{.*}} into %[[MAPPED]] : memref<f64>
+// CHECK:       acc.copyout accPtr(%[[MAPPED]] : memref<f64>)
+
+func.func @par_reduction_already_mapped(%arg0: memref<f64>) {
+  %cst = arith.constant 1.000000e+00 : f64
+  %mapped = acc.copyin varPtr(%arg0 : memref<f64>) dataClause(acc_copy) name("tmp") -> memref<f64>
+  %red = acc.reduction varPtr(%arg0 : memref<f64>) recipe(@reduction_add_memref_f64) name("tmp") -> memref<f64>
+  acc.parallel dataOperands(%mapped : memref<f64>) reduction(%red : memref<f64>) {
+    memref.store %cst, %red[] : memref<f64>
+    acc.yield
+  }
+  acc.copyout accPtr(%mapped : memref<f64>) to varPtr(%arg0 : memref<f64>) dataClause(acc_copy) name("tmp")
+  return
+}
+
+// A nested loop reduction can reduce an outer private value. It must not
+// create a host mapping around the compute construct.
+// CHECK-LABEL: func.func @loop_reduction_private
+// CHECK-NOT:   acc.copyin
+// CHECK:       acc.parallel {
+// CHECK:       %[[SHARED:.*]] = memref.alloca() : memref<f64>
+// CHECK:       %[[PRIVATE:.*]] = acc.reduction_init %[[SHARED]] <add>
+// CHECK:       acc.reduction_combine_region %[[PRIVATE]] into %[[SHARED]]
+// CHECK-NOT:   acc.copyout
+
+func.func @loop_reduction_private() {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %cst = arith.constant 1.000000e+00 : f64
+  acc.parallel {
+    %shared = memref.alloca() : memref<f64>
+    %red = acc.reduction varPtr(%shared : memref<f64>) recipe(@reduction_add_memref_f64) name("tmp") -> memref<f64>
+    acc.loop reduction(%red : memref<f64>) control(%iv : index) = (%c0 : index) to (%c1 : index) step (%c1 : index) {
+      memref.store %cst, %red[] : memref<f64>
+      acc.yield
+    } inclusiveUpperbound(array<i1: false>) independent
     acc.yield
   }
   return


### PR DESCRIPTION
Create or reuse structured reduction mappings before compute-construct reduction recipes are consumed. Materialize initialization and combination against the mapped value while leaving nested loop reductions unchanged.

Assisted-by: Cursor