### PR TITLE
[Clang] Keep qualifiers outside of OverflowBehaviorType nodes

### DIFF
--- a/clang/docs/OverflowBehaviorTypes.md
+++ b/clang/docs/OverflowBehaviorTypes.md
@@ -91,7 +91,7 @@ as they do on any other type:
 ```c
 const __ob_trap int a = 0;
 a = 1; // error: cannot assign to variable 'a' with const-qualified type
-       // 'const __ob_trap int'
+       // '__ob_trap const int'
 ```
 
 ## Examples

--- a/clang/docs/OverflowBehaviorTypes.md
+++ b/clang/docs/OverflowBehaviorTypes.md
@@ -61,6 +61,39 @@ Arithmetic operations containing one or more overflow behavior types follow
 standard C integer promotion and conversion rules while preserving overflow
 behavior information.
 
+## Not a Type Qualifier
+
+An overflow behavior type is a *type specifier*, like `_BitInt(N)`, and not a
+type qualifier like `const`, `volatile`, or `_Atomic`. `__ob_trap int` is a
+distinct type from `int`, not a restricted way of accessing one.
+
+This distinction is observable:
+
+- `__typeof_unqual__` strips `const` and `volatile` from an overflow behavior
+  type, but keeps the overflow behavior itself.
+
+  ```c
+  __typeof_unqual__(const __ob_trap int) x; // x has type '__ob_trap int'
+  ```
+
+  Stripping the overflow behavior here would silently discard a hardening
+  contract, and because the user asked for the unqualified type there would be
+  no opportunity to diagnose it. To deliberately discard overflow behavior,
+  cast to the underlying type.
+
+- An overflow behavior type does not match its underlying type in a `_Generic`
+  association or a C++ template specialization, as described in the
+  "C \_Generic Expressions" and "C++ Template Specializations" sections below.
+
+Qualifiers may still be applied to an overflow behavior type, and they behave
+as they do on any other type:
+
+```c
+const __ob_trap int a = 0;
+a = 1; // error: cannot assign to variable 'a' with const-qualified type
+       // 'const __ob_trap int'
+```
+
 ## Examples
 
 Here are examples using both syntax options:
@@ -110,15 +143,14 @@ undefined behavior might).
 ## Promotion Rules
 
 Overflow behavior types (OBTs) follow the traditional C integer promotion and
-conversion rules while propagating overflow behavior qualifiers through
-implicit casts. This ensures compatibility with existing C semantics while
+conversion rules while propagating overflow behavior through implicit casts. This ensures compatibility with existing C semantics while
 maintaining overflow behavior information throughout arithmetic expressions.
 
 The resulting type characteristics for overflow behavior types (OBTs) across a
 variety of scenarios is detailed below.
 
 - **OBT and Standard Integer Type**: The result follows standard C conversion
