### PR TITLE
[CallGraph] Remove dead removeAllCalledFunctions and stealCalledFunctionsFrom (NFC)

### DIFF
--- a/llvm/include/llvm/Analysis/CallGraph.h
+++ b/llvm/include/llvm/Analysis/CallGraph.h
@@ -218,22 +218,6 @@ public:
   // modified
   //
 
-  /// Removes all edges from this CallGraphNode to any functions it
-  /// calls.
-  void removeAllCalledFunctions() {
-    while (!CalledFunctions.empty()) {
-      CalledFunctions.back().second->DropRef();
-      CalledFunctions.pop_back();
-    }
-  }
-
-  /// Moves all the callee information from N to this node.
-  void stealCalledFunctionsFrom(CallGraphNode *N) {
-    assert(CalledFunctions.empty() &&
-           "Cannot steal callsite information if I already have some");
-    std::swap(CalledFunctions, N->CalledFunctions);
-  }
-
   /// Adds a function to the list of functions called by this one.
   void addCalledFunction(CallBase *Call, CallGraphNode *M) {
     CalledFunctions.emplace_back(Call ? std::optional<WeakTrackingVH>(Call)


### PR DESCRIPTION
CallGraphNode::removeAllCalledFunctions: Added on November 26, 2001 in
commit e409c460bf87ef9211d42e1b6ede0df750aeb64a (originally as
removeAllCalledMethods) without any callers.

CallGraphNode::stealCalledFunctionsFrom: The last caller was removed on
June 24, 2022 in commit 217e85761cd1978931e29546e15716614e3b2fcc.

Assisted-by: Antigravity
