### PR TITLE
[RISCV] Correct some constants in orc-b-patterns.ll. NFC

### DIFF
--- a/llvm/test/CodeGen/RISCV/orc-b-patterns.ll
+++ b/llvm/test/CodeGen/RISCV/orc-b-patterns.ll
@@ -23,7 +23,7 @@ define i32 @orc_b_i32_mul255(i32 %x) nounwind {
 ; RV32ZBB-NEXT:    ret
 entry:
   %and = and i32 %x, 16843009
-  %mul = mul nuw nsw i32 %and, 255
+  %mul = mul i32 %and, 255
   ret i32 %mul
 }
 
@@ -47,7 +47,7 @@ define i32 @orc_b_i32_sub_shl8x_x_lsb(i32  %x)  {
 ; RV32ZBB-NEXT:    ret
 entry:
   %and = and i32 %x, 16843009
-  %sub = mul nuw i32 %and, 255
+  %sub = mul i32 %and, 255
   ret i32 %sub
 }
 
@@ -73,7 +73,7 @@ define i32 @orc_b_i32_sub_shl8x_x_lsb_preshifted(i32 %x){
 entry:
   %shr = lshr i32 %x, 11
   %and = and i32 %shr, 16843009
-  %sub = mul nuw i32 %and, 255
+  %sub = mul i32 %and, 255
   ret i32 %sub
 }
 
@@ -99,8 +99,8 @@ define  i32 @orc_b_i32_sub_shl8x_x_b1(i32  %x)  {
 entry:
   %and = and i32 %x, 33686018
   %shl = shl i32 %and, 7
-  %shr = lshr exact i32 %and, 1
-  %sub = sub nsw i32 %shl, %shr
+  %shr = lshr i32 %and, 1
+  %sub = sub i32 %shl, %shr
   ret i32 %sub
 }
 
