### PR TITLE
[clang][python] Fix get_includes documentation

### DIFF
--- a/clang/bindings/python/clang/cindex.py
+++ b/clang/bindings/python/clang/cindex.py
@@ -3488,8 +3488,8 @@ class TranslationUnit(ClangObject):
     def get_includes(self) -> Iterator[FileInclusion]:
         """
         Return an iterable sequence of FileInclusion objects that describe the
-        sequence of inclusions in a translation unit. The first object in
-        this sequence is always the input file. Note that this method will not
+        sequence of inclusions in a translation unit. The input file itself is not
+        included in this sequence. Note that this method will not
         recursively iterate over header files included through precompiled
         headers.
         """


### PR DESCRIPTION
`TranslationUnit.get_includes()` does not include the input file in the returned sequence, but its docstring currently states that the first object is always the input file. 

The implementation only appends a FileInclusion when depth > 0, while the input file has depth 0. Therefore, the input file is excluded from the returned sequence.

Update the docstring to reflect the actual behavior.