### PR TITLE
[AMDGPU][GISel] Do not scalarize uniform v2f16/v2bf16 operations

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalizeRules.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalizeRules.cpp
@@ -1495,9 +1495,7 @@ RegBankLegalizeRules::RegBankLegalizeRules(const GCNSubtarget &_ST,
       .Div(S32, {{Vgpr32}, {Vgpr32, Vgpr32}})
       .Uni(S64, {{UniInVgprS64}, {Vgpr64, Vgpr64}})
       .Div(S64, {{Vgpr64}, {Vgpr64, Vgpr64}})
-      .Uni(V2S16, {{UniInVgprV2S16}, {VgprV2S16, VgprV2S16}}, !hasSALUFloat)
-      .Uni(V2S16, {{SgprV2S16}, {SgprV2S16, SgprV2S16}, ScalarizeToS16},
-           hasSALUFloat)
+      .Uni(V2S16, {{UniInVgprV2S16}, {VgprV2S16, VgprV2S16}})
       .Div(V2S16, {{VgprV2S16}, {VgprV2S16, VgprV2S16}})
       .Any({{UniV2S32}, {{UniInVgprV2S32}, {VgprV2S32, VgprV2S32}}})
       .Any({{DivV2S32}, {{VgprV2S32}, {VgprV2S32, VgprV2S32}}})
@@ -1510,7 +1508,9 @@ RegBankLegalizeRules::RegBankLegalizeRules(const GCNSubtarget &_ST,
       .Uni(S16, {{Sgpr16}, {Sgpr16, Sgpr16}}, hasSALUFloat)
       .Uni(S16, {{UniInVgprS16}, {Vgpr16, Vgpr16}}, !hasSALUFloat)
       .Uni(S32, {{Sgpr32}, {Sgpr32, Sgpr32}}, hasSALUFloat)
-      .Uni(S32, {{UniInVgprS32}, {Vgpr32, Vgpr32}}, !hasSALUFloat);
+      .Uni(S32, {{UniInVgprS32}, {Vgpr32, Vgpr32}}, !hasSALUFloat)
+      .Uni(V2S16, {{UniInVgprV2S16}, {VgprV2S16, VgprV2S16}})
+      .Div(V2S16, {{VgprV2S16}, {VgprV2S16, VgprV2S16}});
 
   addRulesForGOpcs({G_FMAD}, Standard)
       .Uni(S16, {{UniInVgprS16}, {Vgpr16, Vgpr16, Vgpr16}})
@@ -1527,22 +1527,18 @@ RegBankLegalizeRules::RegBankLegalizeRules(const GCNSubtarget &_ST,
       .Div(S64, {{Vgpr64}, {Vgpr64, Vgpr32}});
 
   addRulesForGOpcs({G_FMA, G_STRICT_FMA}, Standard)
+      .Uni(S16, {{Sgpr16}, {Sgpr16, Sgpr16, Sgpr16}}, hasSALUFloat)
+      .Uni(S16, {{UniInVgprS16}, {Vgpr16, Vgpr16, Vgpr16}}, !hasSALUFloat)
       .Div(S16, {{Vgpr16}, {Vgpr16, Vgpr16, Vgpr16}})
+      .Uni(S32, {{Sgpr32}, {Sgpr32, Sgpr32, Sgpr32}}, hasSALUFloat)
+      .Uni(S32, {{UniInVgprS32}, {Vgpr32, Vgpr32, Vgpr32}}, !hasSALUFloat)
       .Div(S32, {{Vgpr32}, {Vgpr32, Vgpr32, Vgpr32}})
       .Uni(S64, {{UniInVgprS64}, {Vgpr64, Vgpr64, Vgpr64}})
       .Div(S64, {{Vgpr64}, {Vgpr64, Vgpr64, Vgpr64}})
+      .Uni(V2S16, {{UniInVgprV2S16}, {VgprV2S16, VgprV2S16, VgprV2S16}})
       .Div(V2S16, {{VgprV2S16}, {VgprV2S16, VgprV2S16, VgprV2S16}})
       .Any({{UniV2S32}, {{UniInVgprV2S32}, {VgprV2S32, VgprV2S32, VgprV2S32}}})
       .Any({{DivV2S32}, {{VgprV2S32}, {VgprV2S32, VgprV2S32, VgprV2S32}}})
-      .Uni(S16, {{Sgpr16}, {Sgpr16, Sgpr16, Sgpr16}}, hasSALUFloat)
-      .Uni(S16, {{UniInVgprS16}, {Vgpr16, Vgpr16, Vgpr16}}, !hasSALUFloat)
-      .Uni(S32, {{Sgpr32}, {Sgpr32, Sgpr32, Sgpr32}}, hasSALUFloat)
-      .Uni(S32, {{UniInVgprS32}, {Vgpr32, Vgpr32, Vgpr32}}, !hasSALUFloat)
-      .Uni(V2S16,
-           {{SgprV2S16}, {SgprV2S16, SgprV2S16, SgprV2S16}, ScalarizeToS16},
-           hasSALUFloat)
-      .Uni(V2S16, {{UniInVgprV2S16}, {VgprV2S16, VgprV2S16, VgprV2S16}},
-           !hasSALUFloat)
       .Any({{UniV2S64}, {{UniInVgprV2S64}, {VgprV2S64, VgprV2S64, VgprV2S64}}})
       .Any({{DivV2S64}, {{VgprV2S64}, {VgprV2S64, VgprV2S64, VgprV2S64}}});
 
@@ -1572,8 +1568,7 @@ RegBankLegalizeRules::RegBankLegalizeRules(const GCNSubtarget &_ST,
       .Div(S32, {{Vgpr32}, {Vgpr32}})
       .Uni(S64, {{UniInVgprS64}, {Vgpr64}})
       .Div(S64, {{Vgpr64}, {Vgpr64}})
-      .Uni(V2S16, {{UniInVgprV2S16}, {VgprV2S16}}, !hasSALUFloat)
-      .Uni(V2S16, {{SgprV2S16}, {SgprV2S16}, ScalarizeToS16}, hasSALUFloat)
+      .Uni(V2S16, {{UniInVgprV2S16}, {VgprV2S16}})
       .Div(V2S16, {{VgprV2S16}, {VgprV2S16}})
       .Any({{UniV2S32}, {{UniInVgprV2S32}, {VgprV2S32}}})
       .Any({{DivV2S32}, {{VgprV2S32}, {VgprV2S32}}});

--- a/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalizeRules.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalizeRules.cpp
@@ -1568,7 +1568,8 @@ RegBankLegalizeRules::RegBankLegalizeRules(const GCNSubtarget &_ST,
       .Div(S32, {{Vgpr32}, {Vgpr32}})
       .Uni(S64, {{UniInVgprS64}, {Vgpr64}})
       .Div(S64, {{Vgpr64}, {Vgpr64}})
-      .Uni(V2S16, {{UniInVgprV2S16}, {VgprV2S16}})
+      .Uni(V2S16, {{UniInVgprV2S16}, {VgprV2S16}}, !hasSALUFloat)
+      .Uni(V2S16, {{SgprV2S16}, {SgprV2S16}}, hasSALUFloat)
       .Div(V2S16, {{VgprV2S16}, {VgprV2S16}})
       .Any({{UniV2S32}, {{UniInVgprV2S32}, {VgprV2S32}}})
       .Any({{DivV2S32}, {{VgprV2S32}, {VgprV2S32}}});

--- a/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalizeRules.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalizeRules.cpp
@@ -1568,8 +1568,7 @@ RegBankLegalizeRules::RegBankLegalizeRules(const GCNSubtarget &_ST,
       .Div(S32, {{Vgpr32}, {Vgpr32}})
       .Uni(S64, {{UniInVgprS64}, {Vgpr64}})
       .Div(S64, {{Vgpr64}, {Vgpr64}})
-      .Uni(V2S16, {{UniInVgprV2S16}, {VgprV2S16}}, !hasSALUFloat)
-      .Uni(V2S16, {{SgprV2S16}, {SgprV2S16}}, hasSALUFloat)
+      .Uni(V2S16, {{SgprV2S16}, {SgprV2S16}})
       .Div(V2S16, {{VgprV2S16}, {VgprV2S16}})
       .Any({{UniV2S32}, {{UniInVgprV2S32}, {VgprV2S32}}})
       .Any({{DivV2S32}, {{VgprV2S32}, {VgprV2S32}}});

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/add.v2i16.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/add.v2i16.ll
@@ -461,9 +461,7 @@ define amdgpu_ps i32 @s_add_v2i16(<2 x i16> inreg %a, <2 x i16> inreg %b) {
 define amdgpu_ps i32 @s_add_v2i16_fneg_lhs(<2 x half> inreg %a, <2 x i16> inreg %b) {
 ; GFX7-LABEL: s_add_v2i16_fneg_lhs:
 ; GFX7:       ; %bb.0:
-; GFX7-NEXT:    v_mov_b32_e32 v0, s0
-; GFX7-NEXT:    v_xor_b32_e32 v0, 0x80008000, v0
-; GFX7-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX7-NEXT:    s_xor_b32 s0, s0, 0x80008000
 ; GFX7-NEXT:    s_lshr_b32 s2, s0, 16
 ; GFX7-NEXT:    s_lshr_b32 s3, s1, 16
 ; GFX7-NEXT:    s_add_i32 s2, s2, s3
@@ -476,9 +474,7 @@ define amdgpu_ps i32 @s_add_v2i16_fneg_lhs(<2 x half> inreg %a, <2 x i16> inreg 
 ;
 ; GFX9-LABEL: s_add_v2i16_fneg_lhs:
 ; GFX9:       ; %bb.0:
-; GFX9-NEXT:    v_mov_b32_e32 v0, s0
-; GFX9-NEXT:    v_xor_b32_e32 v0, 0x80008000, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX9-NEXT:    s_xor_b32 s0, s0, 0x80008000
 ; GFX9-NEXT:    s_lshr_b32 s2, s0, 16
 ; GFX9-NEXT:    s_lshr_b32 s3, s1, 16
 ; GFX9-NEXT:    s_add_i32 s0, s0, s1
@@ -488,9 +484,7 @@ define amdgpu_ps i32 @s_add_v2i16_fneg_lhs(<2 x half> inreg %a, <2 x i16> inreg 
 ;
 ; GFX8-LABEL: s_add_v2i16_fneg_lhs:
 ; GFX8:       ; %bb.0:
-; GFX8-NEXT:    v_mov_b32_e32 v0, s0
-; GFX8-NEXT:    v_xor_b32_e32 v0, 0x80008000, v0
-; GFX8-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX8-NEXT:    s_xor_b32 s0, s0, 0x80008000
 ; GFX8-NEXT:    s_lshr_b32 s2, s0, 16
 ; GFX8-NEXT:    s_lshr_b32 s3, s1, 16
 ; GFX8-NEXT:    s_add_i32 s2, s2, s3
@@ -503,9 +497,8 @@ define amdgpu_ps i32 @s_add_v2i16_fneg_lhs(<2 x half> inreg %a, <2 x i16> inreg 
 ;
 ; GFX10-LABEL: s_add_v2i16_fneg_lhs:
 ; GFX10:       ; %bb.0:
-; GFX10-NEXT:    v_xor_b32_e64 v0, 0x80008000, s0
+; GFX10-NEXT:    s_xor_b32 s0, s0, 0x80008000
 ; GFX10-NEXT:    s_lshr_b32 s3, s1, 16
-; GFX10-NEXT:    v_readfirstlane_b32 s0, v0
 ; GFX10-NEXT:    s_lshr_b32 s2, s0, 16
 ; GFX10-NEXT:    s_add_i32 s0, s0, s1
 ; GFX10-NEXT:    s_add_i32 s2, s2, s3
@@ -521,9 +514,7 @@ define amdgpu_ps i32 @s_add_v2i16_fneg_lhs(<2 x half> inreg %a, <2 x i16> inreg 
 define amdgpu_ps i32 @s_add_v2i16_fneg_rhs(<2 x i16> inreg %a, <2 x half> inreg %b) {
 ; GFX7-LABEL: s_add_v2i16_fneg_rhs:
 ; GFX7:       ; %bb.0:
-; GFX7-NEXT:    v_mov_b32_e32 v0, s1
-; GFX7-NEXT:    v_xor_b32_e32 v0, 0x80008000, v0
-; GFX7-NEXT:    v_readfirstlane_b32 s1, v0
+; GFX7-NEXT:    s_xor_b32 s1, s1, 0x80008000
 ; GFX7-NEXT:    s_lshr_b32 s2, s0, 16
 ; GFX7-NEXT:    s_lshr_b32 s3, s1, 16
 ; GFX7-NEXT:    s_add_i32 s2, s2, s3
@@ -536,9 +527,7 @@ define amdgpu_ps i32 @s_add_v2i16_fneg_rhs(<2 x i16> inreg %a, <2 x half> inreg 
 ;
 ; GFX9-LABEL: s_add_v2i16_fneg_rhs:
 ; GFX9:       ; %bb.0:
-; GFX9-NEXT:    v_mov_b32_e32 v0, s1
-; GFX9-NEXT:    v_xor_b32_e32 v0, 0x80008000, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s1, v0
+; GFX9-NEXT:    s_xor_b32 s1, s1, 0x80008000
 ; GFX9-NEXT:    s_lshr_b32 s2, s0, 16
 ; GFX9-NEXT:    s_lshr_b32 s3, s1, 16
 ; GFX9-NEXT:    s_add_i32 s0, s0, s1
@@ -548,9 +537,7 @@ define amdgpu_ps i32 @s_add_v2i16_fneg_rhs(<2 x i16> inreg %a, <2 x half> inreg 
 ;
 ; GFX8-LABEL: s_add_v2i16_fneg_rhs:
 ; GFX8:       ; %bb.0:
-; GFX8-NEXT:    v_mov_b32_e32 v0, s1
-; GFX8-NEXT:    v_xor_b32_e32 v0, 0x80008000, v0
-; GFX8-NEXT:    v_readfirstlane_b32 s1, v0
+; GFX8-NEXT:    s_xor_b32 s1, s1, 0x80008000
 ; GFX8-NEXT:    s_lshr_b32 s2, s0, 16
 ; GFX8-NEXT:    s_lshr_b32 s3, s1, 16
 ; GFX8-NEXT:    s_add_i32 s2, s2, s3
@@ -563,9 +550,8 @@ define amdgpu_ps i32 @s_add_v2i16_fneg_rhs(<2 x i16> inreg %a, <2 x half> inreg 
 ;
 ; GFX10-LABEL: s_add_v2i16_fneg_rhs:
 ; GFX10:       ; %bb.0:
-; GFX10-NEXT:    v_xor_b32_e64 v0, 0x80008000, s1
+; GFX10-NEXT:    s_xor_b32 s1, s1, 0x80008000
 ; GFX10-NEXT:    s_lshr_b32 s2, s0, 16
-; GFX10-NEXT:    v_readfirstlane_b32 s1, v0
 ; GFX10-NEXT:    s_lshr_b32 s3, s1, 16
 ; GFX10-NEXT:    s_add_i32 s0, s0, s1
 ; GFX10-NEXT:    s_add_i32 s2, s2, s3
@@ -581,12 +567,8 @@ define amdgpu_ps i32 @s_add_v2i16_fneg_rhs(<2 x i16> inreg %a, <2 x half> inreg 
 define amdgpu_ps i32 @s_add_v2i16_fneg_lhs_fneg_rhs(<2 x half> inreg %a, <2 x half> inreg %b) {
 ; GFX7-LABEL: s_add_v2i16_fneg_lhs_fneg_rhs:
 ; GFX7:       ; %bb.0:
-; GFX7-NEXT:    v_mov_b32_e32 v0, s0
-; GFX7-NEXT:    v_xor_b32_e32 v0, 0x80008000, v0
-; GFX7-NEXT:    v_readfirstlane_b32 s0, v0
-; GFX7-NEXT:    v_mov_b32_e32 v0, s1
-; GFX7-NEXT:    v_xor_b32_e32 v0, 0x80008000, v0
-; GFX7-NEXT:    v_readfirstlane_b32 s1, v0
+; GFX7-NEXT:    s_xor_b32 s0, s0, 0x80008000
+; GFX7-NEXT:    s_xor_b32 s1, s1, 0x80008000
 ; GFX7-NEXT:    s_lshr_b32 s2, s0, 16
 ; GFX7-NEXT:    s_lshr_b32 s3, s1, 16
 ; GFX7-NEXT:    s_add_i32 s2, s2, s3
@@ -599,12 +581,8 @@ define amdgpu_ps i32 @s_add_v2i16_fneg_lhs_fneg_rhs(<2 x half> inreg %a, <2 x ha
 ;
 ; GFX9-LABEL: s_add_v2i16_fneg_lhs_fneg_rhs:
 ; GFX9:       ; %bb.0:
-; GFX9-NEXT:    v_mov_b32_e32 v0, s0
-; GFX9-NEXT:    v_xor_b32_e32 v0, 0x80008000, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s0, v0
-; GFX9-NEXT:    v_mov_b32_e32 v0, s1
-; GFX9-NEXT:    v_xor_b32_e32 v0, 0x80008000, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s1, v0
+; GFX9-NEXT:    s_xor_b32 s0, s0, 0x80008000
+; GFX9-NEXT:    s_xor_b32 s1, s1, 0x80008000
 ; GFX9-NEXT:    s_lshr_b32 s2, s0, 16
 ; GFX9-NEXT:    s_lshr_b32 s3, s1, 16
 ; GFX9-NEXT:    s_add_i32 s0, s0, s1
@@ -614,12 +592,8 @@ define amdgpu_ps i32 @s_add_v2i16_fneg_lhs_fneg_rhs(<2 x half> inreg %a, <2 x ha
 ;
 ; GFX8-LABEL: s_add_v2i16_fneg_lhs_fneg_rhs:
 ; GFX8:       ; %bb.0:
-; GFX8-NEXT:    v_mov_b32_e32 v0, s0
-; GFX8-NEXT:    v_xor_b32_e32 v0, 0x80008000, v0
-; GFX8-NEXT:    v_readfirstlane_b32 s0, v0
-; GFX8-NEXT:    v_mov_b32_e32 v0, s1
-; GFX8-NEXT:    v_xor_b32_e32 v0, 0x80008000, v0
-; GFX8-NEXT:    v_readfirstlane_b32 s1, v0
+; GFX8-NEXT:    s_xor_b32 s0, s0, 0x80008000
+; GFX8-NEXT:    s_xor_b32 s1, s1, 0x80008000
 ; GFX8-NEXT:    s_lshr_b32 s2, s0, 16
 ; GFX8-NEXT:    s_lshr_b32 s3, s1, 16
 ; GFX8-NEXT:    s_add_i32 s2, s2, s3
@@ -632,10 +606,8 @@ define amdgpu_ps i32 @s_add_v2i16_fneg_lhs_fneg_rhs(<2 x half> inreg %a, <2 x ha
 ;
 ; GFX10-LABEL: s_add_v2i16_fneg_lhs_fneg_rhs:
 ; GFX10:       ; %bb.0:
-; GFX10-NEXT:    v_xor_b32_e64 v0, 0x80008000, s0
-; GFX10-NEXT:    v_xor_b32_e64 v1, 0x80008000, s1
-; GFX10-NEXT:    v_readfirstlane_b32 s0, v0
-; GFX10-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX10-NEXT:    s_xor_b32 s0, s0, 0x80008000
+; GFX10-NEXT:    s_xor_b32 s1, s1, 0x80008000
 ; GFX10-NEXT:    s_lshr_b32 s2, s0, 16
 ; GFX10-NEXT:    s_lshr_b32 s3, s1, 16
 ; GFX10-NEXT:    s_add_i32 s0, s0, s1

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/fabs.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/fabs.ll
@@ -170,58 +170,33 @@ define amdgpu_ps void @v_fabs_v2f16(<2 x half> %in, ptr addrspace(1) %out) {
   store <2 x half> %fabs, ptr addrspace(1) %out
   ret void
 }
+
 define amdgpu_ps void @s_fabs_v2f16(<2 x half> inreg %in) {
-; GFX11-LABEL: s_fabs_v2f16:
-; GFX11:       ; %bb.0:
-; GFX11-NEXT:    v_and_b32_e64 v0, 0x7fff7fff, s0
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-NEXT:    v_readfirstlane_b32 s0, v0
-; GFX11-NEXT:    ;;#ASMSTART
-; GFX11-NEXT:    ; use s0
-; GFX11-NEXT:    ;;#ASMEND
-; GFX11-NEXT:    s_endpgm
-;
-; GFX12-LABEL: s_fabs_v2f16:
-; GFX12:       ; %bb.0:
-; GFX12-NEXT:    s_lshr_b32 s1, s0, 16
-; GFX12-NEXT:    s_and_b32 s0, s0, 0x7fff
-; GFX12-NEXT:    s_and_b32 s1, s1, 0x7fff
-; GFX12-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX12-NEXT:    s_pack_ll_b32_b16 s0, s0, s1
-; GFX12-NEXT:    ;;#ASMSTART
-; GFX12-NEXT:    ; use s0
-; GFX12-NEXT:    ;;#ASMEND
-; GFX12-NEXT:    s_endpgm
+; GCN-LABEL: s_fabs_v2f16:
+; GCN:       ; %bb.0:
+; GCN-NEXT:    v_and_b32_e64 v0, 0x7fff7fff, s0
+; GCN-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GCN-NEXT:    v_readfirstlane_b32 s0, v0
+; GCN-NEXT:    ;;#ASMSTART
+; GCN-NEXT:    ; use s0
+; GCN-NEXT:    ;;#ASMEND
+; GCN-NEXT:    s_endpgm
   %fabs = call <2 x half> @llvm.fabs.v2f16(<2 x half> %in)
   call void asm sideeffect "; use $0", "s"(<2 x half> %fabs)
   ret void
 }
 define amdgpu_ps void @s_fabs_v2f16_salu_use(<2 x half> inreg %in, i32 inreg %val) {
-; GFX11-LABEL: s_fabs_v2f16_salu_use:
-; GFX11:       ; %bb.0:
-; GFX11-NEXT:    v_and_b32_e64 v0, 0x7fff7fff, s0
-; GFX11-NEXT:    s_cmp_eq_u32 s1, 0
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-NEXT:    v_readfirstlane_b32 s0, v0
-; GFX11-NEXT:    s_cselect_b32 s0, s0, 0
-; GFX11-NEXT:    ;;#ASMSTART
-; GFX11-NEXT:    ; use s0
-; GFX11-NEXT:    ;;#ASMEND
-; GFX11-NEXT:    s_endpgm
-;
-; GFX12-LABEL: s_fabs_v2f16_salu_use:
-; GFX12:       ; %bb.0:
-; GFX12-NEXT:    s_lshr_b32 s2, s0, 16
-; GFX12-NEXT:    s_and_b32 s0, s0, 0x7fff
-; GFX12-NEXT:    s_and_b32 s2, s2, 0x7fff
-; GFX12-NEXT:    s_cmp_eq_u32 s1, 0
-; GFX12-NEXT:    s_pack_ll_b32_b16 s0, s0, s2
-; GFX12-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX12-NEXT:    s_cselect_b32 s0, s0, 0
-; GFX12-NEXT:    ;;#ASMSTART
-; GFX12-NEXT:    ; use s0
-; GFX12-NEXT:    ;;#ASMEND
-; GFX12-NEXT:    s_endpgm
+; GCN-LABEL: s_fabs_v2f16_salu_use:
+; GCN:       ; %bb.0:
+; GCN-NEXT:    v_and_b32_e64 v0, 0x7fff7fff, s0
+; GCN-NEXT:    s_cmp_eq_u32 s1, 0
+; GCN-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GCN-NEXT:    v_readfirstlane_b32 s0, v0
+; GCN-NEXT:    s_cselect_b32 s0, s0, 0
+; GCN-NEXT:    ;;#ASMSTART
+; GCN-NEXT:    ; use s0
+; GCN-NEXT:    ;;#ASMEND
+; GCN-NEXT:    s_endpgm
   %fabs = call <2 x half> @llvm.fabs.v2f16(<2 x half> %in)
   %cond = icmp eq i32 %val, 0
   %sel = select i1 %cond, <2 x half> %fabs, <2 x half> <half 0.0, half 0.0>

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/fabs.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/fabs.ll
@@ -172,31 +172,49 @@ define amdgpu_ps void @v_fabs_v2f16(<2 x half> %in, ptr addrspace(1) %out) {
 }
 
 define amdgpu_ps void @s_fabs_v2f16(<2 x half> inreg %in) {
-; GCN-LABEL: s_fabs_v2f16:
-; GCN:       ; %bb.0:
-; GCN-NEXT:    v_and_b32_e64 v0, 0x7fff7fff, s0
-; GCN-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GCN-NEXT:    v_readfirstlane_b32 s0, v0
-; GCN-NEXT:    ;;#ASMSTART
-; GCN-NEXT:    ; use s0
-; GCN-NEXT:    ;;#ASMEND
-; GCN-NEXT:    s_endpgm
+; GFX11-LABEL: s_fabs_v2f16:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    v_and_b32_e64 v0, 0x7fff7fff, s0
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX11-NEXT:    ;;#ASMSTART
+; GFX11-NEXT:    ; use s0
+; GFX11-NEXT:    ;;#ASMEND
+; GFX11-NEXT:    s_endpgm
+;
+; GFX12-LABEL: s_fabs_v2f16:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_and_b32 s0, s0, 0x7fff7fff
+; GFX12-NEXT:    ;;#ASMSTART
+; GFX12-NEXT:    ; use s0
+; GFX12-NEXT:    ;;#ASMEND
+; GFX12-NEXT:    s_endpgm
   %fabs = call <2 x half> @llvm.fabs.v2f16(<2 x half> %in)
   call void asm sideeffect "; use $0", "s"(<2 x half> %fabs)
   ret void
 }
 define amdgpu_ps void @s_fabs_v2f16_salu_use(<2 x half> inreg %in, i32 inreg %val) {
-; GCN-LABEL: s_fabs_v2f16_salu_use:
-; GCN:       ; %bb.0:
-; GCN-NEXT:    v_and_b32_e64 v0, 0x7fff7fff, s0
-; GCN-NEXT:    s_cmp_eq_u32 s1, 0
-; GCN-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GCN-NEXT:    v_readfirstlane_b32 s0, v0
-; GCN-NEXT:    s_cselect_b32 s0, s0, 0
-; GCN-NEXT:    ;;#ASMSTART
-; GCN-NEXT:    ; use s0
-; GCN-NEXT:    ;;#ASMEND
-; GCN-NEXT:    s_endpgm
+; GFX11-LABEL: s_fabs_v2f16_salu_use:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    v_and_b32_e64 v0, 0x7fff7fff, s0
+; GFX11-NEXT:    s_cmp_eq_u32 s1, 0
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX11-NEXT:    s_cselect_b32 s0, s0, 0
+; GFX11-NEXT:    ;;#ASMSTART
+; GFX11-NEXT:    ; use s0
+; GFX11-NEXT:    ;;#ASMEND
+; GFX11-NEXT:    s_endpgm
+;
+; GFX12-LABEL: s_fabs_v2f16_salu_use:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_and_b32 s0, s0, 0x7fff7fff
+; GFX12-NEXT:    s_cmp_eq_u32 s1, 0
+; GFX12-NEXT:    s_cselect_b32 s0, s0, 0
+; GFX12-NEXT:    ;;#ASMSTART
+; GFX12-NEXT:    ; use s0
+; GFX12-NEXT:    ;;#ASMEND
+; GFX12-NEXT:    s_endpgm
   %fabs = call <2 x half> @llvm.fabs.v2f16(<2 x half> %in)
   %cond = icmp eq i32 %val, 0
   %sel = select i1 %cond, <2 x half> %fabs, <2 x half> <half 0.0, half 0.0>

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/fabs.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/fabs.ll
@@ -172,49 +172,27 @@ define amdgpu_ps void @v_fabs_v2f16(<2 x half> %in, ptr addrspace(1) %out) {
 }
 
 define amdgpu_ps void @s_fabs_v2f16(<2 x half> inreg %in) {
-; GFX11-LABEL: s_fabs_v2f16:
-; GFX11:       ; %bb.0:
-; GFX11-NEXT:    v_and_b32_e64 v0, 0x7fff7fff, s0
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-NEXT:    v_readfirstlane_b32 s0, v0
-; GFX11-NEXT:    ;;#ASMSTART
-; GFX11-NEXT:    ; use s0
-; GFX11-NEXT:    ;;#ASMEND
-; GFX11-NEXT:    s_endpgm
-;
-; GFX12-LABEL: s_fabs_v2f16:
-; GFX12:       ; %bb.0:
-; GFX12-NEXT:    s_and_b32 s0, s0, 0x7fff7fff
-; GFX12-NEXT:    ;;#ASMSTART
-; GFX12-NEXT:    ; use s0
-; GFX12-NEXT:    ;;#ASMEND
-; GFX12-NEXT:    s_endpgm
+; GCN-LABEL: s_fabs_v2f16:
+; GCN:       ; %bb.0:
+; GCN-NEXT:    s_and_b32 s0, s0, 0x7fff7fff
+; GCN-NEXT:    ;;#ASMSTART
+; GCN-NEXT:    ; use s0
+; GCN-NEXT:    ;;#ASMEND
+; GCN-NEXT:    s_endpgm
   %fabs = call <2 x half> @llvm.fabs.v2f16(<2 x half> %in)
   call void asm sideeffect "; use $0", "s"(<2 x half> %fabs)
   ret void
 }
 define amdgpu_ps void @s_fabs_v2f16_salu_use(<2 x half> inreg %in, i32 inreg %val) {
-; GFX11-LABEL: s_fabs_v2f16_salu_use:
-; GFX11:       ; %bb.0:
-; GFX11-NEXT:    v_and_b32_e64 v0, 0x7fff7fff, s0
-; GFX11-NEXT:    s_cmp_eq_u32 s1, 0
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-NEXT:    v_readfirstlane_b32 s0, v0
-; GFX11-NEXT:    s_cselect_b32 s0, s0, 0
-; GFX11-NEXT:    ;;#ASMSTART
-; GFX11-NEXT:    ; use s0
-; GFX11-NEXT:    ;;#ASMEND
-; GFX11-NEXT:    s_endpgm
-;
-; GFX12-LABEL: s_fabs_v2f16_salu_use:
-; GFX12:       ; %bb.0:
-; GFX12-NEXT:    s_and_b32 s0, s0, 0x7fff7fff
-; GFX12-NEXT:    s_cmp_eq_u32 s1, 0
-; GFX12-NEXT:    s_cselect_b32 s0, s0, 0
-; GFX12-NEXT:    ;;#ASMSTART
-; GFX12-NEXT:    ; use s0
-; GFX12-NEXT:    ;;#ASMEND
-; GFX12-NEXT:    s_endpgm
+; GCN-LABEL: s_fabs_v2f16_salu_use:
+; GCN:       ; %bb.0:
+; GCN-NEXT:    s_and_b32 s0, s0, 0x7fff7fff
+; GCN-NEXT:    s_cmp_eq_u32 s1, 0
+; GCN-NEXT:    s_cselect_b32 s0, s0, 0
+; GCN-NEXT:    ;;#ASMSTART
+; GCN-NEXT:    ; use s0
+; GCN-NEXT:    ;;#ASMEND
+; GCN-NEXT:    s_endpgm
   %fabs = call <2 x half> @llvm.fabs.v2f16(<2 x half> %in)
   %cond = icmp eq i32 %val, 0
   %sel = select i1 %cond, <2 x half> %fabs, <2 x half> <half 0.0, half 0.0>

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/fadd.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/fadd.ll
@@ -109,21 +109,10 @@ define amdgpu_ps void @fadd_s64_div(double %a, double %b, ptr addrspace(1) %ptr)
 }
 
 define amdgpu_ps <2 x half> @fadd_v2s16_uniform(<2 x half> inreg %a, <2 x half> inreg %b) {
-; GFX11-LABEL: fadd_v2s16_uniform:
-; GFX11:       ; %bb.0:
-; GFX11-NEXT:    v_pk_add_f16 v0, s0, s1
-; GFX11-NEXT:    ; return to shader part epilog
-;
-; GFX12-LABEL: fadd_v2s16_uniform:
-; GFX12:       ; %bb.0:
-; GFX12-NEXT:    s_lshr_b32 s2, s0, 16
-; GFX12-NEXT:    s_lshr_b32 s3, s1, 16
-; GFX12-NEXT:    s_add_f16 s0, s0, s1
-; GFX12-NEXT:    s_add_f16 s1, s2, s3
-; GFX12-NEXT:    s_delay_alu instid0(SALU_CYCLE_3) | instskip(NEXT) | instid1(SALU_CYCLE_1)
-; GFX12-NEXT:    s_pack_ll_b32_b16 s0, s0, s1
-; GFX12-NEXT:    v_mov_b32_e32 v0, s0
-; GFX12-NEXT:    ; return to shader part epilog
+; GCN-LABEL: fadd_v2s16_uniform:
+; GCN:       ; %bb.0:
+; GCN-NEXT:    v_pk_add_f16 v0, s0, s1
+; GCN-NEXT:    ; return to shader part epilog
   %fadd = fadd <2 x half> %a, %b
   ret <2 x half> %fadd
 }

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/fma.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/fma.ll
@@ -1736,13 +1736,8 @@ define amdgpu_ps <2 x half> @fma_v2s16_uniform(<2 x half> inreg %a, <2 x half> i
 ;
 ; GFX12-LABEL: fma_v2s16_uniform:
 ; GFX12:       ; %bb.0:
-; GFX12-NEXT:    s_lshr_b32 s3, s0, 16
-; GFX12-NEXT:    s_lshr_b32 s4, s1, 16
-; GFX12-NEXT:    s_lshr_b32 s5, s2, 16
-; GFX12-NEXT:    s_fmac_f16 s2, s0, s1
-; GFX12-NEXT:    s_fmac_f16 s5, s3, s4
-; GFX12-NEXT:    s_pack_ll_b32_b16 s0, s2, s5
-; GFX12-NEXT:    v_mov_b32_e32 v0, s0
+; GFX12-NEXT:    v_mov_b32_e32 v0, s2
+; GFX12-NEXT:    v_pk_fma_f16 v0, s0, s1, v0
 ; GFX12-NEXT:    ; return to shader part epilog
   %fma = call <2 x half> @llvm.fma.v2f16(<2 x half> %a, <2 x half> %b, <2 x half> %c)
   ret <2 x half> %fma

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/fmul.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/fmul.ll
@@ -109,21 +109,10 @@ define amdgpu_ps void @fmul_s64_div(double %a, double %b, ptr addrspace(1) %ptr)
 }
 
 define amdgpu_ps <2 x half> @fmul_v2s16_uniform(<2 x half> inreg %a, <2 x half> inreg %b) {
-; GFX11-LABEL: fmul_v2s16_uniform:
-; GFX11:       ; %bb.0:
-; GFX11-NEXT:    v_pk_mul_f16 v0, s0, s1
-; GFX11-NEXT:    ; return to shader part epilog
-;
-; GFX12-LABEL: fmul_v2s16_uniform:
-; GFX12:       ; %bb.0:
-; GFX12-NEXT:    s_lshr_b32 s2, s0, 16
-; GFX12-NEXT:    s_lshr_b32 s3, s1, 16
-; GFX12-NEXT:    s_mul_f16 s0, s0, s1
-; GFX12-NEXT:    s_mul_f16 s1, s2, s3
-; GFX12-NEXT:    s_delay_alu instid0(SALU_CYCLE_3) | instskip(NEXT) | instid1(SALU_CYCLE_1)
-; GFX12-NEXT:    s_pack_ll_b32_b16 s0, s0, s1
-; GFX12-NEXT:    v_mov_b32_e32 v0, s0
-; GFX12-NEXT:    ; return to shader part epilog
+; GCN-LABEL: fmul_v2s16_uniform:
+; GCN:       ; %bb.0:
+; GCN-NEXT:    v_pk_mul_f16 v0, s0, s1
+; GCN-NEXT:    ; return to shader part epilog
   %result = fmul <2 x half> %a, %b
   ret <2 x half> %result
 }

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/fneg.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/fneg.ll
@@ -172,31 +172,49 @@ define amdgpu_ps void @v_fneg_v2f16(<2 x half> %in, ptr addrspace(1) %out) {
 }
 
 define amdgpu_ps void @s_fneg_v2f16(<2 x half> inreg %in) {
-; GCN-LABEL: s_fneg_v2f16:
-; GCN:       ; %bb.0:
-; GCN-NEXT:    v_xor_b32_e64 v0, 0x80008000, s0
-; GCN-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GCN-NEXT:    v_readfirstlane_b32 s0, v0
-; GCN-NEXT:    ;;#ASMSTART
-; GCN-NEXT:    ; use s0
-; GCN-NEXT:    ;;#ASMEND
-; GCN-NEXT:    s_endpgm
+; GFX11-LABEL: s_fneg_v2f16:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    v_xor_b32_e64 v0, 0x80008000, s0
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX11-NEXT:    ;;#ASMSTART
+; GFX11-NEXT:    ; use s0
+; GFX11-NEXT:    ;;#ASMEND
+; GFX11-NEXT:    s_endpgm
+;
+; GFX12-LABEL: s_fneg_v2f16:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_xor_b32 s0, s0, 0x80008000
+; GFX12-NEXT:    ;;#ASMSTART
+; GFX12-NEXT:    ; use s0
+; GFX12-NEXT:    ;;#ASMEND
+; GFX12-NEXT:    s_endpgm
   %fneg = fneg <2 x half> %in
   call void asm sideeffect "; use $0", "s"(<2 x half> %fneg)
   ret void
 }
 define amdgpu_ps void @s_fneg_v2f16_salu_use(<2 x half> inreg %in, i32 inreg %val) {
-; GCN-LABEL: s_fneg_v2f16_salu_use:
-; GCN:       ; %bb.0:
-; GCN-NEXT:    v_xor_b32_e64 v0, 0x80008000, s0
-; GCN-NEXT:    s_cmp_eq_u32 s1, 0
-; GCN-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GCN-NEXT:    v_readfirstlane_b32 s0, v0
-; GCN-NEXT:    s_cselect_b32 s0, s0, 0
-; GCN-NEXT:    ;;#ASMSTART
-; GCN-NEXT:    ; use s0
-; GCN-NEXT:    ;;#ASMEND
-; GCN-NEXT:    s_endpgm
+; GFX11-LABEL: s_fneg_v2f16_salu_use:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    v_xor_b32_e64 v0, 0x80008000, s0
+; GFX11-NEXT:    s_cmp_eq_u32 s1, 0
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX11-NEXT:    s_cselect_b32 s0, s0, 0
+; GFX11-NEXT:    ;;#ASMSTART
+; GFX11-NEXT:    ; use s0
+; GFX11-NEXT:    ;;#ASMEND
+; GFX11-NEXT:    s_endpgm
+;
+; GFX12-LABEL: s_fneg_v2f16_salu_use:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_xor_b32 s0, s0, 0x80008000
+; GFX12-NEXT:    s_cmp_eq_u32 s1, 0
+; GFX12-NEXT:    s_cselect_b32 s0, s0, 0
+; GFX12-NEXT:    ;;#ASMSTART
+; GFX12-NEXT:    ; use s0
+; GFX12-NEXT:    ;;#ASMEND
+; GFX12-NEXT:    s_endpgm
   %fneg = fneg <2 x half> %in
   %cond = icmp eq i32 %val, 0
   %sel = select i1 %cond, <2 x half> %fneg, <2 x half> <half 0.0, half 0.0>

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/fneg.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/fneg.ll
@@ -172,49 +172,27 @@ define amdgpu_ps void @v_fneg_v2f16(<2 x half> %in, ptr addrspace(1) %out) {
 }
 
 define amdgpu_ps void @s_fneg_v2f16(<2 x half> inreg %in) {
-; GFX11-LABEL: s_fneg_v2f16:
-; GFX11:       ; %bb.0:
-; GFX11-NEXT:    v_xor_b32_e64 v0, 0x80008000, s0
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-NEXT:    v_readfirstlane_b32 s0, v0
-; GFX11-NEXT:    ;;#ASMSTART
-; GFX11-NEXT:    ; use s0
-; GFX11-NEXT:    ;;#ASMEND
-; GFX11-NEXT:    s_endpgm
-;
-; GFX12-LABEL: s_fneg_v2f16:
-; GFX12:       ; %bb.0:
-; GFX12-NEXT:    s_xor_b32 s0, s0, 0x80008000
-; GFX12-NEXT:    ;;#ASMSTART
-; GFX12-NEXT:    ; use s0
-; GFX12-NEXT:    ;;#ASMEND
-; GFX12-NEXT:    s_endpgm
+; GCN-LABEL: s_fneg_v2f16:
+; GCN:       ; %bb.0:
+; GCN-NEXT:    s_xor_b32 s0, s0, 0x80008000
+; GCN-NEXT:    ;;#ASMSTART
+; GCN-NEXT:    ; use s0
+; GCN-NEXT:    ;;#ASMEND
+; GCN-NEXT:    s_endpgm
   %fneg = fneg <2 x half> %in
   call void asm sideeffect "; use $0", "s"(<2 x half> %fneg)
   ret void
 }
 define amdgpu_ps void @s_fneg_v2f16_salu_use(<2 x half> inreg %in, i32 inreg %val) {
-; GFX11-LABEL: s_fneg_v2f16_salu_use:
-; GFX11:       ; %bb.0:
-; GFX11-NEXT:    v_xor_b32_e64 v0, 0x80008000, s0
-; GFX11-NEXT:    s_cmp_eq_u32 s1, 0
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-NEXT:    v_readfirstlane_b32 s0, v0
-; GFX11-NEXT:    s_cselect_b32 s0, s0, 0
-; GFX11-NEXT:    ;;#ASMSTART
-; GFX11-NEXT:    ; use s0
-; GFX11-NEXT:    ;;#ASMEND
-; GFX11-NEXT:    s_endpgm
-;
-; GFX12-LABEL: s_fneg_v2f16_salu_use:
-; GFX12:       ; %bb.0:
-; GFX12-NEXT:    s_xor_b32 s0, s0, 0x80008000
-; GFX12-NEXT:    s_cmp_eq_u32 s1, 0
-; GFX12-NEXT:    s_cselect_b32 s0, s0, 0
-; GFX12-NEXT:    ;;#ASMSTART
-; GFX12-NEXT:    ; use s0
-; GFX12-NEXT:    ;;#ASMEND
-; GFX12-NEXT:    s_endpgm
+; GCN-LABEL: s_fneg_v2f16_salu_use:
+; GCN:       ; %bb.0:
+; GCN-NEXT:    s_xor_b32 s0, s0, 0x80008000
+; GCN-NEXT:    s_cmp_eq_u32 s1, 0
+; GCN-NEXT:    s_cselect_b32 s0, s0, 0
+; GCN-NEXT:    ;;#ASMSTART
+; GCN-NEXT:    ; use s0
+; GCN-NEXT:    ;;#ASMEND
+; GCN-NEXT:    s_endpgm
   %fneg = fneg <2 x half> %in
   %cond = icmp eq i32 %val, 0
   %sel = select i1 %cond, <2 x half> %fneg, <2 x half> <half 0.0, half 0.0>

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/fneg.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/fneg.ll
@@ -170,58 +170,33 @@ define amdgpu_ps void @v_fneg_v2f16(<2 x half> %in, ptr addrspace(1) %out) {
   store <2 x half> %fneg, ptr addrspace(1) %out
   ret void
 }
+
 define amdgpu_ps void @s_fneg_v2f16(<2 x half> inreg %in) {
-; GFX11-LABEL: s_fneg_v2f16:
-; GFX11:       ; %bb.0:
-; GFX11-NEXT:    v_xor_b32_e64 v0, 0x80008000, s0
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-NEXT:    v_readfirstlane_b32 s0, v0
-; GFX11-NEXT:    ;;#ASMSTART
-; GFX11-NEXT:    ; use s0
-; GFX11-NEXT:    ;;#ASMEND
-; GFX11-NEXT:    s_endpgm
-;
-; GFX12-LABEL: s_fneg_v2f16:
-; GFX12:       ; %bb.0:
-; GFX12-NEXT:    s_lshr_b32 s1, s0, 16
-; GFX12-NEXT:    s_xor_b32 s0, s0, 0x8000
-; GFX12-NEXT:    s_xor_b32 s1, s1, 0x8000
-; GFX12-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX12-NEXT:    s_pack_ll_b32_b16 s0, s0, s1
-; GFX12-NEXT:    ;;#ASMSTART
-; GFX12-NEXT:    ; use s0
-; GFX12-NEXT:    ;;#ASMEND
-; GFX12-NEXT:    s_endpgm
+; GCN-LABEL: s_fneg_v2f16:
+; GCN:       ; %bb.0:
+; GCN-NEXT:    v_xor_b32_e64 v0, 0x80008000, s0
+; GCN-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GCN-NEXT:    v_readfirstlane_b32 s0, v0
+; GCN-NEXT:    ;;#ASMSTART
+; GCN-NEXT:    ; use s0
+; GCN-NEXT:    ;;#ASMEND
+; GCN-NEXT:    s_endpgm
   %fneg = fneg <2 x half> %in
   call void asm sideeffect "; use $0", "s"(<2 x half> %fneg)
   ret void
 }
 define amdgpu_ps void @s_fneg_v2f16_salu_use(<2 x half> inreg %in, i32 inreg %val) {
-; GFX11-LABEL: s_fneg_v2f16_salu_use:
-; GFX11:       ; %bb.0:
-; GFX11-NEXT:    v_xor_b32_e64 v0, 0x80008000, s0
-; GFX11-NEXT:    s_cmp_eq_u32 s1, 0
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-NEXT:    v_readfirstlane_b32 s0, v0
-; GFX11-NEXT:    s_cselect_b32 s0, s0, 0
-; GFX11-NEXT:    ;;#ASMSTART
-; GFX11-NEXT:    ; use s0
-; GFX11-NEXT:    ;;#ASMEND
-; GFX11-NEXT:    s_endpgm
-;
-; GFX12-LABEL: s_fneg_v2f16_salu_use:
-; GFX12:       ; %bb.0:
-; GFX12-NEXT:    s_lshr_b32 s2, s0, 16
-; GFX12-NEXT:    s_xor_b32 s0, s0, 0x8000
-; GFX12-NEXT:    s_xor_b32 s2, s2, 0x8000
-; GFX12-NEXT:    s_cmp_eq_u32 s1, 0
-; GFX12-NEXT:    s_pack_ll_b32_b16 s0, s0, s2
-; GFX12-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX12-NEXT:    s_cselect_b32 s0, s0, 0
-; GFX12-NEXT:    ;;#ASMSTART
-; GFX12-NEXT:    ; use s0
-; GFX12-NEXT:    ;;#ASMEND
-; GFX12-NEXT:    s_endpgm
+; GCN-LABEL: s_fneg_v2f16_salu_use:
+; GCN:       ; %bb.0:
+; GCN-NEXT:    v_xor_b32_e64 v0, 0x80008000, s0
+; GCN-NEXT:    s_cmp_eq_u32 s1, 0
+; GCN-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GCN-NEXT:    v_readfirstlane_b32 s0, v0
+; GCN-NEXT:    s_cselect_b32 s0, s0, 0
+; GCN-NEXT:    ;;#ASMSTART
+; GCN-NEXT:    ; use s0
+; GCN-NEXT:    ;;#ASMEND
+; GCN-NEXT:    s_endpgm
   %fneg = fneg <2 x half> %in
   %cond = icmp eq i32 %val, 0
   %sel = select i1 %cond, <2 x half> %fneg, <2 x half> <half 0.0, half 0.0>

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/fsub.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/fsub.ll
@@ -109,23 +109,10 @@ define amdgpu_ps void @fsub_s64_div(double %a, double %b, ptr addrspace(1) %ptr)
 }
 
 define amdgpu_ps <2 x half> @fsub_v2s16_uniform(<2 x half> inreg %a, <2 x half> inreg %b) {
-; GFX11-LABEL: fsub_v2s16_uniform:
-; GFX11:       ; %bb.0:
-; GFX11-NEXT:    v_pk_add_f16 v0, s0, s1 neg_lo:[0,1] neg_hi:[0,1]
-; GFX11-NEXT:    ; return to shader part epilog
-;
-; GFX12-LABEL: fsub_v2s16_uniform:
-; GFX12:       ; %bb.0:
-; GFX12-NEXT:    s_lshr_b32 s2, s1, 16
-; GFX12-NEXT:    s_xor_b32 s1, s1, 0x8000
-; GFX12-NEXT:    s_xor_b32 s2, s2, 0x8000
-; GFX12-NEXT:    s_lshr_b32 s3, s0, 16
-; GFX12-NEXT:    s_add_f16 s0, s0, s1
-; GFX12-NEXT:    s_add_f16 s1, s3, s2
-; GFX12-NEXT:    s_delay_alu instid0(SALU_CYCLE_3) | instskip(NEXT) | instid1(SALU_CYCLE_1)
-; GFX12-NEXT:    s_pack_ll_b32_b16 s0, s0, s1
-; GFX12-NEXT:    v_mov_b32_e32 v0, s0
-; GFX12-NEXT:    ; return to shader part epilog
+; GCN-LABEL: fsub_v2s16_uniform:
+; GCN:       ; %bb.0:
+; GCN-NEXT:    v_pk_add_f16 v0, s0, s1 neg_lo:[0,1] neg_hi:[0,1]
+; GCN-NEXT:    ; return to shader part epilog
   %fsub = fsub <2 x half> %a, %b
   ret <2 x half> %fsub
 }

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/strict_fma.f16.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/strict_fma.f16.ll
@@ -798,12 +798,8 @@ define void @v_constained_fma_v2f16_fpexcept_strict_fneg_fneg_uni(<2 x half> inr
 ; GFX8-LABEL: v_constained_fma_v2f16_fpexcept_strict_fneg_fneg_uni:
 ; GFX8:       ; %bb.0:
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX8-NEXT:    v_mov_b32_e32 v2, s16
-; GFX8-NEXT:    v_xor_b32_e32 v2, 0x80008000, v2
-; GFX8-NEXT:    v_readfirstlane_b32 s4, v2
-; GFX8-NEXT:    v_mov_b32_e32 v2, s17
-; GFX8-NEXT:    v_xor_b32_e32 v2, 0x80008000, v2
-; GFX8-NEXT:    v_readfirstlane_b32 s5, v2
+; GFX8-NEXT:    s_xor_b32 s5, s17, 0x80008000
+; GFX8-NEXT:    s_xor_b32 s4, s16, 0x80008000
 ; GFX8-NEXT:    v_mov_b32_e32 v2, s5
 ; GFX8-NEXT:    v_mov_b32_e32 v3, s18
 ; GFX8-NEXT:    s_lshr_b32 s7, s5, 16

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/strict_fma.f16.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/strict_fma.f16.ll
@@ -172,17 +172,9 @@ define void @v_constained_fma_v2f16_fpexcept_strict_uni(<2 x half> inreg %x, <2 
 ; GFX12-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-NEXT:    s_wait_kmcnt 0x0
-; GFX12-NEXT:    s_lshr_b32 s3, s0, 16
-; GFX12-NEXT:    s_lshr_b32 s4, s1, 16
-; GFX12-NEXT:    s_lshr_b32 s5, s2, 16
-; GFX12-NEXT:    s_fmac_f16 s2, s0, s1
-; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-NEXT:    s_fmac_f16 s5, s3, s4
-; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-NEXT:    s_delay_alu instid0(SALU_CYCLE_2)
-; GFX12-NEXT:    s_pack_ll_b32_b16 s0, s2, s5
-; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-NEXT:    v_mov_b32_e32 v2, s0
+; GFX12-NEXT:    v_mov_b32_e32 v2, s2
+; GFX12-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX12-NEXT:    v_pk_fma_f16 v2, s0, s1, v2
 ; GFX12-NEXT:    global_store_b32 v[0:1], v2, off
 ; GFX12-NEXT:    s_setpc_b64 s[30:31]
   %val = call <2 x half> @llvm.experimental.constrained.fma.v2f16(<2 x half> %x, <2 x half> %y, <2 x half> %z, metadata !"round.tonearest", metadata !"fpexcept.strict")
@@ -396,24 +388,10 @@ define void @v_constained_fma_v4f16_fpexcept_strict_uni(<4 x half> inreg %x, <4 
 ; GFX12-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-NEXT:    s_wait_kmcnt 0x0
-; GFX12-NEXT:    s_lshr_b32 s4, s0, 16
-; GFX12-NEXT:    s_lshr_b32 s5, s2, 16
-; GFX12-NEXT:    s_lshr_b32 s6, s16, 16
-; GFX12-NEXT:    s_fmac_f16 s16, s0, s2
-; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-NEXT:    s_fmac_f16 s6, s4, s5
-; GFX12-NEXT:    s_lshr_b32 s0, s1, 16
-; GFX12-NEXT:    s_lshr_b32 s2, s3, 16
-; GFX12-NEXT:    s_lshr_b32 s4, s17, 16
-; GFX12-NEXT:    s_fmac_f16 s17, s1, s3
-; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-NEXT:    s_fmac_f16 s4, s0, s2
-; GFX12-NEXT:    s_pack_ll_b32_b16 s0, s16, s6
-; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX12-NEXT:    s_pack_ll_b32_b16 s1, s17, s4
-; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-NEXT:    v_dual_mov_b32 v2, s0 :: v_dual_mov_b32 v3, s1
+; GFX12-NEXT:    v_dual_mov_b32 v2, s16 :: v_dual_mov_b32 v3, s17
+; GFX12-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX12-NEXT:    v_pk_fma_f16 v2, s0, s2, v2
+; GFX12-NEXT:    v_pk_fma_f16 v3, s1, s3, v3
 ; GFX12-NEXT:    global_store_b64 v[0:1], v[2:3], off
 ; GFX12-NEXT:    s_setpc_b64 s[30:31]
   %val = call <4 x half> @llvm.experimental.constrained.fma.v4f16(<4 x half> %x, <4 x half> %y, <4 x half> %z, metadata !"round.tonearest", metadata !"fpexcept.strict")
@@ -882,22 +860,9 @@ define void @v_constained_fma_v2f16_fpexcept_strict_fneg_fneg_uni(<2 x half> inr
 ; GFX12-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-NEXT:    s_wait_kmcnt 0x0
-; GFX12-NEXT:    s_lshr_b32 s3, s0, 16
-; GFX12-NEXT:    s_lshr_b32 s4, s1, 16
-; GFX12-NEXT:    s_xor_b32 s0, s0, 0x8000
-; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-NEXT:    s_xor_b32 s3, s3, 0x8000
-; GFX12-NEXT:    s_xor_b32 s1, s1, 0x8000
-; GFX12-NEXT:    s_xor_b32 s4, s4, 0x8000
-; GFX12-NEXT:    s_lshr_b32 s5, s2, 16
-; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-NEXT:    s_fmac_f16 s2, s0, s1
-; GFX12-NEXT:    s_fmac_f16 s5, s3, s4
-; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-NEXT:    s_delay_alu instid0(SALU_CYCLE_2)
-; GFX12-NEXT:    s_pack_ll_b32_b16 s0, s2, s5
-; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-NEXT:    v_mov_b32_e32 v2, s0
+; GFX12-NEXT:    v_mov_b32_e32 v2, s1
+; GFX12-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX12-NEXT:    v_pk_fma_f16 v2, s0, v2, s2 neg_lo:[1,1,0] neg_hi:[1,1,0]
 ; GFX12-NEXT:    global_store_b32 v[0:1], v2, off
 ; GFX12-NEXT:    s_setpc_b64 s[30:31]
   %neg.x = fneg <2 x half> %x

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/sub.v2i16.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/sub.v2i16.ll
@@ -399,9 +399,7 @@ define amdgpu_ps i32 @s_sub_v2i16(<2 x i16> inreg %a, <2 x i16> inreg %b) {
 define amdgpu_ps i32 @s_sub_v2i16_fneg_lhs(<2 x half> inreg %a, <2 x i16> inreg %b) {
 ; GFX9-LABEL: s_sub_v2i16_fneg_lhs:
 ; GFX9:       ; %bb.0:
-; GFX9-NEXT:    v_mov_b32_e32 v0, s0
-; GFX9-NEXT:    v_xor_b32_e32 v0, 0x80008000, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX9-NEXT:    s_xor_b32 s0, s0, 0x80008000
 ; GFX9-NEXT:    s_lshr_b32 s2, s0, 16
 ; GFX9-NEXT:    s_lshr_b32 s3, s1, 16
 ; GFX9-NEXT:    s_sub_i32 s0, s0, s1
@@ -411,9 +409,7 @@ define amdgpu_ps i32 @s_sub_v2i16_fneg_lhs(<2 x half> inreg %a, <2 x i16> inreg 
 ;
 ; GFX8-LABEL: s_sub_v2i16_fneg_lhs:
 ; GFX8:       ; %bb.0:
-; GFX8-NEXT:    v_mov_b32_e32 v0, s0
-; GFX8-NEXT:    v_xor_b32_e32 v0, 0x80008000, v0
-; GFX8-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX8-NEXT:    s_xor_b32 s0, s0, 0x80008000
 ; GFX8-NEXT:    s_lshr_b32 s2, s0, 16
 ; GFX8-NEXT:    s_lshr_b32 s3, s1, 16
 ; GFX8-NEXT:    s_sub_i32 s0, s0, s1
@@ -426,9 +422,8 @@ define amdgpu_ps i32 @s_sub_v2i16_fneg_lhs(<2 x half> inreg %a, <2 x i16> inreg 
 ;
 ; GFX10-LABEL: s_sub_v2i16_fneg_lhs:
 ; GFX10:       ; %bb.0:
-; GFX10-NEXT:    v_xor_b32_e64 v0, 0x80008000, s0
+; GFX10-NEXT:    s_xor_b32 s0, s0, 0x80008000
 ; GFX10-NEXT:    s_lshr_b32 s3, s1, 16
-; GFX10-NEXT:    v_readfirstlane_b32 s0, v0
 ; GFX10-NEXT:    s_lshr_b32 s2, s0, 16
 ; GFX10-NEXT:    s_sub_i32 s0, s0, s1
 ; GFX10-NEXT:    s_sub_i32 s1, s2, s3
@@ -437,9 +432,8 @@ define amdgpu_ps i32 @s_sub_v2i16_fneg_lhs(<2 x half> inreg %a, <2 x i16> inreg 
 ;
 ; GFX11-LABEL: s_sub_v2i16_fneg_lhs:
 ; GFX11:       ; %bb.0:
-; GFX11-NEXT:    v_xor_b32_e64 v0, 0x80008000, s0
+; GFX11-NEXT:    s_xor_b32 s0, s0, 0x80008000
 ; GFX11-NEXT:    s_lshr_b32 s3, s1, 16
-; GFX11-NEXT:    v_readfirstlane_b32 s0, v0
 ; GFX11-NEXT:    s_lshr_b32 s2, s0, 16
 ; GFX11-NEXT:    s_sub_i32 s0, s0, s1
 ; GFX11-NEXT:    s_sub_i32 s1, s2, s3
@@ -455,9 +449,7 @@ define amdgpu_ps i32 @s_sub_v2i16_fneg_lhs(<2 x half> inreg %a, <2 x i16> inreg 
 define amdgpu_ps i32 @s_sub_v2i16_fneg_rhs(<2 x i16> inreg %a, <2 x half> inreg %b) {
 ; GFX9-LABEL: s_sub_v2i16_fneg_rhs:
 ; GFX9:       ; %bb.0:
-; GFX9-NEXT:    v_mov_b32_e32 v0, s1
-; GFX9-NEXT:    v_xor_b32_e32 v0, 0x80008000, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s1, v0
+; GFX9-NEXT:    s_xor_b32 s1, s1, 0x80008000
 ; GFX9-NEXT:    s_lshr_b32 s2, s0, 16
 ; GFX9-NEXT:    s_lshr_b32 s3, s1, 16
 ; GFX9-NEXT:    s_sub_i32 s0, s0, s1
@@ -467,9 +459,7 @@ define amdgpu_ps i32 @s_sub_v2i16_fneg_rhs(<2 x i16> inreg %a, <2 x half> inreg 
 ;
 ; GFX8-LABEL: s_sub_v2i16_fneg_rhs:
 ; GFX8:       ; %bb.0:
-; GFX8-NEXT:    v_mov_b32_e32 v0, s1
-; GFX8-NEXT:    v_xor_b32_e32 v0, 0x80008000, v0
-; GFX8-NEXT:    v_readfirstlane_b32 s1, v0
+; GFX8-NEXT:    s_xor_b32 s1, s1, 0x80008000
 ; GFX8-NEXT:    s_lshr_b32 s2, s0, 16
 ; GFX8-NEXT:    s_lshr_b32 s3, s1, 16
 ; GFX8-NEXT:    s_sub_i32 s0, s0, s1
@@ -482,9 +472,8 @@ define amdgpu_ps i32 @s_sub_v2i16_fneg_rhs(<2 x i16> inreg %a, <2 x half> inreg 
 ;
 ; GFX10-LABEL: s_sub_v2i16_fneg_rhs:
 ; GFX10:       ; %bb.0:
-; GFX10-NEXT:    v_xor_b32_e64 v0, 0x80008000, s1
+; GFX10-NEXT:    s_xor_b32 s1, s1, 0x80008000
 ; GFX10-NEXT:    s_lshr_b32 s2, s0, 16
-; GFX10-NEXT:    v_readfirstlane_b32 s1, v0
 ; GFX10-NEXT:    s_lshr_b32 s3, s1, 16
 ; GFX10-NEXT:    s_sub_i32 s0, s0, s1
 ; GFX10-NEXT:    s_sub_i32 s1, s2, s3
@@ -493,9 +482,8 @@ define amdgpu_ps i32 @s_sub_v2i16_fneg_rhs(<2 x i16> inreg %a, <2 x half> inreg 
 ;
 ; GFX11-LABEL: s_sub_v2i16_fneg_rhs:
 ; GFX11:       ; %bb.0:
-; GFX11-NEXT:    v_xor_b32_e64 v0, 0x80008000, s1
+; GFX11-NEXT:    s_xor_b32 s1, s1, 0x80008000
 ; GFX11-NEXT:    s_lshr_b32 s2, s0, 16
-; GFX11-NEXT:    v_readfirstlane_b32 s1, v0
 ; GFX11-NEXT:    s_lshr_b32 s3, s1, 16
 ; GFX11-NEXT:    s_sub_i32 s0, s0, s1
 ; GFX11-NEXT:    s_sub_i32 s1, s2, s3
@@ -511,12 +499,8 @@ define amdgpu_ps i32 @s_sub_v2i16_fneg_rhs(<2 x i16> inreg %a, <2 x half> inreg 
 define amdgpu_ps i32 @s_sub_v2i16_fneg_lhs_fneg_rhs(<2 x half> inreg %a, <2 x half> inreg %b) {
 ; GFX9-LABEL: s_sub_v2i16_fneg_lhs_fneg_rhs:
 ; GFX9:       ; %bb.0:
-; GFX9-NEXT:    v_mov_b32_e32 v0, s0
-; GFX9-NEXT:    v_xor_b32_e32 v0, 0x80008000, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s0, v0
-; GFX9-NEXT:    v_mov_b32_e32 v0, s1
-; GFX9-NEXT:    v_xor_b32_e32 v0, 0x80008000, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s1, v0
+; GFX9-NEXT:    s_xor_b32 s0, s0, 0x80008000
+; GFX9-NEXT:    s_xor_b32 s1, s1, 0x80008000
 ; GFX9-NEXT:    s_lshr_b32 s2, s0, 16
 ; GFX9-NEXT:    s_lshr_b32 s3, s1, 16
 ; GFX9-NEXT:    s_sub_i32 s0, s0, s1
@@ -526,12 +510,8 @@ define amdgpu_ps i32 @s_sub_v2i16_fneg_lhs_fneg_rhs(<2 x half> inreg %a, <2 x ha
 ;
 ; GFX8-LABEL: s_sub_v2i16_fneg_lhs_fneg_rhs:
 ; GFX8:       ; %bb.0:
-; GFX8-NEXT:    v_mov_b32_e32 v0, s0
-; GFX8-NEXT:    v_xor_b32_e32 v0, 0x80008000, v0
-; GFX8-NEXT:    v_readfirstlane_b32 s0, v0
-; GFX8-NEXT:    v_mov_b32_e32 v0, s1
-; GFX8-NEXT:    v_xor_b32_e32 v0, 0x80008000, v0
-; GFX8-NEXT:    v_readfirstlane_b32 s1, v0
+; GFX8-NEXT:    s_xor_b32 s0, s0, 0x80008000
+; GFX8-NEXT:    s_xor_b32 s1, s1, 0x80008000
 ; GFX8-NEXT:    s_lshr_b32 s2, s0, 16
 ; GFX8-NEXT:    s_lshr_b32 s3, s1, 16
 ; GFX8-NEXT:    s_sub_i32 s0, s0, s1
@@ -544,10 +524,8 @@ define amdgpu_ps i32 @s_sub_v2i16_fneg_lhs_fneg_rhs(<2 x half> inreg %a, <2 x ha
 ;
 ; GFX10-LABEL: s_sub_v2i16_fneg_lhs_fneg_rhs:
 ; GFX10:       ; %bb.0:
-; GFX10-NEXT:    v_xor_b32_e64 v0, 0x80008000, s0
-; GFX10-NEXT:    v_xor_b32_e64 v1, 0x80008000, s1
-; GFX10-NEXT:    v_readfirstlane_b32 s0, v0
-; GFX10-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX10-NEXT:    s_xor_b32 s0, s0, 0x80008000
+; GFX10-NEXT:    s_xor_b32 s1, s1, 0x80008000
 ; GFX10-NEXT:    s_lshr_b32 s2, s0, 16
 ; GFX10-NEXT:    s_lshr_b32 s3, s1, 16
 ; GFX10-NEXT:    s_sub_i32 s0, s0, s1
@@ -557,10 +535,8 @@ define amdgpu_ps i32 @s_sub_v2i16_fneg_lhs_fneg_rhs(<2 x half> inreg %a, <2 x ha
 ;
 ; GFX11-LABEL: s_sub_v2i16_fneg_lhs_fneg_rhs:
 ; GFX11:       ; %bb.0:
-; GFX11-NEXT:    v_xor_b32_e64 v0, 0x80008000, s0
-; GFX11-NEXT:    v_xor_b32_e64 v1, 0x80008000, s1
-; GFX11-NEXT:    v_readfirstlane_b32 s0, v0
-; GFX11-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX11-NEXT:    s_xor_b32 s0, s0, 0x80008000
+; GFX11-NEXT:    s_xor_b32 s1, s1, 0x80008000
 ; GFX11-NEXT:    s_lshr_b32 s2, s0, 16
 ; GFX11-NEXT:    s_lshr_b32 s3, s1, 16
 ; GFX11-NEXT:    s_sub_i32 s0, s0, s1

--- a/llvm/test/CodeGen/AMDGPU/llvm.fptrunc.round.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.fptrunc.round.ll
@@ -1265,15 +1265,14 @@ define amdgpu_gs void @s_fptrunc_round_v2f32_to_v2f16_upward_multiple_calls(<2 x
 ; GFX12-GISEL-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 2, 2), 2
 ; GFX12-GISEL-NEXT:    s_cvt_f16_f32 s2, s2
 ; GFX12-GISEL-NEXT:    s_cvt_f16_f32 s3, s3
-; GFX12-GISEL-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 3, 1), 0
-; GFX12-GISEL-NEXT:    s_add_f16 s0, s0, s4
-; GFX12-GISEL-NEXT:    s_add_f16 s1, s1, s5
-; GFX12-GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_2) | instskip(NEXT) | instid1(SALU_CYCLE_2)
-; GFX12-GISEL-NEXT:    s_add_f16 s0, s2, s0
-; GFX12-GISEL-NEXT:    s_add_f16 s1, s3, s1
-; GFX12-GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_3) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX12-GISEL-NEXT:    s_pack_ll_b32_b16 s0, s0, s1
-; GFX12-GISEL-NEXT:    v_mov_b32_e32 v2, s0
+; GFX12-GISEL-NEXT:    s_pack_ll_b32_b16 s1, s4, s5
+; GFX12-GISEL-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 3, 1), 0
+; GFX12-GISEL-NEXT:    v_pk_add_f16 v2, s0, s1
+; GFX12-GISEL-NEXT:    s_pack_ll_b32_b16 s0, s2, s3
+; GFX12-GISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX12-GISEL-NEXT:    v_pk_add_f16 v2, s0, v2
 ; GFX12-GISEL-NEXT:    global_store_b32 v[0:1], v2, off
 ; GFX12-GISEL-NEXT:    s_endpgm
   %res1 = call <2 x half> @llvm.fptrunc.round.v2f16.v2f32(<2 x float> %a, metadata !"round.upward")

--- a/llvm/test/CodeGen/AMDGPU/strict_fadd.f16.ll
+++ b/llvm/test/CodeGen/AMDGPU/strict_fadd.f16.ll
@@ -585,21 +585,10 @@ define amdgpu_ps <2 x half> @s_constained_fadd_v2f16_fpexcept_strict(<2 x half> 
 ; GFX11-NEXT:    v_pk_add_f16 v0, s2, s3
 ; GFX11-NEXT:    ; return to shader part epilog
 ;
-; GFX12-SDAG-LABEL: s_constained_fadd_v2f16_fpexcept_strict:
-; GFX12-SDAG:       ; %bb.0:
-; GFX12-SDAG-NEXT:    v_pk_add_f16 v0, s2, s3
-; GFX12-SDAG-NEXT:    ; return to shader part epilog
-;
-; GFX12-GISEL-LABEL: s_constained_fadd_v2f16_fpexcept_strict:
-; GFX12-GISEL:       ; %bb.0:
-; GFX12-GISEL-NEXT:    s_lshr_b32 s0, s2, 16
-; GFX12-GISEL-NEXT:    s_lshr_b32 s1, s3, 16
-; GFX12-GISEL-NEXT:    s_add_f16 s2, s2, s3
-; GFX12-GISEL-NEXT:    s_add_f16 s0, s0, s1
-; GFX12-GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_3) | instskip(NEXT) | instid1(SALU_CYCLE_1)
-; GFX12-GISEL-NEXT:    s_pack_ll_b32_b16 s0, s2, s0
-; GFX12-GISEL-NEXT:    v_mov_b32_e32 v0, s0
-; GFX12-GISEL-NEXT:    ; return to shader part epilog
+; GFX12-LABEL: s_constained_fadd_v2f16_fpexcept_strict:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    v_pk_add_f16 v0, s2, s3
+; GFX12-NEXT:    ; return to shader part epilog
   %val = call <2 x half> @llvm.experimental.constrained.fadd.v2f16(<2 x half> %x, <2 x half> %y, metadata !"round.tonearest", metadata !"fpexcept.strict")
   ret <2 x half> %val
 }

--- a/llvm/test/CodeGen/AMDGPU/strict_fmul.f16.ll
+++ b/llvm/test/CodeGen/AMDGPU/strict_fmul.f16.ll
@@ -660,21 +660,10 @@ define amdgpu_ps <2 x half> @s_constained_fmul_v2f16_fpexcept_strict(<2 x half> 
 ; GFX10PLUS-NEXT:    v_pk_mul_f16 v0, s2, s3
 ; GFX10PLUS-NEXT:    ; return to shader part epilog
 ;
-; GFX12-SDAG-LABEL: s_constained_fmul_v2f16_fpexcept_strict:
-; GFX12-SDAG:       ; %bb.0:
-; GFX12-SDAG-NEXT:    v_pk_mul_f16 v0, s2, s3
-; GFX12-SDAG-NEXT:    ; return to shader part epilog
-;
-; GFX12-GISEL-LABEL: s_constained_fmul_v2f16_fpexcept_strict:
-; GFX12-GISEL:       ; %bb.0:
-; GFX12-GISEL-NEXT:    s_lshr_b32 s0, s2, 16
-; GFX12-GISEL-NEXT:    s_lshr_b32 s1, s3, 16
-; GFX12-GISEL-NEXT:    s_mul_f16 s2, s2, s3
-; GFX12-GISEL-NEXT:    s_mul_f16 s0, s0, s1
-; GFX12-GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_3) | instskip(NEXT) | instid1(SALU_CYCLE_1)
-; GFX12-GISEL-NEXT:    s_pack_ll_b32_b16 s0, s2, s0
-; GFX12-GISEL-NEXT:    v_mov_b32_e32 v0, s0
-; GFX12-GISEL-NEXT:    ; return to shader part epilog
+; GFX12-LABEL: s_constained_fmul_v2f16_fpexcept_strict:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    v_pk_mul_f16 v0, s2, s3
+; GFX12-NEXT:    ; return to shader part epilog
   %val = call <2 x half> @llvm.experimental.constrained.fmul.v2f16(<2 x half> %x, <2 x half> %y, metadata !"round.tonearest", metadata !"fpexcept.strict")
   ret <2 x half> %val
 }

--- a/llvm/test/CodeGen/AMDGPU/strict_fsub.f16.ll
+++ b/llvm/test/CodeGen/AMDGPU/strict_fsub.f16.ll
@@ -803,9 +803,7 @@ define amdgpu_ps <2 x half> @s_constained_fsub_v2f16_fpexcept_strict(<2 x half> 
 ;
 ; GFX8-GISEL-LABEL: s_constained_fsub_v2f16_fpexcept_strict:
 ; GFX8-GISEL:       ; %bb.0:
-; GFX8-GISEL-NEXT:    v_mov_b32_e32 v0, s3
-; GFX8-GISEL-NEXT:    v_xor_b32_e32 v0, 0x80008000, v0
-; GFX8-GISEL-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX8-GISEL-NEXT:    s_xor_b32 s0, s3, 0x80008000
 ; GFX8-GISEL-NEXT:    v_mov_b32_e32 v0, s0
 ; GFX8-GISEL-NEXT:    s_lshr_b32 s3, s0, 16
 ; GFX8-GISEL-NEXT:    v_add_f16_e32 v0, s2, v0

--- a/llvm/test/CodeGen/AMDGPU/strict_fsub.f16.ll
+++ b/llvm/test/CodeGen/AMDGPU/strict_fsub.f16.ll
@@ -873,15 +873,7 @@ define amdgpu_ps <2 x half> @s_constained_fsub_v2f16_fpexcept_strict(<2 x half> 
 ;
 ; GFX12-GISEL-LABEL: s_constained_fsub_v2f16_fpexcept_strict:
 ; GFX12-GISEL:       ; %bb.0:
-; GFX12-GISEL-NEXT:    s_lshr_b32 s0, s3, 16
-; GFX12-GISEL-NEXT:    s_xor_b32 s1, s3, 0x8000
-; GFX12-GISEL-NEXT:    s_xor_b32 s0, s0, 0x8000
-; GFX12-GISEL-NEXT:    s_lshr_b32 s3, s2, 16
-; GFX12-GISEL-NEXT:    s_add_f16 s1, s2, s1
-; GFX12-GISEL-NEXT:    s_add_f16 s0, s3, s0
-; GFX12-GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_3) | instskip(NEXT) | instid1(SALU_CYCLE_1)
-; GFX12-GISEL-NEXT:    s_pack_ll_b32_b16 s0, s1, s0
-; GFX12-GISEL-NEXT:    v_mov_b32_e32 v0, s0
+; GFX12-GISEL-NEXT:    v_pk_add_f16 v0, s2, s3 neg_lo:[0,1] neg_hi:[0,1]
 ; GFX12-GISEL-NEXT:    ; return to shader part epilog
   %val = call <2 x half> @llvm.experimental.constrained.fsub.v2f16(<2 x half> %x, <2 x half> %y, metadata !"round.tonearest", metadata !"fpexcept.strict")
   ret <2 x half> %val


### PR DESCRIPTION
  Previously, register bank legalization would scalarize uniform v2f16 and v2bf16
  floating-point operations on targets with hasSALUFloat (GFX12+) using
  the ScalarizeToS16 action. This approach had two problems:

  1. It fails for v2bf16 types because there are no scalar bf16
     instructions - the scalarization produces illegal bf16 operations
     that cannot be selected.

  2. Scalar f16 instructions exist, but scalarization is suboptimal. Packed instructions
     like v_pk_add_f16, v_pk_mul_f16, etc. are more efficient than
     unpacking to two separate s16 operations.

  This patch removes the ScalarizeToS16 rules and instead adds
  unconditional .Uni(V2S16) rules that always use
  packed VGPR operations for uniform cases.

  Operations modified:
  - G_FADD, G_FMUL, G_STRICT_FADD, G_STRICT_FMUL
  - G_FSUB, G_STRICT_FSUB
  - G_FMA, G_STRICT_FMA
  - G_FNEG, G_FABS