### PR TITLE
[SystemZ] XPLINK64: use AExt for 32-bit pointer formals

### DIFF
--- a/llvm/lib/Target/SystemZ/SystemZCallingConv.h
+++ b/llvm/lib/Target/SystemZ/SystemZCallingConv.h
@@ -91,7 +91,7 @@ inline bool CC_XPLINK64_Pointer(unsigned &ValNo, MVT &ValVT, MVT &LocVT,
                                 ISD::ArgFlagsTy &ArgFlags, CCState &State) {
   if (LocVT != MVT::i64) {
     LocVT = MVT::i64;
-    LocInfo = CCValAssign::ZExt;
+    LocInfo = CCValAssign::AExt;
   }
   return false;
 }


### PR DESCRIPTION
CC_XPLINK64_Pointer was setting LocInfo=ZExt, promising the optimizer
that the caller had zero-extended bit 32. Evidence from Open XL 1.1 and
2.2 shows that callers do not consistently zero-extend `__ptr32` arguments
-- Open XL 1.1 emits nothing on the caller side; Open XL 2.2 only
zero-extends in the explicit cast case. Every actual use of a 31-bit
pointer goes through `addrspacecast` which emits `LLGTR` to clear bit 32 at
the point of use, so no callee relies on the register being clean at the
parameter boundary. Change LocInfo to AExt to accurately reflect that
only the low 32 bits are valid.

Extracted from #206833 per reviewer request.