### PR TITLE
[Clang] Fix a crash when forming a type from an indexed TTP.

### DIFF
--- a/clang/lib/Parse/ParseExpr.cpp
+++ b/clang/lib/Parse/ParseExpr.cpp
@@ -905,7 +905,7 @@ Parser::ParseCastExpression(CastParseKind ParseKind, bool isAddressOfOperand,
         if (TryAnnotateTypeOrScopeToken())
           return ExprError();
         if (Tok.isOneOf(tok::annot_cxxscope, tok::annot_pack_indexing_type,
-                        tok::annot_template_id))
+                        tok::annot_template_id, tok::annot_typename))
           return ParseCastExpression(ParseKind, isAddressOfOperand,
                                      CorrectionBehavior, isVectorLiteral,
                                      NotPrimaryExpression);

--- a/clang/test/SemaCXX/cxx2d-pack-indexing-template.cpp
+++ b/clang/test/SemaCXX/cxx2d-pack-indexing-template.cpp
@@ -105,6 +105,18 @@ auto ctad() {
   return x;
 }
 static_assert(__is_same(decltype(ctad<Deduce>()), Deduce<int>));
+
+template <template <class> class... TT>
+auto ctad_paren() {
+  return TT...[0](42);
+}
+static_assert(__is_same(decltype(ctad_paren<Deduce>()), Deduce<int>));
+
+template <template <class> class... TT>
+auto ctad_braced() {
+  return TT...[1]{42};
+}
+static_assert(__is_same(decltype(ctad_braced<A, Deduce>()), Deduce<int>));
 }
 
 namespace deduction_guides {


### PR DESCRIPTION
Unreported 24 issue so no release note.