### PR TITLE
[CGP] Drop poison generating flags when pushing freeze through cmp

### DIFF
--- a/llvm/lib/CodeGen/CodeGenPrepare.cpp
+++ b/llvm/lib/CodeGen/CodeGenPrepare.cpp
@@ -9088,12 +9088,7 @@ bool CodeGenPrepare::optimizeInst(Instruction *I, ModifyDT &ModifiedDT) {
   if (FreezeInst *FI = dyn_cast<FreezeInst>(I)) {
     // freeze(icmp a, const)) -> icmp (freeze a), const
     // This helps generate efficient conditional jumps.
-    Instruction *CmpI = nullptr;
-    if (ICmpInst *II = dyn_cast<ICmpInst>(FI->getOperand(0)))
-      CmpI = II;
-    else if (FCmpInst *F = dyn_cast<FCmpInst>(FI->getOperand(0)))
-      CmpI = F->getFastMathFlags().none() ? F : nullptr;
-
+    CmpInst *CmpI = dyn_cast<CmpInst>(FI->getOperand(0));
     if (CmpI && CmpI->hasOneUse()) {
       auto Op0 = CmpI->getOperand(0), Op1 = CmpI->getOperand(1);
       bool Const0 = isa<ConstantInt>(Op0) || isa<ConstantFP>(Op0) ||

--- a/llvm/lib/CodeGen/CodeGenPrepare.cpp
+++ b/llvm/lib/CodeGen/CodeGenPrepare.cpp
@@ -9105,6 +9105,7 @@ bool CodeGenPrepare::optimizeInst(Instruction *I, ModifyDT &ModifiedDT) {
           auto *F = new FreezeInst(Const0 ? Op1 : Op0, "", CmpI->getIterator());
           F->takeName(FI);
           CmpI->setOperand(Const0 ? 1 : 0, F);
+          CmpI->dropPoisonGeneratingFlags();
         }
         replaceAllUsesWith(FI, CmpI, FreshBBs, IsHugeFunc);
         FI->eraseFromParent();

--- a/llvm/test/Transforms/CodeGenPrepare/X86/freeze-brcond.ll
+++ b/llvm/test/Transforms/CodeGenPrepare/X86/freeze-brcond.ll
@@ -319,5 +319,16 @@ EXIT:
   ret void
 }
 
+define i1 @freeze_samesign(i32 %x) {
+; CHECK-LABEL: @freeze_samesign(
+; CHECK-NEXT:    [[FR:%.*]] = freeze i32 [[X:%.*]]
+; CHECK-NEXT:    [[CMP:%.*]] = icmp samesign ult i32 [[FR]], 42
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %cmp = icmp samesign ult i32 %x, 42
+  %fr = freeze i1 %cmp
+  ret i1 %fr
+}
+
 declare void @g1()
 declare void @g2()

--- a/llvm/test/Transforms/CodeGenPrepare/X86/freeze-brcond.ll
+++ b/llvm/test/Transforms/CodeGenPrepare/X86/freeze-brcond.ll
@@ -322,7 +322,7 @@ EXIT:
 define i1 @freeze_samesign(i32 %x) {
 ; CHECK-LABEL: @freeze_samesign(
 ; CHECK-NEXT:    [[FR:%.*]] = freeze i32 [[X:%.*]]
-; CHECK-NEXT:    [[CMP:%.*]] = icmp samesign ult i32 [[FR]], 42
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i32 [[FR]], 42
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
   %cmp = icmp samesign ult i32 %x, 42

--- a/llvm/test/Transforms/CodeGenPrepare/X86/freeze-brcond.ll
+++ b/llvm/test/Transforms/CodeGenPrepare/X86/freeze-brcond.ll
@@ -96,8 +96,8 @@ define i1 @fcmp(float %a) {
 
 define i1 @fcmp_nan(float %a) {
 ; CHECK-LABEL: @fcmp_nan(
-; CHECK-NEXT:    [[C:%.*]] = fcmp nnan oeq float [[A:%.*]], 0.000000e+00
-; CHECK-NEXT:    [[FR:%.*]] = freeze i1 [[C]]
+; CHECK-NEXT:    [[FR1:%.*]] = freeze float [[A:%.*]]
+; CHECK-NEXT:    [[FR:%.*]] = fcmp oeq float [[FR1]], 0.000000e+00
 ; CHECK-NEXT:    ret i1 [[FR]]
 ;
   %c = fcmp nnan oeq float %a, 0.0


### PR DESCRIPTION
We need to clear the samesign flag when pushing freeze through icmp.

In the last commit, I also adjusted the handling of FMF on fcmp to work the same way -- previously the transform would be skipped instead if the fcmp had fast math flags. I think just clearing the poison-generating flags is preferable (and what we'd do anyway in InstCombine and DAGCombine).

Fixes https://github.com/llvm/llvm-project/issues/222309.