-  rules, with the OBT qualifier applied to the standard result type.
+  rules, with the overflow behavior applied to the standard result type.
 
   ```c++
   typedef char __ob_trap trap_char;
@@ -153,7 +185,7 @@ variety of scenarios is detailed below.
 
 | Operation Type                              | Result Type                                                     |
 | ------------------------------------------- | --------------------------------------------------------------- |
-| OBT + Standard Integer                      | Standard C conversion result with OBT qualifier applied         |
+| OBT + Standard Integer                      | Standard C conversion result with overflow behavior applied     |
 | Same Kind OBTs (both `wrap` or both `trap`) | Standard C conversion result with common overflow behavior      |
 | Different Kind OBTs (`wrap` + `trap`)       | Standard C conversion result with `trap` behavior (dominance)   |
 

--- a/clang/include/clang/AST/TypeBase.h
+++ b/clang/include/clang/AST/TypeBase.h
@@ -6805,9 +6805,10 @@ private:
 
   QualType UnderlyingType;
   OverflowBehaviorKind BehaviorKind;
+  const ASTContext &Context;
 
-  OverflowBehaviorType(QualType Canon, QualType Underlying,
-                       OverflowBehaviorKind Kind);
+  OverflowBehaviorType(const ASTContext &Context, QualType Canon,
+                       QualType Underlying, OverflowBehaviorKind Kind);
 
 public:
   QualType getUnderlyingType() const { return UnderlyingType; }
@@ -6818,6 +6819,8 @@ public:
 
   bool isSugared() const { return false; }
   QualType desugar() const { return getUnderlyingType(); }
+
+  SplitQualType getSplitUnqualifiedType() const;
 
   void Profile(llvm::FoldingSetNodeID &ID) {
     Profile(ID, UnderlyingType, BehaviorKind);

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -5810,6 +5810,14 @@ QualType ASTContext::getOverflowBehaviorType(
     QualType Underlying) const {
   assert(!Underlying->isOverflowBehaviorType() &&
          "Cannot have underlying types that are themselves OBTs");
+
+  // Qualifiers belong outside the OverflowBehaviorType node, which is where the
+  // canonical type already puts them.
+  SplitQualType Split = Underlying.getSplitUnqualifiedType();
+  if (Split.Quals.hasQualifiers())
+    return getQualifiedType(getOverflowBehaviorType(Kind, QualType(Split.Ty, 0)),
+                            Split.Quals);
+
   llvm::FoldingSetNodeID ID;
   OverflowBehaviorType::Profile(ID, Underlying, Kind);
   llvm::FoldingSetInsertToken Token;
@@ -5819,10 +5827,8 @@ QualType ASTContext::getOverflowBehaviorType(
   }
 
   QualType Canonical;
-  if (!Underlying.isCanonical() || Underlying.hasLocalQualifiers()) {
-    SplitQualType canonSplit = getCanonicalType(Underlying).split();
-    Canonical = getOverflowBehaviorType(Kind, QualType(canonSplit.Ty, 0));
-    Canonical = getQualifiedType(Canonical, canonSplit.Quals);
+  if (!Underlying.isCanonical()) {
+    Canonical = getOverflowBehaviorType(Kind, getCanonicalType(Underlying));
     assert(!OverflowBehaviorTypes.lookup(ID, Token) &&
            "Shouldn't be in the map");
   }

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -5815,8 +5815,8 @@ QualType ASTContext::getOverflowBehaviorType(
   // canonical type already puts them.
   SplitQualType Split = Underlying.getSplitUnqualifiedType();
   if (Split.Quals.hasQualifiers())
-    return getQualifiedType(getOverflowBehaviorType(Kind, QualType(Split.Ty, 0)),
-                            Split.Quals);
+    return getQualifiedType(
+        getOverflowBehaviorType(Kind, QualType(Split.Ty, 0)), Split.Quals);
 
   llvm::FoldingSetNodeID ID;
   OverflowBehaviorType::Profile(ID, Underlying, Kind);

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -5811,13 +5811,6 @@ QualType ASTContext::getOverflowBehaviorType(
   assert(!Underlying->isOverflowBehaviorType() &&
          "Cannot have underlying types that are themselves OBTs");
 
-  // Qualifiers belong outside the OverflowBehaviorType node, which is where the
-  // canonical type already puts them.
-  SplitQualType Split = Underlying.getSplitUnqualifiedType();
-  if (Split.Quals.hasQualifiers())
-    return getQualifiedType(
-        getOverflowBehaviorType(Kind, QualType(Split.Ty, 0)), Split.Quals);
-
   llvm::FoldingSetNodeID ID;
   OverflowBehaviorType::Profile(ID, Underlying, Kind);
   llvm::FoldingSetInsertToken Token;
@@ -5827,14 +5820,16 @@ QualType ASTContext::getOverflowBehaviorType(
   }
 
   QualType Canonical;
-  if (!Underlying.isCanonical()) {
-    Canonical = getOverflowBehaviorType(Kind, getCanonicalType(Underlying));
+  if (!Underlying.isCanonical() || Underlying.hasLocalQualifiers()) {
+    SplitQualType canonSplit = getCanonicalType(Underlying).split();
+    Canonical = getOverflowBehaviorType(Kind, QualType(canonSplit.Ty, 0));
+    Canonical = getQualifiedType(Canonical, canonSplit.Quals);
     assert(!OverflowBehaviorTypes.lookup(ID, Token) &&
            "Shouldn't be in the map");
   }
 
   OverflowBehaviorType *Ty = new (*this, alignof(OverflowBehaviorType))
-      OverflowBehaviorType(Canonical, Underlying, Kind);
+      OverflowBehaviorType(*this, Canonical, Underlying, Kind);
 
   Types.push_back(Ty);
   OverflowBehaviorTypes.insert(Ty, Token);

--- a/clang/lib/AST/Type.cpp
+++ b/clang/lib/AST/Type.cpp
@@ -628,6 +628,15 @@ SplitQualType QualType::getSplitUnqualifiedTypeImpl(QualType type) {
   }
 
 done:
+  // An overflow behavior type can have a qualified underlying type. It is not
+  // sugar, so the loop above cannot desugar through it to reach the
+  // qualifiers; rebuild it with an unqualified underlying type instead.
+  if (const auto *OBT = dyn_cast<OverflowBehaviorType>(split.Ty)) {
+    SplitQualType SplitOBT = OBT->getSplitUnqualifiedType();
+    quals.addConsistentQualifiers(SplitOBT.Quals);
+    return SplitQualType(SplitOBT.Ty, quals);
+  }
+
   return SplitQualType(lastTypeWithQuals, quals);
 }
 
@@ -4141,10 +4150,21 @@ void TypeCoupledDeclRefInfo::setFromOpaqueValue(void *V) {
 }
 
 OverflowBehaviorType::OverflowBehaviorType(
-    QualType Canon, QualType Underlying,
+    const ASTContext &Context, QualType Canon, QualType Underlying,
     OverflowBehaviorType::OverflowBehaviorKind Kind)
     : Type(OverflowBehavior, Canon, Underlying->getDependence()),
-      UnderlyingType(Underlying), BehaviorKind(Kind) {}
+      UnderlyingType(Underlying), BehaviorKind(Kind), Context(Context) {}
+
+SplitQualType OverflowBehaviorType::getSplitUnqualifiedType() const {
+  SplitQualType SplitUnderlying = UnderlyingType.getSplitUnqualifiedType();
+  QualType UnqualUnderlyingTy(SplitUnderlying.Ty, 0);
+  if (UnqualUnderlyingTy == UnderlyingType)
+    return SplitQualType(this, Qualifiers());
+
+  QualType UnqualTy =
+      Context.getOverflowBehaviorType(BehaviorKind, UnqualUnderlyingTy);
+  return SplitQualType(UnqualTy.getTypePtr(), SplitUnderlying.Quals);
+}
 
 BoundsAttributedType::BoundsAttributedType(TypeClass TC, QualType Wrapped,
                                            QualType Canon)

--- a/clang/lib/AST/TypePrinter.cpp
+++ b/clang/lib/AST/TypePrinter.cpp
@@ -242,6 +242,7 @@ bool TypePrinter::canPrefixQualifiers(const Type *T,
     case Type::Pipe:
     case Type::BitInt:
     case Type::DependentBitInt:
+    case Type::OverflowBehavior:
     case Type::BTFTagAttributed:
     case Type::HLSLAttributedResource:
     case Type::HLSLInlineSpirv:
@@ -286,7 +287,6 @@ bool TypePrinter::canPrefixQualifiers(const Type *T,
     case Type::PackExpansion:
     case Type::SubstTemplateTypeParm:
     case Type::MacroQualified:
-    case Type::OverflowBehavior:
     case Type::CountAttributed:
     case Type::LateParsedAttr:
       CanPrefixQualifiers = false;

--- a/clang/test/Sema/attr-overflow-behavior.cpp
+++ b/clang/test/Sema/attr-overflow-behavior.cpp
@@ -123,7 +123,7 @@ void cpp_constexpr_bracket_initialization() {
   // expected-warning@-1 {{implicit conversion from 'int' to 'const __ob_trap short' changes value from 100000 to -31072}}
 
   constexpr short cx4 = {(int __ob_trap)100000}; // expected-error {{constant expression evaluates to 100000 which cannot be narrowed to type 'short'}}
-  // expected-warning@-1 {{implicit conversion from '__ob_trap int' to 'const __ob_trap short' changes value from 100000 to -31072}}
+  // expected-warning@-1 {{implicit conversion from '__ob_trap int' to '__ob_trap const short' changes value from 100000 to -31072}}
   // expected-note@-2 {{insert an explicit cast to silence this issue}}
 }
 

--- a/clang/test/Sema/attr-overflow-behavior.cpp
+++ b/clang/test/Sema/attr-overflow-behavior.cpp
@@ -120,10 +120,10 @@ void cpp_constexpr_bracket_initialization() {
   constexpr short __ob_wrap cx2 = {100000}; // expected-error {{constant expression evaluates to 100000 which cannot be narrowed to type '__ob_wrap short'}}
 
   constexpr short __ob_trap cx3 = {(int)100000}; // expected-error {{constant expression evaluates to 100000 which cannot be narrowed to type '__ob_trap short'}}
-  // expected-warning@-1 {{implicit conversion from 'int' to '__ob_trap short const' changes value from 100000 to -31072}}
+  // expected-warning@-1 {{implicit conversion from 'int' to 'const __ob_trap short' changes value from 100000 to -31072}}
 
   constexpr short cx4 = {(int __ob_trap)100000}; // expected-error {{constant expression evaluates to 100000 which cannot be narrowed to type 'short'}}
-  // expected-warning@-1 {{implicit conversion from '__ob_trap int' to '__ob_trap const short' changes value from 100000 to -31072}}
+  // expected-warning@-1 {{implicit conversion from '__ob_trap int' to 'const __ob_trap short' changes value from 100000 to -31072}}
   // expected-note@-2 {{insert an explicit cast to silence this issue}}
 }
 

--- a/clang/test/Sema/overflow-behavior-qualifiers.c
+++ b/clang/test/Sema/overflow-behavior-qualifiers.c
@@ -2,13 +2,13 @@
 
 // An overflow behavior type is a type specifier, not a qualifier, so
 // __typeof_unqual__ strips const/volatile off of it but keeps the overflow
-// behavior itself. Qualifiers are stored outside of the OverflowBehaviorType
-// node so that they can be found and stripped; see
-// ASTContext::getOverflowBehaviorType().
+// behavior itself. The type as written keeps its qualifiers on the underlying
+// type, so they are stripped by OverflowBehaviorType::getSplitUnqualifiedType()
+// rather than by desugaring, which cannot see through the node.
 //
 // The canonical type was always right here, so these tests check the printed
-// type: an OverflowBehaviorType that hides qualifiers in its underlying type
-// reports itself as qualified even though it is not.
+// type: an OverflowBehaviorType whose qualifiers cannot be stripped reports
+// itself as qualified even though it is not.
 
 typedef int __ob_trap tint;
 typedef const int cint;
@@ -21,23 +21,23 @@ void unqual_strips_qualifiers_only(void) {
   char *p1 = a; // expected-error {{initializing 'char *' with an expression of type 'typeof_unqual(__ob_trap int) *' (aka '__ob_trap int *')}}
 
   __typeof_unqual__(const __ob_trap int) *b;
-  char *p2 = b; // expected-error {{initializing 'char *' with an expression of type 'typeof_unqual(const __ob_trap int) *' (aka '__ob_trap int *')}}
+  char *p2 = b; // expected-error {{initializing 'char *' with an expression of type 'typeof_unqual(__ob_trap const int) *' (aka '__ob_trap int *')}}
 
   __typeof_unqual__(__ob_trap const int) *c;
-  char *p3 = c; // expected-error {{initializing 'char *' with an expression of type 'typeof_unqual(const __ob_trap int) *' (aka '__ob_trap int *')}}
+  char *p3 = c; // expected-error {{initializing 'char *' with an expression of type 'typeof_unqual(__ob_trap const int) *' (aka '__ob_trap int *')}}
 
   __typeof_unqual__(volatile __ob_trap int) *d;
-  char *p4 = d; // expected-error {{initializing 'char *' with an expression of type 'typeof_unqual(volatile __ob_trap int) *' (aka '__ob_trap int *')}}
+  char *p4 = d; // expected-error {{initializing 'char *' with an expression of type 'typeof_unqual(__ob_trap volatile int) *' (aka '__ob_trap int *')}}
 
   __typeof_unqual__(const volatile __ob_trap int) *e;
-  char *p5 = e; // expected-error {{initializing 'char *' with an expression of type 'typeof_unqual(const volatile __ob_trap int) *' (aka '__ob_trap int *')}}
+  char *p5 = e; // expected-error {{initializing 'char *' with an expression of type 'typeof_unqual(__ob_trap const volatile int) *' (aka '__ob_trap int *')}}
 
   __typeof_unqual__(const tint) *f;
   char *p6 = f; // expected-error {{initializing 'char *' with an expression of type 'typeof_unqual(const tint) *' (aka '__ob_trap int *')}}
 
   // The qualifier is reachable only through the typedef.
   __typeof_unqual__(__ob_trap cint) *g;
-  char *p7 = g; // expected-error {{initializing 'char *' with an expression of type 'typeof_unqual(const __ob_trap int) *' (aka '__ob_trap int *')}}
+  char *p7 = g; // expected-error {{initializing 'char *' with an expression of type 'typeof_unqual(__ob_trap cint) *' (aka '__ob_trap int *')}}
 
   __typeof_unqual__(const attr_tint) *h;
   char *p8 = h; // expected-error {{initializing 'char *' with an expression of type 'typeof_unqual(const attr_tint) *' (aka '__ob_trap int *')}}
@@ -63,11 +63,11 @@ void unqualified_is_writable(void) {
 // they are not being stripped. Every spelling prints the same way.
 void qualifiers_still_apply(void) {
   const __ob_trap int a = 0; // expected-note {{variable 'a' declared const here}}
-  a = 1; // expected-error {{cannot assign to variable 'a' with const-qualified type 'const __ob_trap int'}}
+  a = 1; // expected-error {{cannot assign to variable 'a' with const-qualified type '__ob_trap const int'}}
   __ob_trap const int b = 0; // expected-note {{variable 'b' declared const here}}
-  b = 1; // expected-error {{cannot assign to variable 'b' with const-qualified type 'const __ob_trap int'}}
+  b = 1; // expected-error {{cannot assign to variable 'b' with const-qualified type '__ob_trap const int'}}
   __ob_trap cint c = 0; // expected-note {{variable 'c' declared const here}}
-  c = 1; // expected-error {{cannot assign to variable 'c' with const-qualified type 'const __ob_trap int'}}
+  c = 1; // expected-error {{cannot assign to variable 'c' with const-qualified type '__ob_trap cint'}}
   const tint d = 0; // expected-note {{variable 'd' declared const here}}
   d = 1; // expected-error {{cannot assign to variable 'd' with const-qualified type 'const tint'}}
 }

--- a/clang/test/Sema/overflow-behavior-qualifiers.c
+++ b/clang/test/Sema/overflow-behavior-qualifiers.c
@@ -1,0 +1,79 @@
+// RUN: %clang_cc1 -fsyntax-only -fexperimental-overflow-behavior-types -verify %s
+
+// An overflow behavior type is a type specifier, not a qualifier, so
+// __typeof_unqual__ strips const/volatile off of it but keeps the overflow
+// behavior itself. Qualifiers are stored outside of the OverflowBehaviorType
+// node so that they can be found and stripped; see
+// ASTContext::getOverflowBehaviorType().
+//
+// The canonical type was always right here, so these tests check the printed
+// type: an OverflowBehaviorType that hides qualifiers in its underlying type
+// reports itself as qualified even though it is not.
+
+typedef int __ob_trap tint;
+typedef const int cint;
+typedef int __attribute__((overflow_behavior(trap))) attr_tint;
+
+// Every spelling of a qualified overflow behavior type strips down to the same
+// unqualified overflow behavior type. Assigning to a 'char *' prints it.
+void unqual_strips_qualifiers_only(void) {
+  __typeof_unqual__(__ob_trap int) *a;
+  char *p1 = a; // expected-error {{initializing 'char *' with an expression of type 'typeof_unqual(__ob_trap int) *' (aka '__ob_trap int *')}}
+
+  __typeof_unqual__(const __ob_trap int) *b;
+  char *p2 = b; // expected-error {{initializing 'char *' with an expression of type 'typeof_unqual(const __ob_trap int) *' (aka '__ob_trap int *')}}
+
+  __typeof_unqual__(__ob_trap const int) *c;
+  char *p3 = c; // expected-error {{initializing 'char *' with an expression of type 'typeof_unqual(const __ob_trap int) *' (aka '__ob_trap int *')}}
+
+  __typeof_unqual__(volatile __ob_trap int) *d;
+  char *p4 = d; // expected-error {{initializing 'char *' with an expression of type 'typeof_unqual(volatile __ob_trap int) *' (aka '__ob_trap int *')}}
+
+  __typeof_unqual__(const volatile __ob_trap int) *e;
+  char *p5 = e; // expected-error {{initializing 'char *' with an expression of type 'typeof_unqual(const volatile __ob_trap int) *' (aka '__ob_trap int *')}}
+
+  __typeof_unqual__(const tint) *f;
+  char *p6 = f; // expected-error {{initializing 'char *' with an expression of type 'typeof_unqual(const tint) *' (aka '__ob_trap int *')}}
+
+  // The qualifier is reachable only through the typedef.
+  __typeof_unqual__(__ob_trap cint) *g;
+  char *p7 = g; // expected-error {{initializing 'char *' with an expression of type 'typeof_unqual(const __ob_trap int) *' (aka '__ob_trap int *')}}
+
+  __typeof_unqual__(const attr_tint) *h;
+  char *p8 = h; // expected-error {{initializing 'char *' with an expression of type 'typeof_unqual(const attr_tint) *' (aka '__ob_trap int *')}}
+}
+
+// The overflow behavior itself must survive __typeof_unqual__.
+void overflow_behavior_survives(void) {
+  __typeof_unqual__(const __ob_trap int) *a;
+  int *p1 = a; // expected-warning {{discards overflow behavior}}
+  __ob_wrap int *p2 = a; // expected-error {{with incompatible overflow behavior types ('__ob_wrap' and '__ob_trap')}}
+  __ob_trap int *p3 = a;
+}
+
+// The stripped type really is writable, not just printed as writable.
+void unqualified_is_writable(void) {
+  __typeof_unqual__(const __ob_trap int) x;
+  x = 1;
+  __typeof_unqual__(__ob_trap cint) y;
+  y = 1;
+}
+
+// Qualifiers on an overflow behavior type still apply, and still print, when
+// they are not being stripped. Every spelling prints the same way.
+void qualifiers_still_apply(void) {
+  const __ob_trap int a = 0; // expected-note {{variable 'a' declared const here}}
+  a = 1; // expected-error {{cannot assign to variable 'a' with const-qualified type 'const __ob_trap int'}}
+  __ob_trap const int b = 0; // expected-note {{variable 'b' declared const here}}
+  b = 1; // expected-error {{cannot assign to variable 'b' with const-qualified type 'const __ob_trap int'}}
+  __ob_trap cint c = 0; // expected-note {{variable 'c' declared const here}}
+  c = 1; // expected-error {{cannot assign to variable 'c' with const-qualified type 'const __ob_trap int'}}
+  const tint d = 0; // expected-note {{variable 'd' declared const here}}
+  d = 1; // expected-error {{cannot assign to variable 'd' with const-qualified type 'const tint'}}
+}
+
+// Controls: stripping is unchanged for types with no overflow behavior.
+extern int e;
+extern __typeof_unqual__(const int) e;
+extern __typeof_unqual__(cint) e;
+extern __typeof_unqual__(_Atomic int) e;

--- a/clang/test/SemaCXX/sugar-common-types.cpp
+++ b/clang/test/SemaCXX/sugar-common-types.cpp
@@ -219,11 +219,11 @@ namespace overflow_behavior_types {
     volatile ConstWrapX1 a = 0;
     const volatile WrapY1 b = 0;
     N ta = a;
-    // expected-error@-1 {{cannot initialize a variable of type 'N' with an lvalue of type 'volatile ConstWrapX1' (aka '__ob_wrap X1 const volatile')}}
+    // expected-error@-1 {{cannot initialize a variable of type 'N' with an lvalue of type 'volatile ConstWrapX1' (aka 'const volatile __ob_wrap X1')}}
     N tb = b;
-    // expected-error@-1 {{cannot initialize a variable of type 'N' with an lvalue of type 'const volatile WrapY1' (aka '__ob_wrap Y1 const volatile')}}
+    // expected-error@-1 {{cannot initialize a variable of type 'N' with an lvalue of type 'const volatile WrapY1' (aka 'const volatile __ob_wrap Y1')}}
     N tc = 0 ? a : b;
-    // expected-error@-1 {{cannot initialize a variable of type 'N' with an lvalue of type '__ob_wrap B1 const volatile'}}
+    // expected-error@-1 {{cannot initialize a variable of type 'N' with an lvalue of type 'const volatile __ob_wrap B1'}}
   } // namespace balanced_qualifiers
 } // namespace overflow_behavior_types
 


### PR DESCRIPTION
`__typeof_unqual__` wasn't stripping `const` off of an overflow behavior type:

```c
  __typeof_unqual__(const __ob_trap int) x; // '__ob_trap const int'
