### PR TITLE
[AMDGPU] Fold high-half 16-bit extracts into VOP3 op_sel

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUISelDAGToDAG.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUISelDAGToDAG.cpp
@@ -4221,16 +4221,28 @@ bool AMDGPUDAGToDAGISel::SelectSWMMACIndex32(SDValue In, SDValue &Src,
 
 bool AMDGPUDAGToDAGISel::SelectVOP3OpSel(SDValue In, SDValue &Src,
                                          SDValue &SrcMods) const {
+  unsigned Mods = SISrcMods::NONE;
   Src = In;
-  // FIXME: Handle op_sel
-  SrcMods = CurDAG->getTargetConstant(0, SDLoc(In), MVT::i32);
+  if (!Subtarget->useRealTrue16Insts() && In.getValueSizeInBits() == 16 &&
+      isExtractHiElt(Src, Src))
+    Mods |= SISrcMods::OP_SEL_0;
+  SrcMods = CurDAG->getTargetConstant(Mods, SDLoc(In), MVT::i32);
   return true;
 }
 
 bool AMDGPUDAGToDAGISel::SelectVOP3OpSelMods(SDValue In, SDValue &Src,
                                              SDValue &SrcMods) const {
-  // FIXME: Handle op_sel
-  return SelectVOP3Mods(In, Src, SrcMods);
+  unsigned Mods;
+  if (!SelectVOP3ModsImpl(In, Src, Mods, /*IsCanonicalizing=*/true,
+                          /*AllowAbs=*/true))
+    return false;
+
+  if (!Subtarget->useRealTrue16Insts() && In.getValueSizeInBits() == 16 &&
+      isExtractHiElt(Src, Src))
+    Mods |= SISrcMods::OP_SEL_0;
+
+  SrcMods = CurDAG->getTargetConstant(Mods, SDLoc(In), MVT::i32);
+  return true;
 }
 
 // Match lowered fpext from bf16 to f32. This is a bit operation extending

--- a/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.cpp
@@ -5720,9 +5720,18 @@ AMDGPUInstructionSelector::selectVOP3OpSelMods(MachineOperand &Root) const {
   unsigned Mods;
   std::tie(Src, Mods) = selectVOP3ModsImpl(Root.getReg());
 
-  // FIXME: Handle op_sel
+  Register ExtractSrc;
+  if (!Subtarget->useRealTrue16Insts() &&
+      MRI->getType(Root.getReg()).getSizeInBits() == 16 &&
+      isExtractHiElt(*MRI, Src, ExtractSrc)) {
+    Src = ExtractSrc;
+    Mods |= SISrcMods::OP_SEL_0;
+  }
+
   return {{
-      [=](MachineInstrBuilder &MIB) { MIB.addReg(Src); },
+      [=](MachineInstrBuilder &MIB) {
+        MIB.addReg(copyToVGPRIfSrcFolded(Src, Mods, Root, MIB));
+      },
       [=](MachineInstrBuilder &MIB) { MIB.addImm(Mods); } // src_mods
   }};
 }

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/fdiv.f16.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/fdiv.f16.ll
@@ -903,135 +903,127 @@ define <2 x half> @v_fdiv_v2f16(<2 x half> %a, <2 x half> %b) {
 ; GFX9-IEEE-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-IEEE-NEXT:    v_cvt_f32_f16_e32 v2, v1
 ; GFX9-IEEE-NEXT:    v_cvt_f32_f16_e32 v4, v0
-; GFX9-IEEE-NEXT:    v_lshrrev_b32_e32 v6, 16, v1
-; GFX9-IEEE-NEXT:    v_cvt_f32_f16_e32 v8, v6
+; GFX9-IEEE-NEXT:    v_cvt_f32_f16_sdwa v3, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX9-IEEE-NEXT:    v_cvt_f32_f16_sdwa v6, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
 ; GFX9-IEEE-NEXT:    v_rcp_f32_e32 v5, v2
-; GFX9-IEEE-NEXT:    v_lshrrev_b32_e32 v3, 16, v0
-; GFX9-IEEE-NEXT:    v_cvt_f32_f16_e32 v7, v3
-; GFX9-IEEE-NEXT:    v_mul_f32_e32 v9, v4, v5
-; GFX9-IEEE-NEXT:    v_mul_f32_e64 v10, -v2, v9
+; GFX9-IEEE-NEXT:    v_rcp_f32_e32 v7, v3
+; GFX9-IEEE-NEXT:    v_mul_f32_e32 v8, v4, v5
+; GFX9-IEEE-NEXT:    v_mul_f32_e64 v10, -v2, v8
 ; GFX9-IEEE-NEXT:    v_add_f32_e32 v10, v10, v4
 ; GFX9-IEEE-NEXT:    v_mul_f32_e32 v10, v10, v5
-; GFX9-IEEE-NEXT:    v_add_f32_e32 v9, v10, v9
-; GFX9-IEEE-NEXT:    v_mul_f32_e64 v2, -v2, v9
+; GFX9-IEEE-NEXT:    v_add_f32_e32 v8, v10, v8
+; GFX9-IEEE-NEXT:    v_mul_f32_e32 v9, v6, v7
+; GFX9-IEEE-NEXT:    v_mul_f32_e64 v2, -v2, v8
 ; GFX9-IEEE-NEXT:    v_add_f32_e32 v2, v2, v4
-; GFX9-IEEE-NEXT:    v_rcp_f32_e32 v4, v8
+; GFX9-IEEE-NEXT:    v_mul_f32_e64 v4, -v3, v9
+; GFX9-IEEE-NEXT:    v_add_f32_e32 v4, v4, v6
+; GFX9-IEEE-NEXT:    v_mul_f32_e32 v4, v4, v7
+; GFX9-IEEE-NEXT:    v_add_f32_e32 v4, v4, v9
+; GFX9-IEEE-NEXT:    v_mul_f32_e64 v3, -v3, v4
+; GFX9-IEEE-NEXT:    v_add_f32_e32 v3, v3, v6
 ; GFX9-IEEE-NEXT:    v_mul_f32_e32 v2, v2, v5
+; GFX9-IEEE-NEXT:    v_mul_f32_e32 v3, v3, v7
 ; GFX9-IEEE-NEXT:    v_and_b32_e32 v2, 0xff800000, v2
-; GFX9-IEEE-NEXT:    v_add_f32_e32 v2, v2, v9
-; GFX9-IEEE-NEXT:    v_mul_f32_e32 v5, v7, v4
-; GFX9-IEEE-NEXT:    v_mul_f32_e64 v9, -v8, v5
-; GFX9-IEEE-NEXT:    v_add_f32_e32 v9, v9, v7
-; GFX9-IEEE-NEXT:    v_mul_f32_e32 v9, v9, v4
-; GFX9-IEEE-NEXT:    v_add_f32_e32 v5, v9, v5
-; GFX9-IEEE-NEXT:    v_mul_f32_e64 v8, -v8, v5
-; GFX9-IEEE-NEXT:    v_add_f32_e32 v7, v8, v7
-; GFX9-IEEE-NEXT:    v_mul_f32_e32 v4, v7, v4
-; GFX9-IEEE-NEXT:    v_and_b32_e32 v4, 0xff800000, v4
-; GFX9-IEEE-NEXT:    v_add_f32_e32 v4, v4, v5
+; GFX9-IEEE-NEXT:    v_and_b32_e32 v3, 0xff800000, v3
+; GFX9-IEEE-NEXT:    v_add_f32_e32 v2, v2, v8
+; GFX9-IEEE-NEXT:    v_add_f32_e32 v3, v3, v4
 ; GFX9-IEEE-NEXT:    v_cvt_f16_f32_e32 v2, v2
-; GFX9-IEEE-NEXT:    v_cvt_f16_f32_e32 v4, v4
-; GFX9-IEEE-NEXT:    v_div_fixup_f16 v0, v2, v1, v0
-; GFX9-IEEE-NEXT:    v_div_fixup_f16 v1, v4, v6, v3
-; GFX9-IEEE-NEXT:    v_pack_b32_f16 v0, v0, v1
+; GFX9-IEEE-NEXT:    v_cvt_f16_f32_e32 v3, v3
+; GFX9-IEEE-NEXT:    v_div_fixup_f16 v2, v2, v1, v0
+; GFX9-IEEE-NEXT:    v_div_fixup_f16 v0, v3, v1, v0 op_sel:[0,1,1,0]
+; GFX9-IEEE-NEXT:    v_pack_b32_f16 v0, v2, v0
 ; GFX9-IEEE-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-FLUSH-LABEL: v_fdiv_v2f16:
 ; GFX9-FLUSH:       ; %bb.0:
 ; GFX9-FLUSH-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-FLUSH-NEXT:    v_cvt_f32_f16_e32 v2, v1
-; GFX9-FLUSH-NEXT:    v_lshrrev_b32_e32 v3, 16, v1
-; GFX9-FLUSH-NEXT:    v_cvt_f32_f16_e32 v4, v3
+; GFX9-FLUSH-NEXT:    v_cvt_f32_f16_sdwa v3, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
 ; GFX9-FLUSH-NEXT:    v_rcp_f32_e32 v2, v2
-; GFX9-FLUSH-NEXT:    v_rcp_f32_e32 v4, v4
-; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v5, v0, v2, neg(0) op_sel_hi:[1,0,0]
-; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v6, -v1, v5, v0 op_sel_hi:[1,0,1]
-; GFX9-FLUSH-NEXT:    v_mac_f32_e32 v5, v6, v2
-; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v7, v0, v4, neg(0) op_sel:[1,0,0] op_sel_hi:[1,0,0]
-; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v8, -v1, v5, v0 op_sel_hi:[1,0,1]
-; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v6, -v1, v7, v0 op_sel:[1,0,1] op_sel_hi:[1,0,1]
-; GFX9-FLUSH-NEXT:    v_mul_f32_e32 v2, v8, v2
+; GFX9-FLUSH-NEXT:    v_rcp_f32_e32 v3, v3
+; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v4, v0, v2, neg(0) op_sel_hi:[1,0,0]
+; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v6, -v1, v4, v0 op_sel_hi:[1,0,1]
+; GFX9-FLUSH-NEXT:    v_mac_f32_e32 v4, v6, v2
+; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v5, v0, v3, neg(0) op_sel:[1,0,0] op_sel_hi:[1,0,0]
+; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v6, -v1, v4, v0 op_sel_hi:[1,0,1]
+; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v7, -v1, v5, v0 op_sel:[1,0,1] op_sel_hi:[1,0,1]
+; GFX9-FLUSH-NEXT:    v_mul_f32_e32 v2, v6, v2
+; GFX9-FLUSH-NEXT:    v_mac_f32_e32 v5, v7, v3
 ; GFX9-FLUSH-NEXT:    v_and_b32_e32 v2, 0xff800000, v2
-; GFX9-FLUSH-NEXT:    v_mac_f32_e32 v7, v6, v4
-; GFX9-FLUSH-NEXT:    v_add_f32_e32 v2, v2, v5
-; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v5, -v1, v7, v0 op_sel:[1,0,1] op_sel_hi:[1,0,1]
-; GFX9-FLUSH-NEXT:    v_mul_f32_e32 v4, v5, v4
-; GFX9-FLUSH-NEXT:    v_and_b32_e32 v4, 0xff800000, v4
-; GFX9-FLUSH-NEXT:    v_add_f32_e32 v4, v4, v7
+; GFX9-FLUSH-NEXT:    v_add_f32_e32 v2, v2, v4
+; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v4, -v1, v5, v0 op_sel:[1,0,1] op_sel_hi:[1,0,1]
+; GFX9-FLUSH-NEXT:    v_mul_f32_e32 v3, v4, v3
+; GFX9-FLUSH-NEXT:    v_and_b32_e32 v3, 0xff800000, v3
+; GFX9-FLUSH-NEXT:    v_add_f32_e32 v3, v3, v5
 ; GFX9-FLUSH-NEXT:    v_cvt_f16_f32_e32 v2, v2
-; GFX9-FLUSH-NEXT:    v_cvt_f16_f32_e32 v4, v4
-; GFX9-FLUSH-NEXT:    v_lshrrev_b32_e32 v5, 16, v0
-; GFX9-FLUSH-NEXT:    v_div_fixup_f16 v0, v2, v1, v0
-; GFX9-FLUSH-NEXT:    v_div_fixup_f16 v1, v4, v3, v5
-; GFX9-FLUSH-NEXT:    v_pack_b32_f16 v0, v0, v1
+; GFX9-FLUSH-NEXT:    v_cvt_f16_f32_e32 v3, v3
+; GFX9-FLUSH-NEXT:    v_div_fixup_f16 v2, v2, v1, v0
+; GFX9-FLUSH-NEXT:    v_div_fixup_f16 v0, v3, v1, v0 op_sel:[0,1,1,0]
+; GFX9-FLUSH-NEXT:    v_pack_b32_f16 v0, v2, v0
 ; GFX9-FLUSH-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-IEEE-LABEL: v_fdiv_v2f16:
 ; GFX10-IEEE:       ; %bb.0:
 ; GFX10-IEEE-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10-IEEE-NEXT:    v_lshrrev_b32_e32 v2, 16, v1
-; GFX10-IEEE-NEXT:    v_cvt_f32_f16_e32 v3, v1
-; GFX10-IEEE-NEXT:    v_cvt_f32_f16_e32 v4, v2
+; GFX10-IEEE-NEXT:    v_cvt_f32_f16_e32 v2, v1
+; GFX10-IEEE-NEXT:    v_cvt_f32_f16_sdwa v3, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX10-IEEE-NEXT:    v_rcp_f32_e32 v2, v2
 ; GFX10-IEEE-NEXT:    v_rcp_f32_e32 v3, v3
-; GFX10-IEEE-NEXT:    v_rcp_f32_e32 v4, v4
-; GFX10-IEEE-NEXT:    v_fma_mix_f32 v5, v0, v3, neg(0) op_sel_hi:[1,0,0]
-; GFX10-IEEE-NEXT:    v_fma_mix_f32 v6, v0, v4, neg(0) op_sel:[1,0,0] op_sel_hi:[1,0,0]
-; GFX10-IEEE-NEXT:    v_fma_mix_f32 v7, -v1, v5, neg(0) op_sel_hi:[1,0,0]
-; GFX10-IEEE-NEXT:    v_fma_mix_f32 v8, -v1, v6, neg(0) op_sel:[1,0,0] op_sel_hi:[1,0,0]
-; GFX10-IEEE-NEXT:    v_fma_mix_f32 v7, v0, 1.0, v7 op_sel_hi:[1,1,0]
-; GFX10-IEEE-NEXT:    v_fma_mix_f32 v8, v0, 1.0, v8 op_sel:[1,0,0] op_sel_hi:[1,1,0]
+; GFX10-IEEE-NEXT:    v_fma_mix_f32 v4, v0, v2, neg(0) op_sel_hi:[1,0,0]
+; GFX10-IEEE-NEXT:    v_fma_mix_f32 v5, v0, v3, neg(0) op_sel:[1,0,0] op_sel_hi:[1,0,0]
+; GFX10-IEEE-NEXT:    v_fma_mix_f32 v6, -v1, v4, neg(0) op_sel_hi:[1,0,0]
+; GFX10-IEEE-NEXT:    v_fma_mix_f32 v7, -v1, v5, neg(0) op_sel:[1,0,0] op_sel_hi:[1,0,0]
+; GFX10-IEEE-NEXT:    v_fma_mix_f32 v6, v0, 1.0, v6 op_sel_hi:[1,1,0]
+; GFX10-IEEE-NEXT:    v_fma_mix_f32 v7, v0, 1.0, v7 op_sel:[1,0,0] op_sel_hi:[1,1,0]
+; GFX10-IEEE-NEXT:    v_mul_f32_e32 v6, v6, v2
 ; GFX10-IEEE-NEXT:    v_mul_f32_e32 v7, v7, v3
-; GFX10-IEEE-NEXT:    v_mul_f32_e32 v8, v8, v4
+; GFX10-IEEE-NEXT:    v_add_f32_e32 v4, v6, v4
 ; GFX10-IEEE-NEXT:    v_add_f32_e32 v5, v7, v5
-; GFX10-IEEE-NEXT:    v_add_f32_e32 v6, v8, v6
-; GFX10-IEEE-NEXT:    v_fma_mix_f32 v7, -v1, v5, neg(0) op_sel_hi:[1,0,0]
-; GFX10-IEEE-NEXT:    v_fma_mix_f32 v8, -v1, v6, neg(0) op_sel:[1,0,0] op_sel_hi:[1,0,0]
-; GFX10-IEEE-NEXT:    v_fma_mix_f32 v7, v0, 1.0, v7 op_sel_hi:[1,1,0]
-; GFX10-IEEE-NEXT:    v_fma_mix_f32 v8, v0, 1.0, v8 op_sel:[1,0,0] op_sel_hi:[1,1,0]
+; GFX10-IEEE-NEXT:    v_fma_mix_f32 v6, -v1, v4, neg(0) op_sel_hi:[1,0,0]
+; GFX10-IEEE-NEXT:    v_fma_mix_f32 v7, -v1, v5, neg(0) op_sel:[1,0,0] op_sel_hi:[1,0,0]
+; GFX10-IEEE-NEXT:    v_fma_mix_f32 v6, v0, 1.0, v6 op_sel_hi:[1,1,0]
+; GFX10-IEEE-NEXT:    v_fma_mix_f32 v7, v0, 1.0, v7 op_sel:[1,0,0] op_sel_hi:[1,1,0]
+; GFX10-IEEE-NEXT:    v_mul_f32_e32 v2, v6, v2
 ; GFX10-IEEE-NEXT:    v_mul_f32_e32 v3, v7, v3
-; GFX10-IEEE-NEXT:    v_mul_f32_e32 v4, v8, v4
+; GFX10-IEEE-NEXT:    v_and_b32_e32 v2, 0xff800000, v2
 ; GFX10-IEEE-NEXT:    v_and_b32_e32 v3, 0xff800000, v3
-; GFX10-IEEE-NEXT:    v_and_b32_e32 v4, 0xff800000, v4
+; GFX10-IEEE-NEXT:    v_add_f32_e32 v2, v2, v4
 ; GFX10-IEEE-NEXT:    v_add_f32_e32 v3, v3, v5
-; GFX10-IEEE-NEXT:    v_lshrrev_b32_e32 v5, 16, v0
-; GFX10-IEEE-NEXT:    v_add_f32_e32 v4, v4, v6
+; GFX10-IEEE-NEXT:    v_cvt_f16_f32_e32 v2, v2
 ; GFX10-IEEE-NEXT:    v_cvt_f16_f32_e32 v3, v3
-; GFX10-IEEE-NEXT:    v_cvt_f16_f32_e32 v4, v4
-; GFX10-IEEE-NEXT:    v_div_fixup_f16 v0, v3, v1, v0
-; GFX10-IEEE-NEXT:    v_div_fixup_f16 v1, v4, v2, v5
-; GFX10-IEEE-NEXT:    v_pack_b32_f16 v0, v0, v1
+; GFX10-IEEE-NEXT:    v_div_fixup_f16 v2, v2, v1, v0
+; GFX10-IEEE-NEXT:    v_div_fixup_f16 v0, v3, v1, v0 op_sel:[0,1,1,0]
+; GFX10-IEEE-NEXT:    v_pack_b32_f16 v0, v2, v0
 ; GFX10-IEEE-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-FLUSH-LABEL: v_fdiv_v2f16:
 ; GFX10-FLUSH:       ; %bb.0:
 ; GFX10-FLUSH-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10-FLUSH-NEXT:    v_lshrrev_b32_e32 v2, 16, v1
-; GFX10-FLUSH-NEXT:    v_cvt_f32_f16_e32 v3, v1
-; GFX10-FLUSH-NEXT:    v_lshrrev_b32_e32 v7, 16, v0
-; GFX10-FLUSH-NEXT:    v_cvt_f32_f16_e32 v8, v0
-; GFX10-FLUSH-NEXT:    v_cvt_f32_f16_e32 v4, v2
+; GFX10-FLUSH-NEXT:    v_cvt_f32_f16_e32 v2, v1
+; GFX10-FLUSH-NEXT:    v_cvt_f32_f16_sdwa v3, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX10-FLUSH-NEXT:    v_cvt_f32_f16_e32 v6, v0
+; GFX10-FLUSH-NEXT:    v_cvt_f32_f16_sdwa v7, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX10-FLUSH-NEXT:    v_rcp_f32_e32 v4, v2
 ; GFX10-FLUSH-NEXT:    v_rcp_f32_e32 v5, v3
-; GFX10-FLUSH-NEXT:    v_cvt_f32_f16_e32 v10, v7
-; GFX10-FLUSH-NEXT:    v_rcp_f32_e32 v6, v4
-; GFX10-FLUSH-NEXT:    v_fma_mix_f32 v9, v0, v5, neg(0) op_sel_hi:[1,0,0]
-; GFX10-FLUSH-NEXT:    v_fma_mix_f32 v11, v0, v6, neg(0) op_sel:[1,0,0] op_sel_hi:[1,0,0]
-; GFX10-FLUSH-NEXT:    v_mad_f32 v12, -v3, v9, v8
-; GFX10-FLUSH-NEXT:    v_mad_f32 v13, -v4, v11, v10
-; GFX10-FLUSH-NEXT:    v_mac_f32_e32 v9, v12, v5
-; GFX10-FLUSH-NEXT:    v_mac_f32_e32 v11, v13, v6
-; GFX10-FLUSH-NEXT:    v_mad_f32 v3, -v3, v9, v8
-; GFX10-FLUSH-NEXT:    v_mad_f32 v4, -v4, v11, v10
+; GFX10-FLUSH-NEXT:    v_fma_mix_f32 v8, v0, v4, neg(0) op_sel_hi:[1,0,0]
+; GFX10-FLUSH-NEXT:    v_fma_mix_f32 v9, v0, v5, neg(0) op_sel:[1,0,0] op_sel_hi:[1,0,0]
+; GFX10-FLUSH-NEXT:    v_mad_f32 v10, -v2, v8, v6
+; GFX10-FLUSH-NEXT:    v_mad_f32 v11, -v3, v9, v7
+; GFX10-FLUSH-NEXT:    v_mac_f32_e32 v8, v10, v4
+; GFX10-FLUSH-NEXT:    v_mac_f32_e32 v9, v11, v5
+; GFX10-FLUSH-NEXT:    v_mad_f32 v2, -v2, v8, v6
+; GFX10-FLUSH-NEXT:    v_mad_f32 v3, -v3, v9, v7
+; GFX10-FLUSH-NEXT:    v_mul_f32_e32 v2, v2, v4
 ; GFX10-FLUSH-NEXT:    v_mul_f32_e32 v3, v3, v5
-; GFX10-FLUSH-NEXT:    v_mul_f32_e32 v4, v4, v6
+; GFX10-FLUSH-NEXT:    v_and_b32_e32 v2, 0xff800000, v2
 ; GFX10-FLUSH-NEXT:    v_and_b32_e32 v3, 0xff800000, v3
-; GFX10-FLUSH-NEXT:    v_and_b32_e32 v4, 0xff800000, v4
+; GFX10-FLUSH-NEXT:    v_add_f32_e32 v2, v2, v8
 ; GFX10-FLUSH-NEXT:    v_add_f32_e32 v3, v3, v9
-; GFX10-FLUSH-NEXT:    v_add_f32_e32 v4, v4, v11
+; GFX10-FLUSH-NEXT:    v_cvt_f16_f32_e32 v2, v2
 ; GFX10-FLUSH-NEXT:    v_cvt_f16_f32_e32 v3, v3
-; GFX10-FLUSH-NEXT:    v_cvt_f16_f32_e32 v4, v4
-; GFX10-FLUSH-NEXT:    v_div_fixup_f16 v0, v3, v1, v0
-; GFX10-FLUSH-NEXT:    v_div_fixup_f16 v1, v4, v2, v7
-; GFX10-FLUSH-NEXT:    v_pack_b32_f16 v0, v0, v1
+; GFX10-FLUSH-NEXT:    v_div_fixup_f16 v2, v2, v1, v0
+; GFX10-FLUSH-NEXT:    v_div_fixup_f16 v0, v3, v1, v0 op_sel:[0,1,1,0]
+; GFX10-FLUSH-NEXT:    v_pack_b32_f16 v0, v2, v0
 ; GFX10-FLUSH-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_fdiv_v2f16:
@@ -1039,27 +1031,26 @@ define <2 x half> @v_fdiv_v2f16(<2 x half> %a, <2 x half> %b) {
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_lshrrev_b32_e32 v2, 16, v1
 ; GFX11-NEXT:    v_cvt_f32_f16_e32 v3, v1
-; GFX11-NEXT:    v_cvt_f32_f16_e32 v4, v2
+; GFX11-NEXT:    v_cvt_f32_f16_e32 v2, v2
 ; GFX11-NEXT:    v_rcp_f32_e32 v3, v3
-; GFX11-NEXT:    v_rcp_f32_e32 v4, v4
+; GFX11-NEXT:    v_rcp_f32_e32 v2, v2
 ; GFX11-NEXT:    s_waitcnt_depctr depctr_va_vdst(0)
-; GFX11-NEXT:    v_fma_mix_f32 v5, v0, v3, neg(0) op_sel_hi:[1,0,0]
-; GFX11-NEXT:    v_fma_mix_f32 v6, v0, v4, neg(0) op_sel:[1,0,0] op_sel_hi:[1,0,0]
-; GFX11-NEXT:    v_fma_mix_f32 v7, -v1, v5, v0 op_sel_hi:[1,0,1]
-; GFX11-NEXT:    v_fma_mix_f32 v8, -v1, v6, v0 op_sel:[1,0,1] op_sel_hi:[1,0,1]
-; GFX11-NEXT:    v_dual_fmac_f32 v5, v7, v3 :: v_dual_fmac_f32 v6, v8, v4
-; GFX11-NEXT:    v_fma_mix_f32 v7, -v1, v5, v0 op_sel_hi:[1,0,1]
-; GFX11-NEXT:    v_fma_mix_f32 v8, -v1, v6, v0 op_sel:[1,0,1] op_sel_hi:[1,0,1]
-; GFX11-NEXT:    v_dual_mul_f32 v3, v7, v3 :: v_dual_mul_f32 v4, v8, v4
-; GFX11-NEXT:    v_and_b32_e32 v4, 0xff800000, v4
-; GFX11-NEXT:    v_dual_add_f32 v4, v4, v6 :: v_dual_and_b32 v3, 0xff800000, v3
-; GFX11-NEXT:    v_add_f32_e32 v3, v3, v5
-; GFX11-NEXT:    v_lshrrev_b32_e32 v5, 16, v0
-; GFX11-NEXT:    v_cvt_f16_f32_e32 v4, v4
+; GFX11-NEXT:    v_fma_mix_f32 v4, v0, v3, neg(0) op_sel_hi:[1,0,0]
+; GFX11-NEXT:    v_fma_mix_f32 v5, v0, v2, neg(0) op_sel:[1,0,0] op_sel_hi:[1,0,0]
+; GFX11-NEXT:    v_fma_mix_f32 v6, -v1, v4, v0 op_sel_hi:[1,0,1]
+; GFX11-NEXT:    v_fma_mix_f32 v7, -v1, v5, v0 op_sel:[1,0,1] op_sel_hi:[1,0,1]
+; GFX11-NEXT:    v_dual_fmac_f32 v4, v6, v3 :: v_dual_fmac_f32 v5, v7, v2
+; GFX11-NEXT:    v_fma_mix_f32 v6, -v1, v4, v0 op_sel_hi:[1,0,1]
+; GFX11-NEXT:    v_fma_mix_f32 v7, -v1, v5, v0 op_sel:[1,0,1] op_sel_hi:[1,0,1]
+; GFX11-NEXT:    v_dual_mul_f32 v3, v6, v3 :: v_dual_mul_f32 v2, v7, v2
+; GFX11-NEXT:    v_and_b32_e32 v2, 0xff800000, v2
+; GFX11-NEXT:    v_dual_add_f32 v2, v2, v5 :: v_dual_and_b32 v3, 0xff800000, v3
+; GFX11-NEXT:    v_add_f32_e32 v3, v3, v4
+; GFX11-NEXT:    v_cvt_f16_f32_e32 v2, v2
 ; GFX11-NEXT:    v_cvt_f16_f32_e32 v3, v3
-; GFX11-NEXT:    v_div_fixup_f16 v0, v3, v1, v0
-; GFX11-NEXT:    v_div_fixup_f16 v1, v4, v2, v5
-; GFX11-NEXT:    v_pack_b32_f16 v0, v0, v1
+; GFX11-NEXT:    v_div_fixup_f16 v3, v3, v1, v0
+; GFX11-NEXT:    v_div_fixup_f16 v0, v2, v1, v0 op_sel:[0,1,1,0]
+; GFX11-NEXT:    v_pack_b32_f16 v0, v3, v0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
   %fdiv = fdiv <2 x half> %a, %b
   ret <2 x half> %fdiv
@@ -1298,135 +1289,127 @@ define <2 x half> @v_fdiv_v2f16_ulp25(<2 x half> %a, <2 x half> %b) {
 ; GFX9-IEEE-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-IEEE-NEXT:    v_cvt_f32_f16_e32 v2, v1
 ; GFX9-IEEE-NEXT:    v_cvt_f32_f16_e32 v4, v0
-; GFX9-IEEE-NEXT:    v_lshrrev_b32_e32 v6, 16, v1
-; GFX9-IEEE-NEXT:    v_cvt_f32_f16_e32 v8, v6
+; GFX9-IEEE-NEXT:    v_cvt_f32_f16_sdwa v3, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX9-IEEE-NEXT:    v_cvt_f32_f16_sdwa v6, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
 ; GFX9-IEEE-NEXT:    v_rcp_f32_e32 v5, v2
-; GFX9-IEEE-NEXT:    v_lshrrev_b32_e32 v3, 16, v0
-; GFX9-IEEE-NEXT:    v_cvt_f32_f16_e32 v7, v3
-; GFX9-IEEE-NEXT:    v_mul_f32_e32 v9, v4, v5
-; GFX9-IEEE-NEXT:    v_mul_f32_e64 v10, -v2, v9
+; GFX9-IEEE-NEXT:    v_rcp_f32_e32 v7, v3
+; GFX9-IEEE-NEXT:    v_mul_f32_e32 v8, v4, v5
+; GFX9-IEEE-NEXT:    v_mul_f32_e64 v10, -v2, v8
 ; GFX9-IEEE-NEXT:    v_add_f32_e32 v10, v10, v4
 ; GFX9-IEEE-NEXT:    v_mul_f32_e32 v10, v10, v5
-; GFX9-IEEE-NEXT:    v_add_f32_e32 v9, v10, v9
-; GFX9-IEEE-NEXT:    v_mul_f32_e64 v2, -v2, v9
+; GFX9-IEEE-NEXT:    v_add_f32_e32 v8, v10, v8
+; GFX9-IEEE-NEXT:    v_mul_f32_e32 v9, v6, v7
+; GFX9-IEEE-NEXT:    v_mul_f32_e64 v2, -v2, v8
 ; GFX9-IEEE-NEXT:    v_add_f32_e32 v2, v2, v4
-; GFX9-IEEE-NEXT:    v_rcp_f32_e32 v4, v8
+; GFX9-IEEE-NEXT:    v_mul_f32_e64 v4, -v3, v9
+; GFX9-IEEE-NEXT:    v_add_f32_e32 v4, v4, v6
+; GFX9-IEEE-NEXT:    v_mul_f32_e32 v4, v4, v7
+; GFX9-IEEE-NEXT:    v_add_f32_e32 v4, v4, v9
+; GFX9-IEEE-NEXT:    v_mul_f32_e64 v3, -v3, v4
+; GFX9-IEEE-NEXT:    v_add_f32_e32 v3, v3, v6
 ; GFX9-IEEE-NEXT:    v_mul_f32_e32 v2, v2, v5
+; GFX9-IEEE-NEXT:    v_mul_f32_e32 v3, v3, v7
 ; GFX9-IEEE-NEXT:    v_and_b32_e32 v2, 0xff800000, v2
-; GFX9-IEEE-NEXT:    v_add_f32_e32 v2, v2, v9
-; GFX9-IEEE-NEXT:    v_mul_f32_e32 v5, v7, v4
-; GFX9-IEEE-NEXT:    v_mul_f32_e64 v9, -v8, v5
-; GFX9-IEEE-NEXT:    v_add_f32_e32 v9, v9, v7
-; GFX9-IEEE-NEXT:    v_mul_f32_e32 v9, v9, v4
-; GFX9-IEEE-NEXT:    v_add_f32_e32 v5, v9, v5
-; GFX9-IEEE-NEXT:    v_mul_f32_e64 v8, -v8, v5
-; GFX9-IEEE-NEXT:    v_add_f32_e32 v7, v8, v7
-; GFX9-IEEE-NEXT:    v_mul_f32_e32 v4, v7, v4
-; GFX9-IEEE-NEXT:    v_and_b32_e32 v4, 0xff800000, v4
-; GFX9-IEEE-NEXT:    v_add_f32_e32 v4, v4, v5
+; GFX9-IEEE-NEXT:    v_and_b32_e32 v3, 0xff800000, v3
+; GFX9-IEEE-NEXT:    v_add_f32_e32 v2, v2, v8
+; GFX9-IEEE-NEXT:    v_add_f32_e32 v3, v3, v4
 ; GFX9-IEEE-NEXT:    v_cvt_f16_f32_e32 v2, v2
-; GFX9-IEEE-NEXT:    v_cvt_f16_f32_e32 v4, v4
-; GFX9-IEEE-NEXT:    v_div_fixup_f16 v0, v2, v1, v0
-; GFX9-IEEE-NEXT:    v_div_fixup_f16 v1, v4, v6, v3
-; GFX9-IEEE-NEXT:    v_pack_b32_f16 v0, v0, v1
+; GFX9-IEEE-NEXT:    v_cvt_f16_f32_e32 v3, v3
+; GFX9-IEEE-NEXT:    v_div_fixup_f16 v2, v2, v1, v0
+; GFX9-IEEE-NEXT:    v_div_fixup_f16 v0, v3, v1, v0 op_sel:[0,1,1,0]
+; GFX9-IEEE-NEXT:    v_pack_b32_f16 v0, v2, v0
 ; GFX9-IEEE-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-FLUSH-LABEL: v_fdiv_v2f16_ulp25:
 ; GFX9-FLUSH:       ; %bb.0:
 ; GFX9-FLUSH-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-FLUSH-NEXT:    v_cvt_f32_f16_e32 v2, v1
-; GFX9-FLUSH-NEXT:    v_lshrrev_b32_e32 v3, 16, v1
-; GFX9-FLUSH-NEXT:    v_cvt_f32_f16_e32 v4, v3
+; GFX9-FLUSH-NEXT:    v_cvt_f32_f16_sdwa v3, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
 ; GFX9-FLUSH-NEXT:    v_rcp_f32_e32 v2, v2
-; GFX9-FLUSH-NEXT:    v_rcp_f32_e32 v4, v4
-; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v5, v0, v2, neg(0) op_sel_hi:[1,0,0]
-; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v6, -v1, v5, v0 op_sel_hi:[1,0,1]
-; GFX9-FLUSH-NEXT:    v_mac_f32_e32 v5, v6, v2
-; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v7, v0, v4, neg(0) op_sel:[1,0,0] op_sel_hi:[1,0,0]
-; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v8, -v1, v5, v0 op_sel_hi:[1,0,1]
-; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v6, -v1, v7, v0 op_sel:[1,0,1] op_sel_hi:[1,0,1]
-; GFX9-FLUSH-NEXT:    v_mul_f32_e32 v2, v8, v2
+; GFX9-FLUSH-NEXT:    v_rcp_f32_e32 v3, v3
+; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v4, v0, v2, neg(0) op_sel_hi:[1,0,0]
+; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v6, -v1, v4, v0 op_sel_hi:[1,0,1]
+; GFX9-FLUSH-NEXT:    v_mac_f32_e32 v4, v6, v2
+; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v5, v0, v3, neg(0) op_sel:[1,0,0] op_sel_hi:[1,0,0]
+; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v6, -v1, v4, v0 op_sel_hi:[1,0,1]
+; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v7, -v1, v5, v0 op_sel:[1,0,1] op_sel_hi:[1,0,1]
+; GFX9-FLUSH-NEXT:    v_mul_f32_e32 v2, v6, v2
+; GFX9-FLUSH-NEXT:    v_mac_f32_e32 v5, v7, v3
 ; GFX9-FLUSH-NEXT:    v_and_b32_e32 v2, 0xff800000, v2
-; GFX9-FLUSH-NEXT:    v_mac_f32_e32 v7, v6, v4
-; GFX9-FLUSH-NEXT:    v_add_f32_e32 v2, v2, v5
-; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v5, -v1, v7, v0 op_sel:[1,0,1] op_sel_hi:[1,0,1]
-; GFX9-FLUSH-NEXT:    v_mul_f32_e32 v4, v5, v4
-; GFX9-FLUSH-NEXT:    v_and_b32_e32 v4, 0xff800000, v4
-; GFX9-FLUSH-NEXT:    v_add_f32_e32 v4, v4, v7
+; GFX9-FLUSH-NEXT:    v_add_f32_e32 v2, v2, v4
+; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v4, -v1, v5, v0 op_sel:[1,0,1] op_sel_hi:[1,0,1]
+; GFX9-FLUSH-NEXT:    v_mul_f32_e32 v3, v4, v3
+; GFX9-FLUSH-NEXT:    v_and_b32_e32 v3, 0xff800000, v3
+; GFX9-FLUSH-NEXT:    v_add_f32_e32 v3, v3, v5
 ; GFX9-FLUSH-NEXT:    v_cvt_f16_f32_e32 v2, v2
-; GFX9-FLUSH-NEXT:    v_cvt_f16_f32_e32 v4, v4
-; GFX9-FLUSH-NEXT:    v_lshrrev_b32_e32 v5, 16, v0
-; GFX9-FLUSH-NEXT:    v_div_fixup_f16 v0, v2, v1, v0
-; GFX9-FLUSH-NEXT:    v_div_fixup_f16 v1, v4, v3, v5
-; GFX9-FLUSH-NEXT:    v_pack_b32_f16 v0, v0, v1
+; GFX9-FLUSH-NEXT:    v_cvt_f16_f32_e32 v3, v3
+; GFX9-FLUSH-NEXT:    v_div_fixup_f16 v2, v2, v1, v0
+; GFX9-FLUSH-NEXT:    v_div_fixup_f16 v0, v3, v1, v0 op_sel:[0,1,1,0]
+; GFX9-FLUSH-NEXT:    v_pack_b32_f16 v0, v2, v0
 ; GFX9-FLUSH-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-IEEE-LABEL: v_fdiv_v2f16_ulp25:
 ; GFX10-IEEE:       ; %bb.0:
 ; GFX10-IEEE-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10-IEEE-NEXT:    v_lshrrev_b32_e32 v2, 16, v1
-; GFX10-IEEE-NEXT:    v_cvt_f32_f16_e32 v3, v1
-; GFX10-IEEE-NEXT:    v_cvt_f32_f16_e32 v4, v2
+; GFX10-IEEE-NEXT:    v_cvt_f32_f16_e32 v2, v1
+; GFX10-IEEE-NEXT:    v_cvt_f32_f16_sdwa v3, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX10-IEEE-NEXT:    v_rcp_f32_e32 v2, v2
 ; GFX10-IEEE-NEXT:    v_rcp_f32_e32 v3, v3
-; GFX10-IEEE-NEXT:    v_rcp_f32_e32 v4, v4
-; GFX10-IEEE-NEXT:    v_fma_mix_f32 v5, v0, v3, neg(0) op_sel_hi:[1,0,0]
-; GFX10-IEEE-NEXT:    v_fma_mix_f32 v6, v0, v4, neg(0) op_sel:[1,0,0] op_sel_hi:[1,0,0]
-; GFX10-IEEE-NEXT:    v_fma_mix_f32 v7, -v1, v5, neg(0) op_sel_hi:[1,0,0]
-; GFX10-IEEE-NEXT:    v_fma_mix_f32 v8, -v1, v6, neg(0) op_sel:[1,0,0] op_sel_hi:[1,0,0]
-; GFX10-IEEE-NEXT:    v_fma_mix_f32 v7, v0, 1.0, v7 op_sel_hi:[1,1,0]
-; GFX10-IEEE-NEXT:    v_fma_mix_f32 v8, v0, 1.0, v8 op_sel:[1,0,0] op_sel_hi:[1,1,0]
+; GFX10-IEEE-NEXT:    v_fma_mix_f32 v4, v0, v2, neg(0) op_sel_hi:[1,0,0]
+; GFX10-IEEE-NEXT:    v_fma_mix_f32 v5, v0, v3, neg(0) op_sel:[1,0,0] op_sel_hi:[1,0,0]
+; GFX10-IEEE-NEXT:    v_fma_mix_f32 v6, -v1, v4, neg(0) op_sel_hi:[1,0,0]
+; GFX10-IEEE-NEXT:    v_fma_mix_f32 v7, -v1, v5, neg(0) op_sel:[1,0,0] op_sel_hi:[1,0,0]
+; GFX10-IEEE-NEXT:    v_fma_mix_f32 v6, v0, 1.0, v6 op_sel_hi:[1,1,0]
+; GFX10-IEEE-NEXT:    v_fma_mix_f32 v7, v0, 1.0, v7 op_sel:[1,0,0] op_sel_hi:[1,1,0]
+; GFX10-IEEE-NEXT:    v_mul_f32_e32 v6, v6, v2
 ; GFX10-IEEE-NEXT:    v_mul_f32_e32 v7, v7, v3
-; GFX10-IEEE-NEXT:    v_mul_f32_e32 v8, v8, v4
+; GFX10-IEEE-NEXT:    v_add_f32_e32 v4, v6, v4
 ; GFX10-IEEE-NEXT:    v_add_f32_e32 v5, v7, v5
-; GFX10-IEEE-NEXT:    v_add_f32_e32 v6, v8, v6
-; GFX10-IEEE-NEXT:    v_fma_mix_f32 v7, -v1, v5, neg(0) op_sel_hi:[1,0,0]
-; GFX10-IEEE-NEXT:    v_fma_mix_f32 v8, -v1, v6, neg(0) op_sel:[1,0,0] op_sel_hi:[1,0,0]
-; GFX10-IEEE-NEXT:    v_fma_mix_f32 v7, v0, 1.0, v7 op_sel_hi:[1,1,0]
-; GFX10-IEEE-NEXT:    v_fma_mix_f32 v8, v0, 1.0, v8 op_sel:[1,0,0] op_sel_hi:[1,1,0]
+; GFX10-IEEE-NEXT:    v_fma_mix_f32 v6, -v1, v4, neg(0) op_sel_hi:[1,0,0]
+; GFX10-IEEE-NEXT:    v_fma_mix_f32 v7, -v1, v5, neg(0) op_sel:[1,0,0] op_sel_hi:[1,0,0]
+; GFX10-IEEE-NEXT:    v_fma_mix_f32 v6, v0, 1.0, v6 op_sel_hi:[1,1,0]
+; GFX10-IEEE-NEXT:    v_fma_mix_f32 v7, v0, 1.0, v7 op_sel:[1,0,0] op_sel_hi:[1,1,0]
+; GFX10-IEEE-NEXT:    v_mul_f32_e32 v2, v6, v2
 ; GFX10-IEEE-NEXT:    v_mul_f32_e32 v3, v7, v3
-; GFX10-IEEE-NEXT:    v_mul_f32_e32 v4, v8, v4
+; GFX10-IEEE-NEXT:    v_and_b32_e32 v2, 0xff800000, v2
 ; GFX10-IEEE-NEXT:    v_and_b32_e32 v3, 0xff800000, v3
-; GFX10-IEEE-NEXT:    v_and_b32_e32 v4, 0xff800000, v4
+; GFX10-IEEE-NEXT:    v_add_f32_e32 v2, v2, v4
 ; GFX10-IEEE-NEXT:    v_add_f32_e32 v3, v3, v5
-; GFX10-IEEE-NEXT:    v_lshrrev_b32_e32 v5, 16, v0
-; GFX10-IEEE-NEXT:    v_add_f32_e32 v4, v4, v6
+; GFX10-IEEE-NEXT:    v_cvt_f16_f32_e32 v2, v2
 ; GFX10-IEEE-NEXT:    v_cvt_f16_f32_e32 v3, v3
-; GFX10-IEEE-NEXT:    v_cvt_f16_f32_e32 v4, v4
-; GFX10-IEEE-NEXT:    v_div_fixup_f16 v0, v3, v1, v0
-; GFX10-IEEE-NEXT:    v_div_fixup_f16 v1, v4, v2, v5
-; GFX10-IEEE-NEXT:    v_pack_b32_f16 v0, v0, v1
+; GFX10-IEEE-NEXT:    v_div_fixup_f16 v2, v2, v1, v0
+; GFX10-IEEE-NEXT:    v_div_fixup_f16 v0, v3, v1, v0 op_sel:[0,1,1,0]
+; GFX10-IEEE-NEXT:    v_pack_b32_f16 v0, v2, v0
 ; GFX10-IEEE-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-FLUSH-LABEL: v_fdiv_v2f16_ulp25:
 ; GFX10-FLUSH:       ; %bb.0:
 ; GFX10-FLUSH-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10-FLUSH-NEXT:    v_lshrrev_b32_e32 v2, 16, v1
-; GFX10-FLUSH-NEXT:    v_cvt_f32_f16_e32 v3, v1
-; GFX10-FLUSH-NEXT:    v_lshrrev_b32_e32 v7, 16, v0
-; GFX10-FLUSH-NEXT:    v_cvt_f32_f16_e32 v8, v0
-; GFX10-FLUSH-NEXT:    v_cvt_f32_f16_e32 v4, v2
+; GFX10-FLUSH-NEXT:    v_cvt_f32_f16_e32 v2, v1
+; GFX10-FLUSH-NEXT:    v_cvt_f32_f16_sdwa v3, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX10-FLUSH-NEXT:    v_cvt_f32_f16_e32 v6, v0
+; GFX10-FLUSH-NEXT:    v_cvt_f32_f16_sdwa v7, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX10-FLUSH-NEXT:    v_rcp_f32_e32 v4, v2
 ; GFX10-FLUSH-NEXT:    v_rcp_f32_e32 v5, v3
-; GFX10-FLUSH-NEXT:    v_cvt_f32_f16_e32 v10, v7
-; GFX10-FLUSH-NEXT:    v_rcp_f32_e32 v6, v4
-; GFX10-FLUSH-NEXT:    v_fma_mix_f32 v9, v0, v5, neg(0) op_sel_hi:[1,0,0]
-; GFX10-FLUSH-NEXT:    v_fma_mix_f32 v11, v0, v6, neg(0) op_sel:[1,0,0] op_sel_hi:[1,0,0]
-; GFX10-FLUSH-NEXT:    v_mad_f32 v12, -v3, v9, v8
-; GFX10-FLUSH-NEXT:    v_mad_f32 v13, -v4, v11, v10
-; GFX10-FLUSH-NEXT:    v_mac_f32_e32 v9, v12, v5
-; GFX10-FLUSH-NEXT:    v_mac_f32_e32 v11, v13, v6
-; GFX10-FLUSH-NEXT:    v_mad_f32 v3, -v3, v9, v8
-; GFX10-FLUSH-NEXT:    v_mad_f32 v4, -v4, v11, v10
+; GFX10-FLUSH-NEXT:    v_fma_mix_f32 v8, v0, v4, neg(0) op_sel_hi:[1,0,0]
+; GFX10-FLUSH-NEXT:    v_fma_mix_f32 v9, v0, v5, neg(0) op_sel:[1,0,0] op_sel_hi:[1,0,0]
+; GFX10-FLUSH-NEXT:    v_mad_f32 v10, -v2, v8, v6
+; GFX10-FLUSH-NEXT:    v_mad_f32 v11, -v3, v9, v7
+; GFX10-FLUSH-NEXT:    v_mac_f32_e32 v8, v10, v4
+; GFX10-FLUSH-NEXT:    v_mac_f32_e32 v9, v11, v5
+; GFX10-FLUSH-NEXT:    v_mad_f32 v2, -v2, v8, v6
+; GFX10-FLUSH-NEXT:    v_mad_f32 v3, -v3, v9, v7
+; GFX10-FLUSH-NEXT:    v_mul_f32_e32 v2, v2, v4
 ; GFX10-FLUSH-NEXT:    v_mul_f32_e32 v3, v3, v5
-; GFX10-FLUSH-NEXT:    v_mul_f32_e32 v4, v4, v6
+; GFX10-FLUSH-NEXT:    v_and_b32_e32 v2, 0xff800000, v2
 ; GFX10-FLUSH-NEXT:    v_and_b32_e32 v3, 0xff800000, v3
-; GFX10-FLUSH-NEXT:    v_and_b32_e32 v4, 0xff800000, v4
+; GFX10-FLUSH-NEXT:    v_add_f32_e32 v2, v2, v8
 ; GFX10-FLUSH-NEXT:    v_add_f32_e32 v3, v3, v9
-; GFX10-FLUSH-NEXT:    v_add_f32_e32 v4, v4, v11
+; GFX10-FLUSH-NEXT:    v_cvt_f16_f32_e32 v2, v2
 ; GFX10-FLUSH-NEXT:    v_cvt_f16_f32_e32 v3, v3
-; GFX10-FLUSH-NEXT:    v_cvt_f16_f32_e32 v4, v4
-; GFX10-FLUSH-NEXT:    v_div_fixup_f16 v0, v3, v1, v0
-; GFX10-FLUSH-NEXT:    v_div_fixup_f16 v1, v4, v2, v7
-; GFX10-FLUSH-NEXT:    v_pack_b32_f16 v0, v0, v1
+; GFX10-FLUSH-NEXT:    v_div_fixup_f16 v2, v2, v1, v0
+; GFX10-FLUSH-NEXT:    v_div_fixup_f16 v0, v3, v1, v0 op_sel:[0,1,1,0]
+; GFX10-FLUSH-NEXT:    v_pack_b32_f16 v0, v2, v0
 ; GFX10-FLUSH-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_fdiv_v2f16_ulp25:
@@ -1434,27 +1417,26 @@ define <2 x half> @v_fdiv_v2f16_ulp25(<2 x half> %a, <2 x half> %b) {
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_lshrrev_b32_e32 v2, 16, v1
 ; GFX11-NEXT:    v_cvt_f32_f16_e32 v3, v1
-; GFX11-NEXT:    v_cvt_f32_f16_e32 v4, v2
+; GFX11-NEXT:    v_cvt_f32_f16_e32 v2, v2
 ; GFX11-NEXT:    v_rcp_f32_e32 v3, v3
-; GFX11-NEXT:    v_rcp_f32_e32 v4, v4
+; GFX11-NEXT:    v_rcp_f32_e32 v2, v2
 ; GFX11-NEXT:    s_waitcnt_depctr depctr_va_vdst(0)
-; GFX11-NEXT:    v_fma_mix_f32 v5, v0, v3, neg(0) op_sel_hi:[1,0,0]
-; GFX11-NEXT:    v_fma_mix_f32 v6, v0, v4, neg(0) op_sel:[1,0,0] op_sel_hi:[1,0,0]
-; GFX11-NEXT:    v_fma_mix_f32 v7, -v1, v5, v0 op_sel_hi:[1,0,1]
-; GFX11-NEXT:    v_fma_mix_f32 v8, -v1, v6, v0 op_sel:[1,0,1] op_sel_hi:[1,0,1]
-; GFX11-NEXT:    v_dual_fmac_f32 v5, v7, v3 :: v_dual_fmac_f32 v6, v8, v4
-; GFX11-NEXT:    v_fma_mix_f32 v7, -v1, v5, v0 op_sel_hi:[1,0,1]
-; GFX11-NEXT:    v_fma_mix_f32 v8, -v1, v6, v0 op_sel:[1,0,1] op_sel_hi:[1,0,1]
-; GFX11-NEXT:    v_dual_mul_f32 v3, v7, v3 :: v_dual_mul_f32 v4, v8, v4
-; GFX11-NEXT:    v_and_b32_e32 v4, 0xff800000, v4
-; GFX11-NEXT:    v_dual_add_f32 v4, v4, v6 :: v_dual_and_b32 v3, 0xff800000, v3
-; GFX11-NEXT:    v_add_f32_e32 v3, v3, v5
-; GFX11-NEXT:    v_lshrrev_b32_e32 v5, 16, v0
-; GFX11-NEXT:    v_cvt_f16_f32_e32 v4, v4
+; GFX11-NEXT:    v_fma_mix_f32 v4, v0, v3, neg(0) op_sel_hi:[1,0,0]
+; GFX11-NEXT:    v_fma_mix_f32 v5, v0, v2, neg(0) op_sel:[1,0,0] op_sel_hi:[1,0,0]
+; GFX11-NEXT:    v_fma_mix_f32 v6, -v1, v4, v0 op_sel_hi:[1,0,1]
+; GFX11-NEXT:    v_fma_mix_f32 v7, -v1, v5, v0 op_sel:[1,0,1] op_sel_hi:[1,0,1]
+; GFX11-NEXT:    v_dual_fmac_f32 v4, v6, v3 :: v_dual_fmac_f32 v5, v7, v2
+; GFX11-NEXT:    v_fma_mix_f32 v6, -v1, v4, v0 op_sel_hi:[1,0,1]
+; GFX11-NEXT:    v_fma_mix_f32 v7, -v1, v5, v0 op_sel:[1,0,1] op_sel_hi:[1,0,1]
+; GFX11-NEXT:    v_dual_mul_f32 v3, v6, v3 :: v_dual_mul_f32 v2, v7, v2
+; GFX11-NEXT:    v_and_b32_e32 v2, 0xff800000, v2
+; GFX11-NEXT:    v_dual_add_f32 v2, v2, v5 :: v_dual_and_b32 v3, 0xff800000, v3
+; GFX11-NEXT:    v_add_f32_e32 v3, v3, v4
+; GFX11-NEXT:    v_cvt_f16_f32_e32 v2, v2
 ; GFX11-NEXT:    v_cvt_f16_f32_e32 v3, v3
-; GFX11-NEXT:    v_div_fixup_f16 v0, v3, v1, v0
-; GFX11-NEXT:    v_div_fixup_f16 v1, v4, v2, v5
-; GFX11-NEXT:    v_pack_b32_f16 v0, v0, v1
+; GFX11-NEXT:    v_div_fixup_f16 v3, v3, v1, v0
+; GFX11-NEXT:    v_div_fixup_f16 v0, v2, v1, v0 op_sel:[0,1,1,0]
+; GFX11-NEXT:    v_pack_b32_f16 v0, v3, v0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
   %fdiv = fdiv <2 x half> %a, %b
   ret <2 x half> %fdiv
@@ -1606,148 +1588,146 @@ define <2 x half> @v_rcp_v2f16(<2 x half> %x) {
 ; GFX9-IEEE:       ; %bb.0:
 ; GFX9-IEEE-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-IEEE-NEXT:    v_cvt_f32_f16_e32 v1, v0
-; GFX9-IEEE-NEXT:    v_lshrrev_b32_e32 v2, 16, v0
-; GFX9-IEEE-NEXT:    v_cvt_f32_f16_e32 v3, v2
-; GFX9-IEEE-NEXT:    v_rcp_f32_e32 v4, v1
-; GFX9-IEEE-NEXT:    v_rcp_f32_e32 v5, v3
-; GFX9-IEEE-NEXT:    v_mul_f32_e64 v6, -v1, v4
+; GFX9-IEEE-NEXT:    v_cvt_f32_f16_sdwa v2, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX9-IEEE-NEXT:    v_rcp_f32_e32 v3, v1
+; GFX9-IEEE-NEXT:    v_rcp_f32_e32 v4, v2
+; GFX9-IEEE-NEXT:    v_mul_f32_e64 v5, -v1, v3
+; GFX9-IEEE-NEXT:    v_mul_f32_e64 v6, -v2, v4
+; GFX9-IEEE-NEXT:    v_add_f32_e32 v5, 1.0, v5
 ; GFX9-IEEE-NEXT:    v_add_f32_e32 v6, 1.0, v6
+; GFX9-IEEE-NEXT:    v_mul_f32_e32 v5, v5, v3
 ; GFX9-IEEE-NEXT:    v_mul_f32_e32 v6, v6, v4
-; GFX9-IEEE-NEXT:    v_mul_f32_e64 v7, -v3, v5
+; GFX9-IEEE-NEXT:    v_add_f32_e32 v5, v5, v3
 ; GFX9-IEEE-NEXT:    v_add_f32_e32 v6, v6, v4
-; GFX9-IEEE-NEXT:    v_add_f32_e32 v7, 1.0, v7
-; GFX9-IEEE-NEXT:    v_mul_f32_e64 v1, -v1, v6
-; GFX9-IEEE-NEXT:    v_mul_f32_e32 v7, v7, v5
+; GFX9-IEEE-NEXT:    v_mul_f32_e64 v1, -v1, v5
+; GFX9-IEEE-NEXT:    v_mul_f32_e64 v2, -v2, v6
 ; GFX9-IEEE-NEXT:    v_add_f32_e32 v1, 1.0, v1
-; GFX9-IEEE-NEXT:    v_mul_f32_e32 v1, v1, v4
-; GFX9-IEEE-NEXT:    v_add_f32_e32 v4, v7, v5
-; GFX9-IEEE-NEXT:    v_mul_f32_e64 v3, -v3, v4
-; GFX9-IEEE-NEXT:    v_add_f32_e32 v3, 1.0, v3
-; GFX9-IEEE-NEXT:    v_mul_f32_e32 v3, v3, v5
+; GFX9-IEEE-NEXT:    v_add_f32_e32 v2, 1.0, v2
+; GFX9-IEEE-NEXT:    v_mul_f32_e32 v1, v1, v3
+; GFX9-IEEE-NEXT:    v_mul_f32_e32 v2, v2, v4
 ; GFX9-IEEE-NEXT:    v_and_b32_e32 v1, 0xff800000, v1
-; GFX9-IEEE-NEXT:    v_and_b32_e32 v3, 0xff800000, v3
-; GFX9-IEEE-NEXT:    v_add_f32_e32 v1, v1, v6
-; GFX9-IEEE-NEXT:    v_add_f32_e32 v3, v3, v4
+; GFX9-IEEE-NEXT:    v_and_b32_e32 v2, 0xff800000, v2
+; GFX9-IEEE-NEXT:    v_add_f32_e32 v1, v1, v5
+; GFX9-IEEE-NEXT:    v_add_f32_e32 v2, v2, v6
 ; GFX9-IEEE-NEXT:    v_cvt_f16_f32_e32 v1, v1
-; GFX9-IEEE-NEXT:    v_cvt_f16_f32_e32 v3, v3
-; GFX9-IEEE-NEXT:    v_div_fixup_f16 v0, v1, v0, 1.0
-; GFX9-IEEE-NEXT:    v_div_fixup_f16 v1, v3, v2, 1.0
-; GFX9-IEEE-NEXT:    v_pack_b32_f16 v0, v0, v1
+; GFX9-IEEE-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; GFX9-IEEE-NEXT:    v_div_fixup_f16 v1, v1, v0, 1.0
+; GFX9-IEEE-NEXT:    v_div_fixup_f16 v0, v2, v0, 1.0 op_sel:[0,1,0,0]
+; GFX9-IEEE-NEXT:    v_pack_b32_f16 v0, v1, v0
 ; GFX9-IEEE-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-FLUSH-LABEL: v_rcp_v2f16:
 ; GFX9-FLUSH:       ; %bb.0:
 ; GFX9-FLUSH-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-FLUSH-NEXT:    v_lshrrev_b32_e32 v2, 16, v0
 ; GFX9-FLUSH-NEXT:    v_cvt_f32_f16_e32 v1, v0
-; GFX9-FLUSH-NEXT:    v_cvt_f32_f16_e32 v3, v2
-; GFX9-FLUSH-NEXT:    v_mov_b32_e32 v4, 1.0
+; GFX9-FLUSH-NEXT:    v_cvt_f32_f16_sdwa v2, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX9-FLUSH-NEXT:    v_mov_b32_e32 v3, 1.0
 ; GFX9-FLUSH-NEXT:    v_rcp_f32_e32 v1, v1
-; GFX9-FLUSH-NEXT:    v_rcp_f32_e32 v3, v3
-; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v5, -v0, v1, v4 op_sel_hi:[1,0,0]
-; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v6, -v0, v3, v4 op_sel:[1,0,0] op_sel_hi:[1,0,0]
-; GFX9-FLUSH-NEXT:    v_mad_f32 v5, v5, v1, v1
-; GFX9-FLUSH-NEXT:    v_mad_f32 v6, v6, v3, v3
-; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v7, -v0, v5, v4 op_sel_hi:[1,0,0]
-; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v4, -v0, v6, v4 op_sel:[1,0,0] op_sel_hi:[1,0,0]
-; GFX9-FLUSH-NEXT:    v_mul_f32_e32 v1, v7, v1
-; GFX9-FLUSH-NEXT:    v_mul_f32_e32 v3, v4, v3
+; GFX9-FLUSH-NEXT:    v_rcp_f32_e32 v2, v2
+; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v4, -v0, v1, v3 op_sel_hi:[1,0,0]
+; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v5, -v0, v2, v3 op_sel:[1,0,0] op_sel_hi:[1,0,0]
+; GFX9-FLUSH-NEXT:    v_mad_f32 v4, v4, v1, v1
+; GFX9-FLUSH-NEXT:    v_mad_f32 v5, v5, v2, v2
+; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v6, -v0, v4, v3 op_sel_hi:[1,0,0]
+; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v3, -v0, v5, v3 op_sel:[1,0,0] op_sel_hi:[1,0,0]
+; GFX9-FLUSH-NEXT:    v_mul_f32_e32 v1, v6, v1
+; GFX9-FLUSH-NEXT:    v_mul_f32_e32 v2, v3, v2
 ; GFX9-FLUSH-NEXT:    v_and_b32_e32 v1, 0xff800000, v1
-; GFX9-FLUSH-NEXT:    v_and_b32_e32 v3, 0xff800000, v3
-; GFX9-FLUSH-NEXT:    v_add_f32_e32 v1, v1, v5
-; GFX9-FLUSH-NEXT:    v_add_f32_e32 v3, v3, v6
+; GFX9-FLUSH-NEXT:    v_and_b32_e32 v2, 0xff800000, v2
+; GFX9-FLUSH-NEXT:    v_add_f32_e32 v1, v1, v4
+; GFX9-FLUSH-NEXT:    v_add_f32_e32 v2, v2, v5
 ; GFX9-FLUSH-NEXT:    v_cvt_f16_f32_e32 v1, v1
-; GFX9-FLUSH-NEXT:    v_cvt_f16_f32_e32 v3, v3
-; GFX9-FLUSH-NEXT:    v_div_fixup_f16 v0, v1, v0, 1.0
-; GFX9-FLUSH-NEXT:    v_div_fixup_f16 v1, v3, v2, 1.0
-; GFX9-FLUSH-NEXT:    v_pack_b32_f16 v0, v0, v1
+; GFX9-FLUSH-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; GFX9-FLUSH-NEXT:    v_div_fixup_f16 v1, v1, v0, 1.0
+; GFX9-FLUSH-NEXT:    v_div_fixup_f16 v0, v2, v0, 1.0 op_sel:[0,1,0,0]
+; GFX9-FLUSH-NEXT:    v_pack_b32_f16 v0, v1, v0
 ; GFX9-FLUSH-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-IEEE-LABEL: v_rcp_v2f16:
 ; GFX10-IEEE:       ; %bb.0:
 ; GFX10-IEEE-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10-IEEE-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX10-IEEE-NEXT:    v_cvt_f32_f16_e32 v2, v0
-; GFX10-IEEE-NEXT:    v_cvt_f32_f16_e32 v3, v1
+; GFX10-IEEE-NEXT:    v_cvt_f32_f16_e32 v1, v0
+; GFX10-IEEE-NEXT:    v_cvt_f32_f16_sdwa v2, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX10-IEEE-NEXT:    v_rcp_f32_e32 v1, v1
 ; GFX10-IEEE-NEXT:    v_rcp_f32_e32 v2, v2
-; GFX10-IEEE-NEXT:    v_rcp_f32_e32 v3, v3
-; GFX10-IEEE-NEXT:    v_fma_mix_f32 v4, -v0, v2, neg(0) op_sel_hi:[1,0,0]
-; GFX10-IEEE-NEXT:    v_fma_mix_f32 v5, -v0, v3, neg(0) op_sel:[1,0,0] op_sel_hi:[1,0,0]
+; GFX10-IEEE-NEXT:    v_fma_mix_f32 v3, -v0, v1, neg(0) op_sel_hi:[1,0,0]
+; GFX10-IEEE-NEXT:    v_fma_mix_f32 v4, -v0, v2, neg(0) op_sel:[1,0,0] op_sel_hi:[1,0,0]
+; GFX10-IEEE-NEXT:    v_add_f32_e32 v3, 1.0, v3
 ; GFX10-IEEE-NEXT:    v_add_f32_e32 v4, 1.0, v4
-; GFX10-IEEE-NEXT:    v_add_f32_e32 v5, 1.0, v5
+; GFX10-IEEE-NEXT:    v_mul_f32_e32 v3, v3, v1
 ; GFX10-IEEE-NEXT:    v_mul_f32_e32 v4, v4, v2
-; GFX10-IEEE-NEXT:    v_mul_f32_e32 v5, v5, v3
+; GFX10-IEEE-NEXT:    v_add_f32_e32 v3, v3, v1
 ; GFX10-IEEE-NEXT:    v_add_f32_e32 v4, v4, v2
-; GFX10-IEEE-NEXT:    v_add_f32_e32 v5, v5, v3
-; GFX10-IEEE-NEXT:    v_fma_mix_f32 v6, -v0, v4, neg(0) op_sel_hi:[1,0,0]
-; GFX10-IEEE-NEXT:    v_fma_mix_f32 v7, -v0, v5, neg(0) op_sel:[1,0,0] op_sel_hi:[1,0,0]
+; GFX10-IEEE-NEXT:    v_fma_mix_f32 v5, -v0, v3, neg(0) op_sel_hi:[1,0,0]
+; GFX10-IEEE-NEXT:    v_fma_mix_f32 v6, -v0, v4, neg(0) op_sel:[1,0,0] op_sel_hi:[1,0,0]
+; GFX10-IEEE-NEXT:    v_add_f32_e32 v5, 1.0, v5
 ; GFX10-IEEE-NEXT:    v_add_f32_e32 v6, 1.0, v6
-; GFX10-IEEE-NEXT:    v_add_f32_e32 v7, 1.0, v7
+; GFX10-IEEE-NEXT:    v_mul_f32_e32 v1, v5, v1
 ; GFX10-IEEE-NEXT:    v_mul_f32_e32 v2, v6, v2
-; GFX10-IEEE-NEXT:    v_mul_f32_e32 v3, v7, v3
+; GFX10-IEEE-NEXT:    v_and_b32_e32 v1, 0xff800000, v1
 ; GFX10-IEEE-NEXT:    v_and_b32_e32 v2, 0xff800000, v2
-; GFX10-IEEE-NEXT:    v_and_b32_e32 v3, 0xff800000, v3
+; GFX10-IEEE-NEXT:    v_add_f32_e32 v1, v1, v3
 ; GFX10-IEEE-NEXT:    v_add_f32_e32 v2, v2, v4
-; GFX10-IEEE-NEXT:    v_add_f32_e32 v3, v3, v5
+; GFX10-IEEE-NEXT:    v_cvt_f16_f32_e32 v1, v1
 ; GFX10-IEEE-NEXT:    v_cvt_f16_f32_e32 v2, v2
-; GFX10-IEEE-NEXT:    v_cvt_f16_f32_e32 v3, v3
-; GFX10-IEEE-NEXT:    v_div_fixup_f16 v0, v2, v0, 1.0
-; GFX10-IEEE-NEXT:    v_div_fixup_f16 v1, v3, v1, 1.0
-; GFX10-IEEE-NEXT:    v_pack_b32_f16 v0, v0, v1
+; GFX10-IEEE-NEXT:    v_div_fixup_f16 v1, v1, v0, 1.0
+; GFX10-IEEE-NEXT:    v_div_fixup_f16 v0, v2, v0, 1.0 op_sel:[0,1,0,0]
+; GFX10-IEEE-NEXT:    v_pack_b32_f16 v0, v1, v0
 ; GFX10-IEEE-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-FLUSH-LABEL: v_rcp_v2f16:
 ; GFX10-FLUSH:       ; %bb.0:
 ; GFX10-FLUSH-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10-FLUSH-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX10-FLUSH-NEXT:    v_cvt_f32_f16_e32 v2, v0
-; GFX10-FLUSH-NEXT:    v_cvt_f32_f16_e32 v3, v1
+; GFX10-FLUSH-NEXT:    v_cvt_f32_f16_e32 v1, v0
+; GFX10-FLUSH-NEXT:    v_cvt_f32_f16_sdwa v2, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX10-FLUSH-NEXT:    v_rcp_f32_e32 v3, v1
 ; GFX10-FLUSH-NEXT:    v_rcp_f32_e32 v4, v2
-; GFX10-FLUSH-NEXT:    v_rcp_f32_e32 v5, v3
+; GFX10-FLUSH-NEXT:    v_mad_f32 v5, -v1, v3, 1.0
 ; GFX10-FLUSH-NEXT:    v_mad_f32 v6, -v2, v4, 1.0
-; GFX10-FLUSH-NEXT:    v_mad_f32 v7, -v3, v5, 1.0
+; GFX10-FLUSH-NEXT:    v_mad_f32 v5, v5, v3, v3
 ; GFX10-FLUSH-NEXT:    v_mad_f32 v6, v6, v4, v4
-; GFX10-FLUSH-NEXT:    v_mad_f32 v7, v7, v5, v5
+; GFX10-FLUSH-NEXT:    v_mad_f32 v1, -v1, v5, 1.0
 ; GFX10-FLUSH-NEXT:    v_mad_f32 v2, -v2, v6, 1.0
-; GFX10-FLUSH-NEXT:    v_mad_f32 v3, -v3, v7, 1.0
+; GFX10-FLUSH-NEXT:    v_mul_f32_e32 v1, v1, v3
 ; GFX10-FLUSH-NEXT:    v_mul_f32_e32 v2, v2, v4
-; GFX10-FLUSH-NEXT:    v_mul_f32_e32 v3, v3, v5
+; GFX10-FLUSH-NEXT:    v_and_b32_e32 v1, 0xff800000, v1
 ; GFX10-FLUSH-NEXT:    v_and_b32_e32 v2, 0xff800000, v2
-; GFX10-FLUSH-NEXT:    v_and_b32_e32 v3, 0xff800000, v3
+; GFX10-FLUSH-NEXT:    v_add_f32_e32 v1, v1, v5
 ; GFX10-FLUSH-NEXT:    v_add_f32_e32 v2, v2, v6
-; GFX10-FLUSH-NEXT:    v_add_f32_e32 v3, v3, v7
+; GFX10-FLUSH-NEXT:    v_cvt_f16_f32_e32 v1, v1
 ; GFX10-FLUSH-NEXT:    v_cvt_f16_f32_e32 v2, v2
-; GFX10-FLUSH-NEXT:    v_cvt_f16_f32_e32 v3, v3
-; GFX10-FLUSH-NEXT:    v_div_fixup_f16 v0, v2, v0, 1.0
-; GFX10-FLUSH-NEXT:    v_div_fixup_f16 v1, v3, v1, 1.0
-; GFX10-FLUSH-NEXT:    v_pack_b32_f16 v0, v0, v1
+; GFX10-FLUSH-NEXT:    v_div_fixup_f16 v1, v1, v0, 1.0
+; GFX10-FLUSH-NEXT:    v_div_fixup_f16 v0, v2, v0, 1.0 op_sel:[0,1,0,0]
+; GFX10-FLUSH-NEXT:    v_pack_b32_f16 v0, v1, v0
 ; GFX10-FLUSH-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_rcp_v2f16:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
 ; GFX11-NEXT:    v_cvt_f32_f16_e32 v2, v0
-; GFX11-NEXT:    v_mov_b32_e32 v4, 1.0
-; GFX11-NEXT:    v_cvt_f32_f16_e32 v3, v1
+; GFX11-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
 ; GFX11-NEXT:    v_rcp_f32_e32 v2, v2
-; GFX11-NEXT:    v_rcp_f32_e32 v3, v3
+; GFX11-NEXT:    v_mov_b32_e32 v3, 1.0
+; GFX11-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; GFX11-NEXT:    v_rcp_f32_e32 v1, v1
 ; GFX11-NEXT:    s_waitcnt_depctr depctr_va_vdst(0)
-; GFX11-NEXT:    v_fma_mix_f32 v5, -v0, v2, v4 op_sel_hi:[1,0,0]
-; GFX11-NEXT:    v_fma_mix_f32 v6, -v0, v3, v4 op_sel:[1,0,0] op_sel_hi:[1,0,0]
-; GFX11-NEXT:    v_fma_f32 v5, v5, v2, v2
-; GFX11-NEXT:    v_fma_f32 v6, v6, v3, v3
-; GFX11-NEXT:    v_fma_mix_f32 v7, -v0, v5, v4 op_sel_hi:[1,0,0]
-; GFX11-NEXT:    v_fma_mix_f32 v4, -v0, v6, v4 op_sel:[1,0,0] op_sel_hi:[1,0,0]
-; GFX11-NEXT:    v_dual_mul_f32 v2, v7, v2 :: v_dual_mul_f32 v3, v4, v3
+; GFX11-NEXT:    v_fma_mix_f32 v4, -v0, v2, v3 op_sel_hi:[1,0,0]
+; GFX11-NEXT:    v_fma_f32 v4, v4, v2, v2
+; GFX11-NEXT:    v_fma_mix_f32 v6, -v0, v4, v3 op_sel_hi:[1,0,0]
+; GFX11-NEXT:    v_mul_f32_e32 v2, v6, v2
+; GFX11-NEXT:    v_fma_mix_f32 v5, -v0, v1, v3 op_sel:[1,0,0] op_sel_hi:[1,0,0]
 ; GFX11-NEXT:    v_and_b32_e32 v2, 0xff800000, v2
-; GFX11-NEXT:    v_dual_add_f32 v2, v2, v5 :: v_dual_and_b32 v3, 0xff800000, v3
-; GFX11-NEXT:    v_add_f32_e32 v3, v3, v6
+; GFX11-NEXT:    v_fma_f32 v5, v5, v1, v1
+; GFX11-NEXT:    v_add_f32_e32 v2, v2, v4
+; GFX11-NEXT:    v_fma_mix_f32 v3, -v0, v5, v3 op_sel:[1,0,0] op_sel_hi:[1,0,0]
 ; GFX11-NEXT:    v_cvt_f16_f32_e32 v2, v2
-; GFX11-NEXT:    v_cvt_f16_f32_e32 v3, v3
-; GFX11-NEXT:    v_div_fixup_f16 v0, v2, v0, 1.0
-; GFX11-NEXT:    v_div_fixup_f16 v1, v3, v1, 1.0
-; GFX11-NEXT:    v_pack_b32_f16 v0, v0, v1
+; GFX11-NEXT:    v_mul_f32_e32 v1, v3, v1
+; GFX11-NEXT:    v_div_fixup_f16 v2, v2, v0, 1.0
+; GFX11-NEXT:    v_and_b32_e32 v1, 0xff800000, v1
+; GFX11-NEXT:    v_add_f32_e32 v1, v1, v5
+; GFX11-NEXT:    v_cvt_f16_f32_e32 v1, v1
+; GFX11-NEXT:    v_div_fixup_f16 v0, v1, v0, 1.0 op_sel:[0,1,0,0]
+; GFX11-NEXT:    v_pack_b32_f16 v0, v2, v0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
   %fdiv = fdiv <2 x half> <half 1.0, half 1.0>, %x
   ret <2 x half> %fdiv
@@ -1899,148 +1879,146 @@ define <2 x half> @v_neg_rcp_v2f16(<2 x half> %x) {
 ; GFX9-IEEE:       ; %bb.0:
 ; GFX9-IEEE-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-IEEE-NEXT:    v_cvt_f32_f16_e32 v1, v0
-; GFX9-IEEE-NEXT:    v_lshrrev_b32_e32 v2, 16, v0
-; GFX9-IEEE-NEXT:    v_cvt_f32_f16_e32 v3, v2
-; GFX9-IEEE-NEXT:    v_rcp_f32_e32 v4, v1
-; GFX9-IEEE-NEXT:    v_rcp_f32_e32 v5, v3
-; GFX9-IEEE-NEXT:    v_mul_f32_e32 v6, v1, v4
+; GFX9-IEEE-NEXT:    v_cvt_f32_f16_sdwa v2, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX9-IEEE-NEXT:    v_rcp_f32_e32 v3, v1
+; GFX9-IEEE-NEXT:    v_rcp_f32_e32 v4, v2
+; GFX9-IEEE-NEXT:    v_mul_f32_e32 v5, v1, v3
+; GFX9-IEEE-NEXT:    v_mul_f32_e32 v6, v2, v4
+; GFX9-IEEE-NEXT:    v_add_f32_e32 v5, -1.0, v5
 ; GFX9-IEEE-NEXT:    v_add_f32_e32 v6, -1.0, v6
+; GFX9-IEEE-NEXT:    v_mul_f32_e32 v5, v5, v3
 ; GFX9-IEEE-NEXT:    v_mul_f32_e32 v6, v6, v4
-; GFX9-IEEE-NEXT:    v_mul_f32_e32 v7, v3, v5
+; GFX9-IEEE-NEXT:    v_sub_f32_e32 v5, v5, v3
 ; GFX9-IEEE-NEXT:    v_sub_f32_e32 v6, v6, v4
-; GFX9-IEEE-NEXT:    v_add_f32_e32 v7, -1.0, v7
-; GFX9-IEEE-NEXT:    v_mul_f32_e64 v1, -v1, v6
-; GFX9-IEEE-NEXT:    v_mul_f32_e32 v7, v7, v5
+; GFX9-IEEE-NEXT:    v_mul_f32_e64 v1, -v1, v5
+; GFX9-IEEE-NEXT:    v_mul_f32_e64 v2, -v2, v6
 ; GFX9-IEEE-NEXT:    v_add_f32_e32 v1, -1.0, v1
-; GFX9-IEEE-NEXT:    v_mul_f32_e32 v1, v1, v4
-; GFX9-IEEE-NEXT:    v_sub_f32_e32 v4, v7, v5
-; GFX9-IEEE-NEXT:    v_mul_f32_e64 v3, -v3, v4
-; GFX9-IEEE-NEXT:    v_add_f32_e32 v3, -1.0, v3
-; GFX9-IEEE-NEXT:    v_mul_f32_e32 v3, v3, v5
+; GFX9-IEEE-NEXT:    v_add_f32_e32 v2, -1.0, v2
+; GFX9-IEEE-NEXT:    v_mul_f32_e32 v1, v1, v3
+; GFX9-IEEE-NEXT:    v_mul_f32_e32 v2, v2, v4
 ; GFX9-IEEE-NEXT:    v_and_b32_e32 v1, 0xff800000, v1
-; GFX9-IEEE-NEXT:    v_and_b32_e32 v3, 0xff800000, v3
-; GFX9-IEEE-NEXT:    v_add_f32_e32 v1, v1, v6
-; GFX9-IEEE-NEXT:    v_add_f32_e32 v3, v3, v4
+; GFX9-IEEE-NEXT:    v_and_b32_e32 v2, 0xff800000, v2
+; GFX9-IEEE-NEXT:    v_add_f32_e32 v1, v1, v5
+; GFX9-IEEE-NEXT:    v_add_f32_e32 v2, v2, v6
 ; GFX9-IEEE-NEXT:    v_cvt_f16_f32_e32 v1, v1
-; GFX9-IEEE-NEXT:    v_cvt_f16_f32_e32 v3, v3
-; GFX9-IEEE-NEXT:    v_div_fixup_f16 v0, v1, v0, -1.0
-; GFX9-IEEE-NEXT:    v_div_fixup_f16 v1, v3, v2, -1.0
-; GFX9-IEEE-NEXT:    v_pack_b32_f16 v0, v0, v1
+; GFX9-IEEE-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; GFX9-IEEE-NEXT:    v_div_fixup_f16 v1, v1, v0, -1.0
+; GFX9-IEEE-NEXT:    v_div_fixup_f16 v0, v2, v0, -1.0 op_sel:[0,1,0,0]
+; GFX9-IEEE-NEXT:    v_pack_b32_f16 v0, v1, v0
 ; GFX9-IEEE-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-FLUSH-LABEL: v_neg_rcp_v2f16:
 ; GFX9-FLUSH:       ; %bb.0:
 ; GFX9-FLUSH-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-FLUSH-NEXT:    v_lshrrev_b32_e32 v2, 16, v0
 ; GFX9-FLUSH-NEXT:    v_cvt_f32_f16_e32 v1, v0
-; GFX9-FLUSH-NEXT:    v_cvt_f32_f16_e32 v3, v2
-; GFX9-FLUSH-NEXT:    v_mov_b32_e32 v4, -1.0
+; GFX9-FLUSH-NEXT:    v_cvt_f32_f16_sdwa v2, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX9-FLUSH-NEXT:    v_mov_b32_e32 v3, -1.0
 ; GFX9-FLUSH-NEXT:    v_rcp_f32_e32 v1, v1
-; GFX9-FLUSH-NEXT:    v_rcp_f32_e32 v3, v3
-; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v5, v0, v1, v4 op_sel_hi:[1,0,0]
-; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v6, v0, v3, v4 op_sel:[1,0,0] op_sel_hi:[1,0,0]
-; GFX9-FLUSH-NEXT:    v_mad_f32 v5, v5, v1, -v1
-; GFX9-FLUSH-NEXT:    v_mad_f32 v6, v6, v3, -v3
-; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v7, -v0, v5, v4 op_sel_hi:[1,0,0]
-; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v4, -v0, v6, v4 op_sel:[1,0,0] op_sel_hi:[1,0,0]
-; GFX9-FLUSH-NEXT:    v_mul_f32_e32 v1, v7, v1
-; GFX9-FLUSH-NEXT:    v_mul_f32_e32 v3, v4, v3
+; GFX9-FLUSH-NEXT:    v_rcp_f32_e32 v2, v2
+; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v4, v0, v1, v3 op_sel_hi:[1,0,0]
+; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v5, v0, v2, v3 op_sel:[1,0,0] op_sel_hi:[1,0,0]
+; GFX9-FLUSH-NEXT:    v_mad_f32 v4, v4, v1, -v1
+; GFX9-FLUSH-NEXT:    v_mad_f32 v5, v5, v2, -v2
+; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v6, -v0, v4, v3 op_sel_hi:[1,0,0]
+; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v3, -v0, v5, v3 op_sel:[1,0,0] op_sel_hi:[1,0,0]
+; GFX9-FLUSH-NEXT:    v_mul_f32_e32 v1, v6, v1
+; GFX9-FLUSH-NEXT:    v_mul_f32_e32 v2, v3, v2
 ; GFX9-FLUSH-NEXT:    v_and_b32_e32 v1, 0xff800000, v1
-; GFX9-FLUSH-NEXT:    v_and_b32_e32 v3, 0xff800000, v3
-; GFX9-FLUSH-NEXT:    v_add_f32_e32 v1, v1, v5
-; GFX9-FLUSH-NEXT:    v_add_f32_e32 v3, v3, v6
+; GFX9-FLUSH-NEXT:    v_and_b32_e32 v2, 0xff800000, v2
+; GFX9-FLUSH-NEXT:    v_add_f32_e32 v1, v1, v4
+; GFX9-FLUSH-NEXT:    v_add_f32_e32 v2, v2, v5
 ; GFX9-FLUSH-NEXT:    v_cvt_f16_f32_e32 v1, v1
-; GFX9-FLUSH-NEXT:    v_cvt_f16_f32_e32 v3, v3
-; GFX9-FLUSH-NEXT:    v_div_fixup_f16 v0, v1, v0, -1.0
-; GFX9-FLUSH-NEXT:    v_div_fixup_f16 v1, v3, v2, -1.0
-; GFX9-FLUSH-NEXT:    v_pack_b32_f16 v0, v0, v1
+; GFX9-FLUSH-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; GFX9-FLUSH-NEXT:    v_div_fixup_f16 v1, v1, v0, -1.0
+; GFX9-FLUSH-NEXT:    v_div_fixup_f16 v0, v2, v0, -1.0 op_sel:[0,1,0,0]
+; GFX9-FLUSH-NEXT:    v_pack_b32_f16 v0, v1, v0
 ; GFX9-FLUSH-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-IEEE-LABEL: v_neg_rcp_v2f16:
 ; GFX10-IEEE:       ; %bb.0:
 ; GFX10-IEEE-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10-IEEE-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX10-IEEE-NEXT:    v_cvt_f32_f16_e32 v2, v0
-; GFX10-IEEE-NEXT:    v_cvt_f32_f16_e32 v3, v1
+; GFX10-IEEE-NEXT:    v_cvt_f32_f16_e32 v1, v0
+; GFX10-IEEE-NEXT:    v_cvt_f32_f16_sdwa v2, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX10-IEEE-NEXT:    v_rcp_f32_e32 v1, v1
 ; GFX10-IEEE-NEXT:    v_rcp_f32_e32 v2, v2
-; GFX10-IEEE-NEXT:    v_rcp_f32_e32 v3, v3
-; GFX10-IEEE-NEXT:    v_fma_mix_f32 v4, v0, v2, neg(0) op_sel_hi:[1,0,0]
-; GFX10-IEEE-NEXT:    v_fma_mix_f32 v5, v0, v3, neg(0) op_sel:[1,0,0] op_sel_hi:[1,0,0]
+; GFX10-IEEE-NEXT:    v_fma_mix_f32 v3, v0, v1, neg(0) op_sel_hi:[1,0,0]
+; GFX10-IEEE-NEXT:    v_fma_mix_f32 v4, v0, v2, neg(0) op_sel:[1,0,0] op_sel_hi:[1,0,0]
+; GFX10-IEEE-NEXT:    v_add_f32_e32 v3, -1.0, v3
 ; GFX10-IEEE-NEXT:    v_add_f32_e32 v4, -1.0, v4
-; GFX10-IEEE-NEXT:    v_add_f32_e32 v5, -1.0, v5
+; GFX10-IEEE-NEXT:    v_mul_f32_e32 v3, v3, v1
 ; GFX10-IEEE-NEXT:    v_mul_f32_e32 v4, v4, v2
-; GFX10-IEEE-NEXT:    v_mul_f32_e32 v5, v5, v3
+; GFX10-IEEE-NEXT:    v_sub_f32_e32 v3, v3, v1
 ; GFX10-IEEE-NEXT:    v_sub_f32_e32 v4, v4, v2
-; GFX10-IEEE-NEXT:    v_sub_f32_e32 v5, v5, v3
-; GFX10-IEEE-NEXT:    v_fma_mix_f32 v6, -v0, v4, neg(0) op_sel_hi:[1,0,0]
-; GFX10-IEEE-NEXT:    v_fma_mix_f32 v7, -v0, v5, neg(0) op_sel:[1,0,0] op_sel_hi:[1,0,0]
+; GFX10-IEEE-NEXT:    v_fma_mix_f32 v5, -v0, v3, neg(0) op_sel_hi:[1,0,0]
+; GFX10-IEEE-NEXT:    v_fma_mix_f32 v6, -v0, v4, neg(0) op_sel:[1,0,0] op_sel_hi:[1,0,0]
+; GFX10-IEEE-NEXT:    v_add_f32_e32 v5, -1.0, v5
 ; GFX10-IEEE-NEXT:    v_add_f32_e32 v6, -1.0, v6
-; GFX10-IEEE-NEXT:    v_add_f32_e32 v7, -1.0, v7
+; GFX10-IEEE-NEXT:    v_mul_f32_e32 v1, v5, v1
 ; GFX10-IEEE-NEXT:    v_mul_f32_e32 v2, v6, v2
-; GFX10-IEEE-NEXT:    v_mul_f32_e32 v3, v7, v3
+; GFX10-IEEE-NEXT:    v_and_b32_e32 v1, 0xff800000, v1
 ; GFX10-IEEE-NEXT:    v_and_b32_e32 v2, 0xff800000, v2
-; GFX10-IEEE-NEXT:    v_and_b32_e32 v3, 0xff800000, v3
+; GFX10-IEEE-NEXT:    v_add_f32_e32 v1, v1, v3
 ; GFX10-IEEE-NEXT:    v_add_f32_e32 v2, v2, v4
-; GFX10-IEEE-NEXT:    v_add_f32_e32 v3, v3, v5
+; GFX10-IEEE-NEXT:    v_cvt_f16_f32_e32 v1, v1
 ; GFX10-IEEE-NEXT:    v_cvt_f16_f32_e32 v2, v2
-; GFX10-IEEE-NEXT:    v_cvt_f16_f32_e32 v3, v3
-; GFX10-IEEE-NEXT:    v_div_fixup_f16 v0, v2, v0, -1.0
-; GFX10-IEEE-NEXT:    v_div_fixup_f16 v1, v3, v1, -1.0
-; GFX10-IEEE-NEXT:    v_pack_b32_f16 v0, v0, v1
+; GFX10-IEEE-NEXT:    v_div_fixup_f16 v1, v1, v0, -1.0
+; GFX10-IEEE-NEXT:    v_div_fixup_f16 v0, v2, v0, -1.0 op_sel:[0,1,0,0]
+; GFX10-IEEE-NEXT:    v_pack_b32_f16 v0, v1, v0
 ; GFX10-IEEE-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-FLUSH-LABEL: v_neg_rcp_v2f16:
 ; GFX10-FLUSH:       ; %bb.0:
 ; GFX10-FLUSH-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10-FLUSH-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX10-FLUSH-NEXT:    v_cvt_f32_f16_e32 v2, v0
-; GFX10-FLUSH-NEXT:    v_cvt_f32_f16_e32 v3, v1
+; GFX10-FLUSH-NEXT:    v_cvt_f32_f16_e32 v1, v0
+; GFX10-FLUSH-NEXT:    v_cvt_f32_f16_sdwa v2, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX10-FLUSH-NEXT:    v_rcp_f32_e32 v3, v1
 ; GFX10-FLUSH-NEXT:    v_rcp_f32_e32 v4, v2
-; GFX10-FLUSH-NEXT:    v_rcp_f32_e32 v5, v3
+; GFX10-FLUSH-NEXT:    v_mad_f32 v5, v1, v3, -1.0
 ; GFX10-FLUSH-NEXT:    v_mad_f32 v6, v2, v4, -1.0
-; GFX10-FLUSH-NEXT:    v_mad_f32 v7, v3, v5, -1.0
+; GFX10-FLUSH-NEXT:    v_mad_f32 v5, v5, v3, -v3
 ; GFX10-FLUSH-NEXT:    v_mad_f32 v6, v6, v4, -v4
-; GFX10-FLUSH-NEXT:    v_mad_f32 v7, v7, v5, -v5
+; GFX10-FLUSH-NEXT:    v_mad_f32 v1, -v1, v5, -1.0
 ; GFX10-FLUSH-NEXT:    v_mad_f32 v2, -v2, v6, -1.0
-; GFX10-FLUSH-NEXT:    v_mad_f32 v3, -v3, v7, -1.0
+; GFX10-FLUSH-NEXT:    v_mul_f32_e32 v1, v1, v3
 ; GFX10-FLUSH-NEXT:    v_mul_f32_e32 v2, v2, v4
-; GFX10-FLUSH-NEXT:    v_mul_f32_e32 v3, v3, v5
+; GFX10-FLUSH-NEXT:    v_and_b32_e32 v1, 0xff800000, v1
 ; GFX10-FLUSH-NEXT:    v_and_b32_e32 v2, 0xff800000, v2
-; GFX10-FLUSH-NEXT:    v_and_b32_e32 v3, 0xff800000, v3
+; GFX10-FLUSH-NEXT:    v_add_f32_e32 v1, v1, v5
 ; GFX10-FLUSH-NEXT:    v_add_f32_e32 v2, v2, v6
-; GFX10-FLUSH-NEXT:    v_add_f32_e32 v3, v3, v7
+; GFX10-FLUSH-NEXT:    v_cvt_f16_f32_e32 v1, v1
 ; GFX10-FLUSH-NEXT:    v_cvt_f16_f32_e32 v2, v2
-; GFX10-FLUSH-NEXT:    v_cvt_f16_f32_e32 v3, v3
-; GFX10-FLUSH-NEXT:    v_div_fixup_f16 v0, v2, v0, -1.0
-; GFX10-FLUSH-NEXT:    v_div_fixup_f16 v1, v3, v1, -1.0
-; GFX10-FLUSH-NEXT:    v_pack_b32_f16 v0, v0, v1
+; GFX10-FLUSH-NEXT:    v_div_fixup_f16 v1, v1, v0, -1.0
+; GFX10-FLUSH-NEXT:    v_div_fixup_f16 v0, v2, v0, -1.0 op_sel:[0,1,0,0]
+; GFX10-FLUSH-NEXT:    v_pack_b32_f16 v0, v1, v0
 ; GFX10-FLUSH-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_neg_rcp_v2f16:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
 ; GFX11-NEXT:    v_cvt_f32_f16_e32 v2, v0
-; GFX11-NEXT:    v_mov_b32_e32 v4, -1.0
-; GFX11-NEXT:    v_cvt_f32_f16_e32 v3, v1
+; GFX11-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
 ; GFX11-NEXT:    v_rcp_f32_e32 v2, v2
-; GFX11-NEXT:    v_rcp_f32_e32 v3, v3
+; GFX11-NEXT:    v_mov_b32_e32 v3, -1.0
+; GFX11-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; GFX11-NEXT:    v_rcp_f32_e32 v1, v1
 ; GFX11-NEXT:    s_waitcnt_depctr depctr_va_vdst(0)
-; GFX11-NEXT:    v_fma_mix_f32 v5, v0, v2, v4 op_sel_hi:[1,0,0]
-; GFX11-NEXT:    v_fma_mix_f32 v6, v0, v3, v4 op_sel:[1,0,0] op_sel_hi:[1,0,0]
-; GFX11-NEXT:    v_fma_f32 v5, v5, v2, -v2
-; GFX11-NEXT:    v_fma_f32 v6, v6, v3, -v3
-; GFX11-NEXT:    v_fma_mix_f32 v7, -v0, v5, v4 op_sel_hi:[1,0,0]
-; GFX11-NEXT:    v_fma_mix_f32 v4, -v0, v6, v4 op_sel:[1,0,0] op_sel_hi:[1,0,0]
-; GFX11-NEXT:    v_dual_mul_f32 v2, v7, v2 :: v_dual_mul_f32 v3, v4, v3
+; GFX11-NEXT:    v_fma_mix_f32 v4, v0, v2, v3 op_sel_hi:[1,0,0]
+; GFX11-NEXT:    v_fma_f32 v4, v4, v2, -v2
+; GFX11-NEXT:    v_fma_mix_f32 v6, -v0, v4, v3 op_sel_hi:[1,0,0]
+; GFX11-NEXT:    v_mul_f32_e32 v2, v6, v2
+; GFX11-NEXT:    v_fma_mix_f32 v5, v0, v1, v3 op_sel:[1,0,0] op_sel_hi:[1,0,0]
 ; GFX11-NEXT:    v_and_b32_e32 v2, 0xff800000, v2
-; GFX11-NEXT:    v_dual_add_f32 v2, v2, v5 :: v_dual_and_b32 v3, 0xff800000, v3
-; GFX11-NEXT:    v_add_f32_e32 v3, v3, v6
+; GFX11-NEXT:    v_fma_f32 v5, v5, v1, -v1
+; GFX11-NEXT:    v_add_f32_e32 v2, v2, v4
+; GFX11-NEXT:    v_fma_mix_f32 v3, -v0, v5, v3 op_sel:[1,0,0] op_sel_hi:[1,0,0]
 ; GFX11-NEXT:    v_cvt_f16_f32_e32 v2, v2
-; GFX11-NEXT:    v_cvt_f16_f32_e32 v3, v3
-; GFX11-NEXT:    v_div_fixup_f16 v0, v2, v0, -1.0
-; GFX11-NEXT:    v_div_fixup_f16 v1, v3, v1, -1.0
-; GFX11-NEXT:    v_pack_b32_f16 v0, v0, v1
+; GFX11-NEXT:    v_mul_f32_e32 v1, v3, v1
+; GFX11-NEXT:    v_div_fixup_f16 v2, v2, v0, -1.0
+; GFX11-NEXT:    v_and_b32_e32 v1, 0xff800000, v1
+; GFX11-NEXT:    v_add_f32_e32 v1, v1, v5
+; GFX11-NEXT:    v_cvt_f16_f32_e32 v1, v1
+; GFX11-NEXT:    v_div_fixup_f16 v0, v1, v0, -1.0 op_sel:[0,1,0,0]
+; GFX11-NEXT:    v_pack_b32_f16 v0, v2, v0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
   %fdiv = fdiv <2 x half> <half -1.0, half -1.0>, %x
   ret <2 x half> %fdiv
@@ -2197,155 +2175,148 @@ define <2 x half> @v_rcp_v2f16_fabs(<2 x half> %x) {
 ; GFX9-IEEE-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-IEEE-NEXT:    v_and_b32_e32 v0, 0x7fff7fff, v0
 ; GFX9-IEEE-NEXT:    v_cvt_f32_f16_e32 v1, v0
-; GFX9-IEEE-NEXT:    v_lshrrev_b32_e32 v2, 16, v0
-; GFX9-IEEE-NEXT:    v_cvt_f32_f16_e32 v3, v2
-; GFX9-IEEE-NEXT:    v_rcp_f32_e32 v4, v1
-; GFX9-IEEE-NEXT:    v_rcp_f32_e32 v5, v3
-; GFX9-IEEE-NEXT:    v_mul_f32_e64 v6, -v1, v4
+; GFX9-IEEE-NEXT:    v_cvt_f32_f16_sdwa v2, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX9-IEEE-NEXT:    v_rcp_f32_e32 v3, v1
+; GFX9-IEEE-NEXT:    v_rcp_f32_e32 v4, v2
+; GFX9-IEEE-NEXT:    v_mul_f32_e64 v5, -v1, v3
+; GFX9-IEEE-NEXT:    v_mul_f32_e64 v6, -v2, v4
+; GFX9-IEEE-NEXT:    v_add_f32_e32 v5, 1.0, v5
 ; GFX9-IEEE-NEXT:    v_add_f32_e32 v6, 1.0, v6
+; GFX9-IEEE-NEXT:    v_mul_f32_e32 v5, v5, v3
 ; GFX9-IEEE-NEXT:    v_mul_f32_e32 v6, v6, v4
-; GFX9-IEEE-NEXT:    v_mul_f32_e64 v7, -v3, v5
+; GFX9-IEEE-NEXT:    v_add_f32_e32 v5, v5, v3
 ; GFX9-IEEE-NEXT:    v_add_f32_e32 v6, v6, v4
-; GFX9-IEEE-NEXT:    v_add_f32_e32 v7, 1.0, v7
-; GFX9-IEEE-NEXT:    v_mul_f32_e64 v1, -v1, v6
-; GFX9-IEEE-NEXT:    v_mul_f32_e32 v7, v7, v5
+; GFX9-IEEE-NEXT:    v_mul_f32_e64 v1, -v1, v5
+; GFX9-IEEE-NEXT:    v_mul_f32_e64 v2, -v2, v6
 ; GFX9-IEEE-NEXT:    v_add_f32_e32 v1, 1.0, v1
-; GFX9-IEEE-NEXT:    v_mul_f32_e32 v1, v1, v4
-; GFX9-IEEE-NEXT:    v_add_f32_e32 v4, v7, v5
-; GFX9-IEEE-NEXT:    v_mul_f32_e64 v3, -v3, v4
-; GFX9-IEEE-NEXT:    v_add_f32_e32 v3, 1.0, v3
-; GFX9-IEEE-NEXT:    v_mul_f32_e32 v3, v3, v5
+; GFX9-IEEE-NEXT:    v_add_f32_e32 v2, 1.0, v2
+; GFX9-IEEE-NEXT:    v_mul_f32_e32 v1, v1, v3
+; GFX9-IEEE-NEXT:    v_mul_f32_e32 v2, v2, v4
 ; GFX9-IEEE-NEXT:    v_and_b32_e32 v1, 0xff800000, v1
-; GFX9-IEEE-NEXT:    v_and_b32_e32 v3, 0xff800000, v3
-; GFX9-IEEE-NEXT:    v_add_f32_e32 v1, v1, v6
-; GFX9-IEEE-NEXT:    v_add_f32_e32 v3, v3, v4
+; GFX9-IEEE-NEXT:    v_and_b32_e32 v2, 0xff800000, v2
+; GFX9-IEEE-NEXT:    v_add_f32_e32 v1, v1, v5
+; GFX9-IEEE-NEXT:    v_add_f32_e32 v2, v2, v6
 ; GFX9-IEEE-NEXT:    v_cvt_f16_f32_e32 v1, v1
-; GFX9-IEEE-NEXT:    v_cvt_f16_f32_e32 v3, v3
-; GFX9-IEEE-NEXT:    v_div_fixup_f16 v0, v1, v0, 1.0
-; GFX9-IEEE-NEXT:    v_div_fixup_f16 v1, v3, v2, 1.0
-; GFX9-IEEE-NEXT:    v_pack_b32_f16 v0, v0, v1
+; GFX9-IEEE-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; GFX9-IEEE-NEXT:    v_div_fixup_f16 v1, v1, v0, 1.0
+; GFX9-IEEE-NEXT:    v_div_fixup_f16 v0, v2, v0, 1.0 op_sel:[0,1,0,0]
+; GFX9-IEEE-NEXT:    v_pack_b32_f16 v0, v1, v0
 ; GFX9-IEEE-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-FLUSH-LABEL: v_rcp_v2f16_fabs:
 ; GFX9-FLUSH:       ; %bb.0:
 ; GFX9-FLUSH-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-FLUSH-NEXT:    v_and_b32_e32 v1, 0x7fff7fff, v0
-; GFX9-FLUSH-NEXT:    v_lshrrev_b32_e32 v3, 16, v1
 ; GFX9-FLUSH-NEXT:    v_cvt_f32_f16_e32 v2, v1
-; GFX9-FLUSH-NEXT:    v_cvt_f32_f16_e32 v4, v3
-; GFX9-FLUSH-NEXT:    v_mov_b32_e32 v5, 1.0
+; GFX9-FLUSH-NEXT:    v_cvt_f32_f16_sdwa v3, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX9-FLUSH-NEXT:    v_mov_b32_e32 v4, 1.0
 ; GFX9-FLUSH-NEXT:    v_rcp_f32_e32 v2, v2
-; GFX9-FLUSH-NEXT:    v_rcp_f32_e32 v4, v4
-; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v6, -v1, v2, v5 op_sel_hi:[1,0,0]
-; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v7, -|v0|, v4, v5 op_sel:[1,0,0] op_sel_hi:[1,0,0]
-; GFX9-FLUSH-NEXT:    v_mad_f32 v6, v6, v2, v2
-; GFX9-FLUSH-NEXT:    v_mad_f32 v7, v7, v4, v4
-; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v8, -v1, v6, v5 op_sel_hi:[1,0,0]
-; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v0, -|v0|, v7, v5 op_sel:[1,0,0] op_sel_hi:[1,0,0]
-; GFX9-FLUSH-NEXT:    v_mul_f32_e32 v2, v8, v2
-; GFX9-FLUSH-NEXT:    v_mul_f32_e32 v0, v0, v4
+; GFX9-FLUSH-NEXT:    v_rcp_f32_e32 v3, v3
+; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v5, -v1, v2, v4 op_sel_hi:[1,0,0]
+; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v6, -|v0|, v3, v4 op_sel:[1,0,0] op_sel_hi:[1,0,0]
+; GFX9-FLUSH-NEXT:    v_mad_f32 v5, v5, v2, v2
+; GFX9-FLUSH-NEXT:    v_mad_f32 v6, v6, v3, v3
+; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v7, -v1, v5, v4 op_sel_hi:[1,0,0]
+; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v0, -|v0|, v6, v4 op_sel:[1,0,0] op_sel_hi:[1,0,0]
+; GFX9-FLUSH-NEXT:    v_mul_f32_e32 v2, v7, v2
+; GFX9-FLUSH-NEXT:    v_mul_f32_e32 v0, v0, v3
 ; GFX9-FLUSH-NEXT:    v_and_b32_e32 v2, 0xff800000, v2
 ; GFX9-FLUSH-NEXT:    v_and_b32_e32 v0, 0xff800000, v0
-; GFX9-FLUSH-NEXT:    v_add_f32_e32 v2, v2, v6
-; GFX9-FLUSH-NEXT:    v_add_f32_e32 v0, v0, v7
+; GFX9-FLUSH-NEXT:    v_add_f32_e32 v2, v2, v5
+; GFX9-FLUSH-NEXT:    v_add_f32_e32 v0, v0, v6
 ; GFX9-FLUSH-NEXT:    v_cvt_f16_f32_e32 v2, v2
 ; GFX9-FLUSH-NEXT:    v_cvt_f16_f32_e32 v0, v0
-; GFX9-FLUSH-NEXT:    v_div_fixup_f16 v1, v2, v1, 1.0
-; GFX9-FLUSH-NEXT:    v_div_fixup_f16 v0, v0, v3, 1.0
-; GFX9-FLUSH-NEXT:    v_pack_b32_f16 v0, v1, v0
+; GFX9-FLUSH-NEXT:    v_div_fixup_f16 v2, v2, v1, 1.0
+; GFX9-FLUSH-NEXT:    v_div_fixup_f16 v0, v0, v1, 1.0 op_sel:[0,1,0,0]
+; GFX9-FLUSH-NEXT:    v_pack_b32_f16 v0, v2, v0
 ; GFX9-FLUSH-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-IEEE-LABEL: v_rcp_v2f16_fabs:
 ; GFX10-IEEE:       ; %bb.0:
 ; GFX10-IEEE-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-IEEE-NEXT:    v_and_b32_e32 v1, 0x7fff7fff, v0
-; GFX10-IEEE-NEXT:    v_lshrrev_b32_e32 v2, 16, v1
-; GFX10-IEEE-NEXT:    v_cvt_f32_f16_e32 v3, v1
-; GFX10-IEEE-NEXT:    v_cvt_f32_f16_e32 v4, v2
+; GFX10-IEEE-NEXT:    v_cvt_f32_f16_e32 v2, v1
+; GFX10-IEEE-NEXT:    v_cvt_f32_f16_sdwa v3, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX10-IEEE-NEXT:    v_rcp_f32_e32 v2, v2
 ; GFX10-IEEE-NEXT:    v_rcp_f32_e32 v3, v3
-; GFX10-IEEE-NEXT:    v_rcp_f32_e32 v4, v4
-; GFX10-IEEE-NEXT:    v_fma_mix_f32 v5, -v1, v3, neg(0) op_sel_hi:[1,0,0]
-; GFX10-IEEE-NEXT:    v_fma_mix_f32 v6, -|v0|, v4, neg(0) op_sel:[1,0,0] op_sel_hi:[1,0,0]
+; GFX10-IEEE-NEXT:    v_fma_mix_f32 v4, -v1, v2, neg(0) op_sel_hi:[1,0,0]
+; GFX10-IEEE-NEXT:    v_fma_mix_f32 v5, -|v0|, v3, neg(0) op_sel:[1,0,0] op_sel_hi:[1,0,0]
+; GFX10-IEEE-NEXT:    v_add_f32_e32 v4, 1.0, v4
 ; GFX10-IEEE-NEXT:    v_add_f32_e32 v5, 1.0, v5
-; GFX10-IEEE-NEXT:    v_add_f32_e32 v6, 1.0, v6
+; GFX10-IEEE-NEXT:    v_mul_f32_e32 v4, v4, v2
 ; GFX10-IEEE-NEXT:    v_mul_f32_e32 v5, v5, v3
-; GFX10-IEEE-NEXT:    v_mul_f32_e32 v6, v6, v4
+; GFX10-IEEE-NEXT:    v_add_f32_e32 v4, v4, v2
 ; GFX10-IEEE-NEXT:    v_add_f32_e32 v5, v5, v3
-; GFX10-IEEE-NEXT:    v_add_f32_e32 v6, v6, v4
-; GFX10-IEEE-NEXT:    v_fma_mix_f32 v7, -v1, v5, neg(0) op_sel_hi:[1,0,0]
-; GFX10-IEEE-NEXT:    v_fma_mix_f32 v0, -|v0|, v6, neg(0) op_sel:[1,0,0] op_sel_hi:[1,0,0]
-; GFX10-IEEE-NEXT:    v_add_f32_e32 v7, 1.0, v7
+; GFX10-IEEE-NEXT:    v_fma_mix_f32 v6, -v1, v4, neg(0) op_sel_hi:[1,0,0]
+; GFX10-IEEE-NEXT:    v_fma_mix_f32 v0, -|v0|, v5, neg(0) op_sel:[1,0,0] op_sel_hi:[1,0,0]
+; GFX10-IEEE-NEXT:    v_add_f32_e32 v6, 1.0, v6
 ; GFX10-IEEE-NEXT:    v_add_f32_e32 v0, 1.0, v0
-; GFX10-IEEE-NEXT:    v_mul_f32_e32 v3, v7, v3
-; GFX10-IEEE-NEXT:    v_mul_f32_e32 v0, v0, v4
-; GFX10-IEEE-NEXT:    v_and_b32_e32 v3, 0xff800000, v3
+; GFX10-IEEE-NEXT:    v_mul_f32_e32 v2, v6, v2
+; GFX10-IEEE-NEXT:    v_mul_f32_e32 v0, v0, v3
+; GFX10-IEEE-NEXT:    v_and_b32_e32 v2, 0xff800000, v2
 ; GFX10-IEEE-NEXT:    v_and_b32_e32 v0, 0xff800000, v0
-; GFX10-IEEE-NEXT:    v_add_f32_e32 v3, v3, v5
-; GFX10-IEEE-NEXT:    v_add_f32_e32 v0, v0, v6
-; GFX10-IEEE-NEXT:    v_cvt_f16_f32_e32 v3, v3
+; GFX10-IEEE-NEXT:    v_add_f32_e32 v2, v2, v4
+; GFX10-IEEE-NEXT:    v_add_f32_e32 v0, v0, v5
+; GFX10-IEEE-NEXT:    v_cvt_f16_f32_e32 v2, v2
 ; GFX10-IEEE-NEXT:    v_cvt_f16_f32_e32 v0, v0
-; GFX10-IEEE-NEXT:    v_div_fixup_f16 v1, v3, v1, 1.0
-; GFX10-IEEE-NEXT:    v_div_fixup_f16 v0, v0, v2, 1.0
-; GFX10-IEEE-NEXT:    v_pack_b32_f16 v0, v1, v0
+; GFX10-IEEE-NEXT:    v_div_fixup_f16 v2, v2, v1, 1.0
+; GFX10-IEEE-NEXT:    v_div_fixup_f16 v0, v0, v1, 1.0 op_sel:[0,1,0,0]
+; GFX10-IEEE-NEXT:    v_pack_b32_f16 v0, v2, v0
 ; GFX10-IEEE-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-FLUSH-LABEL: v_rcp_v2f16_fabs:
 ; GFX10-FLUSH:       ; %bb.0:
 ; GFX10-FLUSH-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-FLUSH-NEXT:    v_and_b32_e32 v0, 0x7fff7fff, v0
-; GFX10-FLUSH-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX10-FLUSH-NEXT:    v_cvt_f32_f16_e32 v2, v0
-; GFX10-FLUSH-NEXT:    v_cvt_f32_f16_e32 v3, v1
+; GFX10-FLUSH-NEXT:    v_cvt_f32_f16_e32 v1, v0
+; GFX10-FLUSH-NEXT:    v_cvt_f32_f16_sdwa v2, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX10-FLUSH-NEXT:    v_rcp_f32_e32 v3, v1
 ; GFX10-FLUSH-NEXT:    v_rcp_f32_e32 v4, v2
-; GFX10-FLUSH-NEXT:    v_rcp_f32_e32 v5, v3
+; GFX10-FLUSH-NEXT:    v_mad_f32 v5, -v1, v3, 1.0
 ; GFX10-FLUSH-NEXT:    v_mad_f32 v6, -v2, v4, 1.0
-; GFX10-FLUSH-NEXT:    v_mad_f32 v7, -v3, v5, 1.0
+; GFX10-FLUSH-NEXT:    v_mad_f32 v5, v5, v3, v3
 ; GFX10-FLUSH-NEXT:    v_mad_f32 v6, v6, v4, v4
-; GFX10-FLUSH-NEXT:    v_mad_f32 v7, v7, v5, v5
+; GFX10-FLUSH-NEXT:    v_mad_f32 v1, -v1, v5, 1.0
 ; GFX10-FLUSH-NEXT:    v_mad_f32 v2, -v2, v6, 1.0
-; GFX10-FLUSH-NEXT:    v_mad_f32 v3, -v3, v7, 1.0
+; GFX10-FLUSH-NEXT:    v_mul_f32_e32 v1, v1, v3
 ; GFX10-FLUSH-NEXT:    v_mul_f32_e32 v2, v2, v4
-; GFX10-FLUSH-NEXT:    v_mul_f32_e32 v3, v3, v5
+; GFX10-FLUSH-NEXT:    v_and_b32_e32 v1, 0xff800000, v1
 ; GFX10-FLUSH-NEXT:    v_and_b32_e32 v2, 0xff800000, v2
-; GFX10-FLUSH-NEXT:    v_and_b32_e32 v3, 0xff800000, v3
+; GFX10-FLUSH-NEXT:    v_add_f32_e32 v1, v1, v5
 ; GFX10-FLUSH-NEXT:    v_add_f32_e32 v2, v2, v6
-; GFX10-FLUSH-NEXT:    v_add_f32_e32 v3, v3, v7
+; GFX10-FLUSH-NEXT:    v_cvt_f16_f32_e32 v1, v1
 ; GFX10-FLUSH-NEXT:    v_cvt_f16_f32_e32 v2, v2
-; GFX10-FLUSH-NEXT:    v_cvt_f16_f32_e32 v3, v3
-; GFX10-FLUSH-NEXT:    v_div_fixup_f16 v0, v2, v0, 1.0
-; GFX10-FLUSH-NEXT:    v_div_fixup_f16 v1, v3, v1, 1.0
-; GFX10-FLUSH-NEXT:    v_pack_b32_f16 v0, v0, v1
+; GFX10-FLUSH-NEXT:    v_div_fixup_f16 v1, v1, v0, 1.0
+; GFX10-FLUSH-NEXT:    v_div_fixup_f16 v0, v2, v0, 1.0 op_sel:[0,1,0,0]
+; GFX10-FLUSH-NEXT:    v_pack_b32_f16 v0, v1, v0
 ; GFX10-FLUSH-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_rcp_v2f16_fabs:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-NEXT:    v_and_b32_e32 v1, 0x7fff7fff, v0
+; GFX11-NEXT:    v_dual_mov_b32 v4, 1.0 :: v_dual_and_b32 v1, 0x7fff7fff, v0
 ; GFX11-NEXT:    v_lshrrev_b32_e32 v2, 16, v1
-; GFX11-NEXT:    v_cvt_f32_f16_e32 v4, v2
-; GFX11-NEXT:    v_rcp_f32_e32 v4, v4
-; GFX11-NEXT:    v_mov_b32_e32 v5, 1.0
-; GFX11-NEXT:    s_waitcnt_depctr depctr_va_vdst(0)
-; GFX11-NEXT:    v_fma_mix_f32 v7, -|v0|, v4, v5 op_sel:[1,0,0] op_sel_hi:[1,0,0]
-; GFX11-NEXT:    v_fma_f32 v7, v7, v4, v4
-; GFX11-NEXT:    v_fma_mix_f32 v0, -|v0|, v7, v5 op_sel:[1,0,0] op_sel_hi:[1,0,0]
-; GFX11-NEXT:    v_mul_f32_e32 v0, v0, v4
-; GFX11-NEXT:    v_and_b32_e32 v0, 0xff800000, v0
-; GFX11-NEXT:    v_add_f32_e32 v0, v0, v7
 ; GFX11-NEXT:    v_cvt_f32_f16_e32 v3, v1
-; GFX11-NEXT:    v_cvt_f16_f32_e32 v0, v0
+; GFX11-NEXT:    v_cvt_f32_f16_e32 v2, v2
 ; GFX11-NEXT:    v_rcp_f32_e32 v3, v3
-; GFX11-NEXT:    v_div_fixup_f16 v0, v0, v2, 1.0
+; GFX11-NEXT:    v_rcp_f32_e32 v2, v2
 ; GFX11-NEXT:    s_waitcnt_depctr depctr_va_vdst(0)
-; GFX11-NEXT:    v_fma_mix_f32 v6, -v1, v3, v5 op_sel_hi:[1,0,0]
-; GFX11-NEXT:    v_fma_f32 v6, v6, v3, v3
-; GFX11-NEXT:    v_fma_mix_f32 v8, -v1, v6, v5 op_sel_hi:[1,0,0]
-; GFX11-NEXT:    v_mul_f32_e32 v3, v8, v3
-; GFX11-NEXT:    v_and_b32_e32 v3, 0xff800000, v3
-; GFX11-NEXT:    v_add_f32_e32 v3, v3, v6
-; GFX11-NEXT:    v_cvt_f16_f32_e32 v3, v3
-; GFX11-NEXT:    v_div_fixup_f16 v1, v3, v1, 1.0
-; GFX11-NEXT:    v_pack_b32_f16 v0, v1, v0
+; GFX11-NEXT:    v_fma_mix_f32 v5, -v1, v3, v4 op_sel_hi:[1,0,0]
+; GFX11-NEXT:    v_fma_mix_f32 v6, -|v0|, v2, v4 op_sel:[1,0,0] op_sel_hi:[1,0,0]
+; GFX11-NEXT:    v_fma_f32 v5, v5, v3, v3
+; GFX11-NEXT:    v_fma_f32 v6, v6, v2, v2
+; GFX11-NEXT:    v_fma_mix_f32 v7, -v1, v5, v4 op_sel_hi:[1,0,0]
+; GFX11-NEXT:    v_fma_mix_f32 v0, -|v0|, v6, v4 op_sel:[1,0,0] op_sel_hi:[1,0,0]
+; GFX11-NEXT:    v_dual_mul_f32 v3, v7, v3 :: v_dual_mul_f32 v0, v0, v2
+; GFX11-NEXT:    v_and_b32_e32 v2, 0xff800000, v3
+; GFX11-NEXT:    v_and_b32_e32 v0, 0xff800000, v0
+; GFX11-NEXT:    v_add_f32_e32 v2, v2, v5
+; GFX11-NEXT:    v_add_f32_e32 v0, v0, v6
+; GFX11-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; GFX11-NEXT:    v_cvt_f16_f32_e32 v0, v0
+; GFX11-NEXT:    v_div_fixup_f16 v2, v2, v1, 1.0
+; GFX11-NEXT:    v_div_fixup_f16 v0, v0, v1, 1.0 op_sel:[0,1,0,0]
+; GFX11-NEXT:    v_pack_b32_f16 v0, v2, v0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
   %x.fabs = call <2 x half> @llvm.fabs.v2f16(<2 x half> %x)
   %fdiv = fdiv <2 x half> <half 1.0, half 1.0>, %x.fabs
@@ -2503,155 +2474,148 @@ define <2 x half> @v_neg_rcp_v2f16_fabs(<2 x half> %x) {
 ; GFX9-IEEE-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-IEEE-NEXT:    v_and_b32_e32 v0, 0x7fff7fff, v0
 ; GFX9-IEEE-NEXT:    v_cvt_f32_f16_e32 v1, v0
-; GFX9-IEEE-NEXT:    v_lshrrev_b32_e32 v2, 16, v0
-; GFX9-IEEE-NEXT:    v_cvt_f32_f16_e32 v3, v2
-; GFX9-IEEE-NEXT:    v_rcp_f32_e32 v4, v1
-; GFX9-IEEE-NEXT:    v_rcp_f32_e32 v5, v3
-; GFX9-IEEE-NEXT:    v_mul_f32_e32 v6, v1, v4
+; GFX9-IEEE-NEXT:    v_cvt_f32_f16_sdwa v2, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX9-IEEE-NEXT:    v_rcp_f32_e32 v3, v1
+; GFX9-IEEE-NEXT:    v_rcp_f32_e32 v4, v2
+; GFX9-IEEE-NEXT:    v_mul_f32_e32 v5, v1, v3
+; GFX9-IEEE-NEXT:    v_mul_f32_e32 v6, v2, v4
+; GFX9-IEEE-NEXT:    v_add_f32_e32 v5, -1.0, v5
 ; GFX9-IEEE-NEXT:    v_add_f32_e32 v6, -1.0, v6
+; GFX9-IEEE-NEXT:    v_mul_f32_e32 v5, v5, v3
 ; GFX9-IEEE-NEXT:    v_mul_f32_e32 v6, v6, v4
-; GFX9-IEEE-NEXT:    v_mul_f32_e32 v7, v3, v5
+; GFX9-IEEE-NEXT:    v_sub_f32_e32 v5, v5, v3
 ; GFX9-IEEE-NEXT:    v_sub_f32_e32 v6, v6, v4
-; GFX9-IEEE-NEXT:    v_add_f32_e32 v7, -1.0, v7
-; GFX9-IEEE-NEXT:    v_mul_f32_e64 v1, -v1, v6
-; GFX9-IEEE-NEXT:    v_mul_f32_e32 v7, v7, v5
+; GFX9-IEEE-NEXT:    v_mul_f32_e64 v1, -v1, v5
+; GFX9-IEEE-NEXT:    v_mul_f32_e64 v2, -v2, v6
 ; GFX9-IEEE-NEXT:    v_add_f32_e32 v1, -1.0, v1
-; GFX9-IEEE-NEXT:    v_mul_f32_e32 v1, v1, v4
-; GFX9-IEEE-NEXT:    v_sub_f32_e32 v4, v7, v5
-; GFX9-IEEE-NEXT:    v_mul_f32_e64 v3, -v3, v4
-; GFX9-IEEE-NEXT:    v_add_f32_e32 v3, -1.0, v3
-; GFX9-IEEE-NEXT:    v_mul_f32_e32 v3, v3, v5
+; GFX9-IEEE-NEXT:    v_add_f32_e32 v2, -1.0, v2
+; GFX9-IEEE-NEXT:    v_mul_f32_e32 v1, v1, v3
+; GFX9-IEEE-NEXT:    v_mul_f32_e32 v2, v2, v4
 ; GFX9-IEEE-NEXT:    v_and_b32_e32 v1, 0xff800000, v1
-; GFX9-IEEE-NEXT:    v_and_b32_e32 v3, 0xff800000, v3
-; GFX9-IEEE-NEXT:    v_add_f32_e32 v1, v1, v6
-; GFX9-IEEE-NEXT:    v_add_f32_e32 v3, v3, v4
+; GFX9-IEEE-NEXT:    v_and_b32_e32 v2, 0xff800000, v2
+; GFX9-IEEE-NEXT:    v_add_f32_e32 v1, v1, v5
+; GFX9-IEEE-NEXT:    v_add_f32_e32 v2, v2, v6
 ; GFX9-IEEE-NEXT:    v_cvt_f16_f32_e32 v1, v1
-; GFX9-IEEE-NEXT:    v_cvt_f16_f32_e32 v3, v3
-; GFX9-IEEE-NEXT:    v_div_fixup_f16 v0, v1, v0, -1.0
-; GFX9-IEEE-NEXT:    v_div_fixup_f16 v1, v3, v2, -1.0
-; GFX9-IEEE-NEXT:    v_pack_b32_f16 v0, v0, v1
+; GFX9-IEEE-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; GFX9-IEEE-NEXT:    v_div_fixup_f16 v1, v1, v0, -1.0
+; GFX9-IEEE-NEXT:    v_div_fixup_f16 v0, v2, v0, -1.0 op_sel:[0,1,0,0]
+; GFX9-IEEE-NEXT:    v_pack_b32_f16 v0, v1, v0
 ; GFX9-IEEE-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-FLUSH-LABEL: v_neg_rcp_v2f16_fabs:
 ; GFX9-FLUSH:       ; %bb.0:
 ; GFX9-FLUSH-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-FLUSH-NEXT:    v_and_b32_e32 v1, 0x7fff7fff, v0
-; GFX9-FLUSH-NEXT:    v_lshrrev_b32_e32 v3, 16, v1
 ; GFX9-FLUSH-NEXT:    v_cvt_f32_f16_e32 v2, v1
-; GFX9-FLUSH-NEXT:    v_cvt_f32_f16_e32 v4, v3
-; GFX9-FLUSH-NEXT:    v_mov_b32_e32 v5, -1.0
+; GFX9-FLUSH-NEXT:    v_cvt_f32_f16_sdwa v3, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX9-FLUSH-NEXT:    v_mov_b32_e32 v4, -1.0
 ; GFX9-FLUSH-NEXT:    v_rcp_f32_e32 v2, v2
-; GFX9-FLUSH-NEXT:    v_rcp_f32_e32 v4, v4
-; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v6, v1, v2, v5 op_sel_hi:[1,0,0]
-; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v7, |v0|, v4, v5 op_sel:[1,0,0] op_sel_hi:[1,0,0]
-; GFX9-FLUSH-NEXT:    v_mad_f32 v6, v6, v2, -v2
-; GFX9-FLUSH-NEXT:    v_mad_f32 v7, v7, v4, -v4
-; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v8, -v1, v6, v5 op_sel_hi:[1,0,0]
-; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v0, -|v0|, v7, v5 op_sel:[1,0,0] op_sel_hi:[1,0,0]
-; GFX9-FLUSH-NEXT:    v_mul_f32_e32 v2, v8, v2
-; GFX9-FLUSH-NEXT:    v_mul_f32_e32 v0, v0, v4
+; GFX9-FLUSH-NEXT:    v_rcp_f32_e32 v3, v3
+; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v5, v1, v2, v4 op_sel_hi:[1,0,0]
+; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v6, |v0|, v3, v4 op_sel:[1,0,0] op_sel_hi:[1,0,0]
+; GFX9-FLUSH-NEXT:    v_mad_f32 v5, v5, v2, -v2
+; GFX9-FLUSH-NEXT:    v_mad_f32 v6, v6, v3, -v3
+; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v7, -v1, v5, v4 op_sel_hi:[1,0,0]
+; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v0, -|v0|, v6, v4 op_sel:[1,0,0] op_sel_hi:[1,0,0]
+; GFX9-FLUSH-NEXT:    v_mul_f32_e32 v2, v7, v2
+; GFX9-FLUSH-NEXT:    v_mul_f32_e32 v0, v0, v3
 ; GFX9-FLUSH-NEXT:    v_and_b32_e32 v2, 0xff800000, v2
 ; GFX9-FLUSH-NEXT:    v_and_b32_e32 v0, 0xff800000, v0
-; GFX9-FLUSH-NEXT:    v_add_f32_e32 v2, v2, v6
-; GFX9-FLUSH-NEXT:    v_add_f32_e32 v0, v0, v7
+; GFX9-FLUSH-NEXT:    v_add_f32_e32 v2, v2, v5
+; GFX9-FLUSH-NEXT:    v_add_f32_e32 v0, v0, v6
 ; GFX9-FLUSH-NEXT:    v_cvt_f16_f32_e32 v2, v2
 ; GFX9-FLUSH-NEXT:    v_cvt_f16_f32_e32 v0, v0
-; GFX9-FLUSH-NEXT:    v_div_fixup_f16 v1, v2, v1, -1.0
-; GFX9-FLUSH-NEXT:    v_div_fixup_f16 v0, v0, v3, -1.0
-; GFX9-FLUSH-NEXT:    v_pack_b32_f16 v0, v1, v0
+; GFX9-FLUSH-NEXT:    v_div_fixup_f16 v2, v2, v1, -1.0
+; GFX9-FLUSH-NEXT:    v_div_fixup_f16 v0, v0, v1, -1.0 op_sel:[0,1,0,0]
+; GFX9-FLUSH-NEXT:    v_pack_b32_f16 v0, v2, v0
 ; GFX9-FLUSH-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-IEEE-LABEL: v_neg_rcp_v2f16_fabs:
 ; GFX10-IEEE:       ; %bb.0:
 ; GFX10-IEEE-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-IEEE-NEXT:    v_and_b32_e32 v1, 0x7fff7fff, v0
-; GFX10-IEEE-NEXT:    v_lshrrev_b32_e32 v2, 16, v1
-; GFX10-IEEE-NEXT:    v_cvt_f32_f16_e32 v3, v1
-; GFX10-IEEE-NEXT:    v_cvt_f32_f16_e32 v4, v2
+; GFX10-IEEE-NEXT:    v_cvt_f32_f16_e32 v2, v1
+; GFX10-IEEE-NEXT:    v_cvt_f32_f16_sdwa v3, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX10-IEEE-NEXT:    v_rcp_f32_e32 v2, v2
 ; GFX10-IEEE-NEXT:    v_rcp_f32_e32 v3, v3
-; GFX10-IEEE-NEXT:    v_rcp_f32_e32 v4, v4
-; GFX10-IEEE-NEXT:    v_fma_mix_f32 v5, v1, v3, neg(0) op_sel_hi:[1,0,0]
-; GFX10-IEEE-NEXT:    v_fma_mix_f32 v6, |v0|, v4, neg(0) op_sel:[1,0,0] op_sel_hi:[1,0,0]
+; GFX10-IEEE-NEXT:    v_fma_mix_f32 v4, v1, v2, neg(0) op_sel_hi:[1,0,0]
+; GFX10-IEEE-NEXT:    v_fma_mix_f32 v5, |v0|, v3, neg(0) op_sel:[1,0,0] op_sel_hi:[1,0,0]
+; GFX10-IEEE-NEXT:    v_add_f32_e32 v4, -1.0, v4
 ; GFX10-IEEE-NEXT:    v_add_f32_e32 v5, -1.0, v5
-; GFX10-IEEE-NEXT:    v_add_f32_e32 v6, -1.0, v6
+; GFX10-IEEE-NEXT:    v_mul_f32_e32 v4, v4, v2
 ; GFX10-IEEE-NEXT:    v_mul_f32_e32 v5, v5, v3
-; GFX10-IEEE-NEXT:    v_mul_f32_e32 v6, v6, v4
+; GFX10-IEEE-NEXT:    v_sub_f32_e32 v4, v4, v2
 ; GFX10-IEEE-NEXT:    v_sub_f32_e32 v5, v5, v3
-; GFX10-IEEE-NEXT:    v_sub_f32_e32 v6, v6, v4
-; GFX10-IEEE-NEXT:    v_fma_mix_f32 v7, -v1, v5, neg(0) op_sel_hi:[1,0,0]
-; GFX10-IEEE-NEXT:    v_fma_mix_f32 v0, -|v0|, v6, neg(0) op_sel:[1,0,0] op_sel_hi:[1,0,0]
-; GFX10-IEEE-NEXT:    v_add_f32_e32 v7, -1.0, v7
+; GFX10-IEEE-NEXT:    v_fma_mix_f32 v6, -v1, v4, neg(0) op_sel_hi:[1,0,0]
+; GFX10-IEEE-NEXT:    v_fma_mix_f32 v0, -|v0|, v5, neg(0) op_sel:[1,0,0] op_sel_hi:[1,0,0]
+; GFX10-IEEE-NEXT:    v_add_f32_e32 v6, -1.0, v6
 ; GFX10-IEEE-NEXT:    v_add_f32_e32 v0, -1.0, v0
-; GFX10-IEEE-NEXT:    v_mul_f32_e32 v3, v7, v3
-; GFX10-IEEE-NEXT:    v_mul_f32_e32 v0, v0, v4
-; GFX10-IEEE-NEXT:    v_and_b32_e32 v3, 0xff800000, v3
+; GFX10-IEEE-NEXT:    v_mul_f32_e32 v2, v6, v2
+; GFX10-IEEE-NEXT:    v_mul_f32_e32 v0, v0, v3
+; GFX10-IEEE-NEXT:    v_and_b32_e32 v2, 0xff800000, v2
 ; GFX10-IEEE-NEXT:    v_and_b32_e32 v0, 0xff800000, v0
-; GFX10-IEEE-NEXT:    v_add_f32_e32 v3, v3, v5
-; GFX10-IEEE-NEXT:    v_add_f32_e32 v0, v0, v6
-; GFX10-IEEE-NEXT:    v_cvt_f16_f32_e32 v3, v3
+; GFX10-IEEE-NEXT:    v_add_f32_e32 v2, v2, v4
+; GFX10-IEEE-NEXT:    v_add_f32_e32 v0, v0, v5
+; GFX10-IEEE-NEXT:    v_cvt_f16_f32_e32 v2, v2
 ; GFX10-IEEE-NEXT:    v_cvt_f16_f32_e32 v0, v0
-; GFX10-IEEE-NEXT:    v_div_fixup_f16 v1, v3, v1, -1.0
-; GFX10-IEEE-NEXT:    v_div_fixup_f16 v0, v0, v2, -1.0
-; GFX10-IEEE-NEXT:    v_pack_b32_f16 v0, v1, v0
+; GFX10-IEEE-NEXT:    v_div_fixup_f16 v2, v2, v1, -1.0
+; GFX10-IEEE-NEXT:    v_div_fixup_f16 v0, v0, v1, -1.0 op_sel:[0,1,0,0]
+; GFX10-IEEE-NEXT:    v_pack_b32_f16 v0, v2, v0
 ; GFX10-IEEE-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-FLUSH-LABEL: v_neg_rcp_v2f16_fabs:
 ; GFX10-FLUSH:       ; %bb.0:
 ; GFX10-FLUSH-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-FLUSH-NEXT:    v_and_b32_e32 v0, 0x7fff7fff, v0
-; GFX10-FLUSH-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX10-FLUSH-NEXT:    v_cvt_f32_f16_e32 v2, v0
-; GFX10-FLUSH-NEXT:    v_cvt_f32_f16_e32 v3, v1
+; GFX10-FLUSH-NEXT:    v_cvt_f32_f16_e32 v1, v0
+; GFX10-FLUSH-NEXT:    v_cvt_f32_f16_sdwa v2, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX10-FLUSH-NEXT:    v_rcp_f32_e32 v3, v1
 ; GFX10-FLUSH-NEXT:    v_rcp_f32_e32 v4, v2
-; GFX10-FLUSH-NEXT:    v_rcp_f32_e32 v5, v3
+; GFX10-FLUSH-NEXT:    v_mad_f32 v5, v1, v3, -1.0
 ; GFX10-FLUSH-NEXT:    v_mad_f32 v6, v2, v4, -1.0
-; GFX10-FLUSH-NEXT:    v_mad_f32 v7, v3, v5, -1.0
+; GFX10-FLUSH-NEXT:    v_mad_f32 v5, v5, v3, -v3
 ; GFX10-FLUSH-NEXT:    v_mad_f32 v6, v6, v4, -v4
-; GFX10-FLUSH-NEXT:    v_mad_f32 v7, v7, v5, -v5
+; GFX10-FLUSH-NEXT:    v_mad_f32 v1, -v1, v5, -1.0
 ; GFX10-FLUSH-NEXT:    v_mad_f32 v2, -v2, v6, -1.0
-; GFX10-FLUSH-NEXT:    v_mad_f32 v3, -v3, v7, -1.0
+; GFX10-FLUSH-NEXT:    v_mul_f32_e32 v1, v1, v3
 ; GFX10-FLUSH-NEXT:    v_mul_f32_e32 v2, v2, v4
-; GFX10-FLUSH-NEXT:    v_mul_f32_e32 v3, v3, v5
+; GFX10-FLUSH-NEXT:    v_and_b32_e32 v1, 0xff800000, v1
 ; GFX10-FLUSH-NEXT:    v_and_b32_e32 v2, 0xff800000, v2
-; GFX10-FLUSH-NEXT:    v_and_b32_e32 v3, 0xff800000, v3
+; GFX10-FLUSH-NEXT:    v_add_f32_e32 v1, v1, v5
 ; GFX10-FLUSH-NEXT:    v_add_f32_e32 v2, v2, v6
-; GFX10-FLUSH-NEXT:    v_add_f32_e32 v3, v3, v7
+; GFX10-FLUSH-NEXT:    v_cvt_f16_f32_e32 v1, v1
 ; GFX10-FLUSH-NEXT:    v_cvt_f16_f32_e32 v2, v2
-; GFX10-FLUSH-NEXT:    v_cvt_f16_f32_e32 v3, v3
-; GFX10-FLUSH-NEXT:    v_div_fixup_f16 v0, v2, v0, -1.0
-; GFX10-FLUSH-NEXT:    v_div_fixup_f16 v1, v3, v1, -1.0
-; GFX10-FLUSH-NEXT:    v_pack_b32_f16 v0, v0, v1
+; GFX10-FLUSH-NEXT:    v_div_fixup_f16 v1, v1, v0, -1.0
+; GFX10-FLUSH-NEXT:    v_div_fixup_f16 v0, v2, v0, -1.0 op_sel:[0,1,0,0]
+; GFX10-FLUSH-NEXT:    v_pack_b32_f16 v0, v1, v0
 ; GFX10-FLUSH-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_neg_rcp_v2f16_fabs:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-NEXT:    v_and_b32_e32 v1, 0x7fff7fff, v0
+; GFX11-NEXT:    v_dual_mov_b32 v4, -1.0 :: v_dual_and_b32 v1, 0x7fff7fff, v0
 ; GFX11-NEXT:    v_lshrrev_b32_e32 v2, 16, v1
-; GFX11-NEXT:    v_cvt_f32_f16_e32 v4, v2
-; GFX11-NEXT:    v_rcp_f32_e32 v4, v4
-; GFX11-NEXT:    v_mov_b32_e32 v5, -1.0
-; GFX11-NEXT:    s_waitcnt_depctr depctr_va_vdst(0)
-; GFX11-NEXT:    v_fma_mix_f32 v7, |v0|, v4, v5 op_sel:[1,0,0] op_sel_hi:[1,0,0]
-; GFX11-NEXT:    v_fma_f32 v7, v7, v4, -v4
-; GFX11-NEXT:    v_fma_mix_f32 v0, -|v0|, v7, v5 op_sel:[1,0,0] op_sel_hi:[1,0,0]
-; GFX11-NEXT:    v_mul_f32_e32 v0, v0, v4
-; GFX11-NEXT:    v_and_b32_e32 v0, 0xff800000, v0
-; GFX11-NEXT:    v_add_f32_e32 v0, v0, v7
 ; GFX11-NEXT:    v_cvt_f32_f16_e32 v3, v1
-; GFX11-NEXT:    v_cvt_f16_f32_e32 v0, v0
+; GFX11-NEXT:    v_cvt_f32_f16_e32 v2, v2
 ; GFX11-NEXT:    v_rcp_f32_e32 v3, v3
-; GFX11-NEXT:    v_div_fixup_f16 v0, v0, v2, -1.0
+; GFX11-NEXT:    v_rcp_f32_e32 v2, v2
 ; GFX11-NEXT:    s_waitcnt_depctr depctr_va_vdst(0)
-; GFX11-NEXT:    v_fma_mix_f32 v6, v1, v3, v5 op_sel_hi:[1,0,0]
-; GFX11-NEXT:    v_fma_f32 v6, v6, v3, -v3
-; GFX11-NEXT:    v_fma_mix_f32 v8, -v1, v6, v5 op_sel_hi:[1,0,0]
-; GFX11-NEXT:    v_mul_f32_e32 v3, v8, v3
-; GFX11-NEXT:    v_and_b32_e32 v3, 0xff800000, v3
-; GFX11-NEXT:    v_add_f32_e32 v3, v3, v6
-; GFX11-NEXT:    v_cvt_f16_f32_e32 v3, v3
-; GFX11-NEXT:    v_div_fixup_f16 v1, v3, v1, -1.0
-; GFX11-NEXT:    v_pack_b32_f16 v0, v1, v0
+; GFX11-NEXT:    v_fma_mix_f32 v5, v1, v3, v4 op_sel_hi:[1,0,0]
+; GFX11-NEXT:    v_fma_mix_f32 v6, |v0|, v2, v4 op_sel:[1,0,0] op_sel_hi:[1,0,0]
+; GFX11-NEXT:    v_fma_f32 v5, v5, v3, -v3
+; GFX11-NEXT:    v_fma_f32 v6, v6, v2, -v2
+; GFX11-NEXT:    v_fma_mix_f32 v7, -v1, v5, v4 op_sel_hi:[1,0,0]
+; GFX11-NEXT:    v_fma_mix_f32 v0, -|v0|, v6, v4 op_sel:[1,0,0] op_sel_hi:[1,0,0]
+; GFX11-NEXT:    v_dual_mul_f32 v3, v7, v3 :: v_dual_mul_f32 v0, v0, v2
+; GFX11-NEXT:    v_and_b32_e32 v2, 0xff800000, v3
+; GFX11-NEXT:    v_and_b32_e32 v0, 0xff800000, v0
+; GFX11-NEXT:    v_add_f32_e32 v2, v2, v5
+; GFX11-NEXT:    v_add_f32_e32 v0, v0, v6
+; GFX11-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; GFX11-NEXT:    v_cvt_f16_f32_e32 v0, v0
+; GFX11-NEXT:    v_div_fixup_f16 v2, v2, v1, -1.0
+; GFX11-NEXT:    v_div_fixup_f16 v0, v0, v1, -1.0 op_sel:[0,1,0,0]
+; GFX11-NEXT:    v_pack_b32_f16 v0, v2, v0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
   %x.fabs = call <2 x half> @llvm.fabs.v2f16(<2 x half> %x)
   %fdiv = fdiv <2 x half> <half -1.0, half -1.0>, %x.fabs
@@ -2977,148 +2941,146 @@ define <2 x half> @v_rcp_v2f16_ulp25(<2 x half> %x) {
 ; GFX9-IEEE:       ; %bb.0:
 ; GFX9-IEEE-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-IEEE-NEXT:    v_cvt_f32_f16_e32 v1, v0
-; GFX9-IEEE-NEXT:    v_lshrrev_b32_e32 v2, 16, v0
-; GFX9-IEEE-NEXT:    v_cvt_f32_f16_e32 v3, v2
-; GFX9-IEEE-NEXT:    v_rcp_f32_e32 v4, v1
-; GFX9-IEEE-NEXT:    v_rcp_f32_e32 v5, v3
-; GFX9-IEEE-NEXT:    v_mul_f32_e64 v6, -v1, v4
+; GFX9-IEEE-NEXT:    v_cvt_f32_f16_sdwa v2, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX9-IEEE-NEXT:    v_rcp_f32_e32 v3, v1
+; GFX9-IEEE-NEXT:    v_rcp_f32_e32 v4, v2
+; GFX9-IEEE-NEXT:    v_mul_f32_e64 v5, -v1, v3
+; GFX9-IEEE-NEXT:    v_mul_f32_e64 v6, -v2, v4
+; GFX9-IEEE-NEXT:    v_add_f32_e32 v5, 1.0, v5
 ; GFX9-IEEE-NEXT:    v_add_f32_e32 v6, 1.0, v6
+; GFX9-IEEE-NEXT:    v_mul_f32_e32 v5, v5, v3
 ; GFX9-IEEE-NEXT:    v_mul_f32_e32 v6, v6, v4
-; GFX9-IEEE-NEXT:    v_mul_f32_e64 v7, -v3, v5
+; GFX9-IEEE-NEXT:    v_add_f32_e32 v5, v5, v3
 ; GFX9-IEEE-NEXT:    v_add_f32_e32 v6, v6, v4
-; GFX9-IEEE-NEXT:    v_add_f32_e32 v7, 1.0, v7
-; GFX9-IEEE-NEXT:    v_mul_f32_e64 v1, -v1, v6
-; GFX9-IEEE-NEXT:    v_mul_f32_e32 v7, v7, v5
+; GFX9-IEEE-NEXT:    v_mul_f32_e64 v1, -v1, v5
+; GFX9-IEEE-NEXT:    v_mul_f32_e64 v2, -v2, v6
 ; GFX9-IEEE-NEXT:    v_add_f32_e32 v1, 1.0, v1
-; GFX9-IEEE-NEXT:    v_mul_f32_e32 v1, v1, v4
-; GFX9-IEEE-NEXT:    v_add_f32_e32 v4, v7, v5
-; GFX9-IEEE-NEXT:    v_mul_f32_e64 v3, -v3, v4
-; GFX9-IEEE-NEXT:    v_add_f32_e32 v3, 1.0, v3
-; GFX9-IEEE-NEXT:    v_mul_f32_e32 v3, v3, v5
+; GFX9-IEEE-NEXT:    v_add_f32_e32 v2, 1.0, v2
+; GFX9-IEEE-NEXT:    v_mul_f32_e32 v1, v1, v3
+; GFX9-IEEE-NEXT:    v_mul_f32_e32 v2, v2, v4
 ; GFX9-IEEE-NEXT:    v_and_b32_e32 v1, 0xff800000, v1
-; GFX9-IEEE-NEXT:    v_and_b32_e32 v3, 0xff800000, v3
-; GFX9-IEEE-NEXT:    v_add_f32_e32 v1, v1, v6
-; GFX9-IEEE-NEXT:    v_add_f32_e32 v3, v3, v4
+; GFX9-IEEE-NEXT:    v_and_b32_e32 v2, 0xff800000, v2
+; GFX9-IEEE-NEXT:    v_add_f32_e32 v1, v1, v5
+; GFX9-IEEE-NEXT:    v_add_f32_e32 v2, v2, v6
 ; GFX9-IEEE-NEXT:    v_cvt_f16_f32_e32 v1, v1
-; GFX9-IEEE-NEXT:    v_cvt_f16_f32_e32 v3, v3
-; GFX9-IEEE-NEXT:    v_div_fixup_f16 v0, v1, v0, 1.0
-; GFX9-IEEE-NEXT:    v_div_fixup_f16 v1, v3, v2, 1.0
-; GFX9-IEEE-NEXT:    v_pack_b32_f16 v0, v0, v1
+; GFX9-IEEE-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; GFX9-IEEE-NEXT:    v_div_fixup_f16 v1, v1, v0, 1.0
+; GFX9-IEEE-NEXT:    v_div_fixup_f16 v0, v2, v0, 1.0 op_sel:[0,1,0,0]
+; GFX9-IEEE-NEXT:    v_pack_b32_f16 v0, v1, v0
 ; GFX9-IEEE-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-FLUSH-LABEL: v_rcp_v2f16_ulp25:
 ; GFX9-FLUSH:       ; %bb.0:
 ; GFX9-FLUSH-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-FLUSH-NEXT:    v_lshrrev_b32_e32 v2, 16, v0
 ; GFX9-FLUSH-NEXT:    v_cvt_f32_f16_e32 v1, v0
-; GFX9-FLUSH-NEXT:    v_cvt_f32_f16_e32 v3, v2
-; GFX9-FLUSH-NEXT:    v_mov_b32_e32 v4, 1.0
+; GFX9-FLUSH-NEXT:    v_cvt_f32_f16_sdwa v2, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX9-FLUSH-NEXT:    v_mov_b32_e32 v3, 1.0
 ; GFX9-FLUSH-NEXT:    v_rcp_f32_e32 v1, v1
-; GFX9-FLUSH-NEXT:    v_rcp_f32_e32 v3, v3
-; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v5, -v0, v1, v4 op_sel_hi:[1,0,0]
-; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v6, -v0, v3, v4 op_sel:[1,0,0] op_sel_hi:[1,0,0]
-; GFX9-FLUSH-NEXT:    v_mad_f32 v5, v5, v1, v1
-; GFX9-FLUSH-NEXT:    v_mad_f32 v6, v6, v3, v3
-; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v7, -v0, v5, v4 op_sel_hi:[1,0,0]
-; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v4, -v0, v6, v4 op_sel:[1,0,0] op_sel_hi:[1,0,0]
-; GFX9-FLUSH-NEXT:    v_mul_f32_e32 v1, v7, v1
-; GFX9-FLUSH-NEXT:    v_mul_f32_e32 v3, v4, v3
+; GFX9-FLUSH-NEXT:    v_rcp_f32_e32 v2, v2
+; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v4, -v0, v1, v3 op_sel_hi:[1,0,0]
+; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v5, -v0, v2, v3 op_sel:[1,0,0] op_sel_hi:[1,0,0]
+; GFX9-FLUSH-NEXT:    v_mad_f32 v4, v4, v1, v1
+; GFX9-FLUSH-NEXT:    v_mad_f32 v5, v5, v2, v2
+; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v6, -v0, v4, v3 op_sel_hi:[1,0,0]
+; GFX9-FLUSH-NEXT:    v_mad_mix_f32 v3, -v0, v5, v3 op_sel:[1,0,0] op_sel_hi:[1,0,0]
+; GFX9-FLUSH-NEXT:    v_mul_f32_e32 v1, v6, v1
+; GFX9-FLUSH-NEXT:    v_mul_f32_e32 v2, v3, v2
 ; GFX9-FLUSH-NEXT:    v_and_b32_e32 v1, 0xff800000, v1
-; GFX9-FLUSH-NEXT:    v_and_b32_e32 v3, 0xff800000, v3
-; GFX9-FLUSH-NEXT:    v_add_f32_e32 v1, v1, v5
-; GFX9-FLUSH-NEXT:    v_add_f32_e32 v3, v3, v6
+; GFX9-FLUSH-NEXT:    v_and_b32_e32 v2, 0xff800000, v2
+; GFX9-FLUSH-NEXT:    v_add_f32_e32 v1, v1, v4
+; GFX9-FLUSH-NEXT:    v_add_f32_e32 v2, v2, v5
 ; GFX9-FLUSH-NEXT:    v_cvt_f16_f32_e32 v1, v1
-; GFX9-FLUSH-NEXT:    v_cvt_f16_f32_e32 v3, v3
-; GFX9-FLUSH-NEXT:    v_div_fixup_f16 v0, v1, v0, 1.0
-; GFX9-FLUSH-NEXT:    v_div_fixup_f16 v1, v3, v2, 1.0
-; GFX9-FLUSH-NEXT:    v_pack_b32_f16 v0, v0, v1
+; GFX9-FLUSH-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; GFX9-FLUSH-NEXT:    v_div_fixup_f16 v1, v1, v0, 1.0
+; GFX9-FLUSH-NEXT:    v_div_fixup_f16 v0, v2, v0, 1.0 op_sel:[0,1,0,0]
+; GFX9-FLUSH-NEXT:    v_pack_b32_f16 v0, v1, v0
 ; GFX9-FLUSH-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-IEEE-LABEL: v_rcp_v2f16_ulp25:
 ; GFX10-IEEE:       ; %bb.0:
 ; GFX10-IEEE-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10-IEEE-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX10-IEEE-NEXT:    v_cvt_f32_f16_e32 v2, v0
-; GFX10-IEEE-NEXT:    v_cvt_f32_f16_e32 v3, v1
+; GFX10-IEEE-NEXT:    v_cvt_f32_f16_e32 v1, v0
+; GFX10-IEEE-NEXT:    v_cvt_f32_f16_sdwa v2, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX10-IEEE-NEXT:    v_rcp_f32_e32 v1, v1
 ; GFX10-IEEE-NEXT:    v_rcp_f32_e32 v2, v2
-; GFX10-IEEE-NEXT:    v_rcp_f32_e32 v3, v3
-; GFX10-IEEE-NEXT:    v_fma_mix_f32 v4, -v0, v2, neg(0) op_sel_hi:[1,0,0]
-; GFX10-IEEE-NEXT:    v_fma_mix_f32 v5, -v0, v3, neg(0) op_sel:[1,0,0] op_sel_hi:[1,0,0]
+; GFX10-IEEE-NEXT:    v_fma_mix_f32 v3, -v0, v1, neg(0) op_sel_hi:[1,0,0]
+; GFX10-IEEE-NEXT:    v_fma_mix_f32 v4, -v0, v2, neg(0) op_sel:[1,0,0] op_sel_hi:[1,0,0]
+; GFX10-IEEE-NEXT:    v_add_f32_e32 v3, 1.0, v3
 ; GFX10-IEEE-NEXT:    v_add_f32_e32 v4, 1.0, v4
-; GFX10-IEEE-NEXT:    v_add_f32_e32 v5, 1.0, v5
+; GFX10-IEEE-NEXT:    v_mul_f32_e32 v3, v3, v1
 ; GFX10-IEEE-NEXT:    v_mul_f32_e32 v4, v4, v2
-; GFX10-IEEE-NEXT:    v_mul_f32_e32 v5, v5, v3
+; GFX10-IEEE-NEXT:    v_add_f32_e32 v3, v3, v1
 ; GFX10-IEEE-NEXT:    v_add_f32_e32 v4, v4, v2
-; GFX10-IEEE-NEXT:    v_add_f32_e32 v5, v5, v3
-; GFX10-IEEE-NEXT:    v_fma_mix_f32 v6, -v0, v4, neg(0) op_sel_hi:[1,0,0]
-; GFX10-IEEE-NEXT:    v_fma_mix_f32 v7, -v0, v5, neg(0) op_sel:[1,0,0] op_sel_hi:[1,0,0]
+; GFX10-IEEE-NEXT:    v_fma_mix_f32 v5, -v0, v3, neg(0) op_sel_hi:[1,0,0]
+; GFX10-IEEE-NEXT:    v_fma_mix_f32 v6, -v0, v4, neg(0) op_sel:[1,0,0] op_sel_hi:[1,0,0]
+; GFX10-IEEE-NEXT:    v_add_f32_e32 v5, 1.0, v5
 ; GFX10-IEEE-NEXT:    v_add_f32_e32 v6, 1.0, v6
-; GFX10-IEEE-NEXT:    v_add_f32_e32 v7, 1.0, v7
+; GFX10-IEEE-NEXT:    v_mul_f32_e32 v1, v5, v1
 ; GFX10-IEEE-NEXT:    v_mul_f32_e32 v2, v6, v2
-; GFX10-IEEE-NEXT:    v_mul_f32_e32 v3, v7, v3
+; GFX10-IEEE-NEXT:    v_and_b32_e32 v1, 0xff800000, v1
 ; GFX10-IEEE-NEXT:    v_and_b32_e32 v2, 0xff800000, v2
-; GFX10-IEEE-NEXT:    v_and_b32_e32 v3, 0xff800000, v3
+; GFX10-IEEE-NEXT:    v_add_f32_e32 v1, v1, v3
 ; GFX10-IEEE-NEXT:    v_add_f32_e32 v2, v2, v4
-; GFX10-IEEE-NEXT:    v_add_f32_e32 v3, v3, v5
+; GFX10-IEEE-NEXT:    v_cvt_f16_f32_e32 v1, v1
 ; GFX10-IEEE-NEXT:    v_cvt_f16_f32_e32 v2, v2
-; GFX10-IEEE-NEXT:    v_cvt_f16_f32_e32 v3, v3
-; GFX10-IEEE-NEXT:    v_div_fixup_f16 v0, v2, v0, 1.0
-; GFX10-IEEE-NEXT:    v_div_fixup_f16 v1, v3, v1, 1.0
-; GFX10-IEEE-NEXT:    v_pack_b32_f16 v0, v0, v1
+; GFX10-IEEE-NEXT:    v_div_fixup_f16 v1, v1, v0, 1.0
+; GFX10-IEEE-NEXT:    v_div_fixup_f16 v0, v2, v0, 1.0 op_sel:[0,1,0,0]
+; GFX10-IEEE-NEXT:    v_pack_b32_f16 v0, v1, v0
 ; GFX10-IEEE-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-FLUSH-LABEL: v_rcp_v2f16_ulp25:
 ; GFX10-FLUSH:       ; %bb.0:
 ; GFX10-FLUSH-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10-FLUSH-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX10-FLUSH-NEXT:    v_cvt_f32_f16_e32 v2, v0
-; GFX10-FLUSH-NEXT:    v_cvt_f32_f16_e32 v3, v1
+; GFX10-FLUSH-NEXT:    v_cvt_f32_f16_e32 v1, v0
+; GFX10-FLUSH-NEXT:    v_cvt_f32_f16_sdwa v2, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX10-FLUSH-NEXT:    v_rcp_f32_e32 v3, v1
 ; GFX10-FLUSH-NEXT:    v_rcp_f32_e32 v4, v2
-; GFX10-FLUSH-NEXT:    v_rcp_f32_e32 v5, v3
+; GFX10-FLUSH-NEXT:    v_mad_f32 v5, -v1, v3, 1.0
 ; GFX10-FLUSH-NEXT:    v_mad_f32 v6, -v2, v4, 1.0
-; GFX10-FLUSH-NEXT:    v_mad_f32 v7, -v3, v5, 1.0
+; GFX10-FLUSH-NEXT:    v_mad_f32 v5, v5, v3, v3
 ; GFX10-FLUSH-NEXT:    v_mad_f32 v6, v6, v4, v4
-; GFX10-FLUSH-NEXT:    v_mad_f32 v7, v7, v5, v5
+; GFX10-FLUSH-NEXT:    v_mad_f32 v1, -v1, v5, 1.0
 ; GFX10-FLUSH-NEXT:    v_mad_f32 v2, -v2, v6, 1.0
-; GFX10-FLUSH-NEXT:    v_mad_f32 v3, -v3, v7, 1.0
+; GFX10-FLUSH-NEXT:    v_mul_f32_e32 v1, v1, v3
 ; GFX10-FLUSH-NEXT:    v_mul_f32_e32 v2, v2, v4
-; GFX10-FLUSH-NEXT:    v_mul_f32_e32 v3, v3, v5
+; GFX10-FLUSH-NEXT:    v_and_b32_e32 v1, 0xff800000, v1
 ; GFX10-FLUSH-NEXT:    v_and_b32_e32 v2, 0xff800000, v2
-; GFX10-FLUSH-NEXT:    v_and_b32_e32 v3, 0xff800000, v3
+; GFX10-FLUSH-NEXT:    v_add_f32_e32 v1, v1, v5
 ; GFX10-FLUSH-NEXT:    v_add_f32_e32 v2, v2, v6
-; GFX10-FLUSH-NEXT:    v_add_f32_e32 v3, v3, v7
+; GFX10-FLUSH-NEXT:    v_cvt_f16_f32_e32 v1, v1
 ; GFX10-FLUSH-NEXT:    v_cvt_f16_f32_e32 v2, v2
-; GFX10-FLUSH-NEXT:    v_cvt_f16_f32_e32 v3, v3
-; GFX10-FLUSH-NEXT:    v_div_fixup_f16 v0, v2, v0, 1.0
-; GFX10-FLUSH-NEXT:    v_div_fixup_f16 v1, v3, v1, 1.0
-; GFX10-FLUSH-NEXT:    v_pack_b32_f16 v0, v0, v1
+; GFX10-FLUSH-NEXT:    v_div_fixup_f16 v1, v1, v0, 1.0
+; GFX10-FLUSH-NEXT:    v_div_fixup_f16 v0, v2, v0, 1.0 op_sel:[0,1,0,0]
+; GFX10-FLUSH-NEXT:    v_pack_b32_f16 v0, v1, v0
 ; GFX10-FLUSH-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_rcp_v2f16_ulp25:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
 ; GFX11-NEXT:    v_cvt_f32_f16_e32 v2, v0
-; GFX11-NEXT:    v_mov_b32_e32 v4, 1.0
-; GFX11-NEXT:    v_cvt_f32_f16_e32 v3, v1
+; GFX11-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
 ; GFX11-NEXT:    v_rcp_f32_e32 v2, v2
-; GFX11-NEXT:    v_rcp_f32_e32 v3, v3
+; GFX11-NEXT:    v_mov_b32_e32 v3, 1.0
+; GFX11-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; GFX11-NEXT:    v_rcp_f32_e32 v1, v1
 ; GFX11-NEXT:    s_waitcnt_depctr depctr_va_vdst(0)
-; GFX11-NEXT:    v_fma_mix_f32 v5, -v0, v2, v4 op_sel_hi:[1,0,0]
-; GFX11-NEXT:    v_fma_mix_f32 v6, -v0, v3, v4 op_sel:[1,0,0] op_sel_hi:[1,0,0]
-; GFX11-NEXT:    v_fma_f32 v5, v5, v2, v2
-; GFX11-NEXT:    v_fma_f32 v6, v6, v3, v3
-; GFX11-NEXT:    v_fma_mix_f32 v7, -v0, v5, v4 op_sel_hi:[1,0,0]
-; GFX11-NEXT:    v_fma_mix_f32 v4, -v0, v6, v4 op_sel:[1,0,0] op_sel_hi:[1,0,0]
-; GFX11-NEXT:    v_dual_mul_f32 v2, v7, v2 :: v_dual_mul_f32 v3, v4, v3
+; GFX11-NEXT:    v_fma_mix_f32 v4, -v0, v2, v3 op_sel_hi:[1,0,0]
+; GFX11-NEXT:    v_fma_f32 v4, v4, v2, v2
+; GFX11-NEXT:    v_fma_mix_f32 v6, -v0, v4, v3 op_sel_hi:[1,0,0]
+; GFX11-NEXT:    v_mul_f32_e32 v2, v6, v2
+; GFX11-NEXT:    v_fma_mix_f32 v5, -v0, v1, v3 op_sel:[1,0,0] op_sel_hi:[1,0,0]
 ; GFX11-NEXT:    v_and_b32_e32 v2, 0xff800000, v2
-; GFX11-NEXT:    v_dual_add_f32 v2, v2, v5 :: v_dual_and_b32 v3, 0xff800000, v3
-; GFX11-NEXT:    v_add_f32_e32 v3, v3, v6
+; GFX11-NEXT:    v_fma_f32 v5, v5, v1, v1
+; GFX11-NEXT:    v_add_f32_e32 v2, v2, v4
+; GFX11-NEXT:    v_fma_mix_f32 v3, -v0, v5, v3 op_sel:[1,0,0] op_sel_hi:[1,0,0]
 ; GFX11-NEXT:    v_cvt_f16_f32_e32 v2, v2
-; GFX11-NEXT:    v_cvt_f16_f32_e32 v3, v3
-; GFX11-NEXT:    v_div_fixup_f16 v0, v2, v0, 1.0
-; GFX11-NEXT:    v_div_fixup_f16 v1, v3, v1, 1.0
-; GFX11-NEXT:    v_pack_b32_f16 v0, v0, v1
+; GFX11-NEXT:    v_mul_f32_e32 v1, v3, v1
+; GFX11-NEXT:    v_div_fixup_f16 v2, v2, v0, 1.0
+; GFX11-NEXT:    v_and_b32_e32 v1, 0xff800000, v1
+; GFX11-NEXT:    v_add_f32_e32 v1, v1, v5
+; GFX11-NEXT:    v_cvt_f16_f32_e32 v1, v1
+; GFX11-NEXT:    v_div_fixup_f16 v0, v1, v0, 1.0 op_sel:[0,1,0,0]
+; GFX11-NEXT:    v_pack_b32_f16 v0, v2, v0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
   %fdiv = fdiv <2 x half> <half 1.0, half 1.0>, %x
   ret <2 x half> %fdiv

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/fshl.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/fshl.ll
@@ -1508,51 +1508,50 @@ define i32 @v_fshl_v4i8(i32 %lhs.arg, i32 %rhs.arg, i32 %amt.arg) {
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_lshrrev_b32_e32 v5, 8, v2
 ; GFX10-NEXT:    v_lshrrev_b32_e32 v3, 8, v0
-; GFX10-NEXT:    v_and_b32_e32 v7, 7, v2
-; GFX10-NEXT:    v_and_b32_e32 v8, 0xff, v1
-; GFX10-NEXT:    v_xor_b32_e32 v9, -1, v2
-; GFX10-NEXT:    v_and_b32_e32 v10, 7, v5
-; GFX10-NEXT:    v_lshrrev_b32_e32 v11, 8, v1
-; GFX10-NEXT:    v_lshrrev_b32_e32 v4, 16, v0
-; GFX10-NEXT:    v_lshrrev_b32_e32 v6, 24, v0
-; GFX10-NEXT:    v_lshlrev_b16 v0, v7, v0
-; GFX10-NEXT:    v_lshrrev_b16 v7, 1, v8
-; GFX10-NEXT:    v_and_b32_e32 v8, 7, v9
-; GFX10-NEXT:    v_lshlrev_b16 v3, v10, v3
-; GFX10-NEXT:    v_and_b32_e32 v9, 0xff, v11
-; GFX10-NEXT:    v_mov_b32_e32 v10, 0xff
+; GFX10-NEXT:    v_lshrrev_b32_e32 v9, 8, v1
 ; GFX10-NEXT:    v_mov_b32_e32 v11, -1
-; GFX10-NEXT:    v_xor_b32_e32 v5, -1, v5
 ; GFX10-NEXT:    v_mov_b32_e32 v12, 7
-; GFX10-NEXT:    v_lshrrev_b16 v9, 1, v9
-; GFX10-NEXT:    v_and_b32_sdwa v10, v1, v10 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:DWORD
+; GFX10-NEXT:    v_and_b32_e32 v10, 7, v5
+; GFX10-NEXT:    v_xor_b32_e32 v5, -1, v5
+; GFX10-NEXT:    v_and_b32_e32 v9, 0xff, v9
 ; GFX10-NEXT:    v_xor_b32_sdwa v13, v2, v11 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:DWORD
 ; GFX10-NEXT:    v_xor_b32_sdwa v11, v2, v11 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_3 src1_sel:DWORD
+; GFX10-NEXT:    v_lshlrev_b16 v3, v10, v3
+; GFX10-NEXT:    v_mov_b32_e32 v10, 0xff
+; GFX10-NEXT:    v_lshrrev_b32_e32 v4, 24, v0
+; GFX10-NEXT:    v_and_b32_e32 v6, 7, v2
+; GFX10-NEXT:    v_and_b32_e32 v7, 0xff, v1
+; GFX10-NEXT:    v_xor_b32_e32 v8, -1, v2
+; GFX10-NEXT:    v_and_b32_sdwa v10, v1, v10 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:DWORD
+; GFX10-NEXT:    v_lshrrev_b16 v9, 1, v9
 ; GFX10-NEXT:    v_and_b32_e32 v5, 7, v5
 ; GFX10-NEXT:    v_and_b32_sdwa v14, v2, v12 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:DWORD
-; GFX10-NEXT:    v_lshrrev_b16 v10, 1, v10
 ; GFX10-NEXT:    v_and_b32_e32 v13, 7, v13
+; GFX10-NEXT:    v_lshrrev_b16 v10, 1, v10
 ; GFX10-NEXT:    v_and_b32_sdwa v2, v2, v12 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_3 src1_sel:DWORD
 ; GFX10-NEXT:    v_lshrrev_b32_e32 v1, 25, v1
 ; GFX10-NEXT:    v_and_b32_e32 v11, 7, v11
+; GFX10-NEXT:    v_lshlrev_b16 v6, v6, v0
+; GFX10-NEXT:    v_lshrrev_b16 v7, 1, v7
+; GFX10-NEXT:    v_and_b32_e32 v8, 7, v8
 ; GFX10-NEXT:    v_lshrrev_b16 v5, v5, v9
-; GFX10-NEXT:    v_lshlrev_b16 v4, v14, v4
+; GFX10-NEXT:    v_lshlrev_b16 v0, v14, v0 op_sel:[0,1,0]
 ; GFX10-NEXT:    v_lshrrev_b16 v9, v13, v10
-; GFX10-NEXT:    v_lshlrev_b16 v2, v2, v6
+; GFX10-NEXT:    v_lshlrev_b16 v2, v2, v4
 ; GFX10-NEXT:    v_lshrrev_b16 v1, v11, v1
-; GFX10-NEXT:    v_lshrrev_b16 v6, v8, v7
+; GFX10-NEXT:    v_lshrrev_b16 v4, v8, v7
 ; GFX10-NEXT:    v_or_b32_e32 v3, v3, v5
 ; GFX10-NEXT:    v_mov_b32_e32 v5, 8
-; GFX10-NEXT:    v_or_b32_e32 v4, v4, v9
+; GFX10-NEXT:    v_or_b32_e32 v0, v0, v9
 ; GFX10-NEXT:    v_or_b32_e32 v1, v2, v1
-; GFX10-NEXT:    v_or_b32_e32 v0, v0, v6
-; GFX10-NEXT:    v_lshlrev_b32_sdwa v2, v5, v3 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:BYTE_0
-; GFX10-NEXT:    v_and_b32_e32 v3, 0xff, v4
+; GFX10-NEXT:    v_or_b32_e32 v2, v6, v4
+; GFX10-NEXT:    v_lshlrev_b32_sdwa v3, v5, v3 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:BYTE_0
+; GFX10-NEXT:    v_and_b32_e32 v0, 0xff, v0
 ; GFX10-NEXT:    v_and_b32_e32 v1, 0xff, v1
-; GFX10-NEXT:    v_and_or_b32 v0, 0xff, v0, v2
-; GFX10-NEXT:    v_lshlrev_b32_e32 v2, 16, v3
+; GFX10-NEXT:    v_and_or_b32 v2, 0xff, v2, v3
+; GFX10-NEXT:    v_lshlrev_b32_e32 v0, 16, v0
 ; GFX10-NEXT:    v_lshlrev_b32_e32 v1, 24, v1
-; GFX10-NEXT:    v_or3_b32 v0, v0, v2, v1
+; GFX10-NEXT:    v_or3_b32 v0, v2, v0, v1
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-TRUE16-LABEL: v_fshl_v4i8:

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/fshr.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/fshr.ll
@@ -1518,50 +1518,49 @@ define i32 @v_fshr_v4i8(i32 %lhs.arg, i32 %rhs.arg, i32 %amt.arg) {
 ; GFX10-NEXT:    v_lshrrev_b32_e32 v4, 8, v0
 ; GFX10-NEXT:    v_xor_b32_e32 v8, -1, v2
 ; GFX10-NEXT:    v_mov_b32_e32 v3, -1
-; GFX10-NEXT:    v_lshrrev_b32_e32 v6, 16, v0
+; GFX10-NEXT:    v_lshlrev_b16 v11, 1, v0
 ; GFX10-NEXT:    v_xor_b32_e32 v10, -1, v5
-; GFX10-NEXT:    v_lshrrev_b32_e32 v7, 24, v0
-; GFX10-NEXT:    v_lshrrev_b32_e32 v9, 8, v1
-; GFX10-NEXT:    v_lshlrev_b16 v0, 1, v0
-; GFX10-NEXT:    v_and_b32_e32 v8, 7, v8
 ; GFX10-NEXT:    v_lshlrev_b16 v4, 1, v4
+; GFX10-NEXT:    v_and_b32_e32 v8, 7, v8
+; GFX10-NEXT:    v_lshrrev_b32_e32 v6, 24, v0
+; GFX10-NEXT:    v_lshrrev_b32_e32 v7, 8, v1
 ; GFX10-NEXT:    v_and_b32_e32 v10, 7, v10
 ; GFX10-NEXT:    v_mov_b32_e32 v14, 0xff
-; GFX10-NEXT:    v_lshrrev_b32_e32 v11, 24, v1
-; GFX10-NEXT:    v_lshlrev_b16 v0, v8, v0
-; GFX10-NEXT:    v_and_b32_e32 v8, 0xff, v9
+; GFX10-NEXT:    v_lshlrev_b16 v8, v8, v11
+; GFX10-NEXT:    v_mov_b32_e32 v11, 7
+; GFX10-NEXT:    v_lshrrev_b32_e32 v9, 24, v1
 ; GFX10-NEXT:    v_lshlrev_b16 v4, v10, v4
-; GFX10-NEXT:    v_xor_b32_sdwa v9, v2, v3 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:DWORD
-; GFX10-NEXT:    v_mov_b32_e32 v10, 7
+; GFX10-NEXT:    v_xor_b32_sdwa v10, v2, v3 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:DWORD
 ; GFX10-NEXT:    v_xor_b32_sdwa v3, v2, v3 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_3 src1_sel:DWORD
 ; GFX10-NEXT:    v_and_b32_e32 v12, 7, v2
 ; GFX10-NEXT:    v_and_b32_e32 v13, 0xff, v1
 ; GFX10-NEXT:    v_and_b32_e32 v5, 7, v5
-; GFX10-NEXT:    v_lshlrev_b16 v6, 1, v6
-; GFX10-NEXT:    v_and_b32_e32 v9, 7, v9
-; GFX10-NEXT:    v_and_b32_sdwa v15, v2, v10 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:DWORD
+; GFX10-NEXT:    v_and_b32_e32 v7, 0xff, v7
+; GFX10-NEXT:    v_lshlrev_b16 v0, 1, v0 op_sel:[0,1,0]
+; GFX10-NEXT:    v_and_b32_e32 v10, 7, v10
+; GFX10-NEXT:    v_and_b32_sdwa v15, v2, v11 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:DWORD
 ; GFX10-NEXT:    v_and_b32_sdwa v1, v1, v14 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:DWORD
-; GFX10-NEXT:    v_lshlrev_b16 v7, 1, v7
+; GFX10-NEXT:    v_lshlrev_b16 v6, 1, v6
 ; GFX10-NEXT:    v_and_b32_e32 v3, 7, v3
-; GFX10-NEXT:    v_and_b32_sdwa v2, v2, v10 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_3 src1_sel:DWORD
-; GFX10-NEXT:    v_lshrrev_b16 v5, v5, v8
-; GFX10-NEXT:    v_lshlrev_b16 v6, v9, v6
+; GFX10-NEXT:    v_and_b32_sdwa v2, v2, v11 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_3 src1_sel:DWORD
+; GFX10-NEXT:    v_lshrrev_b16 v5, v5, v7
+; GFX10-NEXT:    v_lshlrev_b16 v0, v10, v0
 ; GFX10-NEXT:    v_lshrrev_b16 v1, v15, v1
-; GFX10-NEXT:    v_lshlrev_b16 v3, v3, v7
-; GFX10-NEXT:    v_lshrrev_b16 v2, v2, v11
-; GFX10-NEXT:    v_lshrrev_b16 v7, v12, v13
+; GFX10-NEXT:    v_lshlrev_b16 v3, v3, v6
+; GFX10-NEXT:    v_lshrrev_b16 v2, v2, v9
+; GFX10-NEXT:    v_lshrrev_b16 v6, v12, v13
 ; GFX10-NEXT:    v_or_b32_e32 v4, v4, v5
 ; GFX10-NEXT:    v_mov_b32_e32 v5, 8
-; GFX10-NEXT:    v_or_b32_e32 v1, v6, v1
-; GFX10-NEXT:    v_or_b32_e32 v2, v3, v2
-; GFX10-NEXT:    v_or_b32_e32 v0, v0, v7
+; GFX10-NEXT:    v_or_b32_e32 v0, v0, v1
+; GFX10-NEXT:    v_or_b32_e32 v1, v3, v2
+; GFX10-NEXT:    v_or_b32_e32 v2, v8, v6
 ; GFX10-NEXT:    v_lshlrev_b32_sdwa v3, v5, v4 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:BYTE_0
+; GFX10-NEXT:    v_and_b32_e32 v0, 0xff, v0
 ; GFX10-NEXT:    v_and_b32_e32 v1, 0xff, v1
-; GFX10-NEXT:    v_and_b32_e32 v2, 0xff, v2
-; GFX10-NEXT:    v_and_or_b32 v0, 0xff, v0, v3
-; GFX10-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
-; GFX10-NEXT:    v_lshlrev_b32_e32 v2, 24, v2
-; GFX10-NEXT:    v_or3_b32 v0, v0, v1, v2
+; GFX10-NEXT:    v_and_or_b32 v2, 0xff, v2, v3
+; GFX10-NEXT:    v_lshlrev_b32_e32 v0, 16, v0
+; GFX10-NEXT:    v_lshlrev_b32_e32 v1, 24, v1
+; GFX10-NEXT:    v_or3_b32 v0, v2, v0, v1
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-TRUE16-LABEL: v_fshr_v4i8:

--- a/llvm/test/CodeGen/AMDGPU/cvt_f32_ubyte.ll
+++ b/llvm/test/CodeGen/AMDGPU/cvt_f32_ubyte.ll
@@ -1665,17 +1665,17 @@ define amdgpu_kernel void @load_v4i8_to_v4f32_2_uses(ptr addrspace(1) noalias %o
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x34
 ; GFX10-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
+; GFX10-NEXT:    v_mov_b32_e32 v1, 0xffffff00
 ; GFX10-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX10-NEXT:    global_load_dword v0, v0, s[0:1]
 ; GFX10-NEXT:    s_waitcnt_depctr depctr_vm_vsrc(0)
 ; GFX10-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x24
 ; GFX10-NEXT:    s_waitcnt vmcnt(0)
-; GFX10-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
+; GFX10-NEXT:    v_add_nc_u16 v2, v0, 9 op_sel:[1,0,0]
+; GFX10-NEXT:    v_and_b32_sdwa v1, v0, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:DWORD
 ; GFX10-NEXT:    v_and_b32_e32 v3, 0xffffff00, v0
 ; GFX10-NEXT:    v_add_nc_u16 v4, v0, 9
-; GFX10-NEXT:    v_and_b32_e32 v2, 0xffffff00, v1
-; GFX10-NEXT:    v_add_nc_u16 v1, v1, 9
-; GFX10-NEXT:    v_or_b32_sdwa v1, v2, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:BYTE_0
+; GFX10-NEXT:    v_or_b32_sdwa v1, v1, v2 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:BYTE_0
 ; GFX10-NEXT:    v_or_b32_sdwa v2, v3, v4 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:BYTE_0
 ; GFX10-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX10-NEXT:    v_cvt_f32_ubyte3_e32 v3, v0
@@ -1769,26 +1769,27 @@ define amdgpu_kernel void @load_v4i8_to_v4f32_2_uses(ptr addrspace(1) noalias %o
 ; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-FAKE16-NEXT:    v_add_nc_u16 v1, v0, 9
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v2, 16, v0
-; GFX11-FAKE16-NEXT:    v_and_b32_e32 v3, 0xffffff00, v0
-; GFX11-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX11-FAKE16-NEXT:    v_add_nc_u16 v3, v0, 9 op_sel:[1,0,0]
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v4, 0xffffff00, v0
+; GFX11-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
 ; GFX11-FAKE16-NEXT:    v_and_b32_e32 v1, 0xff, v1
-; GFX11-FAKE16-NEXT:    v_add_nc_u16 v4, v2, 9
 ; GFX11-FAKE16-NEXT:    v_and_b32_e32 v2, 0xffffff00, v2
-; GFX11-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
-; GFX11-FAKE16-NEXT:    v_or_b32_e32 v1, v3, v1
-; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v4, 0 :: v_dual_and_b32 v3, 0xff, v4
-; GFX11-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX11-FAKE16-NEXT:    v_add_nc_u16 v1, 0x900, v1
+; GFX11-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v3, 0xff, v3
+; GFX11-FAKE16-NEXT:    v_or_b32_e32 v1, v4, v1
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v4, 0
+; GFX11-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_4)
 ; GFX11-FAKE16-NEXT:    v_or_b32_e32 v2, v2, v3
 ; GFX11-FAKE16-NEXT:    v_cvt_f32_ubyte3_e32 v3, v0
-; GFX11-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
-; GFX11-FAKE16-NEXT:    v_and_b32_e32 v5, 0xffff, v1
-; GFX11-FAKE16-NEXT:    v_add_nc_u16 v6, 0x900, v2
+; GFX11-FAKE16-NEXT:    v_add_nc_u16 v1, 0x900, v1
+; GFX11-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_3)
+; GFX11-FAKE16-NEXT:    v_add_nc_u16 v5, 0x900, v2
 ; GFX11-FAKE16-NEXT:    v_cvt_f32_ubyte2_e32 v2, v0
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v6, 0xffff, v1
 ; GFX11-FAKE16-NEXT:    v_cvt_f32_ubyte1_e32 v1, v0
 ; GFX11-FAKE16-NEXT:    v_cvt_f32_ubyte0_e32 v0, v0
-; GFX11-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_4)
-; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v5, v6, 16, v5
+; GFX11-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_3)
+; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v5, v5, 16, v6
 ; GFX11-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX11-FAKE16-NEXT:    s_clause 0x1
 ; GFX11-FAKE16-NEXT:    global_store_b128 v4, v[0:3], s[0:1]

--- a/llvm/test/CodeGen/AMDGPU/fdiv.bf16.ll
+++ b/llvm/test/CodeGen/AMDGPU/fdiv.bf16.ll
@@ -291,11 +291,10 @@ define <2 x bfloat> @v_rsq_v2bf16(<2 x bfloat> %a) {
 ; GFX1250-FAKE16:       ; %bb.0:
 ; GFX1250-FAKE16-NEXT:    s_wait_loadcnt_dscnt 0x0
 ; GFX1250-FAKE16-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
+; GFX1250-FAKE16-NEXT:    v_rsq_bf16_e64 v1, v0 op_sel:[1,0]
 ; GFX1250-FAKE16-NEXT:    v_rsq_bf16_e32 v0, v0
-; GFX1250-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(TRANS32_DEP_1)
-; GFX1250-FAKE16-NEXT:    v_rsq_bf16_e32 v1, v1
 ; GFX1250-FAKE16-NEXT:    v_nop
+; GFX1250-FAKE16-NEXT:    s_delay_alu instid0(TRANS32_DEP_1)
 ; GFX1250-FAKE16-NEXT:    v_perm_b32 v0, v1, v0, 0x5040100
 ; GFX1250-FAKE16-NEXT:    s_set_pc_i64 s[30:31]
   %sqrt = call contract <2 x bfloat> @llvm.sqrt.v2bf16(<2 x bfloat> %a)
@@ -323,15 +322,14 @@ define <2 x bfloat> @v_neg_rsq_v2bf16(<2 x bfloat> %a) {
 ; GFX1250-FAKE16:       ; %bb.0:
 ; GFX1250-FAKE16-NEXT:    s_wait_loadcnt_dscnt 0x0
 ; GFX1250-FAKE16-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
+; GFX1250-FAKE16-NEXT:    v_rsq_bf16_e64 v1, v0 op_sel:[1,0]
+; GFX1250-FAKE16-NEXT:    v_nop
+; GFX1250-FAKE16-NEXT:    s_delay_alu instid0(TRANS32_DEP_1) | instskip(SKIP_2) | instid1(TRANS32_DEP_1)
+; GFX1250-FAKE16-NEXT:    v_xor_b32_e32 v1, 0x8000, v1
 ; GFX1250-FAKE16-NEXT:    v_rsq_bf16_e32 v0, v0
 ; GFX1250-FAKE16-NEXT:    v_nop
-; GFX1250-FAKE16-NEXT:    s_delay_alu instid0(TRANS32_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_3)
 ; GFX1250-FAKE16-NEXT:    v_xor_b32_e32 v0, 0x8000, v0
-; GFX1250-FAKE16-NEXT:    v_rsq_bf16_e32 v1, v1
-; GFX1250-FAKE16-NEXT:    v_nop
-; GFX1250-FAKE16-NEXT:    s_delay_alu instid0(TRANS32_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1250-FAKE16-NEXT:    v_xor_b32_e32 v1, 0x8000, v1
+; GFX1250-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1250-FAKE16-NEXT:    v_perm_b32 v0, v1, v0, 0x5040100
 ; GFX1250-FAKE16-NEXT:    s_set_pc_i64 s[30:31]
   %sqrt = call contract <2 x bfloat> @llvm.sqrt.v2bf16(<2 x bfloat> %a)

--- a/llvm/test/CodeGen/AMDGPU/fma-mad-f16-hi16.ll
+++ b/llvm/test/CodeGen/AMDGPU/fma-mad-f16-hi16.ll
@@ -3,25 +3,22 @@
 ; RUN: llc -global-isel=1 -mtriple=amdgpu9.00 < %s | FileCheck -check-prefixes=GFX9-GISEL %s
 
 ; Scalar 16-bit VOP3 ternaries reading and writing the high half of a packed
-; register. On GFX9 v_fma_f16 and v_mad_legacy_f16 both support op_sel, so each
-; of these could be a single instruction, but SelectVOP3OpSel() does not set
-; op_sel yet (see the FIXME in AMDGPUISelDAGToDAG.cpp), so the high halves are
-; extracted and re-inserted with explicit shifts instead.
+; register. On GFX9 v_fma_f16 and v_mad_f16 both support op_sel, so fma cases
+; use a single instruction. v_mad_legacy_f16 is selected for legacy mad, which
+; does not have op_sel, so mad cases still extract the high halves explicitly.
 
 ; Only src0 comes from a high half.
 define half @fma_f16_hi_src0(<2 x half> %a, half %b, half %c) {
 ; GFX9-SDAG-LABEL: fma_f16_hi_src0:
 ; GFX9-SDAG:       ; %bb.0:
 ; GFX9-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-SDAG-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
-; GFX9-SDAG-NEXT:    v_fma_f16 v0, v0, v1, v2
+; GFX9-SDAG-NEXT:    v_fma_f16 v0, v0, v1, v2 op_sel:[1,0,0,0]
 ; GFX9-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-GISEL-LABEL: fma_f16_hi_src0:
 ; GFX9-GISEL:       ; %bb.0:
 ; GFX9-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-GISEL-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
-; GFX9-GISEL-NEXT:    v_fma_f16 v0, v0, v1, v2
+; GFX9-GISEL-NEXT:    v_fma_f16 v0, v0, v1, v2 op_sel:[1,0,0,0]
 ; GFX9-GISEL-NEXT:    s_setpc_b64 s[30:31]
   %a1 = extractelement <2 x half> %a, i32 1
   %r = call half @llvm.fma.f16(half %a1, half %b, half %c)
@@ -33,19 +30,13 @@ define half @fma_f16_hi_srcs(<2 x half> %a, <2 x half> %b, <2 x half> %c) {
 ; GFX9-SDAG-LABEL: fma_f16_hi_srcs:
 ; GFX9-SDAG:       ; %bb.0:
 ; GFX9-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-SDAG-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
-; GFX9-SDAG-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
-; GFX9-SDAG-NEXT:    v_lshrrev_b32_e32 v2, 16, v2
-; GFX9-SDAG-NEXT:    v_fma_f16 v0, v0, v1, v2
+; GFX9-SDAG-NEXT:    v_fma_f16 v0, v0, v1, v2 op_sel:[1,1,1,0]
 ; GFX9-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-GISEL-LABEL: fma_f16_hi_srcs:
 ; GFX9-GISEL:       ; %bb.0:
 ; GFX9-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-GISEL-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
-; GFX9-GISEL-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
-; GFX9-GISEL-NEXT:    v_lshrrev_b32_e32 v2, 16, v2
-; GFX9-GISEL-NEXT:    v_fma_f16 v0, v0, v1, v2
+; GFX9-GISEL-NEXT:    v_fma_f16 v0, v0, v1, v2 op_sel:[1,1,1,0]
 ; GFX9-GISEL-NEXT:    s_setpc_b64 s[30:31]
   %a1 = extractelement <2 x half> %a, i32 1
   %b1 = extractelement <2 x half> %b, i32 1
@@ -60,10 +51,7 @@ define <2 x half> @fma_f16_hi_srcs_hi_dst(<2 x half> %a, <2 x half> %b, <2 x hal
 ; GFX9-SDAG-LABEL: fma_f16_hi_srcs_hi_dst:
 ; GFX9-SDAG:       ; %bb.0:
 ; GFX9-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-SDAG-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
-; GFX9-SDAG-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
-; GFX9-SDAG-NEXT:    v_lshrrev_b32_e32 v3, 16, v2
-; GFX9-SDAG-NEXT:    v_fma_f16 v0, v0, v1, v3
+; GFX9-SDAG-NEXT:    v_fma_f16 v0, v0, v1, v2 op_sel:[1,1,1,0]
 ; GFX9-SDAG-NEXT:    s_mov_b32 s4, 0x5040100
 ; GFX9-SDAG-NEXT:    v_perm_b32 v0, v0, v2, s4
 ; GFX9-SDAG-NEXT:    s_setpc_b64 s[30:31]
@@ -71,10 +59,7 @@ define <2 x half> @fma_f16_hi_srcs_hi_dst(<2 x half> %a, <2 x half> %b, <2 x hal
 ; GFX9-GISEL-LABEL: fma_f16_hi_srcs_hi_dst:
 ; GFX9-GISEL:       ; %bb.0:
 ; GFX9-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-GISEL-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
-; GFX9-GISEL-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
-; GFX9-GISEL-NEXT:    v_lshrrev_b32_e32 v3, 16, v2
-; GFX9-GISEL-NEXT:    v_fma_f16 v0, v0, v1, v3
+; GFX9-GISEL-NEXT:    v_fma_f16 v0, v0, v1, v2 op_sel:[1,1,1,0]
 ; GFX9-GISEL-NEXT:    v_mov_b32_e32 v1, 16
 ; GFX9-GISEL-NEXT:    v_lshlrev_b32_sdwa v0, v1, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:WORD_0
 ; GFX9-GISEL-NEXT:    v_mov_b32_e32 v1, 0xffff

--- a/llvm/test/CodeGen/AMDGPU/fmul-2-combine-multi-use.ll
+++ b/llvm/test/CodeGen/AMDGPU/fmul-2-combine-multi-use.ll
@@ -758,9 +758,8 @@ define amdgpu_kernel void @multiple_use_fadd_fmad_f16(ptr addrspace(1) %out, i16
 ; GFX10-DENORM-NEXT:    s_load_dwordx2 s[0:1], s[8:9], 0x0
 ; GFX10-DENORM-NEXT:    v_mov_b32_e32 v0, 0
 ; GFX10-DENORM-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX10-DENORM-NEXT:    s_lshr_b32 s3, s2, 16
 ; GFX10-DENORM-NEXT:    v_add_f16_e64 v1, |s2|, |s2|
-; GFX10-DENORM-NEXT:    v_fma_f16 v2, |s2|, 2.0, s3
+; GFX10-DENORM-NEXT:    v_fma_f16 v2, |s2|, 2.0, s2 op_sel:[0,0,1,0]
 ; GFX10-DENORM-NEXT:    global_store_short v0, v1, s[0:1]
 ; GFX10-DENORM-NEXT:    s_waitcnt_vscnt null, 0x0
 ; GFX10-DENORM-NEXT:    global_store_short v0, v2, s[0:1] offset:2
@@ -806,9 +805,8 @@ define amdgpu_kernel void @multiple_use_fadd_fmad_f16(ptr addrspace(1) %out, i16
 ; GFX11-DENORM-FAKE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x0
 ; GFX11-DENORM-FAKE16-NEXT:    v_mov_b32_e32 v0, 0
 ; GFX11-DENORM-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-DENORM-FAKE16-NEXT:    s_lshr_b32 s3, s2, 16
 ; GFX11-DENORM-FAKE16-NEXT:    v_add_f16_e64 v1, |s2|, |s2|
-; GFX11-DENORM-FAKE16-NEXT:    v_fma_f16 v2, |s2|, 2.0, s3
+; GFX11-DENORM-FAKE16-NEXT:    v_fma_f16 v2, |s2|, 2.0, s2 op_sel:[0,0,1,0]
 ; GFX11-DENORM-FAKE16-NEXT:    global_store_b16 v0, v1, s[0:1] dlc
 ; GFX11-DENORM-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
 ; GFX11-DENORM-FAKE16-NEXT:    global_store_b16 v0, v2, s[0:1] offset:2 dlc
@@ -913,9 +911,8 @@ define amdgpu_kernel void @multiple_use_fadd_multi_fmad_f16(ptr addrspace(1) %ou
 ; GFX10-DENORM-NEXT:    s_load_dwordx4 s[0:3], s[8:9], 0x0
 ; GFX10-DENORM-NEXT:    v_mov_b32_e32 v0, 0
 ; GFX10-DENORM-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX10-DENORM-NEXT:    s_lshr_b32 s4, s2, 16
+; GFX10-DENORM-NEXT:    v_fma_f16 v1, |s2|, 2.0, s2 op_sel:[0,0,1,0]
 ; GFX10-DENORM-NEXT:    v_fma_f16 v2, |s2|, 2.0, s3
-; GFX10-DENORM-NEXT:    v_fma_f16 v1, |s2|, 2.0, s4
 ; GFX10-DENORM-NEXT:    global_store_short v0, v1, s[0:1]
 ; GFX10-DENORM-NEXT:    s_waitcnt_vscnt null, 0x0
 ; GFX10-DENORM-NEXT:    global_store_short v0, v2, s[0:1] offset:2
@@ -956,9 +953,8 @@ define amdgpu_kernel void @multiple_use_fadd_multi_fmad_f16(ptr addrspace(1) %ou
 ; GFX11-DENORM-FAKE16-NEXT:    s_load_b128 s[0:3], s[4:5], 0x0
 ; GFX11-DENORM-FAKE16-NEXT:    v_mov_b32_e32 v0, 0
 ; GFX11-DENORM-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-DENORM-FAKE16-NEXT:    s_lshr_b32 s4, s2, 16
+; GFX11-DENORM-FAKE16-NEXT:    v_fma_f16 v1, |s2|, 2.0, s2 op_sel:[0,0,1,0]
 ; GFX11-DENORM-FAKE16-NEXT:    v_fma_f16 v2, |s2|, 2.0, s3
-; GFX11-DENORM-FAKE16-NEXT:    v_fma_f16 v1, |s2|, 2.0, s4
 ; GFX11-DENORM-FAKE16-NEXT:    global_store_b16 v0, v1, s[0:1] dlc
 ; GFX11-DENORM-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
 ; GFX11-DENORM-FAKE16-NEXT:    global_store_b16 v0, v2, s[0:1] offset:2 dlc

--- a/llvm/test/CodeGen/AMDGPU/fshr.ll
+++ b/llvm/test/CodeGen/AMDGPU/fshr.ll
@@ -1789,25 +1789,23 @@ define <3 x i16> @v_fshr_v3i16(<3 x i16> %src0, <3 x i16> %src1, <3 x i16> %src2
 ; GFX10-LABEL: v_fshr_v3i16:
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10-NEXT:    v_lshrrev_b32_e32 v6, 16, v0
-; GFX10-NEXT:    v_lshrrev_b32_e32 v7, 16, v4
-; GFX10-NEXT:    v_lshrrev_b32_e32 v8, 16, v2
-; GFX10-NEXT:    v_lshlrev_b16 v0, 1, v0
-; GFX10-NEXT:    v_xor_b32_e32 v10, -1, v4
-; GFX10-NEXT:    v_lshlrev_b16 v6, 1, v6
-; GFX10-NEXT:    v_xor_b32_e32 v9, -1, v7
+; GFX10-NEXT:    v_mov_b32_e32 v6, -1
+; GFX10-NEXT:    v_lshlrev_b16 v7, 1, v0
+; GFX10-NEXT:    v_xor_b32_e32 v8, -1, v4
+; GFX10-NEXT:    v_lshlrev_b16 v0, 1, v0 op_sel:[0,1,0]
 ; GFX10-NEXT:    v_lshlrev_b16 v1, 1, v1
-; GFX10-NEXT:    v_lshrrev_b16 v7, v7, v8
-; GFX10-NEXT:    v_lshlrev_b16 v0, v10, v0
-; GFX10-NEXT:    v_lshrrev_b16 v2, v4, v2
-; GFX10-NEXT:    v_lshlrev_b16 v6, v9, v6
-; GFX10-NEXT:    v_xor_b32_e32 v4, -1, v5
-; GFX10-NEXT:    v_lshrrev_b16 v3, v5, v3
+; GFX10-NEXT:    v_xor_b32_sdwa v6, v4, v6 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:DWORD
+; GFX10-NEXT:    v_xor_b32_e32 v9, -1, v5
+; GFX10-NEXT:    v_lshlrev_b16 v7, v8, v7
+; GFX10-NEXT:    v_lshrrev_b16 v8, v4, v2
+; GFX10-NEXT:    v_lshrrev_b16 v2, v4, v2 op_sel:[1,1,0]
+; GFX10-NEXT:    v_lshlrev_b16 v0, v6, v0
+; GFX10-NEXT:    v_lshlrev_b16 v1, v9, v1
+; GFX10-NEXT:    v_or_b32_e32 v4, v7, v8
 ; GFX10-NEXT:    v_or_b32_e32 v0, v0, v2
-; GFX10-NEXT:    v_or_b32_e32 v5, v6, v7
-; GFX10-NEXT:    v_lshlrev_b16 v1, v4, v1
-; GFX10-NEXT:    v_perm_b32 v0, v5, v0, 0x5040100
-; GFX10-NEXT:    v_or_b32_e32 v1, v1, v3
+; GFX10-NEXT:    v_lshrrev_b16 v2, v5, v3
+; GFX10-NEXT:    v_perm_b32 v0, v0, v4, 0x5040100
+; GFX10-NEXT:    v_or_b32_e32 v1, v1, v2
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-TRUE16-LABEL: v_fshr_v3i16:
@@ -2020,34 +2018,29 @@ define <4 x i16> @v_fshr_v4i16(<4 x i16> %src0, <4 x i16> %src1, <4 x i16> %src2
 ; GFX10-LABEL: v_fshr_v4i16:
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10-NEXT:    v_lshrrev_b32_e32 v6, 16, v3
-; GFX10-NEXT:    v_lshrrev_b32_e32 v7, 16, v5
-; GFX10-NEXT:    v_lshrrev_b32_e32 v8, 16, v1
-; GFX10-NEXT:    v_lshrrev_b32_e32 v9, 16, v0
-; GFX10-NEXT:    v_lshrrev_b32_e32 v10, 16, v4
-; GFX10-NEXT:    v_lshrrev_b32_e32 v11, 16, v2
-; GFX10-NEXT:    v_lshrrev_b16 v6, v7, v6
-; GFX10-NEXT:    v_lshlrev_b16 v8, 1, v8
-; GFX10-NEXT:    v_xor_b32_e32 v7, -1, v7
-; GFX10-NEXT:    v_lshlrev_b16 v9, 1, v9
-; GFX10-NEXT:    v_xor_b32_e32 v12, -1, v10
-; GFX10-NEXT:    v_lshlrev_b16 v1, 1, v1
-; GFX10-NEXT:    v_xor_b32_e32 v13, -1, v5
-; GFX10-NEXT:    v_lshlrev_b16 v0, 1, v0
-; GFX10-NEXT:    v_xor_b32_e32 v14, -1, v4
-; GFX10-NEXT:    v_lshlrev_b16 v7, v7, v8
-; GFX10-NEXT:    v_lshrrev_b16 v8, v10, v11
-; GFX10-NEXT:    v_lshlrev_b16 v9, v12, v9
-; GFX10-NEXT:    v_lshlrev_b16 v1, v13, v1
-; GFX10-NEXT:    v_lshlrev_b16 v0, v14, v0
-; GFX10-NEXT:    v_lshrrev_b16 v2, v4, v2
-; GFX10-NEXT:    v_lshrrev_b16 v3, v5, v3
-; GFX10-NEXT:    v_or_b32_e32 v4, v7, v6
-; GFX10-NEXT:    v_or_b32_e32 v5, v9, v8
-; GFX10-NEXT:    v_or_b32_e32 v0, v0, v2
+; GFX10-NEXT:    v_lshlrev_b16 v6, 1, v1
+; GFX10-NEXT:    v_xor_b32_e32 v7, -1, v5
+; GFX10-NEXT:    v_mov_b32_e32 v8, -1
+; GFX10-NEXT:    v_lshlrev_b16 v1, 1, v1 op_sel:[0,1,0]
+; GFX10-NEXT:    v_lshlrev_b16 v9, 1, v0
+; GFX10-NEXT:    v_xor_b32_e32 v10, -1, v4
+; GFX10-NEXT:    v_lshlrev_b16 v6, v7, v6
+; GFX10-NEXT:    v_xor_b32_sdwa v7, v5, v8 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:DWORD
+; GFX10-NEXT:    v_lshlrev_b16 v0, 1, v0 op_sel:[0,1,0]
+; GFX10-NEXT:    v_xor_b32_sdwa v8, v4, v8 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:DWORD
+; GFX10-NEXT:    v_lshrrev_b16 v11, v5, v3
+; GFX10-NEXT:    v_lshrrev_b16 v3, v5, v3 op_sel:[1,1,0]
+; GFX10-NEXT:    v_lshlrev_b16 v1, v7, v1
+; GFX10-NEXT:    v_lshlrev_b16 v7, v10, v9
+; GFX10-NEXT:    v_lshrrev_b16 v9, v4, v2
+; GFX10-NEXT:    v_lshlrev_b16 v0, v8, v0
+; GFX10-NEXT:    v_lshrrev_b16 v2, v4, v2 op_sel:[1,1,0]
+; GFX10-NEXT:    v_or_b32_e32 v4, v6, v11
 ; GFX10-NEXT:    v_or_b32_e32 v1, v1, v3
-; GFX10-NEXT:    v_perm_b32 v0, v5, v0, 0x5040100
-; GFX10-NEXT:    v_perm_b32 v1, v4, v1, 0x5040100
+; GFX10-NEXT:    v_or_b32_e32 v5, v7, v9
+; GFX10-NEXT:    v_or_b32_e32 v0, v0, v2
+; GFX10-NEXT:    v_perm_b32 v1, v1, v4, 0x5040100
+; GFX10-NEXT:    v_perm_b32 v0, v0, v5, 0x5040100
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-TRUE16-LABEL: v_fshr_v4i16:

--- a/llvm/test/CodeGen/AMDGPU/idot4s.ll
+++ b/llvm/test/CodeGen/AMDGPU/idot4s.ll
@@ -1113,25 +1113,23 @@ define amdgpu_kernel void @idot4_acc16_vecMul(ptr addrspace(1) %src1,
 ; GFX10-DL-NEXT:    v_ashrrev_i16 v5, 8, v2
 ; GFX10-DL-NEXT:    v_bfe_i32 v6, v2, 0, 8
 ; GFX10-DL-NEXT:    v_bfe_i32 v7, v1, 0, 8
-; GFX10-DL-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
-; GFX10-DL-NEXT:    v_lshrrev_b32_e32 v2, 16, v2
+; GFX10-DL-NEXT:    v_lshrrev_b32_e32 v8, 16, v1
+; GFX10-DL-NEXT:    v_lshrrev_b32_e32 v9, 16, v2
+; GFX10-DL-NEXT:    v_ashrrev_i16 v1, 8, v1 op_sel:[0,1,0]
 ; GFX10-DL-NEXT:    v_perm_b32 v5, v5, v6, 0x5040100
 ; GFX10-DL-NEXT:    v_perm_b32 v4, v4, v7, 0x5040100
-; GFX10-DL-NEXT:    v_ashrrev_i16 v6, 8, v1
-; GFX10-DL-NEXT:    v_ashrrev_i16 v7, 8, v2
-; GFX10-DL-NEXT:    v_bfe_i32 v2, v2, 0, 8
-; GFX10-DL-NEXT:    v_bfe_i32 v1, v1, 0, 8
+; GFX10-DL-NEXT:    v_ashrrev_i16 v2, 8, v2 op_sel:[0,1,0]
+; GFX10-DL-NEXT:    v_bfe_i32 v6, v9, 0, 8
+; GFX10-DL-NEXT:    v_bfe_i32 v7, v8, 0, 8
 ; GFX10-DL-NEXT:    v_pk_mul_lo_u16 v4, v4, v5
-; GFX10-DL-NEXT:    v_perm_b32 v2, v7, v2, 0x5040100
-; GFX10-DL-NEXT:    v_perm_b32 v1, v6, v1, 0x5040100
-; GFX10-DL-NEXT:    v_lshrrev_b32_e32 v5, 16, v4
+; GFX10-DL-NEXT:    v_perm_b32 v2, v2, v6, 0x5040100
+; GFX10-DL-NEXT:    v_perm_b32 v1, v1, v7, 0x5040100
 ; GFX10-DL-NEXT:    s_waitcnt vmcnt(0)
 ; GFX10-DL-NEXT:    v_add_nc_u16 v3, v4, v3
 ; GFX10-DL-NEXT:    v_pk_mul_lo_u16 v1, v1, v2
-; GFX10-DL-NEXT:    v_add_nc_u16 v2, v3, v5
-; GFX10-DL-NEXT:    v_lshrrev_b32_e32 v3, 16, v1
-; GFX10-DL-NEXT:    v_add_nc_u16 v1, v2, v1
-; GFX10-DL-NEXT:    v_add_nc_u16 v1, v1, v3
+; GFX10-DL-NEXT:    v_add_nc_u16 v2, v3, v4 op_sel:[0,1,0]
+; GFX10-DL-NEXT:    v_add_nc_u16 v2, v2, v1
+; GFX10-DL-NEXT:    v_add_nc_u16 v1, v2, v1 op_sel:[0,1,0]
 ; GFX10-DL-NEXT:    global_store_short v0, v1, s[6:7]
 ; GFX10-DL-NEXT:    s_endpgm
 ;
@@ -1212,17 +1210,15 @@ define amdgpu_kernel void @idot4_acc16_vecMul(ptr addrspace(1) %src1,
 ; GFX11-DL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
 ; GFX11-DL-FAKE16-NEXT:    v_perm_b32 v0, v7, v0, 0x5040100
 ; GFX11-DL-FAKE16-NEXT:    v_perm_b32 v1, v6, v1, 0x5040100
-; GFX11-DL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_2) | instid1(VALU_DEP_3)
-; GFX11-DL-FAKE16-NEXT:    v_lshrrev_b32_e32 v5, 16, v4
 ; GFX11-DL-FAKE16-NEXT:    s_waitcnt vmcnt(0)
+; GFX11-DL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX11-DL-FAKE16-NEXT:    v_add_nc_u16 v3, v4, v3
 ; GFX11-DL-FAKE16-NEXT:    v_pk_mul_lo_u16 v0, v1, v0
-; GFX11-DL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX11-DL-FAKE16-NEXT:    v_add_nc_u16 v1, v3, v5
-; GFX11-DL-FAKE16-NEXT:    v_lshrrev_b32_e32 v3, 16, v0
 ; GFX11-DL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-DL-FAKE16-NEXT:    v_add_nc_u16 v0, v1, v0
-; GFX11-DL-FAKE16-NEXT:    v_add_nc_u16 v0, v0, v3
+; GFX11-DL-FAKE16-NEXT:    v_add_nc_u16 v1, v3, v4 op_sel:[0,1,0]
+; GFX11-DL-FAKE16-NEXT:    v_add_nc_u16 v1, v1, v0
+; GFX11-DL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-DL-FAKE16-NEXT:    v_add_nc_u16 v0, v1, v0 op_sel:[0,1,0]
 ; GFX11-DL-FAKE16-NEXT:    global_store_b16 v2, v0, s[4:5]
 ; GFX11-DL-FAKE16-NEXT:    s_endpgm
                                               ptr addrspace(1) %src2,

--- a/llvm/test/CodeGen/AMDGPU/idot4u.ll
+++ b/llvm/test/CodeGen/AMDGPU/idot4u.ll
@@ -2399,14 +2399,12 @@ define amdgpu_kernel void @udot4_acc16_vecMul(ptr addrspace(1) %src1,
 ; GFX10-DL-NEXT:    v_pk_mul_lo_u16 v4, v4, v5
 ; GFX10-DL-NEXT:    v_perm_b32 v2, v7, v2, 0x5040100
 ; GFX10-DL-NEXT:    v_perm_b32 v1, v6, v1, 0x5040100
-; GFX10-DL-NEXT:    v_lshrrev_b32_e32 v5, 16, v4
 ; GFX10-DL-NEXT:    s_waitcnt vmcnt(0)
 ; GFX10-DL-NEXT:    v_add_nc_u16 v3, v4, v3
 ; GFX10-DL-NEXT:    v_pk_mul_lo_u16 v1, v1, v2
-; GFX10-DL-NEXT:    v_add_nc_u16 v2, v3, v5
-; GFX10-DL-NEXT:    v_lshrrev_b32_e32 v3, 16, v1
-; GFX10-DL-NEXT:    v_add_nc_u16 v1, v2, v1
-; GFX10-DL-NEXT:    v_add_nc_u16 v1, v1, v3
+; GFX10-DL-NEXT:    v_add_nc_u16 v2, v3, v4 op_sel:[0,1,0]
+; GFX10-DL-NEXT:    v_add_nc_u16 v2, v2, v1
+; GFX10-DL-NEXT:    v_add_nc_u16 v1, v2, v1 op_sel:[0,1,0]
 ; GFX10-DL-NEXT:    global_store_short v0, v1, s[6:7]
 ; GFX10-DL-NEXT:    s_endpgm
 ;
@@ -2481,19 +2479,16 @@ define amdgpu_kernel void @udot4_acc16_vecMul(ptr addrspace(1) %src1,
 ; GFX11-DL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_3)
 ; GFX11-DL-FAKE16-NEXT:    v_pk_mul_lo_u16 v4, v4, v5
 ; GFX11-DL-FAKE16-NEXT:    v_perm_b32 v0, v0, v6, 0x5040100
-; GFX11-DL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX11-DL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_3)
 ; GFX11-DL-FAKE16-NEXT:    v_perm_b32 v1, v1, v7, 0x5040100
-; GFX11-DL-FAKE16-NEXT:    v_lshrrev_b32_e32 v5, 16, v4
 ; GFX11-DL-FAKE16-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-DL-FAKE16-NEXT:    v_add_nc_u16 v3, v4, v3
-; GFX11-DL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX11-DL-FAKE16-NEXT:    v_pk_mul_lo_u16 v0, v1, v0
-; GFX11-DL-FAKE16-NEXT:    v_add_nc_u16 v1, v3, v5
 ; GFX11-DL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX11-DL-FAKE16-NEXT:    v_lshrrev_b32_e32 v3, 16, v0
-; GFX11-DL-FAKE16-NEXT:    v_add_nc_u16 v0, v1, v0
-; GFX11-DL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-DL-FAKE16-NEXT:    v_add_nc_u16 v0, v0, v3
+; GFX11-DL-FAKE16-NEXT:    v_pk_mul_lo_u16 v0, v1, v0
+; GFX11-DL-FAKE16-NEXT:    v_add_nc_u16 v1, v3, v4 op_sel:[0,1,0]
+; GFX11-DL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-DL-FAKE16-NEXT:    v_add_nc_u16 v1, v1, v0
+; GFX11-DL-FAKE16-NEXT:    v_add_nc_u16 v0, v1, v0 op_sel:[0,1,0]
 ; GFX11-DL-FAKE16-NEXT:    global_store_b16 v2, v0, s[4:5]
 ; GFX11-DL-FAKE16-NEXT:    s_endpgm
                                               ptr addrspace(1) %src2,
@@ -2672,23 +2667,23 @@ define amdgpu_kernel void @udot4_acc8_vecMul(ptr addrspace(1) %src1,
 ; GFX10-DL-NEXT:    s_waitcnt vmcnt(1)
 ; GFX10-DL-NEXT:    v_lshrrev_b32_e32 v5, 24, v2
 ; GFX10-DL-NEXT:    v_lshrrev_b16 v6, 8, v1
-; GFX10-DL-NEXT:    v_lshrrev_b32_e32 v7, 16, v1
-; GFX10-DL-NEXT:    v_lshrrev_b32_e32 v8, 16, v2
-; GFX10-DL-NEXT:    v_lshrrev_b16 v9, 8, v2
+; GFX10-DL-NEXT:    v_lshrrev_b16 v7, 8, v2
 ; GFX10-DL-NEXT:    v_mul_lo_u16 v4, v4, v5
+; GFX10-DL-NEXT:    v_mul_lo_u16 v5, v1, v2 op_sel:[1,1,0]
+; GFX10-DL-NEXT:    v_mul_lo_u16 v6, v6, v7
 ; GFX10-DL-NEXT:    s_waitcnt vmcnt(0)
-; GFX10-DL-NEXT:    v_mad_u16 v1, v1, v2, v3
-; GFX10-DL-NEXT:    v_mul_lo_u16 v5, v7, v8
-; GFX10-DL-NEXT:    v_mul_lo_u16 v6, v6, v9
+; GFX10-DL-NEXT:    v_mad_u16 v3, v1, v2, v3
+; GFX10-DL-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
 ; GFX10-DL-NEXT:    v_lshlrev_b16 v4, 8, v4
+; GFX10-DL-NEXT:    v_lshrrev_b32_e32 v2, 16, v2
 ; GFX10-DL-NEXT:    v_lshlrev_b16 v6, 8, v6
 ; GFX10-DL-NEXT:    v_or_b32_sdwa v5, v5, v4 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
-; GFX10-DL-NEXT:    v_lshrrev_b32_e32 v2, 8, v4
+; GFX10-DL-NEXT:    v_lshrrev_b32_e32 v4, 8, v4
 ; GFX10-DL-NEXT:    v_or_b32_sdwa v5, v5, v6 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:WORD_0
 ; GFX10-DL-NEXT:    v_lshrrev_b32_e32 v5, 8, v5
-; GFX10-DL-NEXT:    v_add_nc_u16 v1, v1, v5
-; GFX10-DL-NEXT:    v_mad_u16 v1, v7, v8, v1
-; GFX10-DL-NEXT:    v_add_nc_u16 v1, v1, v2
+; GFX10-DL-NEXT:    v_add_nc_u16 v3, v3, v5
+; GFX10-DL-NEXT:    v_mad_u16 v1, v1, v2, v3
+; GFX10-DL-NEXT:    v_add_nc_u16 v1, v1, v4
 ; GFX10-DL-NEXT:    global_store_byte v0, v1, s[6:7]
 ; GFX10-DL-NEXT:    s_endpgm
 ;

--- a/llvm/test/CodeGen/AMDGPU/idot8s.ll
+++ b/llvm/test/CodeGen/AMDGPU/idot8s.ll
@@ -613,58 +613,56 @@ define amdgpu_kernel void @idot8_acc16(ptr addrspace(1) %src1,
 ; GFX10-DL-XNACK-NEXT:    v_mov_b32_e32 v0, 0
 ; GFX10-DL-XNACK-NEXT:    global_load_ushort v3, v0, s[0:1]
 ; GFX10-DL-XNACK-NEXT:    s_waitcnt vmcnt(2)
+; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v9, 4, v1
+; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v13, 12, v1
+; GFX10-DL-XNACK-NEXT:    s_waitcnt vmcnt(1)
+; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v15, 4, v2
+; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v16, 12, v2
+; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v8, 8, v1
+; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v17, 8, v2
+; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v13, 12, v13
+; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v9, 12, v9
+; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v15, 12, v15
+; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v16, 12, v16
+; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v7, 12, v1
+; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v14, 12, v2
+; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v8, 12, v8
+; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v17, 12, v17
+; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v9, 12, v9
+; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v15, 12, v15
+; GFX10-DL-XNACK-NEXT:    s_waitcnt vmcnt(0)
+; GFX10-DL-XNACK-NEXT:    v_mad_u16 v3, v13, v16, v3
+; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v8, 12, v8
+; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v13, 12, v17
+; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v7, 12, v7
+; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v14, 12, v14
+; GFX10-DL-XNACK-NEXT:    v_mad_u16 v3, v9, v15, v3
 ; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v4, 28, v1
 ; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v5, 24, v1
 ; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v6, 20, v1
-; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v7, 16, v1
-; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v8, 12, v1
-; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v9, 8, v1
-; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v10, 4, v1
-; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v1, 12, v1
-; GFX10-DL-XNACK-NEXT:    s_waitcnt vmcnt(1)
-; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v16, 4, v2
-; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v17, 12, v2
-; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v11, 28, v2
-; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v12, 24, v2
-; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v13, 20, v2
-; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v14, 16, v2
-; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v15, 12, v2
-; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v2, 8, v2
-; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v1, 12, v1
-; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v10, 12, v10
-; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v16, 12, v16
-; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v17, 12, v17
-; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v9, 12, v9
-; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v2, 12, v2
-; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v10, 12, v10
-; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v16, 12, v16
-; GFX10-DL-XNACK-NEXT:    s_waitcnt vmcnt(0)
-; GFX10-DL-XNACK-NEXT:    v_mad_u16 v1, v1, v17, v3
-; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v3, 12, v9
-; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v2, 12, v2
-; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v8, 12, v8
-; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v9, 12, v15
-; GFX10-DL-XNACK-NEXT:    v_mad_u16 v1, v10, v16, v1
-; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v7, 12, v7
-; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v10, 12, v14
-; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v8, 12, v8
-; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v9, 12, v9
-; GFX10-DL-XNACK-NEXT:    v_mad_u16 v1, v3, v2, v1
-; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v2, 12, v7
-; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v3, 12, v10
-; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v6, 12, v6
-; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v7, 12, v13
-; GFX10-DL-XNACK-NEXT:    v_mad_u16 v1, v8, v9, v1
-; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v5, 12, v5
-; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v8, 12, v12
-; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v6, 12, v6
+; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v10, 28, v2
+; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v11, 24, v2
+; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v12, 20, v2
+; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v1, 12, v1 op_sel:[0,1,0]
+; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v2, 12, v2 op_sel:[0,1,0]
 ; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v7, 12, v7
-; GFX10-DL-XNACK-NEXT:    v_mad_u16 v1, v2, v3, v1
+; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v9, 12, v14
+; GFX10-DL-XNACK-NEXT:    v_mad_u16 v3, v8, v13, v3
+; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v1, 12, v1
+; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v2, 12, v2
+; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v6, 12, v6
+; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v8, 12, v12
+; GFX10-DL-XNACK-NEXT:    v_mad_u16 v3, v7, v9, v3
+; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v5, 12, v5
+; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v7, 12, v11
+; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v6, 12, v6
+; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v8, 12, v8
+; GFX10-DL-XNACK-NEXT:    v_mad_u16 v1, v1, v2, v3
 ; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v2, 12, v5
-; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v3, 12, v8
+; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v3, 12, v7
 ; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v4, 12, v4
-; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v5, 12, v11
-; GFX10-DL-XNACK-NEXT:    v_mad_u16 v1, v6, v7, v1
+; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v5, 12, v10
+; GFX10-DL-XNACK-NEXT:    v_mad_u16 v1, v6, v8, v1
 ; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v4, 12, v4
 ; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v5, 12, v5
 ; GFX10-DL-XNACK-NEXT:    v_mad_u16 v1, v2, v3, v1
@@ -691,58 +689,56 @@ define amdgpu_kernel void @idot8_acc16(ptr addrspace(1) %src1,
 ; GFX10-DL-NOXNACK-NEXT:    global_load_dword v0, v0, s[10:11]
 ; GFX10-DL-NOXNACK-NEXT:    global_load_ushort v3, v2, s[0:1]
 ; GFX10-DL-NOXNACK-NEXT:    s_waitcnt vmcnt(2)
+; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v9, 4, v1
+; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v13, 12, v1
+; GFX10-DL-NOXNACK-NEXT:    s_waitcnt vmcnt(1)
+; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v15, 4, v0
+; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v16, 12, v0
+; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v8, 8, v1
+; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v17, 8, v0
+; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v13, 12, v13
+; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v9, 12, v9
+; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v15, 12, v15
+; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v16, 12, v16
+; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v7, 12, v1
+; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v14, 12, v0
+; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v8, 12, v8
+; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v17, 12, v17
+; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v9, 12, v9
+; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v15, 12, v15
+; GFX10-DL-NOXNACK-NEXT:    s_waitcnt vmcnt(0)
+; GFX10-DL-NOXNACK-NEXT:    v_mad_u16 v3, v13, v16, v3
+; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v8, 12, v8
+; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v13, 12, v17
+; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v7, 12, v7
+; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v14, 12, v14
+; GFX10-DL-NOXNACK-NEXT:    v_mad_u16 v3, v9, v15, v3
 ; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v4, 28, v1
 ; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v5, 24, v1
 ; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v6, 20, v1
-; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v7, 16, v1
-; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v8, 12, v1
-; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v9, 8, v1
-; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v10, 4, v1
-; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v1, 12, v1
-; GFX10-DL-NOXNACK-NEXT:    s_waitcnt vmcnt(1)
-; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v16, 4, v0
-; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v17, 12, v0
-; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v11, 28, v0
-; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v12, 24, v0
-; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v13, 20, v0
-; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v14, 16, v0
-; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v15, 12, v0
-; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v0, 8, v0
-; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v1, 12, v1
-; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v10, 12, v10
-; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v16, 12, v16
-; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v17, 12, v17
-; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v9, 12, v9
-; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v0, 12, v0
-; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v10, 12, v10
-; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v16, 12, v16
-; GFX10-DL-NOXNACK-NEXT:    s_waitcnt vmcnt(0)
-; GFX10-DL-NOXNACK-NEXT:    v_mad_u16 v1, v1, v17, v3
-; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v3, 12, v9
-; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v0, 12, v0
-; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v8, 12, v8
-; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v9, 12, v15
-; GFX10-DL-NOXNACK-NEXT:    v_mad_u16 v1, v10, v16, v1
-; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v7, 12, v7
-; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v10, 12, v14
-; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v8, 12, v8
-; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v9, 12, v9
-; GFX10-DL-NOXNACK-NEXT:    v_mad_u16 v0, v3, v0, v1
-; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v1, 12, v7
-; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v3, 12, v10
-; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v6, 12, v6
-; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v7, 12, v13
-; GFX10-DL-NOXNACK-NEXT:    v_mad_u16 v0, v8, v9, v0
-; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v5, 12, v5
-; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v8, 12, v12
-; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v6, 12, v6
+; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v10, 28, v0
+; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v11, 24, v0
+; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v12, 20, v0
+; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v1, 12, v1 op_sel:[0,1,0]
+; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v0, 12, v0 op_sel:[0,1,0]
 ; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v7, 12, v7
-; GFX10-DL-NOXNACK-NEXT:    v_mad_u16 v0, v1, v3, v0
+; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v9, 12, v14
+; GFX10-DL-NOXNACK-NEXT:    v_mad_u16 v3, v8, v13, v3
+; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v1, 12, v1
+; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v0, 12, v0
+; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v6, 12, v6
+; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v8, 12, v12
+; GFX10-DL-NOXNACK-NEXT:    v_mad_u16 v3, v7, v9, v3
+; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v5, 12, v5
+; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v7, 12, v11
+; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v6, 12, v6
+; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v8, 12, v8
+; GFX10-DL-NOXNACK-NEXT:    v_mad_u16 v0, v1, v0, v3
 ; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v1, 12, v5
-; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v3, 12, v8
+; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v3, 12, v7
 ; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v4, 12, v4
-; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v5, 12, v11
-; GFX10-DL-NOXNACK-NEXT:    v_mad_u16 v0, v6, v7, v0
+; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v5, 12, v10
+; GFX10-DL-NOXNACK-NEXT:    v_mad_u16 v0, v6, v8, v0
 ; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v4, 12, v4
 ; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v5, 12, v5
 ; GFX10-DL-NOXNACK-NEXT:    v_mad_u16 v0, v1, v3, v0
@@ -1135,58 +1131,56 @@ define amdgpu_kernel void @idot8_acc8(ptr addrspace(1) %src1,
 ; GFX10-DL-XNACK-NEXT:    v_mov_b32_e32 v0, 0
 ; GFX10-DL-XNACK-NEXT:    global_load_ubyte v3, v0, s[0:1]
 ; GFX10-DL-XNACK-NEXT:    s_waitcnt vmcnt(2)
+; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v9, 4, v1
+; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v13, 12, v1
+; GFX10-DL-XNACK-NEXT:    s_waitcnt vmcnt(1)
+; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v15, 4, v2
+; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v16, 12, v2
+; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v8, 8, v1
+; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v17, 8, v2
+; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v13, 12, v13
+; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v9, 12, v9
+; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v15, 12, v15
+; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v16, 12, v16
+; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v7, 12, v1
+; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v14, 12, v2
+; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v8, 12, v8
+; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v17, 12, v17
+; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v9, 12, v9
+; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v15, 12, v15
+; GFX10-DL-XNACK-NEXT:    s_waitcnt vmcnt(0)
+; GFX10-DL-XNACK-NEXT:    v_mad_u16 v3, v13, v16, v3
+; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v8, 12, v8
+; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v13, 12, v17
+; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v7, 12, v7
+; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v14, 12, v14
+; GFX10-DL-XNACK-NEXT:    v_mad_u16 v3, v9, v15, v3
 ; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v4, 28, v1
 ; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v5, 24, v1
 ; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v6, 20, v1
-; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v7, 16, v1
-; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v8, 12, v1
-; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v9, 8, v1
-; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v10, 4, v1
-; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v1, 12, v1
-; GFX10-DL-XNACK-NEXT:    s_waitcnt vmcnt(1)
-; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v16, 4, v2
-; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v17, 12, v2
-; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v11, 28, v2
-; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v12, 24, v2
-; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v13, 20, v2
-; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v14, 16, v2
-; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v15, 12, v2
-; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v2, 8, v2
-; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v1, 12, v1
-; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v10, 12, v10
-; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v16, 12, v16
-; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v17, 12, v17
-; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v9, 12, v9
-; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v2, 12, v2
-; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v10, 12, v10
-; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v16, 12, v16
-; GFX10-DL-XNACK-NEXT:    s_waitcnt vmcnt(0)
-; GFX10-DL-XNACK-NEXT:    v_mad_u16 v1, v1, v17, v3
-; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v3, 12, v9
-; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v2, 12, v2
-; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v8, 12, v8
-; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v9, 12, v15
-; GFX10-DL-XNACK-NEXT:    v_mad_u16 v1, v10, v16, v1
-; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v7, 12, v7
-; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v10, 12, v14
-; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v8, 12, v8
-; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v9, 12, v9
-; GFX10-DL-XNACK-NEXT:    v_mad_u16 v1, v3, v2, v1
-; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v2, 12, v7
-; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v3, 12, v10
-; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v6, 12, v6
-; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v7, 12, v13
-; GFX10-DL-XNACK-NEXT:    v_mad_u16 v1, v8, v9, v1
-; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v5, 12, v5
-; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v8, 12, v12
-; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v6, 12, v6
+; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v10, 28, v2
+; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v11, 24, v2
+; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v12, 20, v2
+; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v1, 12, v1 op_sel:[0,1,0]
+; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v2, 12, v2 op_sel:[0,1,0]
 ; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v7, 12, v7
-; GFX10-DL-XNACK-NEXT:    v_mad_u16 v1, v2, v3, v1
+; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v9, 12, v14
+; GFX10-DL-XNACK-NEXT:    v_mad_u16 v3, v8, v13, v3
+; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v1, 12, v1
+; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v2, 12, v2
+; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v6, 12, v6
+; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v8, 12, v12
+; GFX10-DL-XNACK-NEXT:    v_mad_u16 v3, v7, v9, v3
+; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v5, 12, v5
+; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v7, 12, v11
+; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v6, 12, v6
+; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v8, 12, v8
+; GFX10-DL-XNACK-NEXT:    v_mad_u16 v1, v1, v2, v3
 ; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v2, 12, v5
-; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v3, 12, v8
+; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v3, 12, v7
 ; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v4, 12, v4
-; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v5, 12, v11
-; GFX10-DL-XNACK-NEXT:    v_mad_u16 v1, v6, v7, v1
+; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v5, 12, v10
+; GFX10-DL-XNACK-NEXT:    v_mad_u16 v1, v6, v8, v1
 ; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v4, 12, v4
 ; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v5, 12, v5
 ; GFX10-DL-XNACK-NEXT:    v_mad_u16 v1, v2, v3, v1
@@ -1213,58 +1207,56 @@ define amdgpu_kernel void @idot8_acc8(ptr addrspace(1) %src1,
 ; GFX10-DL-NOXNACK-NEXT:    global_load_dword v0, v0, s[10:11]
 ; GFX10-DL-NOXNACK-NEXT:    global_load_ubyte v3, v2, s[0:1]
 ; GFX10-DL-NOXNACK-NEXT:    s_waitcnt vmcnt(2)
+; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v9, 4, v1
+; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v13, 12, v1
+; GFX10-DL-NOXNACK-NEXT:    s_waitcnt vmcnt(1)
+; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v15, 4, v0
+; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v16, 12, v0
+; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v8, 8, v1
+; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v17, 8, v0
+; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v13, 12, v13
+; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v9, 12, v9
+; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v15, 12, v15
+; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v16, 12, v16
+; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v7, 12, v1
+; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v14, 12, v0
+; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v8, 12, v8
+; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v17, 12, v17
+; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v9, 12, v9
+; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v15, 12, v15
+; GFX10-DL-NOXNACK-NEXT:    s_waitcnt vmcnt(0)
+; GFX10-DL-NOXNACK-NEXT:    v_mad_u16 v3, v13, v16, v3
+; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v8, 12, v8
+; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v13, 12, v17
+; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v7, 12, v7
+; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v14, 12, v14
+; GFX10-DL-NOXNACK-NEXT:    v_mad_u16 v3, v9, v15, v3
 ; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v4, 28, v1
 ; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v5, 24, v1
 ; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v6, 20, v1
-; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v7, 16, v1
-; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v8, 12, v1
-; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v9, 8, v1
-; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v10, 4, v1
-; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v1, 12, v1
-; GFX10-DL-NOXNACK-NEXT:    s_waitcnt vmcnt(1)
-; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v16, 4, v0
-; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v17, 12, v0
-; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v11, 28, v0
-; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v12, 24, v0
-; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v13, 20, v0
-; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v14, 16, v0
-; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v15, 12, v0
-; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v0, 8, v0
-; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v1, 12, v1
-; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v10, 12, v10
-; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v16, 12, v16
-; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v17, 12, v17
-; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v9, 12, v9
-; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v0, 12, v0
-; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v10, 12, v10
-; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v16, 12, v16
-; GFX10-DL-NOXNACK-NEXT:    s_waitcnt vmcnt(0)
-; GFX10-DL-NOXNACK-NEXT:    v_mad_u16 v1, v1, v17, v3
-; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v3, 12, v9
-; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v0, 12, v0
-; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v8, 12, v8
-; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v9, 12, v15
-; GFX10-DL-NOXNACK-NEXT:    v_mad_u16 v1, v10, v16, v1
-; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v7, 12, v7
-; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v10, 12, v14
-; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v8, 12, v8
-; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v9, 12, v9
-; GFX10-DL-NOXNACK-NEXT:    v_mad_u16 v0, v3, v0, v1
-; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v1, 12, v7
-; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v3, 12, v10
-; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v6, 12, v6
-; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v7, 12, v13
-; GFX10-DL-NOXNACK-NEXT:    v_mad_u16 v0, v8, v9, v0
-; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v5, 12, v5
-; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v8, 12, v12
-; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v6, 12, v6
+; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v10, 28, v0
+; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v11, 24, v0
+; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v12, 20, v0
+; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v1, 12, v1 op_sel:[0,1,0]
+; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v0, 12, v0 op_sel:[0,1,0]
 ; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v7, 12, v7
-; GFX10-DL-NOXNACK-NEXT:    v_mad_u16 v0, v1, v3, v0
+; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v9, 12, v14
+; GFX10-DL-NOXNACK-NEXT:    v_mad_u16 v3, v8, v13, v3
+; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v1, 12, v1
+; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v0, 12, v0
+; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v6, 12, v6
+; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v8, 12, v12
+; GFX10-DL-NOXNACK-NEXT:    v_mad_u16 v3, v7, v9, v3
+; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v5, 12, v5
+; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v7, 12, v11
+; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v6, 12, v6
+; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v8, 12, v8
+; GFX10-DL-NOXNACK-NEXT:    v_mad_u16 v0, v1, v0, v3
 ; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v1, 12, v5
-; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v3, 12, v8
+; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v3, 12, v7
 ; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v4, 12, v4
-; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v5, 12, v11
-; GFX10-DL-NOXNACK-NEXT:    v_mad_u16 v0, v6, v7, v0
+; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v5, 12, v10
+; GFX10-DL-NOXNACK-NEXT:    v_mad_u16 v0, v6, v8, v0
 ; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v4, 12, v4
 ; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v5, 12, v5
 ; GFX10-DL-NOXNACK-NEXT:    v_mad_u16 v0, v1, v3, v0
@@ -2327,69 +2319,63 @@ define amdgpu_kernel void @idot8_acc16_vecMul(ptr addrspace(1) %src1,
 ; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v5, 12, v5
 ; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v12, 12, v12
 ; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v7, 12, v1
-; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v8, 16, v1
 ; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v13, 8, v2
 ; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v14, 12, v2
 ; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v4, 12, v4
 ; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v11, 12, v11
-; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v12, 12, v12
 ; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v5, 12, v5
+; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v12, 12, v12
 ; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v6, 12, v6
 ; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v7, 12, v7
-; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v8, 12, v8
 ; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v13, 12, v13
 ; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v14, 12, v14
 ; GFX10-DL-XNACK-NEXT:    v_perm_b32 v11, v12, v11, 0x5040100
 ; GFX10-DL-XNACK-NEXT:    v_perm_b32 v4, v5, v4, 0x5040100
 ; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v9, 20, v1
-; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v15, 16, v2
-; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v16, 20, v2
 ; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v6, 12, v6
 ; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v7, 12, v7
-; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v5, 12, v8
-; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v8, 12, v13
-; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v12, 12, v14
+; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v13, 12, v13
+; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v12, 20, v2
+; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v14, 12, v14
 ; GFX10-DL-XNACK-NEXT:    v_pk_mul_lo_u16 v4, v4, v11
+; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v8, 12, v1 op_sel:[0,1,0]
 ; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v9, 12, v9
-; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v15, 12, v15
-; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v16, 12, v16
-; GFX10-DL-XNACK-NEXT:    v_perm_b32 v8, v12, v8, 0x5040100
+; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v5, 12, v2 op_sel:[0,1,0]
+; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v11, 12, v12
+; GFX10-DL-XNACK-NEXT:    v_perm_b32 v12, v14, v13, 0x5040100
 ; GFX10-DL-XNACK-NEXT:    v_perm_b32 v6, v7, v6, 0x5040100
-; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v7, 16, v4
 ; GFX10-DL-XNACK-NEXT:    s_waitcnt vmcnt(0)
 ; GFX10-DL-XNACK-NEXT:    v_add_nc_u16 v3, v4, v3
 ; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v10, 24, v1
 ; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v1, 28, v1
-; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v17, 24, v2
+; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v8, 12, v8
 ; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v9, 12, v9
-; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v11, 12, v15
+; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v5, 12, v5
+; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v7, 24, v2
 ; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v2, 28, v2
-; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v4, 12, v16
-; GFX10-DL-XNACK-NEXT:    v_pk_mul_lo_u16 v6, v6, v8
-; GFX10-DL-XNACK-NEXT:    v_add_nc_u16 v3, v3, v7
+; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v11, 12, v11
+; GFX10-DL-XNACK-NEXT:    v_pk_mul_lo_u16 v6, v6, v12
+; GFX10-DL-XNACK-NEXT:    v_add_nc_u16 v3, v3, v4 op_sel:[0,1,0]
 ; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v10, 12, v10
 ; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v1, 12, v1
-; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v12, 12, v17
+; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v4, 12, v7
 ; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v2, 12, v2
-; GFX10-DL-XNACK-NEXT:    v_perm_b32 v4, v4, v11, 0x5040100
-; GFX10-DL-XNACK-NEXT:    v_perm_b32 v5, v9, v5, 0x5040100
-; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v7, 16, v6
+; GFX10-DL-XNACK-NEXT:    v_perm_b32 v5, v11, v5, 0x5040100
+; GFX10-DL-XNACK-NEXT:    v_perm_b32 v7, v9, v8, 0x5040100
 ; GFX10-DL-XNACK-NEXT:    v_add_nc_u16 v3, v3, v6
 ; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v10, 12, v10
-; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v6, 12, v12
-; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v2, 12, v2
 ; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v1, 12, v1
-; GFX10-DL-XNACK-NEXT:    v_pk_mul_lo_u16 v4, v5, v4
-; GFX10-DL-XNACK-NEXT:    v_add_nc_u16 v3, v3, v7
-; GFX10-DL-XNACK-NEXT:    v_perm_b32 v2, v2, v6, 0x5040100
+; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v4, 12, v4
+; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v2, 12, v2
+; GFX10-DL-XNACK-NEXT:    v_pk_mul_lo_u16 v5, v7, v5
+; GFX10-DL-XNACK-NEXT:    v_add_nc_u16 v3, v3, v6 op_sel:[0,1,0]
 ; GFX10-DL-XNACK-NEXT:    v_perm_b32 v1, v1, v10, 0x5040100
-; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v5, 16, v4
-; GFX10-DL-XNACK-NEXT:    v_add_nc_u16 v3, v3, v4
+; GFX10-DL-XNACK-NEXT:    v_perm_b32 v2, v2, v4, 0x5040100
+; GFX10-DL-XNACK-NEXT:    v_add_nc_u16 v3, v3, v5
 ; GFX10-DL-XNACK-NEXT:    v_pk_mul_lo_u16 v1, v1, v2
-; GFX10-DL-XNACK-NEXT:    v_add_nc_u16 v2, v3, v5
-; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v3, 16, v1
-; GFX10-DL-XNACK-NEXT:    v_add_nc_u16 v1, v2, v1
-; GFX10-DL-XNACK-NEXT:    v_add_nc_u16 v1, v1, v3
+; GFX10-DL-XNACK-NEXT:    v_add_nc_u16 v2, v3, v5 op_sel:[0,1,0]
+; GFX10-DL-XNACK-NEXT:    v_add_nc_u16 v2, v2, v1
+; GFX10-DL-XNACK-NEXT:    v_add_nc_u16 v1, v2, v1 op_sel:[0,1,0]
 ; GFX10-DL-XNACK-NEXT:    global_store_short v0, v1, s[0:1]
 ; GFX10-DL-XNACK-NEXT:    s_endpgm
 ;
@@ -2421,69 +2407,63 @@ define amdgpu_kernel void @idot8_acc16_vecMul(ptr addrspace(1) %src1,
 ; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v5, 12, v5
 ; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v12, 12, v12
 ; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v7, 12, v1
-; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v8, 16, v1
 ; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v13, 8, v0
 ; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v14, 12, v0
 ; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v4, 12, v4
 ; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v11, 12, v11
-; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v12, 12, v12
 ; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v5, 12, v5
+; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v12, 12, v12
 ; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v6, 12, v6
 ; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v7, 12, v7
-; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v8, 12, v8
 ; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v13, 12, v13
 ; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v14, 12, v14
 ; GFX10-DL-NOXNACK-NEXT:    v_perm_b32 v11, v12, v11, 0x5040100
 ; GFX10-DL-NOXNACK-NEXT:    v_perm_b32 v4, v5, v4, 0x5040100
 ; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v9, 20, v1
-; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v15, 16, v0
-; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v16, 20, v0
 ; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v6, 12, v6
 ; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v7, 12, v7
-; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v5, 12, v8
-; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v8, 12, v13
-; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v12, 12, v14
+; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v13, 12, v13
+; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v12, 20, v0
+; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v14, 12, v14
 ; GFX10-DL-NOXNACK-NEXT:    v_pk_mul_lo_u16 v4, v4, v11
+; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v8, 12, v1 op_sel:[0,1,0]
 ; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v9, 12, v9
-; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v15, 12, v15
-; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v16, 12, v16
-; GFX10-DL-NOXNACK-NEXT:    v_perm_b32 v8, v12, v8, 0x5040100
+; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v5, 12, v0 op_sel:[0,1,0]
+; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v11, 12, v12
+; GFX10-DL-NOXNACK-NEXT:    v_perm_b32 v12, v14, v13, 0x5040100
 ; GFX10-DL-NOXNACK-NEXT:    v_perm_b32 v6, v7, v6, 0x5040100
-; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v7, 16, v4
 ; GFX10-DL-NOXNACK-NEXT:    s_waitcnt vmcnt(0)
 ; GFX10-DL-NOXNACK-NEXT:    v_add_nc_u16 v3, v4, v3
 ; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v10, 24, v1
 ; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v1, 28, v1
-; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v17, 24, v0
+; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v8, 12, v8
 ; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v9, 12, v9
-; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v11, 12, v15
+; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v5, 12, v5
+; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v7, 24, v0
 ; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v0, 28, v0
-; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v4, 12, v16
-; GFX10-DL-NOXNACK-NEXT:    v_pk_mul_lo_u16 v6, v6, v8
-; GFX10-DL-NOXNACK-NEXT:    v_add_nc_u16 v3, v3, v7
+; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v11, 12, v11
+; GFX10-DL-NOXNACK-NEXT:    v_pk_mul_lo_u16 v6, v6, v12
+; GFX10-DL-NOXNACK-NEXT:    v_add_nc_u16 v3, v3, v4 op_sel:[0,1,0]
 ; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v10, 12, v10
 ; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v1, 12, v1
-; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v12, 12, v17
+; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v4, 12, v7
 ; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v0, 12, v0
-; GFX10-DL-NOXNACK-NEXT:    v_perm_b32 v4, v4, v11, 0x5040100
-; GFX10-DL-NOXNACK-NEXT:    v_perm_b32 v5, v9, v5, 0x5040100
-; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v7, 16, v6
+; GFX10-DL-NOXNACK-NEXT:    v_perm_b32 v5, v11, v5, 0x5040100
+; GFX10-DL-NOXNACK-NEXT:    v_perm_b32 v7, v9, v8, 0x5040100
 ; GFX10-DL-NOXNACK-NEXT:    v_add_nc_u16 v3, v3, v6
 ; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v10, 12, v10
-; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v6, 12, v12
-; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v0, 12, v0
 ; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v1, 12, v1
-; GFX10-DL-NOXNACK-NEXT:    v_pk_mul_lo_u16 v4, v5, v4
-; GFX10-DL-NOXNACK-NEXT:    v_add_nc_u16 v3, v3, v7
-; GFX10-DL-NOXNACK-NEXT:    v_perm_b32 v0, v0, v6, 0x5040100
+; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v4, 12, v4
+; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v0, 12, v0
+; GFX10-DL-NOXNACK-NEXT:    v_pk_mul_lo_u16 v5, v7, v5
+; GFX10-DL-NOXNACK-NEXT:    v_add_nc_u16 v3, v3, v6 op_sel:[0,1,0]
 ; GFX10-DL-NOXNACK-NEXT:    v_perm_b32 v1, v1, v10, 0x5040100
-; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v5, 16, v4
-; GFX10-DL-NOXNACK-NEXT:    v_add_nc_u16 v3, v3, v4
+; GFX10-DL-NOXNACK-NEXT:    v_perm_b32 v0, v0, v4, 0x5040100
+; GFX10-DL-NOXNACK-NEXT:    v_add_nc_u16 v3, v3, v5
 ; GFX10-DL-NOXNACK-NEXT:    v_pk_mul_lo_u16 v0, v1, v0
-; GFX10-DL-NOXNACK-NEXT:    v_add_nc_u16 v1, v3, v5
-; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v3, 16, v0
-; GFX10-DL-NOXNACK-NEXT:    v_add_nc_u16 v0, v1, v0
-; GFX10-DL-NOXNACK-NEXT:    v_add_nc_u16 v0, v0, v3
+; GFX10-DL-NOXNACK-NEXT:    v_add_nc_u16 v1, v3, v5 op_sel:[0,1,0]
+; GFX10-DL-NOXNACK-NEXT:    v_add_nc_u16 v1, v1, v0
+; GFX10-DL-NOXNACK-NEXT:    v_add_nc_u16 v0, v1, v0 op_sel:[0,1,0]
 ; GFX10-DL-NOXNACK-NEXT:    global_store_short v2, v0, s[0:1]
 ; GFX10-DL-NOXNACK-NEXT:    s_endpgm
                                               ptr addrspace(1) %src2,
@@ -2895,84 +2875,82 @@ define amdgpu_kernel void @idot8_acc8_vecMul(ptr addrspace(1) %src1,
 ; GFX10-DL-XNACK-NEXT:    global_load_dword v2, v0, s[10:11]
 ; GFX10-DL-XNACK-NEXT:    global_load_ubyte v3, v4, s[0:1]
 ; GFX10-DL-XNACK-NEXT:    s_waitcnt vmcnt(2)
-; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v8, 12, v1
+; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v7, 12, v1
 ; GFX10-DL-XNACK-NEXT:    s_waitcnt vmcnt(1)
-; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v15, 12, v2
-; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v9, 8, v1
-; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v16, 8, v2
-; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v10, 4, v1
-; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v8, 12, v8
-; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v15, 12, v15
-; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v17, 4, v2
-; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v9, 12, v9
-; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v16, 12, v16
-; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v8, 12, v8
-; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v15, 12, v15
+; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v13, 12, v2
 ; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v0, 28, v1
-; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v6, 20, v1
-; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v11, 28, v2
-; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v13, 20, v2
-; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v10, 12, v10
-; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v17, 12, v17
-; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v9, 12, v9
-; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v16, 12, v16
-; GFX10-DL-XNACK-NEXT:    v_mul_lo_u16 v8, v8, v15
 ; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v5, 24, v1
-; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v7, 16, v1
-; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v12, 24, v2
-; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v14, 16, v2
-; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v1, 12, v1
-; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v2, 12, v2
-; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v6, 12, v6
-; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v0, 12, v0
-; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v13, 12, v13
-; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v11, 12, v11
-; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v10, 12, v10
-; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v15, 12, v17
-; GFX10-DL-XNACK-NEXT:    v_mul_lo_u16 v9, v9, v16
-; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v8, 8, v8
-; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v1, 12, v1
+; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v6, 20, v1
+; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v8, 8, v1
+; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v9, 4, v1
+; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v10, 28, v2
+; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v11, 24, v2
+; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v12, 20, v2
+; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v14, 8, v2
+; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v15, 4, v2
+; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v16, 12, v1
+; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v1, 12, v1 op_sel:[0,1,0]
+; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v17, 12, v2
+; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v2, 12, v2 op_sel:[0,1,0]
 ; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v7, 12, v7
-; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v5, 12, v5
-; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v2, 12, v2
+; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v13, 12, v13
+; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v8, 12, v8
+; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v18, 12, v1
+; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v1, 12, v5
+; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v5, 12, v15
+; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v15, 12, v17
 ; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v14, 12, v14
+; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v17, 12, v2
+; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v2, 12, v11
+; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v7, 12, v7
+; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v11, 12, v13
+; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v9, 12, v9
+; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v8, 12, v8
+; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v13, 12, v14
+; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v6, 12, v6
+; GFX10-DL-XNACK-NEXT:    v_mul_lo_u16 v7, v7, v11
+; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v0, 12, v0
 ; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v12, 12, v12
+; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v10, 12, v10
+; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v9, 12, v9
+; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v11, 12, v1
+; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v1, 12, v5
+; GFX10-DL-XNACK-NEXT:    v_mul_lo_u16 v5, v8, v13
+; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v7, 8, v7
 ; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v6, 12, v6
 ; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v0, 12, v0
-; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v13, 12, v13
-; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v11, 12, v11
-; GFX10-DL-XNACK-NEXT:    v_mul_lo_u16 v10, v10, v15
-; GFX10-DL-XNACK-NEXT:    v_or_b32_sdwa v8, v9, v8 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
-; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v7, 12, v7
-; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v5, 12, v5
-; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v14, 12, v14
-; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v12, 12, v12
-; GFX10-DL-XNACK-NEXT:    v_mul_lo_u16 v1, v1, v2
-; GFX10-DL-XNACK-NEXT:    v_mul_lo_u16 v2, v0, v11
-; GFX10-DL-XNACK-NEXT:    v_mul_lo_u16 v6, v6, v13
-; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v9, 8, v10
-; GFX10-DL-XNACK-NEXT:    v_lshlrev_b32_e32 v0, 16, v8
-; GFX10-DL-XNACK-NEXT:    v_mul_lo_u16 v10, v5, v12
-; GFX10-DL-XNACK-NEXT:    v_mul_lo_u16 v11, v7, v14
-; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v13, 8, v2
-; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v2, 8, v6
-; GFX10-DL-XNACK-NEXT:    v_or_b32_sdwa v6, v0, v9 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:WORD_0
-; GFX10-DL-XNACK-NEXT:    v_or_b32_sdwa v1, v1, v9 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
-; GFX10-DL-XNACK-NEXT:    v_or_b32_sdwa v9, v10, v13 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
-; GFX10-DL-XNACK-NEXT:    v_or_b32_sdwa v2, v11, v2 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
-; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v6, 8, v6
+; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v8, 12, v12
+; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v10, 12, v10
+; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v16, 12, v16
+; GFX10-DL-XNACK-NEXT:    v_mul_lo_u16 v1, v9, v1
+; GFX10-DL-XNACK-NEXT:    v_or_b32_sdwa v5, v5, v7 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
+; GFX10-DL-XNACK-NEXT:    v_ashrrev_i16 v12, 12, v2
+; GFX10-DL-XNACK-NEXT:    v_mul_lo_u16 v7, v0, v10
+; GFX10-DL-XNACK-NEXT:    v_mul_lo_u16 v6, v6, v8
+; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v1, 8, v1
+; GFX10-DL-XNACK-NEXT:    v_lshlrev_b32_e32 v0, 16, v5
+; GFX10-DL-XNACK-NEXT:    v_mul_lo_u16 v8, v16, v15
+; GFX10-DL-XNACK-NEXT:    v_mul_lo_u16 v2, v18, v17
+; GFX10-DL-XNACK-NEXT:    v_mul_lo_u16 v9, v11, v12
+; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v7, 8, v7
+; GFX10-DL-XNACK-NEXT:    v_lshlrev_b16 v6, 8, v6
+; GFX10-DL-XNACK-NEXT:    v_or_b32_sdwa v10, v0, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:WORD_0
+; GFX10-DL-XNACK-NEXT:    v_or_b32_sdwa v1, v8, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
+; GFX10-DL-XNACK-NEXT:    v_or_b32_sdwa v8, v9, v7 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
+; GFX10-DL-XNACK-NEXT:    v_or_b32_sdwa v2, v2, v6 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
+; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v6, 8, v10
 ; GFX10-DL-XNACK-NEXT:    s_waitcnt vmcnt(0)
 ; GFX10-DL-XNACK-NEXT:    v_add_nc_u16 v3, v1, v3
-; GFX10-DL-XNACK-NEXT:    v_or_b32_sdwa v1, v9, v2 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:WORD_0
+; GFX10-DL-XNACK-NEXT:    v_or_b32_sdwa v1, v8, v2 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:WORD_0
 ; GFX10-DL-XNACK-NEXT:    v_add_nc_u16 v6, v3, v6
 ; GFX10-DL-XNACK-NEXT:    v_lshrrev_b64 v[2:3], 24, v[0:1]
 ; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v1, 8, v1
-; GFX10-DL-XNACK-NEXT:    v_add_nc_u16 v0, v6, v8
+; GFX10-DL-XNACK-NEXT:    v_add_nc_u16 v0, v6, v5
 ; GFX10-DL-XNACK-NEXT:    v_add_nc_u16 v0, v0, v2
-; GFX10-DL-XNACK-NEXT:    v_mad_u16 v0, v7, v14, v0
+; GFX10-DL-XNACK-NEXT:    v_mad_u16 v0, v18, v17, v0
 ; GFX10-DL-XNACK-NEXT:    v_add_nc_u16 v0, v0, v1
-; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v1, 8, v13
-; GFX10-DL-XNACK-NEXT:    v_mad_u16 v0, v5, v12, v0
+; GFX10-DL-XNACK-NEXT:    v_lshrrev_b32_e32 v1, 8, v7
+; GFX10-DL-XNACK-NEXT:    v_mad_u16 v0, v11, v12, v0
 ; GFX10-DL-XNACK-NEXT:    v_add_nc_u16 v0, v0, v1
 ; GFX10-DL-XNACK-NEXT:    global_store_byte v4, v0, s[0:1]
 ; GFX10-DL-XNACK-NEXT:    s_endpgm
@@ -2996,84 +2974,82 @@ define amdgpu_kernel void @idot8_acc8_vecMul(ptr addrspace(1) %src1,
 ; GFX10-DL-NOXNACK-NEXT:    global_load_dword v0, v0, s[10:11]
 ; GFX10-DL-NOXNACK-NEXT:    global_load_ubyte v2, v4, s[0:1]
 ; GFX10-DL-NOXNACK-NEXT:    s_waitcnt vmcnt(2)
-; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v8, 12, v1
+; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v7, 12, v1
 ; GFX10-DL-NOXNACK-NEXT:    s_waitcnt vmcnt(1)
-; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v15, 12, v0
-; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v9, 8, v1
-; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v16, 8, v0
-; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v10, 4, v1
-; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v8, 12, v8
-; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v15, 12, v15
-; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v17, 4, v0
-; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v9, 12, v9
-; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v16, 12, v16
-; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v8, 12, v8
-; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v15, 12, v15
+; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v13, 12, v0
 ; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v3, 28, v1
-; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v6, 20, v1
-; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v11, 28, v0
-; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v13, 20, v0
-; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v10, 12, v10
-; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v17, 12, v17
-; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v9, 12, v9
-; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v16, 12, v16
-; GFX10-DL-NOXNACK-NEXT:    v_mul_lo_u16 v8, v8, v15
 ; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v5, 24, v1
-; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v7, 16, v1
-; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v12, 24, v0
-; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v14, 16, v0
-; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v6, 12, v6
-; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v3, 12, v3
-; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v13, 12, v13
-; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v11, 12, v11
-; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v1, 12, v1
-; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v0, 12, v0
-; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v10, 12, v10
-; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v15, 12, v17
-; GFX10-DL-NOXNACK-NEXT:    v_mul_lo_u16 v9, v9, v16
-; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v8, 8, v8
+; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v6, 20, v1
+; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v8, 8, v1
+; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v9, 4, v1
+; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v10, 28, v0
+; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v11, 24, v0
+; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v12, 20, v0
+; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v14, 8, v0
+; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v15, 4, v0
+; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v16, 12, v1
+; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v1, 12, v1 op_sel:[0,1,0]
+; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v17, 12, v0
+; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v0, 12, v0 op_sel:[0,1,0]
 ; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v7, 12, v7
-; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v5, 12, v5
+; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v13, 12, v13
+; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v8, 12, v8
+; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v18, 12, v1
+; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v1, 12, v5
+; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v5, 12, v15
+; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v15, 12, v17
 ; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v14, 12, v14
-; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v12, 12, v12
-; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v6, 12, v6
-; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v3, 12, v3
-; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v13, 12, v13
-; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v11, 12, v11
-; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v1, 12, v1
-; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v0, 12, v0
-; GFX10-DL-NOXNACK-NEXT:    v_mul_lo_u16 v10, v10, v15
-; GFX10-DL-NOXNACK-NEXT:    v_or_b32_sdwa v8, v9, v8 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
+; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v17, 12, v0
+; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v0, 12, v11
 ; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v7, 12, v7
-; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v5, 12, v5
-; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v14, 12, v14
-; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v12, 12, v12
-; GFX10-DL-NOXNACK-NEXT:    v_mul_lo_u16 v3, v3, v11
-; GFX10-DL-NOXNACK-NEXT:    v_mul_lo_u16 v6, v6, v13
-; GFX10-DL-NOXNACK-NEXT:    v_mul_lo_u16 v1, v1, v0
-; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v9, 8, v10
-; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b32_e32 v0, 16, v8
-; GFX10-DL-NOXNACK-NEXT:    v_mul_lo_u16 v10, v5, v12
-; GFX10-DL-NOXNACK-NEXT:    v_mul_lo_u16 v11, v7, v14
-; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v13, 8, v3
-; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v3, 8, v6
-; GFX10-DL-NOXNACK-NEXT:    v_or_b32_sdwa v6, v0, v9 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:WORD_0
-; GFX10-DL-NOXNACK-NEXT:    v_or_b32_sdwa v1, v1, v9 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
-; GFX10-DL-NOXNACK-NEXT:    v_or_b32_sdwa v9, v10, v13 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
-; GFX10-DL-NOXNACK-NEXT:    v_or_b32_sdwa v3, v11, v3 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
-; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v6, 8, v6
+; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v11, 12, v13
+; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v9, 12, v9
+; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v3, 12, v3
+; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v8, 12, v8
+; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v13, 12, v14
+; GFX10-DL-NOXNACK-NEXT:    v_mul_lo_u16 v7, v7, v11
+; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v6, 12, v6
+; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v12, 12, v12
+; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v10, 12, v10
+; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v9, 12, v9
+; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v11, 12, v1
+; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v1, 12, v3
+; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v3, 12, v5
+; GFX10-DL-NOXNACK-NEXT:    v_mul_lo_u16 v5, v8, v13
+; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v7, 8, v7
+; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v6, 12, v6
+; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v8, 12, v12
+; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v10, 12, v10
+; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v16, 12, v16
+; GFX10-DL-NOXNACK-NEXT:    v_ashrrev_i16 v12, 12, v0
+; GFX10-DL-NOXNACK-NEXT:    v_mul_lo_u16 v0, v9, v3
+; GFX10-DL-NOXNACK-NEXT:    v_or_b32_sdwa v5, v5, v7 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
+; GFX10-DL-NOXNACK-NEXT:    v_mul_lo_u16 v1, v1, v10
+; GFX10-DL-NOXNACK-NEXT:    v_mul_lo_u16 v6, v6, v8
+; GFX10-DL-NOXNACK-NEXT:    v_mul_lo_u16 v8, v16, v15
+; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v7, 8, v0
+; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b32_e32 v0, 16, v5
+; GFX10-DL-NOXNACK-NEXT:    v_mul_lo_u16 v3, v18, v17
+; GFX10-DL-NOXNACK-NEXT:    v_mul_lo_u16 v9, v11, v12
+; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v10, 8, v1
+; GFX10-DL-NOXNACK-NEXT:    v_lshlrev_b16 v1, 8, v6
+; GFX10-DL-NOXNACK-NEXT:    v_or_b32_sdwa v6, v0, v7 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:WORD_0
+; GFX10-DL-NOXNACK-NEXT:    v_or_b32_sdwa v7, v8, v7 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
+; GFX10-DL-NOXNACK-NEXT:    v_or_b32_sdwa v8, v9, v10 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
+; GFX10-DL-NOXNACK-NEXT:    v_or_b32_sdwa v1, v3, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
+; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v3, 8, v6
 ; GFX10-DL-NOXNACK-NEXT:    s_waitcnt vmcnt(0)
-; GFX10-DL-NOXNACK-NEXT:    v_add_nc_u16 v2, v1, v2
-; GFX10-DL-NOXNACK-NEXT:    v_or_b32_sdwa v1, v9, v3 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:WORD_0
-; GFX10-DL-NOXNACK-NEXT:    v_add_nc_u16 v6, v2, v6
+; GFX10-DL-NOXNACK-NEXT:    v_add_nc_u16 v2, v7, v2
+; GFX10-DL-NOXNACK-NEXT:    v_or_b32_sdwa v1, v8, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:WORD_0
+; GFX10-DL-NOXNACK-NEXT:    v_add_nc_u16 v6, v2, v3
 ; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b64 v[2:3], 24, v[0:1]
 ; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v1, 8, v1
-; GFX10-DL-NOXNACK-NEXT:    v_add_nc_u16 v0, v6, v8
+; GFX10-DL-NOXNACK-NEXT:    v_add_nc_u16 v0, v6, v5
 ; GFX10-DL-NOXNACK-NEXT:    v_add_nc_u16 v0, v0, v2
-; GFX10-DL-NOXNACK-NEXT:    v_mad_u16 v0, v7, v14, v0
+; GFX10-DL-NOXNACK-NEXT:    v_mad_u16 v0, v18, v17, v0
 ; GFX10-DL-NOXNACK-NEXT:    v_add_nc_u16 v0, v0, v1
-; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v1, 8, v13
-; GFX10-DL-NOXNACK-NEXT:    v_mad_u16 v0, v5, v12, v0
+; GFX10-DL-NOXNACK-NEXT:    v_lshrrev_b32_e32 v1, 8, v10
+; GFX10-DL-NOXNACK-NEXT:    v_mad_u16 v0, v11, v12, v0
 ; GFX10-DL-NOXNACK-NEXT:    v_add_nc_u16 v0, v0, v1
 ; GFX10-DL-NOXNACK-NEXT:    global_store_byte v4, v0, s[0:1]
 ; GFX10-DL-NOXNACK-NEXT:    s_endpgm

--- a/llvm/test/CodeGen/AMDGPU/idot8u.ll
+++ b/llvm/test/CodeGen/AMDGPU/idot8u.ll
@@ -2336,7 +2336,7 @@ define amdgpu_kernel void @udot8_acc16_vecMul(ptr addrspace(1) %src1,
 ; GFX10-DL-NEXT:    v_bfe_u32 v7, v1, 4, 4
 ; GFX10-DL-NEXT:    v_bfe_u32 v8, v2, 12, 4
 ; GFX10-DL-NEXT:    v_bfe_u32 v9, v1, 12, 4
-; GFX10-DL-NEXT:    v_bfe_u32 v10, v1, 20, 4
+; GFX10-DL-NEXT:    v_bfe_u32 v10, v2, 20, 4
 ; GFX10-DL-NEXT:    v_perm_b32 v5, v6, v5, 0x5040100
 ; GFX10-DL-NEXT:    v_perm_b32 v4, v7, v4, 0x5040100
 ; GFX10-DL-NEXT:    v_bfe_u32 v6, v1, 8, 4
@@ -2345,32 +2345,28 @@ define amdgpu_kernel void @udot8_acc16_vecMul(ptr addrspace(1) %src1,
 ; GFX10-DL-NEXT:    v_perm_b32 v6, v9, v6, 0x5040100
 ; GFX10-DL-NEXT:    v_perm_b32 v7, v8, v7, 0x5040100
 ; GFX10-DL-NEXT:    v_bfe_u32 v5, v1, 16, 4
-; GFX10-DL-NEXT:    v_bfe_u32 v9, v2, 20, 4
-; GFX10-DL-NEXT:    v_lshrrev_b32_e32 v8, 16, v4
+; GFX10-DL-NEXT:    v_bfe_u32 v8, v1, 20, 4
 ; GFX10-DL-NEXT:    s_waitcnt vmcnt(0)
 ; GFX10-DL-NEXT:    v_add_nc_u16 v3, v4, v3
-; GFX10-DL-NEXT:    v_bfe_u32 v4, v2, 16, 4
+; GFX10-DL-NEXT:    v_bfe_u32 v9, v2, 16, 4
 ; GFX10-DL-NEXT:    v_pk_mul_lo_u16 v6, v6, v7
-; GFX10-DL-NEXT:    v_perm_b32 v5, v10, v5, 0x5040100
-; GFX10-DL-NEXT:    v_bfe_u32 v7, v1, 24, 4
-; GFX10-DL-NEXT:    v_add_nc_u16 v3, v3, v8
-; GFX10-DL-NEXT:    v_perm_b32 v4, v9, v4, 0x5040100
-; GFX10-DL-NEXT:    v_lshrrev_b32_e32 v8, 16, v6
+; GFX10-DL-NEXT:    v_perm_b32 v5, v8, v5, 0x5040100
+; GFX10-DL-NEXT:    v_add_nc_u16 v3, v3, v4 op_sel:[0,1,0]
+; GFX10-DL-NEXT:    v_perm_b32 v7, v10, v9, 0x5040100
+; GFX10-DL-NEXT:    v_bfe_u32 v4, v1, 24, 4
 ; GFX10-DL-NEXT:    v_lshrrev_b32_e32 v1, 28, v1
+; GFX10-DL-NEXT:    v_bfe_u32 v8, v2, 24, 4
 ; GFX10-DL-NEXT:    v_add_nc_u16 v3, v3, v6
-; GFX10-DL-NEXT:    v_bfe_u32 v6, v2, 24, 4
 ; GFX10-DL-NEXT:    v_lshrrev_b32_e32 v2, 28, v2
-; GFX10-DL-NEXT:    v_pk_mul_lo_u16 v4, v5, v4
-; GFX10-DL-NEXT:    v_perm_b32 v1, v1, v7, 0x5040100
-; GFX10-DL-NEXT:    v_add_nc_u16 v3, v3, v8
-; GFX10-DL-NEXT:    v_perm_b32 v2, v2, v6, 0x5040100
-; GFX10-DL-NEXT:    v_lshrrev_b32_e32 v5, 16, v4
-; GFX10-DL-NEXT:    v_add_nc_u16 v3, v3, v4
+; GFX10-DL-NEXT:    v_pk_mul_lo_u16 v5, v5, v7
+; GFX10-DL-NEXT:    v_perm_b32 v1, v1, v4, 0x5040100
+; GFX10-DL-NEXT:    v_add_nc_u16 v3, v3, v6 op_sel:[0,1,0]
+; GFX10-DL-NEXT:    v_perm_b32 v2, v2, v8, 0x5040100
+; GFX10-DL-NEXT:    v_add_nc_u16 v3, v3, v5
 ; GFX10-DL-NEXT:    v_pk_mul_lo_u16 v1, v1, v2
-; GFX10-DL-NEXT:    v_add_nc_u16 v2, v3, v5
-; GFX10-DL-NEXT:    v_lshrrev_b32_e32 v3, 16, v1
-; GFX10-DL-NEXT:    v_add_nc_u16 v1, v2, v1
-; GFX10-DL-NEXT:    v_add_nc_u16 v1, v1, v3
+; GFX10-DL-NEXT:    v_add_nc_u16 v2, v3, v5 op_sel:[0,1,0]
+; GFX10-DL-NEXT:    v_add_nc_u16 v2, v2, v1
+; GFX10-DL-NEXT:    v_add_nc_u16 v1, v2, v1 op_sel:[0,1,0]
 ; GFX10-DL-NEXT:    global_store_short v0, v1, s[6:7]
 ; GFX10-DL-NEXT:    s_endpgm
                                               ptr addrspace(1) %src2,
@@ -3027,7 +3023,7 @@ define amdgpu_kernel void @udot8_acc4_vecMul(ptr addrspace(1) %src1,
 ; GFX10-DL-NEXT:    v_bfe_u32 v7, v1, 4, 4
 ; GFX10-DL-NEXT:    v_bfe_u32 v8, v2, 12, 4
 ; GFX10-DL-NEXT:    v_bfe_u32 v9, v1, 12, 4
-; GFX10-DL-NEXT:    v_bfe_u32 v10, v1, 20, 4
+; GFX10-DL-NEXT:    v_bfe_u32 v10, v2, 20, 4
 ; GFX10-DL-NEXT:    v_perm_b32 v5, v6, v5, 0x5040100
 ; GFX10-DL-NEXT:    v_perm_b32 v4, v7, v4, 0x5040100
 ; GFX10-DL-NEXT:    v_bfe_u32 v6, v1, 8, 4
@@ -3036,32 +3032,28 @@ define amdgpu_kernel void @udot8_acc4_vecMul(ptr addrspace(1) %src1,
 ; GFX10-DL-NEXT:    v_perm_b32 v6, v9, v6, 0x5040100
 ; GFX10-DL-NEXT:    v_perm_b32 v7, v8, v7, 0x5040100
 ; GFX10-DL-NEXT:    v_bfe_u32 v5, v1, 16, 4
-; GFX10-DL-NEXT:    v_bfe_u32 v9, v2, 20, 4
-; GFX10-DL-NEXT:    v_lshrrev_b32_e32 v8, 16, v4
+; GFX10-DL-NEXT:    v_bfe_u32 v8, v1, 20, 4
 ; GFX10-DL-NEXT:    s_waitcnt vmcnt(0)
 ; GFX10-DL-NEXT:    v_add_nc_u16 v3, v4, v3
-; GFX10-DL-NEXT:    v_bfe_u32 v4, v2, 16, 4
+; GFX10-DL-NEXT:    v_bfe_u32 v9, v2, 16, 4
 ; GFX10-DL-NEXT:    v_pk_mul_lo_u16 v6, v6, v7
-; GFX10-DL-NEXT:    v_perm_b32 v5, v10, v5, 0x5040100
-; GFX10-DL-NEXT:    v_bfe_u32 v7, v1, 24, 4
-; GFX10-DL-NEXT:    v_add_nc_u16 v3, v3, v8
-; GFX10-DL-NEXT:    v_perm_b32 v4, v9, v4, 0x5040100
-; GFX10-DL-NEXT:    v_lshrrev_b32_e32 v8, 16, v6
+; GFX10-DL-NEXT:    v_perm_b32 v5, v8, v5, 0x5040100
+; GFX10-DL-NEXT:    v_add_nc_u16 v3, v3, v4 op_sel:[0,1,0]
+; GFX10-DL-NEXT:    v_perm_b32 v7, v10, v9, 0x5040100
+; GFX10-DL-NEXT:    v_bfe_u32 v4, v1, 24, 4
 ; GFX10-DL-NEXT:    v_lshrrev_b32_e32 v1, 28, v1
+; GFX10-DL-NEXT:    v_bfe_u32 v8, v2, 24, 4
 ; GFX10-DL-NEXT:    v_add_nc_u16 v3, v3, v6
-; GFX10-DL-NEXT:    v_bfe_u32 v6, v2, 24, 4
 ; GFX10-DL-NEXT:    v_lshrrev_b32_e32 v2, 28, v2
-; GFX10-DL-NEXT:    v_pk_mul_lo_u16 v4, v5, v4
-; GFX10-DL-NEXT:    v_perm_b32 v1, v1, v7, 0x5040100
-; GFX10-DL-NEXT:    v_add_nc_u16 v3, v3, v8
-; GFX10-DL-NEXT:    v_perm_b32 v2, v2, v6, 0x5040100
-; GFX10-DL-NEXT:    v_lshrrev_b32_e32 v5, 16, v4
-; GFX10-DL-NEXT:    v_add_nc_u16 v3, v3, v4
+; GFX10-DL-NEXT:    v_pk_mul_lo_u16 v5, v5, v7
+; GFX10-DL-NEXT:    v_perm_b32 v1, v1, v4, 0x5040100
+; GFX10-DL-NEXT:    v_add_nc_u16 v3, v3, v6 op_sel:[0,1,0]
+; GFX10-DL-NEXT:    v_perm_b32 v2, v2, v8, 0x5040100
+; GFX10-DL-NEXT:    v_add_nc_u16 v3, v3, v5
 ; GFX10-DL-NEXT:    v_pk_mul_lo_u16 v1, v1, v2
-; GFX10-DL-NEXT:    v_add_nc_u16 v2, v3, v5
-; GFX10-DL-NEXT:    v_lshrrev_b32_e32 v3, 16, v1
-; GFX10-DL-NEXT:    v_add_nc_u16 v1, v2, v1
-; GFX10-DL-NEXT:    v_add_nc_u16 v1, v1, v3
+; GFX10-DL-NEXT:    v_add_nc_u16 v2, v3, v5 op_sel:[0,1,0]
+; GFX10-DL-NEXT:    v_add_nc_u16 v2, v2, v1
+; GFX10-DL-NEXT:    v_add_nc_u16 v1, v2, v1 op_sel:[0,1,0]
 ; GFX10-DL-NEXT:    v_and_b32_e32 v1, 15, v1
 ; GFX10-DL-NEXT:    global_store_byte v0, v1, s[6:7]
 ; GFX10-DL-NEXT:    s_endpgm

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.cvt.f16.fp8.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.cvt.f16.fp8.ll
@@ -733,9 +733,7 @@ define amdgpu_ps float @test_cvt_pk_f16_fp8_v_hi(<2 x i16> %a) {
 ; GFX1250-SDAG-FAKE16-NEXT:    s_mov_b64 s[64:65], 0
 ; GFX1250-SDAG-FAKE16-NEXT:    v_nop
 ; GFX1250-SDAG-FAKE16-NEXT:    global_prefetch_b8 v0, s[64:65] scope:SCOPE_SE
-; GFX1250-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
-; GFX1250-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1250-SDAG-FAKE16-NEXT:    v_cvt_pk_f16_fp8 v0, v0
+; GFX1250-SDAG-FAKE16-NEXT:    v_cvt_pk_f16_fp8 v0, v0 op_sel:[1,0]
 ; GFX1250-SDAG-FAKE16-NEXT:    ; return to shader part epilog
 ;
 ; GFX1250-GISEL-REAL16-LABEL: test_cvt_pk_f16_fp8_v_hi:
@@ -753,9 +751,7 @@ define amdgpu_ps float @test_cvt_pk_f16_fp8_v_hi(<2 x i16> %a) {
 ; GFX1250-GISEL-FAKE16-NEXT:    s_mov_b64 s[64:65], 0
 ; GFX1250-GISEL-FAKE16-NEXT:    v_nop
 ; GFX1250-GISEL-FAKE16-NEXT:    global_prefetch_b8 v0, s[64:65] scope:SCOPE_SE
-; GFX1250-GISEL-FAKE16-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
-; GFX1250-GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1250-GISEL-FAKE16-NEXT:    v_cvt_pk_f16_fp8 v0, v0
+; GFX1250-GISEL-FAKE16-NEXT:    v_cvt_pk_f16_fp8 v0, v0 op_sel:[1,0]
 ; GFX1250-GISEL-FAKE16-NEXT:    ; return to shader part epilog
   %a.1 = extractelement <2 x i16> %a, i32 1
   %cvt = tail call <2 x half> @llvm.amdgcn.cvt.pk.f16.fp8(i16 %a.1)

--- a/llvm/test/CodeGen/AMDGPU/llvm.exp2.bf16.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.exp2.bf16.ll
@@ -878,11 +878,10 @@ define <2 x bfloat> @v_exp2_v2bf16(<2 x bfloat> %in) {
 ; GFX1250-SDAG-FAKE16:       ; %bb.0:
 ; GFX1250-SDAG-FAKE16-NEXT:    s_wait_loadcnt_dscnt 0x0
 ; GFX1250-SDAG-FAKE16-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
+; GFX1250-SDAG-FAKE16-NEXT:    v_exp_bf16_e64 v1, v0 op_sel:[1,0]
 ; GFX1250-SDAG-FAKE16-NEXT:    v_exp_bf16_e32 v0, v0
-; GFX1250-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(TRANS32_DEP_1)
-; GFX1250-SDAG-FAKE16-NEXT:    v_exp_bf16_e32 v1, v1
 ; GFX1250-SDAG-FAKE16-NEXT:    v_nop
+; GFX1250-SDAG-FAKE16-NEXT:    s_delay_alu instid0(TRANS32_DEP_1)
 ; GFX1250-SDAG-FAKE16-NEXT:    v_perm_b32 v0, v1, v0, 0x5040100
 ; GFX1250-SDAG-FAKE16-NEXT:    s_set_pc_i64 s[30:31]
 ;
@@ -898,15 +897,13 @@ define <2 x bfloat> @v_exp2_v2bf16(<2 x bfloat> %in) {
 ; GFX1250-GI-FAKE16:       ; %bb.0:
 ; GFX1250-GI-FAKE16-NEXT:    s_wait_loadcnt_dscnt 0x0
 ; GFX1250-GI-FAKE16-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-GI-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX1250-GI-FAKE16-NEXT:    v_exp_bf16_e32 v0, v0
+; GFX1250-GI-FAKE16-NEXT:    v_exp_bf16_e32 v1, v0
 ; GFX1250-GI-FAKE16-NEXT:    v_nop
-; GFX1250-GI-FAKE16-NEXT:    s_delay_alu instid0(TRANS32_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_3)
-; GFX1250-GI-FAKE16-NEXT:    v_and_b32_e32 v0, 0xffff, v0
-; GFX1250-GI-FAKE16-NEXT:    v_exp_bf16_e32 v1, v1
+; GFX1250-GI-FAKE16-NEXT:    s_delay_alu instid0(TRANS32_DEP_1) | instskip(SKIP_2) | instid1(TRANS32_DEP_1)
+; GFX1250-GI-FAKE16-NEXT:    v_and_b32_e32 v1, 0xffff, v1
+; GFX1250-GI-FAKE16-NEXT:    v_exp_bf16_e64 v0, v0 op_sel:[1,0]
 ; GFX1250-GI-FAKE16-NEXT:    v_nop
-; GFX1250-GI-FAKE16-NEXT:    s_delay_alu instid0(TRANS32_DEP_1)
-; GFX1250-GI-FAKE16-NEXT:    v_lshl_or_b32 v0, v1, 16, v0
+; GFX1250-GI-FAKE16-NEXT:    v_lshl_or_b32 v0, v0, 16, v1
 ; GFX1250-GI-FAKE16-NEXT:    s_set_pc_i64 s[30:31]
   %result = call <2 x bfloat> @llvm.exp2.v2bf16(<2 x bfloat> %in)
   ret <2 x bfloat> %result
@@ -1125,11 +1122,10 @@ define <2 x bfloat> @v_exp2_fabs_v2bf16(<2 x bfloat> %in) {
 ; GFX1250-SDAG-FAKE16:       ; %bb.0:
 ; GFX1250-SDAG-FAKE16-NEXT:    s_wait_loadcnt_dscnt 0x0
 ; GFX1250-SDAG-FAKE16-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
+; GFX1250-SDAG-FAKE16-NEXT:    v_exp_bf16_e64 v1, |v0| op_sel:[1,0]
 ; GFX1250-SDAG-FAKE16-NEXT:    v_exp_bf16_e64 v0, |v0|
-; GFX1250-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(TRANS32_DEP_1)
-; GFX1250-SDAG-FAKE16-NEXT:    v_exp_bf16_e64 v1, |v1|
 ; GFX1250-SDAG-FAKE16-NEXT:    v_nop
+; GFX1250-SDAG-FAKE16-NEXT:    s_delay_alu instid0(TRANS32_DEP_1)
 ; GFX1250-SDAG-FAKE16-NEXT:    v_perm_b32 v0, v1, v0, 0x5040100
 ; GFX1250-SDAG-FAKE16-NEXT:    s_set_pc_i64 s[30:31]
 ;
@@ -1148,15 +1144,14 @@ define <2 x bfloat> @v_exp2_fabs_v2bf16(<2 x bfloat> %in) {
 ; GFX1250-GI-FAKE16-NEXT:    s_wait_loadcnt_dscnt 0x0
 ; GFX1250-GI-FAKE16-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-GI-FAKE16-NEXT:    v_and_b32_e32 v0, 0x7fff7fff, v0
-; GFX1250-GI-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_2) | instid1(TRANS32_DEP_1)
-; GFX1250-GI-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX1250-GI-FAKE16-NEXT:    v_exp_bf16_e32 v0, v0
+; GFX1250-GI-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(TRANS32_DEP_1)
+; GFX1250-GI-FAKE16-NEXT:    v_exp_bf16_e32 v1, v0
 ; GFX1250-GI-FAKE16-NEXT:    v_nop
-; GFX1250-GI-FAKE16-NEXT:    v_and_b32_e32 v0, 0xffff, v0
-; GFX1250-GI-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(TRANS32_DEP_1)
-; GFX1250-GI-FAKE16-NEXT:    v_exp_bf16_e32 v1, v1
+; GFX1250-GI-FAKE16-NEXT:    v_and_b32_e32 v1, 0xffff, v1
+; GFX1250-GI-FAKE16-NEXT:    v_exp_bf16_e64 v0, v0 op_sel:[1,0]
 ; GFX1250-GI-FAKE16-NEXT:    v_nop
-; GFX1250-GI-FAKE16-NEXT:    v_lshl_or_b32 v0, v1, 16, v0
+; GFX1250-GI-FAKE16-NEXT:    s_delay_alu instid0(TRANS32_DEP_1)
+; GFX1250-GI-FAKE16-NEXT:    v_lshl_or_b32 v0, v0, 16, v1
 ; GFX1250-GI-FAKE16-NEXT:    s_set_pc_i64 s[30:31]
   %fabs = call <2 x bfloat> @llvm.fabs.v2bf16(<2 x bfloat> %in)
   %result = call <2 x bfloat> @llvm.exp2.v2bf16(<2 x bfloat> %fabs)
@@ -1375,11 +1370,10 @@ define <2 x bfloat> @v_exp2_fneg_fabs_v2bf16(<2 x bfloat> %in) {
 ; GFX1250-SDAG-FAKE16:       ; %bb.0:
 ; GFX1250-SDAG-FAKE16-NEXT:    s_wait_loadcnt_dscnt 0x0
 ; GFX1250-SDAG-FAKE16-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
+; GFX1250-SDAG-FAKE16-NEXT:    v_exp_bf16_e64 v1, -|v0| op_sel:[1,0]
 ; GFX1250-SDAG-FAKE16-NEXT:    v_exp_bf16_e64 v0, -|v0|
-; GFX1250-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(TRANS32_DEP_1)
-; GFX1250-SDAG-FAKE16-NEXT:    v_exp_bf16_e64 v1, -|v1|
 ; GFX1250-SDAG-FAKE16-NEXT:    v_nop
+; GFX1250-SDAG-FAKE16-NEXT:    s_delay_alu instid0(TRANS32_DEP_1)
 ; GFX1250-SDAG-FAKE16-NEXT:    v_perm_b32 v0, v1, v0, 0x5040100
 ; GFX1250-SDAG-FAKE16-NEXT:    s_set_pc_i64 s[30:31]
 ;
@@ -1398,15 +1392,14 @@ define <2 x bfloat> @v_exp2_fneg_fabs_v2bf16(<2 x bfloat> %in) {
 ; GFX1250-GI-FAKE16-NEXT:    s_wait_loadcnt_dscnt 0x0
 ; GFX1250-GI-FAKE16-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-GI-FAKE16-NEXT:    v_or_b32_e32 v0, 0x80008000, v0
-; GFX1250-GI-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_2) | instid1(TRANS32_DEP_1)
-; GFX1250-GI-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX1250-GI-FAKE16-NEXT:    v_exp_bf16_e32 v0, v0
+; GFX1250-GI-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(TRANS32_DEP_1)
+; GFX1250-GI-FAKE16-NEXT:    v_exp_bf16_e32 v1, v0
 ; GFX1250-GI-FAKE16-NEXT:    v_nop
-; GFX1250-GI-FAKE16-NEXT:    v_and_b32_e32 v0, 0xffff, v0
-; GFX1250-GI-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(TRANS32_DEP_1)
-; GFX1250-GI-FAKE16-NEXT:    v_exp_bf16_e32 v1, v1
+; GFX1250-GI-FAKE16-NEXT:    v_and_b32_e32 v1, 0xffff, v1
+; GFX1250-GI-FAKE16-NEXT:    v_exp_bf16_e64 v0, v0 op_sel:[1,0]
 ; GFX1250-GI-FAKE16-NEXT:    v_nop
-; GFX1250-GI-FAKE16-NEXT:    v_lshl_or_b32 v0, v1, 16, v0
+; GFX1250-GI-FAKE16-NEXT:    s_delay_alu instid0(TRANS32_DEP_1)
+; GFX1250-GI-FAKE16-NEXT:    v_lshl_or_b32 v0, v0, 16, v1
 ; GFX1250-GI-FAKE16-NEXT:    s_set_pc_i64 s[30:31]
   %fabs = call <2 x bfloat> @llvm.fabs.v2bf16(<2 x bfloat> %in)
   %fneg.fabs = fneg <2 x bfloat> %fabs
@@ -1626,11 +1619,10 @@ define <2 x bfloat> @v_exp2_fneg_v2bf16(<2 x bfloat> %in) {
 ; GFX1250-SDAG-FAKE16:       ; %bb.0:
 ; GFX1250-SDAG-FAKE16-NEXT:    s_wait_loadcnt_dscnt 0x0
 ; GFX1250-SDAG-FAKE16-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
+; GFX1250-SDAG-FAKE16-NEXT:    v_exp_bf16_e64 v1, -v0 op_sel:[1,0]
 ; GFX1250-SDAG-FAKE16-NEXT:    v_exp_bf16_e64 v0, -v0
-; GFX1250-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(TRANS32_DEP_1)
-; GFX1250-SDAG-FAKE16-NEXT:    v_exp_bf16_e64 v1, -v1
 ; GFX1250-SDAG-FAKE16-NEXT:    v_nop
+; GFX1250-SDAG-FAKE16-NEXT:    s_delay_alu instid0(TRANS32_DEP_1)
 ; GFX1250-SDAG-FAKE16-NEXT:    v_perm_b32 v0, v1, v0, 0x5040100
 ; GFX1250-SDAG-FAKE16-NEXT:    s_set_pc_i64 s[30:31]
 ;
@@ -1649,15 +1641,14 @@ define <2 x bfloat> @v_exp2_fneg_v2bf16(<2 x bfloat> %in) {
 ; GFX1250-GI-FAKE16-NEXT:    s_wait_loadcnt_dscnt 0x0
 ; GFX1250-GI-FAKE16-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-GI-FAKE16-NEXT:    v_xor_b32_e32 v0, 0x80008000, v0
-; GFX1250-GI-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_2) | instid1(TRANS32_DEP_1)
-; GFX1250-GI-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX1250-GI-FAKE16-NEXT:    v_exp_bf16_e32 v0, v0
+; GFX1250-GI-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(TRANS32_DEP_1)
+; GFX1250-GI-FAKE16-NEXT:    v_exp_bf16_e32 v1, v0
 ; GFX1250-GI-FAKE16-NEXT:    v_nop
-; GFX1250-GI-FAKE16-NEXT:    v_and_b32_e32 v0, 0xffff, v0
-; GFX1250-GI-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(TRANS32_DEP_1)
-; GFX1250-GI-FAKE16-NEXT:    v_exp_bf16_e32 v1, v1
+; GFX1250-GI-FAKE16-NEXT:    v_and_b32_e32 v1, 0xffff, v1
+; GFX1250-GI-FAKE16-NEXT:    v_exp_bf16_e64 v0, v0 op_sel:[1,0]
 ; GFX1250-GI-FAKE16-NEXT:    v_nop
-; GFX1250-GI-FAKE16-NEXT:    v_lshl_or_b32 v0, v1, 16, v0
+; GFX1250-GI-FAKE16-NEXT:    s_delay_alu instid0(TRANS32_DEP_1)
+; GFX1250-GI-FAKE16-NEXT:    v_lshl_or_b32 v0, v0, 16, v1
 ; GFX1250-GI-FAKE16-NEXT:    s_set_pc_i64 s[30:31]
   %fneg = fneg <2 x bfloat> %in
   %result = call <2 x bfloat> @llvm.exp2.v2bf16(<2 x bfloat> %fneg)
@@ -1848,11 +1839,10 @@ define <2 x bfloat> @v_exp2_v2bf16_fast(<2 x bfloat> %in) {
 ; GFX1250-SDAG-FAKE16:       ; %bb.0:
 ; GFX1250-SDAG-FAKE16-NEXT:    s_wait_loadcnt_dscnt 0x0
 ; GFX1250-SDAG-FAKE16-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
+; GFX1250-SDAG-FAKE16-NEXT:    v_exp_bf16_e64 v1, v0 op_sel:[1,0]
 ; GFX1250-SDAG-FAKE16-NEXT:    v_exp_bf16_e32 v0, v0
-; GFX1250-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(TRANS32_DEP_1)
-; GFX1250-SDAG-FAKE16-NEXT:    v_exp_bf16_e32 v1, v1
 ; GFX1250-SDAG-FAKE16-NEXT:    v_nop
+; GFX1250-SDAG-FAKE16-NEXT:    s_delay_alu instid0(TRANS32_DEP_1)
 ; GFX1250-SDAG-FAKE16-NEXT:    v_perm_b32 v0, v1, v0, 0x5040100
 ; GFX1250-SDAG-FAKE16-NEXT:    s_set_pc_i64 s[30:31]
 ;
@@ -1868,15 +1858,13 @@ define <2 x bfloat> @v_exp2_v2bf16_fast(<2 x bfloat> %in) {
 ; GFX1250-GI-FAKE16:       ; %bb.0:
 ; GFX1250-GI-FAKE16-NEXT:    s_wait_loadcnt_dscnt 0x0
 ; GFX1250-GI-FAKE16-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-GI-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX1250-GI-FAKE16-NEXT:    v_exp_bf16_e32 v0, v0
+; GFX1250-GI-FAKE16-NEXT:    v_exp_bf16_e32 v1, v0
 ; GFX1250-GI-FAKE16-NEXT:    v_nop
-; GFX1250-GI-FAKE16-NEXT:    s_delay_alu instid0(TRANS32_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_3)
-; GFX1250-GI-FAKE16-NEXT:    v_and_b32_e32 v0, 0xffff, v0
-; GFX1250-GI-FAKE16-NEXT:    v_exp_bf16_e32 v1, v1
+; GFX1250-GI-FAKE16-NEXT:    s_delay_alu instid0(TRANS32_DEP_1) | instskip(SKIP_2) | instid1(TRANS32_DEP_1)
+; GFX1250-GI-FAKE16-NEXT:    v_and_b32_e32 v1, 0xffff, v1
+; GFX1250-GI-FAKE16-NEXT:    v_exp_bf16_e64 v0, v0 op_sel:[1,0]
 ; GFX1250-GI-FAKE16-NEXT:    v_nop
-; GFX1250-GI-FAKE16-NEXT:    s_delay_alu instid0(TRANS32_DEP_1)
-; GFX1250-GI-FAKE16-NEXT:    v_lshl_or_b32 v0, v1, 16, v0
+; GFX1250-GI-FAKE16-NEXT:    v_lshl_or_b32 v0, v0, 16, v1
 ; GFX1250-GI-FAKE16-NEXT:    s_set_pc_i64 s[30:31]
   %result = call fast <2 x bfloat> @llvm.exp2.v2bf16(<2 x bfloat> %in)
   ret <2 x bfloat> %result

--- a/llvm/test/CodeGen/AMDGPU/llvm.log2.bf16.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.log2.bf16.ll
@@ -113,11 +113,10 @@ define <2 x bfloat> @v_log2_v2bf16(<2 x bfloat> %in) {
 ; GFX-SDAG-FAKE16:       ; %bb.0:
 ; GFX-SDAG-FAKE16-NEXT:    s_wait_loadcnt_dscnt 0x0
 ; GFX-SDAG-FAKE16-NEXT:    s_wait_kmcnt 0x0
-; GFX-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
+; GFX-SDAG-FAKE16-NEXT:    v_log_bf16_e64 v1, v0 op_sel:[1,0]
 ; GFX-SDAG-FAKE16-NEXT:    v_log_bf16_e32 v0, v0
-; GFX-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(TRANS32_DEP_1)
-; GFX-SDAG-FAKE16-NEXT:    v_log_bf16_e32 v1, v1
 ; GFX-SDAG-FAKE16-NEXT:    v_nop
+; GFX-SDAG-FAKE16-NEXT:    s_delay_alu instid0(TRANS32_DEP_1)
 ; GFX-SDAG-FAKE16-NEXT:    v_perm_b32 v0, v1, v0, 0x5040100
 ; GFX-SDAG-FAKE16-NEXT:    s_set_pc_i64 s[30:31]
 ;
@@ -133,12 +132,11 @@ define <2 x bfloat> @v_log2_v2bf16(<2 x bfloat> %in) {
 ; GFX-GISEL-FAKE16:       ; %bb.0:
 ; GFX-GISEL-FAKE16-NEXT:    s_wait_loadcnt_dscnt 0x0
 ; GFX-GISEL-FAKE16-NEXT:    s_wait_kmcnt 0x0
-; GFX-GISEL-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX-GISEL-FAKE16-NEXT:    v_log_bf16_e32 v0, v0
-; GFX-GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(TRANS32_DEP_1)
-; GFX-GISEL-FAKE16-NEXT:    v_log_bf16_e32 v1, v1
+; GFX-GISEL-FAKE16-NEXT:    v_log_bf16_e32 v1, v0
+; GFX-GISEL-FAKE16-NEXT:    v_log_bf16_e64 v0, v0 op_sel:[1,0]
 ; GFX-GISEL-FAKE16-NEXT:    v_nop
-; GFX-GISEL-FAKE16-NEXT:    v_pack_b32_f16 v0, v0, v1
+; GFX-GISEL-FAKE16-NEXT:    s_delay_alu instid0(TRANS32_DEP_1)
+; GFX-GISEL-FAKE16-NEXT:    v_pack_b32_f16 v0, v1, v0
 ; GFX-GISEL-FAKE16-NEXT:    s_set_pc_i64 s[30:31]
   %result = call <2 x bfloat> @llvm.log2.v2bf16(<2 x bfloat> %in)
   ret <2 x bfloat> %result
@@ -159,11 +157,10 @@ define <2 x bfloat> @v_log2_fabs_v2bf16(<2 x bfloat> %in) {
 ; GFX-SDAG-FAKE16:       ; %bb.0:
 ; GFX-SDAG-FAKE16-NEXT:    s_wait_loadcnt_dscnt 0x0
 ; GFX-SDAG-FAKE16-NEXT:    s_wait_kmcnt 0x0
-; GFX-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
+; GFX-SDAG-FAKE16-NEXT:    v_log_bf16_e64 v1, |v0| op_sel:[1,0]
 ; GFX-SDAG-FAKE16-NEXT:    v_log_bf16_e64 v0, |v0|
-; GFX-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(TRANS32_DEP_1)
-; GFX-SDAG-FAKE16-NEXT:    v_log_bf16_e64 v1, |v1|
 ; GFX-SDAG-FAKE16-NEXT:    v_nop
+; GFX-SDAG-FAKE16-NEXT:    s_delay_alu instid0(TRANS32_DEP_1)
 ; GFX-SDAG-FAKE16-NEXT:    v_perm_b32 v0, v1, v0, 0x5040100
 ; GFX-SDAG-FAKE16-NEXT:    s_set_pc_i64 s[30:31]
 ;
@@ -182,13 +179,11 @@ define <2 x bfloat> @v_log2_fabs_v2bf16(<2 x bfloat> %in) {
 ; GFX-GISEL-FAKE16-NEXT:    s_wait_loadcnt_dscnt 0x0
 ; GFX-GISEL-FAKE16-NEXT:    s_wait_kmcnt 0x0
 ; GFX-GISEL-FAKE16-NEXT:    v_and_b32_e32 v0, 0x7fff7fff, v0
-; GFX-GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
-; GFX-GISEL-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX-GISEL-FAKE16-NEXT:    v_log_bf16_e32 v0, v0
-; GFX-GISEL-FAKE16-NEXT:    v_log_bf16_e32 v1, v1
+; GFX-GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_2) | instid1(TRANS32_DEP_1)
+; GFX-GISEL-FAKE16-NEXT:    v_log_bf16_e32 v1, v0
+; GFX-GISEL-FAKE16-NEXT:    v_log_bf16_e64 v0, v0 op_sel:[1,0]
 ; GFX-GISEL-FAKE16-NEXT:    v_nop
-; GFX-GISEL-FAKE16-NEXT:    s_delay_alu instid0(TRANS32_DEP_1)
-; GFX-GISEL-FAKE16-NEXT:    v_pack_b32_f16 v0, v0, v1
+; GFX-GISEL-FAKE16-NEXT:    v_pack_b32_f16 v0, v1, v0
 ; GFX-GISEL-FAKE16-NEXT:    s_set_pc_i64 s[30:31]
   %fabs = call <2 x bfloat> @llvm.fabs.v2bf16(<2 x bfloat> %in)
   %result = call <2 x bfloat> @llvm.log2.v2bf16(<2 x bfloat> %fabs)
@@ -210,11 +205,10 @@ define <2 x bfloat> @v_log2_fneg_fabs_v2bf16(<2 x bfloat> %in) {
 ; GFX-SDAG-FAKE16:       ; %bb.0:
 ; GFX-SDAG-FAKE16-NEXT:    s_wait_loadcnt_dscnt 0x0
 ; GFX-SDAG-FAKE16-NEXT:    s_wait_kmcnt 0x0
-; GFX-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
+; GFX-SDAG-FAKE16-NEXT:    v_log_bf16_e64 v1, -|v0| op_sel:[1,0]
 ; GFX-SDAG-FAKE16-NEXT:    v_log_bf16_e64 v0, -|v0|
-; GFX-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(TRANS32_DEP_1)
-; GFX-SDAG-FAKE16-NEXT:    v_log_bf16_e64 v1, -|v1|
 ; GFX-SDAG-FAKE16-NEXT:    v_nop
+; GFX-SDAG-FAKE16-NEXT:    s_delay_alu instid0(TRANS32_DEP_1)
 ; GFX-SDAG-FAKE16-NEXT:    v_perm_b32 v0, v1, v0, 0x5040100
 ; GFX-SDAG-FAKE16-NEXT:    s_set_pc_i64 s[30:31]
 ;
@@ -233,13 +227,11 @@ define <2 x bfloat> @v_log2_fneg_fabs_v2bf16(<2 x bfloat> %in) {
 ; GFX-GISEL-FAKE16-NEXT:    s_wait_loadcnt_dscnt 0x0
 ; GFX-GISEL-FAKE16-NEXT:    s_wait_kmcnt 0x0
 ; GFX-GISEL-FAKE16-NEXT:    v_or_b32_e32 v0, 0x80008000, v0
-; GFX-GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
-; GFX-GISEL-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX-GISEL-FAKE16-NEXT:    v_log_bf16_e32 v0, v0
-; GFX-GISEL-FAKE16-NEXT:    v_log_bf16_e32 v1, v1
+; GFX-GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_2) | instid1(TRANS32_DEP_1)
+; GFX-GISEL-FAKE16-NEXT:    v_log_bf16_e32 v1, v0
+; GFX-GISEL-FAKE16-NEXT:    v_log_bf16_e64 v0, v0 op_sel:[1,0]
 ; GFX-GISEL-FAKE16-NEXT:    v_nop
-; GFX-GISEL-FAKE16-NEXT:    s_delay_alu instid0(TRANS32_DEP_1)
-; GFX-GISEL-FAKE16-NEXT:    v_pack_b32_f16 v0, v0, v1
+; GFX-GISEL-FAKE16-NEXT:    v_pack_b32_f16 v0, v1, v0
 ; GFX-GISEL-FAKE16-NEXT:    s_set_pc_i64 s[30:31]
   %fabs = call <2 x bfloat> @llvm.fabs.v2bf16(<2 x bfloat> %in)
   %fneg.fabs = fneg <2 x bfloat> %fabs
@@ -262,11 +254,10 @@ define <2 x bfloat> @v_log2_fneg_v2bf16(<2 x bfloat> %in) {
 ; GFX-SDAG-FAKE16:       ; %bb.0:
 ; GFX-SDAG-FAKE16-NEXT:    s_wait_loadcnt_dscnt 0x0
 ; GFX-SDAG-FAKE16-NEXT:    s_wait_kmcnt 0x0
-; GFX-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
+; GFX-SDAG-FAKE16-NEXT:    v_log_bf16_e64 v1, -v0 op_sel:[1,0]
 ; GFX-SDAG-FAKE16-NEXT:    v_log_bf16_e64 v0, -v0
-; GFX-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(TRANS32_DEP_1)
-; GFX-SDAG-FAKE16-NEXT:    v_log_bf16_e64 v1, -v1
 ; GFX-SDAG-FAKE16-NEXT:    v_nop
+; GFX-SDAG-FAKE16-NEXT:    s_delay_alu instid0(TRANS32_DEP_1)
 ; GFX-SDAG-FAKE16-NEXT:    v_perm_b32 v0, v1, v0, 0x5040100
 ; GFX-SDAG-FAKE16-NEXT:    s_set_pc_i64 s[30:31]
 ;
@@ -285,13 +276,11 @@ define <2 x bfloat> @v_log2_fneg_v2bf16(<2 x bfloat> %in) {
 ; GFX-GISEL-FAKE16-NEXT:    s_wait_loadcnt_dscnt 0x0
 ; GFX-GISEL-FAKE16-NEXT:    s_wait_kmcnt 0x0
 ; GFX-GISEL-FAKE16-NEXT:    v_xor_b32_e32 v0, 0x80008000, v0
-; GFX-GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
-; GFX-GISEL-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX-GISEL-FAKE16-NEXT:    v_log_bf16_e32 v0, v0
-; GFX-GISEL-FAKE16-NEXT:    v_log_bf16_e32 v1, v1
+; GFX-GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_2) | instid1(TRANS32_DEP_1)
+; GFX-GISEL-FAKE16-NEXT:    v_log_bf16_e32 v1, v0
+; GFX-GISEL-FAKE16-NEXT:    v_log_bf16_e64 v0, v0 op_sel:[1,0]
 ; GFX-GISEL-FAKE16-NEXT:    v_nop
-; GFX-GISEL-FAKE16-NEXT:    s_delay_alu instid0(TRANS32_DEP_1)
-; GFX-GISEL-FAKE16-NEXT:    v_pack_b32_f16 v0, v0, v1
+; GFX-GISEL-FAKE16-NEXT:    v_pack_b32_f16 v0, v1, v0
 ; GFX-GISEL-FAKE16-NEXT:    s_set_pc_i64 s[30:31]
   %fneg = fneg <2 x bfloat> %in
   %result = call <2 x bfloat> @llvm.log2.v2bf16(<2 x bfloat> %fneg)
@@ -313,11 +302,10 @@ define <2 x bfloat> @v_log2_v2bf16_fast(<2 x bfloat> %in) {
 ; GFX-SDAG-FAKE16:       ; %bb.0:
 ; GFX-SDAG-FAKE16-NEXT:    s_wait_loadcnt_dscnt 0x0
 ; GFX-SDAG-FAKE16-NEXT:    s_wait_kmcnt 0x0
-; GFX-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
+; GFX-SDAG-FAKE16-NEXT:    v_log_bf16_e64 v1, v0 op_sel:[1,0]
 ; GFX-SDAG-FAKE16-NEXT:    v_log_bf16_e32 v0, v0
-; GFX-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(TRANS32_DEP_1)
-; GFX-SDAG-FAKE16-NEXT:    v_log_bf16_e32 v1, v1
 ; GFX-SDAG-FAKE16-NEXT:    v_nop
+; GFX-SDAG-FAKE16-NEXT:    s_delay_alu instid0(TRANS32_DEP_1)
 ; GFX-SDAG-FAKE16-NEXT:    v_perm_b32 v0, v1, v0, 0x5040100
 ; GFX-SDAG-FAKE16-NEXT:    s_set_pc_i64 s[30:31]
 ;
@@ -333,12 +321,11 @@ define <2 x bfloat> @v_log2_v2bf16_fast(<2 x bfloat> %in) {
 ; GFX-GISEL-FAKE16:       ; %bb.0:
 ; GFX-GISEL-FAKE16-NEXT:    s_wait_loadcnt_dscnt 0x0
 ; GFX-GISEL-FAKE16-NEXT:    s_wait_kmcnt 0x0
-; GFX-GISEL-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX-GISEL-FAKE16-NEXT:    v_log_bf16_e32 v0, v0
-; GFX-GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(TRANS32_DEP_1)
-; GFX-GISEL-FAKE16-NEXT:    v_log_bf16_e32 v1, v1
+; GFX-GISEL-FAKE16-NEXT:    v_log_bf16_e32 v1, v0
+; GFX-GISEL-FAKE16-NEXT:    v_log_bf16_e64 v0, v0 op_sel:[1,0]
 ; GFX-GISEL-FAKE16-NEXT:    v_nop
-; GFX-GISEL-FAKE16-NEXT:    v_pack_b32_f16 v0, v0, v1
+; GFX-GISEL-FAKE16-NEXT:    s_delay_alu instid0(TRANS32_DEP_1)
+; GFX-GISEL-FAKE16-NEXT:    v_pack_b32_f16 v0, v1, v0
 ; GFX-GISEL-FAKE16-NEXT:    s_set_pc_i64 s[30:31]
   %result = call fast <2 x bfloat> @llvm.log2.v2bf16(<2 x bfloat> %in)
   ret <2 x bfloat> %result

--- a/llvm/test/CodeGen/AMDGPU/llvm.sqrt.bf16.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.sqrt.bf16.ll
@@ -163,11 +163,10 @@ define amdgpu_kernel void @sqrt_v2bf16(ptr addrspace(1) %r, ptr addrspace(1) %a)
 ; GFX12-FAKE16-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX12-FAKE16-SDAG-NEXT:    v_sqrt_bf16_e32 v1, v0
 ; GFX12-FAKE16-SDAG-NEXT:    v_nop
-; GFX12-FAKE16-SDAG-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
-; GFX12-FAKE16-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(TRANS32_DEP_2)
-; GFX12-FAKE16-SDAG-NEXT:    v_sqrt_bf16_e32 v0, v0
+; GFX12-FAKE16-SDAG-NEXT:    s_delay_alu instid0(TRANS32_DEP_1) | instskip(SKIP_2) | instid1(TRANS32_DEP_1)
 ; GFX12-FAKE16-SDAG-NEXT:    v_and_b32_e32 v1, 0xffff, v1
-; GFX12-FAKE16-SDAG-NEXT:    s_delay_alu instid0(TRANS32_DEP_1) | instid1(VALU_DEP_1)
+; GFX12-FAKE16-SDAG-NEXT:    v_sqrt_bf16_e64 v0, v0 op_sel:[1,0]
+; GFX12-FAKE16-SDAG-NEXT:    v_nop
 ; GFX12-FAKE16-SDAG-NEXT:    v_lshl_or_b32 v0, v0, 16, v1
 ; GFX12-FAKE16-SDAG-NEXT:    buffer_store_b32 v0, off, s[4:7], null
 ; GFX12-FAKE16-SDAG-NEXT:    s_endpgm

--- a/llvm/test/CodeGen/AMDGPU/load-atomic-flat.ll
+++ b/llvm/test/CodeGen/AMDGPU/load-atomic-flat.ll
@@ -121,8 +121,7 @@ define amdgpu_cs void @atomic_load_i16x2_monotonic_agent(ptr addrspace(0) %p, pt
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    flat_load_dword v0, v[0:1] glc dlc
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-; GFX10-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX10-NEXT:    v_add_nc_u16 v0, v0, v1
+; GFX10-NEXT:    v_add_nc_u16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX10-NEXT:    global_store_short v[2:3], v0, off
 ; GFX10-NEXT:    s_endpgm
 ;
@@ -266,10 +265,9 @@ define amdgpu_cs void @atomic_load_i16x4_monotonic_agent(ptr addrspace(0) %p, pt
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    flat_load_dwordx2 v[0:1], v[0:1] glc dlc
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-; GFX10-NEXT:    v_lshrrev_b32_e32 v4, 16, v0
-; GFX10-NEXT:    v_lshrrev_b32_e32 v5, 16, v1
-; GFX10-NEXT:    v_add_nc_u16 v0, v0, v4
-; GFX10-NEXT:    v_mad_u16 v0, v1, v5, v0
+; GFX10-NEXT:    v_lshrrev_b32_e32 v4, 16, v1
+; GFX10-NEXT:    v_add_nc_u16 v0, v0, v0 op_sel:[0,1,0]
+; GFX10-NEXT:    v_mad_u16 v0, v1, v4, v0
 ; GFX10-NEXT:    global_store_short v[2:3], v0, off
 ; GFX10-NEXT:    s_endpgm
 ;
@@ -436,8 +434,7 @@ define amdgpu_cs void @atomic_load_i16x2_monotonic_agent_offset_min(ptr addrspac
 ; GFX10-NEXT:    v_add_co_ci_u32_e32 v1, vcc_lo, -1, v1, vcc_lo
 ; GFX10-NEXT:    flat_load_dword v0, v[0:1] glc dlc
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-; GFX10-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX10-NEXT:    v_add_nc_u16 v0, v0, v1
+; GFX10-NEXT:    v_add_nc_u16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX10-NEXT:    global_store_short v[2:3], v0, off
 ; GFX10-NEXT:    s_endpgm
 ;
@@ -505,8 +502,7 @@ define amdgpu_cs void @atomic_load_i16x2_monotonic_agent_offset_max(ptr addrspac
 ; GFX10-NEXT:    v_add_co_ci_u32_e32 v1, vcc_lo, 0, v1, vcc_lo
 ; GFX10-NEXT:    flat_load_dword v0, v[0:1] glc dlc
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-; GFX10-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX10-NEXT:    v_add_nc_u16 v0, v0, v1
+; GFX10-NEXT:    v_add_nc_u16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX10-NEXT:    global_store_short v[2:3], v0, off
 ; GFX10-NEXT:    s_endpgm
 ;

--- a/llvm/test/CodeGen/AMDGPU/load-atomic-global.ll
+++ b/llvm/test/CodeGen/AMDGPU/load-atomic-global.ll
@@ -336,8 +336,7 @@ define amdgpu_cs void @atomic_load_i16x2_monotonic_agent(ptr addrspace(1) %p, pt
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    global_load_dword v0, v[0:1], off glc dlc
 ; GFX10-NEXT:    s_waitcnt vmcnt(0)
-; GFX10-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX10-NEXT:    v_add_nc_u16 v0, v0, v1
+; GFX10-NEXT:    v_add_nc_u16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX10-NEXT:    global_store_short v[2:3], v0, off
 ; GFX10-NEXT:    s_endpgm
 ;
@@ -400,8 +399,7 @@ define amdgpu_cs void @atomic_load_i16x2_seq_cst_agent(ptr addrspace(1) %p, ptr 
 ; GFX10-NEXT:    s_waitcnt vmcnt(0)
 ; GFX10-NEXT:    buffer_gl1_inv
 ; GFX10-NEXT:    buffer_gl0_inv
-; GFX10-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX10-NEXT:    v_add_nc_u16 v0, v0, v1
+; GFX10-NEXT:    v_add_nc_u16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX10-NEXT:    global_store_short v[2:3], v0, off
 ; GFX10-NEXT:    s_endpgm
 ;
@@ -467,8 +465,7 @@ define amdgpu_cs void @atomic_load_i16x2_monotonic_wavefront(ptr addrspace(1) %p
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    global_load_dword v0, v[0:1], off
 ; GFX10-NEXT:    s_waitcnt vmcnt(0)
-; GFX10-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX10-NEXT:    v_add_nc_u16 v0, v0, v1
+; GFX10-NEXT:    v_add_nc_u16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX10-NEXT:    global_store_short v[2:3], v0, off
 ; GFX10-NEXT:    s_endpgm
 ;
@@ -785,10 +782,9 @@ define amdgpu_cs void @atomic_load_i16x4_monotonic_agent(ptr addrspace(1) %p, pt
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    global_load_dwordx2 v[0:1], v[0:1], off glc dlc
 ; GFX10-NEXT:    s_waitcnt vmcnt(0)
-; GFX10-NEXT:    v_lshrrev_b32_e32 v4, 16, v0
-; GFX10-NEXT:    v_lshrrev_b32_e32 v5, 16, v1
-; GFX10-NEXT:    v_add_nc_u16 v0, v0, v4
-; GFX10-NEXT:    v_mad_u16 v0, v1, v5, v0
+; GFX10-NEXT:    v_lshrrev_b32_e32 v4, 16, v1
+; GFX10-NEXT:    v_add_nc_u16 v0, v0, v0 op_sel:[0,1,0]
+; GFX10-NEXT:    v_mad_u16 v0, v1, v4, v0
 ; GFX10-NEXT:    global_store_short v[2:3], v0, off
 ; GFX10-NEXT:    s_endpgm
 ;
@@ -865,10 +861,9 @@ define amdgpu_cs void @atomic_load_i16x4_seq_cst_agent(ptr addrspace(1) %p, ptr 
 ; GFX10-NEXT:    s_waitcnt vmcnt(0)
 ; GFX10-NEXT:    buffer_gl1_inv
 ; GFX10-NEXT:    buffer_gl0_inv
-; GFX10-NEXT:    v_lshrrev_b32_e32 v4, 16, v0
-; GFX10-NEXT:    v_lshrrev_b32_e32 v5, 16, v1
-; GFX10-NEXT:    v_add_nc_u16 v0, v0, v4
-; GFX10-NEXT:    v_mad_u16 v0, v1, v5, v0
+; GFX10-NEXT:    v_lshrrev_b32_e32 v4, 16, v1
+; GFX10-NEXT:    v_add_nc_u16 v0, v0, v0 op_sel:[0,1,0]
+; GFX10-NEXT:    v_mad_u16 v0, v1, v4, v0
 ; GFX10-NEXT:    global_store_short v[2:3], v0, off
 ; GFX10-NEXT:    s_endpgm
 ;
@@ -948,10 +943,9 @@ define amdgpu_cs void @atomic_load_i16x4_monotonic_wavefront(ptr addrspace(1) %p
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    global_load_dwordx2 v[0:1], v[0:1], off
 ; GFX10-NEXT:    s_waitcnt vmcnt(0)
-; GFX10-NEXT:    v_lshrrev_b32_e32 v4, 16, v0
-; GFX10-NEXT:    v_lshrrev_b32_e32 v5, 16, v1
-; GFX10-NEXT:    v_add_nc_u16 v0, v0, v4
-; GFX10-NEXT:    v_mad_u16 v0, v1, v5, v0
+; GFX10-NEXT:    v_lshrrev_b32_e32 v4, 16, v1
+; GFX10-NEXT:    v_add_nc_u16 v0, v0, v0 op_sel:[0,1,0]
+; GFX10-NEXT:    v_mad_u16 v0, v1, v4, v0
 ; GFX10-NEXT:    global_store_short v[2:3], v0, off
 ; GFX10-NEXT:    s_endpgm
 ;
@@ -1117,8 +1111,7 @@ define amdgpu_cs void @atomic_load_i16x2_monotonic_agent_offset_1(ptr addrspace(
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    global_load_dword v0, v[0:1], off offset:1 glc dlc
 ; GFX10-NEXT:    s_waitcnt vmcnt(0)
-; GFX10-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX10-NEXT:    v_add_nc_u16 v0, v0, v1
+; GFX10-NEXT:    v_add_nc_u16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX10-NEXT:    global_store_short v[2:3], v0, off
 ; GFX10-NEXT:    s_endpgm
 ;
@@ -1181,8 +1174,7 @@ define amdgpu_cs void @atomic_load_i16x2_monotonic_agent_offset_max(ptr addrspac
 ; GFX10-SDAG-NEXT:    v_add_co_ci_u32_e32 v1, vcc_lo, 0, v1, vcc_lo
 ; GFX10-SDAG-NEXT:    global_load_dword v0, v[0:1], off offset:2047 glc dlc
 ; GFX10-SDAG-NEXT:    s_waitcnt vmcnt(0)
-; GFX10-SDAG-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX10-SDAG-NEXT:    v_add_nc_u16 v0, v0, v1
+; GFX10-SDAG-NEXT:    v_add_nc_u16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX10-SDAG-NEXT:    global_store_short v[2:3], v0, off
 ; GFX10-SDAG-NEXT:    s_endpgm
 ;
@@ -1192,8 +1184,7 @@ define amdgpu_cs void @atomic_load_i16x2_monotonic_agent_offset_max(ptr addrspac
 ; GFX10-GISEL-NEXT:    v_add_co_ci_u32_e32 v1, vcc_lo, 0, v1, vcc_lo
 ; GFX10-GISEL-NEXT:    global_load_dword v0, v[0:1], off glc dlc
 ; GFX10-GISEL-NEXT:    s_waitcnt vmcnt(0)
-; GFX10-GISEL-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX10-GISEL-NEXT:    v_add_nc_u16 v0, v0, v1
+; GFX10-GISEL-NEXT:    v_add_nc_u16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX10-GISEL-NEXT:    global_store_short v[2:3], v0, off
 ; GFX10-GISEL-NEXT:    s_endpgm
 ;

--- a/llvm/test/CodeGen/AMDGPU/load-atomic-local.ll
+++ b/llvm/test/CodeGen/AMDGPU/load-atomic-local.ll
@@ -329,8 +329,7 @@ define amdgpu_cs void @atomic_load_i16x2_monotonic_agent(ptr addrspace(3) %p, pt
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    ds_read_b32 v0, v0
 ; GFX10-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX10-NEXT:    v_lshrrev_b32_e32 v2, 16, v0
-; GFX10-NEXT:    v_add_nc_u16 v0, v0, v2
+; GFX10-NEXT:    v_add_nc_u16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX10-NEXT:    ds_write_b16 v1, v0
 ; GFX10-NEXT:    s_endpgm
 ;
@@ -391,8 +390,7 @@ define amdgpu_cs void @atomic_load_i16x2_seq_cst_agent(ptr addrspace(3) %p, ptr 
 ; GFX10-NEXT:    ds_read_b32 v0, v0
 ; GFX10-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX10-NEXT:    buffer_gl0_inv
-; GFX10-NEXT:    v_lshrrev_b32_e32 v2, 16, v0
-; GFX10-NEXT:    v_add_nc_u16 v0, v0, v2
+; GFX10-NEXT:    v_add_nc_u16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX10-NEXT:    ds_write_b16 v1, v0
 ; GFX10-NEXT:    s_endpgm
 ;
@@ -456,8 +454,7 @@ define amdgpu_cs void @atomic_load_i16x2_monotonic_wavefront(ptr addrspace(3) %p
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    ds_read_b32 v0, v0
 ; GFX10-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX10-NEXT:    v_lshrrev_b32_e32 v2, 16, v0
-; GFX10-NEXT:    v_add_nc_u16 v0, v0, v2
+; GFX10-NEXT:    v_add_nc_u16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX10-NEXT:    ds_write_b16 v1, v0
 ; GFX10-NEXT:    s_endpgm
 ;
@@ -770,10 +767,9 @@ define amdgpu_cs void @atomic_load_i16x4_monotonic_agent(ptr addrspace(3) %p, pt
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    ds_read_b64 v[2:3], v0
 ; GFX10-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX10-NEXT:    v_lshrrev_b32_e32 v0, 16, v2
-; GFX10-NEXT:    v_lshrrev_b32_e32 v4, 16, v3
-; GFX10-NEXT:    v_add_nc_u16 v0, v2, v0
-; GFX10-NEXT:    v_mad_u16 v0, v3, v4, v0
+; GFX10-NEXT:    v_lshrrev_b32_e32 v0, 16, v3
+; GFX10-NEXT:    v_add_nc_u16 v2, v2, v2 op_sel:[0,1,0]
+; GFX10-NEXT:    v_mad_u16 v0, v3, v0, v2
 ; GFX10-NEXT:    ds_write_b16 v1, v0
 ; GFX10-NEXT:    s_endpgm
 ;
@@ -848,10 +844,9 @@ define amdgpu_cs void @atomic_load_i16x4_seq_cst_agent(ptr addrspace(3) %p, ptr 
 ; GFX10-NEXT:    ds_read_b64 v[2:3], v0
 ; GFX10-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX10-NEXT:    buffer_gl0_inv
-; GFX10-NEXT:    v_lshrrev_b32_e32 v0, 16, v2
-; GFX10-NEXT:    v_lshrrev_b32_e32 v4, 16, v3
-; GFX10-NEXT:    v_add_nc_u16 v0, v2, v0
-; GFX10-NEXT:    v_mad_u16 v0, v3, v4, v0
+; GFX10-NEXT:    v_lshrrev_b32_e32 v0, 16, v3
+; GFX10-NEXT:    v_add_nc_u16 v2, v2, v2 op_sel:[0,1,0]
+; GFX10-NEXT:    v_mad_u16 v0, v3, v0, v2
 ; GFX10-NEXT:    ds_write_b16 v1, v0
 ; GFX10-NEXT:    s_endpgm
 ;
@@ -929,10 +924,9 @@ define amdgpu_cs void @atomic_load_i16x4_monotonic_wavefront(ptr addrspace(3) %p
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    ds_read_b64 v[2:3], v0
 ; GFX10-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX10-NEXT:    v_lshrrev_b32_e32 v0, 16, v2
-; GFX10-NEXT:    v_lshrrev_b32_e32 v4, 16, v3
-; GFX10-NEXT:    v_add_nc_u16 v0, v2, v0
-; GFX10-NEXT:    v_mad_u16 v0, v3, v4, v0
+; GFX10-NEXT:    v_lshrrev_b32_e32 v0, 16, v3
+; GFX10-NEXT:    v_add_nc_u16 v2, v2, v2 op_sel:[0,1,0]
+; GFX10-NEXT:    v_mad_u16 v0, v3, v0, v2
 ; GFX10-NEXT:    ds_write_b16 v1, v0
 ; GFX10-NEXT:    s_endpgm
 ;
@@ -1086,8 +1080,7 @@ define amdgpu_cs void @atomic_load_i16x2_monotonic_agent_offset_1(ptr addrspace(
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    ds_read_b32 v0, v0 offset:1
 ; GFX10-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX10-NEXT:    v_lshrrev_b32_e32 v2, 16, v0
-; GFX10-NEXT:    v_add_nc_u16 v0, v0, v2
+; GFX10-NEXT:    v_add_nc_u16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX10-NEXT:    ds_write_b16 v1, v0
 ; GFX10-NEXT:    s_endpgm
 ;
@@ -1148,8 +1141,7 @@ define amdgpu_cs void @atomic_load_i16x2_monotonic_agent_offset_max(ptr addrspac
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    ds_read_b32 v0, v0 offset:4095
 ; GFX10-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX10-NEXT:    v_lshrrev_b32_e32 v2, 16, v0
-; GFX10-NEXT:    v_add_nc_u16 v0, v0, v2
+; GFX10-NEXT:    v_add_nc_u16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX10-NEXT:    ds_write_b16 v1, v0
 ; GFX10-NEXT:    s_endpgm
 ;

--- a/llvm/test/CodeGen/AMDGPU/permute_i8.ll
+++ b/llvm/test/CodeGen/AMDGPU/permute_i8.ll
@@ -567,11 +567,9 @@ define hidden void @addUsesOr(ptr addrspace(1) %in0, ptr addrspace(1) %in1, i8 %
 ; GFX10-NEXT:    v_lshrrev_b32_e32 v0, 24, v4
 ; GFX10-NEXT:    s_waitcnt vmcnt(0)
 ; GFX10-NEXT:    v_lshrrev_b32_e32 v1, 24, v7
-; GFX10-NEXT:    v_lshrrev_b32_e32 v2, 16, v4
-; GFX10-NEXT:    v_lshrrev_b32_e32 v3, 16, v7
+; GFX10-NEXT:    v_add_nc_u16 v2, v4, v7 op_sel:[1,1,0]
 ; GFX10-NEXT:    v_add_nc_u16 v0, v0, v1
 ; GFX10-NEXT:    v_lshrrev_b16 v1, 8, v7
-; GFX10-NEXT:    v_add_nc_u16 v2, v2, v3
 ; GFX10-NEXT:    v_lshlrev_b16 v0, 8, v0
 ; GFX10-NEXT:    v_add_nc_u16 v1, v4, v1
 ; GFX10-NEXT:    v_or_b32_sdwa v0, v2, v0 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
@@ -683,12 +681,11 @@ define hidden void @add(ptr addrspace(1) %in0, ptr addrspace(1) %in1, i8 %elt, p
 ; GFX10-NEXT:    s_waitcnt vmcnt(0)
 ; GFX10-NEXT:    v_lshrrev_b32_e32 v1, 24, v7
 ; GFX10-NEXT:    v_lshrrev_b16 v2, 8, v7
-; GFX10-NEXT:    v_lshrrev_b32_e32 v3, 16, v7
-; GFX10-NEXT:    v_lshrrev_b16 v4, 8, v4
+; GFX10-NEXT:    v_lshrrev_b16 v3, 8, v4
 ; GFX10-NEXT:    v_add_nc_u16 v1, v7, v1
 ; GFX10-NEXT:    v_add_nc_u16 v0, v0, v2
-; GFX10-NEXT:    v_add_nc_u16 v2, v2, v3
-; GFX10-NEXT:    v_add_nc_u16 v3, v4, v7
+; GFX10-NEXT:    v_add_nc_u16 v2, v2, v7 op_sel:[0,1,0]
+; GFX10-NEXT:    v_add_nc_u16 v3, v3, v7
 ; GFX10-NEXT:    v_lshlrev_b16 v1, 8, v1
 ; GFX10-NEXT:    v_lshlrev_b16 v0, 8, v0
 ; GFX10-NEXT:    v_or_b32_sdwa v1, v2, v1 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
@@ -917,12 +914,11 @@ define hidden void @add_store_div(ptr addrspace(1) %in0, ptr addrspace(1) %in1, 
 ; GFX10-NEXT:    s_waitcnt vmcnt(0)
 ; GFX10-NEXT:    v_lshrrev_b32_e32 v1, 24, v9
 ; GFX10-NEXT:    v_lshrrev_b16 v2, 8, v9
-; GFX10-NEXT:    v_lshrrev_b32_e32 v3, 16, v9
-; GFX10-NEXT:    v_lshrrev_b16 v10, 8, v4
+; GFX10-NEXT:    v_lshrrev_b16 v3, 8, v4
 ; GFX10-NEXT:    v_add_nc_u16 v1, v9, v1
 ; GFX10-NEXT:    v_add_nc_u16 v0, v0, v2
-; GFX10-NEXT:    v_add_nc_u16 v2, v2, v3
-; GFX10-NEXT:    v_add_nc_u16 v3, v10, v9
+; GFX10-NEXT:    v_add_nc_u16 v2, v2, v9 op_sel:[0,1,0]
+; GFX10-NEXT:    v_add_nc_u16 v3, v3, v9
 ; GFX10-NEXT:    v_lshlrev_b16 v1, 8, v1
 ; GFX10-NEXT:    v_lshlrev_b16 v0, 8, v0
 ; GFX10-NEXT:    v_or_b32_sdwa v1, v2, v1 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
@@ -1222,9 +1218,8 @@ define hidden void @ive_store_div(ptr addrspace(1) %in0, ptr addrspace(1) %in1, 
 ; GFX10-NEXT:    v_add_co_ci_u32_e32 v3, vcc_lo, 0, v3, vcc_lo
 ; GFX10-NEXT:    global_load_dword v9, v[0:1], off
 ; GFX10-NEXT:    global_load_dword v10, v[2:3], off
-; GFX10-NEXT:    v_mov_b32_e32 v0, 16
 ; GFX10-NEXT:    s_waitcnt vmcnt(1)
-; GFX10-NEXT:    v_lshrrev_b32_sdwa v0, v0, v9 dst_sel:BYTE_1 dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:DWORD
+; GFX10-NEXT:    v_lshlrev_b16 v0, 8, v9 op_sel:[0,1,0]
 ; GFX10-NEXT:    s_waitcnt vmcnt(0)
 ; GFX10-NEXT:    v_perm_b32 v1, v10, v4, 0xc0c0006
 ; GFX10-NEXT:    v_or_b32_sdwa v0, v9, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
@@ -1357,12 +1352,11 @@ define hidden void @mul_store_div(ptr addrspace(1) %in0, ptr addrspace(1) %in1, 
 ; GFX10-NEXT:    v_lshrrev_b16 v0, 8, v4
 ; GFX10-NEXT:    s_waitcnt vmcnt(0)
 ; GFX10-NEXT:    v_lshrrev_b32_e32 v1, 24, v9
-; GFX10-NEXT:    v_lshrrev_b32_e32 v2, 16, v9
-; GFX10-NEXT:    v_lshrrev_b16 v3, 8, v9
-; GFX10-NEXT:    v_mul_lo_u16 v1, v2, v1
-; GFX10-NEXT:    v_mul_lo_u16 v0, v0, v3
+; GFX10-NEXT:    v_lshrrev_b16 v2, 8, v9
 ; GFX10-NEXT:    v_mul_lo_u16 v3, v4, v9
-; GFX10-NEXT:    v_mul_lo_u16 v2, v9, v2
+; GFX10-NEXT:    v_mul_lo_u16 v1, v9, v1 op_sel:[1,0,0]
+; GFX10-NEXT:    v_mul_lo_u16 v0, v0, v2
+; GFX10-NEXT:    v_mul_lo_u16 v2, v9, v9 op_sel:[0,1,0]
 ; GFX10-NEXT:    v_lshlrev_b16 v1, 8, v1
 ; GFX10-NEXT:    v_lshlrev_b16 v0, 8, v0
 ; GFX10-NEXT:    v_or_b32_sdwa v1, v2, v1 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
@@ -1421,22 +1415,21 @@ define hidden void @or_store_div(ptr addrspace(1) %in0, ptr addrspace(1) %in1, i
 ; GFX10-NEXT:    v_add_co_ci_u32_e32 v3, vcc_lo, 0, v3, vcc_lo
 ; GFX10-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v4
 ; GFX10-NEXT:    v_add_co_ci_u32_e32 v1, vcc_lo, 0, v1, vcc_lo
-; GFX10-NEXT:    global_load_dword v4, v[2:3], off
-; GFX10-NEXT:    global_load_dword v9, v[0:1], off
-; GFX10-NEXT:    v_mov_b32_e32 v0, 16
-; GFX10-NEXT:    v_bfrev_b32_e32 v2, 4.0
+; GFX10-NEXT:    global_load_dword v2, v[2:3], off
+; GFX10-NEXT:    v_bfrev_b32_e32 v4, 4.0
+; GFX10-NEXT:    global_load_dword v0, v[0:1], off
 ; GFX10-NEXT:    s_waitcnt vmcnt(1)
-; GFX10-NEXT:    v_lshlrev_b16 v1, 8, v4
-; GFX10-NEXT:    v_lshrrev_b32_sdwa v0, v0, v4 dst_sel:BYTE_1 dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:DWORD
+; GFX10-NEXT:    v_lshlrev_b16 v1, 8, v2 op_sel:[0,1,0]
+; GFX10-NEXT:    v_lshlrev_b16 v3, 8, v2
+; GFX10-NEXT:    v_or_b32_sdwa v1, v2, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_1 src1_sel:DWORD
 ; GFX10-NEXT:    s_waitcnt vmcnt(0)
-; GFX10-NEXT:    v_or_b32_sdwa v1, v9, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_1 src1_sel:DWORD
-; GFX10-NEXT:    v_or_b32_sdwa v0, v4, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_1 src1_sel:DWORD
-; GFX10-NEXT:    v_or_b32_e32 v1, 0x201, v1
-; GFX10-NEXT:    v_or_b32_sdwa v0, v0, v2 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:DWORD
-; GFX10-NEXT:    v_or_b32_sdwa v0, v0, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:WORD_0
-; GFX10-NEXT:    v_perm_b32 v1, v9, v4, 0x2010005
-; GFX10-NEXT:    global_store_dword v[5:6], v0, off
-; GFX10-NEXT:    global_store_dword v[7:8], v1, off
+; GFX10-NEXT:    v_or_b32_sdwa v3, v0, v3 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_1 src1_sel:DWORD
+; GFX10-NEXT:    v_perm_b32 v0, v0, v2, 0x2010005
+; GFX10-NEXT:    v_or_b32_sdwa v1, v1, v4 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:DWORD
+; GFX10-NEXT:    v_or_b32_e32 v3, 0x201, v3
+; GFX10-NEXT:    v_or_b32_sdwa v1, v1, v3 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:WORD_0
+; GFX10-NEXT:    global_store_dword v[5:6], v1, off
+; GFX10-NEXT:    global_store_dword v[7:8], v0, off
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: or_store_div:
@@ -1599,14 +1592,12 @@ define hidden void @sext_store_div(ptr addrspace(1) %in0, ptr addrspace(1) %in1,
 ; GFX10-NEXT:    global_load_dword v4, v[2:3], off
 ; GFX10-NEXT:    global_load_dword v9, v[0:1], off
 ; GFX10-NEXT:    s_waitcnt vmcnt(1)
-; GFX10-NEXT:    v_lshrrev_b32_e32 v0, 16, v4
+; GFX10-NEXT:    v_ashrrev_i16 v0, 8, v4 op_sel:[0,1,0]
+; GFX10-NEXT:    v_ashrrev_i16 v1, 8, v4
 ; GFX10-NEXT:    s_waitcnt vmcnt(0)
-; GFX10-NEXT:    v_lshrrev_b32_e32 v1, 16, v9
-; GFX10-NEXT:    v_ashrrev_i16 v2, 8, v4
-; GFX10-NEXT:    v_ashrrev_i16 v0, 8, v0
-; GFX10-NEXT:    v_ashrrev_i16 v3, 8, v1
-; GFX10-NEXT:    v_perm_b32 v1, v0, v2, 0x5040100
-; GFX10-NEXT:    v_perm_b32 v0, v3, v3, 0x5040100
+; GFX10-NEXT:    v_ashrrev_i16 v2, 8, v9 op_sel:[0,1,0]
+; GFX10-NEXT:    v_perm_b32 v1, v0, v1, 0x5040100
+; GFX10-NEXT:    v_perm_b32 v0, v2, v2, 0x5040100
 ; GFX10-NEXT:    v_perm_b32 v2, v9, v4, 0x3010707
 ; GFX10-NEXT:    global_store_dwordx2 v[7:8], v[0:1], off
 ; GFX10-NEXT:    global_store_dword v[5:6], v2, off
@@ -1927,19 +1918,18 @@ define hidden void @sub_store_div(ptr addrspace(1) %in0, ptr addrspace(1) %in1, 
 ; GFX10-NEXT:    global_load_dword v0, v[0:1], off
 ; GFX10-NEXT:    s_waitcnt vmcnt(1)
 ; GFX10-NEXT:    v_lshrrev_b32_e32 v1, 24, v2
-; GFX10-NEXT:    v_lshrrev_b32_e32 v3, 16, v2
-; GFX10-NEXT:    v_lshrrev_b16 v4, 8, v2
-; GFX10-NEXT:    v_sub_nc_u16 v9, v3, v1
+; GFX10-NEXT:    v_lshrrev_b16 v3, 8, v2
+; GFX10-NEXT:    v_sub_nc_u16 v4, v2, v1 op_sel:[1,0,0]
 ; GFX10-NEXT:    s_waitcnt vmcnt(0)
-; GFX10-NEXT:    v_sub_nc_u16 v4, v0, v4
-; GFX10-NEXT:    v_sub_nc_u16 v3, v1, v3
+; GFX10-NEXT:    v_sub_nc_u16 v3, v0, v3
+; GFX10-NEXT:    v_sub_nc_u16 v9, v1, v2 op_sel:[0,1,0]
 ; GFX10-NEXT:    v_sub_nc_u16 v1, v1, v2
 ; GFX10-NEXT:    v_perm_b32 v0, v2, v0, 0x6070007
-; GFX10-NEXT:    v_lshlrev_b16 v9, 8, v9
 ; GFX10-NEXT:    v_lshlrev_b16 v4, 8, v4
-; GFX10-NEXT:    v_or_b32_sdwa v3, v3, v9 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
-; GFX10-NEXT:    v_or_b32_sdwa v1, v1, v4 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
-; GFX10-NEXT:    v_or_b32_sdwa v1, v3, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:WORD_0
+; GFX10-NEXT:    v_lshlrev_b16 v3, 8, v3
+; GFX10-NEXT:    v_or_b32_sdwa v4, v9, v4 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
+; GFX10-NEXT:    v_or_b32_sdwa v1, v1, v3 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
+; GFX10-NEXT:    v_or_b32_sdwa v1, v4, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:WORD_0
 ; GFX10-NEXT:    global_store_dword v[5:6], v1, off
 ; GFX10-NEXT:    global_store_dword v[7:8], v0, off
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]

--- a/llvm/test/CodeGen/AMDGPU/reduction.ll
+++ b/llvm/test/CodeGen/AMDGPU/reduction.ll
@@ -300,13 +300,10 @@ define i16 @reduction_umin_v8i16_woslp(<8 x i16> %vec8) {
 ; GFX9-LABEL: reduction_umin_v8i16_woslp:
 ; GFX9:       ; %bb.0: ; %entry
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-NEXT:    v_lshrrev_b32_e32 v4, 16, v1
 ; GFX9-NEXT:    v_min_u16_sdwa v0, v0, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:DWORD
-; GFX9-NEXT:    v_lshrrev_b32_e32 v5, 16, v2
-; GFX9-NEXT:    v_min3_u16 v0, v4, v1, v0
-; GFX9-NEXT:    v_lshrrev_b32_e32 v6, 16, v3
-; GFX9-NEXT:    v_min3_u16 v0, v5, v2, v0
-; GFX9-NEXT:    v_min3_u16 v0, v6, v3, v0
+; GFX9-NEXT:    v_min3_u16 v0, v1, v1, v0 op_sel:[1,0,0,0]
+; GFX9-NEXT:    v_min3_u16 v0, v2, v2, v0 op_sel:[1,0,0,0]
+; GFX9-NEXT:    v_min3_u16 v0, v3, v3, v0 op_sel:[1,0,0,0]
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; VI-LABEL: reduction_umin_v8i16_woslp:
@@ -405,21 +402,14 @@ define i16 @reduction_smin_v16i16_woslp(<16 x i16> %vec16) {
 ; GFX9-LABEL: reduction_smin_v16i16_woslp:
 ; GFX9:       ; %bb.0: ; %entry
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-NEXT:    v_lshrrev_b32_e32 v8, 16, v1
 ; GFX9-NEXT:    v_min_i16_sdwa v0, v0, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:DWORD
-; GFX9-NEXT:    v_lshrrev_b32_e32 v9, 16, v2
-; GFX9-NEXT:    v_min3_i16 v0, v8, v1, v0
-; GFX9-NEXT:    v_lshrrev_b32_e32 v10, 16, v3
-; GFX9-NEXT:    v_min3_i16 v0, v9, v2, v0
-; GFX9-NEXT:    v_lshrrev_b32_e32 v11, 16, v4
-; GFX9-NEXT:    v_min3_i16 v0, v10, v3, v0
-; GFX9-NEXT:    v_lshrrev_b32_e32 v12, 16, v5
-; GFX9-NEXT:    v_min3_i16 v0, v11, v4, v0
-; GFX9-NEXT:    v_lshrrev_b32_e32 v13, 16, v6
-; GFX9-NEXT:    v_min3_i16 v0, v12, v5, v0
-; GFX9-NEXT:    v_lshrrev_b32_e32 v14, 16, v7
-; GFX9-NEXT:    v_min3_i16 v0, v13, v6, v0
-; GFX9-NEXT:    v_min3_i16 v0, v14, v7, v0
+; GFX9-NEXT:    v_min3_i16 v0, v1, v1, v0 op_sel:[1,0,0,0]
+; GFX9-NEXT:    v_min3_i16 v0, v2, v2, v0 op_sel:[1,0,0,0]
+; GFX9-NEXT:    v_min3_i16 v0, v3, v3, v0 op_sel:[1,0,0,0]
+; GFX9-NEXT:    v_min3_i16 v0, v4, v4, v0 op_sel:[1,0,0,0]
+; GFX9-NEXT:    v_min3_i16 v0, v5, v5, v0 op_sel:[1,0,0,0]
+; GFX9-NEXT:    v_min3_i16 v0, v6, v6, v0 op_sel:[1,0,0,0]
+; GFX9-NEXT:    v_min3_i16 v0, v7, v7, v0 op_sel:[1,0,0,0]
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; VI-LABEL: reduction_smin_v16i16_woslp:

--- a/llvm/test/CodeGen/AMDGPU/sdwa-peephole.ll
+++ b/llvm/test/CodeGen/AMDGPU/sdwa-peephole.ll
@@ -1243,15 +1243,13 @@ define amdgpu_kernel void @mul_v4i8(ptr addrspace(1) %out, ptr addrspace(1) %ina
 ; GFX10-NEXT:    s_waitcnt vmcnt(0)
 ; GFX10-NEXT:    v_lshrrev_b32_e32 v4, 24, v2
 ; GFX10-NEXT:    v_lshrrev_b16 v5, 8, v2
-; GFX10-NEXT:    v_lshrrev_b32_e32 v6, 16, v1
-; GFX10-NEXT:    v_lshrrev_b32_e32 v7, 16, v2
-; GFX10-NEXT:    v_mul_lo_u16 v1, v1, v2
 ; GFX10-NEXT:    v_mul_lo_u16 v3, v3, v4
 ; GFX10-NEXT:    v_mul_lo_u16 v0, v0, v5
-; GFX10-NEXT:    v_mul_lo_u16 v2, v6, v7
-; GFX10-NEXT:    v_lshlrev_b16 v3, 8, v3
+; GFX10-NEXT:    v_mul_lo_u16 v4, v1, v2 op_sel:[1,1,0]
+; GFX10-NEXT:    v_mul_lo_u16 v1, v1, v2
+; GFX10-NEXT:    v_lshlrev_b16 v2, 8, v3
 ; GFX10-NEXT:    v_lshlrev_b16 v0, 8, v0
-; GFX10-NEXT:    v_or_b32_sdwa v2, v2, v3 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
+; GFX10-NEXT:    v_or_b32_sdwa v2, v4, v2 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
 ; GFX10-NEXT:    v_or_b32_sdwa v0, v1, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
 ; GFX10-NEXT:    v_mov_b32_e32 v1, 0
 ; GFX10-NEXT:    v_or_b32_sdwa v0, v2, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:WORD_0
@@ -1401,37 +1399,33 @@ define amdgpu_kernel void @mul_v8i8(ptr addrspace(1) %out, ptr addrspace(1) %ina
 ; GFX10-NEXT:    global_load_dwordx2 v[2:3], v4, s[6:7]
 ; GFX10-NEXT:    s_waitcnt vmcnt(1)
 ; GFX10-NEXT:    v_lshrrev_b16 v4, 8, v1
-; GFX10-NEXT:    v_lshrrev_b32_e32 v6, 24, v1
-; GFX10-NEXT:    v_lshrrev_b32_e32 v8, 24, v0
-; GFX10-NEXT:    v_lshrrev_b16 v9, 8, v0
+; GFX10-NEXT:    v_lshrrev_b32_e32 v5, 24, v1
+; GFX10-NEXT:    v_lshrrev_b32_e32 v6, 24, v0
+; GFX10-NEXT:    v_lshrrev_b16 v7, 8, v0
 ; GFX10-NEXT:    s_waitcnt vmcnt(0)
-; GFX10-NEXT:    v_lshrrev_b16 v10, 8, v3
-; GFX10-NEXT:    v_lshrrev_b32_e32 v12, 24, v3
-; GFX10-NEXT:    v_lshrrev_b16 v13, 8, v2
-; GFX10-NEXT:    v_lshrrev_b32_e32 v14, 24, v2
-; GFX10-NEXT:    v_lshrrev_b32_e32 v5, 16, v1
-; GFX10-NEXT:    v_lshrrev_b32_e32 v7, 16, v0
-; GFX10-NEXT:    v_lshrrev_b32_e32 v11, 16, v3
-; GFX10-NEXT:    v_lshrrev_b32_e32 v15, 16, v2
-; GFX10-NEXT:    v_mul_lo_u16 v0, v0, v2
+; GFX10-NEXT:    v_lshrrev_b16 v8, 8, v3
+; GFX10-NEXT:    v_lshrrev_b32_e32 v9, 24, v3
+; GFX10-NEXT:    v_lshrrev_b16 v10, 8, v2
+; GFX10-NEXT:    v_lshrrev_b32_e32 v11, 24, v2
+; GFX10-NEXT:    v_mul_lo_u16 v12, v0, v2
+; GFX10-NEXT:    v_mul_lo_u16 v4, v4, v8
+; GFX10-NEXT:    v_mul_lo_u16 v5, v5, v9
+; GFX10-NEXT:    v_mul_lo_u16 v7, v7, v10
+; GFX10-NEXT:    v_mul_lo_u16 v6, v6, v11
+; GFX10-NEXT:    v_mul_lo_u16 v0, v0, v2 op_sel:[1,1,0]
+; GFX10-NEXT:    v_mul_lo_u16 v2, v1, v3 op_sel:[1,1,0]
 ; GFX10-NEXT:    v_mul_lo_u16 v1, v1, v3
-; GFX10-NEXT:    v_mul_lo_u16 v2, v9, v13
-; GFX10-NEXT:    v_mul_lo_u16 v3, v8, v14
-; GFX10-NEXT:    v_mul_lo_u16 v6, v6, v12
-; GFX10-NEXT:    v_mul_lo_u16 v4, v4, v10
-; GFX10-NEXT:    v_mul_lo_u16 v7, v7, v15
-; GFX10-NEXT:    v_mul_lo_u16 v5, v5, v11
-; GFX10-NEXT:    v_lshlrev_b16 v2, 8, v2
-; GFX10-NEXT:    v_lshlrev_b16 v3, 8, v3
+; GFX10-NEXT:    v_lshlrev_b16 v3, 8, v7
 ; GFX10-NEXT:    v_lshlrev_b16 v6, 8, v6
+; GFX10-NEXT:    v_lshlrev_b16 v5, 8, v5
 ; GFX10-NEXT:    v_lshlrev_b16 v4, 8, v4
-; GFX10-NEXT:    v_or_b32_sdwa v0, v0, v2 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
-; GFX10-NEXT:    v_or_b32_sdwa v2, v7, v3 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
-; GFX10-NEXT:    v_or_b32_sdwa v3, v5, v6 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
+; GFX10-NEXT:    v_or_b32_sdwa v3, v12, v3 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
+; GFX10-NEXT:    v_or_b32_sdwa v0, v0, v6 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
+; GFX10-NEXT:    v_or_b32_sdwa v2, v2, v5 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
 ; GFX10-NEXT:    v_or_b32_sdwa v1, v1, v4 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
 ; GFX10-NEXT:    v_mov_b32_e32 v4, 0
-; GFX10-NEXT:    v_or_b32_sdwa v0, v2, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:WORD_0
-; GFX10-NEXT:    v_or_b32_sdwa v1, v3, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:WORD_0
+; GFX10-NEXT:    v_or_b32_sdwa v0, v0, v3 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:WORD_0
+; GFX10-NEXT:    v_or_b32_sdwa v1, v2, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:WORD_0
 ; GFX10-NEXT:    global_store_dwordx2 v4, v[0:1], s[0:1]
 ; GFX10-NEXT:    s_endpgm
 entry:

--- a/llvm/test/CodeGen/AMDGPU/strict_fma.f16.ll
+++ b/llvm/test/CodeGen/AMDGPU/strict_fma.f16.ll
@@ -117,18 +117,12 @@ define <4 x half> @v_constained_fma_v4f16_fpexcept_strict(<4 x half> %x, <4 x ha
 ; GFX9-LABEL: v_constained_fma_v4f16_fpexcept_strict:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-NEXT:    v_lshrrev_b32_e32 v6, 16, v5
-; GFX9-NEXT:    v_lshrrev_b32_e32 v7, 16, v3
-; GFX9-NEXT:    v_lshrrev_b32_e32 v8, 16, v1
-; GFX9-NEXT:    v_fma_f16 v6, v8, v7, v6
-; GFX9-NEXT:    v_lshrrev_b32_e32 v7, 16, v4
-; GFX9-NEXT:    v_lshrrev_b32_e32 v8, 16, v2
-; GFX9-NEXT:    v_lshrrev_b32_e32 v9, 16, v0
-; GFX9-NEXT:    v_fma_f16 v7, v9, v8, v7
+; GFX9-NEXT:    v_fma_f16 v6, v1, v3, v5 op_sel:[1,1,1,0]
 ; GFX9-NEXT:    v_fma_f16 v1, v1, v3, v5
+; GFX9-NEXT:    v_fma_f16 v3, v0, v2, v4 op_sel:[1,1,1,0]
 ; GFX9-NEXT:    v_fma_f16 v0, v0, v2, v4
 ; GFX9-NEXT:    s_mov_b32 s4, 0x5040100
-; GFX9-NEXT:    v_perm_b32 v0, v7, v0, s4
+; GFX9-NEXT:    v_perm_b32 v0, v3, v0, s4
 ; GFX9-NEXT:    v_perm_b32 v1, v6, v1, s4
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;

--- a/llvm/test/CodeGen/AMDGPU/vector-reduce-add.ll
+++ b/llvm/test/CodeGen/AMDGPU/vector-reduce-add.ll
@@ -1199,8 +1199,7 @@ define i16 @test_vector_reduce_add_v2i16(<2 x i16> %v) {
 ; GFX10-SDAG-LABEL: test_vector_reduce_add_v2i16:
 ; GFX10-SDAG:       ; %bb.0: ; %entry
 ; GFX10-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10-SDAG-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX10-SDAG-NEXT:    v_add_nc_u16 v0, v0, v1
+; GFX10-SDAG-NEXT:    v_add_nc_u16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX10-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-GISEL-LABEL: test_vector_reduce_add_v2i16:
@@ -1221,9 +1220,7 @@ define i16 @test_vector_reduce_add_v2i16(<2 x i16> %v) {
 ; GFX11-SDAG-FAKE16-LABEL: test_vector_reduce_add_v2i16:
 ; GFX11-SDAG-FAKE16:       ; %bb.0: ; %entry
 ; GFX11-SDAG-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX11-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-SDAG-FAKE16-NEXT:    v_add_nc_u16 v0, v0, v1
+; GFX11-SDAG-FAKE16-NEXT:    v_add_nc_u16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX11-SDAG-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-GISEL-TRUE16-LABEL: test_vector_reduce_add_v2i16:
@@ -1261,9 +1258,7 @@ define i16 @test_vector_reduce_add_v2i16(<2 x i16> %v) {
 ; GFX12-SDAG-FAKE16-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-SDAG-FAKE16-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-SDAG-FAKE16-NEXT:    s_wait_kmcnt 0x0
-; GFX12-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX12-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX12-SDAG-FAKE16-NEXT:    v_add_nc_u16 v0, v0, v1
+; GFX12-SDAG-FAKE16-NEXT:    v_add_nc_u16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX12-SDAG-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-GISEL-TRUE16-LABEL: test_vector_reduce_add_v2i16:
@@ -1337,16 +1332,14 @@ define i16 @test_vector_reduce_add_v3i16(<3 x i16> %v) {
 ; GFX10-SDAG-LABEL: test_vector_reduce_add_v3i16:
 ; GFX10-SDAG:       ; %bb.0: ; %entry
 ; GFX10-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10-SDAG-NEXT:    v_lshrrev_b32_e32 v2, 16, v0
-; GFX10-SDAG-NEXT:    v_pk_add_u16 v0, v0, v1
-; GFX10-SDAG-NEXT:    v_add_nc_u16 v0, v0, v2
+; GFX10-SDAG-NEXT:    v_pk_add_u16 v1, v0, v1
+; GFX10-SDAG-NEXT:    v_add_nc_u16 v0, v1, v0 op_sel:[0,1,0]
 ; GFX10-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-GISEL-LABEL: test_vector_reduce_add_v3i16:
 ; GFX10-GISEL:       ; %bb.0: ; %entry
 ; GFX10-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10-GISEL-NEXT:    v_lshrrev_b32_e32 v2, 16, v0
-; GFX10-GISEL-NEXT:    v_add_nc_u16 v0, v0, v2
+; GFX10-GISEL-NEXT:    v_add_nc_u16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX10-GISEL-NEXT:    v_add_nc_u16 v0, v0, v1
 ; GFX10-GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -1362,10 +1355,9 @@ define i16 @test_vector_reduce_add_v3i16(<3 x i16> %v) {
 ; GFX11-SDAG-FAKE16-LABEL: test_vector_reduce_add_v3i16:
 ; GFX11-SDAG-FAKE16:       ; %bb.0: ; %entry
 ; GFX11-SDAG-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v2, 16, v0
-; GFX11-SDAG-FAKE16-NEXT:    v_pk_add_u16 v0, v0, v1
+; GFX11-SDAG-FAKE16-NEXT:    v_pk_add_u16 v1, v0, v1
 ; GFX11-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-SDAG-FAKE16-NEXT:    v_add_nc_u16 v0, v0, v2
+; GFX11-SDAG-FAKE16-NEXT:    v_add_nc_u16 v0, v1, v0 op_sel:[0,1,0]
 ; GFX11-SDAG-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-GISEL-TRUE16-LABEL: test_vector_reduce_add_v3i16:
@@ -1379,9 +1371,8 @@ define i16 @test_vector_reduce_add_v3i16(<3 x i16> %v) {
 ; GFX11-GISEL-FAKE16-LABEL: test_vector_reduce_add_v3i16:
 ; GFX11-GISEL-FAKE16:       ; %bb.0: ; %entry
 ; GFX11-GISEL-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-GISEL-FAKE16-NEXT:    v_lshrrev_b32_e32 v2, 16, v0
-; GFX11-GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-GISEL-FAKE16-NEXT:    v_add_nc_u16 v0, v0, v2
+; GFX11-GISEL-FAKE16-NEXT:    v_add_nc_u16 v0, v0, v0 op_sel:[0,1,0]
+; GFX11-GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX11-GISEL-FAKE16-NEXT:    v_add_nc_u16 v0, v0, v1
 ; GFX11-GISEL-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -1405,10 +1396,9 @@ define i16 @test_vector_reduce_add_v3i16(<3 x i16> %v) {
 ; GFX12-SDAG-FAKE16-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-SDAG-FAKE16-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-SDAG-FAKE16-NEXT:    s_wait_kmcnt 0x0
-; GFX12-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v2, 16, v0
-; GFX12-SDAG-FAKE16-NEXT:    v_pk_add_u16 v0, v0, v1
+; GFX12-SDAG-FAKE16-NEXT:    v_pk_add_u16 v1, v0, v1
 ; GFX12-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX12-SDAG-FAKE16-NEXT:    v_add_nc_u16 v0, v0, v2
+; GFX12-SDAG-FAKE16-NEXT:    v_add_nc_u16 v0, v1, v0 op_sel:[0,1,0]
 ; GFX12-SDAG-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-GISEL-TRUE16-LABEL: test_vector_reduce_add_v3i16:
@@ -1430,9 +1420,8 @@ define i16 @test_vector_reduce_add_v3i16(<3 x i16> %v) {
 ; GFX12-GISEL-FAKE16-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-GISEL-FAKE16-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-GISEL-FAKE16-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GISEL-FAKE16-NEXT:    v_lshrrev_b32_e32 v2, 16, v0
-; GFX12-GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX12-GISEL-FAKE16-NEXT:    v_add_nc_u16 v0, v0, v2
+; GFX12-GISEL-FAKE16-NEXT:    v_add_nc_u16 v0, v0, v0 op_sel:[0,1,0]
+; GFX12-GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX12-GISEL-FAKE16-NEXT:    v_add_nc_u16 v0, v0, v1
 ; GFX12-GISEL-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 entry:
@@ -1506,8 +1495,7 @@ define i16 @test_vector_reduce_add_v4i16(<4 x i16> %v) {
 ; GFX10-SDAG:       ; %bb.0: ; %entry
 ; GFX10-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-SDAG-NEXT:    v_pk_add_u16 v0, v0, v1
-; GFX10-SDAG-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX10-SDAG-NEXT:    v_add_nc_u16 v0, v0, v1
+; GFX10-SDAG-NEXT:    v_add_nc_u16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX10-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-GISEL-LABEL: test_vector_reduce_add_v4i16:
@@ -1531,9 +1519,8 @@ define i16 @test_vector_reduce_add_v4i16(<4 x i16> %v) {
 ; GFX11-SDAG-FAKE16:       ; %bb.0: ; %entry
 ; GFX11-SDAG-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-SDAG-FAKE16-NEXT:    v_pk_add_u16 v0, v0, v1
-; GFX11-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX11-SDAG-FAKE16-NEXT:    v_add_nc_u16 v0, v0, v1
+; GFX11-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-SDAG-FAKE16-NEXT:    v_add_nc_u16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX11-SDAG-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-GISEL-TRUE16-LABEL: test_vector_reduce_add_v4i16:
@@ -1575,9 +1562,8 @@ define i16 @test_vector_reduce_add_v4i16(<4 x i16> %v) {
 ; GFX12-SDAG-FAKE16-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-SDAG-FAKE16-NEXT:    s_wait_kmcnt 0x0
 ; GFX12-SDAG-FAKE16-NEXT:    v_pk_add_u16 v0, v0, v1
-; GFX12-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX12-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX12-SDAG-FAKE16-NEXT:    v_add_nc_u16 v0, v0, v1
+; GFX12-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX12-SDAG-FAKE16-NEXT:    v_add_nc_u16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX12-SDAG-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-GISEL-TRUE16-LABEL: test_vector_reduce_add_v4i16:
@@ -1704,8 +1690,7 @@ define i16 @test_vector_reduce_add_v8i16(<8 x i16> %v) {
 ; GFX10-SDAG-NEXT:    v_pk_add_u16 v1, v1, v3
 ; GFX10-SDAG-NEXT:    v_pk_add_u16 v0, v0, v2
 ; GFX10-SDAG-NEXT:    v_pk_add_u16 v0, v0, v1
-; GFX10-SDAG-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX10-SDAG-NEXT:    v_add_nc_u16 v0, v0, v1
+; GFX10-SDAG-NEXT:    v_add_nc_u16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX10-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-GISEL-LABEL: test_vector_reduce_add_v8i16:
@@ -1737,9 +1722,7 @@ define i16 @test_vector_reduce_add_v8i16(<8 x i16> %v) {
 ; GFX11-SDAG-FAKE16-NEXT:    v_pk_add_u16 v0, v0, v2
 ; GFX11-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX11-SDAG-FAKE16-NEXT:    v_pk_add_u16 v0, v0, v1
-; GFX11-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX11-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-SDAG-FAKE16-NEXT:    v_add_nc_u16 v0, v0, v1
+; GFX11-SDAG-FAKE16-NEXT:    v_add_nc_u16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX11-SDAG-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-GISEL-TRUE16-LABEL: test_vector_reduce_add_v8i16:
@@ -1793,9 +1776,7 @@ define i16 @test_vector_reduce_add_v8i16(<8 x i16> %v) {
 ; GFX12-SDAG-FAKE16-NEXT:    v_pk_add_u16 v0, v0, v2
 ; GFX12-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX12-SDAG-FAKE16-NEXT:    v_pk_add_u16 v0, v0, v1
-; GFX12-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX12-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX12-SDAG-FAKE16-NEXT:    v_add_nc_u16 v0, v0, v1
+; GFX12-SDAG-FAKE16-NEXT:    v_add_nc_u16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX12-SDAG-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-GISEL-TRUE16-LABEL: test_vector_reduce_add_v8i16:
@@ -1980,8 +1961,7 @@ define i16 @test_vector_reduce_add_v16i16(<16 x i16> %v) {
 ; GFX10-SDAG-NEXT:    v_pk_add_u16 v1, v1, v3
 ; GFX10-SDAG-NEXT:    v_pk_add_u16 v0, v0, v2
 ; GFX10-SDAG-NEXT:    v_pk_add_u16 v0, v0, v1
-; GFX10-SDAG-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX10-SDAG-NEXT:    v_add_nc_u16 v0, v0, v1
+; GFX10-SDAG-NEXT:    v_add_nc_u16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX10-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-GISEL-LABEL: test_vector_reduce_add_v16i16:
@@ -2027,9 +2007,7 @@ define i16 @test_vector_reduce_add_v16i16(<16 x i16> %v) {
 ; GFX11-SDAG-FAKE16-NEXT:    v_pk_add_u16 v0, v0, v2
 ; GFX11-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX11-SDAG-FAKE16-NEXT:    v_pk_add_u16 v0, v0, v1
-; GFX11-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX11-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-SDAG-FAKE16-NEXT:    v_add_nc_u16 v0, v0, v1
+; GFX11-SDAG-FAKE16-NEXT:    v_add_nc_u16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX11-SDAG-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-GISEL-TRUE16-LABEL: test_vector_reduce_add_v16i16:
@@ -2103,9 +2081,7 @@ define i16 @test_vector_reduce_add_v16i16(<16 x i16> %v) {
 ; GFX12-SDAG-FAKE16-NEXT:    v_pk_add_u16 v0, v0, v2
 ; GFX12-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX12-SDAG-FAKE16-NEXT:    v_pk_add_u16 v0, v0, v1
-; GFX12-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX12-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX12-SDAG-FAKE16-NEXT:    v_add_nc_u16 v0, v0, v1
+; GFX12-SDAG-FAKE16-NEXT:    v_add_nc_u16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX12-SDAG-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-GISEL-TRUE16-LABEL: test_vector_reduce_add_v16i16:

--- a/llvm/test/CodeGen/AMDGPU/vector-reduce-fmax.ll
+++ b/llvm/test/CodeGen/AMDGPU/vector-reduce-fmax.ll
@@ -1396,23 +1396,16 @@ define half @test_vector_reduce_fmax_v16half(<16 x half> %v) {
 ; GFX9-SDAG-LABEL: test_vector_reduce_fmax_v16half:
 ; GFX9-SDAG:       ; %bb.0: ; %entry
 ; GFX9-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-SDAG-NEXT:    v_max_f16_sdwa v15, v0, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:WORD_1
+; GFX9-SDAG-NEXT:    v_max_f16_sdwa v8, v0, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:WORD_1
 ; GFX9-SDAG-NEXT:    v_max_f16_e32 v0, v0, v0
-; GFX9-SDAG-NEXT:    v_lshrrev_b32_e32 v14, 16, v1
-; GFX9-SDAG-NEXT:    v_max_f16_e32 v0, v0, v15
-; GFX9-SDAG-NEXT:    v_lshrrev_b32_e32 v13, 16, v2
-; GFX9-SDAG-NEXT:    v_max3_f16 v0, v0, v1, v14
-; GFX9-SDAG-NEXT:    v_lshrrev_b32_e32 v12, 16, v3
-; GFX9-SDAG-NEXT:    v_max3_f16 v0, v0, v2, v13
-; GFX9-SDAG-NEXT:    v_lshrrev_b32_e32 v11, 16, v4
-; GFX9-SDAG-NEXT:    v_max3_f16 v0, v0, v3, v12
-; GFX9-SDAG-NEXT:    v_lshrrev_b32_e32 v10, 16, v5
-; GFX9-SDAG-NEXT:    v_max3_f16 v0, v0, v4, v11
-; GFX9-SDAG-NEXT:    v_lshrrev_b32_e32 v9, 16, v6
-; GFX9-SDAG-NEXT:    v_max3_f16 v0, v0, v5, v10
-; GFX9-SDAG-NEXT:    v_lshrrev_b32_e32 v8, 16, v7
-; GFX9-SDAG-NEXT:    v_max3_f16 v0, v0, v6, v9
-; GFX9-SDAG-NEXT:    v_max3_f16 v0, v0, v7, v8
+; GFX9-SDAG-NEXT:    v_max_f16_e32 v0, v0, v8
+; GFX9-SDAG-NEXT:    v_max3_f16 v0, v0, v1, v1 op_sel:[0,0,1,0]
+; GFX9-SDAG-NEXT:    v_max3_f16 v0, v0, v2, v2 op_sel:[0,0,1,0]
+; GFX9-SDAG-NEXT:    v_max3_f16 v0, v0, v3, v3 op_sel:[0,0,1,0]
+; GFX9-SDAG-NEXT:    v_max3_f16 v0, v0, v4, v4 op_sel:[0,0,1,0]
+; GFX9-SDAG-NEXT:    v_max3_f16 v0, v0, v5, v5 op_sel:[0,0,1,0]
+; GFX9-SDAG-NEXT:    v_max3_f16 v0, v0, v6, v6 op_sel:[0,0,1,0]
+; GFX9-SDAG-NEXT:    v_max3_f16 v0, v0, v7, v7 op_sel:[0,0,1,0]
 ; GFX9-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-GISEL-LABEL: test_vector_reduce_fmax_v16half:
@@ -1451,21 +1444,14 @@ define half @test_vector_reduce_fmax_v16half(<16 x half> %v) {
 ; GFX10-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-SDAG-NEXT:    v_max_f16_sdwa v8, v0, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:WORD_1
 ; GFX10-SDAG-NEXT:    v_max_f16_e32 v0, v0, v0
-; GFX10-SDAG-NEXT:    v_lshrrev_b32_e32 v9, 16, v1
 ; GFX10-SDAG-NEXT:    v_max_f16_e32 v0, v0, v8
-; GFX10-SDAG-NEXT:    v_lshrrev_b32_e32 v8, 16, v2
-; GFX10-SDAG-NEXT:    v_max3_f16 v0, v0, v1, v9
-; GFX10-SDAG-NEXT:    v_lshrrev_b32_e32 v1, 16, v3
-; GFX10-SDAG-NEXT:    v_max3_f16 v0, v0, v2, v8
-; GFX10-SDAG-NEXT:    v_lshrrev_b32_e32 v2, 16, v4
-; GFX10-SDAG-NEXT:    v_max3_f16 v0, v0, v3, v1
-; GFX10-SDAG-NEXT:    v_lshrrev_b32_e32 v1, 16, v5
-; GFX10-SDAG-NEXT:    v_max3_f16 v0, v0, v4, v2
-; GFX10-SDAG-NEXT:    v_lshrrev_b32_e32 v2, 16, v6
-; GFX10-SDAG-NEXT:    v_max3_f16 v0, v0, v5, v1
-; GFX10-SDAG-NEXT:    v_lshrrev_b32_e32 v1, 16, v7
-; GFX10-SDAG-NEXT:    v_max3_f16 v0, v0, v6, v2
-; GFX10-SDAG-NEXT:    v_max3_f16 v0, v0, v7, v1
+; GFX10-SDAG-NEXT:    v_max3_f16 v0, v0, v1, v1 op_sel:[0,0,1,0]
+; GFX10-SDAG-NEXT:    v_max3_f16 v0, v0, v2, v2 op_sel:[0,0,1,0]
+; GFX10-SDAG-NEXT:    v_max3_f16 v0, v0, v3, v3 op_sel:[0,0,1,0]
+; GFX10-SDAG-NEXT:    v_max3_f16 v0, v0, v4, v4 op_sel:[0,0,1,0]
+; GFX10-SDAG-NEXT:    v_max3_f16 v0, v0, v5, v5 op_sel:[0,0,1,0]
+; GFX10-SDAG-NEXT:    v_max3_f16 v0, v0, v6, v6 op_sel:[0,0,1,0]
+; GFX10-SDAG-NEXT:    v_max3_f16 v0, v0, v7, v7 op_sel:[0,0,1,0]
 ; GFX10-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-GISEL-LABEL: test_vector_reduce_fmax_v16half:
@@ -1532,27 +1518,20 @@ define half @test_vector_reduce_fmax_v16half(<16 x half> %v) {
 ; GFX11-SDAG-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v8, 16, v0
 ; GFX11-SDAG-FAKE16-NEXT:    v_max_f16_e32 v0, v0, v0
-; GFX11-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v9, 16, v1
-; GFX11-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX11-SDAG-FAKE16-NEXT:    v_max_f16_e32 v8, v8, v8
 ; GFX11-SDAG-FAKE16-NEXT:    v_max_f16_e32 v0, v0, v8
-; GFX11-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v8, 16, v2
-; GFX11-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GFX11-SDAG-FAKE16-NEXT:    v_max3_f16 v0, v0, v1, v9
-; GFX11-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v3
-; GFX11-SDAG-FAKE16-NEXT:    v_max3_f16 v0, v0, v2, v8
-; GFX11-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v2, 16, v4
-; GFX11-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GFX11-SDAG-FAKE16-NEXT:    v_max3_f16 v0, v0, v3, v1
-; GFX11-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v5
-; GFX11-SDAG-FAKE16-NEXT:    v_max3_f16 v0, v0, v4, v2
-; GFX11-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v2, 16, v6
-; GFX11-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GFX11-SDAG-FAKE16-NEXT:    v_max3_f16 v0, v0, v5, v1
-; GFX11-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v7
-; GFX11-SDAG-FAKE16-NEXT:    v_max3_f16 v0, v0, v6, v2
+; GFX11-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-SDAG-FAKE16-NEXT:    v_max3_f16 v0, v0, v1, v1 op_sel:[0,0,1,0]
+; GFX11-SDAG-FAKE16-NEXT:    v_max3_f16 v0, v0, v2, v2 op_sel:[0,0,1,0]
+; GFX11-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-SDAG-FAKE16-NEXT:    v_max3_f16 v0, v0, v3, v3 op_sel:[0,0,1,0]
+; GFX11-SDAG-FAKE16-NEXT:    v_max3_f16 v0, v0, v4, v4 op_sel:[0,0,1,0]
+; GFX11-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-SDAG-FAKE16-NEXT:    v_max3_f16 v0, v0, v5, v5 op_sel:[0,0,1,0]
+; GFX11-SDAG-FAKE16-NEXT:    v_max3_f16 v0, v0, v6, v6 op_sel:[0,0,1,0]
 ; GFX11-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-SDAG-FAKE16-NEXT:    v_max3_f16 v0, v0, v7, v1
+; GFX11-SDAG-FAKE16-NEXT:    v_max3_f16 v0, v0, v7, v7 op_sel:[0,0,1,0]
 ; GFX11-SDAG-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-GISEL-TRUE16-LABEL: test_vector_reduce_fmax_v16half:
@@ -1662,27 +1641,20 @@ define half @test_vector_reduce_fmax_v16half(<16 x half> %v) {
 ; GFX1170-SDAG-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX1170-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v8, 16, v0
 ; GFX1170-SDAG-FAKE16-NEXT:    v_max_num_f16_e32 v0, v0, v0
-; GFX1170-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v9, 16, v1
-; GFX1170-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1170-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX1170-SDAG-FAKE16-NEXT:    v_max_num_f16_e32 v8, v8, v8
 ; GFX1170-SDAG-FAKE16-NEXT:    v_max_num_f16_e32 v0, v0, v8
-; GFX1170-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v8, 16, v2
-; GFX1170-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GFX1170-SDAG-FAKE16-NEXT:    v_max3_num_f16 v0, v0, v1, v9
-; GFX1170-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v3
-; GFX1170-SDAG-FAKE16-NEXT:    v_max3_num_f16 v0, v0, v2, v8
-; GFX1170-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v2, 16, v4
-; GFX1170-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GFX1170-SDAG-FAKE16-NEXT:    v_max3_num_f16 v0, v0, v3, v1
-; GFX1170-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v5
-; GFX1170-SDAG-FAKE16-NEXT:    v_max3_num_f16 v0, v0, v4, v2
-; GFX1170-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v2, 16, v6
-; GFX1170-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GFX1170-SDAG-FAKE16-NEXT:    v_max3_num_f16 v0, v0, v5, v1
-; GFX1170-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v7
-; GFX1170-SDAG-FAKE16-NEXT:    v_max3_num_f16 v0, v0, v6, v2
+; GFX1170-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1170-SDAG-FAKE16-NEXT:    v_max3_num_f16 v0, v0, v1, v1 op_sel:[0,0,1,0]
+; GFX1170-SDAG-FAKE16-NEXT:    v_max3_num_f16 v0, v0, v2, v2 op_sel:[0,0,1,0]
+; GFX1170-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1170-SDAG-FAKE16-NEXT:    v_max3_num_f16 v0, v0, v3, v3 op_sel:[0,0,1,0]
+; GFX1170-SDAG-FAKE16-NEXT:    v_max3_num_f16 v0, v0, v4, v4 op_sel:[0,0,1,0]
+; GFX1170-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1170-SDAG-FAKE16-NEXT:    v_max3_num_f16 v0, v0, v5, v5 op_sel:[0,0,1,0]
+; GFX1170-SDAG-FAKE16-NEXT:    v_max3_num_f16 v0, v0, v6, v6 op_sel:[0,0,1,0]
 ; GFX1170-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1170-SDAG-FAKE16-NEXT:    v_max3_num_f16 v0, v0, v7, v1
+; GFX1170-SDAG-FAKE16-NEXT:    v_max3_num_f16 v0, v0, v7, v7 op_sel:[0,0,1,0]
 ; GFX1170-SDAG-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX1170-GISEL-TRUE16-LABEL: test_vector_reduce_fmax_v16half:
@@ -1800,27 +1772,20 @@ define half @test_vector_reduce_fmax_v16half(<16 x half> %v) {
 ; GFX12-SDAG-FAKE16-NEXT:    s_wait_kmcnt 0x0
 ; GFX12-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v8, 16, v0
 ; GFX12-SDAG-FAKE16-NEXT:    v_max_num_f16_e32 v0, v0, v0
-; GFX12-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v9, 16, v1
-; GFX12-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX12-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX12-SDAG-FAKE16-NEXT:    v_max_num_f16_e32 v8, v8, v8
 ; GFX12-SDAG-FAKE16-NEXT:    v_max_num_f16_e32 v0, v0, v8
-; GFX12-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v8, 16, v2
-; GFX12-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GFX12-SDAG-FAKE16-NEXT:    v_max3_num_f16 v0, v0, v1, v9
-; GFX12-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v3
-; GFX12-SDAG-FAKE16-NEXT:    v_max3_num_f16 v0, v0, v2, v8
-; GFX12-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v2, 16, v4
-; GFX12-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GFX12-SDAG-FAKE16-NEXT:    v_max3_num_f16 v0, v0, v3, v1
-; GFX12-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v5
-; GFX12-SDAG-FAKE16-NEXT:    v_max3_num_f16 v0, v0, v4, v2
-; GFX12-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v2, 16, v6
-; GFX12-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GFX12-SDAG-FAKE16-NEXT:    v_max3_num_f16 v0, v0, v5, v1
-; GFX12-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v7
-; GFX12-SDAG-FAKE16-NEXT:    v_max3_num_f16 v0, v0, v6, v2
+; GFX12-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX12-SDAG-FAKE16-NEXT:    v_max3_num_f16 v0, v0, v1, v1 op_sel:[0,0,1,0]
+; GFX12-SDAG-FAKE16-NEXT:    v_max3_num_f16 v0, v0, v2, v2 op_sel:[0,0,1,0]
+; GFX12-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX12-SDAG-FAKE16-NEXT:    v_max3_num_f16 v0, v0, v3, v3 op_sel:[0,0,1,0]
+; GFX12-SDAG-FAKE16-NEXT:    v_max3_num_f16 v0, v0, v4, v4 op_sel:[0,0,1,0]
+; GFX12-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX12-SDAG-FAKE16-NEXT:    v_max3_num_f16 v0, v0, v5, v5 op_sel:[0,0,1,0]
+; GFX12-SDAG-FAKE16-NEXT:    v_max3_num_f16 v0, v0, v6, v6 op_sel:[0,0,1,0]
 ; GFX12-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX12-SDAG-FAKE16-NEXT:    v_max3_num_f16 v0, v0, v7, v1
+; GFX12-SDAG-FAKE16-NEXT:    v_max3_num_f16 v0, v0, v7, v7 op_sel:[0,0,1,0]
 ; GFX12-SDAG-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-GISEL-TRUE16-LABEL: test_vector_reduce_fmax_v16half:

--- a/llvm/test/CodeGen/AMDGPU/vector-reduce-fmaximum.ll
+++ b/llvm/test/CodeGen/AMDGPU/vector-reduce-fmaximum.ll
@@ -83,9 +83,7 @@ define half @test_vector_reduce_fmaximum_v2half(<2 x half> %v) {
 ; GFX1170-SDAG-FAKE16-LABEL: test_vector_reduce_fmaximum_v2half:
 ; GFX1170-SDAG-FAKE16:       ; %bb.0: ; %entry
 ; GFX1170-SDAG-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX1170-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX1170-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1170-SDAG-FAKE16-NEXT:    v_maximum_f16 v0, v0, v1
+; GFX1170-SDAG-FAKE16-NEXT:    v_maximum_f16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX1170-SDAG-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-SDAG-TRUE16-LABEL: test_vector_reduce_fmaximum_v2half:
@@ -107,9 +105,7 @@ define half @test_vector_reduce_fmaximum_v2half(<2 x half> %v) {
 ; GFX12-SDAG-FAKE16-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-SDAG-FAKE16-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-SDAG-FAKE16-NEXT:    s_wait_kmcnt 0x0
-; GFX12-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX12-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX12-SDAG-FAKE16-NEXT:    v_maximum_f16 v0, v0, v1
+; GFX12-SDAG-FAKE16-NEXT:    v_maximum_f16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX12-SDAG-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 entry:
   %res = call half @llvm.vector.reduce.fmaximum.v2half(<2 x half> %v)
@@ -220,9 +216,8 @@ define half @test_vector_reduce_fmaximum_v3half(<3 x half> %v) {
 ; GFX1170-SDAG-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX1170-SDAG-FAKE16-NEXT:    v_perm_b32 v1, s0, v1, 0x5040100
 ; GFX1170-SDAG-FAKE16-NEXT:    v_pk_maximum_f16 v0, v0, v1
-; GFX1170-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1170-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX1170-SDAG-FAKE16-NEXT:    v_maximum_f16 v0, v0, v1
+; GFX1170-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1170-SDAG-FAKE16-NEXT:    v_maximum_f16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX1170-SDAG-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-SDAG-TRUE16-LABEL: test_vector_reduce_fmaximum_v3half:
@@ -252,9 +247,7 @@ define half @test_vector_reduce_fmaximum_v3half(<3 x half> %v) {
 ; GFX12-SDAG-FAKE16-NEXT:    v_perm_b32 v1, s0, v1, 0x5040100
 ; GFX12-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX12-SDAG-FAKE16-NEXT:    v_pk_maximum_f16 v0, v0, v1
-; GFX12-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX12-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX12-SDAG-FAKE16-NEXT:    v_maximum_f16 v0, v0, v1
+; GFX12-SDAG-FAKE16-NEXT:    v_maximum_f16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX12-SDAG-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 entry:
   %res = call half @llvm.vector.reduce.fmaximum.v3half(<3 x half> %v)
@@ -389,9 +382,8 @@ define half @test_vector_reduce_fmaximum_v4half(<4 x half> %v) {
 ; GFX1170-SDAG-FAKE16:       ; %bb.0: ; %entry
 ; GFX1170-SDAG-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX1170-SDAG-FAKE16-NEXT:    v_pk_maximum_f16 v0, v0, v1
-; GFX1170-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1170-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX1170-SDAG-FAKE16-NEXT:    v_maximum_f16 v0, v0, v1
+; GFX1170-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1170-SDAG-FAKE16-NEXT:    v_maximum_f16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX1170-SDAG-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-SDAG-TRUE16-LABEL: test_vector_reduce_fmaximum_v4half:
@@ -415,9 +407,8 @@ define half @test_vector_reduce_fmaximum_v4half(<4 x half> %v) {
 ; GFX12-SDAG-FAKE16-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-SDAG-FAKE16-NEXT:    s_wait_kmcnt 0x0
 ; GFX12-SDAG-FAKE16-NEXT:    v_pk_maximum_f16 v0, v0, v1
-; GFX12-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX12-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX12-SDAG-FAKE16-NEXT:    v_maximum_f16 v0, v0, v1
+; GFX12-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX12-SDAG-FAKE16-NEXT:    v_maximum_f16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX12-SDAG-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 entry:
   %res = call half @llvm.vector.reduce.fmaximum.v4half(<4 x half> %v)
@@ -659,9 +650,7 @@ define half @test_vector_reduce_fmaximum_v8half(<8 x half> %v) {
 ; GFX1170-SDAG-FAKE16-NEXT:    v_pk_maximum_f16 v0, v0, v2
 ; GFX1170-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX1170-SDAG-FAKE16-NEXT:    v_pk_maximum_f16 v0, v0, v1
-; GFX1170-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX1170-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1170-SDAG-FAKE16-NEXT:    v_maximum_f16 v0, v0, v1
+; GFX1170-SDAG-FAKE16-NEXT:    v_maximum_f16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX1170-SDAG-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-SDAG-TRUE16-LABEL: test_vector_reduce_fmaximum_v8half:
@@ -691,9 +680,7 @@ define half @test_vector_reduce_fmaximum_v8half(<8 x half> %v) {
 ; GFX12-SDAG-FAKE16-NEXT:    v_pk_maximum_f16 v0, v0, v2
 ; GFX12-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX12-SDAG-FAKE16-NEXT:    v_pk_maximum_f16 v0, v0, v1
-; GFX12-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX12-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX12-SDAG-FAKE16-NEXT:    v_maximum_f16 v0, v0, v1
+; GFX12-SDAG-FAKE16-NEXT:    v_maximum_f16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX12-SDAG-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 entry:
   %res = call half @llvm.vector.reduce.fmaximum.v8half(<8 x half> %v)
@@ -1150,9 +1137,7 @@ define half @test_vector_reduce_fmaximum_v16half(<16 x half> %v) {
 ; GFX1170-SDAG-FAKE16-NEXT:    v_pk_maximum_f16 v0, v0, v2
 ; GFX1170-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX1170-SDAG-FAKE16-NEXT:    v_pk_maximum_f16 v0, v0, v1
-; GFX1170-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX1170-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1170-SDAG-FAKE16-NEXT:    v_maximum_f16 v0, v0, v1
+; GFX1170-SDAG-FAKE16-NEXT:    v_maximum_f16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX1170-SDAG-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-SDAG-TRUE16-LABEL: test_vector_reduce_fmaximum_v16half:
@@ -1192,9 +1177,7 @@ define half @test_vector_reduce_fmaximum_v16half(<16 x half> %v) {
 ; GFX12-SDAG-FAKE16-NEXT:    v_pk_maximum_f16 v0, v0, v2
 ; GFX12-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX12-SDAG-FAKE16-NEXT:    v_pk_maximum_f16 v0, v0, v1
-; GFX12-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX12-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX12-SDAG-FAKE16-NEXT:    v_maximum_f16 v0, v0, v1
+; GFX12-SDAG-FAKE16-NEXT:    v_maximum_f16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX12-SDAG-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 entry:
   %res = call half @llvm.vector.reduce.fmaximum.v16half(<16 x half> %v)

--- a/llvm/test/CodeGen/AMDGPU/vector-reduce-fmin.ll
+++ b/llvm/test/CodeGen/AMDGPU/vector-reduce-fmin.ll
@@ -1396,23 +1396,16 @@ define half @test_vector_reduce_fmin_v16half(<16 x half> %v) {
 ; GFX9-SDAG-LABEL: test_vector_reduce_fmin_v16half:
 ; GFX9-SDAG:       ; %bb.0: ; %entry
 ; GFX9-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-SDAG-NEXT:    v_max_f16_sdwa v15, v0, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:WORD_1
+; GFX9-SDAG-NEXT:    v_max_f16_sdwa v8, v0, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:WORD_1
 ; GFX9-SDAG-NEXT:    v_max_f16_e32 v0, v0, v0
-; GFX9-SDAG-NEXT:    v_lshrrev_b32_e32 v14, 16, v1
-; GFX9-SDAG-NEXT:    v_min_f16_e32 v0, v0, v15
-; GFX9-SDAG-NEXT:    v_lshrrev_b32_e32 v13, 16, v2
-; GFX9-SDAG-NEXT:    v_min3_f16 v0, v0, v1, v14
-; GFX9-SDAG-NEXT:    v_lshrrev_b32_e32 v12, 16, v3
-; GFX9-SDAG-NEXT:    v_min3_f16 v0, v0, v2, v13
-; GFX9-SDAG-NEXT:    v_lshrrev_b32_e32 v11, 16, v4
-; GFX9-SDAG-NEXT:    v_min3_f16 v0, v0, v3, v12
-; GFX9-SDAG-NEXT:    v_lshrrev_b32_e32 v10, 16, v5
-; GFX9-SDAG-NEXT:    v_min3_f16 v0, v0, v4, v11
-; GFX9-SDAG-NEXT:    v_lshrrev_b32_e32 v9, 16, v6
-; GFX9-SDAG-NEXT:    v_min3_f16 v0, v0, v5, v10
-; GFX9-SDAG-NEXT:    v_lshrrev_b32_e32 v8, 16, v7
-; GFX9-SDAG-NEXT:    v_min3_f16 v0, v0, v6, v9
-; GFX9-SDAG-NEXT:    v_min3_f16 v0, v0, v7, v8
+; GFX9-SDAG-NEXT:    v_min_f16_e32 v0, v0, v8
+; GFX9-SDAG-NEXT:    v_min3_f16 v0, v0, v1, v1 op_sel:[0,0,1,0]
+; GFX9-SDAG-NEXT:    v_min3_f16 v0, v0, v2, v2 op_sel:[0,0,1,0]
+; GFX9-SDAG-NEXT:    v_min3_f16 v0, v0, v3, v3 op_sel:[0,0,1,0]
+; GFX9-SDAG-NEXT:    v_min3_f16 v0, v0, v4, v4 op_sel:[0,0,1,0]
+; GFX9-SDAG-NEXT:    v_min3_f16 v0, v0, v5, v5 op_sel:[0,0,1,0]
+; GFX9-SDAG-NEXT:    v_min3_f16 v0, v0, v6, v6 op_sel:[0,0,1,0]
+; GFX9-SDAG-NEXT:    v_min3_f16 v0, v0, v7, v7 op_sel:[0,0,1,0]
 ; GFX9-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-GISEL-LABEL: test_vector_reduce_fmin_v16half:
@@ -1451,21 +1444,14 @@ define half @test_vector_reduce_fmin_v16half(<16 x half> %v) {
 ; GFX10-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-SDAG-NEXT:    v_max_f16_sdwa v8, v0, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:WORD_1
 ; GFX10-SDAG-NEXT:    v_max_f16_e32 v0, v0, v0
-; GFX10-SDAG-NEXT:    v_lshrrev_b32_e32 v9, 16, v1
 ; GFX10-SDAG-NEXT:    v_min_f16_e32 v0, v0, v8
-; GFX10-SDAG-NEXT:    v_lshrrev_b32_e32 v8, 16, v2
-; GFX10-SDAG-NEXT:    v_min3_f16 v0, v0, v1, v9
-; GFX10-SDAG-NEXT:    v_lshrrev_b32_e32 v1, 16, v3
-; GFX10-SDAG-NEXT:    v_min3_f16 v0, v0, v2, v8
-; GFX10-SDAG-NEXT:    v_lshrrev_b32_e32 v2, 16, v4
-; GFX10-SDAG-NEXT:    v_min3_f16 v0, v0, v3, v1
-; GFX10-SDAG-NEXT:    v_lshrrev_b32_e32 v1, 16, v5
-; GFX10-SDAG-NEXT:    v_min3_f16 v0, v0, v4, v2
-; GFX10-SDAG-NEXT:    v_lshrrev_b32_e32 v2, 16, v6
-; GFX10-SDAG-NEXT:    v_min3_f16 v0, v0, v5, v1
-; GFX10-SDAG-NEXT:    v_lshrrev_b32_e32 v1, 16, v7
-; GFX10-SDAG-NEXT:    v_min3_f16 v0, v0, v6, v2
-; GFX10-SDAG-NEXT:    v_min3_f16 v0, v0, v7, v1
+; GFX10-SDAG-NEXT:    v_min3_f16 v0, v0, v1, v1 op_sel:[0,0,1,0]
+; GFX10-SDAG-NEXT:    v_min3_f16 v0, v0, v2, v2 op_sel:[0,0,1,0]
+; GFX10-SDAG-NEXT:    v_min3_f16 v0, v0, v3, v3 op_sel:[0,0,1,0]
+; GFX10-SDAG-NEXT:    v_min3_f16 v0, v0, v4, v4 op_sel:[0,0,1,0]
+; GFX10-SDAG-NEXT:    v_min3_f16 v0, v0, v5, v5 op_sel:[0,0,1,0]
+; GFX10-SDAG-NEXT:    v_min3_f16 v0, v0, v6, v6 op_sel:[0,0,1,0]
+; GFX10-SDAG-NEXT:    v_min3_f16 v0, v0, v7, v7 op_sel:[0,0,1,0]
 ; GFX10-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-GISEL-LABEL: test_vector_reduce_fmin_v16half:
@@ -1532,27 +1518,20 @@ define half @test_vector_reduce_fmin_v16half(<16 x half> %v) {
 ; GFX11-SDAG-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v8, 16, v0
 ; GFX11-SDAG-FAKE16-NEXT:    v_max_f16_e32 v0, v0, v0
-; GFX11-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v9, 16, v1
-; GFX11-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX11-SDAG-FAKE16-NEXT:    v_max_f16_e32 v8, v8, v8
 ; GFX11-SDAG-FAKE16-NEXT:    v_min_f16_e32 v0, v0, v8
-; GFX11-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v8, 16, v2
-; GFX11-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GFX11-SDAG-FAKE16-NEXT:    v_min3_f16 v0, v0, v1, v9
-; GFX11-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v3
-; GFX11-SDAG-FAKE16-NEXT:    v_min3_f16 v0, v0, v2, v8
-; GFX11-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v2, 16, v4
-; GFX11-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GFX11-SDAG-FAKE16-NEXT:    v_min3_f16 v0, v0, v3, v1
-; GFX11-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v5
-; GFX11-SDAG-FAKE16-NEXT:    v_min3_f16 v0, v0, v4, v2
-; GFX11-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v2, 16, v6
-; GFX11-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GFX11-SDAG-FAKE16-NEXT:    v_min3_f16 v0, v0, v5, v1
-; GFX11-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v7
-; GFX11-SDAG-FAKE16-NEXT:    v_min3_f16 v0, v0, v6, v2
+; GFX11-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-SDAG-FAKE16-NEXT:    v_min3_f16 v0, v0, v1, v1 op_sel:[0,0,1,0]
+; GFX11-SDAG-FAKE16-NEXT:    v_min3_f16 v0, v0, v2, v2 op_sel:[0,0,1,0]
+; GFX11-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-SDAG-FAKE16-NEXT:    v_min3_f16 v0, v0, v3, v3 op_sel:[0,0,1,0]
+; GFX11-SDAG-FAKE16-NEXT:    v_min3_f16 v0, v0, v4, v4 op_sel:[0,0,1,0]
+; GFX11-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-SDAG-FAKE16-NEXT:    v_min3_f16 v0, v0, v5, v5 op_sel:[0,0,1,0]
+; GFX11-SDAG-FAKE16-NEXT:    v_min3_f16 v0, v0, v6, v6 op_sel:[0,0,1,0]
 ; GFX11-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-SDAG-FAKE16-NEXT:    v_min3_f16 v0, v0, v7, v1
+; GFX11-SDAG-FAKE16-NEXT:    v_min3_f16 v0, v0, v7, v7 op_sel:[0,0,1,0]
 ; GFX11-SDAG-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-GISEL-TRUE16-LABEL: test_vector_reduce_fmin_v16half:
@@ -1662,27 +1641,20 @@ define half @test_vector_reduce_fmin_v16half(<16 x half> %v) {
 ; GFX1170-SDAG-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX1170-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v8, 16, v0
 ; GFX1170-SDAG-FAKE16-NEXT:    v_max_num_f16_e32 v0, v0, v0
-; GFX1170-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v9, 16, v1
-; GFX1170-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1170-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX1170-SDAG-FAKE16-NEXT:    v_max_num_f16_e32 v8, v8, v8
 ; GFX1170-SDAG-FAKE16-NEXT:    v_min_num_f16_e32 v0, v0, v8
-; GFX1170-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v8, 16, v2
-; GFX1170-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GFX1170-SDAG-FAKE16-NEXT:    v_min3_num_f16 v0, v0, v1, v9
-; GFX1170-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v3
-; GFX1170-SDAG-FAKE16-NEXT:    v_min3_num_f16 v0, v0, v2, v8
-; GFX1170-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v2, 16, v4
-; GFX1170-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GFX1170-SDAG-FAKE16-NEXT:    v_min3_num_f16 v0, v0, v3, v1
-; GFX1170-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v5
-; GFX1170-SDAG-FAKE16-NEXT:    v_min3_num_f16 v0, v0, v4, v2
-; GFX1170-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v2, 16, v6
-; GFX1170-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GFX1170-SDAG-FAKE16-NEXT:    v_min3_num_f16 v0, v0, v5, v1
-; GFX1170-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v7
-; GFX1170-SDAG-FAKE16-NEXT:    v_min3_num_f16 v0, v0, v6, v2
+; GFX1170-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1170-SDAG-FAKE16-NEXT:    v_min3_num_f16 v0, v0, v1, v1 op_sel:[0,0,1,0]
+; GFX1170-SDAG-FAKE16-NEXT:    v_min3_num_f16 v0, v0, v2, v2 op_sel:[0,0,1,0]
+; GFX1170-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1170-SDAG-FAKE16-NEXT:    v_min3_num_f16 v0, v0, v3, v3 op_sel:[0,0,1,0]
+; GFX1170-SDAG-FAKE16-NEXT:    v_min3_num_f16 v0, v0, v4, v4 op_sel:[0,0,1,0]
+; GFX1170-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1170-SDAG-FAKE16-NEXT:    v_min3_num_f16 v0, v0, v5, v5 op_sel:[0,0,1,0]
+; GFX1170-SDAG-FAKE16-NEXT:    v_min3_num_f16 v0, v0, v6, v6 op_sel:[0,0,1,0]
 ; GFX1170-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1170-SDAG-FAKE16-NEXT:    v_min3_num_f16 v0, v0, v7, v1
+; GFX1170-SDAG-FAKE16-NEXT:    v_min3_num_f16 v0, v0, v7, v7 op_sel:[0,0,1,0]
 ; GFX1170-SDAG-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX1170-GISEL-TRUE16-LABEL: test_vector_reduce_fmin_v16half:
@@ -1800,27 +1772,20 @@ define half @test_vector_reduce_fmin_v16half(<16 x half> %v) {
 ; GFX12-SDAG-FAKE16-NEXT:    s_wait_kmcnt 0x0
 ; GFX12-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v8, 16, v0
 ; GFX12-SDAG-FAKE16-NEXT:    v_max_num_f16_e32 v0, v0, v0
-; GFX12-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v9, 16, v1
-; GFX12-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX12-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX12-SDAG-FAKE16-NEXT:    v_max_num_f16_e32 v8, v8, v8
 ; GFX12-SDAG-FAKE16-NEXT:    v_min_num_f16_e32 v0, v0, v8
-; GFX12-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v8, 16, v2
-; GFX12-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GFX12-SDAG-FAKE16-NEXT:    v_min3_num_f16 v0, v0, v1, v9
-; GFX12-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v3
-; GFX12-SDAG-FAKE16-NEXT:    v_min3_num_f16 v0, v0, v2, v8
-; GFX12-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v2, 16, v4
-; GFX12-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GFX12-SDAG-FAKE16-NEXT:    v_min3_num_f16 v0, v0, v3, v1
-; GFX12-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v5
-; GFX12-SDAG-FAKE16-NEXT:    v_min3_num_f16 v0, v0, v4, v2
-; GFX12-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v2, 16, v6
-; GFX12-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GFX12-SDAG-FAKE16-NEXT:    v_min3_num_f16 v0, v0, v5, v1
-; GFX12-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v7
-; GFX12-SDAG-FAKE16-NEXT:    v_min3_num_f16 v0, v0, v6, v2
+; GFX12-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX12-SDAG-FAKE16-NEXT:    v_min3_num_f16 v0, v0, v1, v1 op_sel:[0,0,1,0]
+; GFX12-SDAG-FAKE16-NEXT:    v_min3_num_f16 v0, v0, v2, v2 op_sel:[0,0,1,0]
+; GFX12-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX12-SDAG-FAKE16-NEXT:    v_min3_num_f16 v0, v0, v3, v3 op_sel:[0,0,1,0]
+; GFX12-SDAG-FAKE16-NEXT:    v_min3_num_f16 v0, v0, v4, v4 op_sel:[0,0,1,0]
+; GFX12-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX12-SDAG-FAKE16-NEXT:    v_min3_num_f16 v0, v0, v5, v5 op_sel:[0,0,1,0]
+; GFX12-SDAG-FAKE16-NEXT:    v_min3_num_f16 v0, v0, v6, v6 op_sel:[0,0,1,0]
 ; GFX12-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX12-SDAG-FAKE16-NEXT:    v_min3_num_f16 v0, v0, v7, v1
+; GFX12-SDAG-FAKE16-NEXT:    v_min3_num_f16 v0, v0, v7, v7 op_sel:[0,0,1,0]
 ; GFX12-SDAG-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-GISEL-TRUE16-LABEL: test_vector_reduce_fmin_v16half:

--- a/llvm/test/CodeGen/AMDGPU/vector-reduce-fminimum.ll
+++ b/llvm/test/CodeGen/AMDGPU/vector-reduce-fminimum.ll
@@ -87,9 +87,7 @@ define half @test_vector_reduce_fminimum_v2half(<2 x half> %v) {
 ; GFX1170-SDAG-FAKE16-LABEL: test_vector_reduce_fminimum_v2half:
 ; GFX1170-SDAG-FAKE16:       ; %bb.0: ; %entry
 ; GFX1170-SDAG-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX1170-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX1170-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1170-SDAG-FAKE16-NEXT:    v_minimum_f16 v0, v0, v1
+; GFX1170-SDAG-FAKE16-NEXT:    v_minimum_f16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX1170-SDAG-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX1170-GISEL-TRUE16-LABEL: test_vector_reduce_fminimum_v2half:
@@ -127,9 +125,7 @@ define half @test_vector_reduce_fminimum_v2half(<2 x half> %v) {
 ; GFX12-SDAG-FAKE16-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-SDAG-FAKE16-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-SDAG-FAKE16-NEXT:    s_wait_kmcnt 0x0
-; GFX12-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX12-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX12-SDAG-FAKE16-NEXT:    v_minimum_f16 v0, v0, v1
+; GFX12-SDAG-FAKE16-NEXT:    v_minimum_f16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX12-SDAG-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-GISEL-TRUE16-LABEL: test_vector_reduce_fminimum_v2half:
@@ -264,9 +260,8 @@ define half @test_vector_reduce_fminimum_v3half(<3 x half> %v) {
 ; GFX1170-SDAG-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX1170-SDAG-FAKE16-NEXT:    v_perm_b32 v1, s0, v1, 0x5040100
 ; GFX1170-SDAG-FAKE16-NEXT:    v_pk_minimum_f16 v0, v0, v1
-; GFX1170-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1170-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX1170-SDAG-FAKE16-NEXT:    v_minimum_f16 v0, v0, v1
+; GFX1170-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1170-SDAG-FAKE16-NEXT:    v_minimum_f16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX1170-SDAG-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX1170-GISEL-TRUE16-LABEL: test_vector_reduce_fminimum_v3half:
@@ -278,9 +273,7 @@ define half @test_vector_reduce_fminimum_v3half(<3 x half> %v) {
 ; GFX1170-GISEL-FAKE16-LABEL: test_vector_reduce_fminimum_v3half:
 ; GFX1170-GISEL-FAKE16:       ; %bb.0: ; %entry
 ; GFX1170-GISEL-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX1170-GISEL-FAKE16-NEXT:    v_lshrrev_b32_e32 v2, 16, v0
-; GFX1170-GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1170-GISEL-FAKE16-NEXT:    v_minimum3_f16 v0, v0, v2, v1
+; GFX1170-GISEL-FAKE16-NEXT:    v_minimum3_f16 v0, v0, v0, v1 op_sel:[0,1,0,0]
 ; GFX1170-GISEL-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-SDAG-TRUE16-LABEL: test_vector_reduce_fminimum_v3half:
@@ -310,9 +303,7 @@ define half @test_vector_reduce_fminimum_v3half(<3 x half> %v) {
 ; GFX12-SDAG-FAKE16-NEXT:    v_perm_b32 v1, s0, v1, 0x5040100
 ; GFX12-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX12-SDAG-FAKE16-NEXT:    v_pk_minimum_f16 v0, v0, v1
-; GFX12-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX12-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX12-SDAG-FAKE16-NEXT:    v_minimum_f16 v0, v0, v1
+; GFX12-SDAG-FAKE16-NEXT:    v_minimum_f16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX12-SDAG-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-GISEL-TRUE16-LABEL: test_vector_reduce_fminimum_v3half:
@@ -332,9 +323,7 @@ define half @test_vector_reduce_fminimum_v3half(<3 x half> %v) {
 ; GFX12-GISEL-FAKE16-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-GISEL-FAKE16-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-GISEL-FAKE16-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GISEL-FAKE16-NEXT:    v_lshrrev_b32_e32 v2, 16, v0
-; GFX12-GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX12-GISEL-FAKE16-NEXT:    v_minimum3_f16 v0, v0, v2, v1
+; GFX12-GISEL-FAKE16-NEXT:    v_minimum3_f16 v0, v0, v0, v1 op_sel:[0,1,0,0]
 ; GFX12-GISEL-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 entry:
   %res = call half @llvm.vector.reduce.fminimum.v3half(<3 x half> %v)
@@ -469,9 +458,8 @@ define half @test_vector_reduce_fminimum_v4half(<4 x half> %v) {
 ; GFX1170-SDAG-FAKE16:       ; %bb.0: ; %entry
 ; GFX1170-SDAG-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX1170-SDAG-FAKE16-NEXT:    v_pk_minimum_f16 v0, v0, v1
-; GFX1170-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1170-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX1170-SDAG-FAKE16-NEXT:    v_minimum_f16 v0, v0, v1
+; GFX1170-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1170-SDAG-FAKE16-NEXT:    v_minimum_f16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX1170-SDAG-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX1170-GISEL-TRUE16-LABEL: test_vector_reduce_fminimum_v4half:
@@ -513,9 +501,8 @@ define half @test_vector_reduce_fminimum_v4half(<4 x half> %v) {
 ; GFX12-SDAG-FAKE16-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-SDAG-FAKE16-NEXT:    s_wait_kmcnt 0x0
 ; GFX12-SDAG-FAKE16-NEXT:    v_pk_minimum_f16 v0, v0, v1
-; GFX12-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX12-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX12-SDAG-FAKE16-NEXT:    v_minimum_f16 v0, v0, v1
+; GFX12-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX12-SDAG-FAKE16-NEXT:    v_minimum_f16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX12-SDAG-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-GISEL-TRUE16-LABEL: test_vector_reduce_fminimum_v4half:
@@ -783,9 +770,7 @@ define half @test_vector_reduce_fminimum_v8half(<8 x half> %v) {
 ; GFX1170-SDAG-FAKE16-NEXT:    v_pk_minimum_f16 v0, v0, v2
 ; GFX1170-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX1170-SDAG-FAKE16-NEXT:    v_pk_minimum_f16 v0, v0, v1
-; GFX1170-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX1170-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1170-SDAG-FAKE16-NEXT:    v_minimum_f16 v0, v0, v1
+; GFX1170-SDAG-FAKE16-NEXT:    v_minimum_f16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX1170-SDAG-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX1170-GISEL-TRUE16-LABEL: test_vector_reduce_fminimum_v8half:
@@ -839,9 +824,7 @@ define half @test_vector_reduce_fminimum_v8half(<8 x half> %v) {
 ; GFX12-SDAG-FAKE16-NEXT:    v_pk_minimum_f16 v0, v0, v2
 ; GFX12-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX12-SDAG-FAKE16-NEXT:    v_pk_minimum_f16 v0, v0, v1
-; GFX12-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX12-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX12-SDAG-FAKE16-NEXT:    v_minimum_f16 v0, v0, v1
+; GFX12-SDAG-FAKE16-NEXT:    v_minimum_f16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX12-SDAG-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-GISEL-TRUE16-LABEL: test_vector_reduce_fminimum_v8half:
@@ -1330,9 +1313,7 @@ define half @test_vector_reduce_fminimum_v16half(<16 x half> %v) {
 ; GFX1170-SDAG-FAKE16-NEXT:    v_pk_minimum_f16 v0, v0, v2
 ; GFX1170-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX1170-SDAG-FAKE16-NEXT:    v_pk_minimum_f16 v0, v0, v1
-; GFX1170-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX1170-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1170-SDAG-FAKE16-NEXT:    v_minimum_f16 v0, v0, v1
+; GFX1170-SDAG-FAKE16-NEXT:    v_minimum_f16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX1170-SDAG-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX1170-GISEL-TRUE16-LABEL: test_vector_reduce_fminimum_v16half:
@@ -1406,9 +1387,7 @@ define half @test_vector_reduce_fminimum_v16half(<16 x half> %v) {
 ; GFX12-SDAG-FAKE16-NEXT:    v_pk_minimum_f16 v0, v0, v2
 ; GFX12-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX12-SDAG-FAKE16-NEXT:    v_pk_minimum_f16 v0, v0, v1
-; GFX12-SDAG-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX12-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX12-SDAG-FAKE16-NEXT:    v_minimum_f16 v0, v0, v1
+; GFX12-SDAG-FAKE16-NEXT:    v_minimum_f16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX12-SDAG-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-GISEL-TRUE16-LABEL: test_vector_reduce_fminimum_v16half:

--- a/llvm/test/CodeGen/AMDGPU/vector-reduce-mul.ll
+++ b/llvm/test/CodeGen/AMDGPU/vector-reduce-mul.ll
@@ -1273,16 +1273,14 @@ define i16 @test_vector_reduce_mul_v3i16(<3 x i16> %v) {
 ; GFX10-SDAG-LABEL: test_vector_reduce_mul_v3i16:
 ; GFX10-SDAG:       ; %bb.0: ; %entry
 ; GFX10-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10-SDAG-NEXT:    v_lshrrev_b32_e32 v2, 16, v0
-; GFX10-SDAG-NEXT:    v_pk_mul_lo_u16 v0, v0, v1
-; GFX10-SDAG-NEXT:    v_mul_lo_u16 v0, v0, v2
+; GFX10-SDAG-NEXT:    v_pk_mul_lo_u16 v1, v0, v1
+; GFX10-SDAG-NEXT:    v_mul_lo_u16 v0, v1, v0 op_sel:[0,1,0]
 ; GFX10-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-GISEL-LABEL: test_vector_reduce_mul_v3i16:
 ; GFX10-GISEL:       ; %bb.0: ; %entry
 ; GFX10-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10-GISEL-NEXT:    v_lshrrev_b32_e32 v2, 16, v0
-; GFX10-GISEL-NEXT:    v_mul_lo_u16 v0, v0, v2
+; GFX10-GISEL-NEXT:    v_mul_lo_u16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX10-GISEL-NEXT:    v_mul_lo_u16 v0, v0, v1
 ; GFX10-GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;

--- a/llvm/test/CodeGen/AMDGPU/vector-reduce-smax.ll
+++ b/llvm/test/CodeGen/AMDGPU/vector-reduce-smax.ll
@@ -1615,8 +1615,7 @@ define i16 @test_vector_reduce_smax_v2i16(<2 x i16> %v) {
 ; GFX10-SDAG-LABEL: test_vector_reduce_smax_v2i16:
 ; GFX10-SDAG:       ; %bb.0: ; %entry
 ; GFX10-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10-SDAG-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX10-SDAG-NEXT:    v_max_i16 v0, v0, v1
+; GFX10-SDAG-NEXT:    v_max_i16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX10-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-GISEL-LABEL: test_vector_reduce_smax_v2i16:
@@ -1732,8 +1731,7 @@ define i16 @test_vector_reduce_smax_v3i16(<3 x i16> %v) {
 ; GFX9-GISEL-LABEL: test_vector_reduce_smax_v3i16:
 ; GFX9-GISEL:       ; %bb.0: ; %entry
 ; GFX9-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-GISEL-NEXT:    v_lshrrev_b32_e32 v2, 16, v0
-; GFX9-GISEL-NEXT:    v_max3_i16 v0, v0, v2, v1
+; GFX9-GISEL-NEXT:    v_max3_i16 v0, v0, v0, v1 op_sel:[0,1,0,0]
 ; GFX9-GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-SDAG-LABEL: test_vector_reduce_smax_v3i16:
@@ -1742,15 +1740,13 @@ define i16 @test_vector_reduce_smax_v3i16(<3 x i16> %v) {
 ; GFX10-SDAG-NEXT:    s_movk_i32 s4, 0x8000
 ; GFX10-SDAG-NEXT:    v_perm_b32 v1, s4, v1, 0x5040100
 ; GFX10-SDAG-NEXT:    v_pk_max_i16 v0, v0, v1
-; GFX10-SDAG-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX10-SDAG-NEXT:    v_max_i16 v0, v0, v1
+; GFX10-SDAG-NEXT:    v_max_i16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX10-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-GISEL-LABEL: test_vector_reduce_smax_v3i16:
 ; GFX10-GISEL:       ; %bb.0: ; %entry
 ; GFX10-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10-GISEL-NEXT:    v_lshrrev_b32_e32 v2, 16, v0
-; GFX10-GISEL-NEXT:    v_max3_i16 v0, v0, v2, v1
+; GFX10-GISEL-NEXT:    v_max3_i16 v0, v0, v0, v1 op_sel:[0,1,0,0]
 ; GFX10-GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-SDAG-TRUE16-LABEL: test_vector_reduce_smax_v3i16:
@@ -1779,9 +1775,7 @@ define i16 @test_vector_reduce_smax_v3i16(<3 x i16> %v) {
 ; GFX11-GISEL-LABEL: test_vector_reduce_smax_v3i16:
 ; GFX11-GISEL:       ; %bb.0: ; %entry
 ; GFX11-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-GISEL-NEXT:    v_lshrrev_b32_e32 v2, 16, v0
-; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-GISEL-NEXT:    v_max3_i16 v0, v0, v2, v1
+; GFX11-GISEL-NEXT:    v_max3_i16 v0, v0, v0, v1 op_sel:[0,1,0,0]
 ; GFX11-GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-SDAG-TRUE16-LABEL: test_vector_reduce_smax_v3i16:
@@ -1823,9 +1817,7 @@ define i16 @test_vector_reduce_smax_v3i16(<3 x i16> %v) {
 ; GFX12-GISEL-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-GISEL-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-GISEL-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GISEL-NEXT:    v_lshrrev_b32_e32 v2, 16, v0
-; GFX12-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX12-GISEL-NEXT:    v_max3_i16 v0, v0, v2, v1
+; GFX12-GISEL-NEXT:    v_max3_i16 v0, v0, v0, v1 op_sel:[0,1,0,0]
 ; GFX12-GISEL-NEXT:    s_setpc_b64 s[30:31]
 entry:
   %res = call i16 @llvm.vector.reduce.smax.v3i16(<3 x i16> %v)
@@ -1901,8 +1893,7 @@ define i16 @test_vector_reduce_smax_v4i16(<4 x i16> %v) {
 ; GFX10-SDAG:       ; %bb.0: ; %entry
 ; GFX10-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-SDAG-NEXT:    v_pk_max_i16 v0, v0, v1
-; GFX10-SDAG-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX10-SDAG-NEXT:    v_max_i16 v0, v0, v1
+; GFX10-SDAG-NEXT:    v_max_i16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX10-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-GISEL-LABEL: test_vector_reduce_smax_v4i16:
@@ -2082,8 +2073,7 @@ define i16 @test_vector_reduce_smax_v8i16(<8 x i16> %v) {
 ; GFX10-SDAG-NEXT:    v_pk_max_i16 v1, v1, v3
 ; GFX10-SDAG-NEXT:    v_pk_max_i16 v0, v0, v2
 ; GFX10-SDAG-NEXT:    v_pk_max_i16 v0, v0, v1
-; GFX10-SDAG-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX10-SDAG-NEXT:    v_max_i16 v0, v0, v1
+; GFX10-SDAG-NEXT:    v_max_i16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX10-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-GISEL-LABEL: test_vector_reduce_smax_v8i16:
@@ -2338,8 +2328,7 @@ define i16 @test_vector_reduce_smax_v16i16(<16 x i16> %v) {
 ; GFX10-SDAG-NEXT:    v_pk_max_i16 v1, v1, v3
 ; GFX10-SDAG-NEXT:    v_pk_max_i16 v0, v0, v2
 ; GFX10-SDAG-NEXT:    v_pk_max_i16 v0, v0, v1
-; GFX10-SDAG-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX10-SDAG-NEXT:    v_max_i16 v0, v0, v1
+; GFX10-SDAG-NEXT:    v_max_i16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX10-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-GISEL-LABEL: test_vector_reduce_smax_v16i16:

--- a/llvm/test/CodeGen/AMDGPU/vector-reduce-smin.ll
+++ b/llvm/test/CodeGen/AMDGPU/vector-reduce-smin.ll
@@ -1615,8 +1615,7 @@ define i16 @test_vector_reduce_smin_v2i16(<2 x i16> %v) {
 ; GFX10-SDAG-LABEL: test_vector_reduce_smin_v2i16:
 ; GFX10-SDAG:       ; %bb.0: ; %entry
 ; GFX10-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10-SDAG-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX10-SDAG-NEXT:    v_min_i16 v0, v0, v1
+; GFX10-SDAG-NEXT:    v_min_i16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX10-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-GISEL-LABEL: test_vector_reduce_smin_v2i16:
@@ -1732,8 +1731,7 @@ define i16 @test_vector_reduce_smin_v3i16(<3 x i16> %v) {
 ; GFX9-GISEL-LABEL: test_vector_reduce_smin_v3i16:
 ; GFX9-GISEL:       ; %bb.0: ; %entry
 ; GFX9-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-GISEL-NEXT:    v_lshrrev_b32_e32 v2, 16, v0
-; GFX9-GISEL-NEXT:    v_min3_i16 v0, v0, v2, v1
+; GFX9-GISEL-NEXT:    v_min3_i16 v0, v0, v0, v1 op_sel:[0,1,0,0]
 ; GFX9-GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-SDAG-LABEL: test_vector_reduce_smin_v3i16:
@@ -1742,15 +1740,13 @@ define i16 @test_vector_reduce_smin_v3i16(<3 x i16> %v) {
 ; GFX10-SDAG-NEXT:    s_movk_i32 s4, 0x7fff
 ; GFX10-SDAG-NEXT:    v_perm_b32 v1, s4, v1, 0x5040100
 ; GFX10-SDAG-NEXT:    v_pk_min_i16 v0, v0, v1
-; GFX10-SDAG-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX10-SDAG-NEXT:    v_min_i16 v0, v0, v1
+; GFX10-SDAG-NEXT:    v_min_i16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX10-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-GISEL-LABEL: test_vector_reduce_smin_v3i16:
 ; GFX10-GISEL:       ; %bb.0: ; %entry
 ; GFX10-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10-GISEL-NEXT:    v_lshrrev_b32_e32 v2, 16, v0
-; GFX10-GISEL-NEXT:    v_min3_i16 v0, v0, v2, v1
+; GFX10-GISEL-NEXT:    v_min3_i16 v0, v0, v0, v1 op_sel:[0,1,0,0]
 ; GFX10-GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-SDAG-TRUE16-LABEL: test_vector_reduce_smin_v3i16:
@@ -1779,9 +1775,7 @@ define i16 @test_vector_reduce_smin_v3i16(<3 x i16> %v) {
 ; GFX11-GISEL-LABEL: test_vector_reduce_smin_v3i16:
 ; GFX11-GISEL:       ; %bb.0: ; %entry
 ; GFX11-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-GISEL-NEXT:    v_lshrrev_b32_e32 v2, 16, v0
-; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-GISEL-NEXT:    v_min3_i16 v0, v0, v2, v1
+; GFX11-GISEL-NEXT:    v_min3_i16 v0, v0, v0, v1 op_sel:[0,1,0,0]
 ; GFX11-GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-SDAG-TRUE16-LABEL: test_vector_reduce_smin_v3i16:
@@ -1823,9 +1817,7 @@ define i16 @test_vector_reduce_smin_v3i16(<3 x i16> %v) {
 ; GFX12-GISEL-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-GISEL-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-GISEL-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GISEL-NEXT:    v_lshrrev_b32_e32 v2, 16, v0
-; GFX12-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX12-GISEL-NEXT:    v_min3_i16 v0, v0, v2, v1
+; GFX12-GISEL-NEXT:    v_min3_i16 v0, v0, v0, v1 op_sel:[0,1,0,0]
 ; GFX12-GISEL-NEXT:    s_setpc_b64 s[30:31]
 entry:
   %res = call i16 @llvm.vector.reduce.smin.v3i16(<3 x i16> %v)
@@ -1901,8 +1893,7 @@ define i16 @test_vector_reduce_smin_v4i16(<4 x i16> %v) {
 ; GFX10-SDAG:       ; %bb.0: ; %entry
 ; GFX10-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-SDAG-NEXT:    v_pk_min_i16 v0, v0, v1
-; GFX10-SDAG-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX10-SDAG-NEXT:    v_min_i16 v0, v0, v1
+; GFX10-SDAG-NEXT:    v_min_i16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX10-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-GISEL-LABEL: test_vector_reduce_smin_v4i16:
@@ -2082,8 +2073,7 @@ define i16 @test_vector_reduce_smin_v8i16(<8 x i16> %v) {
 ; GFX10-SDAG-NEXT:    v_pk_min_i16 v1, v1, v3
 ; GFX10-SDAG-NEXT:    v_pk_min_i16 v0, v0, v2
 ; GFX10-SDAG-NEXT:    v_pk_min_i16 v0, v0, v1
-; GFX10-SDAG-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX10-SDAG-NEXT:    v_min_i16 v0, v0, v1
+; GFX10-SDAG-NEXT:    v_min_i16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX10-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-GISEL-LABEL: test_vector_reduce_smin_v8i16:
@@ -2337,8 +2327,7 @@ define i16 @test_vector_reduce_smin_v16i16(<16 x i16> %v) {
 ; GFX10-SDAG-NEXT:    v_pk_min_i16 v1, v1, v3
 ; GFX10-SDAG-NEXT:    v_pk_min_i16 v0, v0, v2
 ; GFX10-SDAG-NEXT:    v_pk_min_i16 v0, v0, v1
-; GFX10-SDAG-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX10-SDAG-NEXT:    v_min_i16 v0, v0, v1
+; GFX10-SDAG-NEXT:    v_min_i16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX10-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-GISEL-LABEL: test_vector_reduce_smin_v16i16:

--- a/llvm/test/CodeGen/AMDGPU/vector-reduce-umax.ll
+++ b/llvm/test/CodeGen/AMDGPU/vector-reduce-umax.ll
@@ -1504,8 +1504,7 @@ define i16 @test_vector_reduce_umax_v2i16(<2 x i16> %v) {
 ; GFX10-SDAG-LABEL: test_vector_reduce_umax_v2i16:
 ; GFX10-SDAG:       ; %bb.0: ; %entry
 ; GFX10-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10-SDAG-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX10-SDAG-NEXT:    v_max_u16 v0, v0, v1
+; GFX10-SDAG-NEXT:    v_max_u16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX10-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-GISEL-LABEL: test_vector_reduce_umax_v2i16:
@@ -1618,8 +1617,7 @@ define i16 @test_vector_reduce_umax_v3i16(<3 x i16> %v) {
 ; GFX9-GISEL-LABEL: test_vector_reduce_umax_v3i16:
 ; GFX9-GISEL:       ; %bb.0: ; %entry
 ; GFX9-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-GISEL-NEXT:    v_lshrrev_b32_e32 v2, 16, v0
-; GFX9-GISEL-NEXT:    v_max3_u16 v0, v0, v2, v1
+; GFX9-GISEL-NEXT:    v_max3_u16 v0, v0, v0, v1 op_sel:[0,1,0,0]
 ; GFX9-GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-SDAG-LABEL: test_vector_reduce_umax_v3i16:
@@ -1627,15 +1625,13 @@ define i16 @test_vector_reduce_umax_v3i16(<3 x i16> %v) {
 ; GFX10-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-SDAG-NEXT:    v_and_b32_e32 v1, 0xffff, v1
 ; GFX10-SDAG-NEXT:    v_pk_max_u16 v0, v0, v1
-; GFX10-SDAG-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX10-SDAG-NEXT:    v_max_u16 v0, v0, v1
+; GFX10-SDAG-NEXT:    v_max_u16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX10-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-GISEL-LABEL: test_vector_reduce_umax_v3i16:
 ; GFX10-GISEL:       ; %bb.0: ; %entry
 ; GFX10-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10-GISEL-NEXT:    v_lshrrev_b32_e32 v2, 16, v0
-; GFX10-GISEL-NEXT:    v_max3_u16 v0, v0, v2, v1
+; GFX10-GISEL-NEXT:    v_max3_u16 v0, v0, v0, v1 op_sel:[0,1,0,0]
 ; GFX10-GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-SDAG-TRUE16-LABEL: test_vector_reduce_umax_v3i16:
@@ -1663,9 +1659,7 @@ define i16 @test_vector_reduce_umax_v3i16(<3 x i16> %v) {
 ; GFX11-GISEL-LABEL: test_vector_reduce_umax_v3i16:
 ; GFX11-GISEL:       ; %bb.0: ; %entry
 ; GFX11-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-GISEL-NEXT:    v_lshrrev_b32_e32 v2, 16, v0
-; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-GISEL-NEXT:    v_max3_u16 v0, v0, v2, v1
+; GFX11-GISEL-NEXT:    v_max3_u16 v0, v0, v0, v1 op_sel:[0,1,0,0]
 ; GFX11-GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-SDAG-TRUE16-LABEL: test_vector_reduce_umax_v3i16:
@@ -1705,9 +1699,7 @@ define i16 @test_vector_reduce_umax_v3i16(<3 x i16> %v) {
 ; GFX12-GISEL-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-GISEL-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-GISEL-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GISEL-NEXT:    v_lshrrev_b32_e32 v2, 16, v0
-; GFX12-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX12-GISEL-NEXT:    v_max3_u16 v0, v0, v2, v1
+; GFX12-GISEL-NEXT:    v_max3_u16 v0, v0, v0, v1 op_sel:[0,1,0,0]
 ; GFX12-GISEL-NEXT:    s_setpc_b64 s[30:31]
 entry:
   %res = call i16 @llvm.vector.reduce.umax.v3i16(<3 x i16> %v)
@@ -1781,8 +1773,7 @@ define i16 @test_vector_reduce_umax_v4i16(<4 x i16> %v) {
 ; GFX10-SDAG:       ; %bb.0: ; %entry
 ; GFX10-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-SDAG-NEXT:    v_pk_max_u16 v0, v0, v1
-; GFX10-SDAG-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX10-SDAG-NEXT:    v_max_u16 v0, v0, v1
+; GFX10-SDAG-NEXT:    v_max_u16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX10-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-GISEL-LABEL: test_vector_reduce_umax_v4i16:
@@ -1960,8 +1951,7 @@ define i16 @test_vector_reduce_umax_v8i16(<8 x i16> %v) {
 ; GFX10-SDAG-NEXT:    v_pk_max_u16 v1, v1, v3
 ; GFX10-SDAG-NEXT:    v_pk_max_u16 v0, v0, v2
 ; GFX10-SDAG-NEXT:    v_pk_max_u16 v0, v0, v1
-; GFX10-SDAG-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX10-SDAG-NEXT:    v_max_u16 v0, v0, v1
+; GFX10-SDAG-NEXT:    v_max_u16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX10-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-GISEL-LABEL: test_vector_reduce_umax_v8i16:
@@ -2214,8 +2204,7 @@ define i16 @test_vector_reduce_umax_v16i16(<16 x i16> %v) {
 ; GFX10-SDAG-NEXT:    v_pk_max_u16 v1, v1, v3
 ; GFX10-SDAG-NEXT:    v_pk_max_u16 v0, v0, v2
 ; GFX10-SDAG-NEXT:    v_pk_max_u16 v0, v0, v1
-; GFX10-SDAG-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX10-SDAG-NEXT:    v_max_u16 v0, v0, v1
+; GFX10-SDAG-NEXT:    v_max_u16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX10-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-GISEL-LABEL: test_vector_reduce_umax_v16i16:

--- a/llvm/test/CodeGen/AMDGPU/vector-reduce-umin.ll
+++ b/llvm/test/CodeGen/AMDGPU/vector-reduce-umin.ll
@@ -1284,8 +1284,7 @@ define i16 @test_vector_reduce_umin_v2i16(<2 x i16> %v) {
 ; GFX10-SDAG-LABEL: test_vector_reduce_umin_v2i16:
 ; GFX10-SDAG:       ; %bb.0: ; %entry
 ; GFX10-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10-SDAG-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX10-SDAG-NEXT:    v_min_u16 v0, v0, v1
+; GFX10-SDAG-NEXT:    v_min_u16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX10-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-GISEL-LABEL: test_vector_reduce_umin_v2i16:
@@ -1400,8 +1399,7 @@ define i16 @test_vector_reduce_umin_v3i16(<3 x i16> %v) {
 ; GFX9-GISEL-LABEL: test_vector_reduce_umin_v3i16:
 ; GFX9-GISEL:       ; %bb.0: ; %entry
 ; GFX9-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-GISEL-NEXT:    v_lshrrev_b32_e32 v2, 16, v0
-; GFX9-GISEL-NEXT:    v_min3_u16 v0, v0, v2, v1
+; GFX9-GISEL-NEXT:    v_min3_u16 v0, v0, v0, v1 op_sel:[0,1,0,0]
 ; GFX9-GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-SDAG-LABEL: test_vector_reduce_umin_v3i16:
@@ -1409,15 +1407,13 @@ define i16 @test_vector_reduce_umin_v3i16(<3 x i16> %v) {
 ; GFX10-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-SDAG-NEXT:    v_perm_b32 v1, -1, v1, 0x5040100
 ; GFX10-SDAG-NEXT:    v_pk_min_u16 v0, v0, v1
-; GFX10-SDAG-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX10-SDAG-NEXT:    v_min_u16 v0, v0, v1
+; GFX10-SDAG-NEXT:    v_min_u16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX10-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-GISEL-LABEL: test_vector_reduce_umin_v3i16:
 ; GFX10-GISEL:       ; %bb.0: ; %entry
 ; GFX10-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10-GISEL-NEXT:    v_lshrrev_b32_e32 v2, 16, v0
-; GFX10-GISEL-NEXT:    v_min3_u16 v0, v0, v2, v1
+; GFX10-GISEL-NEXT:    v_min3_u16 v0, v0, v0, v1 op_sel:[0,1,0,0]
 ; GFX10-GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-SDAG-TRUE16-LABEL: test_vector_reduce_umin_v3i16:
@@ -1445,9 +1441,7 @@ define i16 @test_vector_reduce_umin_v3i16(<3 x i16> %v) {
 ; GFX11-GISEL-LABEL: test_vector_reduce_umin_v3i16:
 ; GFX11-GISEL:       ; %bb.0: ; %entry
 ; GFX11-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-GISEL-NEXT:    v_lshrrev_b32_e32 v2, 16, v0
-; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-GISEL-NEXT:    v_min3_u16 v0, v0, v2, v1
+; GFX11-GISEL-NEXT:    v_min3_u16 v0, v0, v0, v1 op_sel:[0,1,0,0]
 ; GFX11-GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-SDAG-TRUE16-LABEL: test_vector_reduce_umin_v3i16:
@@ -1487,9 +1481,7 @@ define i16 @test_vector_reduce_umin_v3i16(<3 x i16> %v) {
 ; GFX12-GISEL-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-GISEL-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-GISEL-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GISEL-NEXT:    v_lshrrev_b32_e32 v2, 16, v0
-; GFX12-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX12-GISEL-NEXT:    v_min3_u16 v0, v0, v2, v1
+; GFX12-GISEL-NEXT:    v_min3_u16 v0, v0, v0, v1 op_sel:[0,1,0,0]
 ; GFX12-GISEL-NEXT:    s_setpc_b64 s[30:31]
 entry:
   %res = call i16 @llvm.vector.reduce.umin.v3i16(<3 x i16> %v)
@@ -1560,8 +1552,7 @@ define i16 @test_vector_reduce_umin_v4i16(<4 x i16> %v) {
 ; GFX10-SDAG:       ; %bb.0: ; %entry
 ; GFX10-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-SDAG-NEXT:    v_pk_min_u16 v0, v0, v1
-; GFX10-SDAG-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX10-SDAG-NEXT:    v_min_u16 v0, v0, v1
+; GFX10-SDAG-NEXT:    v_min_u16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX10-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-GISEL-LABEL: test_vector_reduce_umin_v4i16:
@@ -1736,8 +1727,7 @@ define i16 @test_vector_reduce_umin_v8i16(<8 x i16> %v) {
 ; GFX10-SDAG-NEXT:    v_pk_min_u16 v1, v1, v3
 ; GFX10-SDAG-NEXT:    v_pk_min_u16 v0, v0, v2
 ; GFX10-SDAG-NEXT:    v_pk_min_u16 v0, v0, v1
-; GFX10-SDAG-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX10-SDAG-NEXT:    v_min_u16 v0, v0, v1
+; GFX10-SDAG-NEXT:    v_min_u16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX10-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-GISEL-LABEL: test_vector_reduce_umin_v8i16:
@@ -1987,8 +1977,7 @@ define i16 @test_vector_reduce_umin_v16i16(<16 x i16> %v) {
 ; GFX10-SDAG-NEXT:    v_pk_min_u16 v1, v1, v3
 ; GFX10-SDAG-NEXT:    v_pk_min_u16 v0, v0, v2
 ; GFX10-SDAG-NEXT:    v_pk_min_u16 v0, v0, v1
-; GFX10-SDAG-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
-; GFX10-SDAG-NEXT:    v_min_u16 v0, v0, v1
+; GFX10-SDAG-NEXT:    v_min_u16 v0, v0, v0 op_sel:[0,1,0]
 ; GFX10-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-GISEL-LABEL: test_vector_reduce_umin_v16i16:


### PR DESCRIPTION
fixes: #220528

Implement SelectVOP3OpSel/SelectVOP3OpSelMods in SDAG and selectVOP3OpSelMods in GlobalIsel selector so that VOP3 op-sel capable 16-bit instruction read the high half of a packed 32-bit source register via the op_sel modifier instead of emitting explicit shift/extract instruction. 