### PR TITLE
[ORC] Require symbol name kind in SymbolNameSpec constructor.

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/Shared/SymbolNameSpec.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Shared/SymbolNameSpec.h
@@ -38,8 +38,7 @@ enum class SymbolNameKind {
 /// previously took an already-mangled StringRef.
 class SymbolNameSpec {
 public:
-  constexpr SymbolNameSpec(StringRef Name,
-                           SymbolNameKind Kind = SymbolNameKind::Verbatim)
+  constexpr SymbolNameSpec(StringRef Name, SymbolNameKind Kind)
       : Name(Name), Kind(Kind) {}
 
   static constexpr SymbolNameSpec verbatim(StringRef Name) {


### PR DESCRIPTION
Require clients to spell out the naming level that SymbolNameSpecs are expressed in. (An implicit default is a footgun, and adds limited convenience)