### PR TITLE
[LLVM][CodeGen][AArch64] Fix incorrect chain usage when lowering ISD::STRICT_FP_EXTEND.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -4989,9 +4989,9 @@ SDValue AArch64TargetLowering::LowerFP_EXTEND(SDValue Op,
     if (Op0VT == MVT::bf16 && IsStrict) {
       SDValue Ext1 =
           DAG.getNode(ISD::STRICT_FP_EXTEND, SDLoc(Op), {MVT::f32, MVT::Other},
-                      {Op0, Op.getOperand(0)});
+                      {Op.getOperand(0), Op0});
       return DAG.getNode(ISD::STRICT_FP_EXTEND, SDLoc(Op), {VT, MVT::Other},
-                         {Ext1, Ext1.getValue(1)});
+                         {Ext1.getValue(1), Ext1});
     }
     if (Op0VT == MVT::bf16)
       return DAG.getNode(ISD::FP_EXTEND, SDLoc(Op), VT,

--- a/llvm/test/CodeGen/AArch64/fp-intrinsics-bf16.ll
+++ b/llvm/test/CodeGen/AArch64/fp-intrinsics-bf16.ll
@@ -1541,4 +1541,15 @@ define float @fpext_f32_bf16(bfloat %x) #0 {
   ret float %val
 }
 
+define double @fpext_f64_bf16(bfloat %x) #0 {
+; CHECK-LABEL: fpext_f64_bf16:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    // kill: def $h0 killed $h0 def $d0
+; CHECK-NEXT:    shll v0.4s, v0.4h, #16
+; CHECK-NEXT:    fcvt d0, s0
+; CHECK-NEXT:    ret
+  %val = call double @llvm.experimental.constrained.fpext.f64.bf16(bfloat %x, metadata !"fpexcept.strict") #0
+  ret double %val
+}
+
 attributes #0 = { strictfp }


### PR DESCRIPTION
The chain was being passed as the last operand when it should be the first.