@@ -126,103 +126,143 @@ define  i32 @orc_b_i32_sub_shl8x_x_b2(i32  %x)  {
 entry:
   %and = and i32 %x, 67372036
   %shl = shl i32 %and, 6
-  %shr = lshr exact i32 %and, 2
-  %sub = sub nsw i32 %shl, %shr
+  %shr = lshr i32 %and, 2
+  %sub = sub i32 %shl, %shr
   ret i32 %sub
 }
 
 
 define i32 @orc_b_i32_sub_shl8x_x_b3(i32  %x)  {
-; CHECK-LABEL: orc_b_i32_sub_shl8x_x_b3:
-; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lui a1, 24672
-; CHECK-NEXT:    addi a1, a1, 1542
-; CHECK-NEXT:    and a0, a0, a1
-; CHECK-NEXT:    slli a1, a0, 5
-; CHECK-NEXT:    srli a0, a0, 3
-; CHECK-NEXT:    sub a0, a1, a0
-; CHECK-NEXT:    ret
+; RV32I-LABEL: orc_b_i32_sub_shl8x_x_b3:
+; RV32I:       # %bb.0: # %entry
+; RV32I-NEXT:    lui a1, 32897
+; RV32I-NEXT:    addi a1, a1, -2040
+; RV32I-NEXT:    and a0, a0, a1
+; RV32I-NEXT:    slli a1, a0, 5
+; RV32I-NEXT:    srli a0, a0, 3
+; RV32I-NEXT:    sub a0, a1, a0
+; RV32I-NEXT:    ret
+;
+; RV32ZBB-LABEL: orc_b_i32_sub_shl8x_x_b3:
+; RV32ZBB:       # %bb.0: # %entry
+; RV32ZBB-NEXT:    lui a1, 32897
+; RV32ZBB-NEXT:    addi a1, a1, -2040
+; RV32ZBB-NEXT:    and a0, a0, a1
+; RV32ZBB-NEXT:    orc.b a0, a0
+; RV32ZBB-NEXT:    ret
 entry:
-  %and = and i32 %x, 101058054
-  %shl = shl nuw i32 %and, 5
+  %and = and i32 %x, 134744072
+  %shl = shl i32 %and, 5
   %shr = lshr i32 %and, 3
-  %sub = sub nsw i32 %shl, %shr
+  %sub = sub i32 %shl, %shr
   ret i32 %sub
 }
 
 
 define  i32 @orc_b_i32_sub_shl8x_x_b4(i32  %x)  {
-; CHECK-LABEL: orc_b_i32_sub_shl8x_x_b4:
-; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lui a1, 32897
-; CHECK-NEXT:    addi a1, a1, -2040
-; CHECK-NEXT:    and a0, a0, a1
-; CHECK-NEXT:    slli a1, a0, 4
-; CHECK-NEXT:    srli a0, a0, 4
-; CHECK-NEXT:    sub a0, a1, a0
-; CHECK-NEXT:    ret
+; RV32I-LABEL: orc_b_i32_sub_shl8x_x_b4:
+; RV32I:       # %bb.0: # %entry
+; RV32I-NEXT:    lui a1, 65793
+; RV32I-NEXT:    addi a1, a1, 16
+; RV32I-NEXT:    and a0, a0, a1
+; RV32I-NEXT:    slli a1, a0, 4
+; RV32I-NEXT:    srli a0, a0, 4
+; RV32I-NEXT:    sub a0, a1, a0
+; RV32I-NEXT:    ret
+;
+; RV32ZBB-LABEL: orc_b_i32_sub_shl8x_x_b4:
+; RV32ZBB:       # %bb.0: # %entry
+; RV32ZBB-NEXT:    lui a1, 65793
+; RV32ZBB-NEXT:    addi a1, a1, 16
+; RV32ZBB-NEXT:    and a0, a0, a1
+; RV32ZBB-NEXT:    orc.b a0, a0
+; RV32ZBB-NEXT:    ret
 entry:
-  %and = and i32 %x, 134744072
-  %shl = shl nuw i32 %and, 4
+  %and = and i32 %x, 269488144
+  %shl = shl i32 %and, 4
   %shr = lshr i32 %and, 4
-  %sub = sub nsw i32 %shl, %shr
+  %sub = sub i32 %shl, %shr
   ret i32 %sub
 }
 
 
 define  i32 @orc_b_i32_sub_shl8x_x_b5(i32  %x)  {
-; CHECK-LABEL: orc_b_i32_sub_shl8x_x_b5:
-; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lui a1, 65793
-; CHECK-NEXT:    addi a1, a1, 16
-; CHECK-NEXT:    and a0, a0, a1
-; CHECK-NEXT:    slli a1, a0, 3
-; CHECK-NEXT:    srli a0, a0, 5
-; CHECK-NEXT:    sub a0, a1, a0
-; CHECK-NEXT:    ret
+; RV32I-LABEL: orc_b_i32_sub_shl8x_x_b5:
+; RV32I:       # %bb.0: # %entry
+; RV32I-NEXT:    lui a1, 131586
+; RV32I-NEXT:    addi a1, a1, 32
+; RV32I-NEXT:    and a0, a0, a1
+; RV32I-NEXT:    slli a1, a0, 3
+; RV32I-NEXT:    srli a0, a0, 5
+; RV32I-NEXT:    sub a0, a1, a0
+; RV32I-NEXT:    ret
+;
+; RV32ZBB-LABEL: orc_b_i32_sub_shl8x_x_b5:
+; RV32ZBB:       # %bb.0: # %entry
+; RV32ZBB-NEXT:    lui a1, 131586
+; RV32ZBB-NEXT:    addi a1, a1, 32
+; RV32ZBB-NEXT:    and a0, a0, a1
+; RV32ZBB-NEXT:    orc.b a0, a0
+; RV32ZBB-NEXT:    ret
 entry:
-  %and = and i32 %x, 269488144
-  %shl = shl nuw i32 %and, 3
+  %and = and i32 %x, 538976288
+  %shl = shl i32 %and, 3
   %shr = lshr i32 %and, 5
-  %sub = sub nsw i32 %shl, %shr
+  %sub = sub i32 %shl, %shr
   ret i32 %sub
 }
 
 
 define i32 @orc_b_i32_sub_shl8x_x_b6(i32 %x)  {
-; CHECK-LABEL: orc_b_i32_sub_shl8x_x_b6:
-; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lui a1, 131586
-; CHECK-NEXT:    addi a1, a1, 32
-; CHECK-NEXT:    and a0, a0, a1
-; CHECK-NEXT:    slli a1, a0, 2
-; CHECK-NEXT:    srli a0, a0, 6
-; CHECK-NEXT:    sub a0, a1, a0
-; CHECK-NEXT:    ret
+; RV32I-LABEL: orc_b_i32_sub_shl8x_x_b6:
+; RV32I:       # %bb.0: # %entry
+; RV32I-NEXT:    lui a1, 263172
+; RV32I-NEXT:    addi a1, a1, 64
+; RV32I-NEXT:    and a0, a0, a1
+; RV32I-NEXT:    slli a1, a0, 2
+; RV32I-NEXT:    srli a0, a0, 6
+; RV32I-NEXT:    sub a0, a1, a0
+; RV32I-NEXT:    ret
+;
+; RV32ZBB-LABEL: orc_b_i32_sub_shl8x_x_b6:
+; RV32ZBB:       # %bb.0: # %entry
+; RV32ZBB-NEXT:    lui a1, 263172
+; RV32ZBB-NEXT:    addi a1, a1, 64
+; RV32ZBB-NEXT:    and a0, a0, a1
+; RV32ZBB-NEXT:    orc.b a0, a0
+; RV32ZBB-NEXT:    ret
 entry:
-  %and = and i32 %x, 538976288
-  %shl = shl nuw i32 %and, 2
+  %and = and i32 %x, 1077952576
+  %shl = shl i32 %and, 2
   %shr = lshr i32 %and, 6
-  %sub = sub nsw i32 %shl, %shr
+  %sub = sub i32 %shl, %shr
   ret i32 %sub
 }
 
 
 define i32 @orc_b_i32_sub_shl8x_x_b7(i32 %x)  {
-; CHECK-LABEL: orc_b_i32_sub_shl8x_x_b7:
-; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lui a1, 263172
-; CHECK-NEXT:    addi a1, a1, 64
-; CHECK-NEXT:    and a0, a0, a1
-; CHECK-NEXT:    slli a1, a0, 1
-; CHECK-NEXT:    srli a0, a0, 7
-; CHECK-NEXT:    sub a0, a1, a0
-; CHECK-NEXT:    ret
+; RV32I-LABEL: orc_b_i32_sub_shl8x_x_b7:
+; RV32I:       # %bb.0: # %entry
+; RV32I-NEXT:    lui a1, 526344
+; RV32I-NEXT:    addi a1, a1, 128
+; RV32I-NEXT:    and a0, a0, a1
+; RV32I-NEXT:    slli a1, a0, 1
+; RV32I-NEXT:    srli a0, a0, 7
+; RV32I-NEXT:    sub a0, a1, a0
+; RV32I-NEXT:    ret
+;
+; RV32ZBB-LABEL: orc_b_i32_sub_shl8x_x_b7:
+; RV32ZBB:       # %bb.0: # %entry
+; RV32ZBB-NEXT:    lui a1, 526344
+; RV32ZBB-NEXT:    addi a1, a1, 128
+; RV32ZBB-NEXT:    and a0, a0, a1
+; RV32ZBB-NEXT:    orc.b a0, a0
+; RV32ZBB-NEXT:    ret
 entry:
-  %and = and i32 %x, 1077952576
-  %shl = shl nuw i32 %and, 1
+  %and = and i32 %x, 2155905152
+  %shl = shl i32 %and, 1
   %shr = lshr i32 %and, 7
-  %sub = sub nsw i32 %shl, %shr
+  %sub = sub i32 %shl, %shr
   ret i32 %sub
 }
 
