### PR TITLE
[Object] Reject overflowing offload bundle offsets

### DIFF
--- a/llvm/lib/Object/OffloadBundle.cpp
+++ b/llvm/lib/Object/OffloadBundle.cpp
@@ -19,6 +19,7 @@
 #include "llvm/Object/IRObjectFile.h"
 #include "llvm/Object/ObjectFile.h"
 #include "llvm/Support/BinaryStreamReader.h"
+#include "llvm/Support/CheckedArithmetic.h"
 #include "llvm/Support/EndianStream.h"
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/Timer.h"
@@ -158,8 +159,13 @@ Error OffloadBundleFatBin::readEntries(StringRef Buffer,
     if (Error Err = Reader.readFixedString(EntryID, EntryIDSize))
       return Err;
 
+    std::optional<uint64_t> AbsoluteOffset =
+        checkedAddUnsigned(EntryOffset, SectionOffset);
+    if (!AbsoluteOffset)
+      return errorCodeToError(object_error::parse_failed);
+
     auto Entry = std::make_unique<OffloadBundleEntry>(
-        EntryOffset + SectionOffset, EntrySize, EntryIDSize, EntryID);
+        *AbsoluteOffset, EntrySize, EntryIDSize, EntryID);
 
     Entries.push_back(*Entry);
   }

--- a/llvm/unittests/Object/OffloadingBundleTest.cpp
+++ b/llvm/unittests/Object/OffloadingBundleTest.cpp
@@ -10,6 +10,7 @@
 #include "llvm/Support/YAMLTraits.h"
 #include "llvm/Testing/Support/Error.h"
 #include "gtest/gtest.h"
+#include <limits>
 #include <random>
 
 using namespace llvm;
@@ -48,6 +49,24 @@ toBinary(SmallVectorImpl<char> &Storage, StringRef Yaml) {
                              "unable to convert YAML");
   return object::ObjectFile::createELFObjectFile(
       MemoryBufferRef(OS.str(), "dummyELF"));
+}
+
+static void appendU64(SmallVectorImpl<char> &Bytes, uint64_t Value) {
+  for (unsigned I = 0; I != sizeof(Value); ++I)
+    Bytes.push_back(static_cast<char>(Value >> (I * 8)));
+}
+
+TEST(OffloadingBundleTest, RejectsOverflowingEntryOffset) {
+  SmallString<64> Bundle("__CLANG_OFFLOAD_BUNDLE__");
+  appendU64(Bundle, 1);
+  appendU64(Bundle, std::numeric_limits<uint64_t>::max());
+  appendU64(Bundle, 1);
+  appendU64(Bundle, 0);
+
+  Expected<std::unique_ptr<OffloadBundleFatBin>> BundleOrErr =
+      OffloadBundleFatBin::create(MemoryBufferRef(Bundle, "bundle"),
+                                  /*SectionOffset=*/1, "bundle");
+  EXPECT_THAT_EXPECTED(BundleOrErr, Failed());
 }
 
 TEST(OffloadingBundleTest, checkExtractOffloadBundleFatBinary) {


### PR DESCRIPTION
## Summary

- reject legacy offload bundle entries when adding the containing-section offset would overflow uint64_t
- return a parse error instead of wrapping the absolute entry offset
- add a regression test for the overflow case

## Testing

- Built ObjectTests
- Ran OffloadingBundleTest: 3 tests passed