### PR TITLE
[DAGCombiner] Use canonical shift amount type when decomposing a multiply.

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -5027,12 +5027,13 @@ SDValue DAGCombiner::visitMUL(SDNode *N) {
       ShAmt += TZeros;
       assert(ShAmt < BitWidth &&
              "multiply-by-constant generated out of bounds shift");
-      SDValue Shl =
-          DAG.getNode(ISD::SHL, DL, VT, N0, DAG.getConstant(ShAmt, DL, VT));
+      SDValue Shl = DAG.getNode(ISD::SHL, DL, VT, N0,
+                                DAG.getShiftAmountConstant(ShAmt, VT, DL));
       SDValue R =
-          TZeros ? DAG.getNode(MathOp, DL, VT, Shl,
-                               DAG.getNode(ISD::SHL, DL, VT, N0,
-                                           DAG.getConstant(TZeros, DL, VT)))
+          TZeros ? DAG.getNode(
+                       MathOp, DL, VT, Shl,
+                       DAG.getNode(ISD::SHL, DL, VT, N0,
+                                   DAG.getShiftAmountConstant(TZeros, VT, DL)))
                  : DAG.getNode(MathOp, DL, VT, Shl, N0);
       if (ConstValue1.isNegative())
         R = DAG.getNegative(R, DL, VT);

--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -5029,12 +5029,11 @@ SDValue DAGCombiner::visitMUL(SDNode *N) {
              "multiply-by-constant generated out of bounds shift");
       SDValue Shl = DAG.getNode(ISD::SHL, DL, VT, N0,
                                 DAG.getShiftAmountConstant(ShAmt, VT, DL));
-      SDValue R =
-          TZeros ? DAG.getNode(
-                       MathOp, DL, VT, Shl,
-                       DAG.getNode(ISD::SHL, DL, VT, N0,
-                                   DAG.getShiftAmountConstant(TZeros, VT, DL)))
-                 : DAG.getNode(MathOp, DL, VT, Shl, N0);
+      SDValue R = N0;
+      if (TZeros)
+        R = DAG.getNode(ISD::SHL, DL, VT, N0,
+                        DAG.getShiftAmountConstant(TZeros, VT, DL));
+      R = DAG.getNode(MathOp, DL, VT, Shl, R);
       if (ConstValue1.isNegative())
         R = DAG.getNegative(R, DL, VT);
       return R;


### PR DESCRIPTION
This allows the shifts to CSE with other shifts that are already in canonical form.