### PR TITLE
[LoopIdiom] Recognize the ctlz/cttz idiom when the input is known non-zero

### DIFF
--- a/llvm/lib/Transforms/Scalar/LoopIdiomRecognize.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopIdiomRecognize.cpp
@@ -2737,12 +2737,11 @@ bool LoopIdiomRecognize::insertFFSIfProfitable(Intrinsic::ID IntrinID,
   // would have identical behavior in the original loop and thus
   if (!IsCntPhiUsedOutsideLoop) {
     auto *PreCondBB = PH->getSinglePredecessor();
-    if (!PreCondBB)
-      return false;
-    auto *PreCondBI = dyn_cast<CondBrInst>(PreCondBB->getTerminator());
-    if (!PreCondBI)
-      return false;
-    if (matchCondition(PreCondBI, PH) != InitX)
+    auto *PreCondBI =
+        PreCondBB ? dyn_cast<CondBrInst>(PreCondBB->getTerminator()) : nullptr;
+    if (!(PreCondBI && matchCondition(PreCondBI, PH) == InitX) &&
+        !isKnownNonZero(
+            InitX, SimplifyQuery(*DL, DT, /*AC=*/nullptr, PH->getTerminator())))
       return false;
     ZeroCheck = true;
   }

--- a/llvm/test/Transforms/LoopIdiom/X86/ctlz.ll
+++ b/llvm/test/Transforms/LoopIdiom/X86/ctlz.ll
@@ -766,3 +766,41 @@ while.end:                                        ; preds = %while.cond
 
 declare i32 @llvm.abs.i32(i32, i1)
 declare i16 @llvm.abs.i16(i16, i1)
+
+; Same loop as ctlz_bad, but the input is known to be non-zero. The missing
+; zero check in front of the loop is not needed, so the idiom is recognized.
+define i32 @ctlz_known_nonzero_no_check(i32 %n) {
+; ALL-LABEL: @ctlz_known_nonzero_no_check(
+; ALL-NEXT:  entry:
+; ALL-NEXT:    [[N_NONZERO:%.*]] = or i32 [[N:%.*]], 1
+; ALL-NEXT:    [[TMP0:%.*]] = call i32 @llvm.ctlz.i32(i32 [[N_NONZERO]], i1 true)
+; ALL-NEXT:    [[TMP1:%.*]] = sub i32 32, [[TMP0]]
+; ALL-NEXT:    br label [[WHILE_COND:%.*]]
+; ALL:       while.cond:
+; ALL-NEXT:    [[TCPHI:%.*]] = phi i32 [ [[TMP1]], [[ENTRY:%.*]] ], [ [[TCDEC:%.*]], [[WHILE_COND]] ]
+; ALL-NEXT:    [[N_ADDR_0:%.*]] = phi i32 [ [[N_NONZERO]], [[ENTRY]] ], [ [[SHR:%.*]], [[WHILE_COND]] ]
+; ALL-NEXT:    [[I_0:%.*]] = phi i32 [ 0, [[ENTRY]] ], [ [[INC:%.*]], [[WHILE_COND]] ]
+; ALL-NEXT:    [[SHR]] = lshr i32 [[N_ADDR_0]], 1
+; ALL-NEXT:    [[TCDEC]] = sub nsw i32 [[TCPHI]], 1
+; ALL-NEXT:    [[TOBOOL:%.*]] = icmp eq i32 [[TCDEC]], 0
+; ALL-NEXT:    [[INC]] = add nsw i32 [[I_0]], 1
+; ALL-NEXT:    br i1 [[TOBOOL]], label [[WHILE_END:%.*]], label [[WHILE_COND]]
+; ALL:       while.end:
+; ALL-NEXT:    [[INC_LCSSA:%.*]] = phi i32 [ [[TMP1]], [[WHILE_COND]] ]
+; ALL-NEXT:    ret i32 [[INC_LCSSA]]
+;
+entry:
+  %n.nonzero = or i32 %n, 1
+  br label %while.cond
+
+while.cond:                                       ; preds = %while.cond, %entry
+  %n.addr.0 = phi i32 [ %n.nonzero, %entry ], [ %shr, %while.cond ]
+  %i.0 = phi i32 [ 0, %entry ], [ %inc, %while.cond ]
+  %shr = lshr i32 %n.addr.0, 1
+  %tobool = icmp eq i32 %shr, 0
+  %inc = add nsw i32 %i.0, 1
+  br i1 %tobool, label %while.end, label %while.cond
+
+while.end:                                        ; preds = %while.cond
+  ret i32 %inc
+}

--- a/llvm/test/Transforms/PhaseOrdering/X86/ctlz-loop.ll
+++ b/llvm/test/Transforms/PhaseOrdering/X86/ctlz-loop.ll
@@ -6,7 +6,6 @@ target triple = "x86_64-unknown-linux-gnu"
 
 ; This test ensures we are able to optimize the following loop to an llvm.abs
 ; followed by an llvm.ctlz.
-; FIXME: LoopIdiom recongize is not forming llvm.ctlz.
 
 ; int ctlz_zero_check(int n)
 ; {
@@ -24,18 +23,13 @@ define i32 @ctlz_loop_with_abs(i32 %n) {
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[TOBOOL_NOT1:%.*]] = icmp eq i32 [[N:%.*]], 0
 ; CHECK-NEXT:    br i1 [[TOBOOL_NOT1]], label [[WHILE_END:%.*]], label [[WHILE_BODY_PREHEADER:%.*]]
-; CHECK:       while.body.preheader:
+; CHECK:       while.end.loopexit:
 ; CHECK-NEXT:    [[TMP0:%.*]] = tail call i32 @llvm.abs.i32(i32 [[N]], i1 true)
-; CHECK-NEXT:    br label [[WHILE_BODY:%.*]]
-; CHECK:       while.body:
-; CHECK-NEXT:    [[N_ADDR_03:%.*]] = phi i32 [ [[TMP1:%.*]], [[WHILE_BODY]] ], [ [[TMP0]], [[WHILE_BODY_PREHEADER]] ]
-; CHECK-NEXT:    [[I_02:%.*]] = phi i32 [ [[INC:%.*]], [[WHILE_BODY]] ], [ 0, [[WHILE_BODY_PREHEADER]] ]
-; CHECK-NEXT:    [[TMP1]] = lshr i32 [[N_ADDR_03]], 1
-; CHECK-NEXT:    [[INC]] = add nuw nsw i32 [[I_02]], 1
-; CHECK-NEXT:    [[TOBOOL_NOT:%.*]] = icmp eq i32 [[TMP1]], 0
-; CHECK-NEXT:    br i1 [[TOBOOL_NOT]], label [[WHILE_END]], label [[WHILE_BODY]]
+; CHECK-NEXT:    [[TMP2:%.*]] = tail call range(i32 1, 33) i32 @llvm.ctlz.i32(i32 [[TMP0]], i1 true)
+; CHECK-NEXT:    [[TMP1:%.*]] = sub nuw nsw i32 32, [[TMP2]]
+; CHECK-NEXT:    br label [[WHILE_END]]
 ; CHECK:       while.end:
-; CHECK-NEXT:    [[I_0_LCSSA:%.*]] = phi i32 [ 0, [[ENTRY:%.*]] ], [ [[INC]], [[WHILE_BODY]] ]
+; CHECK-NEXT:    [[I_0_LCSSA:%.*]] = phi i32 [ 0, [[ENTRY:%.*]] ], [ [[TMP1]], [[WHILE_BODY_PREHEADER]] ]
 ; CHECK-NEXT:    ret i32 [[I_0_LCSSA]]
 ;
 entry:


### PR DESCRIPTION
LoopIdiomRecognize converts a shift-until-zero loop to `ctlz`/`cttz`. When the loop uses the count outside the loop, it needs a zero check of the input before the loop. Without the check, the inputs 0 and 1 give the same count. The recognizer stops when the check is not present.

The check is not necessary when the input is known non-zero. InstCombine can remove the check for such inputs. Then the recognizer does not convert the loop. This happens in `sbc_calc_scalefactors` from ffmpeg with #222334: the input is an or reduction that starts at 32768, so it is never zero, and the loop stays a loop.

This patch makes the recognizer accept a known non-zero input in place of the zero check. The conversion is exact in this case.

`ctlz-loop.ll` in PhaseOrdering had a FIXME for a loop over `abs(n)`. The recognizer now converts that loop too.

For the ffmpeg case, `isKnownNonZero` must also see that an or recurrence with a non-zero start is non-zero. That change goes into #222334.
