### PR TITLE
[clang-tools-extra][docs] Remove page-local contents directives

### DIFF
--- a/clang-tools-extra/Maintainers.md
+++ b/clang-tools-extra/Maintainers.md
@@ -4,9 +4,6 @@ This file is a list of the
 [maintainers](https://llvm.org/docs/DeveloperPolicy.html#maintainers)
 for the [Extra Clang Tools](https://clang.llvm.org/extra/index.html) project.
 
-```{contents} Table of Contents
-:depth: 2
-```
 
 # Active Maintainers
 

--- a/clang-tools-extra/docs/ReleaseNotes.md
+++ b/clang-tools-extra/docs/ReleaseNotes.md
@@ -12,10 +12,6 @@ myst:
 {#extra-clang-tools-release-releasenotestitle}
 # Extra Clang Tools {{env.config.release}} {{ (('(In-Progress) ' if env.app.tags.has('PreRelease') else '') ~ 'Release Notes') }}
 
-```{contents}
-:depth: 3
-:local: true
-```
 
 Written by the [LLVM Team](https://llvm.org/)
 

--- a/clang-tools-extra/docs/clang-change-namespace.md
+++ b/clang-tools-extra/docs/clang-change-namespace.md
@@ -1,7 +1,5 @@
 # Clang-Change-Namespace
 
-```{contents}
-```
 
 ```{toctree}
 :maxdepth: 1

--- a/clang-tools-extra/docs/clang-doc.md
+++ b/clang-tools-extra/docs/clang-doc.md
@@ -1,7 +1,5 @@
 # Clang-Doc
 
-```{contents}
-```
 
 ```{toctree}
 :maxdepth: 1

--- a/clang-tools-extra/docs/clang-include-fixer.md
+++ b/clang-tools-extra/docs/clang-include-fixer.md
@@ -1,7 +1,5 @@
 # Clang-Include-Fixer
 
-```{contents}
-```
 
 One of the major nuisances of C++ compared to other languages is the manual
 management of `#include` directives in any file.

--- a/clang-tools-extra/docs/clang-reorder-fields.md
+++ b/clang-tools-extra/docs/clang-reorder-fields.md
@@ -1,7 +1,5 @@
 # Clang-Reorder-Fields
 
-```{contents}
-```
 
 ```{toctree}
 :maxdepth: 1

--- a/clang-tools-extra/docs/clang-tidy/index.rst
+++ b/clang-tools-extra/docs/clang-tidy/index.rst
@@ -2,8 +2,6 @@
 Clang-Tidy
 ==========
 
-.. contents::
-
 See also:
 
 .. toctree::

--- a/utils/docs/remove_page_tocs.py
+++ b/utils/docs/remove_page_tocs.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Remove page-local contents directives from Sphinx documentation."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+CONTENTS = re.compile(
+    r"(?m)^```\{contents\}[^\n]*\n(?:.*\n)*?^```\n?|"
+    r"\n*^\.\. contents::[^\n]*(?:\n(?:[ \t].*|[ \t]*))*\n*"
+)
+SUFFIXES = (".rst", ".md", ".td")
+
+
+def iter_sources(root: Path):
+    if root.is_file():
+        if root.suffix in SUFFIXES:
+            yield root
+        return
+
+    for suffix in SUFFIXES:
+        yield from root.rglob(f"*{suffix}")
+
+
+def rewrite(path: Path) -> int:
+    text = path.read_text(encoding="utf-8")
+
+    def replacement(match: re.Match[str]) -> str:
+        if match.group(0).lstrip("\n").startswith("```") or not match.start():
+            return ""
+        return "\n\n" if match.end() < len(text) else "\n"
+
+    new_text, removed = CONTENTS.subn(replacement, text)
+    if new_text != text:
+        path.write_text(new_text, encoding="utf-8")
+    return removed
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "roots",
+        nargs="*",
+        type=Path,
+        default=[
+            Path("clang/docs"),
+            Path("clang/Maintainers.md"),
+            Path("clang/include/clang/Basic"),
+            Path("clang/include/clang/Options"),
+        ],
+        help="Documentation roots to scan, defaults to Clang docs and generated-doc inputs.",
+    )
+    args = parser.parse_args()
+
+    removals = [
+        (path, rewrite(path))
+        for root in args.roots
+        for path in sorted(iter_sources(root))
+    ]
+    changed = [(path, count) for path, count in removals if count]
+    for path, count in changed:
+        print(f"{path}: removed {count} contents directive(s)")
+    print(
+        f"removed {sum(count for _, count in changed)} contents directive(s) from {len(changed)} file(s)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Remove page-local TOCs before adopting Furo. This mechanical change was generated with `utils/docs/remove_page_tocs.py`, included here for conflict regeneration.

Clang Furo PR: https://github.com/llvm/llvm-project/pull/214869
RFC: https://discourse.llvm.org/t/rfc-use-furo-theme-for-clang-docs/91505/7
Preview: https://clangdocs.staging.reidkleckner.dev/after/clang-tools-extra/docs/
