### PR TITLE
[NFC][BOLT][RISCV] Fix call-relocation-pair test after NOP removal

### DIFF
--- a/bolt/test/RISCV/call-relocation-pair.s
+++ b/bolt/test/RISCV/call-relocation-pair.s
@@ -20,15 +20,15 @@
 // BOLT-NEXT:  nop
 // BOLT-NEXT:  call target_backward
 
+// The temporary NOPs created by fix-riscv-calls may be removed before
+// emission. Check the rewritten calls and their targets independently of them.
 // OBJDUMP-LABEL: <_start>:
-// OBJDUMP:       nop
-// OBJDUMP-NEXT:  auipc ra,
-// OBJDUMP-NEXT:  jalr {{.*}}(ra)
-// OBJDUMP-NEXT:  nop
-// OBJDUMP-NEXT:  auipc ra,
-// OBJDUMP-NEXT:  jalr {{.*}}(ra)
-// OBJDUMP-NEXT:  nop
-// OBJDUMP-NEXT:  jal {{.*}} <target_backward>
+// OBJDUMP:       auipc ra,
+// OBJDUMP-NEXT:  jalr {{.*}}(ra) <target_call>
+// OBJDUMP:       auipc ra,
+// OBJDUMP-NEXT:  jalr {{.*}}(ra) <target_call_plt>
+// OBJDUMP:       jal {{.*}} <target_backward>
+// OBJDUMP-NEXT:  ret
 // OBJDUMP-LABEL: <target_call>:
 // OBJDUMP-LABEL: <target_call_plt>:
 


### PR DESCRIPTION
The test introduced by https://github.com/llvm/llvm-project/pull/216882 expects temporary NOPs from FixRISCVCalls in the emitted binary. https://github.com/llvm/llvm-project/pull/221965 marks those NOPs for removal, causing FileCheck to match trailing alignment padding instead of the rewritten calls.

This caused the call-relocation-pair.s failure on [bolt-aarch64-ubuntu-dylib, build 6378](https://lab.llvm.org/buildbot/#/builders/216/builds/6378).

Check emitted calls independently of the temporary NOPs and verify the forward-call target symbols. Preserve the intermediate-pass NOP checks.

Validation: all five test RUN commands pass with local BOLT builds that retain and remove the temporary NOPs. The original test reproduces the reported FileCheck failure with the NOP-removing build.
