### PR TITLE
[MLIR] Fix and classify generated-header dependencies

### DIFF
--- a/clang/lib/CIR/Dialect/IR/CMakeLists.txt
+++ b/clang/lib/CIR/Dialect/IR/CMakeLists.txt
@@ -20,6 +20,6 @@ add_clang_library(MLIRCIR
   MLIRDataLayoutInterfaces
   MLIRFuncDialect
   MLIRLoopLikeInterface
-  MLIRCIRInterfaces
+  MLIRPtrMemorySpaceInterfaces
   clangAST
   )

--- a/clang/lib/CIR/Interfaces/CMakeLists.txt
+++ b/clang/lib/CIR/Interfaces/CMakeLists.txt
@@ -13,8 +13,19 @@ add_clang_library(MLIRCIRInterfaces
   MLIRCIRTypeInterfacesIncGen
   MLIRCIRLoopOpInterfaceIncGen
   MLIRCIROpInterfacesIncGen
+  MLIRCIROpsIncGen
+  MLIRCIRTypeConstraintsIncGen
+  # CIR interface headers include generated core MLIR interfaces without
+  # linking all of their owning libraries.
+  MLIRCallInterfacesIncGen
+  MLIRControlFlowInterfacesIncGen
+  MLIRFunctionInterfacesIncGen
+  MLIRInferTypeOpInterfaceIncGen
+  MLIRLoopLikeInterfaceIncGen
+  MLIRSideEffectInterfacesIncGen
 
   LINK_LIBS
   MLIRIR
+  MLIRPtrMemorySpaceInterfaces
   MLIRSupport
  )

--- a/mlir/include/mlir/Dialect/OpenACC/CMakeLists.txt
+++ b/mlir/include/mlir/Dialect/OpenACC/CMakeLists.txt
@@ -3,6 +3,8 @@ add_subdirectory(Transforms)
 set(LLVM_TARGET_DEFINITIONS ${LLVM_MAIN_INCLUDE_DIR}/llvm/Frontend/OpenACC/ACC.td)
 mlir_tablegen(AccCommon.td --gen-directive-decl --directives-dialect=OpenACC)
 add_mlir_dialect_tablegen_target(acc_common_td)
+# Subsequent TableGen inputs include the generated AccCommon.td file.
+list(APPEND LLVM_TARGET_DEPENDS acc_common_td)
 
 add_mlir_dialect(OpenACCOps acc)
 

--- a/mlir/include/mlir/Dialect/OpenMP/CMakeLists.txt
+++ b/mlir/include/mlir/Dialect/OpenMP/CMakeLists.txt
@@ -3,6 +3,8 @@ add_subdirectory(Transforms)
 set(LLVM_TARGET_DEFINITIONS ${LLVM_MAIN_INCLUDE_DIR}/llvm/Frontend/OpenMP/OMP.td)
 mlir_tablegen(OmpCommon.td --gen-directive-decl --directives-dialect=OpenMP)
 add_mlir_dialect_tablegen_target(omp_common_td)
+# Subsequent TableGen inputs include the generated OmpCommon.td file.
+list(APPEND LLVM_TARGET_DEPENDS omp_common_td)
 
 set(LLVM_TARGET_DEFINITIONS OpenMPOps.td)
 

--- a/mlir/include/mlir/Transforms/CMakeLists.txt
+++ b/mlir/include/mlir/Transforms/CMakeLists.txt
@@ -3,10 +3,10 @@ set(LLVM_TARGET_DEFINITIONS Passes.td)
 mlir_tablegen(Passes.h.inc -gen-pass-decls -name Transforms)
 mlir_tablegen(Transforms.capi.h.inc -gen-pass-capi-header --prefix Transforms)
 mlir_tablegen(Transforms.capi.cpp.inc -gen-pass-capi-impl --prefix Transforms)
