### PR TITLE
[libc++] Remove `_LIBCPP_EXPLICIT_SINCE_CXX14`

### DIFF
--- a/libcxx/include/__configuration/language.h
+++ b/libcxx/include/__configuration/language.h
@@ -58,12 +58,6 @@
 #  define _LIBCPP_HAS_CHAR8_T 1
 #endif
 
-#if _LIBCPP_STD_VER <= 11
-#  define _LIBCPP_EXPLICIT_SINCE_CXX14
-#else
-#  define _LIBCPP_EXPLICIT_SINCE_CXX14 explicit
-#endif
-
 #if _LIBCPP_STD_VER >= 14
 #  define _LIBCPP_CONSTEXPR_SINCE_CXX14 constexpr
 #else

--- a/libcxx/include/__locale_dir/wbuffer_convert.h
+++ b/libcxx/include/__locale_dir/wbuffer_convert.h
@@ -63,7 +63,7 @@ public:
   explicit _LIBCPP_HIDE_FROM_ABI
   wbuffer_convert(streambuf* __bytebuf, _Codecvt* __pcvt = new _Codecvt, state_type __state = state_type());
 #    else
-  _LIBCPP_EXPLICIT_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI
+  _LIBCPP_HIDE_FROM_ABI
   wbuffer_convert(streambuf* __bytebuf = nullptr, _Codecvt* __pcvt = new _Codecvt, state_type __state = state_type());
 #    endif
 

--- a/libcxx/include/__locale_dir/wstring_convert.h
+++ b/libcxx/include/__locale_dir/wstring_convert.h
@@ -50,11 +50,11 @@ public:
   _LIBCPP_HIDE_FROM_ABI wstring_convert() : wstring_convert(new _Codecvt) {}
   _LIBCPP_HIDE_FROM_ABI explicit wstring_convert(_Codecvt* __pcvt);
 #    else
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_EXPLICIT_SINCE_CXX14 wstring_convert(_Codecvt* __pcvt = new _Codecvt);
+  _LIBCPP_HIDE_FROM_ABI wstring_convert(_Codecvt* __pcvt = new _Codecvt);
 #    endif
 
   _LIBCPP_HIDE_FROM_ABI wstring_convert(_Codecvt* __pcvt, state_type __state);
-  _LIBCPP_EXPLICIT_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI
+  explicit _LIBCPP_HIDE_FROM_ABI
   wstring_convert(const byte_string& __byte_err, const wide_string& __wide_err = wide_string());
 #    ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI wstring_convert(wstring_convert&& __wc);

--- a/libcxx/include/locale
+++ b/libcxx/include/locale
@@ -92,16 +92,14 @@ public:
     typedef typename Codecvt::state_type                      state_type;
     typedef typename wide_string::traits_type::int_type       int_type;
 
-    wstring_convert(Codecvt* pcvt = new Codecvt);          // before C++14
-    explicit wstring_convert(Codecvt* pcvt = new Codecvt); // before C++20
-    wstring_convert() : wstring_convert(new Codecvt) {}    // C++20
-    explicit wstring_convert(Codecvt* pcvt);               // C++20
+    wstring_convert() : wstring_convert(new Codecvt) {}
+    explicit wstring_convert(Codecvt* pcvt);
 
     wstring_convert(Codecvt* pcvt, state_type state);
-    explicit wstring_convert(const byte_string& byte_err,           // explicit in C++14
+    explicit wstring_convert(const byte_string& byte_err,
                     const wide_string& wide_err = wide_string());
-    wstring_convert(const wstring_convert&) = delete;               // C++14
-    wstring_convert & operator=(const wstring_convert &) = delete;  // C++14
+    wstring_convert(const wstring_convert&) = delete;
+    wstring_convert & operator=(const wstring_convert &) = delete;
     ~wstring_convert();
 
     wide_string from_bytes(char byte);
@@ -125,17 +123,13 @@ class wbuffer_convert                                               // Removed i
 public:
     typedef typename Tr::state_type state_type;
 
-    wbuffer_convert(streambuf* bytebuf = 0, Codecvt* pcvt = new Codecvt,
-                    state_type state = state_type());          // before C++14
-    explicit wbuffer_convert(streambuf* bytebuf = nullptr, Codecvt* pcvt = new Codecvt,
-                            state_type state = state_type()); // before C++20
-    wbuffer_convert() : wbuffer_convert(nullptr) {} // C++20
+    wbuffer_convert() : wbuffer_convert(nullptr) {}
     explicit wbuffer_convert(streambuf* bytebuf, Codecvt* pcvt = new Codecvt,
-                            state_type state = state_type()); // C++20
+                            state_type state = state_type());
 
-    wbuffer_convert(const wbuffer_convert&) = delete;               // C++14
-    wbuffer_convert & operator=(const wbuffer_convert &) = delete;  // C++14
-    ~wbuffer_convert();                                             // C++14
+    wbuffer_convert(const wbuffer_convert&) = delete;
+    wbuffer_convert & operator=(const wbuffer_convert &) = delete;
+    ~wbuffer_convert();
 
     streambuf* rdbuf() const;
     streambuf* rdbuf(streambuf* bytebuf);

