### PR TITLE
[CIR] Fix OpenMP tests by adding a triple.

### DIFF
--- a/clang/test/CIR/CodeGenOpenMP/barrier.c
+++ b/clang/test/CIR/CodeGenOpenMP/barrier.c
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fopenmp -emit-cir -fclangir %s -o - | FileCheck %s
+// RUN: %clang_cc1 -fopenmp -triple x86_64-linux-gnu -emit-cir -fclangir %s -o - | FileCheck %s
 
 void before(void);
 void after(void);

--- a/clang/test/CIR/CodeGenOpenMP/decl-not-yet-implemented.c
+++ b/clang/test/CIR/CodeGenOpenMP/decl-not-yet-implemented.c
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fopenmp -fclangir %s -verify -emit-cir -o -
+// RUN: %clang_cc1 -fopenmp -triple x86_64-linux-gnu -fclangir %s -verify -emit-cir -o -
 
 int a;
 // expected-error@+1{{ClangIR code gen Not Yet Implemented: OpenMP OMPThreadPrivateDecl}}

--- a/clang/test/CIR/CodeGenOpenMP/not-yet-implemented.c
+++ b/clang/test/CIR/CodeGenOpenMP/not-yet-implemented.c
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fopenmp -fclangir %s -verify -emit-cir -o -
+// RUN: %clang_cc1 -fopenmp -triple x86_64-linux-gnu -fclangir %s -verify -emit-cir -o -
 
 void do_things() {
   // expected-error@+1{{ClangIR code gen Not Yet Implemented: OpenMP OMPCriticalDirective}}

--- a/clang/test/CIR/CodeGenOpenMP/omp-module-attrs.c
+++ b/clang/test/CIR/CodeGenOpenMP/omp-module-attrs.c
@@ -39,6 +39,7 @@
 
 // Device, CPU
 // RUN: %clang_cc1 -fopenmp -fclangir -emit-cir \
+// RUN:   -triple x86_64-linux-gnu \
 // RUN:   -fopenmp-is-target-device %s -o - \
 // RUN:   | FileCheck %s --check-prefix=CPU-DEVICE
 

--- a/clang/test/CIR/CodeGenOpenMP/parallel.c
+++ b/clang/test/CIR/CodeGenOpenMP/parallel.c
@@ -1,4 +1,4 @@
-// RUN: not %clang_cc1 -fopenmp -emit-cir -fclangir %s -o - | FileCheck %s
+// RUN: not %clang_cc1 -fopenmp -triple x86_64-linux-gnu -emit-cir -fclangir %s -o - | FileCheck %s
 
 void before(int);
 void during(int);

--- a/clang/test/CIR/CodeGenOpenMP/target-host-op-filtering.c
+++ b/clang/test/CIR/CodeGenOpenMP/target-host-op-filtering.c
@@ -1,6 +1,6 @@
 // Verifies the omp-host-op-filtering pass runs in the CIR-to-LLVM device
 // pipeline.//
-// RUN: %clang_cc1 -fopenmp -fopenmp-targets=amdgpu9.00-amd-amdhsa \
+// RUN: %clang_cc1 -fopenmp -triple x86_64-linux-gnu -fopenmp-targets=amdgpu9.00-amd-amdhsa \
 // RUN:   -fclangir -emit-llvm-bc %s -o %t-cir-host.bc
 // RUN: %clang_cc1 -triple amdgpu9.00-amd-amdhsa -fopenmp -fopenmp-is-target-device \
 // RUN:   -fopenmp-host-ir-file-path %t-cir-host.bc \

--- a/clang/test/CIR/CodeGenOpenMP/target-map-llvm-device.c
+++ b/clang/test/CIR/CodeGenOpenMP/target-map-llvm-device.c
@@ -1,9 +1,9 @@
 // Two-step host-BC ->  device pipeline that mirrors the offloading driver.
 //
 // Step 1: Host compilation to bitcode (provides offload entry info to device pass).
-// RUN: %clang_cc1 -fopenmp -fopenmp-targets=amdgpu-amd-amdhsa \
+// RUN: %clang_cc1 -fopenmp -triple x86_64-linux-gnu -fopenmp-targets=amdgpu-amd-amdhsa \
 // RUN:   -fclangir -emit-llvm-bc %s -o %t-cir-host.bc
-// RUN: %clang_cc1 -fopenmp -fopenmp-targets=amdgpu-amd-amdhsa \
+// RUN: %clang_cc1 -fopenmp -triple x86_64-linux-gnu -fopenmp-targets=amdgpu-amd-amdhsa \
 // RUN:   -emit-llvm-bc %s -o %t-ogcg-host.bc
 //
 // Step 2: Device compilation using host BC.

--- a/clang/test/CIR/CodeGenOpenMP/target-map.c
+++ b/clang/test/CIR/CodeGenOpenMP/target-map.c
@@ -1,5 +1,5 @@
 // Host compilation (x86 host, AMDGPU offload target): no address space on allocas.
-// RUN: %clang_cc1 -fopenmp -fopenmp-targets=amdgpu-amd-amdhsa -emit-cir -fclangir %s -o - \
+// RUN: %clang_cc1 -fopenmp -triple x86_64-linux-gnu -fopenmp-targets=amdgpu-amd-amdhsa -emit-cir -fclangir %s -o - \
 // RUN:   | FileCheck %s --check-prefix=CIR-HOST
 
 // Device compilation (AMDGPU): allocas in private address space, addrspacecast for map info.


### PR DESCRIPTION
Now that we're trying to build by default, we actually have to be able to build on other buildbots! But since we still don't have the ABI/target stuff for non linux, we need to make sure our tests don't hit that.