### PR TITLE
[clang][deps] Track directory dependencies of modules

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -238,6 +238,12 @@ features cannot lower the translation-unit ABI level;
 
 - Added support for the `__builtin_strlcat` builtin.
 
+- Added support for efficiently detecting when adding a header file to the file
+  system should invalidate a module with an umbrella. `clang-scan-deps` reports
+  such paths via `directory-deps` in its `experimental-full` output. Build
+  systems can watch these directories and pass invalidated ones to
+  `clang-scan-deps` via `-invalidated-directory=` in future incremental scans.
+
 ### New Compiler Flags
 
 - New option `-fdefined-pointer-subtraction` added to preserve stable semantics

--- a/clang/include/clang/Basic/DiagnosticSerializationKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSerializationKinds.td
@@ -109,6 +109,15 @@ def remark_module_validation : Remark<
   "validating %0 input files in module '%1' from '%2'">,
   ShowInSystemHeader,
   InGroup<ModuleValidation>;
+def remark_module_directory_dep_changed
+    : Remark<"module '%0' is out of date because the build system reported "
+             "that the contents of directory '%1' changed">,
+      ShowInSystemHeader,
+      InGroup<ModuleValidation>;
+def err_module_directory_dep_changed
+    : Error<"module '%0' cannot be reused because the build system reported "
+            "that the contents of directory '%1' changed">,
+      ShowInSystemHeader, DefaultFatal;
 def remark_module_check_relocation
     : Remark<"checking if module '%0' from '%1' has relocated">,
       ShowInSystemHeader,

--- a/clang/include/clang/Basic/Module.h
+++ b/clang/include/clang/Basic/Module.h
@@ -403,6 +403,9 @@ public:
   /// The location of the umbrella header or directory declaration.
   SourceLocation UmbrellaDeclLoc;
 
+  /// Directories this module depends on the listing of.
+  std::vector<std::string> DirectoryDependencies;
+
   /// The module signature.
   ASTFileSignature Signature;
 
@@ -993,6 +996,15 @@ public:
   /// explicitly written in the module map file, or the parent of the umbrella
   /// header.
   OptionalDirectoryEntryRef getEffectiveUmbrellaDir() const;
+
+  /// Record that this module depends on the listing of \p Path, which must name
+  /// a location in an underlying file system, not in a VFS overlay. Callers
+  /// normally want \c ModuleMap::recordDirectoryDependencies.
+  void addDirectoryDependency(StringRef Path);
+
+  ArrayRef<std::string> getDirectoryDependencies() const {
+    return DirectoryDependencies;
+  }
 
   /// Add a top-level header associated with this module.
   void addTopHeader(FileEntryRef File);

