### PR TITLE
[mlir][OpenACC][NFC] Fix par_width syntax in code examples

### DIFF
--- a/mlir/include/mlir/Dialect/OpenACC/OpenACCCGOps.td
+++ b/mlir/include/mlir/Dialect/OpenACC/OpenACCCGOps.td
@@ -713,8 +713,8 @@ def OpenACC_PredicateRegionOp
     //   !$acc atomic update
     //   !$acc loop vector
     //     !$acc atomic update
-    %w_gang = acc.par_width %cNG {par_dim = #acc.par_dim<block_x>}
-    %w_vector = acc.par_width %cVL {par_dim = #acc.par_dim<thread_x>}
+    %w_gang = acc.par_width %cNG par_dim(#acc.par_dim<block_x>)
+    %w_vector = acc.par_width %cVL par_dim(#acc.par_dim<thread_x>)
     acc.compute_region launch(%ng = %w_gang, %vl = %w_vector)
         ins(%arg_c1 = %c1, %arg_c2 = %c2) : (memref<i32>, memref<i32>) {
       scf.parallel (%i) = (%c1) to (%cN) step (%c1) {

--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCCGToGPU.cpp
@@ -53,7 +53,7 @@
 // --------
 // Before:
 //   %c128 = arith.constant 128 : index
-//   %tx = acc.par_width %c128 {par_dim = #acc.par_dim<thread_x>}
+//   %tx = acc.par_width %c128 par_dim(#acc.par_dim<thread_x>)
 //   acc.compute_region launch(%arg0 = %tx) {
 //     %c0 = arith.constant 0 : index
 //     %c1 = arith.constant 1 : index


### PR DESCRIPTION
Update the acc.predicate_region documentation and the ACCCGToGPU example to use the explicit par_dim(...) syntax required since #217298.

These examples still use the old attribute-dictionary spelling. This is a documentation-only change; operation definitions and lowering behavior are unchanged.