### PR TITLE
[mlir][NFC] Prune unused copyArrayRefInto template

### DIFF
--- a/mlir/lib/IR/MLIRContext.cpp
+++ b/mlir/lib/IR/MLIRContext.cpp
@@ -373,16 +373,6 @@ MLIRContext::~MLIRContext() {
   impl->remarkEngine.reset();
 }
 
-/// Copy the specified array of elements into memory managed by the provided
-/// bump pointer allocator.  This assumes the elements are all PODs.
-template <typename T>
-static ArrayRef<T> copyArrayRefInto(llvm::BumpPtrAllocator &allocator,
-                                    ArrayRef<T> elements) {
-  auto result = allocator.Allocate<T>(elements.size());
-  llvm::uninitialized_copy(elements, result);
-  return ArrayRef<T>(result, elements.size());
-}
-
 //===----------------------------------------------------------------------===//
 // Action Handling
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
`copyArrayRefInto` has internal linkage, so it is only reachable from MLIRContext.cpp, and it has no callers there. It is the only mention of the name in the MLIR tree.

An unused internal-linkage template fires -Wunused-template. That warning is not in -Wall on main today, having been reverted by 8710728e0418, but it did ship enabled in clang 23.1.0, so building MLIR with that released compiler under -Werror fails here:

  mlir/lib/IR/MLIRContext.cpp:379:20: error: unused function template
  'copyArrayRefInto' [-Werror,-Wunused-template]

This is the same deletion as one hunk of #221480, which cleans up the same warning across 21 MLIR files and is still open. Landing that PR is the better outcome; this is split out only because the file blocks a release/23.x build today.

Assisted-by: Claude