### PR TITLE
[CIR] Fix CIR tests by adding a triple/Requires.

### DIFF
--- a/clang/test/CIR/CodeGen/cxx20-module-initializer.cppm
+++ b/clang/test/CIR/CodeGen/cxx20-module-initializer.cppm
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -std=c++20 -triple %itanium_abi_triple -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-linux-gnu -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s --check-prefix=CIR
 
 // CIRGen precomputes the mangled C++20 named-module initializer function

--- a/clang/test/CIR/CodeGenCXX/typeid-most-derived.cpp
+++ b/clang/test/CIR/CodeGenCXX/typeid-most-derived.cpp
@@ -1,8 +1,8 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir -mmlir --mlir-print-ir-before=cir-lowering-prepare %s -o %t.cir 2> %t-before.cir
 // RUN: FileCheck %s --input-file=%t-before.cir --check-prefixes=CIR
 // RUN: FileCheck %s --input-file=%t.cir --check-prefixes=CIR
-// RUN: %clang_cc1 %s -triple %itanium_abi_triple -Wno-unused-value -std=c++11 -fclangir -emit-llvm -o - -std=c++11 | FileCheck %s --check-prefixes=CIR-TO-LLVM
-// RUN: %clang_cc1 %s -triple %itanium_abi_triple -Wno-unused-value -std=c++11 -emit-llvm -o - -std=c++11 | FileCheck %s --check-prefixes=LLVM
+// RUN: %clang_cc1 %s -triple x86_64-linux-gnu -Wno-unused-value -std=c++11 -fclangir -emit-llvm -o - -std=c++11 | FileCheck %s --check-prefixes=CIR-TO-LLVM
+// RUN: %clang_cc1 %s -triple x86_64-linux-gnu -Wno-unused-value -std=c++11 -emit-llvm -o - -std=c++11 | FileCheck %s --check-prefixes=LLVM
 
 // FIXME: missing `inbounds` in `getelementptr` in CIR-TO-LLVM output.
 

--- a/clang/test/CIR/CodeGenCXX/typeid-should-throw.cpp
+++ b/clang/test/CIR/CodeGenCXX/typeid-should-throw.cpp
@@ -1,8 +1,8 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir -mmlir --mlir-print-ir-before=cir-lowering-prepare %s -o %t.cir 2> %t-before.cir
 // RUN: FileCheck %s --input-file=%t-before.cir --check-prefixes=CIR
 // RUN: FileCheck %s --input-file=%t.cir --check-prefixes=CIR
-// RUN: %clang_cc1 %s -triple %itanium_abi_triple -Wno-unused-value -std=c++11 -fclangir -emit-llvm -o - -std=c++11 | FileCheck %s --check-prefixes=LLVM
-// RUN: %clang_cc1 %s -triple %itanium_abi_triple -Wno-unused-value -std=c++11 -emit-llvm -o - -std=c++11 | FileCheck %s --check-prefixes=LLVM
+// RUN: %clang_cc1 %s -triple x86_64-linux-gnu -Wno-unused-value -std=c++11 -fclangir -emit-llvm -o - -std=c++11 | FileCheck %s --check-prefixes=LLVM
+// RUN: %clang_cc1 %s -triple x86_64-linux-gnu -Wno-unused-value -std=c++11 -emit-llvm -o - -std=c++11 | FileCheck %s --check-prefixes=LLVM
 namespace std {
 struct type_info;
 }

--- a/clang/test/CIR/Lowering/calling-conv.cir
+++ b/clang/test/CIR/Lowering/calling-conv.cir
@@ -1,5 +1,6 @@
 // RUN: cir-opt %s -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
 // RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering | FileCheck %s -check-prefix=LLVM
