### PR TITLE
[BOLT][NFC] Fix CoreTests linking with shared libraries

### DIFF
--- a/bolt/unittests/Core/CMakeLists.txt
+++ b/bolt/unittests/Core/CMakeLists.txt
@@ -2,6 +2,7 @@ set(LLVM_LINK_COMPONENTS
   DebugInfoDWARF
   Object
   MC
+  TargetParser
   ${BOLT_TARGETS_TO_BUILD}
   )
 


### PR DESCRIPTION
`CoreTests` directly uses `Triple` and `SubtargetFeatures` constructors from `LLVMTargetParser` but does not declare the dependency. This causes undefined-symbol errors with BUILD_SHARED_LIBS=ON. https://github.com/llvm/llvm-project/pull/220581
Fix https://lab.llvm.org/buildbot/#/builders/218/builds/6464.