--- a/clang/include/clang/DependencyScanning/DependencyGraph.h
+++ b/clang/include/clang/DependencyScanning/DependencyGraph.h
@@ -107,6 +107,12 @@ struct ModuleDeps {
   /// on, not including transitive dependencies.
   std::vector<PrebuiltModuleDep> PrebuiltModuleDeps;
 
+  /// Absolute paths to directories this module depends on the listing of. The
+  /// build system may watch these recursively and report changes via
+  /// \c DependencyScanningService::addInvalidatedDirectories to support
+  /// incremental builds when headers are added to umbrella directories.
+  std::vector<std::string> DirectoryDeps;
+
   /// A list of module identifiers this module directly depends on, not
   /// including transitive dependencies.
   ///

--- a/clang/include/clang/DependencyScanning/DependencyScanningService.h
+++ b/clang/include/clang/DependencyScanning/DependencyScanningService.h
@@ -12,6 +12,7 @@
 #include "clang/Basic/AtomicLineLogger.h"
 #include "clang/DependencyScanning/DependencyScanningFilesystem.h"
 #include "clang/DependencyScanning/InProcessModuleCache.h"
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/BitmaskEnum.h"
 
 namespace clang {
@@ -123,6 +124,15 @@ public:
   }
 
   ModuleCacheEntries &getModuleCacheEntries() { return ModCacheEntries; }
+
+  /// Atomically add directories that changed since the previous scan. This
+  /// allows cached scanning modules to be invalidated when headers are added.
+  ///
+  /// These paths need to be identical to the paths returned in
+  /// \c ModuleDeps::DirectoryDeps.
+  void addInvalidatedDirectories(llvm::ArrayRef<std::string> Dirs) {
+    ModCacheEntries.addInvalidatedDirectories(Dirs);
+  }
 
   AtomicLineLogger &getLogger() { return Logger; }
 

--- a/clang/include/clang/DependencyScanning/InProcessModuleCache.h
+++ b/clang/include/clang/DependencyScanning/InProcessModuleCache.h
@@ -11,7 +11,9 @@
 
 #include "clang/Basic/AtomicLineLogger.h"
 #include "clang/Serialization/ModuleCache.h"
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringMap.h"
+#include "llvm/ADT/StringSet.h"
 
 #include <atomic>
 #include <condition_variable>
@@ -33,6 +35,8 @@ struct ModuleCacheEntry {
 
   std::atomic<std::time_t> Timestamp = 0;
 
+  std::atomic<bool> DirectoriesValidated = false;
+
   enum {
     S_Unknown,
     S_Read,
@@ -50,8 +54,19 @@ struct ModuleCacheEntries {
   std::mutex Mutex;
   llvm::StringMap<std::unique_ptr<ModuleCacheEntry>> Map;
 
+  void addInvalidatedDirectories(llvm::ArrayRef<std::string> Dirs);
+  bool isDirectoryInvalidated(StringRef Directory) const;
+  bool hasInvalidatedDirectories() const {
+    return AnyInvalidatedDirs.load(std::memory_order_acquire);
+  }
+
   /// Flushes all PCMs built in-process to disk.
   void flush();
+
+private:
+  mutable std::mutex InvalidatedDirsMutex;
+  llvm::StringSet<> InvalidatedDirs;
+  std::atomic<bool> AnyInvalidatedDirs = false;
 };
 
 std::shared_ptr<ModuleCache>

--- a/clang/include/clang/Frontend/CompilerInstance.h
+++ b/clang/include/clang/Frontend/CompilerInstance.h
@@ -112,6 +112,11 @@ class CompilerInstance : public ModuleLoader {
   /// The cache of PCM files.
   std::shared_ptr<ModuleCache> ModCache;
 
+  /// Directory dependencies from the instance that requested this module build.
+  /// An inferred framework is built from printed module map text rather than by
+  /// repeating the inference, so its \c Frameworks listing is only seen there.
+  std::vector<std::string> InheritedDirectoryDependencies;
+
   /// Functor for getting the dependency preprocessor directives of a file.
   std::unique_ptr<DependencyDirectivesGetter> GetDependencyDirectives;
 
@@ -1000,6 +1005,14 @@ public:
 
   ModuleCache &getModuleCache() const { return *ModCache; }
   std::shared_ptr<ModuleCache> getModuleCachePtr() const { return ModCache; }
+
+  /// See \c InheritedDirectoryDependencies.
+  ArrayRef<std::string> getInheritedDirectoryDependencies() const {
+    return InheritedDirectoryDependencies;
+  }
+  void setInheritedDirectoryDependencies(ArrayRef<std::string> Dirs) {
+    InheritedDirectoryDependencies.assign(Dirs.begin(), Dirs.end());
+  }
 };
 
 } // end namespace clang

--- a/clang/include/clang/Lex/ModuleMap.h
+++ b/clang/include/clang/Lex/ModuleMap.h
@@ -732,6 +732,9 @@ public:
                              const Twine &PathRelativeToRootModuleDirectory,
                              SourceLocation Loc = SourceLocation());
 
+  /// Record that \p Mod depends on the listing of \p Dir. \p Dir is a VFS path.
+  void recordDirectoryDependencies(Module *Mod, StringRef Dir);
+
   /// Sets the umbrella directory of the given module to the given directory.
   void setUmbrellaDirAsWritten(Module *Mod, DirectoryEntryRef UmbrellaDir,
                                const Twine &NameAsWritten,

--- a/clang/include/clang/Serialization/ASTBitCodes.h
+++ b/clang/include/clang/Serialization/ASTBitCodes.h
@@ -44,7 +44,7 @@ namespace serialization {
 /// Version 4 of AST files also requires that the version control branch and
 /// revision match exactly, since there is no backward compatibility of
 /// AST files at this time.
-const unsigned VERSION_MAJOR = 39;
+const unsigned VERSION_MAJOR = 40;
 
 /// AST file minor version number supported by this version of
 /// Clang.
@@ -367,6 +367,10 @@ enum ControlRecordTypes {
 
   /// Record code for the module build directory.
   MODULE_DIRECTORY,
+
+  /// Record code for the directories this AST file depends on the listing of.
+  /// Only emitted when non-empty.
+  MODULE_DIRECTORY_DEPENDENCIES,
 };
 
 /// Record types that occur within the options block inside

--- a/clang/include/clang/Serialization/ASTReader.h
+++ b/clang/include/clang/Serialization/ASTReader.h
@@ -1581,6 +1581,10 @@ private:
   ASTReadResult ReadModuleMapFileBlock(RecordData &Record, ModuleFile &F,
                                        const ModuleFile *ImportedBy,
                                        unsigned ClientLoadCapabilities);
+
+  ASTReadResult ReadDirectoryDependencies(const RecordData &Record,
+                                          ModuleFile &F,
+                                          unsigned ClientLoadCapabilities);
   static bool ParseLanguageOptions(const RecordData &Record,
                                    StringRef ModuleFilename, bool Complain,
                                    ASTReaderListener &Listener,

--- a/clang/include/clang/Serialization/ModuleCache.h
+++ b/clang/include/clang/Serialization/ModuleCache.h
@@ -13,6 +13,7 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/StringMap.h"
+#include "llvm/ADT/StringRef.h"
 #include "llvm/Support/FileSystem/UniqueID.h"
 
 #include <ctime>
@@ -72,6 +73,20 @@ public:
   /// Updates the timestamp denoting the last time inputs of the module file
   /// were validated.
   virtual void updateModuleTimestamp(StringRef ModuleFilename) = 0;
+
+  /// Whether \p ModuleFilename still needs checking against the directories the
+  /// build system reported as changed. Caches that don't track this return
+  /// false, disabling the check.
+  virtual bool needsDirectoryValidation(StringRef ModuleFilename) {
+    return false;
+  }
+
+  virtual bool isDirectoryInvalidated(StringRef Directory) { return false; }
+
+  /// Record that \p ModuleFilename is up to date with respect to the
+  /// directories the build system reported as changed, so it is not checked
+  /// again.
+  virtual void markDirectoriesValidated(StringRef ModuleFilename) {}
 
   /// Prune module files that haven't been accessed in a long time.
   virtual void maybePrune(StringRef Path, time_t PruneInterval,

--- a/clang/include/clang/Serialization/ModuleFile.h
+++ b/clang/include/clang/Serialization/ModuleFile.h
@@ -204,6 +204,9 @@ public:
 
   std::string ModuleMapPath;
 
+  /// Directories this module file depends on the listing of.
+  std::vector<std::string> DirectoryDependencies;
+
   /// Whether this precompiled header is a relocatable PCH file.
   bool RelocatablePCH = false;
 

--- a/clang/lib/Basic/Module.cpp
+++ b/clang/lib/Basic/Module.cpp
@@ -24,6 +24,7 @@
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/Path.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cassert>
 #include <functional>
@@ -267,6 +268,27 @@ OptionalDirectoryEntryRef Module::getEffectiveUmbrellaDir() const {
   if (const auto *Dir = std::get_if<DirectoryEntryRef>(&Umbrella))
     return *Dir;
   return std::nullopt;
+}
+
+/// Whether watching \p Ancestor recursively also covers \p Path.
+static bool coversPath(StringRef Ancestor, StringRef Path) {
+  return Path.starts_with(Ancestor) &&
+         (Path.size() == Ancestor.size() ||
+          llvm::sys::path::is_separator(Path[Ancestor.size()]));
+}
+
+void Module::addDirectoryDependency(StringRef Path) {
+  Module *TopLevel = getTopLevelModule();
+  std::vector<std::string> &Deps = TopLevel->DirectoryDependencies;
+  // These are recursive dependencies, so an entry under one already recorded
+  // adds nothing. Submodules contribute to the same list, and their umbrellas
+  // often nest.
+  for (const std::string &Dep : Deps)
+    if (coversPath(Dep, Path))
+      return;
+  llvm::erase_if(Deps,
+                 [&](const std::string &Dep) { return coversPath(Path, Dep); });
+  Deps.emplace_back(Path);
 }
 
 void Module::addTopHeader(FileEntryRef File) {

--- a/clang/lib/DependencyScanning/InProcessModuleCache.cpp
+++ b/clang/lib/DependencyScanning/InProcessModuleCache.cpp
@@ -22,6 +22,29 @@
 using namespace clang;
 using namespace dependencies;
 
+void ModuleCacheEntries::addInvalidatedDirectories(
+    llvm::ArrayRef<std::string> Dirs) {
+  if (Dirs.empty())
+    return;
+  bool Added = false;
+  {
+    std::lock_guard<std::mutex> Lock(InvalidatedDirsMutex);
+    for (StringRef Dir : Dirs) {
+      SmallString<256> Canonical(Dir);
+      llvm::sys::fs::make_absolute(Canonical);
+      llvm::sys::path::remove_dots(Canonical, /*remove_dot_dot=*/true);
+      Added |= InvalidatedDirs.insert(Canonical).second;
+    }
+  }
+  if (Added)
+    AnyInvalidatedDirs.store(true, std::memory_order_release);
+}
+
+bool ModuleCacheEntries::isDirectoryInvalidated(StringRef Directory) const {
+  std::lock_guard<std::mutex> Lock(InvalidatedDirsMutex);
+  return InvalidatedDirs.contains(Directory);
+}
+
 void ModuleCacheEntries::flush() {
   auto BypassSandbox = llvm::sys::sandbox::scopedDisable();
   for (auto &[Path, Entry] : Map) {
@@ -132,6 +155,23 @@ public:
 
     Logger.log() << "timestamp_write: " << Filename;
     Timestamp.store(llvm::sys::toTimeT(std::chrono::system_clock::now()));
+  }
+
+  bool needsDirectoryValidation(StringRef Filename) override {
+    if (!Entries.hasInvalidatedDirectories())
+      return false; // The build system reported nothing changed.
+    return !getOrCreateEntry(Filename).DirectoriesValidated.load(
+        std::memory_order_acquire);
+  }
+
+  bool isDirectoryInvalidated(StringRef Directory) override {
+    return Entries.isDirectoryInvalidated(Directory);
+  }
+
+  void markDirectoriesValidated(StringRef Filename) override {
+    if (Entries.hasInvalidatedDirectories())
+      getOrCreateEntry(Filename).DirectoriesValidated.store(
+          true, std::memory_order_release);
   }
 
   void maybePrune(StringRef Path, time_t PruneInterval,

--- a/clang/lib/DependencyScanning/ModuleDepCollector.cpp
+++ b/clang/lib/DependencyScanning/ModuleDepCollector.cpp
@@ -808,6 +808,11 @@ ModuleDepCollector::handleTopLevelModule(serialization::ModuleFile *MF) {
         MD.ModuleMapFileDeps.emplace_back(*ResolvedFilenameAsRequested);
       });
 
+  MD.DirectoryDeps = MF->DirectoryDependencies;
+  llvm::sort(MD.DirectoryDeps);
+  MD.DirectoryDeps.erase(llvm::unique(MD.DirectoryDeps),
+                         MD.DirectoryDeps.end());
+
   bool IgnoreCWD = false;
   CowCompilerInvocation CI =
       MDC.getInvocationAdjustedForModuleBuildWithoutOutputs(

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -1436,11 +1436,14 @@ std::unique_ptr<CompilerInstance> CompilerInstance::cloneForModuleCompile(
     bool IsSystem = isSystem(SLoc.getFile().getFileCharacteristic());
 
     // Use the module map where this module resides.
-    return cloneForModuleCompileImpl(
+    auto Instance = cloneForModuleCompileImpl(
         ImportLoc, ModuleName,
         FrontendInputFile(ModuleMapFilePath, IK, IsSystem),
         ModMap.getModuleMapFileForUniquing(Module)->getName(), ModuleFileName,
         std::move(ThreadSafeConfig));
+    Instance->setInheritedDirectoryDependencies(
+        Module->getDirectoryDependencies());
+    return Instance;
   }
 
   // FIXME: We only need to fake up an input file here as a way of
@@ -1459,6 +1462,12 @@ std::unique_ptr<CompilerInstance> CompilerInstance::cloneForModuleCompile(
       FrontendInputFile(FakeModuleMapFile, IK, +Module->IsSystem),
       ModMap.getModuleMapFileForUniquing(Module)->getName(), ModuleFileName,
       std::move(ThreadSafeConfig));
+  // This instance builds from the module map text printed above rather than by
+  // repeating the inference, so directories the inference enumerated (a
+  // framework's Frameworks subdirectory) are only known here. Hand them over so
+  // they reach the module's AST file.
+  Instance->setInheritedDirectoryDependencies(
+      Module->getDirectoryDependencies());
 
   std::unique_ptr<llvm::MemoryBuffer> ModuleMapBuffer =
       llvm::MemoryBuffer::getMemBufferCopy(InferredModuleMapContent);
@@ -1555,6 +1564,10 @@ static bool compileModuleImpl(CompilerInstance &ImportingInstance,
           .ModulesValidateOncePerBuildSession) {
     ImportingInstance.getModuleCache().updateModuleTimestamp(ModuleFileName);
   }
+
+  // This module was just built, so it reflects the current contents of every
+  // directory it enumerated.
+  ImportingInstance.getModuleCache().markDirectoriesValidated(ModuleFileName);
 
   // This isn't strictly necessary, but it's more efficient to extract the AST
   // file (which may be wrapped in an object file) now rather than doing so

--- a/clang/lib/Frontend/FrontendAction.cpp
+++ b/clang/lib/Frontend/FrontendAction.cpp
@@ -828,6 +828,11 @@ static std::unique_ptr<llvm::MemoryBuffer>
 getInputBufferForModule(CompilerInstance &CI, Module *M) {
   FileManager &FileMgr = CI.getFileManager();
 
+  // Merge in directories the requesting instance enumerated on this module's
+  // behalf.
+  for (StringRef Dir : CI.getInheritedDirectoryDependencies())
+    M->addDirectoryDependency(Dir);
+
   // Collect the set of #includes we need to build the module.
   SmallString<256> HeaderContents;
   std::error_code Err = std::error_code();

--- a/clang/lib/Lex/ModuleMap.cpp
+++ b/clang/lib/Lex/ModuleMap.cpp
@@ -1266,6 +1266,8 @@ Module *ModuleMap::inferFrameworkModule(DirectoryEntryRef FrameworkDir,
   llvm::sys::path::append(SubframeworksDirName, "Frameworks");
   llvm::sys::path::native(SubframeworksDirName);
   llvm::vfs::FileSystem &FS = FileMgr.getVirtualFileSystem();
+  // Every entry here becomes a submodule of this framework.
+  recordDirectoryDependencies(Result, SubframeworksDirName);
   for (llvm::vfs::directory_iterator
            Dir = FS.dir_begin(SubframeworksDirName, EC),
            DirEnd;
@@ -1340,10 +1342,23 @@ void ModuleMap::setUmbrellaHeaderAsWritten(
   Mod->UmbrellaRelativeToRootModuleDirectory =
       PathRelativeToRootModuleDirectory.str();
   UmbrellaDirs[UmbrellaHeader.getDir()] = Mod;
+  recordDirectoryDependencies(Mod, UmbrellaHeader.getDir().getName());
 
   // Notify callbacks that we just added a new header.
   for (const auto &Cb : Callbacks)
     Cb->moduleMapAddUmbrellaHeader(UmbrellaHeader);
+}
+
+void ModuleMap::recordDirectoryDependencies(Module *Mod, StringRef Dir) {
+  FileManager &FileMgr = SourceMgr.getFileManager();
+  SmallVector<std::string, 2> Sources;
+  FileMgr.getVirtualFileSystem().getDirectoryContentSources(Dir, Sources);
+  for (StringRef Source : Sources) {
+    SmallString<256> Canonical(Source);
+    FileMgr.makeAbsolutePath(Canonical);
+    llvm::sys::path::remove_dots(Canonical, /*remove_dot_dot=*/true);
+    Mod->addDirectoryDependency(Canonical);
+  }
 }
 
 void ModuleMap::setUmbrellaDirAsWritten(
@@ -1355,6 +1370,8 @@ void ModuleMap::setUmbrellaDirAsWritten(
   Mod->UmbrellaRelativeToRootModuleDirectory =
       PathRelativeToRootModuleDirectory.str();
   UmbrellaDirs[UmbrellaDir] = Mod;
+  // The umbrella directory tree is enumerated to collect the module's headers.
+  recordDirectoryDependencies(Mod, UmbrellaDir.getName());
 }
 
 void ModuleMap::addUnresolvedHeader(Module *Mod,
@@ -2217,6 +2234,7 @@ void ModuleMapLoader::handleUmbrellaDirDecl(
     SmallVector<Module::Header, 6> Headers;
     llvm::vfs::FileSystem &FS =
         SourceMgr.getFileManager().getVirtualFileSystem();
+    Map.recordDirectoryDependencies(ActiveModule, Dir->getName());
     for (llvm::vfs::recursive_directory_iterator I(FS, Dir->getName(), EC), E;
          I != E && !EC; I.increment(EC)) {
       if (auto FE = SourceMgr.getFileManager().getOptionalFileRef(I->path())) {

--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -3689,6 +3689,12 @@ ASTReader::ReadControlBlock(ModuleFile &F,
         return Result;
       break;
 
+    case MODULE_DIRECTORY_DEPENDENCIES:
+      if (ASTReadResult Result =
+              ReadDirectoryDependencies(Record, F, ClientLoadCapabilities))
+        return Result;
+      break;
+
     case INPUT_FILE_OFFSETS:
       NumInputs = Record[0];
       NumUserInputs = Record[1];
@@ -4840,6 +4846,32 @@ ASTReader::ReadModuleMapFileBlock(RecordData &Record, ModuleFile &F,
 
   if (Listener)
     Listener->ReadModuleMapFile(F.ModuleMapPath);
+
+  return Success;
+}
+
+ASTReader::ASTReadResult
+ASTReader::ReadDirectoryDependencies(const RecordData &Record, ModuleFile &F,
+                                     unsigned ClientLoadCapabilities) {
+  unsigned Idx = 0;
+  unsigned N = Record[Idx++];
+  F.DirectoryDependencies.reserve(N);
+  for (unsigned I = 0; I != N; ++I)
+    F.DirectoryDependencies.push_back(ReadPath(F, Record, Idx));
+
+  ModuleCache &ModCache = getModuleManager().getModuleCache();
+  if (F.Kind != MK_ImplicitModule ||
+      !ModCache.needsDirectoryValidation(F.FileName))
+    return Success;
+
+  for (StringRef Dir : F.DirectoryDependencies) {
+    if (!ModCache.isDirectoryInvalidated(Dir))
+      continue;
+    Diag(diag::remark_module_directory_dep_changed) << F.ModuleName << Dir;
+    if (!canRecoverFromOutOfDate(F.FileName, ClientLoadCapabilities))
+      Diag(diag::err_module_directory_dep_changed) << F.ModuleName << Dir;
+    return OutOfDate;
+  }
   return Success;
 }
 
@@ -5229,6 +5261,11 @@ ASTReader::ASTReadResult ASTReader::ReadAST(ModuleFileName FileName,
             M.Mod->FileName);
     }
   }
+
+  ModuleCache &ModCache = getModuleManager().getModuleCache();
+  for (ImportedModule &M : Loaded)
+    if (M.Mod->Kind == MK_ImplicitModule)
+      ModCache.markDirectoriesValidated(M.Mod->FileName);
 
   return Success;
 }

--- a/clang/lib/Serialization/ASTWriter.cpp
+++ b/clang/lib/Serialization/ASTWriter.cpp
@@ -898,6 +898,7 @@ void ASTWriter::WriteBlockInfoBlock() {
   RECORD(MODULE_NAME);
   RECORD(MODULE_DIRECTORY);
   RECORD(MODULE_MAP_FILE);
+  RECORD(MODULE_DIRECTORY_DEPENDENCIES);
   RECORD(IMPORT);
   RECORD(ORIGINAL_FILE);
   RECORD(ORIGINAL_FILE_ID);
@@ -1556,6 +1557,15 @@ void ASTWriter::WriteControlBlock(Preprocessor &PP, StringRef isysroot) {
     }
 
     Stream.EmitRecord(MODULE_MAP_FILE, Record);
+  }
+
+  if (WritingModule && !WritingModule->getDirectoryDependencies().empty()) {
+    Record.clear();
+    ArrayRef<std::string> Dirs = WritingModule->getDirectoryDependencies();
+    Record.push_back(Dirs.size());
+    for (StringRef Dir : Dirs)
+      AddPath(Dir, Record);
+    Stream.EmitRecord(MODULE_DIRECTORY_DEPENDENCIES, Record);
   }
 
   // Imports

--- a/clang/test/ClangScanDeps/link-libraries.c
+++ b/clang/test/ClangScanDeps/link-libraries.c
@@ -43,6 +43,10 @@ module transitive {
 // CHECK-NEXT:       "command-line": [
 // CHECK:            ],
 // CHECK-NEXT:       "context-hash": "{{.*}}",
+// CHECK-NEXT:       "directory-deps": [
+// CHECK-NEXT:         "[[PREFIX]]/Inputs/frameworks/Framework.framework/Frameworks",
+// CHECK-NEXT:         "[[PREFIX]]/Inputs/frameworks/Framework.framework/Headers"
+// CHECK-NEXT:       ],
 // CHECK-NEXT:       "file-deps": [
 // CHECK-NEXT:         "[[PREFIX]]/Inputs/frameworks/module.modulemap",
 // CHECK-NEXT:         "[[PREFIX]]/Inputs/frameworks/Framework.framework/Headers/Framework.h"

--- a/clang/test/ClangScanDeps/modules-directory-deps.c
+++ b/clang/test/ClangScanDeps/modules-directory-deps.c
@@ -1,0 +1,134 @@
+// Test directory dependency tracking. This handles the negative dependency case
+// of adding a header to an umbrella directory between incremental scans.
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: sed "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
+
+//--- include/Umb/module.modulemap
+module UmbDir {
+  umbrella "sub"
+  module * { export * }
+}
+module UmbHdr {
+  umbrella header "umb.h"
+}
+
+//--- include/Umb/sub/a.h
+//--- include/Umb/umb.h
+
+//--- tu.c
+#include "Umb/sub/a.h"
+#include "Umb/umb.h"
+
+//--- cdb.json.template
+[{
+  "file": "DIR/tu.c",
+  "directory": "DIR",
+  "command": "clang -fmodules -fmodules-cache-path=DIR/cache -I DIR/include -c DIR/tu.c -o DIR/tu.o"
+}]
+
+// 1) A clean scan reports the enumerated umbrella directory for UmbDir, and the
+//    umbrella header's directory for UmbHdr.
+// RUN: clang-scan-deps -compilation-database %t/cdb.json \
+// RUN:   -format experimental-full 2>&1 | sed 's:\\\\\?:/:g' \
+// RUN:   | FileCheck %s -DPREFIX=%/t --check-prefix=CLEAN
+
+// CLEAN:      "directory-deps": [
+// CLEAN-NEXT:   "[[PREFIX]]/include/Umb/sub"
+// CLEAN-NEXT: ]
+// CLEAN:      "file-deps": [
+// CLEAN-NEXT:   "[[PREFIX]]/include/Umb/module.modulemap"
+// CLEAN-NEXT:   "[[PREFIX]]/include/Umb/sub/a.h"
+// CLEAN-NEXT: ]
+// CLEAN:      "name": "UmbDir"
+// CLEAN:      "directory-deps": [
+// CLEAN-NEXT:   "[[PREFIX]]/include/Umb"
+// CLEAN-NEXT: ]
+// CLEAN:      "name": "UmbHdr"
+
+// 2) The first scan populated the module cache. Add a header to the enumerated
+//    directory.
+// RUN: touch %t/include/Umb/sub/b.h
+
+// 3) Re-scan without -invalidated-directory: the cached module is reused, so
+//    b.h is not picked up. This is the negative dependency the build system has
+//    to close, and is why the field is reported at all.
+// RUN: clang-scan-deps -compilation-database %t/cdb.json \
+// RUN:   -format experimental-full 2>&1 | sed 's:\\\\\?:/:g' \
+// RUN:   | FileCheck %s -DPREFIX=%/t --check-prefix=STALE
+
+// STALE:      "file-deps": [
+// STALE-NEXT:   "[[PREFIX]]/include/Umb/module.modulemap"
+// STALE-NEXT:   "[[PREFIX]]/include/Umb/sub/a.h"
+// STALE-NEXT: ]
+// STALE:      "name": "UmbDir"
+// STALE-NOT:  "[[PREFIX]]/include/Umb/sub/b.h"
+
+// 4) Re-scan with -invalidated-directory: the module that enumerated the
+//    changed directory is out of date and rebuilt, so b.h now appears.
+// RUN: clang-scan-deps -compilation-database %t/cdb.json \
+// RUN:   -format experimental-full \
+// RUN:   -invalidated-directory=%/t/include/Umb/sub \
+// RUN:   -invalidated-directory=%/t/nonexistent 2>&1 | sed 's:\\\\\?:/:g' \
+// RUN:   | FileCheck %s -DPREFIX=%/t --check-prefix=FRESH
+
+// FRESH:      "file-deps": [
+// FRESH-NEXT:   "[[PREFIX]]/include/Umb/module.modulemap"
+// FRESH-NEXT:   "[[PREFIX]]/include/Umb/sub/a.h"
+// FRESH-NEXT:   "[[PREFIX]]/include/Umb/sub/b.h"
+// FRESH-NEXT: ]
+// FRESH:      "name": "UmbDir"
+
+// 5) Paths that differ only in spelling still match: `.` components and a
+//    trailing separator are removed before comparison.
+// RUN: touch %t/include/Umb/sub/c.h
+// RUN: clang-scan-deps -compilation-database %t/cdb.json \
+// RUN:   -format experimental-full \
+// RUN:   -invalidated-directory=%/t/include/./Umb/sub/ 2>&1 | sed 's:\\\\\?:/:g' \
+// RUN:   | FileCheck %s -DPREFIX=%/t --check-prefix=SPELLING
+
+// SPELLING:      "file-deps": [
+// SPELLING-NEXT:   "[[PREFIX]]/include/Umb/module.modulemap"
+// SPELLING-NEXT:   "[[PREFIX]]/include/Umb/sub/a.h"
+// SPELLING-NEXT:   "[[PREFIX]]/include/Umb/sub/b.h"
+// SPELLING-NEXT:   "[[PREFIX]]/include/Umb/sub/c.h"
+// SPELLING-NEXT: ]
+// SPELLING:      "name": "UmbDir"
+
+// 6) An inferred framework enumerates its Frameworks subdirectory, since anything
+//    dropped in there becomes a submodule.
+// RUN: sed "s|DIR|%/t|g" %t/fw-cdb.json.template > %t/fw-cdb.json
+// RUN: clang-scan-deps -compilation-database %t/fw-cdb.json \
+// RUN:   -format experimental-full 2>&1 | sed 's:\\\\\?:/:g' \
+// RUN:   | FileCheck %s -DPREFIX=%/t --check-prefix=FW
+
+// FW:      "directory-deps": [
+// FW-NEXT:   "[[PREFIX]]/frameworks/Inferred.framework/Frameworks",
+// FW-NEXT:   "[[PREFIX]]/frameworks/Inferred.framework/Headers"
+// FW-NEXT: ]
+// FW:      "name": "Inferred"
+
+// RUN: mkdir -p %t/frameworks/Inferred.framework/Frameworks/Sub.framework/Headers
+// RUN: echo "// sub" > %t/frameworks/Inferred.framework/Frameworks/Sub.framework/Headers/Sub.h
+// RUN: clang-scan-deps -compilation-database %t/fw-cdb.json \
+// RUN:   -format experimental-full \
+// RUN:   -invalidated-directory=%/t/frameworks/Inferred.framework/Frameworks 2>&1 \
+// RUN:   | sed 's:\\\\\?:/:g' | FileCheck %s -DPREFIX=%/t --check-prefix=FW-SUB
+
+// FW-SUB: "[[PREFIX]]/frameworks/Inferred.framework/Frameworks/Sub.framework/Headers/Sub.h"
+
+//--- frameworks/module.modulemap
+framework module * {}
+
+//--- frameworks/Inferred.framework/Headers/Inferred.h
+
+//--- fw.m
+#import <Inferred/Inferred.h>
+
+//--- fw-cdb.json.template
+[{
+  "file": "DIR/fw.m",
+  "directory": "DIR",
+  "command": "clang -fmodules -fmodules-cache-path=DIR/fwcache -F DIR/frameworks -c DIR/fw.m -o DIR/fw.o"
+}]

--- a/clang/test/ClangScanDeps/modules-symlink-dir-vfs.c
+++ b/clang/test/ClangScanDeps/modules-symlink-dir-vfs.c
@@ -74,6 +74,9 @@ framework module FW { umbrella header "FW.h" }
 // CHECK-NEXT:         "[[PREFIX]]/frameworks-symlink/FW.framework/Modules/module.modulemap",
 // CHECK:            ],
 // CHECK-NEXT:       "context-hash": "{{.*}}",
+// CHECK-NEXT:       "directory-deps": [
+// CHECK-NEXT:         "[[PREFIX]]/frameworks-symlink/FW.framework/Headers"
+// CHECK-NEXT:       ],
 // CHECK-NEXT:       "file-deps": [
 // CHECK-NEXT:         "[[PREFIX]]/frameworks-symlink/FW.framework/Modules/module.modulemap",
 // CHECK-NEXT:         "[[PREFIX]]/copy/FW.h",

--- a/clang/test/ClangScanDeps/optimize-canonicalize-macros.m
+++ b/clang/test/ClangScanDeps/optimize-canonicalize-macros.m
@@ -25,6 +25,8 @@
 // CHECK-NOT:          "K"
 // CHECK:            ],
 // CHECK-NEXT:       "context-hash": "{{.*}}",
+// CHECK-NEXT:       "directory-deps": [
+// CHECK:            ],
 // CHECK-NEXT:       "file-deps": [
 // CHECK:            ],
 // CHECK-NEXT:       "link-libraries": [],
@@ -40,6 +42,8 @@
 // CHECK:              "K"
 // CHECK:            ],
 // CHECK-NEXT:       "context-hash": "{{.*}}",
+// CHECK-NEXT:       "directory-deps": [
+// CHECK:            ],
 // CHECK-NEXT:       "file-deps": [
 // CHECK:            ],
 // CHECK-NEXT:       "link-libraries": [],

--- a/clang/test/ClangScanDeps/optimize-system-warnings.m
+++ b/clang/test/ClangScanDeps/optimize-system-warnings.m
@@ -19,6 +19,8 @@
 // CHECK-NOT:          "-W
 // CHECK:            ],
 // CHECK-NEXT:       "context-hash": "{{.*}}",
+// CHECK-NEXT:       "directory-deps": [
+// CHECK:            ],
 // CHECK-NEXT:       "file-deps": [
 // CHECK:            ],
 // CHECK-NEXT:       "link-libraries": [],
@@ -31,6 +33,8 @@
 // CHECK-NOT:          "-W
 // CHECK:            ],
 // CHECK-NEXT:       "context-hash": "{{.*}}",
+// CHECK-NEXT:       "directory-deps": [
+// CHECK:            ],
 // CHECK-NEXT:       "file-deps": [
 // CHECK:            ],
 // CHECK-NEXT:       "link-libraries": [],
@@ -43,6 +47,8 @@
 // CHECK:              "-Wmaybe-unused
 // CHECK:            ],
 // CHECK-NEXT:       "context-hash": "{{.*}}",
+// CHECK-NEXT:       "directory-deps": [
+// CHECK:            ],
 // CHECK-NEXT:       "file-deps": [
 // CHECK:            ],
 // CHECK-NEXT:       "link-libraries": [],

--- a/clang/test/ClangScanDeps/optimize-vfs-pch.m
+++ b/clang/test/ClangScanDeps/optimize-vfs-pch.m
@@ -63,6 +63,8 @@
 // CHECK-NEXT:         "[[PREFIX]]/build/pch-overlay.yaml"
 // CHECK:            ],
 // CHECK-NEXT:       "context-hash": "{{.*}}",
+// CHECK-NEXT:       "directory-deps": [
+// CHECK:            ],
 // CHECK-NEXT:       "file-deps": [
 // CHECK-NEXT:         "{{.*}}"
 // CHECK-NEXT:         "{{.*}}"
@@ -78,6 +80,8 @@
 // CHECK-NOT:          "-ivfsoverlay"
 // CHECK:            ],
 // CHECK-NEXT:       "context-hash": "{{.*}}",
+// CHECK-NEXT:       "directory-deps": [
+// CHECK:            ],
 // CHECK-NEXT:       "file-deps": [
 // CHECK-NEXT:         "{{.*}}"
 // CHECK-NEXT:         "{{.*}}"

--- a/clang/test/ClangScanDeps/optimize-vfs.m
+++ b/clang/test/ClangScanDeps/optimize-vfs.m
@@ -23,6 +23,9 @@
 // CHECK-NOT:          "build/unused-vfs.yaml"
 // CHECK:            ],
 // CHECK-NEXT:       "context-hash": "{{.*}}",
+// CHECK-NEXT:       "directory-deps": [
+// CHECK-NEXT:         "[[PREFIX]]/modules/A"
+// CHECK-NEXT:       ],
 // CHECK-NEXT:       "file-deps": [
 // CHECK-NEXT:         "[[PREFIX]]/build/module.modulemap",
 // CHECK-NEXT:         "[[PREFIX]]/build/A.h"
@@ -37,6 +40,9 @@
 // CHECK-NOT:          "-ivfsoverlay"
 // CHECK:            ],
 // CHECK-NEXT:       "context-hash": "{{.*}}",
+// CHECK-NEXT:       "directory-deps": [
+// CHECK-NEXT:         "[[PREFIX]]/modules/B"
+// CHECK-NEXT:       ],
 // CHECK-NEXT:       "file-deps": [
 // CHECK-NEXT:         "[[PREFIX]]/modules/B/module.modulemap",
 // CHECK-NEXT:         "[[PREFIX]]/modules/B/B.h"
@@ -56,6 +62,9 @@
 // CHECK-NOT:          "-ivfsoverlay"
 // CHECK:            ],
 // CHECK-NEXT:       "context-hash": "{{.*}}",
+// CHECK-NEXT:       "directory-deps": [
+// CHECK-NEXT:         "[[PREFIX]]/modules/C"
+// CHECK-NEXT:       ],
 // CHECK-NEXT:       "file-deps": [
 // CHECK-NEXT:         "[[PREFIX]]/modules/C/module.modulemap",
 // CHECK-NEXT:         "[[PREFIX]]/modules/C/C.h",

--- a/clang/test/ClangScanDeps/working-dir.m
+++ b/clang/test/ClangScanDeps/working-dir.m
@@ -15,6 +15,8 @@
 // CHECK-NEXT:       "command-line": [
 // CHECK:            ],
 // CHECK-NEXT:       "context-hash": "{{.*}}",
+// CHECK-NEXT:       "directory-deps": [
+// CHECK:            ],
 // CHECK-NEXT:       "file-deps": [
 // CHECK:            ],
 // CHECK-NEXT:       "link-libraries": [],
@@ -26,6 +28,8 @@
 // CHECK-NEXT:       "command-line": [
 // CHECK:            ],
 // CHECK-NEXT:       "context-hash": "{{.*}}",
+// CHECK-NEXT:       "directory-deps": [
+// CHECK:            ],
 // CHECK-NEXT:       "file-deps": [
 // CHECK:            ],
 // CHECK-NEXT:       "link-libraries": [],
@@ -38,6 +42,8 @@
 // CHECK-NEXT:       "command-line": [
 // CHECK:            ],
 // CHECK-NEXT:       "context-hash": "{{.*}}",
+// CHECK-NEXT:       "directory-deps": [
+// CHECK:            ],
 // CHECK-NEXT:       "file-deps": [
 // CHECK:            ],
 // CHECK-NEXT:       "link-libraries": [],
@@ -50,6 +56,8 @@
 // CHECK-NEXT:       "command-line": [
 // CHECK:            ],
 // CHECK-NEXT:       "context-hash": "{{.*}}",
+// CHECK-NEXT:       "directory-deps": [
+// CHECK:            ],
 // CHECK-NEXT:       "file-deps": [
 // CHECK:            ],
 // CHECK-NEXT:       "link-libraries": [],

--- a/clang/tools/clang-scan-deps/ClangScanDeps.cpp
+++ b/clang/tools/clang-scan-deps/ClangScanDeps.cpp
@@ -104,6 +104,7 @@ static ScanningOptimizations OptimizeArgs;
 static std::string ModuleFilesDir;
 static bool EagerLoadModules;
 static bool CacheNegativeStats;
+static std::vector<std::string> InvalidatedDirectories;
 static unsigned NumThreads = 0;
 static std::string CompilationDB;
 static std::optional<std::string> ModuleNames;
@@ -215,6 +216,9 @@ static void ParseArgs(int argc, char **argv) {
   EagerLoadModules = Args.hasArg(OPT_eager_load_pcm);
 
   CacheNegativeStats = Args.hasArg(OPT_cache_negative_stats);
+
+  for (const llvm::opt::Arg *A : Args.filtered(OPT_invalidated_directory_EQ))
+    InvalidatedDirectories.emplace_back(A->getValue());
 
   if (const llvm::opt::Arg *A = Args.getLastArg(OPT_j)) {
     StringRef S{A->getValue()};
@@ -517,6 +521,9 @@ public:
             JOS.attributeArray("command-line",
                                toJSONStrings(JOS, MD.getBuildArguments()));
             JOS.attribute("context-hash", StringRef(MD.ID.ContextHash));
+            if (!MD.DirectoryDeps.empty())
+              JOS.attributeArray("directory-deps",
+                                 toJSONStrings(JOS, MD.DirectoryDeps));
             JOS.attributeArray("file-deps", [&] {
               MD.forEachFileDep([&](StringRef FileDep) {
                 // Not reporting SDKSettings.json so that test checks can remain
@@ -1182,6 +1189,9 @@ int clang_scan_deps_main(int argc, char **argv, const llvm::ToolContext &) {
 
   {
     DependencyScanningService Service(std::move(Opts));
+
+    if (!InvalidatedDirectories.empty())
+      Service.addInvalidatedDirectories(InvalidatedDirectories);
 
     if (Inputs.size() == 1) {
       ScanningTask(Service);

--- a/clang/tools/clang-scan-deps/Opts.td
+++ b/clang/tools/clang-scan-deps/Opts.td
@@ -24,6 +24,12 @@ def optimize_args_EQ : CommaJoined<["-", "--"], "optimize-args=">, HelpText<"Whi
 def eager_load_pcm : F<"eager-load-pcm", "Load PCM files eagerly (instead of lazily on import)">;
 def cache_negative_stats : F<"cache-negative-stats", "Cache stat failures">;
 
+defm invalidated_directory
+    : Eq<"invalidated-directory",
+         "Treat the contents of the given directory as changed since the last "
+         "scan, so that cached modules reporting it in 'directory-deps' are "
+         "rebuilt. May be given more than once">;
+
 def j : Arg<"j", "Number of worker threads to use (default: use all concurrent threads)">;
 
 defm compilation_database : Eq<"compilation-database", "Compilation database">;

--- a/llvm/include/llvm/Support/VirtualFileSystem.h
+++ b/llvm/include/llvm/Support/VirtualFileSystem.h
@@ -315,6 +315,15 @@ public:
   virtual std::error_code getRealPath(const Twine &Path,
                                       SmallVectorImpl<char> &Output);
 
+  /// Collect the paths in the underlying file system that contribute to a
+  /// potentially virtual directory when iterated via \a dir_begin. This can be
+  /// used for directory watching.
+  ///
+  /// Only a file system backed by storage a caller can observe itself
+  /// contributes a path, so a purely virtual file system contributes nothing.
+  virtual void getDirectoryContentSources(const Twine &Dir,
+                                          SmallVectorImpl<std::string> &Out) {}
+
   /// Check whether \p Path exists. By default this uses \c status(), but
   /// filesystems may provide a more efficient implementation if available.
   virtual bool exists(const Twine &Path);
@@ -418,6 +427,8 @@ public:
   std::error_code isLocal(const Twine &Path, bool &Result) override;
   std::error_code getRealPath(const Twine &Path,
                               SmallVectorImpl<char> &Output) override;
+  void getDirectoryContentSources(const Twine &Dir,
+                                  SmallVectorImpl<std::string> &Out) override;
 
   using iterator = FileSystemList::reverse_iterator;
   using const_iterator = FileSystemList::const_reverse_iterator;
@@ -481,6 +492,10 @@ public:
   std::error_code getRealPath(const Twine &Path,
                               SmallVectorImpl<char> &Output) override {
     return FS->getRealPath(Path, Output);
+  }
+  void getDirectoryContentSources(const Twine &Dir,
+                                  SmallVectorImpl<std::string> &Out) override {
+    return FS->getDirectoryContentSources(Dir, Out);
   }
   std::error_code isLocal(const Twine &Path, bool &Result) override {
     return FS->isLocal(Path, Result);
@@ -1080,6 +1095,9 @@ public:
 
   std::error_code getRealPath(const Twine &Path,
                               SmallVectorImpl<char> &Output) override;
+
+  void getDirectoryContentSources(const Twine &Dir,
+                                  SmallVectorImpl<std::string> &Out) override;
 
   llvm::ErrorOr<std::string> getCurrentWorkingDirectory() const override;
 

--- a/llvm/lib/Support/FileCollector.cpp
+++ b/llvm/lib/Support/FileCollector.cpp
@@ -291,6 +291,11 @@ public:
     return EC;
   }
 
+  void getDirectoryContentSources(const Twine &Dir,
+                                  SmallVectorImpl<std::string> &Out) override {
+    FS->getDirectoryContentSources(Dir, Out);
+  }
+
   std::error_code isLocal(const Twine &Path, bool &Result) override {
     return FS->isLocal(Path, Result);
   }

--- a/llvm/lib/Support/VirtualFileSystem.cpp
+++ b/llvm/lib/Support/VirtualFileSystem.cpp
@@ -295,6 +295,10 @@ public:
   llvm::ErrorOr<std::string> getCurrentWorkingDirectory() const override;
   std::error_code setCurrentWorkingDirectory(const Twine &Path) override;
   std::error_code isLocal(const Twine &Path, bool &Result) override;
+  void getDirectoryContentSources(const Twine &Dir,
+                                  SmallVectorImpl<std::string> &Out) override {
+    Out.push_back(Dir.str());
+  }
   std::error_code getRealPath(const Twine &Path,
                               SmallVectorImpl<char> &Output) override;
 
@@ -542,6 +546,13 @@ std::error_code OverlayFileSystem::getRealPath(const Twine &Path,
     if (FS->exists(Path))
       return FS->getRealPath(Path, Output);
   return errc::no_such_file_or_directory;
+}
+
+void OverlayFileSystem::getDirectoryContentSources(
+    const Twine &Dir, SmallVectorImpl<std::string> &Out) {
+  // All layers contribute.
+  for (iterator I = overlays_begin(), E = overlays_end(); I != E; ++I)
+    (*I)->getDirectoryContentSources(Dir, Out);
 }
 
 void OverlayFileSystem::visitChildFileSystems(VisitCallbackTy Callback) {
@@ -2699,6 +2710,46 @@ RedirectingFileSystem::getRealPath(const Twine &OriginalPath,
     return {};
   }
   return llvm::errc::invalid_argument;
+}
+
+void RedirectingFileSystem::getDirectoryContentSources(
+    const Twine &Dir, SmallVectorImpl<std::string> &Out) {
+  SmallString<256> Path;
+  Dir.toVector(Path);
+
+  if (makeAbsolute(Path))
+    return;
+
+  // Fallthrough and Fallback both consult ExternalFS, differing only in order.
+  const bool ConsultsExternalFS = Redirection != RedirectKind::RedirectOnly;
+
+  ErrorOr<RedirectingFileSystem::LookupResult> Result = lookupPath(Path);
+  if (!Result) {
+    // dir_begin() delegates entirely to ExternalFS.
+    if (ConsultsExternalFS)
+      ExternalFS->getDirectoryContentSources(Path, Out);
+    return;
+  }
+
+  switch (Result->E->getKind()) {
+  case EK_File:
+    return;
+  case EK_Directory:
+    // The names come from the overlay, which has no location in ExternalFS.
+    break;
+  case EK_DirectoryRemap: {
+    // Make the target absolute as status() does, so a relative
+    // 'external-contents' is not passed down raw.
+    SmallString<256> RemappedPath(*Result->getExternalRedirect());
+    if (!makeAbsolute(RemappedPath))
+      ExternalFS->getDirectoryContentSources(RemappedPath, Out);
+    break;
+  }
+  }
+
+  // dir_begin() also iterates the original path in ExternalFS.
+  if (ConsultsExternalFS)
+    ExternalFS->getDirectoryContentSources(Path, Out);
 }
 
 std::unique_ptr<FileSystem>

--- a/llvm/unittests/Support/VirtualFileSystemTest.cpp
+++ b/llvm/unittests/Support/VirtualFileSystemTest.cpp
@@ -82,6 +82,12 @@ public:
     WorkingDirectory = Path.str();
     return std::error_code();
   }
+  // Stand in for a file system backed by observable storage, so that callers of
+  // getDirectoryContentSources can be exercised.
+  void getDirectoryContentSources(const Twine &Dir,
+                                  SmallVectorImpl<std::string> &Out) override {
+    Out.push_back(Dir.str());
+  }
   // Map any symlink to "/symlink".
   std::error_code getRealPath(const Twine &Path,
                               SmallVectorImpl<char> &Output) override {
@@ -2754,6 +2760,227 @@ TEST_F(VFSFromYAMLTest, ErrorMap) {
 
   // Lookup a file location that doesn't exist.
   ASSERT_FALSE(FS->status("/root/bar/file"));
+}
+
+TEST(VirtualFileSystemTest, GetDirectoryContentSourcesBase) {
+  auto Dummy = makeIntrusiveRefCnt<DummyFileSystem>();
+  Dummy->addDirectory("//root/foo");
+
+  SmallVector<std::string, 4> Sources;
+  Dummy->getDirectoryContentSources("//root/foo", Sources);
+  EXPECT_THAT(Sources, ElementsAre("//root/foo"));
+
+  // A directory that does not exist still has a location where it would
+  // appear.
+  Sources.clear();
+  Dummy->getDirectoryContentSources("//root/does_not_exist", Sources);
+  EXPECT_THAT(Sources, ElementsAre("//root/does_not_exist"));
+
+  // A file system with no storage a caller can observe has nothing to report.
+  auto InMemory = makeIntrusiveRefCnt<vfs::InMemoryFileSystem>();
+  Sources.clear();
+  InMemory->getDirectoryContentSources("//root/foo", Sources);
+  EXPECT_THAT(Sources, testing::IsEmpty());
+}
+
+TEST_F(VFSFromYAMLTest, GetDirectoryContentSourcesDirectoryRemap) {
+  auto Lower = makeIntrusiveRefCnt<DummyFileSystem>();
+  Lower->addDirectory("//root/realheaders");
+  Lower->addDirectory("//root/real/Headers");
+  IntrusiveRefCntPtr<vfs::FileSystem> FS =
+      getFromYAMLString("{ 'roots': [\n"
+                        "{\n"
+                        "  'type': 'directory-remap',\n"
+                        "  'name': '//root/real/Headers',\n"
+                        "  'external-contents': '//root/realheaders'\n"
+                        "}\n"
+                        "]\n"
+                        "}",
+                        Lower);
+  ASSERT_NE(FS.get(), nullptr);
+
+  // Should expect to see both paths for fallthrough.
+  SmallVector<std::string, 4> Sources;
+  FS->getDirectoryContentSources("//root/real/Headers", Sources);
+  EXPECT_THAT(Sources, UnorderedElementsAre("//root/realheaders",
+                                            "//root/real/Headers"));
+
+  // The same holds for a path inside the remapped directory, which does not
+  // need to exist in either location.
+  Sources.clear();
+  FS->getDirectoryContentSources("//root/real/Headers/sub", Sources);
+  EXPECT_THAT(Sources, UnorderedElementsAre("//root/realheaders/sub",
+                                            "//root/real/Headers/sub"));
+
+  // A path the YAML says nothing about is handled entirely by ExternalFS.
+  Sources.clear();
+  FS->getDirectoryContentSources("//root/elsewhere", Sources);
+  EXPECT_THAT(Sources, ElementsAre("//root/elsewhere"));
+}
+
+TEST_F(VFSFromYAMLTest, GetDirectoryContentSourcesRedirectOnly) {
+  auto Lower = makeIntrusiveRefCnt<DummyFileSystem>();
+  Lower->addDirectory("//root/realheaders");
+  Lower->addDirectory("//root/real/Headers");
+  IntrusiveRefCntPtr<vfs::FileSystem> FS =
+      getFromYAMLString("{ 'redirecting-with': 'redirect-only',\n"
+                        "  'roots': [\n"
+                        "{\n"
+                        "  'type': 'directory-remap',\n"
+                        "  'name': '//root/real/Headers',\n"
+                        "  'external-contents': '//root/realheaders'\n"
+                        "}\n"
+                        "]\n"
+                        "}",
+                        Lower);
+  ASSERT_NE(FS.get(), nullptr);
+
+  // We expect to only see the redirected path for redirect-only
+  SmallVector<std::string, 4> Sources;
+  FS->getDirectoryContentSources("//root/real/Headers", Sources);
+  EXPECT_THAT(Sources, ElementsAre("//root/realheaders"));
+
+  // A path the YAML says nothing about cannot be enumerated at all.
+  Sources.clear();
+  FS->getDirectoryContentSources("//root/elsewhere", Sources);
+  EXPECT_THAT(Sources, testing::IsEmpty());
+}
+
+TEST_F(VFSFromYAMLTest, GetDirectoryContentSourcesDirectoryNode) {
+  auto Lower = makeIntrusiveRefCnt<DummyFileSystem>();
+  Lower->addDirectory("//root/real/Headers");
+  Lower->addRegularFile("//root/extra/injected.h");
+  IntrusiveRefCntPtr<vfs::FileSystem> FS = getFromYAMLString(
+      "{ 'roots': [\n"
+      "{\n"
+      "  'type': 'directory',\n"
+      "  'name': '//root/real/Headers',\n"
+      "  'contents': [ {\n"
+      "                  'type': 'file',\n"
+      "                  'name': 'injected.h',\n"
+      "                  'external-contents': '//root/extra/injected.h'\n"
+      "                }\n"
+      "              ]\n"
+      "}\n"
+      "]\n"
+      "}",
+      Lower);
+  ASSERT_NE(FS.get(), nullptr);
+
+  // //root/extra isn't iterated, so shouldn't be included.
+  SmallVector<std::string, 4> Sources;
+  FS->getDirectoryContentSources("//root/real/Headers", Sources);
+  EXPECT_THAT(Sources, ElementsAre("//root/real/Headers"));
+}
+
+TEST_F(VFSFromYAMLTest, GetDirectoryContentSourcesRelativeExternalContents) {
+  auto Lower = makeIntrusiveRefCnt<DummyFileSystem>();
+  Lower->addDirectory("//root/cwd");
+  Lower->addDirectory("//root/cwd/rel/target");
+  Lower->setCurrentWorkingDirectory("//root/cwd");
+  IntrusiveRefCntPtr<vfs::FileSystem> FS =
+      getFromYAMLString("{ 'roots': [\n"
+                        "{\n"
+                        "  'type': 'directory-remap',\n"
+                        "  'name': '//root/virtual',\n"
+                        "  'external-contents': 'rel/target'\n"
+                        "}\n"
+                        "]\n"
+                        "}",
+                        Lower);
+  ASSERT_NE(FS.get(), nullptr);
+
+  // Relative paths need to be returned as absolute.
+  SmallVector<std::string, 4> Sources;
+  FS->getDirectoryContentSources("//root/virtual", Sources);
+  EXPECT_THAT(Sources,
+              UnorderedElementsAre("//root/cwd/rel/target", "//root/virtual"));
+
+  // A relative Dir is made absolute too.
+  Sources.clear();
+  FS->getDirectoryContentSources("sub", Sources);
+  EXPECT_THAT(Sources, ElementsAre("//root/cwd/sub"));
+}
+
+TEST_F(VFSFromYAMLTest, GetDirectoryContentSourcesStackedOverlays) {
+  auto Lower = makeIntrusiveRefCnt<DummyFileSystem>();
+  Lower->addDirectory("//root/c");
+
+  // The inner overlay remaps //root/b to //root/c.
+  IntrusiveRefCntPtr<vfs::FileSystem> Inner =
+      getFromYAMLString("{ 'roots': [\n"
+                        "{\n"
+                        "  'type': 'directory-remap',\n"
+                        "  'name': '//root/b',\n"
+                        "  'external-contents': '//root/c'\n"
+                        "}\n"
+                        "]\n"
+                        "}",
+                        Lower);
+  ASSERT_NE(Inner.get(), nullptr);
+
+  // The outer overlay remaps //root/a to //root/b, which the inner overlay
+  // further remaps to //root/c.
+  IntrusiveRefCntPtr<vfs::FileSystem> Outer =
+      getFromYAMLString("{ 'roots': [\n"
+                        "{\n"
+                        "  'type': 'directory-remap',\n"
+                        "  'name': '//root/a',\n"
+                        "  'external-contents': '//root/b'\n"
+                        "}\n"
+                        "]\n"
+                        "}",
+                        Inner);
+  ASSERT_NE(Outer.get(), nullptr);
+
+  // Looking from the top reaches all dirs.
+  SmallVector<std::string, 4> Sources;
+  Outer->getDirectoryContentSources("//root/a", Sources);
+  EXPECT_THAT(Sources,
+              UnorderedElementsAre("//root/c", "//root/b", "//root/a"));
+
+  Sources.clear();
+  Outer->getDirectoryContentSources("//root/a/sub", Sources);
+  EXPECT_THAT(Sources, UnorderedElementsAre("//root/c/sub", "//root/b/sub",
+                                            "//root/a/sub"));
+
+  // A path only described by the inner overlay is still followed.
+  Sources.clear();
+  Outer->getDirectoryContentSources("//root/b", Sources);
+  EXPECT_THAT(Sources, UnorderedElementsAre("//root/c", "//root/b"));
+
+  // A path neither overlay mentions comes back unchanged.
+  Sources.clear();
+  Outer->getDirectoryContentSources("//root/c", Sources);
+  EXPECT_THAT(Sources, ElementsAre("//root/c"));
+}
+
+TEST_F(VFSFromYAMLTest, GetDirectoryContentSourcesOverlayFileSystem) {
+  auto Lower = makeIntrusiveRefCnt<DummyFileSystem>();
+
+  // A redirect-only layer contributes only its target, so the two layers
+  // contribute disjoint sets and a skipped layer is visible without relying on
+  // duplicates.
+  IntrusiveRefCntPtr<vfs::FileSystem> Redirecting =
+      getFromYAMLString("{ 'redirecting-with': 'redirect-only',\n"
+                        "  'roots': [\n"
+                        "{\n"
+                        "  'type': 'directory-remap',\n"
+                        "  'name': '//root/foo',\n"
+                        "  'external-contents': '//root/bar'\n"
+                        "}\n"
+                        "]\n"
+                        "}",
+                        makeIntrusiveRefCnt<DummyFileSystem>());
+  ASSERT_NE(Redirecting.get(), nullptr);
+
+  auto O = makeIntrusiveRefCnt<vfs::OverlayFileSystem>(Lower);
+  O->pushOverlay(Redirecting);
+
+  // dir_begin() combines every layer, so both contribute.
+  SmallVector<std::string, 4> Sources;
+  O->getDirectoryContentSources("//root/foo", Sources);
+  EXPECT_THAT(Sources, UnorderedElementsAre("//root/bar", "//root/foo"));
 }
 
 TEST_F(VFSFromYAMLTest, WorkingDirectory) {


### PR DESCRIPTION
In some cases a module depends on the contents of a directory in addition to
individual files. This happens for umbrella modules and framework modules.

This patch adds support to explicitly built modules for:
* discovering and reporting these dependencies during dependency scanning, and
* letting the build system report which directories have been invalidated on
  future incremental builds.

This is supported by clang-scan-deps via the `-invalidated-directory` flag.

Assisted-by: Claude Code: opus-5


This also includes https://github.com/llvm/llvm-project/pull/216889, which this depends on.