### PR TITLE
[VPlan] Add scalar-type-infer assert for casts (NFC)

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
@@ -578,6 +578,8 @@ Type *llvm::computeScalarTypeForInstruction(unsigned Opcode,
   case Instruction::Call:
     return getCalledFunction(Operands)->getReturnType();
   default:
+    if (Instruction::isCast(Opcode))
+      llvm_unreachable("type must be passed explicitly");
     break;
   }
 


### PR DESCRIPTION
Casts require the ResultTy to be passed: add an assert to computeScalarTypeForInstruction to guard against incorrect usage.