### PR TITLE
[release/23.x] Backport -Wunused-template fixes

### DIFF
--- a/clang-tools-extra/clangd/unittests/CallHierarchyTests.cpp
+++ b/clang-tools-extra/clangd/unittests/CallHierarchyTests.cpp
@@ -46,7 +46,6 @@ using ::testing::UnorderedElementsAre;
 MATCHER_P(withName, N, "") { return arg.name == N; }
 MATCHER_P(withDetail, N, "") { return arg.detail == N; }
 MATCHER_P(withFile, N, "") { return arg.uri.file() == N; }
-MATCHER_P(withSelectionRange, R, "") { return arg.selectionRange == R; }
 
 template <class ItemMatcher>
 ::testing::Matcher<CallHierarchyIncomingCall> from(ItemMatcher M) {

--- a/clang-tools-extra/clangd/unittests/ClangdLSPServerTests.cpp
+++ b/clang-tools-extra/clangd/unittests/ClangdLSPServerTests.cpp
@@ -366,15 +366,6 @@ TEST_F(LSPTest, ModulesTest) {
               ElementsAre(llvm::json::Value(2), llvm::json::Value(10)));
 }
 
-// Creates a Callback that writes its received value into an
-// std::optional<Expected>.
-template <typename T>
-llvm::unique_function<void(llvm::Expected<T>)>
-capture(std::optional<llvm::Expected<T>> &Out) {
-  Out.reset();
-  return [&Out](llvm::Expected<T> V) { Out.emplace(std::move(V)); };
-}
-
 TEST_F(LSPTest, FeatureModulesThreadingTest) {
   // A feature module that does its work on a background thread, and so
   // exercises the block/shutdown protocol.

--- a/clang-tools-extra/clangd/unittests/ParsedASTTests.cpp
+++ b/clang-tools-extra/clangd/unittests/ParsedASTTests.cpp
@@ -348,8 +348,6 @@ TEST(ParsedASTTest, CollectsMainFileMacroExpansions) {
               testing::UnorderedElementsAreArray(TestCase.points()));
 }
 
