### PR TITLE
[MISched] Apply debug filters before starting a block

### DIFF
--- a/llvm/lib/CodeGen/MachineScheduler.cpp
+++ b/llvm/lib/CodeGen/MachineScheduler.cpp
@@ -815,9 +815,6 @@ void MachineSchedulerBase::scheduleRegions(ScheduleDAGInstrs &Scheduler,
   // loop tree. Then we can optionally compute global RegPressure.
   for (MachineFunction::iterator MBB = MF->begin(), MBBEnd = MF->end();
        MBB != MBBEnd; ++MBB) {
-
-    Scheduler.startBlock(&*MBB);
-
 #ifndef NDEBUG
     if (SchedOnlyFunc.getNumOccurrences() && SchedOnlyFunc != MF->getName())
       continue;
@@ -825,6 +822,8 @@ void MachineSchedulerBase::scheduleRegions(ScheduleDAGInstrs &Scheduler,
         && (int)SchedOnlyBlock != MBB->getNumber())
       continue;
 #endif
+
+    Scheduler.startBlock(&*MBB);
 
     // Break the block into scheduling regions [I, RegionEnd). RegionEnd
     // points to the scheduling boundary at the bottom of the region. The DAG

--- a/llvm/test/CodeGen/SystemZ/postra-sched-filter.mir
+++ b/llvm/test/CodeGen/SystemZ/postra-sched-filter.mir
@@ -1,0 +1,21 @@
+# REQUIRES: asserts
+# RUN: llc -mtriple=s390x-linux-gnu -mcpu=z13 -run-pass=postmisched \
+# RUN:   -misched-only-block=1 -debug-only=machine-scheduler -o /dev/null %s \
+# RUN:   2>&1 | FileCheck %s
+
+# CHECK-NOT: ** Entering %bb.0
+# CHECK: ** Entering %bb.1:
+
+---
+name:            test
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    successors: %bb.1(0x80000000)
+
+    J %bb.1
+
+  bb.1:
+    $r2l = LHI 0
+    Return implicit killed $r2l
+...


### PR DESCRIPTION
Apply the `misched-only-func` and `misched-only-block` filters before calling `startBlock`. This avoids entering a target scheduling strategy for a filtered block without a matching `finishBlock`/`leaveMBB` call.

Add a SystemZ post-RA scheduler regression that checks a filtered block does not contribute hazard-recognizer state.

Split from #221984 in response to review.