### PR TITLE
[Analysis] Fix GCC warnings on ABI annotations

### DIFF
--- a/llvm/include/llvm/Analysis/DominanceFrontier.h
+++ b/llvm/include/llvm/Analysis/DominanceFrontier.h
@@ -91,6 +91,10 @@ public:
   void analyze(const DomTreeT &DT);
 };
 
+extern template class LLVM_TEMPLATE_ABI
+    DominanceFrontierBase<BasicBlock, false>;
+extern template class LLVM_TEMPLATE_ABI DominanceFrontierBase<BasicBlock, true>;
+
 class DominanceFrontier : public DominanceFrontierBase<BasicBlock, false> {
 public:
   using DomTreeT = DomTreeBase<BasicBlock>;
@@ -125,10 +129,6 @@ public:
 
   void dump() const;
 };
-
-extern template class LLVM_TEMPLATE_ABI
-    DominanceFrontierBase<BasicBlock, false>;
-extern template class LLVM_TEMPLATE_ABI DominanceFrontierBase<BasicBlock, true>;
 
 /// Analysis pass which computes a \c DominanceFrontier.
 class DominanceFrontierAnalysis

--- a/llvm/include/llvm/Analysis/RegionInfo.h
+++ b/llvm/include/llvm/Analysis/RegionInfo.h
@@ -874,6 +874,8 @@ public:
   void verifyAnalysis() const;
 };
 
+extern template class LLVM_TEMPLATE_ABI RegionNodeBase<RegionTraits<Function>>;
+
 class RegionNode : public RegionNodeBase<RegionTraits<Function>> {
 public:
   inline RegionNode(Region *Parent, BasicBlock *Entry, bool isSubRegion = false)
@@ -883,6 +885,8 @@ public:
     return this == reinterpret_cast<const RegionNode *>(&RN);
   }
 };
+
+extern template class LLVM_TEMPLATE_ABI RegionBase<RegionTraits<Function>>;
 
 class Region : public RegionBase<RegionTraits<Function>> {
 public:
@@ -895,8 +899,6 @@ public:
   }
 };
 
-extern template class LLVM_TEMPLATE_ABI RegionBase<RegionTraits<Function>>;
-extern template class LLVM_TEMPLATE_ABI RegionNodeBase<RegionTraits<Function>>;
 extern template class LLVM_TEMPLATE_ABI RegionInfoBase<RegionTraits<Function>>;
 
 class LLVM_ABI RegionInfo : public RegionInfoBase<RegionTraits<Function>> {

--- a/llvm/lib/Analysis/DominanceFrontier.cpp
+++ b/llvm/lib/Analysis/DominanceFrontier.cpp
@@ -21,8 +21,8 @@ using namespace llvm;
 
 namespace llvm {
 
-template class LLVM_TEMPLATE_ABI DominanceFrontierBase<BasicBlock, false>;
-template class LLVM_TEMPLATE_ABI DominanceFrontierBase<BasicBlock, true>;
+template class LLVM_EXPORT_TEMPLATE DominanceFrontierBase<BasicBlock, false>;
+template class LLVM_EXPORT_TEMPLATE DominanceFrontierBase<BasicBlock, true>;
 
 } // end namespace llvm
 

--- a/llvm/lib/Analysis/RegionInfo.cpp
+++ b/llvm/lib/Analysis/RegionInfo.cpp
@@ -28,9 +28,9 @@ using namespace llvm;
 
 namespace llvm {
 
-template class LLVM_TEMPLATE_ABI RegionBase<RegionTraits<Function>>;
-template class LLVM_TEMPLATE_ABI RegionNodeBase<RegionTraits<Function>>;
-template class LLVM_TEMPLATE_ABI RegionInfoBase<RegionTraits<Function>>;
+template class LLVM_EXPORT_TEMPLATE RegionBase<RegionTraits<Function>>;
+template class LLVM_EXPORT_TEMPLATE RegionNodeBase<RegionTraits<Function>>;
+template class LLVM_EXPORT_TEMPLATE RegionInfoBase<RegionTraits<Function>>;
 
 } // end namespace llvm
 


### PR DESCRIPTION
The GCC build is cluttered by type attribute warnings on some header files:

```
llvm/include/llvm/Analysis/RegionInfo.h:898:41: warning: type attributes ignored after type is already defined [-Wattributes]
  898 | extern template class LLVM_TEMPLATE_ABI RegionBase<RegionTraits<Function>>;
      |                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

The type attributes originate from PR #199019. The warnings occur because the
specific template instantiation is triggered implicitly earlier, without the
type attribute. This can be fixed by placing the extern template declaration
before the implicit use.

Also, the implementation files were using `LLVM_TEMPLATE_ABI` instead of
`LLVM_EXPORT_TEMPLATE`, contrary to the guidance in
`llvm/docs/InterfaceExportAnnotations.rst` ("Explicitly Instantiated Template
Classes"). This would trigger the same type of GCC warning in the
implementation file.
