### PR TITLE
[SPIR-V] Fix legalization rewriting non-zero size arrays to pointers

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVLegalizeZeroSizeArrays.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVLegalizeZeroSizeArrays.cpp
@@ -114,7 +114,7 @@ Type *SPIRVLegalizeZeroSizeArraysImpl::legalizeType(Type *Ty) {
 
   Type *LegalizedTy = Ty;
 
-  if (isa<ArrayType>(Ty)) {
+  if (shouldLegalizeInstType(Ty)) {
     LegalizedTy = PointerType::get(
         Ty->getContext(),
         storageClassToAddressSpace(SPIRV::StorageClass::Generic));

--- a/llvm/test/CodeGen/SPIRV/legalize-zero-size-arrays-struct.ll
+++ b/llvm/test/CodeGen/SPIRV/legalize-zero-size-arrays-struct.ll
@@ -7,5 +7,11 @@
 
 @global_struct = addrspace(1) global %struct.with_zero zeroinitializer
 
+%struct.mixed = type { [4 x i32], [0 x i32] }
+
+@global_mixed = addrspace(1) global %struct.mixed zeroinitializer
+
 ; CHECK: %struct.with_zero.legalized = type { i32, ptr addrspace(4), i32 }
+; CHECK: %struct.mixed.legalized = type { [4 x i32], ptr addrspace(4) }
 ; CHECK: @global_struct = addrspace(1) global %struct.with_zero.legalized zeroinitializer
+; CHECK: @global_mixed = addrspace(1) global %struct.mixed.legalized zeroinitializer


### PR DESCRIPTION
legalizeType checked `isa<ArrayType>` with no size guard

Use `shouldLegalizeInstType`, which already checks for zero size