### PR TITLE
[BOLT][RISCV] Support reading RV64 RELR relocations

### DIFF
--- a/bolt/lib/Core/Relocation.cpp
+++ b/bolt/lib/Core/Relocation.cpp
@@ -988,6 +988,7 @@ uint32_t Relocation::getRelative() {
   case Triple::aarch64:
     return ELF::R_AARCH64_RELATIVE;
   case Triple::riscv64:
+    return ELF::R_RISCV_RELATIVE;
   case Triple::riscv32:
     llvm_unreachable("not implemented");
   case Triple::x86_64:

--- a/bolt/test/RISCV/relr.s
+++ b/bolt/test/RISCV/relr.s
@@ -1,0 +1,35 @@
+# RUN: llvm-mc -triple=riscv64 -filetype=obj %s -o %t.o
+# RUN: ld.lld -pie --emit-relocs --pack-dyn-relocs=relr %t.o -o %t.exe
+# RUN: llvm-readelf -d %t.exe | FileCheck %s --check-prefix=INPUT
+# RUN: llvm-bolt %t.exe -o %t.bolt --reorder-functions=cdsort
+# RUN: llvm-readelf -r %t.bolt | FileCheck %s --check-prefix=RELOC
+# RUN: llvm-nm %t.bolt | FileCheck %s --check-prefix=SYMBOL
+# RUN: llvm-readelf -x .data %t.bolt | FileCheck %s --check-prefix=DATA
+
+## Reduced from the RELR-packed clang input: reading relative relocations
+## works on RV64, and references to a moved function must be updated.
+# INPUT: (RELR)
+# RELOC: Relocation section '.relr.dyn'
+# RELOC: pointers{{$}}
+# RELOC-NEXT: pointers + 0x8
+# RELOC-NEXT: pointers + 0x10
+# SYMBOL: 0000000000400000 T _start
+# DATA: 00004000 00000000 00004000 00000000
+# DATA-NEXT: 00004000 00000000
+
+  .text
+  .globl _start
+  .type _start,@function
+_start:
+  nop
+  ret
+  .reloc 0, R_RISCV_NONE
+  .size _start, .-_start
+
+  .data
+  .p2align 3
+  .globl pointers
+pointers:
+  .quad _start
+  .quad _start
+  .quad _start


### PR DESCRIPTION
Clang linked with packed relative dynamic relocations aborts when the RELR reader requests the target relative relocation type. Return `R_RISCV_RELATIVE` for RV64, preserving the RV32 restriction and other targets.

Assisted by GPT-6.