--- a/libcxx/test/std/localization/locales/locale.convenience/conversions/conversions.buffer/ctor.pass.cpp
+++ b/libcxx/test/std/localization/locales/locale.convenience/conversions/conversions.buffer/ctor.pass.cpp
@@ -12,13 +12,8 @@
 
 // wbuffer_convert<Codecvt, Elem, Tr>
 
-// wbuffer_convert(streambuf* bytebuf = 0, Codecvt* pcvt = new Codecvt,
-//                 state_type state = state_type());          // before C++14
-// explicit wbuffer_convert(streambuf* bytebuf = nullptr, Codecvt* pcvt = new Codecvt,
-//                          state_type state = state_type()); // before C++20
-// wbuffer_convert() : wbuffer_convert(nullptr) {} // C++20
-// explicit wbuffer_convert(streambuf* bytebuf, Codecvt* pcvt = new Codecvt,
-//                          state_type state = state_type()); // C++20
+// wbuffer_convert() : wbuffer_convert(nullptr) {}
+// explicit wbuffer_convert(streambuf* bytebuf, Codecvt* pcvt = new Codecvt, state_type state = state_type());
 
 // XFAIL: no-wide-characters
 
@@ -37,10 +32,8 @@ int main(int, char**)
 {
     globalMemCounter.reset();
     typedef std::wbuffer_convert<std::codecvt_utf8<wchar_t> > B;
-#if TEST_STD_VER > 11
     static_assert(!std::is_convertible<std::streambuf*, B>::value, "");
-    static_assert( std::is_constructible<B, std::streambuf*>::value, "");
-#endif
+    static_assert(std::is_constructible<B, std::streambuf*>::value, "");
     {
         B b;
         assert(b.rdbuf() == nullptr);

--- a/libcxx/test/std/localization/locales/locale.convenience/conversions/conversions.string/ctor_codecvt.pass.cpp
+++ b/libcxx/test/std/localization/locales/locale.convenience/conversions/conversions.string/ctor_codecvt.pass.cpp
@@ -12,10 +12,8 @@
 
 // wstring_convert<Codecvt, Elem, Wide_alloc, Byte_alloc>
 
-// wstring_convert(Codecvt* pcvt = new Codecvt);          // before C++14
-// explicit wstring_convert(Codecvt* pcvt = new Codecvt); // before C++20
-// wstring_convert() : wstring_convert(new Codecvt) {}    // C++20
-// explicit wstring_convert(Codecvt* pcvt);               // C++20
+// wstring_convert() : wstring_convert(new Codecvt) {}
+// explicit wstring_convert(Codecvt* pcvt);
 
 // XFAIL: no-wide-characters
 
@@ -42,10 +40,8 @@ int main(int, char**)
         typedef std::wstring_convert<Codecvt> Myconv;
         Myconv myconv(new Codecvt);
         assert(myconv.converted() == 0);
-#if TEST_STD_VER > 11
         static_assert(!std::is_convertible<Codecvt*, Myconv>::value, "");
-        static_assert( std::is_constructible<Myconv, Codecvt*>::value, "");
-#endif
+        static_assert(std::is_constructible<Myconv, Codecvt*>::value, "");
     }
 
 #if TEST_STD_VER >= 11

--- a/libcxx/test/std/localization/locales/locale.convenience/conversions/conversions.string/ctor_err_string.pass.cpp
+++ b/libcxx/test/std/localization/locales/locale.convenience/conversions/conversions.string/ctor_err_string.pass.cpp
@@ -12,8 +12,8 @@
 
 // wstring_convert<Codecvt, Elem, Wide_alloc, Byte_alloc>
 
-// wstring_convert(const byte_string& byte_err,
-//                 const wide_string& wide_err = wide_string());
+// explicit wstring_convert(const byte_string& byte_err,
+//                          const wide_string& wide_err = wide_string());
 
 // XFAIL: no-wide-characters
 
@@ -28,10 +28,9 @@ int main(int, char**)
 {
     typedef std::codecvt_utf8<wchar_t> Codecvt;
     typedef std::wstring_convert<Codecvt> Myconv;
-#if TEST_STD_VER > 11
     static_assert(!std::is_convertible<std::string, Myconv>::value, "");
-    static_assert( std::is_constructible<Myconv, std::string>::value, "");
-#endif
+    static_assert(std::is_constructible<Myconv, std::string>::value, "");
+
 #ifndef TEST_HAS_NO_EXCEPTIONS
     {
         Myconv myconv;


### PR DESCRIPTION
The existence of `_LIBCPP_EXPLICIT_SINCE_CXX14` is a relic of the questionable status quo of LWG2176 - we only implement its resolution since C++14 mode (7988106b21628afe7004b57ae66ec9b43cbc8942). In a11f8b1ad66d68ca0a3a277ce776007abff9c7eb (https://reviews.llvm.org/D91292), we implemented P0935R0 as a Defect Report against C++11, and P0935R0 somehow superseded LWG2176. So it is a bit unreasonable to leave LWG2176 not backported.

This patch backports the remaining parts of LWG2176 to old modes. As the copy constructor of `wbuffer_convert` and `wstring_convert` are deleted, implicit conversions to them cannot be performed in C++03 even if the related converting constructors lack `explicit`.

As drive-by, also drops `// C++20` comments on these constructors due to P0935R0 and `// C++14` comments due to LWG2176.