@@ -250,9 +290,9 @@ define i32 @orc_b_i32_sub_shl8x_x_b1_shl_used(i32 %x, ptr %arr) {
 entry:
   %and = and i32 %x, 33686018
   %shl = shl i32 %and, 7
-  %shr = lshr exact i32 %and, 1
+  %shr = lshr i32 %and, 1
   store i32 %shr, ptr %arr, align 4
-  %sub = sub nsw i32 %shl, %shr
+  %sub = sub i32 %shl, %shr
   ret i32 %sub
 }
 
@@ -280,9 +320,9 @@ define i32 @orc_b_i32_sub_shl8x_x_b1_srl_used(i32  %x, ptr %arr) {
 entry:
   %and = and i32 %x, 33686018
   %shl = shl i32 %and, 7
-  %shr = lshr exact i32 %and, 1
+  %shr = lshr i32 %and, 1
   store i32 %shl, ptr %arr, align 4
-  %sub = sub nsw i32 %shl, %shr
+  %sub = sub i32 %shl, %shr
   ret i32 %sub
 }
 
@@ -308,8 +348,8 @@ define i32 @orc_b_i32_sub_shl8x_x_b1_not_used(i32  %x, ptr %arr) {
 entry:
   %and = and i32 %x, 33686018
   %shl = shl i32 %and, 7
-  %shr = lshr exact i32 %and, 1
-  %sub = sub nsw i32 %shl, %shr
+  %shr = lshr i32 %and, 1
+  %sub = sub i32 %shl, %shr
   ret i32 %sub
 }
 
@@ -327,7 +367,7 @@ entry:
   %and = and i32 %x, 16843009
   %shl = shl i32 %and, 8
   store i32 %shl, ptr %arr, align 4
-  %sub = mul nuw i32 %and, 255
+  %sub = mul i32 %and, 255
   ret i32 %sub
 }
 
@@ -346,11 +386,11 @@ define i32 @orc_b_i32_sub_shl8x_x_b1_both_used(i32  %x, ptr %arr) {
 entry:
   %and = and i32 %x, 33686018
   %shl = shl i32 %and, 7
-  %shr = lshr exact i32 %and, 1
+  %shr = lshr i32 %and, 1
   store i32 %shl, ptr %arr, align 4
   %arrayidx1 = getelementptr inbounds i8, ptr %arr, i32 4
   store i32 %shr, ptr %arrayidx1, align 4
-  %sub = sub nsw i32 %shl, %shr
+  %sub = sub i32 %shl, %shr
   ret i32 %sub
 }
 
@@ -367,6 +407,6 @@ define i32 @orc_b_i32_sub_x_shr8x(i32 %x)  {
 entry:
   %and = and i32 %x, 16843009
   %shr = lshr i32 %and, 8
-  %sub = sub nsw i32 %and, %shr
+  %sub = sub i32 %and, %shr
   ret i32 %sub
 }


### PR DESCRIPTION
Based on the test function names being similar to other function, I assume these were supposed to generate orc.b.

Also remove unnecessary nuw, nsw, and exact flags.