### PR TITLE
[gold] Don't hardcode section index in test

### DIFF
--- a/llvm/test/tools/gold/X86/multiple-sections.ll
+++ b/llvm/test/tools/gold/X86/multiple-sections.ll
@@ -9,9 +9,9 @@
 
 ; Check that the order of the sections is tin -> _start -> pat.
 
-; CHECK:      [[#%x, ADDR:]]       1  FUNC    LOCAL  DEFAULT    1 pat
-; CHECK:      [[#%x, ADDR - 31]]   1  FUNC    LOCAL  DEFAULT    1 tin
-; CHECK:      [[#%x, ADDR - 15]]   15 FUNC    GLOBAL DEFAULT    1 _start
+; CHECK:      [[#%x, ADDR:]]       1  FUNC    LOCAL  DEFAULT    [[#IDX:]] pat
+; CHECK:      [[#%x, ADDR - 31]]   1  FUNC    LOCAL  DEFAULT    [[#IDX]] tin
+; CHECK:      [[#%x, ADDR - 15]]   15 FUNC    GLOBAL DEFAULT    [[#IDX]] _start
 
 ;--- order
 .text : {


### PR DESCRIPTION
This can either be 1 or 2 depending on whether binutils was
compiled with --enable-rosegment=yes. The test does not care
about the index (only the address), so make it a wildcard.