-MATCHER_P(withFileName, Inc, "") { return arg.FileName == Inc; }
-
 TEST(ParsedASTTest, PatchesAdditionalIncludes) {
   llvm::StringLiteral ModifiedContents = R"cpp(
     #include "baz.h"

--- a/clang-tools-extra/clangd/unittests/PreambleTests.cpp
+++ b/clang-tools-extra/clangd/unittests/PreambleTests.cpp
@@ -54,10 +54,6 @@ namespace clang {
 namespace clangd {
 namespace {
 
-MATCHER_P2(Distance, File, D, "") {
-  return arg.first() == File && arg.second == D;
-}
-
 // Builds a preamble for BaselineContents, patches it for ModifiedContents and
 // returns the includes in the patch.
 IncludeStructure

--- a/clang-tools-extra/clangd/unittests/SymbolCollectorTests.cpp
+++ b/clang-tools-extra/clangd/unittests/SymbolCollectorTests.cpp
@@ -58,7 +58,6 @@ MATCHER_P(snippet, S, "") {
   return (arg.Name + arg.CompletionSnippetSuffix).str() == S;
 }
 MATCHER_P(qName, Name, "") { return (arg.Scope + arg.Name).str() == Name; }
-MATCHER_P(hasName, Name, "") { return arg.Name == Name; }
 MATCHER_P(templateArgs, TemplArgs, "") {
   return arg.TemplateSpecializationArgs == TemplArgs;
 }

--- a/clang-tools-extra/clangd/unittests/TUSchedulerTests.cpp
+++ b/clang-tools-extra/clangd/unittests/TUSchedulerTests.cpp
@@ -63,19 +63,6 @@ using ::testing::Pointee;
 using ::testing::SizeIs;
 using ::testing::UnorderedElementsAre;
 
-MATCHER_P2(TUState, PreambleActivity, ASTActivity, "") {
-  if (arg.PreambleActivity != PreambleActivity) {
-    *result_listener << "preamblestate is "
-                     << static_cast<uint8_t>(arg.PreambleActivity);
-    return false;
-  }
-  if (arg.ASTActivity.K != ASTActivity) {
-    *result_listener << "aststate is " << arg.ASTActivity.K;
-    return false;
-  }
-  return true;
-}
-
 // Simple ContextProvider to verify the provider is invoked & contexts are used.
 static Key<std::string> BoundPath;
 Context bindPath(PathRef F) {

--- a/clang-tools-extra/clangd/unittests/XRefsTests.cpp
+++ b/clang-tools-extra/clangd/unittests/XRefsTests.cpp
@@ -46,9 +46,6 @@ std::string guard(llvm::StringRef Code) {
   return "#pragma once\n" + Code.str();
 }
 
-MATCHER_P2(FileRange, File, Range, "") {
-  return Location{URIForFile::canonicalize(File, testRoot()), Range} == arg;
-}
 MATCHER(declRange, "") {
   const LocatedSymbol &Sym = ::testing::get<0>(arg);
   const Range &Range = ::testing::get<1>(arg);

--- a/clang-tools-extra/unittests/clang-tidy/ClangTidyOptionsTest.cpp
+++ b/clang-tools-extra/unittests/clang-tidy/ClangTidyOptionsTest.cpp
@@ -305,10 +305,6 @@ public:
     return Options.get(std::forward<Args>(Arguments)...);
   }
 
-  template <typename... Args> auto getGlobal(Args &&... Arguments) {
-    return Options.getLocalOrGlobal(std::forward<Args>(Arguments)...);
-  }
-
   template <typename IntType = int, typename... Args>
   auto getIntLocal(Args &&... Arguments) {
     return Options.get<IntType>(std::forward<Args>(Arguments)...);

--- a/clang/unittests/Analysis/FlowSensitive/SignAnalysisTest.cpp
+++ b/clang/unittests/Analysis/FlowSensitive/SignAnalysisTest.cpp
@@ -444,6 +444,7 @@ void runDataflow(llvm::StringRef Code, Matcher Match,
 
 // FIXME add this to testing support.
 template <typename NodeType, typename MatcherType>
+[[maybe_unused]]
 const NodeType *findFirst(ASTContext &ASTCtx, const MatcherType &M) {
   auto TargetNodes = match(M.bind("v"), ASTCtx);
   assert(TargetNodes.size() == 1 && "Match must be unique");

--- a/clang/unittests/Analysis/IntervalPartitionTest.cpp
+++ b/clang/unittests/Analysis/IntervalPartitionTest.cpp
@@ -90,7 +90,7 @@ using ::testing::UnorderedElementsAre;
 
 MATCHER_P(intervalID, ID, "") { return arg->ID == ID; }
 
-template <typename... T> auto blockIDs(T... IDs) {
+template <typename... T> [[maybe_unused]] auto blockIDs(T... IDs) {
   return UnorderedElementsAre(Property(&CFGBlock::getBlockID, IDs)...);
 }
 

--- a/compiler-rt/lib/asan/asan_interceptors.cpp
+++ b/compiler-rt/lib/asan/asan_interceptors.cpp
@@ -178,6 +178,7 @@ DECLARE_REAL_AND_INTERCEPTOR(void, free, void*)
       *begin = *end = 0;                               \
     }
 
+#  if SANITIZER_INTERCEPT_MMAP
 template <class Mmap>
 static void* mmap_interceptor(Mmap real_mmap, void* addr, SIZE_T length,
                               int prot, int flags, int fd, OFF64_T offset) {
@@ -243,6 +244,7 @@ static int munmap_interceptor(Munmap real_munmap, void* addr, SIZE_T length) {
   }
   return real_munmap(addr, length);
 }
+#  endif  // SANITIZER_INTERCEPT_MMAP
 
 #  define COMMON_INTERCEPTOR_MMAP_IMPL(ctx, mmap, addr, length, prot, flags, \
                                        fd, offset)                           \

--- a/compiler-rt/lib/tsan/rtl/tsan_interface_atomic.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_interface_atomic.cpp
@@ -350,12 +350,13 @@ struct OpFetchAdd {
 
 struct OpFetchSub {
   template <typename T>
-  static T NoTsanAtomic(morder mo, volatile T *a, T v) {
+  [[maybe_unused]] static T NoTsanAtomic(morder mo, volatile T* a, T v) {
     return func_sub(a, v);
   }
 
   template <typename T>
-  static T Atomic(ThreadState *thr, uptr pc, morder mo, volatile T *a, T v) {
+  [[maybe_unused]] static T Atomic(ThreadState* thr, uptr pc, morder mo,
+                                   volatile T* a, T v) {
     return AtomicRMW<T, func_sub>(thr, pc, a, v, mo);
   }
 };
@@ -386,24 +387,26 @@ struct OpFetchOr {
 
 struct OpFetchXor {
   template <typename T>
-  static T NoTsanAtomic(morder mo, volatile T *a, T v) {
+  [[maybe_unused]] static T NoTsanAtomic(morder mo, volatile T* a, T v) {
     return func_xor(a, v);
   }
 
   template <typename T>
-  static T Atomic(ThreadState *thr, uptr pc, morder mo, volatile T *a, T v) {
+  [[maybe_unused]] static T Atomic(ThreadState* thr, uptr pc, morder mo,
+                                   volatile T* a, T v) {
     return AtomicRMW<T, func_xor>(thr, pc, a, v, mo);
   }
 };
 
 struct OpFetchNand {
   template <typename T>
-  static T NoTsanAtomic(morder mo, volatile T *a, T v) {
+  [[maybe_unused]] static T NoTsanAtomic(morder mo, volatile T* a, T v) {
     return func_nand(a, v);
   }
 
   template <typename T>
-  static T Atomic(ThreadState *thr, uptr pc, morder mo, volatile T *a, T v) {
+  [[maybe_unused]] static T Atomic(ThreadState* thr, uptr pc, morder mo,
+                                   volatile T* a, T v) {
     return AtomicRMW<T, func_nand>(thr, pc, a, v, mo);
   }
 };

--- a/lldb/unittests/Protocol/ProtocolMCPServerTest.cpp
+++ b/lldb/unittests/Protocol/ProtocolMCPServerTest.cpp
@@ -211,41 +211,7 @@ public:
     Response resp = promised_result.get_future().get();
     return toJSON(resp);
   }
-
-  template <typename Result>
-  Expected<json::Value>
-  Capture(llvm::unique_function<void(Reply<Result>)> &fn) {
-    std::promise<llvm::Expected<Result>> promised_result;
-    fn([&promised_result](llvm::Expected<Result> result) {
-      promised_result.set_value(std::move(result));
-    });
-    Run();
-    llvm::Expected<Result> result = promised_result.get_future().get();
-    if (!result)
-      return result.takeError();
-    return toJSON(*result);
-  }
-
-  template <typename Result, typename Params>
-  Expected<json::Value>
-  Capture(llvm::unique_function<void(const Params &, Reply<Result>)> &fn,
-          const Params &params) {
-    std::promise<llvm::Expected<Result>> promised_result;
-    fn(params, [&promised_result](llvm::Expected<Result> result) {
-      promised_result.set_value(std::move(result));
-    });
-    Run();
-    llvm::Expected<Result> result = promised_result.get_future().get();
-    if (!result)
-      return result.takeError();
-    return toJSON(*result);
-  }
 };
-
-template <typename T>
-inline testing::internal::EqMatcher<llvm::json::Value> HasJSON(T x) {
-  return testing::internal::EqMatcher<llvm::json::Value>(toJSON(x));
-}
 
 } // namespace
 

--- a/lldb/unittests/TestingSupport/TestUtilities.h
+++ b/lldb/unittests/TestingSupport/TestUtilities.h
@@ -65,7 +65,7 @@ private:
   std::string Buffer;
 };
 
-template <typename T> static llvm::Expected<T> roundtripJSON(const T &input) {
+template <typename T> llvm::Expected<T> roundtripJSON(const T &input) {
   std::string encoded;
   llvm::raw_string_ostream OS(encoded);
   OS << toJSON(input);

--- a/llvm/include/llvm/Support/LSP/Transport.h
+++ b/llvm/include/llvm/Support/LSP/Transport.h
@@ -27,13 +27,6 @@
 #include <memory>
 
 namespace llvm {
-// Simple helper function that returns a string as printed from a op.
-template <typename T> static std::string debugString(T &&Op) {
-  std::string InstrStr;
-  llvm::raw_string_ostream Os(InstrStr);
-  Os << Op;
-  return Os.str();
-}
 namespace lsp {
 class MessageHandler;
 
@@ -227,6 +220,14 @@ public:
       Logger::info("--> {0}", Method);
       Transport.notify(Method, llvm::json::Value(Params));
     };
+  }
+
+  // Simple helper function that returns a string as printed from a op.
+  template <typename T> static std::string debugString(T &&Op) {
+    std::string InstrStr;
+    llvm::raw_string_ostream Os(InstrStr);
+    Os << Op;
+    return Os.str();
   }
 
   /// Create an OutgoingRequest function that, when called, sends a request with

--- a/llvm/lib/Target/AArch64/Disassembler/AArch64Disassembler.cpp
+++ b/llvm/lib/Target/AArch64/Disassembler/AArch64Disassembler.cpp
@@ -38,9 +38,6 @@ using DecodeStatus = MCDisassembler::DecodeStatus;
 template <int Bits>
 static DecodeStatus DecodeSImm(MCInst &Inst, uint64_t Imm, uint64_t Address,
                                const MCDisassembler *Decoder);
-template <int Bits>
-static DecodeStatus DecodeUImm(MCInst &Inst, uint64_t Imm, uint64_t Address,
-                               const MCDisassembler *Decoder);
 
 #define Success MCDisassembler::Success
 #define Fail MCDisassembler::Fail
@@ -1439,16 +1436,6 @@ static DecodeStatus DecodeSImm(MCInst &Inst, uint64_t Imm, uint64_t Address,
   // Imm is a signed immediate, so sign extend it.
   if (Imm & (1 << (Bits - 1)))
     Imm |= ~((1LL << Bits) - 1);
-
-  Inst.addOperand(MCOperand::createImm(Imm));
-  return Success;
-}
-
-template <int Bits>
-static DecodeStatus DecodeUImm(MCInst &Inst, uint64_t Imm, uint64_t Address,
-                               const MCDisassembler *Decoder) {
-  if (Imm & ~((1ULL << Bits) - 1))
-    return Fail;
 
   Inst.addOperand(MCOperand::createImm(Imm));
   return Success;

--- a/llvm/unittests/ADT/HashingTest.cpp
+++ b/llvm/unittests/ADT/HashingTest.cpp
@@ -390,9 +390,6 @@ TEST(HashingTest, HashWithHashBuilder) {
 struct StructWithHashBuilderAndHashValueSupport {
   char C;
   int I;
-  template <typename HasherT, llvm::endianness Endianness>
-  friend void addHash(llvm::HashBuilder<HasherT, Endianness> &HBuilder,
-                      const StructWithHashBuilderAndHashValueSupport &Value) {}
   friend hash_code
   hash_value(const StructWithHashBuilderAndHashValueSupport &Value) {
     return 0xbeef;

--- a/llvm/unittests/ADT/SmallVectorTest.cpp
+++ b/llvm/unittests/ADT/SmallVectorTest.cpp
@@ -1063,11 +1063,6 @@ struct Emplaceable {
       : A0(std::forward<A0Ty>(A0)), A1(std::forward<A1Ty>(A1)),
         State(ES_Emplaced) {}
 
-  template <class A0Ty, class A1Ty, class A2Ty>
-  Emplaceable(A0Ty &&A0, A1Ty &&A1, A2Ty &&A2)
-      : A0(std::forward<A0Ty>(A0)), A1(std::forward<A1Ty>(A1)),
-        A2(std::forward<A2Ty>(A2)), State(ES_Emplaced) {}
-
   template <class A0Ty, class A1Ty, class A2Ty, class A3Ty>
   Emplaceable(A0Ty &&A0, A1Ty &&A1, A2Ty &&A2, A3Ty &&A3)
       : A0(std::forward<A0Ty>(A0)), A1(std::forward<A1Ty>(A1)),

--- a/llvm/unittests/IR/ConstantFPRangeTest.cpp
+++ b/llvm/unittests/IR/ConstantFPRangeTest.cpp
@@ -154,6 +154,7 @@ static void EnumerateConstantFPRanges(Fn TestFn, SparseLevel Level,
                                 /*MayBeSNaN=*/true);
 }
 
+#if defined(EXPENSIVE_CHECKS)
 template <typename Fn>
 static void EnumerateTwoInterestingConstantFPRanges(Fn TestFn,
                                                     SparseLevel Level) {
@@ -165,6 +166,7 @@ static void EnumerateTwoInterestingConstantFPRanges(Fn TestFn,
       },
       Level, /*IgnoreSNaNs=*/true);
 }
+#endif
 
 template <typename Fn>
 static void EnumerateValuesInConstantFPRange(const ConstantFPRange &CR,
@@ -203,6 +205,7 @@ static void EnumerateValuesInConstantFPRange(const ConstantFPRange &CR,
   }
 }
 
+#if defined(EXPENSIVE_CHECKS)
 template <typename Fn>
 static bool AnyOfValueInConstantFPRange(const ConstantFPRange &CR, Fn TestFn,
                                         bool IgnoreNaNPayload) {
@@ -245,6 +248,7 @@ static bool AnyOfValueInConstantFPRange(const ConstantFPRange &CR, Fn TestFn,
   }
   return false;
 }
+#endif
 
 TEST_F(ConstantFPRangeTest, Basics) {
   EXPECT_TRUE(Full.isFullSet());

--- a/llvm/unittests/IR/IntrinsicsTest.cpp
+++ b/llvm/unittests/IR/IntrinsicsTest.cpp
@@ -57,9 +57,6 @@ public:
     }
     return Builder.CreateCall(Decl, ProcessedArgs);
   }
-  template <typename T> void checkIsa(const Instruction &I) {
-    EXPECT_TRUE(isa<T>(I));
-  }
 };
 
 TEST(IntrinsicNameLookup, Basic) {

--- a/llvm/unittests/Support/LSP/Transport.cpp
+++ b/llvm/unittests/Support/LSP/Transport.cpp
@@ -182,7 +182,7 @@ TEST_F(TransportInputTest, OutgoingRequestJSONParseFailure) {
         llvm::Error err = result.takeError();
         EXPECT_EQ(id, 109);
         ASSERT_TRUE((bool)err);
-        EXPECT_THAT(debugString(err),
+        EXPECT_THAT(MessageHandler::debugString(err),
                     HasSubstr("failed to decode "
                               "reply:outgoing-request-json-parse-failure(109) "
                               "response: missing value at (root).character"));

--- a/llvm/unittests/Support/RecyclerTest.cpp
+++ b/llvm/unittests/Support/RecyclerTest.cpp
@@ -30,11 +30,6 @@ public:
     DeallocCount++;
     MallocAllocator::Deallocate(Ptr, Size, Alignment);
   }
-
-  template <typename T> void Deallocate(T *Ptr) {
-    DeallocCount++;
-    MallocAllocator::Deallocate(Ptr);
-  }
 };
 
 TEST(RecyclerTest, RecycleAllocation) {

--- a/mlir/cmake/modules/AddMLIRPython.cmake
+++ b/mlir/cmake/modules/AddMLIRPython.cmake
@@ -385,6 +385,7 @@ function(build_nanobind_lib)
         -Wno-deprecated-literal-operator
         -Wno-nested-anon-types
         -Wno-unused-parameter
+	-Wno-unused-template
         -Wno-zero-length-array
         -Wno-missing-field-initializers
         ${eh_rtti_enable})
@@ -1055,6 +1056,7 @@ function(add_mlir_python_extension libname extname nb_library_target_name)
         -Wno-deprecated-literal-operator
         -Wno-nested-anon-types
         -Wno-unused-parameter
+	-Wno-unused-template
         -Wno-zero-length-array
         -Wno-missing-field-initializers)
   endif()

--- a/mlir/include/mlir/Bytecode/BytecodeImplementation.h
+++ b/mlir/include/mlir/Bytecode/BytecodeImplementation.h
@@ -443,8 +443,8 @@ public:
 
 /// Helper for resource handle reading that returns LogicalResult.
 template <typename T, typename... Ts>
-static LogicalResult readResourceHandle(DialectBytecodeReader &reader,
-                                        FailureOr<T> &value, Ts &&...params) {
+LogicalResult readResourceHandle(DialectBytecodeReader &reader,
+                                 FailureOr<T> &value, Ts &&...params) {
   FailureOr<T> handle = reader.readResourceHandle<T>();
   if (failed(handle))
     return failure();

--- a/mlir/include/mlir/Dialect/Utils/ReshapeOpsUtils.h
+++ b/mlir/include/mlir/Dialect/Utils/ReshapeOpsUtils.h
@@ -84,8 +84,8 @@ bool isReassociationValid(ArrayRef<AffineMap> reassociation,
                           int *invalidIndex = nullptr);
 
 template <typename ReshapeOpTy, typename InverseReshapeOpTy>
-static OpFoldResult foldReshapeOp(ReshapeOpTy reshapeOp,
-                                  ArrayRef<Attribute> operands) {
+OpFoldResult foldReshapeOp(ReshapeOpTy reshapeOp,
+                           ArrayRef<Attribute> operands) {
   // Fold identity reshape.
   if (reshapeOp.getSrcType() == reshapeOp.getType())
     return reshapeOp.getSrc();
@@ -140,8 +140,8 @@ static OpFoldResult foldReshapeOp(ReshapeOpTy reshapeOp,
 /// Common verifier for reshape-like types. Fills `expandedType` and
 ///`collapsedType` with the proper `src` or `result` type.
 template <typename Op, typename T>
-static LogicalResult verifyReshapeLikeTypes(Op op, T expandedType,
-                                            T collapsedType, bool isExpansion) {
+LogicalResult verifyReshapeLikeTypes(Op op, T expandedType, T collapsedType,
+                                     bool isExpansion) {
 
   unsigned expandedRank = expandedType.getRank();
   unsigned collapsedRank = collapsedType.getRank();

--- a/mlir/include/mlir/IR/AffineMap.h
+++ b/mlir/include/mlir/IR/AffineMap.h
@@ -694,8 +694,8 @@ SmallVector<T> applyPermutationMap(AffineMap map, llvm::ArrayRef<T> source) {
 /// Calculates maximum dimension and symbol positions from the expressions
 /// in `exprsLists` and stores them in `maxDim` and `maxSym` respectively.
 template <typename AffineExprContainer>
-static void getMaxDimAndSymbol(ArrayRef<AffineExprContainer> exprsList,
-                               int64_t &maxDim, int64_t &maxSym) {
+void getMaxDimAndSymbol(ArrayRef<AffineExprContainer> exprsList,
+                        int64_t &maxDim, int64_t &maxSym) {
   for (const auto &exprs : exprsList) {
     for (auto expr : exprs) {
       expr.walk([&maxDim, &maxSym](AffineExpr e) {

--- a/mlir/include/mlir/IR/OpDefinition.h
+++ b/mlir/include/mlir/IR/OpDefinition.h
@@ -1607,8 +1607,8 @@ using detect_has_any_fold_trait =
 /// Returns the result of folding a trait that implements a `foldTrait` function
 /// that is specialized for operations that have a single result.
 template <typename Trait>
-static std::enable_if_t<detect_has_single_result_fold_trait<Trait>::value,
-                        LogicalResult>
+std::enable_if_t<detect_has_single_result_fold_trait<Trait>::value,
+                 LogicalResult>
 foldTrait(Operation *op, ArrayRef<Attribute> operands,
           SmallVectorImpl<OpFoldResult> &results) {
   assert(op->hasTrait<OpTrait::OneResult>() &&
@@ -1629,7 +1629,7 @@ foldTrait(Operation *op, ArrayRef<Attribute> operands,
 /// Returns the result of folding a trait that implements a generalized
 /// `foldTrait` function that is supports any operation type.
 template <typename Trait>
-static std::enable_if_t<detect_has_fold_trait<Trait>::value, LogicalResult>
+std::enable_if_t<detect_has_fold_trait<Trait>::value, LogicalResult>
 foldTrait(Operation *op, ArrayRef<Attribute> operands,
           SmallVectorImpl<OpFoldResult> &results) {
   // If a previous trait has already been folded and replaced this operation, we
@@ -1637,8 +1637,7 @@ foldTrait(Operation *op, ArrayRef<Attribute> operands,
   return results.empty() ? Trait::foldTrait(op, operands, results) : failure();
 }
 template <typename Trait>
-static inline std::enable_if_t<!detect_has_any_fold_trait<Trait>::value,
-                               LogicalResult>
+inline std::enable_if_t<!detect_has_any_fold_trait<Trait>::value, LogicalResult>
 foldTrait(Operation *, ArrayRef<Attribute>, SmallVectorImpl<OpFoldResult> &) {
   return failure();
 }
@@ -1646,8 +1645,8 @@ foldTrait(Operation *, ArrayRef<Attribute>, SmallVectorImpl<OpFoldResult> &) {
 /// Given a tuple type containing a set of traits, return the result of folding
 /// the given operation.
 template <typename... Ts>
-static LogicalResult foldTraits(Operation *op, ArrayRef<Attribute> operands,
-                                SmallVectorImpl<OpFoldResult> &results) {
+LogicalResult foldTraits(Operation *op, ArrayRef<Attribute> operands,
+                         SmallVectorImpl<OpFoldResult> &results) {
   return success((succeeded(foldTrait<Ts>(op, operands, results)) || ...));
 }
 

--- a/mlir/include/mlir/IR/PDLPatternMatch.h.inc
+++ b/mlir/include/mlir/IR/PDLPatternMatch.h.inc
@@ -642,8 +642,8 @@ void assertArgs(PatternRewriter &rewriter, ArrayRef<PDLValue> values,
 
 /// Store a single result within the result list.
 template <typename T>
-static LogicalResult processResults(PatternRewriter &rewriter,
-                                    PDLResultList &results, T &&value) {
+LogicalResult processResults(PatternRewriter &rewriter, PDLResultList &results,
+                             T &&value) {
   ProcessPDLValue<T>::processAsResult(rewriter, results,
                                       std::forward<T>(value));
   return success();
@@ -651,9 +651,8 @@ static LogicalResult processResults(PatternRewriter &rewriter,
 
 /// Store a std::pair<> as individual results within the result list.
 template <typename T1, typename T2>
-static LogicalResult processResults(PatternRewriter &rewriter,
-                                    PDLResultList &results,
-                                    std::pair<T1, T2> &&pair) {
+LogicalResult processResults(PatternRewriter &rewriter, PDLResultList &results,
+                             std::pair<T1, T2> &&pair) {
   if (failed(processResults(rewriter, results, std::move(pair.first))) ||
       failed(processResults(rewriter, results, std::move(pair.second))))
     return failure();
@@ -662,9 +661,8 @@ static LogicalResult processResults(PatternRewriter &rewriter,
 
 /// Store a std::tuple<> as individual results within the result list.
 template <typename... Ts>
-static LogicalResult processResults(PatternRewriter &rewriter,
-                                    PDLResultList &results,
-                                    std::tuple<Ts...> &&tuple) {
+LogicalResult processResults(PatternRewriter &rewriter, PDLResultList &results,
+                             std::tuple<Ts...> &&tuple) {
   auto applyFn = [&](auto &&...args) {
     return (succeeded(processResults(rewriter, results, std::move(args))) &&
             ...);
@@ -679,9 +677,8 @@ inline LogicalResult processResults(PatternRewriter &rewriter,
   return result;
 }
 template <typename T>
-static LogicalResult processResults(PatternRewriter &rewriter,
-                                    PDLResultList &results,
-                                    FailureOr<T> &&result) {
+LogicalResult processResults(PatternRewriter &rewriter, PDLResultList &results,
+                             FailureOr<T> &&result) {
   if (failed(result))
     return failure();
   return processResults(rewriter, results, std::move(*result));

--- a/mlir/include/mlir/Pass/PassOptions.h
+++ b/mlir/include/mlir/Pass/PassOptions.h
@@ -57,11 +57,11 @@ using has_stream_operator = llvm::is_detected<has_stream_operator_trait, T>;
 
 /// Utility methods for printing option values.
 template <typename ParserT>
-static void printOptionValue(raw_ostream &os, const bool &value) {
+void printOptionValue(raw_ostream &os, const bool &value) {
   os << (value ? StringRef("true") : StringRef("false"));
 }
 template <typename ParserT>
-static void printOptionValue(raw_ostream &os, const std::string &str) {
+void printOptionValue(raw_ostream &os, const std::string &str) {
   // Check if the string needs to be escaped before writing it to the ostream.
   const size_t spaceIndex = str.find_first_of(' ');
   const size_t escapeIndex =
@@ -75,7 +75,7 @@ static void printOptionValue(raw_ostream &os, const std::string &str) {
     os << "}";
 }
 template <typename ParserT, typename DataT>
-static void printOptionValue(raw_ostream &os, const DataT &value) {
+void printOptionValue(raw_ostream &os, const DataT &value) {
   if constexpr (has_stream_operator<DataT>::value)
     os << value;
   else

--- a/mlir/tools/mlir-tblgen/DialectGen.cpp
+++ b/mlir/tools/mlir-tblgen/DialectGen.cpp
@@ -31,20 +31,12 @@
 
 using namespace mlir;
 using namespace mlir::tblgen;
-using llvm::Record;
 using llvm::RecordKeeper;
 
 static llvm::cl::OptionCategory dialectGenCat("Options for -gen-dialect-*");
 static llvm::cl::opt<std::string>
     selectedDialect("dialect", llvm::cl::desc("The dialect to gen for"),
                     llvm::cl::cat(dialectGenCat), llvm::cl::CommaSeparated);
-
-/// Utility iterator used for filtering records for a specific dialect.
-namespace {
-using DialectFilterIterator =
-    llvm::filter_iterator<ArrayRef<Record *>::iterator,
-                          std::function<bool(const Record *)>>;
-} // namespace
 
 static void populateDiscardableAttributes(
     Dialect &dialect, const llvm::DagInit *discardableAttrDag,
@@ -59,18 +51,6 @@ static void populateDiscardableAttributes(
     discardableAttributes.push_back(
         {givenName.str(), arg->getAsUnquotedString()});
   }
-}
-
-/// Given a set of records for a T, filter the ones that correspond to
-/// the given dialect.
-template <typename T>
-static iterator_range<DialectFilterIterator>
-filterForDialect(ArrayRef<Record *> records, Dialect &dialect) {
-  auto filterFn = [&](const Record *record) {
-    return T(record).getDialect() == dialect;
-  };
-  return {DialectFilterIterator(records.begin(), records.end(), filterFn),
-          DialectFilterIterator(records.end(), records.end(), filterFn)};
 }
 
 std::optional<Dialect>


### PR DESCRIPTION
`-Wunused-template` was added to `-Wall` by 1529d35adbd6 (reland of #206123, 2026-07-08).

`release/23.x` branched on 2026-07-14, so it inherited the warning enabled. The revert 8710728e0418 (#218638) landed on main 2026-08-25 and was backported here the same day, but it missed the 23.1.0 tag by hours, so **clang 23.1.0 ships with `-Wunused-template` in `-Wall`**. 23.1.1 has it off again.

The practical consequence is that building this branch with a released 23.1.0 compiler and `-Werror` fails, because the tree still contains the violations that were since cleaned up on `main`. Observed failures include:

```
    lldb/unittests/TestingSupport/TestUtilities.h:68:48: error: unused function template
    'roundtripJSON' [-Werror,-Wunused-template]

    llvm/lib/Target/AArch64/Disassembler/AArch64Disassembler.cpp:1448:21: error: unused function
    template 'DecodeUImm' [-Werror,-Wunused-template]
```

The `roundtripJSON` one alone affects 44 translation units on this branch, since it is a header
included by most of the LLDB unit tests.

This backports the upstream cleanup so 23.x can be built with the compiler it shipped.