+// REQUIRES: target={{x86_64-linux}}
 
 module {
   // MLIR: llvm.func @default_cc()

--- a/clang/test/CIR/Lowering/module-asm.cir
+++ b/clang/test/CIR/Lowering/module-asm.cir
@@ -3,6 +3,7 @@
 
 // RUN: cir-translate -cir-to-llvmir --disable-cc-lowering -o %t.ll %s
 // RUN: FileCheck -check-prefix=LLVM --input-file=%t.ll %s
+// REQUIRES: target={{x86_64-linux}}
 
 // CHECK: llvm.module_asm =  [".globl bar", ".globl foo"]
 // LLVM: module asm

--- a/clang/test/CIR/Lowering/poison.cir
+++ b/clang/test/CIR/Lowering/poison.cir
@@ -1,5 +1,6 @@
 // RUN: cir-translate -cir-to-llvmir --disable-cc-lowering -o %t.ll %s
 // RUN: FileCheck -check-prefix=LLVM --input-file=%t.ll %s
+// REQUIRES: target={{x86_64-linux}}
 
 !s32i = !cir.int<s, 32>
 

--- a/clang/test/CIR/Lowering/select.cir
+++ b/clang/test/CIR/Lowering/select.cir
@@ -1,5 +1,6 @@
 // RUN: cir-translate -cir-to-llvmir --disable-cc-lowering -o - %s | FileCheck -check-prefix=LLVM %s
 // RUN: cir-translate -target aarch64 -cir-to-llvmir --disable-cc-lowering -o - %s | FileCheck -check-prefix=LLVM %s
+// REQUIRES: target={{x86_64-linux}}
 
 !s32i = !cir.int<s, 32>
 

--- a/clang/test/CIR/Lowering/strictfp.cir
+++ b/clang/test/CIR/Lowering/strictfp.cir
@@ -1,5 +1,6 @@
 // RUN: cir-opt %s -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
 // RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering | FileCheck %s -check-prefix=LLVM
+// REQUIRES: target={{x86_64-linux}}
 
 // Functions tagged with the `strictfp` CIR function attribute should be
 // lowered to `llvm.func` operations whose `passthrough` array contains

--- a/clang/test/CIR/Lowering/ternary.cir
+++ b/clang/test/CIR/Lowering/ternary.cir
@@ -1,5 +1,6 @@
 // RUN: cir-translate -cir-to-llvmir --disable-cc-lowering -o %t.ll %s
 // RUN: FileCheck --input-file=%t.ll -check-prefix=LLVM %s
+// REQUIRES: target={{x86_64-linux}}
 
 !u32i = !cir.int<u, 32>
 

--- a/clang/test/CIR/Tools/warn-default-triple.cir
+++ b/clang/test/CIR/Tools/warn-default-triple.cir
@@ -1,4 +1,5 @@
 // RUN: cir-translate -verify-diagnostics --cir-to-llvmir --disable-cc-lowering %s
+// REQUIRES: target={{x86_64-linux}}
 
 // expected-warning@below {{no target triple provided, assuming}}
 module {

--- a/clang/test/CIR/Transforms/idiom-recognizer.cpp
+++ b/clang/test/CIR/Transforms/idiom-recognizer.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fclangir -emit-cir -mmlir --mlir-print-ir-after-all -clangir-enable-idiom-recognizer %s -o %t.cir 2>&1 | FileCheck %s -check-prefix=CIR
+// RUN: %clang_cc1 -fclangir -emit-cir -triple x86_64-linux-gnu -mmlir --mlir-print-ir-after-all -clangir-enable-idiom-recognizer %s -o %t.cir 2>&1 | FileCheck %s -check-prefix=CIR
 // CIR: IR Dump After IdiomRecognizer: cir-idiom-recognizer
 
 // The implicit-check-not on the RAISED run makes any surviving std::find call

--- a/clang/test/CIR/Transforms/lib-opt.cpp
+++ b/clang/test/CIR/Transforms/lib-opt.cpp
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 -fclangir -O1 -emit-cir -mmlir --mlir-print-ir-after-all -clangir-lib-opt=all %s -o - 2>&1 | FileCheck %s -check-prefix=ENABLED
-// RUN: %clang_cc1 -fclangir -O1 -emit-cir -mmlir --mlir-print-ir-after-all %s -o - 2>&1 | FileCheck %s -check-prefix=DISABLED
-// RUN: %clang_cc1 -fclangir -O0 -emit-cir -mmlir --mlir-print-ir-after-all -clangir-lib-opt=all %s -o - 2>&1 | FileCheck %s -check-prefix=DISABLED
+// RUN: %clang_cc1 -fclangir -O1 -emit-cir -triple x86_64-linux-gnu -mmlir --mlir-print-ir-after-all -clangir-lib-opt=all %s -o - 2>&1 | FileCheck %s -check-prefix=ENABLED
+// RUN: %clang_cc1 -fclangir -O1 -emit-cir -triple x86_64-linux-gnu -mmlir --mlir-print-ir-after-all %s -o - 2>&1 | FileCheck %s -check-prefix=DISABLED
+// RUN: %clang_cc1 -fclangir -O0 -emit-cir -triple x86_64-linux-gnu -mmlir --mlir-print-ir-after-all -clangir-lib-opt=all %s -o - 2>&1 | FileCheck %s -check-prefix=DISABLED
 
 // ENABLED: IR Dump After LibOpt: cir-lib-opt
 // DISABLED-NOT: IR Dump After LibOpt: cir-lib-opt


### PR DESCRIPTION
Now that we're trying to build by default, we actually have to be able to build on other buildbots! But since we still don't have the ABI/target stuff for non linux, we need to make sure our tests don't hit that.  Tests that execute 'clang' in some way are given a triple, ones that are on .cir files we just add a 'requires'.  Some day we should be able to remove those, but it'll require us to add the cxxabi/etc for windows.