### PR TITLE
[orc-rt] Add Session::attach for pre-mode ControllerAccesses.

### DIFF
--- a/orc-rt/include/orc-rt/bedrock/Session.h
+++ b/orc-rt/include/orc-rt/bedrock/Session.h
@@ -424,6 +424,18 @@ public:
     return addService(std::move(*Srv));
   }
 
+  /// Attach to an already constructed ControllerAccess instance.
+  ///
+  /// A Session may be attached at most once, and attach must not be called
+  /// after -- or concurrently with -- detach or shutdown: by the time a detach
+  /// has been requested it may be arbitrarily far along, so there is no point
+  /// at which a newly attached controller could be connected, or its
+  /// disconnection coherently reported. Violating this is a programming error,
+  /// checked by assertion.
+  void attach(std::shared_ptr<ControllerAccess> CA, BootstrapInfo BI) noexcept {
+    doAttach(std::move(CA), std::move(BI));
+  }
+
   /// Construct a ControllerAccessT and immediately attach using the given
   /// BootstrapInfo.
   ///

--- a/orc-rt/test/unit/bedrock/SessionTest.cpp
+++ b/orc-rt/test/unit/bedrock/SessionTest.cpp
@@ -897,6 +897,24 @@ TEST(ControllerAccessTest, BootstrapInfoPassedToConnect) {
   ASSERT_TRUE(OnConnectRan);
 }
 
+TEST(ControllerAccessTest, PlainAttach) {
+  // Attach a with pre-constructed ControllerAccess instance.
+  QueueingRunner<>::WorkQueue Tasks;
+  Session S(mockExecutorProcessInfo(), QueueingRunner(Tasks), noErrors);
+  auto CA = cantFail(MockControllerAccess::Create(S, false, postOnto(Tasks)));
+  S.attach(std::move(CA), BootstrapInfo(S));
+
+  int32_t Result = 0;
+  SPSWrapperFunction<int32_t(int32_t, int32_t)>::call(
+      S.controllerCaller(
+          reinterpret_cast<orc_rt_ControllerHandlerTag>(add_sps_wrapper)),
+      [&](Expected<int32_t> R) { Result = cantFail(std::move(R)); }, 41, 1);
+
+  QueueingRunner<>::runFIFOUntilEmpty(Tasks);
+
+  EXPECT_EQ(Result, 42);
+}
+
 TEST(ControllerAccessTest, TryAttachSuccess) {
   // A successful Create attaches the controller, which then services calls
   // just like one attached via attach<T>.


### PR DESCRIPTION
Allow clients to attach a session using a pre-constructed ControllerAccess object. This allows clients to use non-trivial construction methods (e.g. factories) to build ControllerAccess objects.