### PR TITLE
[clang-tools-extra][docs] Use Furo theme to match clang

### DIFF
--- a/clang-tools-extra/Maintainers.md
+++ b/clang-tools-extra/Maintainers.md
@@ -4,9 +4,6 @@ This file is a list of the
 [maintainers](https://llvm.org/docs/DeveloperPolicy.html#maintainers)
 for the [Extra Clang Tools](https://clang.llvm.org/extra/index.html) project.
 
-```{contents} Table of Contents
-:depth: 2
-```
 
 # Active Maintainers
 

--- a/clang-tools-extra/docs/ReleaseNotes.md
+++ b/clang-tools-extra/docs/ReleaseNotes.md
@@ -12,10 +12,6 @@ myst:
 {#extra-clang-tools-release-releasenotestitle}
 # Extra Clang Tools {{env.config.release}} {{ (('(In-Progress) ' if env.app.tags.has('PreRelease') else '') ~ 'Release Notes') }}
 
-```{contents}
-:depth: 3
-:local: true
-```
 
 Written by the [LLVM Team](https://llvm.org/)
 

--- a/clang-tools-extra/docs/_static/clang-tools-extra-styles.css
+++ b/clang-tools-extra/docs/_static/clang-tools-extra-styles.css
@@ -21,3 +21,24 @@ details summary:hover {
   background-color: rgba(50, 150, 220, 0.2);
   cursor: pointer;
 }
+
+/* Use the full viewport on ordinary desktop displays, where Furo's fixed
+   content width leaves little room after both sidebars. Once the content area
+   reaches 90em (84em plus padding), grow symmetric outer margins instead. */
+@media (min-width: 67em) {
+  .page .sidebar-drawer {
+    width: max(15em, calc(50% - 45em));
+  }
+
+  .main > .content {
+    width: min(84em, calc(100vw - 36em));
+  }
+}
+
+/* Furo moves the page-local TOC into a drawer below 82em, freeing its 15em
+   column for the main content. */
+@media (min-width: 67em) and (max-width: 82em) {
+  .main > .content {
+    width: calc(100vw - 21em);
+  }
+}

--- a/clang-tools-extra/docs/_static/clang-tools-extra-styles.css
+++ b/clang-tools-extra/docs/_static/clang-tools-extra-styles.css
@@ -22,6 +22,13 @@ details summary:hover {
   cursor: pointer;
 }
 
+/* The two check tables contain long identifiers whose dots are not natural
+   line-breaking opportunities. Let table layout wrap them when needed. */
+.clang-tidy-checks-table th,
+.clang-tidy-checks-table td {
+  overflow-wrap: anywhere;
+}
+
 /* Use the full viewport on ordinary desktop displays, where Furo's fixed
    content width leaves little room after both sidebars. Once the content area
    reaches 90em (84em plus padding), grow symmetric outer margins instead. */

--- a/clang-tools-extra/docs/clang-change-namespace.md
+++ b/clang-tools-extra/docs/clang-change-namespace.md
@@ -1,7 +1,5 @@
 # Clang-Change-Namespace
 
-```{contents}
-```
 
 ```{toctree}
 :maxdepth: 1

--- a/clang-tools-extra/docs/clang-change-namespace.md
+++ b/clang-tools-extra/docs/clang-change-namespace.md
@@ -1,10 +1,6 @@
 # Clang-Change-Namespace
 
 
-```{toctree}
-:maxdepth: 1
-```
-
 {program}`clang-change-namespace` can be used to change the surrounding
 namespaces of class/function definitions.
 

--- a/clang-tools-extra/docs/clang-doc.md
+++ b/clang-tools-extra/docs/clang-doc.md
@@ -1,7 +1,5 @@
 # Clang-Doc
 
-```{contents}
-```
 
 ```{toctree}
 :maxdepth: 1

--- a/clang-tools-extra/docs/clang-doc.md
+++ b/clang-tools-extra/docs/clang-doc.md
@@ -1,10 +1,6 @@
 # Clang-Doc
 
 
-```{toctree}
-:maxdepth: 1
-```
-
 {program}`clang-doc` is a tool for generating C and C++ documentation from
 source code and comments.
 

--- a/clang-tools-extra/docs/clang-include-fixer.md
+++ b/clang-tools-extra/docs/clang-include-fixer.md
@@ -1,7 +1,5 @@
 # Clang-Include-Fixer
 
-```{contents}
-```
 
 One of the major nuisances of C++ compared to other languages is the manual
 management of `#include` directives in any file.

--- a/clang-tools-extra/docs/clang-reorder-fields.md
+++ b/clang-tools-extra/docs/clang-reorder-fields.md
@@ -1,7 +1,5 @@
 # Clang-Reorder-Fields
 
-```{contents}
-```
 
 ```{toctree}
 :maxdepth: 1

--- a/clang-tools-extra/docs/clang-reorder-fields.md
+++ b/clang-tools-extra/docs/clang-reorder-fields.md
@@ -1,10 +1,6 @@
 # Clang-Reorder-Fields
 
 
-```{toctree}
-:maxdepth: 1
-```
-
 {program}`clang-reorder-fields` is a refactoring tool to reorder fields in
 C/C++ structs and classes. This tool automatically updates:
 
@@ -401,4 +397,3 @@ by type, or by access pattern).
 ### Field grouping
 
 Group related fields together for better code organization and readability.
-

--- a/clang-tools-extra/docs/clang-tidy/checks/list.md
+++ b/clang-tools-extra/docs/clang-tidy/checks/list.md
@@ -32,6 +32,10 @@ portability/*
 readability/*
 ```
 
+:::{table}
+:class: clang-tidy-checks-table
+:widths: 90 10
+
 | Name | Offers fixes |
 | --- | --- |
 | {doc}`abseil-cleanup-ctad <abseil/cleanup-ctad>` | Yes |
@@ -445,7 +449,13 @@ readability/*
 | {doc}`readability-use-concise-preprocessor-directives <readability/use-concise-preprocessor-directives>` | Yes |
 | {doc}`readability-use-std-min-max <readability/use-std-min-max>` | Yes |
 
+:::
+
 ## Check aliases
+
+:::{table}
+:class: clang-tidy-checks-table
+:widths: 45 45 10
 
 | Name | Redirect | Offers fixes |
 | --- | --- | --- |
@@ -626,3 +636,5 @@ readability/*
 | {doc}`llvm-else-after-return <llvm/else-after-return>` | {doc}`readability-else-after-return <readability/else-after-return>` | Yes |
 | {doc}`llvm-qualified-auto <llvm/qualified-auto>` | {doc}`readability-qualified-auto <readability/qualified-auto>` | Yes |
 | {doc}`performance-faster-string-find <performance/faster-string-find>` | {doc}`performance-prefer-single-char-overloads <performance/prefer-single-char-overloads>` | Yes |
+
+:::

--- a/clang-tools-extra/docs/clang-tidy/index.rst
+++ b/clang-tools-extra/docs/clang-tidy/index.rst
@@ -2,8 +2,6 @@
 Clang-Tidy
 ==========
 
-.. contents::
-
 See also:
 
 .. toctree::

--- a/clang-tools-extra/docs/conf.py
+++ b/clang-tools-extra/docs/conf.py
@@ -70,14 +70,13 @@ rst_epilog = f"""
 
 # -- Options for HTML output ---------------------------------------------------
 
-# The theme to use for HTML and HTML Help pages.  See the documentation for
-# a list of builtin themes.
-html_theme = "haiku"
-
-# Theme options are theme-specific and customize the look and feel of a theme
-# further.  For a list of options available for each theme, see the
-# documentation.
-# html_theme_options = {}
+configure_furo(
+    globals(),
+    source_directory="clang-tools-extra/docs/",
+    html_title="Extra Clang Tools",
+    local_static_path=["_static"],
+    extra_css_files=["clang-tools-extra-styles.css"],
+)
 
 # Add any paths that contain custom themes here, relative to this directory.
 # html_theme_path = []
@@ -97,11 +96,6 @@ html_theme = "haiku"
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.
 # html_favicon = None
-
-# Add any paths that contain custom static files (such as style sheets) here,
-# relative to this directory. They are copied after the builtin static files,
-# so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/clang-tools-extra/docs/pp-trace.md
+++ b/clang-tools-extra/docs/pp-trace.md
@@ -3,10 +3,6 @@
 
 # pp-trace User's Manual
 
-```{toctree}
-:hidden: true
-```
-
 {program}`pp-trace` is a standalone tool that traces preprocessor
 activity. It's also used as a test of Clang's PPCallbacks interface.
 It runs a given source file through the Clang preprocessor, displaying
@@ -771,4 +767,3 @@ To build from source:
 [building llvm with cmake]: https://llvm.org/docs/CMake.html
 [clang tools documentation]: https://clang.llvm.org/docs/ClangTools.html
 [getting started with the llvm system]: https://llvm.org/docs/GettingStarted.html
-

--- a/utils/docs/llvm_sphinx/ext/furo.py
+++ b/utils/docs/llvm_sphinx/ext/furo.py
@@ -1,11 +1,49 @@
 """Shared Furo theme assets for LLVM Sphinx projects."""
 
+import zlib
 from pathlib import Path
 
 from sphinx.util.fileutil import copy_asset
 
 _SHARED_STATIC_PREFIX = "llvm-sphinx"
 _SHARED_STATIC_DIR = Path(__file__).parents[1] / "_static"
+
+
+def _furo_pygments_stylesheet():
+    from furo import get_pygments_stylesheet
+
+    return get_pygments_stylesheet()
+
+
+def _rebuild_on_pygments_change(app, env, added, changed, removed):
+    if app.builder.format != "html":
+        return ()
+
+    stylesheet = _furo_pygments_stylesheet().encode()
+    checksum = zlib.crc32(stylesheet.translate(None, b"\r"))
+    previous_checksum = getattr(env, "_llvm_furo_pygments_checksum", None)
+    env._llvm_furo_pygments_checksum = checksum
+    if checksum != previous_checksum:
+        return env.found_docs
+    return ()
+
+
+def _install_furo_pygments_writer(app):
+    if app.builder.format != "html":
+        return
+
+    # Sphinx normally writes pygments.css immediately before rendering HTML,
+    # which lets it add a checksum of that file to the stylesheet URL. Furo
+    # replaces the file at build-finished to add dark-mode styles, after Sphinx
+    # has already calculated the checksum. Generate Furo's final contents at
+    # Sphinx's normal asset-writing point so the checksum matches the file that
+    # Furo writes again at build-finished.
+    def create_pygments_style_file():
+        pygments_css = Path(app.builder.outdir) / "_static" / "pygments.css"
+        pygments_css.parent.mkdir(parents=True, exist_ok=True)
+        pygments_css.write_text(_furo_pygments_stylesheet(), encoding="utf-8")
+
+    app.builder.create_pygments_style_file = create_pygments_style_file
 
 
 def _add_shared_static_files(app):
@@ -27,6 +65,10 @@ def _copy_shared_static_files(app, exception):
 
 
 def setup(app):
+    # Furo initializes the light and dark Pygments styles in its own
+    # builder-inited handler at the default priority (500).
+    app.connect("builder-inited", _install_furo_pygments_writer, priority=600)
+    app.connect("env-get-outdated", _rebuild_on_pygments_change)
     app.connect("builder-inited", _add_shared_static_files)
     app.connect("build-finished", _copy_shared_static_files)
     return {

--- a/utils/docs/remove_page_tocs.py
+++ b/utils/docs/remove_page_tocs.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Remove page-local contents directives from Sphinx documentation."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+CONTENTS = re.compile(
+    r"(?m)^```\{contents\}[^\n]*\n(?:.*\n)*?^```\n?|"
+    r"\n*^\.\. contents::[^\n]*(?:\n(?:[ \t].*|[ \t]*))*\n*"
+)
+SUFFIXES = (".rst", ".md", ".td")
+
+
+def iter_sources(root: Path):
+    if root.is_file():
+        if root.suffix in SUFFIXES:
+            yield root
+        return
+
+    for suffix in SUFFIXES:
+        yield from root.rglob(f"*{suffix}")
+
+
+def rewrite(path: Path) -> int:
+    text = path.read_text(encoding="utf-8")
+
+    def replacement(match: re.Match[str]) -> str:
+        if match.group(0).lstrip("\n").startswith("```") or not match.start():
+            return ""
+        return "\n\n" if match.end() < len(text) else "\n"
+
+    new_text, removed = CONTENTS.subn(replacement, text)
+    if new_text != text:
+        path.write_text(new_text, encoding="utf-8")
+    return removed
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "roots",
+        nargs="*",
+        type=Path,
+        default=[
+            Path("clang/docs"),
+            Path("clang/Maintainers.md"),
+            Path("clang/include/clang/Basic"),
+            Path("clang/include/clang/Options"),
+        ],
+        help="Documentation roots to scan, defaults to Clang docs and generated-doc inputs.",
+    )
+    args = parser.parse_args()
+
+    removals = [
+        (path, rewrite(path))
+        for root in args.roots
+        for path in sorted(iter_sources(root))
+    ]
+    changed = [(path, count) for path, count in removals if count]
+    for path, count in changed:
+        print(f"{path}: removed {count} contents directive(s)")
+    print(
+        f"removed {sum(count for _, count in changed)} contents directive(s) from {len(changed)} file(s)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adopt the shared Furo configuration for the clang-tools-extra documentation.

I forgot to commit the `utils/docs/remove_page_tocs.py` helper script that I used to scrub the TOCs, so I included it in this PR. We can remove the script later. Anyway, I used it in this PR to remove the TOCs from clang-tools-extra.

I also ported over the CSS viewport width rules from Clang, but I'm keeping them separate between all the doc projects that use furo now (llvm, libc, clang, clang-tools-extra) since different projects have made different choices.

Clang Furo PR: https://github.com/llvm/llvm-project/pull/214869
RFC: https://discourse.llvm.org/t/rfc-use-furo-theme-for-clang-docs/91505/7
Preview: https://clangdocs.staging.reidkleckner.dev/after/clang-tools-extra/docs/
