### PR TITLE
[ConstantInitBuilder] Use ptradd for self references

### DIFF
--- a/clang/include/clang/CodeGen/ConstantInitBuilder.h
+++ b/clang/include/clang/CodeGen/ConstantInitBuilder.h
@@ -54,9 +54,10 @@ class CodeGenModule;
 class ConstantInitBuilderBase {
   struct SelfReference {
     llvm::GlobalVariable *Dummy;
-    llvm::SmallVector<llvm::Constant*, 4> Indices;
+    CharUnits Offset;
 
-    SelfReference(llvm::GlobalVariable *dummy) : Dummy(dummy) {}
+    SelfReference(llvm::GlobalVariable *Dummy, CharUnits Offset)
+        : Dummy(Dummy), Offset(Offset) {}
   };
   CodeGenModule &CGM;
   llvm::SmallVector<llvm::Constant*, 16> Buffer;
@@ -320,20 +321,11 @@ public:
   /// type can differ from the type of the actual element.
   llvm::Constant *getAddrOfPosition(llvm::Type *type, size_t position);
 
-  llvm::ArrayRef<llvm::Constant*> getGEPIndicesToCurrentPosition(
-                           llvm::SmallVectorImpl<llvm::Constant*> &indices) {
-    getGEPIndicesTo(indices, Builder.Buffer.size());
-    return indices;
-  }
-
 protected:
   llvm::Constant *finishArray(llvm::Type *eltTy);
   llvm::Constant *finishStruct(llvm::StructType *structTy);
 
 private:
-  void getGEPIndicesTo(llvm::SmallVectorImpl<llvm::Constant*> &indices,
-                       size_t position) const;
-
   llvm::Constant *getRelativeOffset(llvm::IntegerType *offsetType,
                                     llvm::Constant *target);
 

--- a/clang/lib/CodeGen/ConstantInitBuilder.cpp
+++ b/clang/lib/CodeGen/ConstantInitBuilder.cpp
@@ -94,9 +94,8 @@ void ConstantInitBuilderBase::setGlobalInitializer(llvm::GlobalVariable *GV,
 
 void ConstantInitBuilderBase::resolveSelfReferences(llvm::GlobalVariable *GV) {
   for (auto &entry : SelfReferences) {
-    llvm::Constant *resolvedReference =
-      llvm::ConstantExpr::getInBoundsGetElementPtr(
-        GV->getValueType(), GV, entry.Indices);
+    llvm::Constant *resolvedReference = llvm::ConstantExpr::getInBoundsPtrAdd(
+        GV, llvm::ConstantInt::get(CGM.SizeTy, entry.Offset.getQuantity()));
     auto dummy = entry.Dummy;
     dummy->replaceAllUsesWith(resolvedReference);
     dummy->eraseFromParent();
@@ -158,9 +157,8 @@ ConstantAggregateBuilderBase::getAddrOfPosition(llvm::Type *type,
   auto dummy = new llvm::GlobalVariable(Builder.CGM.getModule(), type, true,
                                         llvm::GlobalVariable::PrivateLinkage,
                                         nullptr, "");
-  Builder.SelfReferences.emplace_back(dummy);
-  auto &entry = Builder.SelfReferences.back();
-  getGEPIndicesTo(entry.Indices, position + Begin);
+  Builder.SelfReferences.emplace_back(dummy,
+                                      getOffsetFromGlobalTo(position + Begin));
   return dummy;
 }
 
@@ -172,30 +170,8 @@ ConstantAggregateBuilderBase::getAddrOfCurrentPosition(llvm::Type *type) {
     new llvm::GlobalVariable(Builder.CGM.getModule(), type, true,
                              llvm::GlobalVariable::PrivateLinkage,
                              nullptr, "");
-  Builder.SelfReferences.emplace_back(dummy);
-  auto &entry = Builder.SelfReferences.back();
-  (void) getGEPIndicesToCurrentPosition(entry.Indices);
+  Builder.SelfReferences.emplace_back(dummy, getNextOffsetFromGlobal());
   return dummy;
-}
-
-void ConstantAggregateBuilderBase::getGEPIndicesTo(
-                               llvm::SmallVectorImpl<llvm::Constant*> &indices,
-                               size_t position) const {
-  // Recurse on the parent builder if present.
-  if (Parent) {
-    Parent->getGEPIndicesTo(indices, Begin);
-
-  // Otherwise, add an index to drill into the first level of pointer.
-  } else {
-    assert(indices.empty());
-    indices.push_back(llvm::ConstantInt::get(Builder.CGM.Int32Ty, 0));
-  }
-
-  assert(position >= Begin);
-  // We have to use i32 here because struct GEPs demand i32 indices.
-  // It's rather unlikely to matter in practice.
-  indices.push_back(llvm::ConstantInt::get(Builder.CGM.Int32Ty,
-                                           position - Begin));
 }
 
 ConstantAggregateBuilderBase::PlaceholderPosition


### PR DESCRIPTION
Instead of producing a typed GEP, directly produce the canonical ptradd form with a byte offset. This makes the implementation slightly simpler.