-add_mlir_dialect_tablegen_target(MLIRTransformsPassIncGen)
+add_mlir_generic_tablegen_target(MLIRTransformsPassIncGen)
 
 set(LLVM_TARGET_DEFINITIONS DialectInlinerInterface.td)
 mlir_tablegen(DialectInlinerInterface.h.inc -gen-dialect-interface-decls)
-add_mlir_dialect_tablegen_target(MLIRTransformsDialectInterfaceIncGen)
+add_mlir_generic_tablegen_target(MLIRTransformsDialectInterfaceIncGen)
 
 add_mlir_doc(Passes GeneralPasses ./ -gen-pass-doc)

--- a/mlir/lib/Bytecode/CMakeLists.txt
+++ b/mlir/lib/Bytecode/CMakeLists.txt
@@ -7,6 +7,10 @@ add_mlir_library(MLIRBytecodeOpInterface
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Bytecode
 
+  DEPENDS
+  MLIRBytecodeOpInterfaceIncGen
+  MLIRBytecodeDialectInterfaceIncGen
+
   LINK_LIBS PUBLIC
   MLIRIR
   MLIRSupport

--- a/mlir/lib/Dialect/ArmNeon/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/ArmNeon/IR/CMakeLists.txt
@@ -6,6 +6,7 @@ add_mlir_dialect_library(MLIRArmNeonDialect
 
   DEPENDS
   MLIRArmNeonIncGen
+  MLIRArmNeonConversionsIncGen
 
   LINK_LIBS PUBLIC
   MLIRIR

--- a/mlir/lib/Dialect/ArmSME/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/ArmSME/IR/CMakeLists.txt
@@ -8,6 +8,9 @@ add_mlir_dialect_library(MLIRArmSMEDialect
   DEPENDS
   MLIRArmSMEOpsIncGen
   MLIRArmSMEIntrinsicOpsIncGen
+  MLIRArmSMEIncGen
+  MLIRArmSMEConversionsIncGen
+  MLIRArmSMEOpInterfaces
 
   LINK_LIBS PUBLIC
   MLIRIR

--- a/mlir/lib/Dialect/ArmSVE/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/ArmSVE/IR/CMakeLists.txt
@@ -6,6 +6,7 @@ add_mlir_dialect_library(MLIRArmSVEDialect
 
   DEPENDS
   MLIRArmSVEIncGen
+  MLIRArmSVEConversionsIncGen
 
   LINK_LIBS PUBLIC
   MLIRIR

--- a/mlir/lib/Dialect/Bufferization/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/Bufferization/IR/CMakeLists.txt
@@ -16,6 +16,10 @@ add_mlir_dialect_library(MLIRBufferizationDialect
   MLIRAllocationOpInterfaceIncGen
   MLIRBufferizationOpsIncGen
   MLIRBufferizationEnumsIncGen
+  MLIRBufferDeallocationOpInterfaceIncGen
+  MLIRBufferizableOpInterfaceIncGen
+  MLIRBufferViewFlowOpInterfaceIncGen
+  MLIRBufferizationTypeInterfacesIncGen
 
   LINK_LIBS PUBLIC
   MLIRAffineDialect

--- a/mlir/lib/Dialect/DLTI/CMakeLists.txt
+++ b/mlir/lib/Dialect/DLTI/CMakeLists.txt
@@ -5,6 +5,7 @@ add_mlir_dialect_library(MLIRDLTIDialect
 
   DEPENDS
   MLIRDLTIIncGen
+  MLIRDLTIAttrsIncGen
 
   LINK_LIBS PUBLIC
   MLIRIR

--- a/mlir/lib/Dialect/EmitC/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/EmitC/IR/CMakeLists.txt
@@ -7,6 +7,7 @@ add_mlir_dialect_library(MLIREmitCDialect
   DEPENDS
   MLIREmitCIncGen
   MLIREmitCAttributesIncGen
+  MLIREmitCInterfacesIncGen
 
   LINK_LIBS PUBLIC
   MLIRCallInterfaces

--- a/mlir/lib/Dialect/GPU/CMakeLists.txt
+++ b/mlir/lib/Dialect/GPU/CMakeLists.txt
@@ -12,6 +12,10 @@ add_mlir_dialect_library(MLIRGPUDialect
   MLIRGPUOpsEnumsGen
   MLIRGPUOpInterfacesIncGen
   MLIRGPUCompilationAttrInterfacesIncGen
+  MLIRParallelLoopMapperEnumsGen
+  MLIRGPUDeviceMapperEnumsGen
+  # GPU dialect sources include llvm/IR/Attributes.h.
+  intrinsics_gen
 
   LINK_LIBS PUBLIC
   MLIRArithDialect

--- a/mlir/lib/Dialect/GPU/Utils/CMakeLists.txt
+++ b/mlir/lib/Dialect/GPU/Utils/CMakeLists.txt
@@ -5,10 +5,15 @@ add_mlir_dialect_library(MLIRGPUUtils
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/GPU/Utils
 
+  # GPU utility headers include llvm/IR/Attributes.h.
+  DEPENDS
+  intrinsics_gen
+
   LINK_LIBS PUBLIC
   MLIRArithDialect
   MLIRAffineDialect
   MLIRGPUDialect
   MLIRSupport
   MLIRIR
+  MLIRVectorDialect
   )

--- a/mlir/lib/Dialect/IRDL/CMakeLists.txt
+++ b/mlir/lib/Dialect/IRDL/CMakeLists.txt
@@ -9,6 +9,8 @@ add_mlir_dialect_library(MLIRIRDL
   MLIRIRDLIncGen
   MLIRIRDLOpsIncGen
   MLIRIRDLTypesIncGen
+  MLIRIRDLInterfacesIncGen
+  MLIRIRDLAttributesIncGen
 
   LINK_LIBS PUBLIC
   MLIRDialect

--- a/mlir/lib/Dialect/LLVMIR/CMakeLists.txt
+++ b/mlir/lib/Dialect/LLVMIR/CMakeLists.txt
@@ -39,6 +39,8 @@ add_mlir_dialect_library(MLIRLLVMDialect
   MLIRLLVMTypesIncGen
   MLIROpenMPOpsIncGen
   intrinsics_gen
+  MLIRLLVMConversionsIncGen
+  MLIRLLVMIntrinsicConversionsIncGen
 
   LINK_COMPONENTS
   BinaryFormat

--- a/mlir/lib/Dialect/Linalg/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/Linalg/IR/CMakeLists.txt
@@ -15,6 +15,7 @@ add_mlir_dialect_library(MLIRLinalgDialect
   MLIRLinalgStructuredOpsIncGen
   MLIRLinalgRelayoutOpsIncGen
   MLIRShardingInterfaceIncGen
+  MLIRRelayoutOpInterfaceIncGen
 
   LINK_LIBS PUBLIC
   MLIRAffineDialect

--- a/mlir/lib/Dialect/NVGPU/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/NVGPU/IR/CMakeLists.txt
@@ -9,6 +9,7 @@ add_mlir_dialect_library(MLIRNVGPUDialect
   MLIRNVGPUEnumsIncGen
   MLIRNVGPUAttributesIncGen
   MLIRNVGPUTypesIncGen
+  MLIRNVGPUIncGen
 
   LINK_LIBS PUBLIC
   MLIRGPUDialect

--- a/mlir/lib/Dialect/OpenACCMPCommon/Interfaces/CMakeLists.txt
+++ b/mlir/lib/Dialect/OpenACCMPCommon/Interfaces/CMakeLists.txt
@@ -5,8 +5,8 @@ ADDITIONAL_HEADER_DIRS
 ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/OpenACCMPCommon/Interfaces
 
 DEPENDS
-MLIRArithOpsIncGen
 MLIRAtomicInterfacesIncGen
+MLIROpenACCMPOpsInterfacesIncGen
 
 LINK_LIBS PUBLIC
 MLIRArithDialect

--- a/mlir/lib/Dialect/Ptr/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/Ptr/IR/CMakeLists.txt
@@ -10,7 +10,6 @@ add_mlir_dialect_library(
   MemorySpaceInterfaces.cpp
 
   DEPENDS
-  MLIRPtrOpsEnumsGen
   MLIRPtrMemorySpaceInterfacesIncGen
   LINK_LIBS
   PUBLIC

--- a/mlir/lib/Dialect/SCF/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/SCF/IR/CMakeLists.txt
@@ -9,6 +9,7 @@ add_mlir_dialect_library(MLIRSCFDialect
 
   DEPENDS
   MLIRSCFOpsIncGen
+  MLIRDeviceMappingInterfacesIncGen
 
   LINK_LIBS PUBLIC
   MLIRArithDialect

--- a/mlir/lib/Dialect/SPIRV/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/SPIRV/IR/CMakeLists.txt
@@ -54,6 +54,9 @@ add_mlir_dialect_library(MLIRSPIRVDialect
   MLIRSPIRVImageInterfacesIncGen
   MLIRSPIRVOpsIncGen
   MLIRSPIRVOpsShardGen
+  MLIRSPIRVSerializationGen
+  # SPIRVDialect.cpp includes llvm/IR/Attributes.h.
+  intrinsics_gen
 
   LINK_LIBS PUBLIC
   MLIRControlFlowInterfaces

--- a/mlir/lib/Dialect/SparseTensor/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/SparseTensor/IR/CMakeLists.txt
@@ -42,6 +42,7 @@ add_mlir_dialect_library(MLIRSparseTensorDialect
   MLIRSparseTensorAttrDefsIncGen
   MLIRSparseTensorOpsIncGen
   MLIRSparseTensorTypesIncGen
+  MLIRSparseTensorInterfacesIncGen
 
   LINK_LIBS PUBLIC
   MLIRArithDialect

--- a/mlir/lib/Dialect/Transform/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/Transform/IR/CMakeLists.txt
@@ -5,6 +5,13 @@ add_mlir_dialect_library(MLIRTransformDialect
   TransformTypes.cpp
   Utils.cpp
 
+  DEPENDS
+  MLIRTransformDialectIncGen
+  MLIRTransformTypesIncGen
+  MLIRTransformDialectEnumIncGen
+  MLIRTransformDialectAttributesIncGen
+  MLIRTransformOpsIncGen
+
   LINK_LIBS PUBLIC
   MLIRCastInterfaces
   MLIRFunctionInterfaces

--- a/mlir/lib/Dialect/Transform/Interfaces/CMakeLists.txt
+++ b/mlir/lib/Dialect/Transform/Interfaces/CMakeLists.txt
@@ -5,6 +5,8 @@ add_mlir_library(MLIRTransformDialectInterfaces
   DEPENDS
   MLIRMatchInterfacesIncGen
   MLIRTransformInterfacesIncGen
+  MLIRTransformDialectTypeInterfacesIncGen
+  MLIRTransformDialectAttrInterfacesIncGen
 
   LINK_LIBS PUBLIC
   MLIRCastInterfaces
@@ -14,4 +16,3 @@ add_mlir_library(MLIRTransformDialectInterfaces
   MLIRTransforms
   MLIRTransformDialectUtils
 )
-

--- a/mlir/lib/Dialect/Vector/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/Vector/IR/CMakeLists.txt
@@ -11,6 +11,7 @@ add_mlir_dialect_library(MLIRVectorDialect
   MLIRMaskingOpInterfaceIncGen
   MLIRVectorOpsIncGen
   MLIRVectorAttributesIncGen
+  MLIRVectorIncGen
 
   LINK_LIBS PUBLIC
   MLIRAffineDialect

--- a/mlir/lib/Dialect/X86/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/X86/IR/CMakeLists.txt
@@ -6,6 +6,7 @@ add_mlir_dialect_library(MLIRX86Dialect
 
   DEPENDS
   MLIRX86IncGen
+  MLIRX86InterfacesIncGen
 
   LINK_LIBS PUBLIC
   MLIRIR

--- a/mlir/lib/Dialect/XeGPU/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/XeGPU/IR/CMakeLists.txt
@@ -10,6 +10,7 @@ add_mlir_dialect_library(MLIRXeGPUDialect
   MLIRXeGPUAttrInterfaceIncGen
   MLIRXeGPUAttrsIncGen
   MLIRXeGPUEnumsIncGen
+  MLIRXeGPUOpInterfaceIncGen
 
   LINK_LIBS PUBLIC
   MLIRArithDialect

--- a/mlir/lib/IR/CMakeLists.txt
+++ b/mlir/lib/IR/CMakeLists.txt
@@ -71,6 +71,8 @@ add_mlir_library(MLIRIR
   MLIRSymbolInterfacesIncGen
   MLIRTensorEncodingIncGen
   MLIROpAsmDialectInterfaceIncGen
+  MLIRBytecodeDialectInterfaceIncGen
+  MLIRBytecodeOpInterfaceIncGen
 
   LINK_LIBS PUBLIC
   MLIRSupport

--- a/mlir/lib/Target/LLVMIR/CMakeLists.txt
+++ b/mlir/lib/Target/LLVMIR/CMakeLists.txt
@@ -29,6 +29,7 @@ add_mlir_translation_library(MLIRTargetLLVMIRExport
 
   DEPENDS
   intrinsics_gen
+  MLIRLLVMTranslationDialectInterfaceIncGen
 
   LINK_COMPONENTS
   Analysis

--- a/mlir/lib/Target/SPIRV/CMakeLists.txt
+++ b/mlir/lib/Target/SPIRV/CMakeLists.txt
@@ -28,6 +28,10 @@ add_mlir_translation_library(MLIRSPIRVTranslateRegistration
 add_mlir_dialect_library(MLIRSPIRVTarget
   Target.cpp
 
+  # Target.cpp includes llvm/IR/Attributes.h.
+  DEPENDS
+  intrinsics_gen
+
   LINK_LIBS PUBLIC
   MLIRIR
   MLIRGPUDialect

--- a/mlir/lib/Transforms/CMakeLists.txt
+++ b/mlir/lib/Transforms/CMakeLists.txt
@@ -28,7 +28,6 @@ add_mlir_library(MLIRTransforms
 
   DEPENDS
   MLIRTransformsPassIncGen
-  MLIRTransformsDialectInterfaceIncGen
 
   LINK_LIBS PUBLIC
   MLIRAnalysis

--- a/mlir/lib/Transforms/Utils/CMakeLists.txt
+++ b/mlir/lib/Transforms/Utils/CMakeLists.txt
@@ -15,6 +15,9 @@ add_mlir_library(MLIRTransformUtils
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Transforms
 
+  DEPENDS
+  MLIRTransformsDialectInterfaceIncGen
+
   LINK_LIBS PUBLIC
   MLIRAnalysis
   MLIRCallInterfaces


### PR DESCRIPTION
This is fixing missing CMake dependencies to make our build graph correct. It is a bit verbose but will be cleaned up in a following patch making handling of the generated header automatic.

List the TableGen targets owned by each affected library, and add the missing LLVM generated-header, SPIR-V source-generation, OpenACC/OpenMP generated-input, and CIR operation/type prerequisites found by clean dependency audits. Correct two stale copy-paste dependencies and the duplicate CIR link entry.

The Transforms pass declarations and dialect inliner interface are independent of any dialect. Classify both under mlir-generic-headers, and associate the inliner interface with MLIRTransformUtils, which publishes InliningUtils.h. This gives every MLIR library the required ordering without repeated header-only edges.

Assisted-by: Codex
Assisted-by: Claude Code