### PR TITLE
[offload][lit] Fix failing/hanging/XPASSing tests on Intel GPU 

### DIFF
--- a/offload/test/jit/type_punning.c
+++ b/offload/test/jit/type_punning.c
@@ -9,7 +9,7 @@
 // clang-format on
 
 // REQUIRES: gpu
-// XFAIL: intelgpu
+// UNSUPPORTED: intelgpu
 
 // Ensure that there is only the kernel function left, not any outlined
 // parallel regions.

--- a/offload/test/offloading/bug64959_compile_only.c
+++ b/offload/test/offloading/bug64959_compile_only.c
@@ -1,6 +1,5 @@
 // RUN: %libomptarget-compile-generic
 // RUN: %libomptarget-compileopt-generic
-// XFAIL: intelgpu
 
 #include <stdio.h>
 #define N 10

--- a/offload/test/offloading/complex_reduction.cpp
+++ b/offload/test/offloading/complex_reduction.cpp
@@ -1,7 +1,7 @@
 // clang-format off
 // RUN: %libomptarget-compilexx-generic -O3 && %libomptarget-run-generic
 // RUN: %libomptarget-compilexx-generic -O3 -ffast-math && %libomptarget-run-generic
-// XFAIL: intelgpu
+// UNSUPPORTED: intelgpu
 // clang-format on
 
 #include <complex>

--- a/offload/test/offloading/ctor_dtor_api.cpp
+++ b/offload/test/offloading/ctor_dtor_api.cpp
@@ -1,6 +1,5 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
 // RUN: %libomptarget-compileoptxx-run-and-check-generic
-// XFAIL: intelgpu
 
 #include <cstdio>
 #include <omp.h>

--- a/offload/test/offloading/nested_parallel_reduction.c
+++ b/offload/test/offloading/nested_parallel_reduction.c
@@ -5,6 +5,7 @@
 // RUN: %libomptarget-run-generic | %fcheck-generic
 
 // REQUIRES: gpu
+// XFAIL: intelgpu
 
 #include <stdio.h>
 


### PR DESCRIPTION
The buildbot was down for a few days due to changes that broke it and we saw some required changes come up during that time. With this PR merged we can reenable the buildbot as everything consistently passes. 