### PR TITLE
[AggressiveInstCombine] Fix terminology in a few comments (NFC)

### DIFF
--- a/llvm/lib/Transforms/AggressiveInstCombine/AggressiveInstCombineInternal.h
+++ b/llvm/lib/Transforms/AggressiveInstCombine/AggressiveInstCombineInternal.h
@@ -21,7 +21,7 @@
 #include "llvm/Support/KnownBits.h"
 
 //===----------------------------------------------------------------------===//
-// TruncInstCombine - looks for expression graphs dominated by trunc
+// TruncInstCombine - looks for expression graphs post-dominated by trunc
 // instructions and for each eligible graph, it will create a reduced bit-width
 // expression and replace the old expression with this new one and remove the
 // old one. Eligible expression graph is such that:
@@ -85,8 +85,8 @@ public:
   bool run(Function &F);
 
 private:
-  /// Build expression graph dominated by the /p CurrentTruncInst and append it
-  /// to the InstInfoMap container.
+  /// Build expression graph post-dominated by the \p CurrentTruncInst and
+  /// append it to the InstInfoMap container.
   ///
   /// \return true only if succeed to generate an eligible sub expression graph.
   bool buildTruncExpressionGraph();
@@ -98,8 +98,8 @@ private:
   /// truncate's operand can be shrunk to.
   unsigned getMinBitWidth();
 
-  /// Build an expression graph dominated by the current processed TruncInst and
-  /// Check if it is eligible to be reduced to a smaller type.
+  /// Build an expression graph post-dominated by the current processed
+  /// TruncInst and check if it is eligible to be reduced to a smaller type.
   ///
   /// \return the scalar version of the new type to be used for the reduced
   ///         expression graph, or nullptr if the expression graph is not

--- a/llvm/lib/Transforms/AggressiveInstCombine/TruncInstCombine.cpp
+++ b/llvm/lib/Transforms/AggressiveInstCombine/TruncInstCombine.cpp
@@ -555,7 +555,7 @@ bool TruncInstCombine::run(Function &F) {
     if (Type *NewDstSclTy = getBestTruncatedType()) {
       LLVM_DEBUG(
           dbgs() << "ICE: TruncInstCombine reducing type of expression graph "
-                    "dominated by: "
+                    "post-dominated by: "
                  << CurrentTruncInst << '\n');
       ReduceExpressionGraph(NewDstSclTy);
       ++NumExprsReduced;


### PR DESCRIPTION
Fix the comments (and a debug print) that say "dominated by trunc" rather than "post-dominated".

Also fixes a Doxygen syntax (use \p instead of /p) and fix capitalization in the middle of a sentence.