### PR TITLE
[CIR] Enable PCH Build

### DIFF
--- a/clang/lib/CIR/CodeGen/CMakeLists.txt
+++ b/clang/lib/CIR/CodeGen/CMakeLists.txt
@@ -64,6 +64,10 @@ add_clang_library(clangCIR
   MLIRCIR
   MLIRCIROpInterfacesIncGen
 
+  DISABLE_PCH_REUSE # PCH contains private headers
+  PRECOMPILE_HEADERS
+  [["pch.h"]]
+
   LINK_LIBS
   clangAST
   clangBasic

--- a/clang/lib/CIR/CodeGen/pch.h
+++ b/clang/lib/CIR/CodeGen/pch.h
@@ -18,6 +18,5 @@
 #include "CIRGenValue.h"
 #include "mlir/Dialect/OpenACC/OpenACC.h"
 #include "mlir/Dialect/OpenMP/OpenMPDialect.h"
-#include "mlir/Dialect/Ptr/IR/MemorySpaceInterfaces.h"
 #include "clang/AST/pch.h"
 #include "llvm/Support/pch.h"

--- a/clang/lib/CIR/CodeGen/pch.h
+++ b/clang/lib/CIR/CodeGen/pch.h
@@ -1,0 +1,23 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// Precompiled header for clangCIR. Uses private headers.
+///
+//===----------------------------------------------------------------------===//
+
+#include "Address.h"
+#include "CIRGenBuilder.h"
+#include "CIRGenCXXABI.h"
+#include "CIRGenFunction.h"
+#include "CIRGenModule.h"
+#include "CIRGenValue.h"
+#include "mlir/Dialect/OpenACC/OpenACC.h"
+#include "mlir/Dialect/OpenMP/OpenMPDialect.h"
+#include "mlir/Dialect/Ptr/IR/MemorySpaceInterfaces.h"
+#include "clang/AST/pch.h"
+#include "llvm/Support/pch.h"

--- a/clang/lib/CIR/Dialect/CMakeLists.txt
+++ b/clang/lib/CIR/Dialect/CMakeLists.txt
@@ -1,5 +1,10 @@
-add_subdirectory(Analysis)
+# IR must be processed first: it defines MLIRCIR, whose PCH other CIR
+# dialect libraries below (Analysis, OpenACC, OpenMP, Transforms) can
+# automatically reuse via llvm_update_pch's LLVM_PCH_PRIORITY dependency
+# scan -- that scan only sees targets that already exist, so MLIRCIR must
+# be defined before anything that wants to reuse its PCH.
 add_subdirectory(IR)
+add_subdirectory(Analysis)
 add_subdirectory(OpenACC)
 add_subdirectory(OpenMP)
 add_subdirectory(Transforms)

--- a/clang/lib/CIR/Dialect/IR/CMakeLists.txt
+++ b/clang/lib/CIR/Dialect/IR/CMakeLists.txt
@@ -13,6 +13,13 @@ add_clang_library(MLIRCIR
   MLIRCIROpInterfacesIncGen
   MLIRCIRLoopOpInterfaceIncGen
 
+  # CIRDialect.h is a public header and the most commonly-included header
+  # across the rest of clang/lib/CIR; building it here (rather than as a
+  # private per-library PCH) lets every other CIR library that links
+  # MLIRCIR automatically reuse this PCH too.
+  PRECOMPILE_HEADERS
+  [["clang/CIR/Dialect/IR/CIRDialect.h"]]
+
   LINK_LIBS PUBLIC
   MLIRIR
   MLIRCIRInterfaces

--- a/clang/lib/CIR/Dialect/Transforms/CMakeLists.txt
+++ b/clang/lib/CIR/Dialect/Transforms/CMakeLists.txt
@@ -18,6 +18,10 @@ add_clang_library(MLIRCIRTransforms
   DEPENDS
   MLIRCIRPassIncGen
 
+  DISABLE_PCH_REUSE # PCH contains private headers
+  PRECOMPILE_HEADERS
+  [["pch.h"]]
+
   LINK_LIBS PUBLIC
   clangAST
   clangBasic

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CMakeLists.txt
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CMakeLists.txt
@@ -11,6 +11,10 @@ add_clang_library(MLIRCIRTargetLowering
   DEPENDS
   clangBasic
 
+  DISABLE_PCH_REUSE # PCH contains private headers
+  PRECOMPILE_HEADERS
+  [["pch.h"]]
+
   LINK_COMPONENTS
   TargetParser
 

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/pch.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/pch.h
@@ -1,0 +1,15 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// Precompiled header for MLIRCIRTargetLowering. Uses private headers.
+///
+//===----------------------------------------------------------------------===//
+
+#include "CIRCXXABI.h"
+#include "LowerModule.h"
+#include "TargetLoweringInfo.h"

--- a/clang/lib/CIR/Dialect/Transforms/pch.h
+++ b/clang/lib/CIR/Dialect/Transforms/pch.h
@@ -11,10 +11,10 @@
 //===----------------------------------------------------------------------===//
 
 #include "PassDetail.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/DialectConversion.h"
 #include "clang/CIR/Dialect/Builder/CIRBaseBuilder.h"
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
 #include "clang/CIR/Dialect/Passes.h"
 #include "clang/CIR/Dialect/Transforms/CIRTransformUtils.h"
 #include "clang/CIR/MissingFeatures.h"
-#include "mlir/IR/PatternMatch.h"
-#include "mlir/Transforms/DialectConversion.h"

--- a/clang/lib/CIR/Dialect/Transforms/pch.h
+++ b/clang/lib/CIR/Dialect/Transforms/pch.h
@@ -1,0 +1,20 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// Precompiled header for MLIRCIRTransforms. Uses private headers.
+///
+//===----------------------------------------------------------------------===//
+
+#include "PassDetail.h"
+#include "clang/CIR/Dialect/Builder/CIRBaseBuilder.h"
+#include "clang/CIR/Dialect/IR/CIRDialect.h"
+#include "clang/CIR/Dialect/Passes.h"
+#include "clang/CIR/Dialect/Transforms/CIRTransformUtils.h"
+#include "clang/CIR/MissingFeatures.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/DialectConversion.h"


### PR DESCRIPTION
A very simple PCH file that seems to gain us about 3% on build time.  On my personal build (with a bunch of our other optimizations) it goes from:

real: 7m58  -->7m42
user: 612m53-->585m18
sys:  36m27 -->34m57

I suspect there are more gains to be had by adding other files here, but this improvement seems worth doing.