### PR TITLE
[lldb] Link API unit tests against LLVMTestingSupport.

### DIFF
--- a/lldb/unittests/API/CMakeLists.txt
+++ b/lldb/unittests/API/CMakeLists.txt
@@ -10,6 +10,7 @@ add_lldb_unittest(APITests
 
   LINK_LIBS
     liblldb
+    LLVMTestingSupport
     lldbSBUtilityHelpers
   )
 


### PR DESCRIPTION
Changes to lldb have added a dependency on llvm::detail::TakeError, this fails to link on my desktop without the dependency.  Most other unittests already link to LLVMTestingSupport.