```

The canonical type was always right, so `x` really is writable -- we just printed it as const, which is the opposite of the truth.

`getOverflowBehaviorType()` hoisted qualifiers out for the canonical type but stored the underlying type verbatim in the sugar node, so `const __ob_trap int` became `OBT{const int}` with nothing qualified at the `QualType` level. `getUnqualifiedType()` checks the canonical type to decide there's something to strip, then strips it by desugaring one step at a time. `OverflowBehaviorType` isn't sugar, so that walk dead-ends on it and the qualifiers never come off.

So the rule is: a type node you can't desugar through shouldn't have a canonical type with local qualifiers on it. Split the qualifiers off at construction and put them back outside the node, which is where the canonical already puts them.

Local qualifiers alone aren't enough here. `__ob_trap cint`, where `cint` is a `typedef const int`, has the const in its canonical type but not in its local qualifier set, and it's broken the same way. `getSplitUnqualifiedType()` gets both. We lose the `cint` spelling in that case but I think that's fine... that typedef is what was hiding the qualifier in the first place.

While here, let `canPrefixQualifiers()` prefix an OBT so we print `const __ob_trap int` instead of `__ob_trap int const`. That list is for types that wrap the declarator, and an OBT just puts a keyword in front of an integer like `_BitInt` and `_Atomic` do. We were already printing the same type two different ways in attr-overflow-behavior.cpp, which is a pretty good hint it was in the wrong list.

Note the new test checks the *printed* types. Since the canonical type was never wrong, anything that only looks at canonical types passes either way and doesn't actually test this.

Also spell out in the docs that an OBT is a type specifier and not a qualifier.


Assisted-by: claude