### PR TITLE
[OpenMP] Make all syntactic properties explicit

### DIFF
--- a/llvm/include/llvm/Frontend/OpenMP/OMPDescriptors.h.inc
+++ b/llvm/include/llvm/Frontend/OpenMP/OMPDescriptors.h.inc
@@ -11,6 +11,7 @@
   AllDataEnvironments,
   First_ = AllDataEnvironments,
   AllPrivatizing,
+  Compatible,
   Complex,
   Constant,
   DataCopying,
@@ -25,6 +26,7 @@
   DispatchRequirement,
   EndClause,
   Exclusive,
+  Free,
   IcvDefaulted,
   IcvModifying,
   InnermostLeaf,
@@ -124,13 +126,6 @@
   VariableCategory,
   Last_ = VariableCategory,
 #endif // GEN_OMP_MODIFIER_ENUMS
-#ifdef GEN_OMP_MODIFIER_SET_ENUMS
-  DependModifierSet1,
-  First_ = DependModifierSet1,
-  NumTeamsModifierSet1,
-  ReductionModifierSet1,
-  Last_ = ReductionModifierSet1,
-#endif // GEN_OMP_MODIFIER_SET_ENUMS
 #ifdef GEN_OMP_MODIFIER_GROUP_ENUMS
   AdjustOp,
   First_ = AdjustOp,
@@ -141,4 +136,11 @@
   VariableSelector,
   Last_ = VariableSelector,
 #endif // GEN_OMP_MODIFIER_GROUP_ENUMS
+#ifdef GEN_OMP_MODIFIER_SET_ENUMS
+  DependModifierSet1,
+  First_ = DependModifierSet1,
+  NumTeamsModifierSet1,
+  ReductionModifierSet1,
+  Last_ = ReductionModifierSet1,
+#endif // GEN_OMP_MODIFIER_SET_ENUMS
    // clang-format on

--- a/llvm/lib/Frontend/OpenMP/OMPDescriptors.inc
+++ b/llvm/lib/Frontend/OpenMP/OMPDescriptors.inc
@@ -13,10 +13,10 @@
     descriptor::Clause(
       "absent",
       {
-        {Version(51), {{{Property::Unique}}, "absent", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::Unique}}, "absent", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::Unique}}, "absent", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::Unique}}, "absent", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "absent", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "absent", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "absent", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "absent", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -25,11 +25,11 @@
     descriptor::Clause(
       "acq_rel",
       {
-        {Version(50), {{{Property::Unique}}, "acq_rel", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::Unique}}, "acq_rel", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::Unique}}, "acq_rel", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::Unique}}, "acq_rel", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::Unique}}, "acq_rel", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "acq_rel", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "acq_rel", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "acq_rel", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "acq_rel", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "acq_rel", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -38,11 +38,11 @@
     descriptor::Clause(
       "acquire",
       {
-        {Version(50), {{{Property::Unique}}, "acquire", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::Unique}}, "acquire", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::Unique}}, "acquire", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::Unique}}, "acquire", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::Unique}}, "acquire", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "acquire", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "acquire", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "acquire", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "acquire", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "acquire", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -51,10 +51,10 @@
     descriptor::Clause(
       "adjust_args",
       {
-        {Version(51), {{{Property::DispatchCompliant}}, "adjust_args", {Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AdjustOp}, {}}},
-        {Version(52), {{{Property::DispatchCompliant}}, "adjust_args", {Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AdjustOp}, {}}},
-        {Version(60), {{{Property::DispatchCompliant}}, "adjust_args", {Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AdjustOp, Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::DispatchCompliant}}, "adjust_args", {Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {ModifierSet::AdjustOp}}},
+        {Version(51), {{{Property::Compatible, Property::DispatchCompliant, Property::Free, Property::Optional, Property::Repeatable}}, "adjust_args", {Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AdjustOp}, {}}},
+        {Version(52), {{{Property::Compatible, Property::DispatchCompliant, Property::Free, Property::Optional, Property::Repeatable}}, "adjust_args", {Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AdjustOp}, {}}},
+        {Version(60), {{{Property::Compatible, Property::DispatchCompliant, Property::Free, Property::Optional, Property::Repeatable}}, "adjust_args", {Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AdjustOp, Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::DispatchCompliant, Property::Free, Property::Optional, Property::Repeatable}}, "adjust_args", {Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {ModifierSet::AdjustOp}}},
       }
     ),
   },
@@ -63,11 +63,11 @@
     descriptor::Clause(
       "affinity",
       {
-        {Version(50), {{{}}, "affinity", {Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Iterator}, {}}},
-        {Version(51), {{{}}, "affinity", {Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Iterator}, {}}},
-        {Version(52), {{{Property::Unique}}, "affinity", {Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Iterator}, {}}},
-        {Version(60), {{{Property::TaskInherited}}, "affinity", {Directive::OMPD_target_data, Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Iterator}, {}}},
-        {Version(61), {{{Property::TaskInherited}}, "affinity", {Directive::OMPD_target_data, Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Iterator}, {}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::Optional, Property::Repeatable}}, "affinity", {Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Iterator}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Repeatable}}, "affinity", {Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Iterator}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "affinity", {Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Iterator}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Repeatable, Property::TaskInherited}}, "affinity", {Directive::OMPD_target_data, Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Iterator}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Repeatable, Property::TaskInherited}}, "affinity", {Directive::OMPD_target_data, Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Iterator}, {}}},
       }
     ),
   },
@@ -76,10 +76,10 @@
     descriptor::Clause(
       "align",
       {
-        {Version(51), {{{Property::Unique}}, "align", {Directive::OMPD_allocate}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::Unique}}, "align", {Directive::OMPD_allocate}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::Unique}}, "align", {Directive::OMPD_allocate}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::Unique}}, "align", {Directive::OMPD_allocate}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "align", {Directive::OMPD_allocate}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "align", {Directive::OMPD_allocate}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "align", {Directive::OMPD_allocate}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "align", {Directive::OMPD_allocate}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -88,12 +88,12 @@
     descriptor::Clause(
       "aligned",
       {
-        {Version(45), {{{Property::DataEnvironmentAttribute, Property::PostModified}}, "aligned", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Alignment}, {}}},
-        {Version(50), {{{Property::DataEnvironmentAttribute, Property::PostModified}}, "aligned", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Alignment}, {}}},
-        {Version(51), {{{Property::DataEnvironmentAttribute, Property::PostModified}}, "aligned", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Alignment}, {}}},
-        {Version(52), {{{Property::DataEnvironmentAttribute, Property::PostModified}}, "aligned", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Alignment}, {}}},
-        {Version(60), {{{Property::DataEnvironmentAttribute, Property::PostModified}}, "aligned", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Alignment, Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::DataEnvironmentAttribute, Property::PostModified}}, "aligned", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Alignment, Modifier::DirectiveNameModifier}, {}}},
+        {Version(45), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::Free, Property::Optional, Property::PostModified, Property::Repeatable}}, "aligned", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Alignment}, {}}},
+        {Version(50), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::Free, Property::Optional, Property::PostModified, Property::Repeatable}}, "aligned", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Alignment}, {}}},
+        {Version(51), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::Free, Property::Optional, Property::PostModified, Property::Repeatable}}, "aligned", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Alignment}, {}}},
+        {Version(52), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::Free, Property::Optional, Property::PostModified, Property::Repeatable}}, "aligned", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Alignment}, {}}},
+        {Version(60), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::Free, Property::Optional, Property::PostModified, Property::Repeatable}}, "aligned", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Alignment, Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::Free, Property::Optional, Property::PostModified, Property::Repeatable}}, "aligned", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Alignment, Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -102,11 +102,11 @@
     descriptor::Clause(
       "allocate",
       {
-        {Version(50), {{{Property::AllPrivatizing}}, "allocate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskgroup, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AllocatorSimpleModifier}, {}}},
-        {Version(51), {{{Property::AllPrivatizing}}, "allocate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskgroup, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AlignModifier, Modifier::AllocatorSimpleModifier}, {}}},
-        {Version(52), {{{Property::AllPrivatizing}}, "allocate", {Directive::OMPD_allocators, Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskgroup, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AlignModifier, Modifier::AllocatorComplexModifier, Modifier::AllocatorSimpleModifier}, {}}},
-        {Version(60), {{{Property::AllPrivatizing}}, "allocate", {Directive::OMPD_allocators, Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskgroup, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AlignModifier, Modifier::AllocatorComplexModifier, Modifier::AllocatorSimpleModifier, Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::AllPrivatizing, Property::TargetConsistent}}, "allocate", {Directive::OMPD_allocators, Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskgroup, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AlignModifier, Modifier::AllocatorComplexModifier, Modifier::AllocatorSimpleModifier, Modifier::DirectiveNameModifier}, {}}},
+        {Version(50), {{{Property::AllPrivatizing, Property::Compatible, Property::Free, Property::Optional, Property::Repeatable}}, "allocate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskgroup, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AllocatorSimpleModifier}, {}}},
+        {Version(51), {{{Property::AllPrivatizing, Property::Compatible, Property::Free, Property::Optional, Property::Repeatable}}, "allocate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskgroup, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AlignModifier, Modifier::AllocatorSimpleModifier}, {}}},
+        {Version(52), {{{Property::AllPrivatizing, Property::Compatible, Property::Free, Property::Optional, Property::Repeatable}}, "allocate", {Directive::OMPD_allocators, Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskgroup, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AlignModifier, Modifier::AllocatorComplexModifier, Modifier::AllocatorSimpleModifier}, {}}},
+        {Version(60), {{{Property::AllPrivatizing, Property::Compatible, Property::Free, Property::Optional, Property::Repeatable}}, "allocate", {Directive::OMPD_allocators, Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskgroup, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AlignModifier, Modifier::AllocatorComplexModifier, Modifier::AllocatorSimpleModifier, Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::AllPrivatizing, Property::Compatible, Property::Free, Property::Optional, Property::Repeatable, Property::TargetConsistent}}, "allocate", {Directive::OMPD_allocators, Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskgroup, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AlignModifier, Modifier::AllocatorComplexModifier, Modifier::AllocatorSimpleModifier, Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -115,11 +115,11 @@
     descriptor::Clause(
       "allocator",
       {
-        {Version(50), {{{Property::IcvDefaulted, Property::Unique}}, "allocator", {Directive::OMPD_allocate}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::IcvDefaulted, Property::Unique}}, "allocator", {Directive::OMPD_allocate}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::IcvDefaulted, Property::Unique}}, "allocator", {Directive::OMPD_allocate}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::IcvDefaulted, Property::Unique}}, "allocator", {Directive::OMPD_allocate}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::IcvDefaulted, Property::Unique}}, "allocator", {Directive::OMPD_allocate}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::IcvDefaulted, Property::Optional, Property::Unique}}, "allocator", {Directive::OMPD_allocate}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::IcvDefaulted, Property::Optional, Property::Unique}}, "allocator", {Directive::OMPD_allocate}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::IcvDefaulted, Property::Optional, Property::Unique}}, "allocator", {Directive::OMPD_allocate}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::IcvDefaulted, Property::Optional, Property::Unique}}, "allocator", {Directive::OMPD_allocate}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::IcvDefaulted, Property::Optional, Property::Unique}}, "allocator", {Directive::OMPD_allocate}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -128,10 +128,10 @@
     descriptor::Clause(
       "append_args",
       {
-        {Version(51), {{{Property::DispatchCompliant, Property::Unique}}, "append_args", {Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::DispatchCompliant, Property::Unique}}, "append_args", {Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::DispatchCompliant, Property::Unique}}, "append_args", {Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::DispatchCompliant, Property::Unique}}, "append_args", {Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(51), {{{Property::Compatible, Property::DispatchCompliant, Property::Free, Property::Optional, Property::Unique}}, "append_args", {Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::DispatchCompliant, Property::Free, Property::Optional, Property::Unique}}, "append_args", {Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::DispatchCompliant, Property::Free, Property::Optional, Property::Unique}}, "append_args", {Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::DispatchCompliant, Property::Free, Property::Optional, Property::Unique}}, "append_args", {Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -140,8 +140,8 @@
     descriptor::Clause(
       "apply",
       {
-        {Version(60), {{{}}, "apply", {Directive::OMPD_fuse, Directive::OMPD_interchange, Directive::OMPD_nothing, Directive::OMPD_reverse, Directive::OMPD_split, Directive::OMPD_stripe, Directive::OMPD_tile, Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::LoopModifier}, {}}},
-        {Version(61), {{{}}, "apply", {Directive::OMPD_flatten, Directive::OMPD_fuse, Directive::OMPD_interchange, Directive::OMPD_nothing, Directive::OMPD_reverse, Directive::OMPD_split, Directive::OMPD_stripe, Directive::OMPD_tile, Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::LoopModifier}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Repeatable}}, "apply", {Directive::OMPD_fuse, Directive::OMPD_interchange, Directive::OMPD_nothing, Directive::OMPD_reverse, Directive::OMPD_split, Directive::OMPD_stripe, Directive::OMPD_tile, Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::LoopModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Repeatable}}, "apply", {Directive::OMPD_flatten, Directive::OMPD_fuse, Directive::OMPD_interchange, Directive::OMPD_nothing, Directive::OMPD_reverse, Directive::OMPD_split, Directive::OMPD_stripe, Directive::OMPD_tile, Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::LoopModifier}, {}}},
       }
     ),
   },
@@ -150,10 +150,10 @@
     descriptor::Clause(
       "at",
       {
-        {Version(51), {{{Property::Unique}}, "at", {Directive::OMPD_error}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::Unique}}, "at", {Directive::OMPD_error}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::Unique}}, "at", {Directive::OMPD_error}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::Unique}}, "at", {Directive::OMPD_error}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "at", {Directive::OMPD_error}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "at", {Directive::OMPD_error}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "at", {Directive::OMPD_error}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "at", {Directive::OMPD_error}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -162,11 +162,11 @@
     descriptor::Clause(
       "atomic_default_mem_order",
       {
-        {Version(50), {{{Property::Unique}}, "atomic_default_mem_order", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::Unique}}, "atomic_default_mem_order", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::Unique}}, "atomic_default_mem_order", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::Unique}}, "atomic_default_mem_order", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::Unique}}, "atomic_default_mem_order", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "atomic_default_mem_order", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "atomic_default_mem_order", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "atomic_default_mem_order", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "atomic_default_mem_order", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "atomic_default_mem_order", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -175,11 +175,11 @@
     descriptor::Clause(
       "bind",
       {
-        {Version(50), {{{Property::Unique}}, "bind", {Directive::OMPD_loop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::Unique}}, "bind", {Directive::OMPD_loop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::Unique}}, "bind", {Directive::OMPD_loop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::Unique}}, "bind", {Directive::OMPD_loop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::Unique}}, "bind", {Directive::OMPD_loop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "bind", {Directive::OMPD_loop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "bind", {Directive::OMPD_loop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "bind", {Directive::OMPD_loop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "bind", {Directive::OMPD_loop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "bind", {Directive::OMPD_loop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -188,12 +188,12 @@
     descriptor::Clause(
       "capture",
       {
-        {Version(45), {{{Property::InnermostLeaf, Property::Unique}}, "capture", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(50), {{{Property::InnermostLeaf, Property::Unique}}, "capture", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::InnermostLeaf, Property::Unique}}, "capture", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::InnermostLeaf, Property::Unique}}, "capture", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::InnermostLeaf, Property::Unique}}, "capture", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::InnermostLeaf, Property::Unique}}, "capture", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(45), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "capture", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "capture", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "capture", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "capture", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "capture", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "capture", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -202,12 +202,12 @@
     descriptor::Clause(
       "collapse",
       {
-        {Version(45), {{{Property::OnceForAllConstituents, Property::Unique}}, "collapse", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(50), {{{Property::OnceForAllConstituents, Property::Unique}}, "collapse", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::OnceForAllConstituents, Property::Unique}}, "collapse", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::OnceForAllConstituents, Property::Unique}}, "collapse", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::OnceForAllConstituents, Property::Unique}}, "collapse", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::OnceForAllConstituents, Property::Unique}}, "collapse", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(45), {{{Property::Compatible, Property::Free, Property::OnceForAllConstituents, Property::Optional, Property::Unique}}, "collapse", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::OnceForAllConstituents, Property::Optional, Property::Unique}}, "collapse", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::OnceForAllConstituents, Property::Optional, Property::Unique}}, "collapse", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::OnceForAllConstituents, Property::Optional, Property::Unique}}, "collapse", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::OnceForAllConstituents, Property::Optional, Property::Unique}}, "collapse", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::OnceForAllConstituents, Property::Optional, Property::Unique}}, "collapse", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -216,8 +216,8 @@
     descriptor::Clause(
       "collector",
       {
-        {Version(60), {{{Property::Required, Property::Unique}}, "collector", {Directive::OMPD_declare_induction}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::Required, Property::Unique}}, "collector", {Directive::OMPD_declare_induction}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Required, Property::Unique}}, "collector", {Directive::OMPD_declare_induction}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Required, Property::Unique}}, "collector", {Directive::OMPD_declare_induction}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -226,8 +226,8 @@
     descriptor::Clause(
       "combiner",
       {
-        {Version(60), {{{Property::Required, Property::Unique}}, "combiner", {Directive::OMPD_declare_reduction}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::Required, Property::Unique}}, "combiner", {Directive::OMPD_declare_reduction}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Required, Property::Unique}}, "combiner", {Directive::OMPD_declare_reduction}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Required, Property::Unique}}, "combiner", {Directive::OMPD_declare_reduction}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -236,10 +236,10 @@
     descriptor::Clause(
       "compare",
       {
-        {Version(51), {{{Property::InnermostLeaf, Property::Unique}}, "compare", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::InnermostLeaf, Property::Unique}}, "compare", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::InnermostLeaf, Property::Unique}}, "compare", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::InnermostLeaf, Property::Unique}}, "compare", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "compare", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "compare", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "compare", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "compare", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -248,10 +248,10 @@
     descriptor::Clause(
       "contains",
       {
-        {Version(51), {{{Property::Unique}}, "contains", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::Unique}}, "contains", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::Unique}}, "contains", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::Unique}}, "contains", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "contains", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "contains", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "contains", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "contains", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -260,12 +260,12 @@
     descriptor::Clause(
       "copyin",
       {
-        {Version(45), {{{Property::DataCopying, Property::OutermostLeaf}}, "copyin", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(50), {{{Property::DataCopying, Property::OutermostLeaf}}, "copyin", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::DataCopying, Property::OutermostLeaf}}, "copyin", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::DataCopying, Property::OutermostLeaf}}, "copyin", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::DataCopying, Property::OutermostLeaf}}, "copyin", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::DataCopying, Property::OutermostLeaf}}, "copyin", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(45), {{{Property::Compatible, Property::DataCopying, Property::Free, Property::Optional, Property::OutermostLeaf, Property::Repeatable}}, "copyin", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(50), {{{Property::Compatible, Property::DataCopying, Property::Free, Property::Optional, Property::OutermostLeaf, Property::Repeatable}}, "copyin", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::DataCopying, Property::Free, Property::Optional, Property::OutermostLeaf, Property::Repeatable}}, "copyin", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::DataCopying, Property::Free, Property::Optional, Property::OutermostLeaf, Property::Repeatable}}, "copyin", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::DataCopying, Property::Free, Property::Optional, Property::OutermostLeaf, Property::Repeatable}}, "copyin", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::DataCopying, Property::Free, Property::Optional, Property::OutermostLeaf, Property::Repeatable}}, "copyin", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -274,12 +274,12 @@
     descriptor::Clause(
       "copyprivate",
       {
-        {Version(45), {{{Property::DataCopying, Property::EndClause, Property::InnermostLeaf}}, "copyprivate", {Directive::OMPD_single}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(50), {{{Property::DataCopying, Property::EndClause, Property::InnermostLeaf}}, "copyprivate", {Directive::OMPD_single}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::DataCopying, Property::EndClause, Property::InnermostLeaf}}, "copyprivate", {Directive::OMPD_single}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::DataCopying, Property::EndClause, Property::InnermostLeaf}}, "copyprivate", {Directive::OMPD_single}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::DataCopying, Property::EndClause, Property::InnermostLeaf}}, "copyprivate", {Directive::OMPD_single}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::DataCopying, Property::EndClause, Property::InnermostLeaf}}, "copyprivate", {Directive::OMPD_single}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(45), {{{Property::Compatible, Property::DataCopying, Property::EndClause, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Repeatable}}, "copyprivate", {Directive::OMPD_single}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(50), {{{Property::Compatible, Property::DataCopying, Property::EndClause, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Repeatable}}, "copyprivate", {Directive::OMPD_single}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::DataCopying, Property::EndClause, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Repeatable}}, "copyprivate", {Directive::OMPD_single}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::DataCopying, Property::EndClause, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Repeatable}}, "copyprivate", {Directive::OMPD_single}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::DataCopying, Property::EndClause, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Repeatable}}, "copyprivate", {Directive::OMPD_single}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::DataCopying, Property::EndClause, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Repeatable}}, "copyprivate", {Directive::OMPD_single}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -288,8 +288,8 @@
     descriptor::Clause(
       "counts",
       {
-        {Version(60), {{{Property::Required, Property::Unique}}, "counts", {Directive::OMPD_split}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::Required, Property::Unique}}, "counts", {Directive::OMPD_split}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Required, Property::Unique}}, "counts", {Directive::OMPD_split}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Required, Property::Unique}}, "counts", {Directive::OMPD_split}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -298,12 +298,12 @@
     descriptor::Clause(
       "default",
       {
-        {Version(45), {{{Property::DefaultAttribute, Property::PostModified, Property::Unique}}, "default", {Directive::OMPD_parallel, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(50), {{{Property::DefaultAttribute, Property::PostModified, Property::Unique}}, "default", {Directive::OMPD_parallel, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::VariableCategory}, {}}},
-        {Version(51), {{{Property::DefaultAttribute, Property::PostModified, Property::Unique}}, "default", {Directive::OMPD_parallel, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::VariableCategory}, {}}},
-        {Version(52), {{{Property::DefaultAttribute, Property::PostModified, Property::Unique}}, "default", {Directive::OMPD_parallel, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::VariableCategory}, {}}},
-        {Version(60), {{{Property::DefaultAttribute, Property::PostModified, Property::Unique}}, "default", {Directive::OMPD_parallel, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::VariableCategory}, {}}},
-        {Version(61), {{{Property::DefaultAttribute, Property::PostModified}}, "default", {Directive::OMPD_parallel, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {ModifierSet::VariableSelector}}},
+        {Version(45), {{{Property::Compatible, Property::DefaultAttribute, Property::Free, Property::Optional, Property::PostModified, Property::Unique}}, "default", {Directive::OMPD_parallel, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(50), {{{Property::Compatible, Property::DefaultAttribute, Property::Free, Property::Optional, Property::PostModified, Property::Unique}}, "default", {Directive::OMPD_parallel, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::VariableCategory}, {}}},
+        {Version(51), {{{Property::Compatible, Property::DefaultAttribute, Property::Free, Property::Optional, Property::PostModified, Property::Unique}}, "default", {Directive::OMPD_parallel, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::VariableCategory}, {}}},
+        {Version(52), {{{Property::Compatible, Property::DefaultAttribute, Property::Free, Property::Optional, Property::PostModified, Property::Unique}}, "default", {Directive::OMPD_parallel, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::VariableCategory}, {}}},
+        {Version(60), {{{Property::Compatible, Property::DefaultAttribute, Property::Free, Property::Optional, Property::PostModified, Property::Unique}}, "default", {Directive::OMPD_parallel, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::VariableCategory}, {}}},
+        {Version(61), {{{Property::Compatible, Property::DefaultAttribute, Property::Free, Property::Optional, Property::PostModified, Property::Repeatable}}, "default", {Directive::OMPD_parallel, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {ModifierSet::VariableSelector}}},
       }
     ),
   },
@@ -312,8 +312,8 @@
     descriptor::Clause(
       "default-variant",
       {
-        {Version(50), {{{Property::Ultimate, Property::Unique}}, "default-variant", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::Ultimate, Property::Unique}}, "default-variant", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(50), {{{Property::Compatible, Property::Optional, Property::Ultimate, Property::Unique}}, "default-variant", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Optional, Property::Ultimate, Property::Unique}}, "default-variant", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
       }
     ),
   },
@@ -322,12 +322,12 @@
     descriptor::Clause(
       "defaultmap",
       {
-        {Version(45), {{{Property::DefaultAttribute, Property::PostModified, Property::Unique}}, "defaultmap", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::VariableCategory}, {}}},
-        {Version(50), {{{Property::DefaultAttribute, Property::PostModified, Property::Unique}}, "defaultmap", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::VariableCategory}, {}}},
-        {Version(51), {{{Property::DefaultAttribute, Property::PostModified, Property::Unique}}, "defaultmap", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::VariableCategory}, {}}},
-        {Version(52), {{{Property::DefaultAttribute, Property::PostModified, Property::Unique}}, "defaultmap", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::VariableCategory}, {}}},
-        {Version(60), {{{Property::DefaultAttribute, Property::PostModified, Property::Unique}}, "defaultmap", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::VariableCategory}, {}}},
-        {Version(61), {{{Property::DefaultAttribute, Property::PostModified}}, "defaultmap", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {ModifierSet::VariableSelector}}},
+        {Version(45), {{{Property::Compatible, Property::DefaultAttribute, Property::Free, Property::Optional, Property::PostModified, Property::Unique}}, "defaultmap", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::VariableCategory}, {}}},
+        {Version(50), {{{Property::Compatible, Property::DefaultAttribute, Property::Free, Property::Optional, Property::PostModified, Property::Unique}}, "defaultmap", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::VariableCategory}, {}}},
+        {Version(51), {{{Property::Compatible, Property::DefaultAttribute, Property::Free, Property::Optional, Property::PostModified, Property::Unique}}, "defaultmap", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::VariableCategory}, {}}},
+        {Version(52), {{{Property::Compatible, Property::DefaultAttribute, Property::Free, Property::Optional, Property::PostModified, Property::Unique}}, "defaultmap", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::VariableCategory}, {}}},
+        {Version(60), {{{Property::Compatible, Property::DefaultAttribute, Property::Free, Property::Optional, Property::PostModified, Property::Unique}}, "defaultmap", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::VariableCategory}, {}}},
+        {Version(61), {{{Property::Compatible, Property::DefaultAttribute, Property::Free, Property::Optional, Property::PostModified, Property::Repeatable}}, "defaultmap", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {ModifierSet::VariableSelector}}},
       }
     ),
   },
@@ -336,12 +336,12 @@
     descriptor::Clause(
       "depend",
       {
-        {Version(45), {{{}}, "depend", {Directive::OMPD_ordered_standalone, Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DependenceType, Modifier::TaskDependenceType}, {ModifierSet::DependModifierSet1}}},
-        {Version(50), {{{}}, "depend", {Directive::OMPD_depobj, Directive::OMPD_ordered_standalone, Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskwait}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DependenceType, Modifier::Iterator, Modifier::TaskDependenceType}, {ModifierSet::DependModifierSet1}}},
-        {Version(51), {{{Property::DispatchRequirement}}, "depend", {Directive::OMPD_depobj, Directive::OMPD_dispatch, Directive::OMPD_interop, Directive::OMPD_ordered_standalone, Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskwait}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DependenceType, Modifier::Iterator, Modifier::TaskDependenceType}, {ModifierSet::DependModifierSet1}}},
-        {Version(52), {{{Property::DispatchRequirement}}, "depend", {Directive::OMPD_depobj, Directive::OMPD_dispatch, Directive::OMPD_interop, Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskwait}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Iterator, Modifier::TaskDependenceType}, {}}},
-        {Version(60), {{{Property::DispatchRequirement, Property::TaskInherited, Property::TaskgraphAltering}}, "depend", {Directive::OMPD_dispatch, Directive::OMPD_interop, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskwait}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Iterator, Modifier::TaskDependenceType}, {}}},
-        {Version(61), {{{Property::DispatchRequirement, Property::TaskInherited, Property::TaskSynchronizing, Property::TaskgraphAltering}}, "depend", {Directive::OMPD_dispatch, Directive::OMPD_interop, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskwait}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Iterator, Modifier::TaskDependenceType}, {ModifierSet::DependListType}}},
+        {Version(45), {{{Property::Compatible, Property::Free, Property::Optional, Property::Repeatable}}, "depend", {Directive::OMPD_ordered_standalone, Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DependenceType, Modifier::TaskDependenceType}, {ModifierSet::DependModifierSet1}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::Optional, Property::Repeatable}}, "depend", {Directive::OMPD_depobj, Directive::OMPD_ordered_standalone, Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskwait}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DependenceType, Modifier::Iterator, Modifier::TaskDependenceType}, {ModifierSet::DependModifierSet1}}},
+        {Version(51), {{{Property::Compatible, Property::DispatchRequirement, Property::Free, Property::Optional, Property::Repeatable}}, "depend", {Directive::OMPD_depobj, Directive::OMPD_dispatch, Directive::OMPD_interop, Directive::OMPD_ordered_standalone, Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskwait}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DependenceType, Modifier::Iterator, Modifier::TaskDependenceType}, {ModifierSet::DependModifierSet1}}},
+        {Version(52), {{{Property::Compatible, Property::DispatchRequirement, Property::Free, Property::Optional, Property::Repeatable}}, "depend", {Directive::OMPD_depobj, Directive::OMPD_dispatch, Directive::OMPD_interop, Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskwait}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Iterator, Modifier::TaskDependenceType}, {}}},
+        {Version(60), {{{Property::Compatible, Property::DispatchRequirement, Property::Free, Property::Optional, Property::Repeatable, Property::TaskInherited, Property::TaskgraphAltering}}, "depend", {Directive::OMPD_dispatch, Directive::OMPD_interop, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskwait}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Iterator, Modifier::TaskDependenceType}, {}}},
+        {Version(61), {{{Property::Compatible, Property::DispatchRequirement, Property::Free, Property::Optional, Property::Repeatable, Property::TaskInherited, Property::TaskSynchronizing, Property::TaskgraphAltering}}, "depend", {Directive::OMPD_dispatch, Directive::OMPD_interop, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskwait}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Iterator, Modifier::TaskDependenceType}, {ModifierSet::DependListType, ModifierSet::DependModifierSet1}}},
       }
     ),
   },
@@ -350,7 +350,7 @@
     descriptor::Clause(
       "depth",
       {
-        {Version(61), {{{Property::Unique}}, "depth", {Directive::OMPD_flatten, Directive::OMPD_fuse}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "depth", {Directive::OMPD_flatten, Directive::OMPD_fuse}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -359,11 +359,11 @@
     descriptor::Clause(
       "destroy",
       {
-        {Version(50), {{{}}, "destroy", {Directive::OMPD_depobj}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{}}, "destroy", {Directive::OMPD_depobj, Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{}}, "destroy", {Directive::OMPD_depobj, Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{}}, "destroy", {Directive::OMPD_depobj, Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{}}, "destroy", {Directive::OMPD_depobj, Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::Optional, Property::Repeatable}}, "destroy", {Directive::OMPD_depobj}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Repeatable}}, "destroy", {Directive::OMPD_depobj, Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Repeatable}}, "destroy", {Directive::OMPD_depobj, Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Repeatable}}, "destroy", {Directive::OMPD_depobj, Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Repeatable}}, "destroy", {Directive::OMPD_depobj, Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -372,11 +372,11 @@
     descriptor::Clause(
       "detach",
       {
-        {Version(50), {{{Property::DataSharingAttribute, Property::InnermostLeaf, Property::Privatization, Property::Unique}}, "detach", {Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::DataSharingAttribute, Property::InnermostLeaf, Property::Privatization, Property::Unique}}, "detach", {Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::DataSharingAttribute, Property::InnermostLeaf, Property::Privatization, Property::Unique}}, "detach", {Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::DataSharingAttribute, Property::InnermostLeaf, Property::Privatization, Property::Unique}}, "detach", {Directive::OMPD_target_data, Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::DataSharingAttribute, Property::InnermostLeaf, Property::Privatization, Property::Unique}}, "detach", {Directive::OMPD_target_data, Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(50), {{{Property::Compatible, Property::DataSharingAttribute, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Privatization, Property::Unique}}, "detach", {Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::DataSharingAttribute, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Privatization, Property::Unique}}, "detach", {Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::DataSharingAttribute, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Privatization, Property::Unique}}, "detach", {Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::DataSharingAttribute, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Privatization, Property::Unique}}, "detach", {Directive::OMPD_target_data, Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::DataSharingAttribute, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Privatization, Property::Unique}}, "detach", {Directive::OMPD_target_data, Directive::OMPD_task}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -385,12 +385,12 @@
     descriptor::Clause(
       "device",
       {
-        {Version(45), {{{Property::IcvDefaulted, Property::Unique}}, "device", {Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(50), {{{Property::IcvDefaulted, Property::Unique}}, "device", {Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DeviceModifier}, {}}},
-        {Version(51), {{{Property::IcvDefaulted, Property::Unique}}, "device", {Directive::OMPD_dispatch, Directive::OMPD_interop, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DeviceModifier}, {}}},
-        {Version(52), {{{Property::IcvDefaulted, Property::Unique}}, "device", {Directive::OMPD_dispatch, Directive::OMPD_interop, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DeviceModifier}, {}}},
-        {Version(60), {{{Property::IcvDefaulted, Property::Unique}}, "device", {Directive::OMPD_dispatch, Directive::OMPD_interop, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DeviceModifier, Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::IcvDefaulted, Property::Unique}}, "device", {Directive::OMPD_dispatch, Directive::OMPD_interop, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DeviceModifier, Modifier::DirectiveNameModifier}, {}}},
+        {Version(45), {{{Property::Compatible, Property::Free, Property::IcvDefaulted, Property::Optional, Property::Unique}}, "device", {Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::IcvDefaulted, Property::Optional, Property::Unique}}, "device", {Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DeviceModifier}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::IcvDefaulted, Property::Optional, Property::Unique}}, "device", {Directive::OMPD_dispatch, Directive::OMPD_interop, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DeviceModifier}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::IcvDefaulted, Property::Optional, Property::Unique}}, "device", {Directive::OMPD_dispatch, Directive::OMPD_interop, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DeviceModifier}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::IcvDefaulted, Property::Optional, Property::Unique}}, "device", {Directive::OMPD_dispatch, Directive::OMPD_interop, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DeviceModifier, Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::IcvDefaulted, Property::Optional, Property::Unique}}, "device", {Directive::OMPD_dispatch, Directive::OMPD_interop, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DeviceModifier, Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -399,8 +399,8 @@
     descriptor::Clause(
       "device_safesync",
       {
-        {Version(60), {{{Property::DeviceGlobalRequirement, Property::Unique}}, "device_safesync", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::DeviceGlobalRequirement, Property::Unique}}, "device_safesync", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(60), {{{Property::Compatible, Property::DeviceGlobalRequirement, Property::Free, Property::Optional, Property::Unique}}, "device_safesync", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::DeviceGlobalRequirement, Property::Free, Property::Optional, Property::Unique}}, "device_safesync", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -409,11 +409,11 @@
     descriptor::Clause(
       "device_type",
       {
-        {Version(50), {{{Property::Unique}}, "device_type", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::Unique}}, "device_type", {Directive::OMPD_begin_declare_target, Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::Unique}}, "device_type", {Directive::OMPD_begin_declare_target, Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::Unique}}, "device_type", {Directive::OMPD_begin_declare_target, Directive::OMPD_declare_target, Directive::OMPD_groupprivate, Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::Unique}}, "device_type", {Directive::OMPD_begin_declare_target, Directive::OMPD_declare_target, Directive::OMPD_groupprivate, Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "device_type", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "device_type", {Directive::OMPD_begin_declare_target, Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "device_type", {Directive::OMPD_begin_declare_target, Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "device_type", {Directive::OMPD_begin_declare_target, Directive::OMPD_declare_target, Directive::OMPD_groupprivate, Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "device_type", {Directive::OMPD_begin_declare_target, Directive::OMPD_declare_target, Directive::OMPD_groupprivate, Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -422,12 +422,12 @@
     descriptor::Clause(
       "dist_schedule",
       {
-        {Version(45), {{{Property::ScheduleSpecification, Property::Unique}}, "dist_schedule", {Directive::OMPD_distribute}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(50), {{{Property::ScheduleSpecification, Property::Unique}}, "dist_schedule", {Directive::OMPD_distribute}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::ScheduleSpecification, Property::Unique}}, "dist_schedule", {Directive::OMPD_distribute}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::ScheduleSpecification, Property::Unique}}, "dist_schedule", {Directive::OMPD_distribute}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::ScheduleSpecification, Property::Unique}}, "dist_schedule", {Directive::OMPD_distribute}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::ScheduleSpecification, Property::Unique}}, "dist_schedule", {Directive::OMPD_distribute}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(45), {{{Property::Compatible, Property::Free, Property::Optional, Property::ScheduleSpecification, Property::Unique}}, "dist_schedule", {Directive::OMPD_distribute}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::Optional, Property::ScheduleSpecification, Property::Unique}}, "dist_schedule", {Directive::OMPD_distribute}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::ScheduleSpecification, Property::Unique}}, "dist_schedule", {Directive::OMPD_distribute}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::ScheduleSpecification, Property::Unique}}, "dist_schedule", {Directive::OMPD_distribute}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::ScheduleSpecification, Property::Unique}}, "dist_schedule", {Directive::OMPD_distribute}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::ScheduleSpecification, Property::Unique}}, "dist_schedule", {Directive::OMPD_distribute}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -436,9 +436,9 @@
     descriptor::Clause(
       "doacross",
       {
-        {Version(52), {{{Property::Required}}, "doacross", {Directive::OMPD_ordered_standalone}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DependenceType}, {}}},
-        {Version(60), {{{Property::Required}}, "doacross", {Directive::OMPD_ordered_standalone}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DependenceType, Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::Required}}, "doacross", {Directive::OMPD_ordered_standalone}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DependenceType, Modifier::DirectiveNameModifier}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Repeatable, Property::Required}}, "doacross", {Directive::OMPD_ordered_standalone}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DependenceType}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Repeatable, Property::Required}}, "doacross", {Directive::OMPD_ordered_standalone}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DependenceType, Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Repeatable, Property::Required}}, "doacross", {Directive::OMPD_ordered_standalone}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DependenceType, Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -447,7 +447,7 @@
     descriptor::Clause(
       "dyn_groupprivate",
       {
-        {Version(61), {{{Property::TargetConsistent}}, "dyn_groupprivate", {Directive::OMPD_target, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AccessGroup, Modifier::DirectiveNameModifier, Modifier::FallbackModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Repeatable, Property::TargetConsistent}}, "dyn_groupprivate", {Directive::OMPD_target, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AccessGroup, Modifier::DirectiveNameModifier, Modifier::FallbackModifier}, {}}},
       }
     ),
   },
@@ -456,11 +456,11 @@
     descriptor::Clause(
       "dynamic_allocators",
       {
-        {Version(50), {{{Property::Unique}}, "dynamic_allocators", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::Unique}}, "dynamic_allocators", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::Unique}}, "dynamic_allocators", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::Unique}}, "dynamic_allocators", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::Unique}}, "dynamic_allocators", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "dynamic_allocators", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "dynamic_allocators", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "dynamic_allocators", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "dynamic_allocators", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "dynamic_allocators", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -469,9 +469,9 @@
     descriptor::Clause(
       "enter",
       {
-        {Version(52), {{{Property::DataEnvironmentAttribute, Property::DataMappingAttribute}}, "enter", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::DataEnvironmentAttribute, Property::DataMappingAttribute}}, "enter", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AutomapModifier, Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::DataEnvironmentAttribute, Property::DataMappingAttribute}}, "enter", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AutomapModifier, Modifier::DirectiveNameModifier}, {}}},
+        {Version(52), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataMappingAttribute, Property::Free, Property::Optional, Property::Repeatable}}, "enter", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataMappingAttribute, Property::Free, Property::Optional, Property::Repeatable}}, "enter", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AutomapModifier, Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataMappingAttribute, Property::Free, Property::Optional, Property::Repeatable}}, "enter", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AutomapModifier, Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -480,11 +480,11 @@
     descriptor::Clause(
       "exclusive",
       {
-        {Version(50), {{{Property::InnermostLeaf, Property::Unique}}, "exclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::InnermostLeaf, Property::Unique}}, "exclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::InnermostLeaf, Property::Unique}}, "exclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::InnermostLeaf, Property::Unique}}, "exclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::InnermostLeaf, Property::Unique}}, "exclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "exclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "exclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "exclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "exclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "exclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -493,10 +493,10 @@
     descriptor::Clause(
       "fail",
       {
-        {Version(51), {{{Property::InnermostLeaf, Property::Unique}}, "fail", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::InnermostLeaf, Property::Unique}}, "fail", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::InnermostLeaf, Property::Unique}}, "fail", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::InnermostLeaf, Property::Unique}}, "fail", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "fail", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "fail", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "fail", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "fail", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -505,10 +505,10 @@
     descriptor::Clause(
       "filter",
       {
-        {Version(51), {{{Property::Unique}}, "filter", {Directive::OMPD_masked}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::Unique}}, "filter", {Directive::OMPD_masked}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::Unique}}, "filter", {Directive::OMPD_masked}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::Unique}}, "filter", {Directive::OMPD_masked}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "filter", {Directive::OMPD_masked}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "filter", {Directive::OMPD_masked}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "filter", {Directive::OMPD_masked}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "filter", {Directive::OMPD_masked}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -517,12 +517,12 @@
     descriptor::Clause(
       "final",
       {
-        {Version(45), {{{Property::Unique}}, "final", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(50), {{{Property::Unique}}, "final", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::Unique}}, "final", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::Unique}}, "final", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::Unique}}, "final", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::Unique}}, "final", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(45), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "final", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "final", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "final", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "final", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "final", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "final", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -531,12 +531,12 @@
     descriptor::Clause(
       "firstprivate",
       {
-        {Version(45), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Privatization}}, "firstprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(50), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Privatization}}, "firstprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Privatization}}, "firstprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Privatization}}, "firstprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Privatization}}, "firstprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Saved}, {}}},
-        {Version(61), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Privatization}}, "firstprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Saved}, {}}},
+        {Version(45), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Free, Property::Optional, Property::Privatization, Property::Repeatable}}, "firstprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(50), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Free, Property::Optional, Property::Privatization, Property::Repeatable}}, "firstprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Free, Property::Optional, Property::Privatization, Property::Repeatable}}, "firstprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Free, Property::Optional, Property::Privatization, Property::Repeatable}}, "firstprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Free, Property::Optional, Property::Privatization, Property::Repeatable}}, "firstprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Saved}, {}}},
+        {Version(61), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Free, Property::Optional, Property::Privatization, Property::Repeatable}}, "firstprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Saved}, {}}},
       }
     ),
   },
@@ -545,12 +545,12 @@
     descriptor::Clause(
       "from",
       {
-        {Version(45), {{{Property::DataMotionAttribute}}, "from", {Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(50), {{{Property::DataMotionAttribute}}, "from", {Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Mapper}, {}}},
-        {Version(51), {{{Property::DataMotionAttribute}}, "from", {Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Iterator, Modifier::Mapper, Modifier::MotionModifier}, {}}},
-        {Version(52), {{{Property::DataMotionAttribute}}, "from", {Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Expectation, Modifier::Iterator, Modifier::Mapper}, {}}},
-        {Version(60), {{{Property::DataMotionAttribute}}, "from", {Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Iterator, Modifier::Mapper, Modifier::PresentModifier}, {}}},
-        {Version(61), {{{Property::DataMotionAttribute}}, "from", {Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Iterator, Modifier::Mapper, Modifier::PresentModifier}, {}}},
+        {Version(45), {{{Property::Compatible, Property::DataMotionAttribute, Property::Free, Property::Optional, Property::Repeatable}}, "from", {Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(50), {{{Property::Compatible, Property::DataMotionAttribute, Property::Free, Property::Optional, Property::Repeatable}}, "from", {Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Mapper}, {}}},
+        {Version(51), {{{Property::Compatible, Property::DataMotionAttribute, Property::Free, Property::Optional, Property::Repeatable}}, "from", {Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Iterator, Modifier::Mapper, Modifier::MotionModifier}, {}}},
+        {Version(52), {{{Property::Compatible, Property::DataMotionAttribute, Property::Free, Property::Optional, Property::Repeatable}}, "from", {Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Expectation, Modifier::Iterator, Modifier::Mapper}, {}}},
+        {Version(60), {{{Property::Compatible, Property::DataMotionAttribute, Property::Free, Property::Optional, Property::Repeatable}}, "from", {Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Iterator, Modifier::Mapper, Modifier::PresentModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::DataMotionAttribute, Property::Free, Property::Optional, Property::Repeatable}}, "from", {Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Iterator, Modifier::Mapper, Modifier::PresentModifier}, {}}},
       }
     ),
   },
@@ -559,10 +559,10 @@
     descriptor::Clause(
       "full",
       {
-        {Version(51), {{{Property::Unique}}, "full", {Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::Unique}}, "full", {Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::Unique}}, "full", {Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::Unique}}, "full", {Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "full", {Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "full", {Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "full", {Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "full", {Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -571,12 +571,12 @@
     descriptor::Clause(
       "grainsize",
       {
-        {Version(45), {{{Property::Unique}}, "grainsize", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(50), {{{Property::Unique}}, "grainsize", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::Unique}}, "grainsize", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Prescriptiveness}, {}}},
-        {Version(52), {{{Property::Unique}}, "grainsize", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Prescriptiveness}, {}}},
-        {Version(60), {{{Property::TaskgraphAltering, Property::Unique}}, "grainsize", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Prescriptiveness}, {}}},
-        {Version(61), {{{Property::TaskgraphAltering, Property::Unique}}, "grainsize", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Prescriptiveness}, {}}},
+        {Version(45), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "grainsize", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "grainsize", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "grainsize", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Prescriptiveness}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "grainsize", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Prescriptiveness}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::TaskgraphAltering, Property::Unique}}, "grainsize", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Prescriptiveness}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::TaskgraphAltering, Property::Unique}}, "grainsize", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Prescriptiveness}, {}}},
       }
     ),
   },
@@ -585,8 +585,8 @@
     descriptor::Clause(
       "graph_id",
       {
-        {Version(60), {{{Property::Unique}}, "graph_id", {Directive::OMPD_taskgraph}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::Unique}}, "graph_id", {Directive::OMPD_taskgraph}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "graph_id", {Directive::OMPD_taskgraph}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "graph_id", {Directive::OMPD_taskgraph}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -595,8 +595,8 @@
     descriptor::Clause(
       "graph_reset",
       {
-        {Version(60), {{{Property::Unique}}, "graph_reset", {Directive::OMPD_taskgraph}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::Unique}}, "graph_reset", {Directive::OMPD_taskgraph}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "graph_reset", {Directive::OMPD_taskgraph}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "graph_reset", {Directive::OMPD_taskgraph}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -605,10 +605,10 @@
     descriptor::Clause(
       "has_device_addr",
       {
-        {Version(51), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::OutermostLeaf}}, "has_device_addr", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::OutermostLeaf}}, "has_device_addr", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::DispatchRequirement, Property::OutermostLeaf}}, "has_device_addr", {Directive::OMPD_dispatch, Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::DispatchRequirement, Property::OutermostLeaf}}, "has_device_addr", {Directive::OMPD_dispatch, Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(51), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::Free, Property::Optional, Property::OutermostLeaf, Property::Repeatable}}, "has_device_addr", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::Free, Property::Optional, Property::OutermostLeaf, Property::Repeatable}}, "has_device_addr", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::DispatchRequirement, Property::Free, Property::Optional, Property::OutermostLeaf, Property::Repeatable}}, "has_device_addr", {Directive::OMPD_dispatch, Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::DispatchRequirement, Property::Free, Property::Optional, Property::OutermostLeaf, Property::Repeatable}}, "has_device_addr", {Directive::OMPD_dispatch, Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -617,12 +617,12 @@
     descriptor::Clause(
       "hint",
       {
-        {Version(45), {{{Property::Unique}}, "hint", {Directive::OMPD_critical}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(50), {{{Property::Unique}}, "hint", {Directive::OMPD_atomic, Directive::OMPD_critical}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::Unique}}, "hint", {Directive::OMPD_atomic, Directive::OMPD_critical}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::Unique}}, "hint", {Directive::OMPD_atomic, Directive::OMPD_critical}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::Unique}}, "hint", {Directive::OMPD_atomic, Directive::OMPD_critical}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::Unique}}, "hint", {Directive::OMPD_atomic, Directive::OMPD_critical}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(45), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "hint", {Directive::OMPD_critical}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "hint", {Directive::OMPD_atomic, Directive::OMPD_critical}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "hint", {Directive::OMPD_atomic, Directive::OMPD_critical}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "hint", {Directive::OMPD_atomic, Directive::OMPD_critical}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "hint", {Directive::OMPD_atomic, Directive::OMPD_critical}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "hint", {Directive::OMPD_atomic, Directive::OMPD_critical}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -631,10 +631,10 @@
     descriptor::Clause(
       "holds",
       {
-        {Version(51), {{{Property::Unique}}, "holds", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::Unique}}, "holds", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::Unique}}, "holds", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::Unique}}, "holds", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "holds", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "holds", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "holds", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "holds", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -643,12 +643,12 @@
     descriptor::Clause(
       "if",
       {
-        {Version(45), {{{Property::TargetConsistent}}, "if", {Directive::OMPD_cancel, Directive::OMPD_parallel, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(50), {{{Property::TargetConsistent}}, "if", {Directive::OMPD_cancel, Directive::OMPD_parallel, Directive::OMPD_simd, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(51), {{{Property::TargetConsistent}}, "if", {Directive::OMPD_cancel, Directive::OMPD_parallel, Directive::OMPD_simd, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(52), {{{Property::TargetConsistent}}, "if", {Directive::OMPD_cancel, Directive::OMPD_parallel, Directive::OMPD_simd, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(60), {{{Property::TargetConsistent}}, "if", {Directive::OMPD_cancel, Directive::OMPD_parallel, Directive::OMPD_simd, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskgraph, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::TargetConsistent}}, "if", {Directive::OMPD_cancel, Directive::OMPD_parallel, Directive::OMPD_simd, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskgraph, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(45), {{{Property::Compatible, Property::Free, Property::Optional, Property::Repeatable, Property::TargetConsistent}}, "if", {Directive::OMPD_cancel, Directive::OMPD_parallel, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::Optional, Property::Repeatable, Property::TargetConsistent}}, "if", {Directive::OMPD_cancel, Directive::OMPD_parallel, Directive::OMPD_simd, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Repeatable, Property::TargetConsistent}}, "if", {Directive::OMPD_cancel, Directive::OMPD_parallel, Directive::OMPD_simd, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Repeatable, Property::TargetConsistent}}, "if", {Directive::OMPD_cancel, Directive::OMPD_parallel, Directive::OMPD_simd, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Repeatable, Property::TargetConsistent}}, "if", {Directive::OMPD_cancel, Directive::OMPD_parallel, Directive::OMPD_simd, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskgraph, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Repeatable, Property::TargetConsistent}}, "if", {Directive::OMPD_cancel, Directive::OMPD_parallel, Directive::OMPD_simd, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskgraph, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -657,11 +657,11 @@
     descriptor::Clause(
       "in_reduction",
       {
-        {Version(50), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Privatization, Property::ReductionParticipating}}, "in_reduction", {Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier}, {}}},
-        {Version(51), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Privatization, Property::ReductionParticipating}}, "in_reduction", {Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier}, {}}},
-        {Version(52), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Privatization, Property::ReductionParticipating}}, "in_reduction", {Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier}, {}}},
-        {Version(60), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Privatization, Property::ReductionParticipating}}, "in_reduction", {Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::ReductionIdentifier}, {}}},
-        {Version(61), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Privatization, Property::ReductionParticipating}}, "in_reduction", {Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::ReductionIdentifier}, {}}},
+        {Version(50), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Free, Property::Optional, Property::Privatization, Property::ReductionParticipating, Property::Repeatable}}, "in_reduction", {Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier}, {}}},
+        {Version(51), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Free, Property::Optional, Property::Privatization, Property::ReductionParticipating, Property::Repeatable}}, "in_reduction", {Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier}, {}}},
+        {Version(52), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Free, Property::Optional, Property::Privatization, Property::ReductionParticipating, Property::Repeatable}}, "in_reduction", {Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier}, {}}},
+        {Version(60), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Free, Property::Optional, Property::Privatization, Property::ReductionParticipating, Property::Repeatable}}, "in_reduction", {Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::ReductionIdentifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Free, Property::Optional, Property::Privatization, Property::ReductionParticipating, Property::Repeatable}}, "in_reduction", {Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::ReductionIdentifier}, {}}},
       }
     ),
   },
@@ -670,12 +670,12 @@
     descriptor::Clause(
       "inbranch",
       {
-        {Version(45), {{{Property::Unique}}, "inbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(50), {{{Property::Unique}}, "inbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::Unique}}, "inbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::Unique}}, "inbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::Unique}}, "inbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::Unique}}, "inbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(45), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "inbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "inbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "inbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "inbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "inbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "inbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -684,11 +684,11 @@
     descriptor::Clause(
       "inclusive",
       {
-        {Version(50), {{{Property::InnermostLeaf, Property::Unique}}, "inclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::InnermostLeaf, Property::Unique}}, "inclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::InnermostLeaf, Property::Unique}}, "inclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::InnermostLeaf, Property::Unique}}, "inclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::InnermostLeaf, Property::Unique}}, "inclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "inclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "inclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "inclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "inclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "inclusive", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -697,10 +697,10 @@
     descriptor::Clause(
       "indirect",
       {
-        {Version(51), {{{Property::Unique}}, "indirect", {Directive::OMPD_begin_declare_target, Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::Unique}}, "indirect", {Directive::OMPD_begin_declare_target, Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::Unique}}, "indirect", {Directive::OMPD_begin_declare_target, Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::Unique}}, "indirect", {Directive::OMPD_begin_declare_target, Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "indirect", {Directive::OMPD_begin_declare_target, Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "indirect", {Directive::OMPD_begin_declare_target, Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "indirect", {Directive::OMPD_begin_declare_target, Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "indirect", {Directive::OMPD_begin_declare_target, Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -709,8 +709,8 @@
     descriptor::Clause(
       "induction",
       {
-        {Version(60), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization}}, "induction", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::InductionIdentifier, Modifier::InductionModifier, Modifier::StepModifier}, {}}},
-        {Version(61), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization}}, "induction", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::InductionIdentifier, Modifier::InductionModifier, Modifier::StepModifier}, {}}},
+        {Version(60), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Free, Property::Optional, Property::OriginalListItemUpdating, Property::Privatization, Property::Repeatable}}, "induction", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::InductionIdentifier, Modifier::InductionModifier, Modifier::StepModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Free, Property::Optional, Property::OriginalListItemUpdating, Property::Privatization, Property::Repeatable}}, "induction", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::InductionIdentifier, Modifier::InductionModifier, Modifier::StepModifier}, {}}},
       }
     ),
   },
@@ -719,8 +719,8 @@
     descriptor::Clause(
       "inductor",
       {
-        {Version(60), {{{Property::Required, Property::Unique}}, "inductor", {Directive::OMPD_declare_induction}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::Required, Property::Unique}}, "inductor", {Directive::OMPD_declare_induction}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Required, Property::Unique}}, "inductor", {Directive::OMPD_declare_induction}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Required, Property::Unique}}, "inductor", {Directive::OMPD_declare_induction}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -729,10 +729,10 @@
     descriptor::Clause(
       "init",
       {
-        {Version(51), {{{Property::InnermostLeaf}}, "init", {Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::InteropType}, {}}},
-        {Version(52), {{{Property::InnermostLeaf}}, "init", {Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::InteropType}, {}}},
-        {Version(60), {{{Property::InnermostLeaf}}, "init", {Directive::OMPD_depobj, Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DepinfoModifier, Modifier::DirectiveNameModifier, Modifier::InteropType, Modifier::PreferType}, {}}},
-        {Version(61), {{{Property::InnermostLeaf}}, "init", {Directive::OMPD_depobj, Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DepinfoModifier, Modifier::DirectiveNameModifier, Modifier::PreferType}, {ModifierSet::InteropType}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Repeatable}}, "init", {Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::InteropType}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Repeatable}}, "init", {Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::InteropType}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Repeatable}}, "init", {Directive::OMPD_depobj, Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DepinfoModifier, Modifier::DirectiveNameModifier, Modifier::InteropType, Modifier::PreferType}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Repeatable}}, "init", {Directive::OMPD_depobj, Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DepinfoModifier, Modifier::DirectiveNameModifier, Modifier::PreferType}, {ModifierSet::InteropType}}},
       }
     ),
   },
@@ -741,8 +741,8 @@
     descriptor::Clause(
       "init_complete",
       {
-        {Version(60), {{{Property::InnermostLeaf, Property::Unique}}, "init_complete", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::InnermostLeaf, Property::Unique}}, "init_complete", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "init_complete", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "init_complete", {Directive::OMPD_scan}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -751,11 +751,11 @@
     descriptor::Clause(
       "initializer",
       {
-        {Version(50), {{{Property::Unique}}, "initializer", {Directive::OMPD_declare_reduction}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::Unique}}, "initializer", {Directive::OMPD_declare_reduction}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::Unique}}, "initializer", {Directive::OMPD_declare_reduction}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::Unique}}, "initializer", {Directive::OMPD_declare_reduction}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::Unique}}, "initializer", {Directive::OMPD_declare_reduction}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "initializer", {Directive::OMPD_declare_reduction}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "initializer", {Directive::OMPD_declare_reduction}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "initializer", {Directive::OMPD_declare_reduction}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "initializer", {Directive::OMPD_declare_reduction}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "initializer", {Directive::OMPD_declare_reduction}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -764,8 +764,8 @@
     descriptor::Clause(
       "interop",
       {
-        {Version(60), {{{Property::DispatchRequirement, Property::Unique}}, "interop", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::DispatchRequirement, Property::Unique}}, "interop", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(60), {{{Property::Compatible, Property::DispatchRequirement, Property::Free, Property::Optional, Property::Unique}}, "interop", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::DispatchRequirement, Property::Free, Property::Optional, Property::Unique}}, "interop", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -774,12 +774,12 @@
     descriptor::Clause(
       "is_device_ptr",
       {
-        {Version(45), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::InnermostLeaf, Property::Privatization}}, "is_device_ptr", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(50), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::InnermostLeaf, Property::Privatization}}, "is_device_ptr", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::DispatchRequirement, Property::InnermostLeaf, Property::Privatization}}, "is_device_ptr", {Directive::OMPD_dispatch, Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::DispatchRequirement, Property::InnermostLeaf, Property::Privatization}}, "is_device_ptr", {Directive::OMPD_dispatch, Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::DispatchRequirement, Property::InnermostLeaf, Property::Privatization}}, "is_device_ptr", {Directive::OMPD_dispatch, Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::DispatchRequirement, Property::InnermostLeaf, Property::Privatization}}, "is_device_ptr", {Directive::OMPD_dispatch, Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(45), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Privatization, Property::Repeatable}}, "is_device_ptr", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(50), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Privatization, Property::Repeatable}}, "is_device_ptr", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::DispatchRequirement, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Privatization, Property::Repeatable}}, "is_device_ptr", {Directive::OMPD_dispatch, Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::DispatchRequirement, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Privatization, Property::Repeatable}}, "is_device_ptr", {Directive::OMPD_dispatch, Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::DispatchRequirement, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Privatization, Property::Repeatable}}, "is_device_ptr", {Directive::OMPD_dispatch, Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::DispatchRequirement, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Privatization, Property::Repeatable}}, "is_device_ptr", {Directive::OMPD_dispatch, Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -788,12 +788,12 @@
     descriptor::Clause(
       "lastprivate",
       {
-        {Version(45), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization}}, "lastprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(50), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization}}, "lastprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LastprivateModifier}, {}}},
-        {Version(51), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization}}, "lastprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LastprivateModifier}, {}}},
-        {Version(52), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization}}, "lastprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LastprivateModifier}, {}}},
-        {Version(60), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization}}, "lastprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::LastprivateModifier}, {}}},
-        {Version(61), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization}}, "lastprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::LastprivateModifier}, {}}},
+        {Version(45), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Free, Property::Optional, Property::OriginalListItemUpdating, Property::Privatization, Property::Repeatable}}, "lastprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(50), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Free, Property::Optional, Property::OriginalListItemUpdating, Property::Privatization, Property::Repeatable}}, "lastprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LastprivateModifier}, {}}},
+        {Version(51), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Free, Property::Optional, Property::OriginalListItemUpdating, Property::Privatization, Property::Repeatable}}, "lastprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LastprivateModifier}, {}}},
+        {Version(52), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Free, Property::Optional, Property::OriginalListItemUpdating, Property::Privatization, Property::Repeatable}}, "lastprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LastprivateModifier}, {}}},
+        {Version(60), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Free, Property::Optional, Property::OriginalListItemUpdating, Property::Privatization, Property::Repeatable}}, "lastprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::LastprivateModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Free, Property::Optional, Property::OriginalListItemUpdating, Property::Privatization, Property::Repeatable}}, "lastprivate", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::LastprivateModifier}, {}}},
       }
     ),
   },
@@ -802,12 +802,12 @@
     descriptor::Clause(
       "linear",
       {
-        {Version(45), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::PostModified, Property::Privatization}}, "linear", {Directive::OMPD_declare_simd, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LinearModifier, Modifier::LinearStep}, {}}},
-        {Version(50), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::PostModified, Property::Privatization}}, "linear", {Directive::OMPD_declare_simd, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LinearModifier, Modifier::LinearStep}, {}}},
-        {Version(51), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::PostModified, Property::Privatization}}, "linear", {Directive::OMPD_declare_simd, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LinearModifier, Modifier::LinearStep}, {}}},
-        {Version(52), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::PostModified, Property::Privatization}}, "linear", {Directive::OMPD_declare_simd, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LinearModifier, Modifier::StepComplexModifier, Modifier::StepSimpleModifier}, {}}},
-        {Version(60), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::PostModified, Property::Privatization}}, "linear", {Directive::OMPD_declare_simd, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::LinearModifier, Modifier::StepComplexModifier, Modifier::StepSimpleModifier}, {}}},
-        {Version(61), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::PostModified, Property::Privatization}}, "linear", {Directive::OMPD_declare_simd, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::LinearModifier, Modifier::StepComplexModifier, Modifier::StepSimpleModifier}, {}}},
+        {Version(45), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Free, Property::InnermostLeaf, Property::Optional, Property::PostModified, Property::Privatization, Property::Repeatable}}, "linear", {Directive::OMPD_declare_simd, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LinearModifier, Modifier::LinearStep}, {}}},
+        {Version(50), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Free, Property::InnermostLeaf, Property::Optional, Property::PostModified, Property::Privatization, Property::Repeatable}}, "linear", {Directive::OMPD_declare_simd, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LinearModifier, Modifier::LinearStep}, {}}},
+        {Version(51), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Free, Property::InnermostLeaf, Property::Optional, Property::PostModified, Property::Privatization, Property::Repeatable}}, "linear", {Directive::OMPD_declare_simd, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LinearModifier, Modifier::LinearStep}, {}}},
+        {Version(52), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Free, Property::InnermostLeaf, Property::Optional, Property::PostModified, Property::Privatization, Property::Repeatable}}, "linear", {Directive::OMPD_declare_simd, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LinearModifier, Modifier::StepComplexModifier, Modifier::StepSimpleModifier}, {}}},
+        {Version(60), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Free, Property::InnermostLeaf, Property::Optional, Property::PostModified, Property::Privatization, Property::Repeatable}}, "linear", {Directive::OMPD_declare_simd, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::LinearModifier, Modifier::StepComplexModifier, Modifier::StepSimpleModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Free, Property::InnermostLeaf, Property::Optional, Property::PostModified, Property::Privatization, Property::Repeatable}}, "linear", {Directive::OMPD_declare_simd, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::LinearModifier, Modifier::StepComplexModifier, Modifier::StepSimpleModifier}, {}}},
       }
     ),
   },
@@ -816,12 +816,12 @@
     descriptor::Clause(
       "link",
       {
-        {Version(45), {{{Property::DataEnvironmentAttribute}}, "link", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(50), {{{Property::DataEnvironmentAttribute}}, "link", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::DataEnvironmentAttribute}}, "link", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::DataEnvironmentAttribute}}, "link", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::DataEnvironmentAttribute}}, "link", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::DataEnvironmentAttribute}}, "link", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(45), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::Free, Property::Optional, Property::Repeatable}}, "link", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(50), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::Free, Property::Optional, Property::Repeatable}}, "link", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::Free, Property::Optional, Property::Repeatable}}, "link", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::Free, Property::Optional, Property::Repeatable}}, "link", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::Free, Property::Optional, Property::Repeatable}}, "link", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::Free, Property::Optional, Property::Repeatable}}, "link", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -830,8 +830,8 @@
     descriptor::Clause(
       "local",
       {
-        {Version(60), {{{Property::DataEnvironmentAttribute}}, "local", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::DataEnvironmentAttribute}}, "local", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(60), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::Free, Property::Optional, Property::Repeatable}}, "local", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::Free, Property::Optional, Property::Repeatable}}, "local", {Directive::OMPD_declare_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -840,8 +840,8 @@
     descriptor::Clause(
       "looprange",
       {
-        {Version(60), {{{Property::Unique}}, "looprange", {Directive::OMPD_fuse}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::Unique}}, "looprange", {Directive::OMPD_fuse}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "looprange", {Directive::OMPD_fuse}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "looprange", {Directive::OMPD_fuse}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -850,12 +850,12 @@
     descriptor::Clause(
       "map",
       {
-        {Version(45), {{{Property::DataEnvironmentAttribute, Property::DataMappingAttribute}}, "map", {Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::MapType, Modifier::MapTypeModifier, Modifier::OmpxHoldModifier}, {}}},
-        {Version(50), {{{Property::DataEnvironmentAttribute, Property::DataMappingAttribute}}, "map", {Directive::OMPD_declare_mapper, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::MapType, Modifier::MapTypeModifier, Modifier::Mapper, Modifier::OmpxHoldModifier}, {}}},
-        {Version(51), {{{Property::DataEnvironmentAttribute, Property::DataMappingAttribute}}, "map", {Directive::OMPD_declare_mapper, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Iterator, Modifier::MapType, Modifier::MapTypeModifier, Modifier::Mapper, Modifier::OmpxHoldModifier}, {}}},
-        {Version(52), {{{Property::DataEnvironmentAttribute, Property::DataMappingAttribute}}, "map", {Directive::OMPD_declare_mapper, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Iterator, Modifier::MapType, Modifier::MapTypeModifier, Modifier::Mapper, Modifier::OmpxHoldModifier}, {}}},
-        {Version(60), {{{Property::DataEnvironmentAttribute, Property::DataMappingAttribute}}, "map", {Directive::OMPD_declare_mapper, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AlwaysModifier, Modifier::CloseModifier, Modifier::DeleteModifier, Modifier::DirectiveNameModifier, Modifier::Iterator, Modifier::MapType, Modifier::Mapper, Modifier::OmpxHoldModifier, Modifier::PresentModifier, Modifier::RefModifier, Modifier::SelfModifier}, {}}},
-        {Version(61), {{{Property::DataEnvironmentAttribute, Property::DataMappingAttribute}}, "map", {Directive::OMPD_declare_mapper, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AttachModifier, Modifier::DirectiveNameModifier, Modifier::Iterator, Modifier::MapType, Modifier::Mapper, Modifier::OmpxHoldModifier, Modifier::RefModifier}, {ModifierSet::MapTypeModifying}}},
+        {Version(45), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataMappingAttribute, Property::Free, Property::Optional, Property::Repeatable}}, "map", {Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::MapType, Modifier::MapTypeModifier, Modifier::OmpxHoldModifier}, {}}},
+        {Version(50), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataMappingAttribute, Property::Free, Property::Optional, Property::Repeatable}}, "map", {Directive::OMPD_declare_mapper, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::MapType, Modifier::MapTypeModifier, Modifier::Mapper, Modifier::OmpxHoldModifier}, {}}},
+        {Version(51), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataMappingAttribute, Property::Free, Property::Optional, Property::Repeatable}}, "map", {Directive::OMPD_declare_mapper, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Iterator, Modifier::MapType, Modifier::MapTypeModifier, Modifier::Mapper, Modifier::OmpxHoldModifier}, {}}},
+        {Version(52), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataMappingAttribute, Property::Free, Property::Optional, Property::Repeatable}}, "map", {Directive::OMPD_declare_mapper, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Iterator, Modifier::MapType, Modifier::MapTypeModifier, Modifier::Mapper, Modifier::OmpxHoldModifier}, {}}},
+        {Version(60), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataMappingAttribute, Property::Free, Property::Optional, Property::Repeatable}}, "map", {Directive::OMPD_declare_mapper, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AlwaysModifier, Modifier::CloseModifier, Modifier::DeleteModifier, Modifier::DirectiveNameModifier, Modifier::Iterator, Modifier::MapType, Modifier::Mapper, Modifier::OmpxHoldModifier, Modifier::PresentModifier, Modifier::RefModifier, Modifier::SelfModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataMappingAttribute, Property::Free, Property::Optional, Property::Repeatable}}, "map", {Directive::OMPD_declare_mapper, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::AttachModifier, Modifier::DirectiveNameModifier, Modifier::Iterator, Modifier::MapType, Modifier::Mapper, Modifier::OmpxHoldModifier, Modifier::RefModifier}, {ModifierSet::MapTypeModifying}}},
       }
     ),
   },
@@ -864,11 +864,11 @@
     descriptor::Clause(
       "match",
       {
-        {Version(50), {{{Property::Required, Property::Unique}}, "match", {Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::Required, Property::Unique}}, "match", {Directive::OMPD_begin_declare_variant, Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::Required, Property::Unique}}, "match", {Directive::OMPD_begin_declare_variant, Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::Required, Property::Unique}}, "match", {Directive::OMPD_begin_declare_variant, Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::Required, Property::Unique}}, "match", {Directive::OMPD_begin_declare_variant, Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::Required, Property::Unique}}, "match", {Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Required, Property::Unique}}, "match", {Directive::OMPD_begin_declare_variant, Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Required, Property::Unique}}, "match", {Directive::OMPD_begin_declare_variant, Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Required, Property::Unique}}, "match", {Directive::OMPD_begin_declare_variant, Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Required, Property::Unique}}, "match", {Directive::OMPD_begin_declare_variant, Directive::OMPD_declare_variant}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -877,8 +877,8 @@
     descriptor::Clause(
       "memscope",
       {
-        {Version(60), {{{Property::Unique}}, "memscope", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::Unique}}, "memscope", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "memscope", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "memscope", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -887,12 +887,12 @@
     descriptor::Clause(
       "mergeable",
       {
-        {Version(45), {{{Property::Unique}}, "mergeable", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(50), {{{Property::Unique}}, "mergeable", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::Unique}}, "mergeable", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::Unique}}, "mergeable", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::Unique}}, "mergeable", {Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::Unique}}, "mergeable", {Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(45), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "mergeable", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "mergeable", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "mergeable", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "mergeable", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "mergeable", {Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "mergeable", {Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -901,10 +901,10 @@
     descriptor::Clause(
       "message",
       {
-        {Version(51), {{{Property::Unique}}, "message", {Directive::OMPD_error}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::Unique}}, "message", {Directive::OMPD_error}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::Unique}}, "message", {Directive::OMPD_error, Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::Unique}}, "message", {Directive::OMPD_error, Directive::OMPD_parallel, Directive::OMPD_target, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "message", {Directive::OMPD_error}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "message", {Directive::OMPD_error}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "message", {Directive::OMPD_error, Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "message", {Directive::OMPD_error, Directive::OMPD_parallel, Directive::OMPD_target, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -913,10 +913,10 @@
     descriptor::Clause(
       "no_openmp",
       {
-        {Version(51), {{{Property::Unique}}, "no_openmp", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::Unique}}, "no_openmp", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::Unique}}, "no_openmp", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::Unique}}, "no_openmp", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "no_openmp", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "no_openmp", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "no_openmp", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "no_openmp", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -925,8 +925,8 @@
     descriptor::Clause(
       "no_openmp_constructs",
       {
-        {Version(60), {{{Property::Unique}}, "no_openmp_constructs", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::Unique}}, "no_openmp_constructs", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "no_openmp_constructs", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "no_openmp_constructs", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -935,10 +935,10 @@
     descriptor::Clause(
       "no_openmp_routines",
       {
-        {Version(51), {{{Property::Unique}}, "no_openmp_routines", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::Unique}}, "no_openmp_routines", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::Unique}}, "no_openmp_routines", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::Unique}}, "no_openmp_routines", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "no_openmp_routines", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "no_openmp_routines", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "no_openmp_routines", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "no_openmp_routines", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -947,10 +947,10 @@
     descriptor::Clause(
       "no_parallelism",
       {
-        {Version(51), {{{Property::Unique}}, "no_parallelism", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::Unique}}, "no_parallelism", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::Unique}}, "no_parallelism", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::Unique}}, "no_parallelism", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "no_parallelism", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "no_parallelism", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "no_parallelism", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "no_parallelism", {Directive::OMPD_assume, Directive::OMPD_assumes, Directive::OMPD_begin_assumes}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -959,10 +959,10 @@
     descriptor::Clause(
       "nocontext",
       {
-        {Version(51), {{{Property::Unique}}, "nocontext", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::Unique}}, "nocontext", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::Unique}}, "nocontext", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::Unique}}, "nocontext", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "nocontext", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "nocontext", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "nocontext", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "nocontext", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -971,12 +971,12 @@
     descriptor::Clause(
       "nogroup",
       {
-        {Version(45), {{{Property::OutermostLeaf, Property::Unique}}, "nogroup", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(50), {{{Property::OutermostLeaf, Property::Unique}}, "nogroup", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::OutermostLeaf, Property::Unique}}, "nogroup", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::OutermostLeaf, Property::Unique}}, "nogroup", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::OutermostLeaf, Property::Unique}}, "nogroup", {Directive::OMPD_target_data, Directive::OMPD_taskgraph, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::OutermostLeaf, Property::TaskSynchronizing, Property::Unique}}, "nogroup", {Directive::OMPD_target_data, Directive::OMPD_taskgraph, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(45), {{{Property::Compatible, Property::Free, Property::Optional, Property::OutermostLeaf, Property::Unique}}, "nogroup", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::Optional, Property::OutermostLeaf, Property::Unique}}, "nogroup", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::OutermostLeaf, Property::Unique}}, "nogroup", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::OutermostLeaf, Property::Unique}}, "nogroup", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::OutermostLeaf, Property::Unique}}, "nogroup", {Directive::OMPD_target_data, Directive::OMPD_taskgraph, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::OutermostLeaf, Property::TaskSynchronizing, Property::Unique}}, "nogroup", {Directive::OMPD_target_data, Directive::OMPD_taskgraph, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -985,11 +985,11 @@
     descriptor::Clause(
       "nontemporal",
       {
-        {Version(50), {{{}}, "nontemporal", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{}}, "nontemporal", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{}}, "nontemporal", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{}}, "nontemporal", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{}}, "nontemporal", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::Optional, Property::Repeatable}}, "nontemporal", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Repeatable}}, "nontemporal", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Repeatable}}, "nontemporal", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Repeatable}}, "nontemporal", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Repeatable}}, "nontemporal", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -998,12 +998,12 @@
     descriptor::Clause(
       "notinbranch",
       {
-        {Version(45), {{{Property::Unique}}, "notinbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(50), {{{Property::Unique}}, "notinbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::Unique}}, "notinbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::Unique}}, "notinbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::Unique}}, "notinbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::Unique}}, "notinbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(45), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "notinbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "notinbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "notinbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "notinbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "notinbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "notinbranch", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1012,10 +1012,10 @@
     descriptor::Clause(
       "novariants",
       {
-        {Version(51), {{{Property::Unique}}, "novariants", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::Unique}}, "novariants", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::Unique}}, "novariants", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::Unique}}, "novariants", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "novariants", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "novariants", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "novariants", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "novariants", {Directive::OMPD_dispatch}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1024,12 +1024,12 @@
     descriptor::Clause(
       "nowait",
       {
-        {Version(45), {{{Property::EndClause, Property::OutermostLeaf, Property::Unique}}, "nowait", {Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(50), {{{Property::EndClause, Property::OutermostLeaf, Property::Unique}}, "nowait", {Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_taskwait, Directive::OMPD_workshare}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::DispatchRequirement, Property::EndClause, Property::OutermostLeaf, Property::Unique}}, "nowait", {Directive::OMPD_dispatch, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_interop, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_taskwait, Directive::OMPD_workshare}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::DispatchRequirement, Property::EndClause, Property::OutermostLeaf, Property::Unique}}, "nowait", {Directive::OMPD_dispatch, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_interop, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_taskwait, Directive::OMPD_workshare}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::DispatchRequirement, Property::EndClause, Property::OutermostLeaf, Property::Unique}}, "nowait", {Directive::OMPD_dispatch, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_interop, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_taskwait, Directive::OMPD_workshare}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::DispatchRequirement, Property::EndClause, Property::OutermostLeaf, Property::TaskSynchronizing, Property::Unique}}, "nowait", {Directive::OMPD_dispatch, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_interop, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_taskwait, Directive::OMPD_workshare}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(45), {{{Property::Compatible, Property::EndClause, Property::Free, Property::Optional, Property::OutermostLeaf, Property::Unique}}, "nowait", {Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(50), {{{Property::Compatible, Property::EndClause, Property::Free, Property::Optional, Property::OutermostLeaf, Property::Unique}}, "nowait", {Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_taskwait, Directive::OMPD_workshare}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::DispatchRequirement, Property::EndClause, Property::Free, Property::Optional, Property::OutermostLeaf, Property::Unique}}, "nowait", {Directive::OMPD_dispatch, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_interop, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_taskwait, Directive::OMPD_workshare}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::DispatchRequirement, Property::EndClause, Property::Free, Property::Optional, Property::OutermostLeaf, Property::Unique}}, "nowait", {Directive::OMPD_dispatch, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_interop, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_taskwait, Directive::OMPD_workshare}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::DispatchRequirement, Property::EndClause, Property::Free, Property::Optional, Property::OutermostLeaf, Property::Unique}}, "nowait", {Directive::OMPD_dispatch, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_interop, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_taskwait, Directive::OMPD_workshare}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::DispatchRequirement, Property::EndClause, Property::Free, Property::Optional, Property::OutermostLeaf, Property::TaskSynchronizing, Property::Unique}}, "nowait", {Directive::OMPD_dispatch, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_interop, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_taskwait, Directive::OMPD_workshare}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1038,12 +1038,12 @@
     descriptor::Clause(
       "num_tasks",
       {
-        {Version(45), {{{Property::Unique}}, "num_tasks", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(50), {{{Property::Unique}}, "num_tasks", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::Unique}}, "num_tasks", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Prescriptiveness}, {}}},
-        {Version(52), {{{Property::Unique}}, "num_tasks", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Prescriptiveness}, {}}},
-        {Version(60), {{{Property::TaskgraphAltering, Property::Unique}}, "num_tasks", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Prescriptiveness}, {}}},
-        {Version(61), {{{Property::TaskgraphAltering, Property::Unique}}, "num_tasks", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Prescriptiveness}, {}}},
+        {Version(45), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "num_tasks", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "num_tasks", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "num_tasks", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Prescriptiveness}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "num_tasks", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Prescriptiveness}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::TaskgraphAltering, Property::Unique}}, "num_tasks", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Prescriptiveness}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::TaskgraphAltering, Property::Unique}}, "num_tasks", {Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Prescriptiveness}, {}}},
       }
     ),
   },
@@ -1052,12 +1052,12 @@
     descriptor::Clause(
       "num_teams",
       {
-        {Version(45), {{{Property::TargetConsistent, Property::Unique}}, "num_teams", {Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(50), {{{Property::TargetConsistent, Property::Unique}}, "num_teams", {Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LowerBound}, {}}},
-        {Version(51), {{{Property::TargetConsistent, Property::Unique}}, "num_teams", {Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LowerBound}, {}}},
-        {Version(52), {{{Property::TargetConsistent, Property::Unique}}, "num_teams", {Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LowerBound}, {}}},
-        {Version(60), {{{Property::TargetConsistent, Property::Unique}}, "num_teams", {Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::LowerBound}, {}}},
-        {Version(61), {{{Property::SpaceConfiguring, Property::TargetConsistent, Property::Unique}}, "num_teams", {Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DimsModifier, Modifier::DirectiveNameModifier, Modifier::LowerBound}, {ModifierSet::NumTeamsModifierSet1}}},
+        {Version(45), {{{Property::Compatible, Property::Free, Property::Optional, Property::TargetConsistent, Property::Unique}}, "num_teams", {Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::Optional, Property::TargetConsistent, Property::Unique}}, "num_teams", {Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LowerBound}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::TargetConsistent, Property::Unique}}, "num_teams", {Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LowerBound}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::TargetConsistent, Property::Unique}}, "num_teams", {Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::LowerBound}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::TargetConsistent, Property::Unique}}, "num_teams", {Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::LowerBound}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::SpaceConfiguring, Property::TargetConsistent, Property::Unique}}, "num_teams", {Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DimsModifier, Modifier::DirectiveNameModifier, Modifier::LowerBound}, {ModifierSet::NumTeamsModifierSet1}}},
       }
     ),
   },
@@ -1066,12 +1066,12 @@
     descriptor::Clause(
       "num_threads",
       {
-        {Version(45), {{{Property::Unique}}, "num_threads", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(50), {{{Property::Unique}}, "num_threads", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::Unique}}, "num_threads", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::Unique}}, "num_threads", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::Unique}}, "num_threads", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Prescriptiveness}, {}}},
-        {Version(61), {{{Property::SpaceConfiguring, Property::Unique}}, "num_threads", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DimsModifier, Modifier::DirectiveNameModifier, Modifier::PrescriptivenessModifier}, {}}},
+        {Version(45), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "num_threads", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "num_threads", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "num_threads", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "num_threads", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "num_threads", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Prescriptiveness}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::SpaceConfiguring, Property::Unique}}, "num_threads", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DimsModifier, Modifier::DirectiveNameModifier, Modifier::PrescriptivenessModifier}, {}}},
       }
     ),
   },
@@ -1080,11 +1080,11 @@
     descriptor::Clause(
       "order",
       {
-        {Version(50), {{{Property::ScheduleSpecification, Property::Unique}}, "order", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::ScheduleSpecification, Property::Unique}}, "order", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::OrderModifier}, {}}},
-        {Version(52), {{{Property::ScheduleSpecification, Property::Unique}}, "order", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::OrderModifier}, {}}},
-        {Version(60), {{{Property::ScheduleSpecification, Property::Unique}}, "order", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::OrderModifier}, {}}},
-        {Version(61), {{{Property::ScheduleSpecification, Property::Unique}}, "order", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::OrderModifier}, {}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::Optional, Property::ScheduleSpecification, Property::Unique}}, "order", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::ScheduleSpecification, Property::Unique}}, "order", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::OrderModifier}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::ScheduleSpecification, Property::Unique}}, "order", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::OrderModifier}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::ScheduleSpecification, Property::Unique}}, "order", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::OrderModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::ScheduleSpecification, Property::Unique}}, "order", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::OrderModifier}, {}}},
       }
     ),
   },
@@ -1093,12 +1093,12 @@
     descriptor::Clause(
       "ordered",
       {
-        {Version(45), {{{Property::OnceForAllConstituents, Property::Unique}}, "ordered", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(50), {{{Property::OnceForAllConstituents, Property::Unique}}, "ordered", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::OnceForAllConstituents, Property::Unique}}, "ordered", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::OnceForAllConstituents, Property::Unique}}, "ordered", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::OnceForAllConstituents, Property::Unique}}, "ordered", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::OnceForAllConstituents, Property::Unique}}, "ordered", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(45), {{{Property::Compatible, Property::Free, Property::OnceForAllConstituents, Property::Optional, Property::Unique}}, "ordered", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::OnceForAllConstituents, Property::Optional, Property::Unique}}, "ordered", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::OnceForAllConstituents, Property::Optional, Property::Unique}}, "ordered", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::OnceForAllConstituents, Property::Optional, Property::Unique}}, "ordered", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::OnceForAllConstituents, Property::Optional, Property::Unique}}, "ordered", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::OnceForAllConstituents, Property::Optional, Property::Unique}}, "ordered", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1107,9 +1107,9 @@
     descriptor::Clause(
       "otherwise",
       {
-        {Version(52), {{{Property::Ultimate, Property::Unique}}, "otherwise", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::Ultimate, Property::Unique}}, "otherwise", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::Ultimate, Property::Unique}}, "otherwise", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Optional, Property::Ultimate, Property::Unique}}, "otherwise", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Optional, Property::Ultimate, Property::Unique}}, "otherwise", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Optional, Property::Ultimate, Property::Unique}}, "otherwise", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1118,10 +1118,10 @@
     descriptor::Clause(
       "partial",
       {
-        {Version(51), {{{Property::Unique}}, "partial", {Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::Unique}}, "partial", {Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::Unique}}, "partial", {Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::Unique}}, "partial", {Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "partial", {Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "partial", {Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "partial", {Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "partial", {Directive::OMPD_unroll}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1130,8 +1130,8 @@
     descriptor::Clause(
       "permutation",
       {
-        {Version(60), {{{Property::Unique}}, "permutation", {Directive::OMPD_interchange}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::Unique}}, "permutation", {Directive::OMPD_interchange}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "permutation", {Directive::OMPD_interchange}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "permutation", {Directive::OMPD_interchange}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1140,12 +1140,12 @@
     descriptor::Clause(
       "priority",
       {
-        {Version(45), {{{Property::Unique}}, "priority", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(50), {{{Property::Unique}}, "priority", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::Unique}}, "priority", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::Unique}}, "priority", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::Unique}}, "priority", {Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskgraph, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::Unique}}, "priority", {Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskgraph, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(45), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "priority", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "priority", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "priority", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "priority", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "priority", {Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskgraph, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "priority", {Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskgraph, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1154,12 +1154,12 @@
     descriptor::Clause(
       "private",
       {
-        {Version(45), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::Privatization}}, "private", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(50), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::Privatization}}, "private", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::Privatization}}, "private", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::Privatization}}, "private", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::Privatization}}, "private", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::InnermostLeaf, Property::Privatization}}, "private", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(45), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Privatization, Property::Repeatable}}, "private", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(50), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Privatization, Property::Repeatable}}, "private", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Privatization, Property::Repeatable}}, "private", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Privatization, Property::Repeatable}}, "private", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Privatization, Property::Repeatable}}, "private", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Privatization, Property::Repeatable}}, "private", {Directive::OMPD_distribute, Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_single, Directive::OMPD_target, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1168,12 +1168,12 @@
     descriptor::Clause(
       "proc_bind",
       {
-        {Version(45), {{{Property::Unique}}, "proc_bind", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(50), {{{Property::Unique}}, "proc_bind", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::Unique}}, "proc_bind", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::Unique}}, "proc_bind", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::Unique}}, "proc_bind", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::Unique}}, "proc_bind", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(45), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "proc_bind", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "proc_bind", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "proc_bind", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "proc_bind", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "proc_bind", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "proc_bind", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1182,12 +1182,12 @@
     descriptor::Clause(
       "read",
       {
-        {Version(45), {{{Property::InnermostLeaf, Property::Unique}}, "read", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(50), {{{Property::InnermostLeaf, Property::Unique}}, "read", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::InnermostLeaf, Property::Unique}}, "read", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::InnermostLeaf, Property::Unique}}, "read", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::InnermostLeaf, Property::Unique}}, "read", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::InnermostLeaf, Property::Unique}}, "read", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(45), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "read", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "read", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "read", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "read", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "read", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "read", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1196,12 +1196,12 @@
     descriptor::Clause(
       "reduction",
       {
-        {Version(45), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionParticipating, Property::ReductionScoping}}, "reduction", {Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier}, {}}},
-        {Version(50), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionParticipating, Property::ReductionScoping}}, "reduction", {Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier, Modifier::ReductionModifier}, {}}},
-        {Version(51), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionParticipating, Property::ReductionScoping}}, "reduction", {Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier, Modifier::ReductionModifier}, {}}},
-        {Version(52), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionParticipating, Property::ReductionScoping}}, "reduction", {Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier, Modifier::ReductionModifier}, {}}},
-        {Version(60), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionParticipating, Property::ReductionScoping}}, "reduction", {Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::OriginalSharingModifier, Modifier::ReductionIdentifier, Modifier::ReductionModifier}, {}}},
-        {Version(61), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionParticipating, Property::ReductionScoping}}, "reduction", {Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::OriginalSharingModifier, Modifier::PerThreadModifier, Modifier::ReductionIdentifier}, {ModifierSet::ReductionModifierSet1, ModifierSet::ReductionType}}},
+        {Version(45), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Free, Property::Optional, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionParticipating, Property::ReductionScoping, Property::Repeatable}}, "reduction", {Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_parallel, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier}, {}}},
+        {Version(50), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Free, Property::Optional, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionParticipating, Property::ReductionScoping, Property::Repeatable}}, "reduction", {Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier, Modifier::ReductionModifier}, {}}},
+        {Version(51), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Free, Property::Optional, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionParticipating, Property::ReductionScoping, Property::Repeatable}}, "reduction", {Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier, Modifier::ReductionModifier}, {}}},
+        {Version(52), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Free, Property::Optional, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionParticipating, Property::ReductionScoping, Property::Repeatable}}, "reduction", {Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier, Modifier::ReductionModifier}, {}}},
+        {Version(60), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Free, Property::Optional, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionParticipating, Property::ReductionScoping, Property::Repeatable}}, "reduction", {Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::OriginalSharingModifier, Modifier::ReductionIdentifier, Modifier::ReductionModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Free, Property::Optional, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionParticipating, Property::ReductionScoping, Property::Repeatable}}, "reduction", {Directive::OMPD_do, Directive::OMPD_for, Directive::OMPD_loop, Directive::OMPD_parallel, Directive::OMPD_scope, Directive::OMPD_sections, Directive::OMPD_simd, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::OriginalSharingModifier, Modifier::PerThreadModifier, Modifier::ReductionIdentifier}, {ModifierSet::ReductionModifierSet1, ModifierSet::ReductionType}}},
       }
     ),
   },
@@ -1210,11 +1210,11 @@
     descriptor::Clause(
       "relaxed",
       {
-        {Version(50), {{{Property::Unique}}, "relaxed", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::Unique}}, "relaxed", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::Unique}}, "relaxed", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::Unique}}, "relaxed", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::Unique}}, "relaxed", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "relaxed", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "relaxed", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "relaxed", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "relaxed", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "relaxed", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1223,11 +1223,11 @@
     descriptor::Clause(
       "release",
       {
-        {Version(50), {{{Property::Unique}}, "release", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::Unique}}, "release", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::Unique}}, "release", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::Unique}}, "release", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::Unique}}, "release", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "release", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "release", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "release", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "release", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "release", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1236,8 +1236,8 @@
     descriptor::Clause(
       "replayable",
       {
-        {Version(60), {{{Property::Unique}}, "replayable", {Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_taskwait}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::Unique}}, "replayable", {Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_taskwait}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "replayable", {Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_taskwait}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "replayable", {Directive::OMPD_target, Directive::OMPD_target_enter_data, Directive::OMPD_target_exit_data, Directive::OMPD_target_update, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_taskwait}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1246,11 +1246,11 @@
     descriptor::Clause(
       "reverse_offload",
       {
-        {Version(50), {{{Property::DeviceGlobalRequirement, Property::Unique}}, "reverse_offload", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::DeviceGlobalRequirement, Property::Unique}}, "reverse_offload", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::DeviceGlobalRequirement, Property::Unique}}, "reverse_offload", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::DeviceGlobalRequirement, Property::Unique}}, "reverse_offload", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::DeviceGlobalRequirement, Property::Unique}}, "reverse_offload", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(50), {{{Property::Compatible, Property::DeviceGlobalRequirement, Property::Free, Property::Optional, Property::Unique}}, "reverse_offload", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::DeviceGlobalRequirement, Property::Free, Property::Optional, Property::Unique}}, "reverse_offload", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::DeviceGlobalRequirement, Property::Free, Property::Optional, Property::Unique}}, "reverse_offload", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::DeviceGlobalRequirement, Property::Free, Property::Optional, Property::Unique}}, "reverse_offload", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::DeviceGlobalRequirement, Property::Free, Property::Optional, Property::Unique}}, "reverse_offload", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1259,12 +1259,12 @@
     descriptor::Clause(
       "safelen",
       {
-        {Version(45), {{{Property::Unique}}, "safelen", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(50), {{{Property::Unique}}, "safelen", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::Unique}}, "safelen", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::Unique}}, "safelen", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::Unique}}, "safelen", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::Unique}}, "safelen", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(45), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "safelen", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "safelen", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "safelen", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "safelen", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "safelen", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "safelen", {Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1273,8 +1273,8 @@
     descriptor::Clause(
       "safesync",
       {
-        {Version(60), {{{Property::Unique}}, "safesync", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::Unique}}, "safesync", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "safesync", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "safesync", {Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1283,12 +1283,12 @@
     descriptor::Clause(
       "schedule",
       {
-        {Version(45), {{{Property::ScheduleSpecification, Property::Unique}}, "schedule", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ChunkModifier, Modifier::OrderingModifier}, {}}},
-        {Version(50), {{{Property::ScheduleSpecification, Property::Unique}}, "schedule", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ChunkModifier, Modifier::OrderingModifier}, {}}},
-        {Version(51), {{{Property::ScheduleSpecification, Property::Unique}}, "schedule", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ChunkModifier, Modifier::OrderingModifier}, {}}},
-        {Version(52), {{{Property::ScheduleSpecification, Property::Unique}}, "schedule", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ChunkModifier, Modifier::OrderingModifier}, {}}},
-        {Version(60), {{{Property::ScheduleSpecification, Property::Unique}}, "schedule", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ChunkModifier, Modifier::DirectiveNameModifier, Modifier::OrderingModifier}, {}}},
-        {Version(61), {{{Property::ScheduleSpecification, Property::Unique}}, "schedule", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ChunkModifier, Modifier::DirectiveNameModifier, Modifier::OrderingModifier}, {}}},
+        {Version(45), {{{Property::Compatible, Property::Free, Property::Optional, Property::ScheduleSpecification, Property::Unique}}, "schedule", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ChunkModifier, Modifier::OrderingModifier}, {}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::Optional, Property::ScheduleSpecification, Property::Unique}}, "schedule", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ChunkModifier, Modifier::OrderingModifier}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::ScheduleSpecification, Property::Unique}}, "schedule", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ChunkModifier, Modifier::OrderingModifier}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::ScheduleSpecification, Property::Unique}}, "schedule", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ChunkModifier, Modifier::OrderingModifier}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::ScheduleSpecification, Property::Unique}}, "schedule", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ChunkModifier, Modifier::DirectiveNameModifier, Modifier::OrderingModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::ScheduleSpecification, Property::Unique}}, "schedule", {Directive::OMPD_do, Directive::OMPD_for}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ChunkModifier, Modifier::DirectiveNameModifier, Modifier::OrderingModifier}, {}}},
       }
     ),
   },
@@ -1297,8 +1297,8 @@
     descriptor::Clause(
       "self_maps",
       {
-        {Version(60), {{{Property::DeviceGlobalRequirement, Property::Unique}}, "self_maps", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::DeviceGlobalRequirement, Property::Unique}}, "self_maps", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(60), {{{Property::Compatible, Property::DeviceGlobalRequirement, Property::Free, Property::Optional, Property::Unique}}, "self_maps", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::DeviceGlobalRequirement, Property::Free, Property::Optional, Property::Unique}}, "self_maps", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1307,12 +1307,12 @@
     descriptor::Clause(
       "seq_cst",
       {
-        {Version(45), {{{Property::Unique}}, "seq_cst", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(50), {{{Property::Unique}}, "seq_cst", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::Unique}}, "seq_cst", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::Unique}}, "seq_cst", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::Unique}}, "seq_cst", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::Unique}}, "seq_cst", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(45), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "seq_cst", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "seq_cst", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "seq_cst", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "seq_cst", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "seq_cst", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "seq_cst", {Directive::OMPD_atomic, Directive::OMPD_flush}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1321,10 +1321,10 @@
     descriptor::Clause(
       "severity",
       {
-        {Version(51), {{{Property::Unique}}, "severity", {Directive::OMPD_error}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::Unique}}, "severity", {Directive::OMPD_error}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::Unique}}, "severity", {Directive::OMPD_error, Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::Unique}}, "severity", {Directive::OMPD_error, Directive::OMPD_parallel, Directive::OMPD_target, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "severity", {Directive::OMPD_error}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "severity", {Directive::OMPD_error}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "severity", {Directive::OMPD_error, Directive::OMPD_parallel}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "severity", {Directive::OMPD_error, Directive::OMPD_parallel, Directive::OMPD_target, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1333,12 +1333,12 @@
     descriptor::Clause(
       "shared",
       {
-        {Version(45), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute}}, "shared", {Directive::OMPD_parallel, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(50), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute}}, "shared", {Directive::OMPD_parallel, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute}}, "shared", {Directive::OMPD_parallel, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute}}, "shared", {Directive::OMPD_parallel, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute}}, "shared", {Directive::OMPD_parallel, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute}}, "shared", {Directive::OMPD_parallel, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(45), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Free, Property::Optional, Property::Repeatable}}, "shared", {Directive::OMPD_parallel, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(50), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Free, Property::Optional, Property::Repeatable}}, "shared", {Directive::OMPD_parallel, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Free, Property::Optional, Property::Repeatable}}, "shared", {Directive::OMPD_parallel, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Free, Property::Optional, Property::Repeatable}}, "shared", {Directive::OMPD_parallel, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Free, Property::Optional, Property::Repeatable}}, "shared", {Directive::OMPD_parallel, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Free, Property::Optional, Property::Repeatable}}, "shared", {Directive::OMPD_parallel, Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1347,12 +1347,12 @@
     descriptor::Clause(
       "simd",
       {
-        {Version(45), {{{Property::InnermostLeaf, Property::Unique}}, "simd", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(50), {{{Property::InnermostLeaf, Property::Unique}}, "simd", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::InnermostLeaf, Property::Unique}}, "simd", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::InnermostLeaf, Property::Unique}}, "simd", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::InnermostLeaf, Property::Unique}}, "simd", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::InnermostLeaf, Property::Unique}}, "simd", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(45), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "simd", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "simd", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "simd", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "simd", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "simd", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "simd", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1361,12 +1361,12 @@
     descriptor::Clause(
       "simdlen",
       {
-        {Version(45), {{{Property::Unique}}, "simdlen", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(50), {{{Property::Unique}}, "simdlen", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::Unique}}, "simdlen", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::Unique}}, "simdlen", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::Unique}}, "simdlen", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::Unique}}, "simdlen", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::ScaledModifier}, {}}},
+        {Version(45), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "simdlen", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "simdlen", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "simdlen", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "simdlen", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "simdlen", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "simdlen", {Directive::OMPD_declare_simd, Directive::OMPD_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::ScaledModifier}, {}}},
       }
     ),
   },
@@ -1375,10 +1375,10 @@
     descriptor::Clause(
       "sizes",
       {
-        {Version(51), {{{Property::Required, Property::Unique}}, "sizes", {Directive::OMPD_tile}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::Required, Property::Unique}}, "sizes", {Directive::OMPD_tile}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::Required, Property::Unique}}, "sizes", {Directive::OMPD_stripe, Directive::OMPD_tile}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::Required, Property::Unique}}, "sizes", {Directive::OMPD_stripe, Directive::OMPD_tile}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::SizesSelector}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Required, Property::Unique}}, "sizes", {Directive::OMPD_tile}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Required, Property::Unique}}, "sizes", {Directive::OMPD_tile}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Required, Property::Unique}}, "sizes", {Directive::OMPD_stripe, Directive::OMPD_tile}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Required, Property::Unique}}, "sizes", {Directive::OMPD_stripe, Directive::OMPD_tile}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::SizesSelector}, {}}},
       }
     ),
   },
@@ -1387,11 +1387,11 @@
     descriptor::Clause(
       "task_reduction",
       {
-        {Version(50), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionScoping}}, "task_reduction", {Directive::OMPD_taskgroup}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier}, {}}},
-        {Version(51), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionScoping}}, "task_reduction", {Directive::OMPD_taskgroup}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier}, {}}},
-        {Version(52), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionScoping}}, "task_reduction", {Directive::OMPD_taskgroup}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier}, {}}},
-        {Version(60), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionScoping}}, "task_reduction", {Directive::OMPD_taskgroup}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::ReductionIdentifier}, {}}},
-        {Version(61), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionScoping}}, "task_reduction", {Directive::OMPD_taskgroup}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::ReductionIdentifier}, {}}},
+        {Version(50), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Free, Property::Optional, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionScoping, Property::Repeatable}}, "task_reduction", {Directive::OMPD_taskgroup}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier}, {}}},
+        {Version(51), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Free, Property::Optional, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionScoping, Property::Repeatable}}, "task_reduction", {Directive::OMPD_taskgroup}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier}, {}}},
+        {Version(52), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Free, Property::Optional, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionScoping, Property::Repeatable}}, "task_reduction", {Directive::OMPD_taskgroup}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ReductionIdentifier}, {}}},
+        {Version(60), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Free, Property::Optional, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionScoping, Property::Repeatable}}, "task_reduction", {Directive::OMPD_taskgroup}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::ReductionIdentifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Free, Property::Optional, Property::OriginalListItemUpdating, Property::Privatization, Property::ReductionScoping, Property::Repeatable}}, "task_reduction", {Directive::OMPD_taskgroup}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::ReductionIdentifier}, {}}},
       }
     ),
   },
@@ -1400,12 +1400,12 @@
     descriptor::Clause(
       "thread_limit",
       {
-        {Version(45), {{{Property::IcvModifying, Property::TargetConsistent, Property::Unique}}, "thread_limit", {Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(50), {{{Property::IcvModifying, Property::TargetConsistent, Property::Unique}}, "thread_limit", {Directive::OMPD_target, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::IcvModifying, Property::TargetConsistent, Property::Unique}}, "thread_limit", {Directive::OMPD_target, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::IcvModifying, Property::TargetConsistent, Property::Unique}}, "thread_limit", {Directive::OMPD_target, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::IcvModifying, Property::TargetConsistent, Property::Unique}}, "thread_limit", {Directive::OMPD_target, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::IcvModifying, Property::SpaceConfiguring, Property::TargetConsistent, Property::Unique}}, "thread_limit", {Directive::OMPD_target, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DimsModifier, Modifier::DirectiveNameModifier, Modifier::PrescriptivenessModifier}, {}}},
+        {Version(45), {{{Property::Compatible, Property::Free, Property::IcvModifying, Property::Optional, Property::TargetConsistent, Property::Unique}}, "thread_limit", {Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::IcvModifying, Property::Optional, Property::TargetConsistent, Property::Unique}}, "thread_limit", {Directive::OMPD_target, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::IcvModifying, Property::Optional, Property::TargetConsistent, Property::Unique}}, "thread_limit", {Directive::OMPD_target, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::IcvModifying, Property::Optional, Property::TargetConsistent, Property::Unique}}, "thread_limit", {Directive::OMPD_target, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::IcvModifying, Property::Optional, Property::TargetConsistent, Property::Unique}}, "thread_limit", {Directive::OMPD_target, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::IcvModifying, Property::Optional, Property::SpaceConfiguring, Property::TargetConsistent, Property::Unique}}, "thread_limit", {Directive::OMPD_target, Directive::OMPD_teams}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DimsModifier, Modifier::DirectiveNameModifier, Modifier::PrescriptivenessModifier}, {}}},
       }
     ),
   },
@@ -1414,12 +1414,12 @@
     descriptor::Clause(
       "threads",
       {
-        {Version(45), {{{Property::InnermostLeaf, Property::Unique}}, "threads", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(50), {{{Property::InnermostLeaf, Property::Unique}}, "threads", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::InnermostLeaf, Property::Unique}}, "threads", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::InnermostLeaf, Property::Unique}}, "threads", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::InnermostLeaf, Property::Unique}}, "threads", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::InnermostLeaf, Property::Unique}}, "threads", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(45), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "threads", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "threads", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "threads", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "threads", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "threads", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "threads", {Directive::OMPD_ordered_blockassoc}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1428,8 +1428,8 @@
     descriptor::Clause(
       "threadset",
       {
-        {Version(60), {{{Property::Unique}}, "threadset", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::Unique}}, "threadset", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "threadset", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "threadset", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1438,12 +1438,12 @@
     descriptor::Clause(
       "to",
       {
-        {Version(45), {{{Property::DataMotionAttribute}}, "to", {Directive::OMPD_declare_target, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(50), {{{Property::DataMotionAttribute}}, "to", {Directive::OMPD_declare_target, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Mapper}, {}}},
-        {Version(51), {{{Property::DataMotionAttribute}}, "to", {Directive::OMPD_declare_target, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Iterator, Modifier::Mapper, Modifier::MotionModifier}, {}}},
-        {Version(52), {{{Property::DataMotionAttribute}}, "to", {Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Expectation, Modifier::Iterator, Modifier::Mapper}, {}}},
-        {Version(60), {{{Property::DataMotionAttribute}}, "to", {Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Iterator, Modifier::Mapper, Modifier::PresentModifier}, {}}},
-        {Version(61), {{{Property::DataMotionAttribute}}, "to", {Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Iterator, Modifier::Mapper, Modifier::PresentModifier}, {}}},
+        {Version(45), {{{Property::Compatible, Property::DataMotionAttribute, Property::Free, Property::Optional, Property::Repeatable}}, "to", {Directive::OMPD_declare_target, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(50), {{{Property::Compatible, Property::DataMotionAttribute, Property::Free, Property::Optional, Property::Repeatable}}, "to", {Directive::OMPD_declare_target, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Mapper}, {}}},
+        {Version(51), {{{Property::Compatible, Property::DataMotionAttribute, Property::Free, Property::Optional, Property::Repeatable}}, "to", {Directive::OMPD_declare_target, Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Iterator, Modifier::Mapper, Modifier::MotionModifier}, {}}},
+        {Version(52), {{{Property::Compatible, Property::DataMotionAttribute, Property::Free, Property::Optional, Property::Repeatable}}, "to", {Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::Expectation, Modifier::Iterator, Modifier::Mapper}, {}}},
+        {Version(60), {{{Property::Compatible, Property::DataMotionAttribute, Property::Free, Property::Optional, Property::Repeatable}}, "to", {Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Iterator, Modifier::Mapper, Modifier::PresentModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::DataMotionAttribute, Property::Free, Property::Optional, Property::Repeatable}}, "to", {Directive::OMPD_target_update}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Iterator, Modifier::Mapper, Modifier::PresentModifier}, {}}},
       }
     ),
   },
@@ -1452,8 +1452,8 @@
     descriptor::Clause(
       "transparent",
       {
-        {Version(60), {{{Property::Unique}}, "transparent", {Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::Unique}}, "transparent", {Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "transparent", {Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "transparent", {Directive::OMPD_target_data, Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1462,11 +1462,11 @@
     descriptor::Clause(
       "unified_address",
       {
-        {Version(50), {{{Property::DeviceGlobalRequirement, Property::Unique}}, "unified_address", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::DeviceGlobalRequirement, Property::Unique}}, "unified_address", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::DeviceGlobalRequirement, Property::Unique}}, "unified_address", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::DeviceGlobalRequirement, Property::Unique}}, "unified_address", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::DeviceGlobalRequirement, Property::Unique}}, "unified_address", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(50), {{{Property::Compatible, Property::DeviceGlobalRequirement, Property::Free, Property::Optional, Property::Unique}}, "unified_address", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::DeviceGlobalRequirement, Property::Free, Property::Optional, Property::Unique}}, "unified_address", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::DeviceGlobalRequirement, Property::Free, Property::Optional, Property::Unique}}, "unified_address", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::DeviceGlobalRequirement, Property::Free, Property::Optional, Property::Unique}}, "unified_address", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::DeviceGlobalRequirement, Property::Free, Property::Optional, Property::Unique}}, "unified_address", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1475,11 +1475,11 @@
     descriptor::Clause(
       "unified_shared_memory",
       {
-        {Version(50), {{{Property::DeviceGlobalRequirement, Property::Unique}}, "unified_shared_memory", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::DeviceGlobalRequirement, Property::Unique}}, "unified_shared_memory", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::DeviceGlobalRequirement, Property::Unique}}, "unified_shared_memory", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::DeviceGlobalRequirement, Property::Unique}}, "unified_shared_memory", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::DeviceGlobalRequirement, Property::Unique}}, "unified_shared_memory", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(50), {{{Property::Compatible, Property::DeviceGlobalRequirement, Property::Free, Property::Optional, Property::Unique}}, "unified_shared_memory", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::DeviceGlobalRequirement, Property::Free, Property::Optional, Property::Unique}}, "unified_shared_memory", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::DeviceGlobalRequirement, Property::Free, Property::Optional, Property::Unique}}, "unified_shared_memory", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::DeviceGlobalRequirement, Property::Free, Property::Optional, Property::Unique}}, "unified_shared_memory", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::DeviceGlobalRequirement, Property::Free, Property::Optional, Property::Unique}}, "unified_shared_memory", {Directive::OMPD_requires}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1488,12 +1488,12 @@
     descriptor::Clause(
       "uniform",
       {
-        {Version(45), {{{Property::DataEnvironmentAttribute}}, "uniform", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(50), {{{Property::DataEnvironmentAttribute}}, "uniform", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::DataEnvironmentAttribute}}, "uniform", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::DataEnvironmentAttribute}}, "uniform", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::DataEnvironmentAttribute}}, "uniform", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::DataEnvironmentAttribute}}, "uniform", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(45), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::Free, Property::Optional, Property::Repeatable}}, "uniform", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(50), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::Free, Property::Optional, Property::Repeatable}}, "uniform", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::Free, Property::Optional, Property::Repeatable}}, "uniform", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::Free, Property::Optional, Property::Repeatable}}, "uniform", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::Free, Property::Optional, Property::Repeatable}}, "uniform", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::Free, Property::Optional, Property::Repeatable}}, "uniform", {Directive::OMPD_declare_simd}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1502,12 +1502,12 @@
     descriptor::Clause(
       "untied",
       {
-        {Version(45), {{{Property::Unique}}, "untied", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(50), {{{Property::Unique}}, "untied", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::Unique}}, "untied", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::Unique}}, "untied", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::Unique}}, "untied", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::Unique}}, "untied", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(45), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "untied", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "untied", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "untied", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "untied", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "untied", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, "untied", {Directive::OMPD_task, Directive::OMPD_taskloop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1516,12 +1516,12 @@
     descriptor::Clause(
       "update",
       {
-        {Version(45), {{{Property::InnermostLeaf, Property::Unique}}, "update", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(50), {{{Property::InnermostLeaf, Property::Unique}}, "update", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::InnermostLeaf, Property::Unique}}, "update", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::InnermostLeaf, Property::Unique}}, "update", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::InnermostLeaf, Property::Unique}}, "update", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::InnermostLeaf, Property::Unique}}, "update", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(45), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "update", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "update", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "update", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "update", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "update", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "update", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1530,11 +1530,11 @@
     descriptor::Clause(
       "update-depend_objects",
       {
-        {Version(50), {{{Property::InnermostLeaf, Property::Unique}}, "update", {Directive::OMPD_depobj}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::InnermostLeaf, Property::Unique}}, "update", {Directive::OMPD_depobj}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::InnermostLeaf, Property::Unique}}, "update", {Directive::OMPD_depobj}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::InnermostLeaf, Property::Unique}}, "update", {Directive::OMPD_depobj}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::TaskDependenceType}, {}}},
-        {Version(61), {{{Property::InnermostLeaf, Property::Unique}}, "update", {Directive::OMPD_depobj}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::TaskDependenceType}, {}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "update", {Directive::OMPD_depobj}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "update", {Directive::OMPD_depobj}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "update", {Directive::OMPD_depobj}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "update", {Directive::OMPD_depobj}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::TaskDependenceType}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "update", {Directive::OMPD_depobj}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::TaskDependenceType}, {}}},
       }
     ),
   },
@@ -1543,10 +1543,10 @@
     descriptor::Clause(
       "use",
       {
-        {Version(51), {{{}}, "use", {Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{}}, "use", {Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{}}, "use", {Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{}}, "use", {Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Repeatable}}, "use", {Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Repeatable}}, "use", {Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Repeatable}}, "use", {Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Repeatable}}, "use", {Directive::OMPD_interop}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1555,11 +1555,11 @@
     descriptor::Clause(
       "use_device_addr",
       {
-        {Version(50), {{{Property::AllDataEnvironments, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated}}, "use_device_addr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::AllDataEnvironments, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated}}, "use_device_addr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::AllDataEnvironments, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated}}, "use_device_addr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::AllDataEnvironments, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated}}, "use_device_addr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::AllDataEnvironments, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated}}, "use_device_addr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(50), {{{Property::AllDataEnvironments, Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::Free, Property::Optional, Property::Repeatable}}, "use_device_addr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::AllDataEnvironments, Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::Free, Property::Optional, Property::Repeatable}}, "use_device_addr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::AllDataEnvironments, Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::Free, Property::Optional, Property::Repeatable}}, "use_device_addr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::AllDataEnvironments, Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::Free, Property::Optional, Property::Repeatable}}, "use_device_addr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::AllDataEnvironments, Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::Free, Property::Optional, Property::Repeatable}}, "use_device_addr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1568,12 +1568,12 @@
     descriptor::Clause(
       "use_device_ptr",
       {
-        {Version(45), {{{Property::AllDataEnvironments, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::Privatization}}, "use_device_ptr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(50), {{{Property::AllDataEnvironments, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::Privatization}}, "use_device_ptr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::AllDataEnvironments, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::Privatization}}, "use_device_ptr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::AllDataEnvironments, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::Privatization}}, "use_device_ptr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::AllDataEnvironments, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::Privatization}}, "use_device_ptr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::AllDataEnvironments, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::Privatization}}, "use_device_ptr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Fallback}, {}}},
+        {Version(45), {{{Property::AllDataEnvironments, Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::Free, Property::Optional, Property::Privatization, Property::Repeatable}}, "use_device_ptr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(50), {{{Property::AllDataEnvironments, Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::Free, Property::Optional, Property::Privatization, Property::Repeatable}}, "use_device_ptr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::AllDataEnvironments, Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::Free, Property::Optional, Property::Privatization, Property::Repeatable}}, "use_device_ptr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::AllDataEnvironments, Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::Free, Property::Optional, Property::Privatization, Property::Repeatable}}, "use_device_ptr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::AllDataEnvironments, Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::Free, Property::Optional, Property::Privatization, Property::Repeatable}}, "use_device_ptr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::AllDataEnvironments, Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::DeviceAssociated, Property::Free, Property::Optional, Property::Privatization, Property::Repeatable}}, "use_device_ptr", {Directive::OMPD_target_data}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::Fallback}, {}}},
       }
     ),
   },
@@ -1582,11 +1582,11 @@
     descriptor::Clause(
       "uses_allocators",
       {
-        {Version(50), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute}}, "uses_allocators", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute}}, "uses_allocators", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute}}, "uses_allocators", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::MemSpace, Modifier::TraitsArray}, {}}},
-        {Version(60), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute}}, "uses_allocators", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::MemSpace, Modifier::TraitsArray}, {}}},
-        {Version(61), {{{Property::DataEnvironmentAttribute, Property::DataSharingAttribute}}, "uses_allocators", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::MemSpace, Modifier::TraitsArray}, {}}},
+        {Version(50), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Free, Property::Optional, Property::Repeatable}}, "uses_allocators", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Free, Property::Optional, Property::Repeatable}}, "uses_allocators", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Free, Property::Optional, Property::Repeatable}}, "uses_allocators", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::MemSpace, Modifier::TraitsArray}, {}}},
+        {Version(60), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Free, Property::Optional, Property::Repeatable}}, "uses_allocators", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::MemSpace, Modifier::TraitsArray}, {}}},
+        {Version(61), {{{Property::Compatible, Property::DataEnvironmentAttribute, Property::DataSharingAttribute, Property::Free, Property::Optional, Property::Repeatable}}, "uses_allocators", {Directive::OMPD_target}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier, Modifier::MemSpace, Modifier::TraitsArray}, {}}},
       }
     ),
   },
@@ -1595,10 +1595,10 @@
     descriptor::Clause(
       "weak",
       {
-        {Version(51), {{{Property::InnermostLeaf, Property::Unique}}, "weak", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::InnermostLeaf, Property::Unique}}, "weak", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::InnermostLeaf, Property::Unique}}, "weak", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::InnermostLeaf, Property::Unique}}, "weak", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "weak", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "weak", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "weak", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "weak", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1607,11 +1607,11 @@
     descriptor::Clause(
       "when",
       {
-        {Version(50), {{{}}, "when", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ContextSelector}, {}}},
-        {Version(51), {{{}}, "when", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ContextSelector}, {}}},
-        {Version(52), {{{}}, "when", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ContextSelector}, {}}},
-        {Version(60), {{{}}, "when", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ContextSelector, Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{}}, "when", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ContextSelector, Modifier::DirectiveNameModifier}, {}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::Optional, Property::Repeatable}}, "when", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ContextSelector}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Repeatable}}, "when", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ContextSelector}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Repeatable}}, "when", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ContextSelector}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Repeatable}}, "when", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ContextSelector, Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Repeatable}}, "when", {Directive::OMPD_metadirective}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::ContextSelector, Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1620,12 +1620,12 @@
     descriptor::Clause(
       "write",
       {
-        {Version(45), {{{Property::InnermostLeaf, Property::Unique}}, "write", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(50), {{{Property::InnermostLeaf, Property::Unique}}, "write", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(51), {{{Property::InnermostLeaf, Property::Unique}}, "write", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(52), {{{Property::InnermostLeaf, Property::Unique}}, "write", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
-        {Version(60), {{{Property::InnermostLeaf, Property::Unique}}, "write", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
-        {Version(61), {{{Property::InnermostLeaf, Property::Unique}}, "write", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(45), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "write", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "write", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "write", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "write", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {}, {}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "write", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::InnermostLeaf, Property::Optional, Property::Unique}}, "write", {Directive::OMPD_atomic}, SourceLanguage::C | SourceLanguage::Fortran, {Modifier::DirectiveNameModifier}, {}}},
       }
     ),
   },
@@ -1636,7 +1636,7 @@
     descriptor::Modifier(
       "access-group",
       {
-        {Version(61), {{{Property::Unique}}, {Clause::OMPC_dyn_groupprivate}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_dyn_groupprivate}}},
       }
     ),
   },
@@ -1645,9 +1645,9 @@
     descriptor::Modifier(
       "adjust-op",
       {
-        {Version(51), {{{Property::Required, Property::Unique}}, {Clause::OMPC_adjust_args}}},
-        {Version(52), {{{Property::Required, Property::Unique}}, {Clause::OMPC_adjust_args}}},
-        {Version(60), {{{Property::Required, Property::Unique}}, {Clause::OMPC_adjust_args}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Required, Property::Unique}}, {Clause::OMPC_adjust_args}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Required, Property::Unique}}, {Clause::OMPC_adjust_args}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Required, Property::Unique}}, {Clause::OMPC_adjust_args}}},
       }
     ),
   },
@@ -1656,10 +1656,10 @@
     descriptor::Modifier(
       "align-modifier",
       {
-        {Version(51), {{{Property::Unique}}, {Clause::OMPC_allocate}}},
-        {Version(52), {{{Property::Unique}}, {Clause::OMPC_allocate}}},
-        {Version(60), {{{Property::Unique}}, {Clause::OMPC_allocate}}},
-        {Version(61), {{{Property::Unique}}, {Clause::OMPC_allocate}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_allocate}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_allocate}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_allocate}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_allocate}}},
       }
     ),
   },
@@ -1668,12 +1668,12 @@
     descriptor::Modifier(
       "alignment",
       {
-        {Version(45), {{{Property::Constant, Property::Positive, Property::Ultimate, Property::Unique}}, {Clause::OMPC_aligned}}},
-        {Version(50), {{{Property::Constant, Property::Positive, Property::Ultimate, Property::Unique}}, {Clause::OMPC_aligned}}},
-        {Version(51), {{{Property::Positive, Property::RegionInvariant, Property::Ultimate, Property::Unique}}, {Clause::OMPC_aligned}}},
-        {Version(52), {{{Property::Positive, Property::RegionInvariant, Property::Ultimate, Property::Unique}}, {Clause::OMPC_aligned}}},
-        {Version(60), {{{Property::Constant, Property::Positive, Property::Ultimate, Property::Unique}}, {Clause::OMPC_aligned}}},
-        {Version(61), {{{Property::Constant, Property::Positive, Property::Ultimate, Property::Unique}}, {Clause::OMPC_aligned}}},
+        {Version(45), {{{Property::Compatible, Property::Constant, Property::Optional, Property::Positive, Property::Ultimate, Property::Unique}}, {Clause::OMPC_aligned}}},
+        {Version(50), {{{Property::Compatible, Property::Constant, Property::Optional, Property::Positive, Property::Ultimate, Property::Unique}}, {Clause::OMPC_aligned}}},
+        {Version(51), {{{Property::Compatible, Property::Optional, Property::Positive, Property::RegionInvariant, Property::Ultimate, Property::Unique}}, {Clause::OMPC_aligned}}},
+        {Version(52), {{{Property::Compatible, Property::Optional, Property::Positive, Property::RegionInvariant, Property::Ultimate, Property::Unique}}, {Clause::OMPC_aligned}}},
+        {Version(60), {{{Property::Compatible, Property::Constant, Property::Optional, Property::Positive, Property::Ultimate, Property::Unique}}, {Clause::OMPC_aligned}}},
+        {Version(61), {{{Property::Compatible, Property::Constant, Property::Optional, Property::Positive, Property::Ultimate, Property::Unique}}, {Clause::OMPC_aligned}}},
       }
     ),
   },
@@ -1682,9 +1682,9 @@
     descriptor::Modifier(
       "allocator-complex-modifier",
       {
-        {Version(52), {{{Property::Unique}}, {Clause::OMPC_allocate}}},
-        {Version(60), {{{Property::Unique}}, {Clause::OMPC_allocate}}},
-        {Version(61), {{{Property::Unique}}, {Clause::OMPC_allocate}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_allocate}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_allocate}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_allocate}}},
       }
     ),
   },
@@ -1693,11 +1693,11 @@
     descriptor::Modifier(
       "allocator-simple-modifier",
       {
-        {Version(50), {{{Property::Exclusive, Property::Unique}}, {Clause::OMPC_allocate}}},
-        {Version(51), {{{Property::Exclusive, Property::Unique}}, {Clause::OMPC_allocate}}},
-        {Version(52), {{{Property::Exclusive, Property::Unique}}, {Clause::OMPC_allocate}}},
-        {Version(60), {{{Property::Exclusive, Property::Unique}}, {Clause::OMPC_allocate}}},
-        {Version(61), {{{Property::Exclusive, Property::Unique}}, {Clause::OMPC_allocate}}},
+        {Version(50), {{{Property::Exclusive, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_allocate}}},
+        {Version(51), {{{Property::Exclusive, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_allocate}}},
+        {Version(52), {{{Property::Exclusive, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_allocate}}},
+        {Version(60), {{{Property::Exclusive, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_allocate}}},
+        {Version(61), {{{Property::Exclusive, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_allocate}}},
       }
     ),
   },
@@ -1706,8 +1706,8 @@
     descriptor::Modifier(
       "always-modifier",
       {
-        {Version(60), {{{Property::MapTypeModifying, Property::Unique}}, {Clause::OMPC_map}}},
-        {Version(61), {{{Property::Unique}}, {Clause::OMPC_map}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::MapTypeModifying, Property::Optional, Property::Unique}}, {Clause::OMPC_map}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_map}}},
       }
     ),
   },
@@ -1716,7 +1716,7 @@
     descriptor::Modifier(
       "attach-modifier",
       {
-        {Version(61), {{{Property::Unique}}, {Clause::OMPC_map}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_map}}},
       }
     ),
   },
@@ -1725,8 +1725,8 @@
     descriptor::Modifier(
       "automap-modifier",
       {
-        {Version(60), {{{Property::Unique}}, {Clause::OMPC_enter}}},
-        {Version(61), {{{Property::Unique}}, {Clause::OMPC_enter}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_enter}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_enter}}},
       }
     ),
   },
@@ -1735,12 +1735,12 @@
     descriptor::Modifier(
       "chunk-modifier",
       {
-        {Version(45), {{{Property::Unique}}, {Clause::OMPC_schedule}}},
-        {Version(50), {{{Property::Unique}}, {Clause::OMPC_schedule}}},
-        {Version(51), {{{Property::Unique}}, {Clause::OMPC_schedule}}},
-        {Version(52), {{{Property::Unique}}, {Clause::OMPC_schedule}}},
-        {Version(60), {{{Property::Unique}}, {Clause::OMPC_schedule}}},
-        {Version(61), {{{Property::Unique}}, {Clause::OMPC_schedule}}},
+        {Version(45), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_schedule}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_schedule}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_schedule}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_schedule}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_schedule}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_schedule}}},
       }
     ),
   },
@@ -1749,8 +1749,8 @@
     descriptor::Modifier(
       "close-modifier",
       {
-        {Version(60), {{{Property::MapTypeModifying, Property::Unique}}, {Clause::OMPC_map}}},
-        {Version(61), {{{Property::Unique}}, {Clause::OMPC_map}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::MapTypeModifying, Property::Optional, Property::Unique}}, {Clause::OMPC_map}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_map}}},
       }
     ),
   },
@@ -1759,11 +1759,11 @@
     descriptor::Modifier(
       "context-selector",
       {
-        {Version(50), {{{Property::Required, Property::Unique}}, {Clause::OMPC_when}}},
-        {Version(51), {{{Property::Required, Property::Unique}}, {Clause::OMPC_when}}},
-        {Version(52), {{{Property::Required, Property::Unique}}, {Clause::OMPC_when}}},
-        {Version(60), {{{Property::Required, Property::Unique}}, {Clause::OMPC_when}}},
-        {Version(61), {{{Property::Required, Property::Unique}}, {Clause::OMPC_when}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::Required, Property::Unique}}, {Clause::OMPC_when}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Required, Property::Unique}}, {Clause::OMPC_when}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Required, Property::Unique}}, {Clause::OMPC_when}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Required, Property::Unique}}, {Clause::OMPC_when}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Required, Property::Unique}}, {Clause::OMPC_when}}},
       }
     ),
   },
@@ -1772,7 +1772,7 @@
     descriptor::Modifier(
       "default-modifier",
       {
-        {Version(61), {{{Property::Unique}}, {Clause::OMPC_reduction}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_reduction}}},
       }
     ),
   },
@@ -1781,8 +1781,8 @@
     descriptor::Modifier(
       "delete-modifier",
       {
-        {Version(60), {{{Property::MapTypeModifying, Property::Unique}}, {Clause::OMPC_map}}},
-        {Version(61), {{{Property::Unique}}, {Clause::OMPC_map}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::MapTypeModifying, Property::Optional, Property::Unique}}, {Clause::OMPC_map}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_map}}},
       }
     ),
   },
@@ -1791,12 +1791,12 @@
     descriptor::Modifier(
       "dependence-type",
       {
-        {Version(45), {{{Property::Unique}}, {Clause::OMPC_depend}}},
-        {Version(50), {{{Property::Unique}}, {Clause::OMPC_depend}}},
-        {Version(51), {{{Property::Unique}}, {Clause::OMPC_depend}}},
-        {Version(52), {{{Property::Required, Property::Unique}}, {Clause::OMPC_doacross}}},
-        {Version(60), {{{Property::Required, Property::Unique}}, {Clause::OMPC_doacross}}},
-        {Version(61), {{{Property::Required, Property::Unique}}, {Clause::OMPC_doacross}}},
+        {Version(45), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_depend}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_depend}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_depend}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Required, Property::Unique}}, {Clause::OMPC_doacross}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Required, Property::Unique}}, {Clause::OMPC_doacross}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Required, Property::Unique}}, {Clause::OMPC_doacross}}},
       }
     ),
   },
@@ -1805,8 +1805,8 @@
     descriptor::Modifier(
       "depinfo-modifier",
       {
-        {Version(60), {{{Property::Complex, Property::Unique}}, {Clause::OMPC_init}}},
-        {Version(61), {{{Property::Complex, Property::Unique}}, {Clause::OMPC_init}}},
+        {Version(60), {{{Property::Compatible, Property::Complex, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_init}}},
+        {Version(61), {{{Property::Compatible, Property::Complex, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_init}}},
       }
     ),
   },
@@ -1815,7 +1815,7 @@
     descriptor::Modifier(
       "depobj-modifier",
       {
-        {Version(61), {{{Property::Unique}}, {Clause::OMPC_depend}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_depend}}},
       }
     ),
   },
@@ -1824,11 +1824,11 @@
     descriptor::Modifier(
       "device-modifier",
       {
-        {Version(50), {{{Property::Unique}}, {Clause::OMPC_device}}},
-        {Version(51), {{{Property::Unique}}, {Clause::OMPC_device}}},
-        {Version(52), {{{Property::Unique}}, {Clause::OMPC_device}}},
-        {Version(60), {{{Property::Unique}}, {Clause::OMPC_device}}},
-        {Version(61), {{{Property::Unique}}, {Clause::OMPC_device}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_device}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_device}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_device}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_device}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_device}}},
       }
     ),
   },
@@ -1837,7 +1837,7 @@
     descriptor::Modifier(
       "dims-modifier",
       {
-        {Version(61), {{{Property::Unique}}, {Clause::OMPC_num_teams, Clause::OMPC_num_threads, Clause::OMPC_thread_limit}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_num_teams, Clause::OMPC_num_threads, Clause::OMPC_thread_limit}}},
       }
     ),
   },
@@ -1846,12 +1846,12 @@
     descriptor::Modifier(
       "directive-name-modifier",
       {
-        {Version(45), {{{Property::Unique}}, {Clause::OMPC_if}}},
-        {Version(50), {{{Property::Unique}}, {Clause::OMPC_if}}},
-        {Version(51), {{{Property::Unique}}, {Clause::OMPC_if}}},
-        {Version(52), {{{Property::Unique}}, {Clause::OMPC_if}}},
-        {Version(60), {{{Property::Unique}}, {Clause::OMPC_absent, Clause::OMPC_acq_rel, Clause::OMPC_acquire, Clause::OMPC_adjust_args, Clause::OMPC_affinity, Clause::OMPC_align, Clause::OMPC_aligned, Clause::OMPC_allocate, Clause::OMPC_allocator, Clause::OMPC_append_args, Clause::OMPC_apply, Clause::OMPC_at, Clause::OMPC_atomic_default_mem_order, Clause::OMPC_bind, Clause::OMPC_capture, Clause::OMPC_collapse, Clause::OMPC_collector, Clause::OMPC_combiner, Clause::OMPC_compare, Clause::OMPC_contains, Clause::OMPC_copyin, Clause::OMPC_copyprivate, Clause::OMPC_counts, Clause::OMPC_default, Clause::OMPC_defaultmap, Clause::OMPC_depend, Clause::OMPC_destroy, Clause::OMPC_detach, Clause::OMPC_device, Clause::OMPC_device_safesync, Clause::OMPC_device_type, Clause::OMPC_dist_schedule, Clause::OMPC_doacross, Clause::OMPC_dynamic_allocators, Clause::OMPC_enter, Clause::OMPC_exclusive, Clause::OMPC_fail, Clause::OMPC_filter, Clause::OMPC_final, Clause::OMPC_firstprivate, Clause::OMPC_from, Clause::OMPC_full, Clause::OMPC_grainsize, Clause::OMPC_graph_id, Clause::OMPC_graph_reset, Clause::OMPC_has_device_addr, Clause::OMPC_hint, Clause::OMPC_holds, Clause::OMPC_if, Clause::OMPC_in_reduction, Clause::OMPC_inbranch, Clause::OMPC_inclusive, Clause::OMPC_indirect, Clause::OMPC_induction, Clause::OMPC_inductor, Clause::OMPC_init, Clause::OMPC_init_complete, Clause::OMPC_initializer, Clause::OMPC_interop, Clause::OMPC_is_device_ptr, Clause::OMPC_lastprivate, Clause::OMPC_linear, Clause::OMPC_link, Clause::OMPC_local, Clause::OMPC_looprange, Clause::OMPC_map, Clause::OMPC_match, Clause::OMPC_memscope, Clause::OMPC_mergeable, Clause::OMPC_message, Clause::OMPC_no_openmp, Clause::OMPC_no_openmp_constructs, Clause::OMPC_no_openmp_routines, Clause::OMPC_no_parallelism, Clause::OMPC_nocontext, Clause::OMPC_nogroup, Clause::OMPC_nontemporal, Clause::OMPC_notinbranch, Clause::OMPC_novariants, Clause::OMPC_nowait, Clause::OMPC_num_tasks, Clause::OMPC_num_teams, Clause::OMPC_num_threads, Clause::OMPC_order, Clause::OMPC_ordered, Clause::OMPC_otherwise, Clause::OMPC_partial, Clause::OMPC_permutation, Clause::OMPC_priority, Clause::OMPC_private, Clause::OMPC_proc_bind, Clause::OMPC_read, Clause::OMPC_reduction, Clause::OMPC_relaxed, Clause::OMPC_release, Clause::OMPC_replayable, Clause::OMPC_reverse_offload, Clause::OMPC_safelen, Clause::OMPC_safesync, Clause::OMPC_schedule, Clause::OMPC_self_maps, Clause::OMPC_seq_cst, Clause::OMPC_severity, Clause::OMPC_shared, Clause::OMPC_simd, Clause::OMPC_simdlen, Clause::OMPC_sizes, Clause::OMPC_task_reduction, Clause::OMPC_thread_limit, Clause::OMPC_threads, Clause::OMPC_threadset, Clause::OMPC_to, Clause::OMPC_transparent, Clause::OMPC_unified_address, Clause::OMPC_unified_shared_memory, Clause::OMPC_uniform, Clause::OMPC_untied, Clause::OMPC_update, Clause::OMPC_update_depend_objects, Clause::OMPC_use, Clause::OMPC_use_device_addr, Clause::OMPC_use_device_ptr, Clause::OMPC_uses_allocators, Clause::OMPC_weak, Clause::OMPC_when, Clause::OMPC_write}}},
-        {Version(61), {{{Property::Unique}}, {Clause::OMPC_absent, Clause::OMPC_acq_rel, Clause::OMPC_acquire, Clause::OMPC_adjust_args, Clause::OMPC_affinity, Clause::OMPC_align, Clause::OMPC_aligned, Clause::OMPC_allocate, Clause::OMPC_allocator, Clause::OMPC_append_args, Clause::OMPC_apply, Clause::OMPC_at, Clause::OMPC_atomic_default_mem_order, Clause::OMPC_bind, Clause::OMPC_capture, Clause::OMPC_collapse, Clause::OMPC_collector, Clause::OMPC_combiner, Clause::OMPC_compare, Clause::OMPC_contains, Clause::OMPC_copyin, Clause::OMPC_copyprivate, Clause::OMPC_counts, Clause::OMPC_default, Clause::OMPC_defaultmap, Clause::OMPC_depend, Clause::OMPC_depth, Clause::OMPC_destroy, Clause::OMPC_detach, Clause::OMPC_device, Clause::OMPC_device_safesync, Clause::OMPC_device_type, Clause::OMPC_dist_schedule, Clause::OMPC_doacross, Clause::OMPC_dyn_groupprivate, Clause::OMPC_dynamic_allocators, Clause::OMPC_enter, Clause::OMPC_exclusive, Clause::OMPC_fail, Clause::OMPC_filter, Clause::OMPC_final, Clause::OMPC_firstprivate, Clause::OMPC_from, Clause::OMPC_full, Clause::OMPC_grainsize, Clause::OMPC_graph_id, Clause::OMPC_graph_reset, Clause::OMPC_has_device_addr, Clause::OMPC_hint, Clause::OMPC_holds, Clause::OMPC_if, Clause::OMPC_in_reduction, Clause::OMPC_inbranch, Clause::OMPC_inclusive, Clause::OMPC_indirect, Clause::OMPC_induction, Clause::OMPC_inductor, Clause::OMPC_init, Clause::OMPC_init_complete, Clause::OMPC_initializer, Clause::OMPC_interop, Clause::OMPC_is_device_ptr, Clause::OMPC_lastprivate, Clause::OMPC_linear, Clause::OMPC_link, Clause::OMPC_local, Clause::OMPC_looprange, Clause::OMPC_map, Clause::OMPC_match, Clause::OMPC_memscope, Clause::OMPC_mergeable, Clause::OMPC_message, Clause::OMPC_no_openmp, Clause::OMPC_no_openmp_constructs, Clause::OMPC_no_openmp_routines, Clause::OMPC_no_parallelism, Clause::OMPC_nocontext, Clause::OMPC_nogroup, Clause::OMPC_nontemporal, Clause::OMPC_notinbranch, Clause::OMPC_novariants, Clause::OMPC_nowait, Clause::OMPC_num_tasks, Clause::OMPC_num_teams, Clause::OMPC_num_threads, Clause::OMPC_order, Clause::OMPC_ordered, Clause::OMPC_otherwise, Clause::OMPC_partial, Clause::OMPC_permutation, Clause::OMPC_priority, Clause::OMPC_private, Clause::OMPC_proc_bind, Clause::OMPC_read, Clause::OMPC_reduction, Clause::OMPC_relaxed, Clause::OMPC_release, Clause::OMPC_replayable, Clause::OMPC_reverse_offload, Clause::OMPC_safelen, Clause::OMPC_safesync, Clause::OMPC_schedule, Clause::OMPC_self_maps, Clause::OMPC_seq_cst, Clause::OMPC_severity, Clause::OMPC_shared, Clause::OMPC_simd, Clause::OMPC_simdlen, Clause::OMPC_sizes, Clause::OMPC_task_reduction, Clause::OMPC_thread_limit, Clause::OMPC_threads, Clause::OMPC_threadset, Clause::OMPC_to, Clause::OMPC_transparent, Clause::OMPC_unified_address, Clause::OMPC_unified_shared_memory, Clause::OMPC_uniform, Clause::OMPC_untied, Clause::OMPC_update, Clause::OMPC_update_depend_objects, Clause::OMPC_use, Clause::OMPC_use_device_addr, Clause::OMPC_use_device_ptr, Clause::OMPC_uses_allocators, Clause::OMPC_weak, Clause::OMPC_when, Clause::OMPC_write}}},
+        {Version(45), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_if}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_if}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_if}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_if}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_absent, Clause::OMPC_acq_rel, Clause::OMPC_acquire, Clause::OMPC_adjust_args, Clause::OMPC_affinity, Clause::OMPC_align, Clause::OMPC_aligned, Clause::OMPC_allocate, Clause::OMPC_allocator, Clause::OMPC_append_args, Clause::OMPC_apply, Clause::OMPC_at, Clause::OMPC_atomic_default_mem_order, Clause::OMPC_bind, Clause::OMPC_capture, Clause::OMPC_collapse, Clause::OMPC_collector, Clause::OMPC_combiner, Clause::OMPC_compare, Clause::OMPC_contains, Clause::OMPC_copyin, Clause::OMPC_copyprivate, Clause::OMPC_counts, Clause::OMPC_default, Clause::OMPC_defaultmap, Clause::OMPC_depend, Clause::OMPC_destroy, Clause::OMPC_detach, Clause::OMPC_device, Clause::OMPC_device_safesync, Clause::OMPC_device_type, Clause::OMPC_dist_schedule, Clause::OMPC_doacross, Clause::OMPC_dynamic_allocators, Clause::OMPC_enter, Clause::OMPC_exclusive, Clause::OMPC_fail, Clause::OMPC_filter, Clause::OMPC_final, Clause::OMPC_firstprivate, Clause::OMPC_from, Clause::OMPC_full, Clause::OMPC_grainsize, Clause::OMPC_graph_id, Clause::OMPC_graph_reset, Clause::OMPC_has_device_addr, Clause::OMPC_hint, Clause::OMPC_holds, Clause::OMPC_if, Clause::OMPC_in_reduction, Clause::OMPC_inbranch, Clause::OMPC_inclusive, Clause::OMPC_indirect, Clause::OMPC_induction, Clause::OMPC_inductor, Clause::OMPC_init, Clause::OMPC_init_complete, Clause::OMPC_initializer, Clause::OMPC_interop, Clause::OMPC_is_device_ptr, Clause::OMPC_lastprivate, Clause::OMPC_linear, Clause::OMPC_link, Clause::OMPC_local, Clause::OMPC_looprange, Clause::OMPC_map, Clause::OMPC_match, Clause::OMPC_memscope, Clause::OMPC_mergeable, Clause::OMPC_message, Clause::OMPC_no_openmp, Clause::OMPC_no_openmp_constructs, Clause::OMPC_no_openmp_routines, Clause::OMPC_no_parallelism, Clause::OMPC_nocontext, Clause::OMPC_nogroup, Clause::OMPC_nontemporal, Clause::OMPC_notinbranch, Clause::OMPC_novariants, Clause::OMPC_nowait, Clause::OMPC_num_tasks, Clause::OMPC_num_teams, Clause::OMPC_num_threads, Clause::OMPC_order, Clause::OMPC_ordered, Clause::OMPC_otherwise, Clause::OMPC_partial, Clause::OMPC_permutation, Clause::OMPC_priority, Clause::OMPC_private, Clause::OMPC_proc_bind, Clause::OMPC_read, Clause::OMPC_reduction, Clause::OMPC_relaxed, Clause::OMPC_release, Clause::OMPC_replayable, Clause::OMPC_reverse_offload, Clause::OMPC_safelen, Clause::OMPC_safesync, Clause::OMPC_schedule, Clause::OMPC_self_maps, Clause::OMPC_seq_cst, Clause::OMPC_severity, Clause::OMPC_shared, Clause::OMPC_simd, Clause::OMPC_simdlen, Clause::OMPC_sizes, Clause::OMPC_task_reduction, Clause::OMPC_thread_limit, Clause::OMPC_threads, Clause::OMPC_threadset, Clause::OMPC_to, Clause::OMPC_transparent, Clause::OMPC_unified_address, Clause::OMPC_unified_shared_memory, Clause::OMPC_uniform, Clause::OMPC_untied, Clause::OMPC_update, Clause::OMPC_update_depend_objects, Clause::OMPC_use, Clause::OMPC_use_device_addr, Clause::OMPC_use_device_ptr, Clause::OMPC_uses_allocators, Clause::OMPC_weak, Clause::OMPC_when, Clause::OMPC_write}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_absent, Clause::OMPC_acq_rel, Clause::OMPC_acquire, Clause::OMPC_adjust_args, Clause::OMPC_affinity, Clause::OMPC_align, Clause::OMPC_aligned, Clause::OMPC_allocate, Clause::OMPC_allocator, Clause::OMPC_append_args, Clause::OMPC_apply, Clause::OMPC_at, Clause::OMPC_atomic_default_mem_order, Clause::OMPC_bind, Clause::OMPC_capture, Clause::OMPC_collapse, Clause::OMPC_collector, Clause::OMPC_combiner, Clause::OMPC_compare, Clause::OMPC_contains, Clause::OMPC_copyin, Clause::OMPC_copyprivate, Clause::OMPC_counts, Clause::OMPC_default, Clause::OMPC_defaultmap, Clause::OMPC_depend, Clause::OMPC_depth, Clause::OMPC_destroy, Clause::OMPC_detach, Clause::OMPC_device, Clause::OMPC_device_safesync, Clause::OMPC_device_type, Clause::OMPC_dist_schedule, Clause::OMPC_doacross, Clause::OMPC_dyn_groupprivate, Clause::OMPC_dynamic_allocators, Clause::OMPC_enter, Clause::OMPC_exclusive, Clause::OMPC_fail, Clause::OMPC_filter, Clause::OMPC_final, Clause::OMPC_firstprivate, Clause::OMPC_from, Clause::OMPC_full, Clause::OMPC_grainsize, Clause::OMPC_graph_id, Clause::OMPC_graph_reset, Clause::OMPC_has_device_addr, Clause::OMPC_hint, Clause::OMPC_holds, Clause::OMPC_if, Clause::OMPC_in_reduction, Clause::OMPC_inbranch, Clause::OMPC_inclusive, Clause::OMPC_indirect, Clause::OMPC_induction, Clause::OMPC_inductor, Clause::OMPC_init, Clause::OMPC_init_complete, Clause::OMPC_initializer, Clause::OMPC_interop, Clause::OMPC_is_device_ptr, Clause::OMPC_lastprivate, Clause::OMPC_linear, Clause::OMPC_link, Clause::OMPC_local, Clause::OMPC_looprange, Clause::OMPC_map, Clause::OMPC_match, Clause::OMPC_memscope, Clause::OMPC_mergeable, Clause::OMPC_message, Clause::OMPC_no_openmp, Clause::OMPC_no_openmp_constructs, Clause::OMPC_no_openmp_routines, Clause::OMPC_no_parallelism, Clause::OMPC_nocontext, Clause::OMPC_nogroup, Clause::OMPC_nontemporal, Clause::OMPC_notinbranch, Clause::OMPC_novariants, Clause::OMPC_nowait, Clause::OMPC_num_tasks, Clause::OMPC_num_teams, Clause::OMPC_num_threads, Clause::OMPC_order, Clause::OMPC_ordered, Clause::OMPC_otherwise, Clause::OMPC_partial, Clause::OMPC_permutation, Clause::OMPC_priority, Clause::OMPC_private, Clause::OMPC_proc_bind, Clause::OMPC_read, Clause::OMPC_reduction, Clause::OMPC_relaxed, Clause::OMPC_release, Clause::OMPC_replayable, Clause::OMPC_reverse_offload, Clause::OMPC_safelen, Clause::OMPC_safesync, Clause::OMPC_schedule, Clause::OMPC_self_maps, Clause::OMPC_seq_cst, Clause::OMPC_severity, Clause::OMPC_shared, Clause::OMPC_simd, Clause::OMPC_simdlen, Clause::OMPC_sizes, Clause::OMPC_task_reduction, Clause::OMPC_thread_limit, Clause::OMPC_threads, Clause::OMPC_threadset, Clause::OMPC_to, Clause::OMPC_transparent, Clause::OMPC_unified_address, Clause::OMPC_unified_shared_memory, Clause::OMPC_uniform, Clause::OMPC_untied, Clause::OMPC_update, Clause::OMPC_update_depend_objects, Clause::OMPC_use, Clause::OMPC_use_device_addr, Clause::OMPC_use_device_ptr, Clause::OMPC_uses_allocators, Clause::OMPC_weak, Clause::OMPC_when, Clause::OMPC_write}}},
       }
     ),
   },
@@ -1860,7 +1860,7 @@
     descriptor::Modifier(
       "expectation",
       {
-        {Version(52), {{{Property::Unique}}, {Clause::OMPC_from, Clause::OMPC_to}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_from, Clause::OMPC_to}}},
       }
     ),
   },
@@ -1869,7 +1869,7 @@
     descriptor::Modifier(
       "fallback",
       {
-        {Version(61), {{{Property::Unique}}, {Clause::OMPC_use_device_ptr}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_use_device_ptr}}},
       }
     ),
   },
@@ -1878,7 +1878,7 @@
     descriptor::Modifier(
       "fallback-modifier",
       {
-        {Version(61), {{{Property::Unique}}, {Clause::OMPC_dyn_groupprivate}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_dyn_groupprivate}}},
       }
     ),
   },
@@ -1887,8 +1887,8 @@
     descriptor::Modifier(
       "induction-identifier",
       {
-        {Version(60), {{{Property::Required, Property::Ultimate, Property::Unique}}, {Clause::OMPC_induction}}},
-        {Version(61), {{{Property::Required, Property::Ultimate, Property::Unique}}, {Clause::OMPC_induction}}},
+        {Version(60), {{{Property::Compatible, Property::Required, Property::Ultimate, Property::Unique}}, {Clause::OMPC_induction}}},
+        {Version(61), {{{Property::Compatible, Property::Required, Property::Ultimate, Property::Unique}}, {Clause::OMPC_induction}}},
       }
     ),
   },
@@ -1897,8 +1897,8 @@
     descriptor::Modifier(
       "induction-modifier",
       {
-        {Version(60), {{{Property::Unique}}, {Clause::OMPC_induction}}},
-        {Version(61), {{{Property::Unique}}, {Clause::OMPC_induction}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_induction}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_induction}}},
       }
     ),
   },
@@ -1907,7 +1907,7 @@
     descriptor::Modifier(
       "inscan-modifier",
       {
-        {Version(61), {{{Property::Unique}}, {Clause::OMPC_reduction}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_reduction}}},
       }
     ),
   },
@@ -1916,9 +1916,9 @@
     descriptor::Modifier(
       "interop-type",
       {
-        {Version(51), {{{Property::Repeatable, Property::Required}}, {Clause::OMPC_init}}},
-        {Version(52), {{{Property::Repeatable, Property::Required}}, {Clause::OMPC_init}}},
-        {Version(60), {{{Property::Repeatable}}, {Clause::OMPC_init}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Repeatable, Property::Required}}, {Clause::OMPC_init}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Repeatable, Property::Required}}, {Clause::OMPC_init}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Repeatable}}, {Clause::OMPC_init}}},
       }
     ),
   },
@@ -1927,11 +1927,11 @@
     descriptor::Modifier(
       "iterator",
       {
-        {Version(50), {{{Property::Unique}}, {Clause::OMPC_affinity, Clause::OMPC_depend}}},
-        {Version(51), {{{Property::Unique}}, {Clause::OMPC_affinity, Clause::OMPC_depend, Clause::OMPC_from, Clause::OMPC_map, Clause::OMPC_to}}},
-        {Version(52), {{{Property::Unique}}, {Clause::OMPC_affinity, Clause::OMPC_depend, Clause::OMPC_from, Clause::OMPC_map, Clause::OMPC_to}}},
-        {Version(60), {{{Property::Unique}}, {Clause::OMPC_affinity, Clause::OMPC_depend, Clause::OMPC_from, Clause::OMPC_map, Clause::OMPC_to}}},
-        {Version(61), {{{Property::Unique}}, {Clause::OMPC_affinity, Clause::OMPC_depend, Clause::OMPC_from, Clause::OMPC_map, Clause::OMPC_to}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_affinity, Clause::OMPC_depend}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_affinity, Clause::OMPC_depend, Clause::OMPC_from, Clause::OMPC_map, Clause::OMPC_to}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_affinity, Clause::OMPC_depend, Clause::OMPC_from, Clause::OMPC_map, Clause::OMPC_to}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_affinity, Clause::OMPC_depend, Clause::OMPC_from, Clause::OMPC_map, Clause::OMPC_to}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_affinity, Clause::OMPC_depend, Clause::OMPC_from, Clause::OMPC_map, Clause::OMPC_to}}},
       }
     ),
   },
@@ -1940,11 +1940,11 @@
     descriptor::Modifier(
       "lastprivate-modifier",
       {
-        {Version(50), {{{Property::Unique}}, {Clause::OMPC_lastprivate}}},
-        {Version(51), {{{Property::Unique}}, {Clause::OMPC_lastprivate}}},
-        {Version(52), {{{Property::Unique}}, {Clause::OMPC_lastprivate}}},
-        {Version(60), {{{Property::Unique}}, {Clause::OMPC_lastprivate}}},
-        {Version(61), {{{Property::Unique}}, {Clause::OMPC_lastprivate}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_lastprivate}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_lastprivate}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_lastprivate}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_lastprivate}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_lastprivate}}},
       }
     ),
   },
@@ -1953,12 +1953,12 @@
     descriptor::Modifier(
       "linear-modifier",
       {
-        {Version(45), {{{Property::Unique}}, {Clause::OMPC_linear}}},
-        {Version(50), {{{Property::Unique}}, {Clause::OMPC_linear}}},
-        {Version(51), {{{Property::Unique}}, {Clause::OMPC_linear}}},
-        {Version(52), {{{Property::Unique}}, {Clause::OMPC_linear}}},
-        {Version(60), {{{Property::Unique}}, {Clause::OMPC_linear}}},
-        {Version(61), {{{Property::Unique}}, {Clause::OMPC_linear}}},
+        {Version(45), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_linear}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_linear}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_linear}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_linear}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_linear}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_linear}}},
       }
     ),
   },
@@ -1967,9 +1967,9 @@
     descriptor::Modifier(
       "linear-step",
       {
-        {Version(45), {{{Property::RegionInvariant, Property::Unique}}, {Clause::OMPC_linear}}},
-        {Version(50), {{{Property::RegionInvariant, Property::Unique}}, {Clause::OMPC_linear}}},
-        {Version(51), {{{Property::RegionInvariant, Property::Unique}}, {Clause::OMPC_linear}}},
+        {Version(45), {{{Property::Compatible, Property::Free, Property::Optional, Property::RegionInvariant, Property::Unique}}, {Clause::OMPC_linear}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::Optional, Property::RegionInvariant, Property::Unique}}, {Clause::OMPC_linear}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::RegionInvariant, Property::Unique}}, {Clause::OMPC_linear}}},
       }
     ),
   },
@@ -1978,7 +1978,7 @@
     descriptor::Modifier(
       "loc-modifier",
       {
-        {Version(61), {{{Property::Unique}}, {Clause::OMPC_depend}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_depend}}},
       }
     ),
   },
@@ -1987,8 +1987,8 @@
     descriptor::Modifier(
       "loop-modifier",
       {
-        {Version(60), {{{Property::Optional, Property::Unique}}, {Clause::OMPC_apply}}},
-        {Version(61), {{{Property::Optional, Property::Unique}}, {Clause::OMPC_apply}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_apply}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_apply}}},
       }
     ),
   },
@@ -1997,11 +1997,11 @@
     descriptor::Modifier(
       "lower-bound",
       {
-        {Version(50), {{{Property::Positive, Property::Ultimate, Property::Unique}}, {Clause::OMPC_num_teams}}},
-        {Version(51), {{{Property::Positive, Property::Ultimate, Property::Unique}}, {Clause::OMPC_num_teams}}},
-        {Version(52), {{{Property::Positive, Property::Ultimate, Property::Unique}}, {Clause::OMPC_num_teams}}},
-        {Version(60), {{{Property::Positive, Property::Ultimate, Property::Unique}}, {Clause::OMPC_num_teams}}},
-        {Version(61), {{{Property::Positive, Property::Ultimate, Property::Unique}}, {Clause::OMPC_num_teams}}},
+        {Version(50), {{{Property::Compatible, Property::Optional, Property::Positive, Property::Ultimate, Property::Unique}}, {Clause::OMPC_num_teams}}},
+        {Version(51), {{{Property::Compatible, Property::Optional, Property::Positive, Property::Ultimate, Property::Unique}}, {Clause::OMPC_num_teams}}},
+        {Version(52), {{{Property::Compatible, Property::Optional, Property::Positive, Property::Ultimate, Property::Unique}}, {Clause::OMPC_num_teams}}},
+        {Version(60), {{{Property::Compatible, Property::Optional, Property::Positive, Property::Ultimate, Property::Unique}}, {Clause::OMPC_num_teams}}},
+        {Version(61), {{{Property::Compatible, Property::Optional, Property::Positive, Property::Ultimate, Property::Unique}}, {Clause::OMPC_num_teams}}},
       }
     ),
   },
@@ -2010,12 +2010,12 @@
     descriptor::Modifier(
       "map-type",
       {
-        {Version(45), {{{Property::Ultimate, Property::Unique}}, {Clause::OMPC_map}}},
-        {Version(50), {{{Property::Ultimate, Property::Unique}}, {Clause::OMPC_map}}},
-        {Version(51), {{{Property::Ultimate, Property::Unique}}, {Clause::OMPC_map}}},
-        {Version(52), {{{Property::Ultimate, Property::Unique}}, {Clause::OMPC_map}}},
-        {Version(60), {{{Property::Unique}}, {Clause::OMPC_map}}},
-        {Version(61), {{{Property::Unique}}, {Clause::OMPC_map}}},
+        {Version(45), {{{Property::Compatible, Property::Optional, Property::Ultimate, Property::Unique}}, {Clause::OMPC_map}}},
+        {Version(50), {{{Property::Compatible, Property::Optional, Property::Ultimate, Property::Unique}}, {Clause::OMPC_map}}},
+        {Version(51), {{{Property::Compatible, Property::Optional, Property::Ultimate, Property::Unique}}, {Clause::OMPC_map}}},
+        {Version(52), {{{Property::Compatible, Property::Optional, Property::Ultimate, Property::Unique}}, {Clause::OMPC_map}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_map}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_map}}},
       }
     ),
   },
@@ -2024,10 +2024,10 @@
     descriptor::Modifier(
       "map-type-modifier",
       {
-        {Version(45), {{{Property::MapTypeModifying, Property::Repeatable}}, {Clause::OMPC_map}}},
-        {Version(50), {{{Property::MapTypeModifying, Property::Repeatable}}, {Clause::OMPC_map}}},
-        {Version(51), {{{Property::MapTypeModifying, Property::Repeatable}}, {Clause::OMPC_map}}},
-        {Version(52), {{{Property::MapTypeModifying, Property::Repeatable}}, {Clause::OMPC_map}}},
+        {Version(45), {{{Property::Compatible, Property::Free, Property::MapTypeModifying, Property::Optional, Property::Repeatable}}, {Clause::OMPC_map}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::MapTypeModifying, Property::Optional, Property::Repeatable}}, {Clause::OMPC_map}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::MapTypeModifying, Property::Optional, Property::Repeatable}}, {Clause::OMPC_map}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::MapTypeModifying, Property::Optional, Property::Repeatable}}, {Clause::OMPC_map}}},
       }
     ),
   },
@@ -2036,11 +2036,11 @@
     descriptor::Modifier(
       "mapper",
       {
-        {Version(50), {{{Property::Unique}}, {Clause::OMPC_from, Clause::OMPC_map, Clause::OMPC_to}}},
-        {Version(51), {{{Property::Unique}}, {Clause::OMPC_from, Clause::OMPC_map, Clause::OMPC_to}}},
-        {Version(52), {{{Property::Unique}}, {Clause::OMPC_from, Clause::OMPC_map, Clause::OMPC_to}}},
-        {Version(60), {{{Property::Unique}}, {Clause::OMPC_from, Clause::OMPC_map, Clause::OMPC_to}}},
-        {Version(61), {{{Property::Unique}}, {Clause::OMPC_from, Clause::OMPC_map, Clause::OMPC_to}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_from, Clause::OMPC_map, Clause::OMPC_to}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_from, Clause::OMPC_map, Clause::OMPC_to}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_from, Clause::OMPC_map, Clause::OMPC_to}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_from, Clause::OMPC_map, Clause::OMPC_to}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_from, Clause::OMPC_map, Clause::OMPC_to}}},
       }
     ),
   },
@@ -2049,9 +2049,9 @@
     descriptor::Modifier(
       "mem-space",
       {
-        {Version(52), {{{Property::Unique}}, {Clause::OMPC_uses_allocators}}},
-        {Version(60), {{{Property::Unique}}, {Clause::OMPC_uses_allocators}}},
-        {Version(61), {{{Property::Unique}}, {Clause::OMPC_uses_allocators}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_uses_allocators}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_uses_allocators}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_uses_allocators}}},
       }
     ),
   },
@@ -2060,7 +2060,7 @@
     descriptor::Modifier(
       "motion-modifier",
       {
-        {Version(51), {{{Property::Unique}}, {Clause::OMPC_from, Clause::OMPC_to}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_from, Clause::OMPC_to}}},
       }
     ),
   },
@@ -2069,7 +2069,7 @@
     descriptor::Modifier(
       "need-device-addr",
       {
-        {Version(61), {{{Property::Unique}}, {Clause::OMPC_adjust_args}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_adjust_args}}},
       }
     ),
   },
@@ -2078,7 +2078,7 @@
     descriptor::Modifier(
       "need-device-ptr",
       {
-        {Version(61), {{{Property::Unique}}, {Clause::OMPC_adjust_args}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_adjust_args}}},
       }
     ),
   },
@@ -2087,7 +2087,7 @@
     descriptor::Modifier(
       "noncommutative-modifier",
       {
-        {Version(61), {{{Property::Unique}}, {Clause::OMPC_reduction}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_reduction}}},
       }
     ),
   },
@@ -2096,7 +2096,7 @@
     descriptor::Modifier(
       "nothing",
       {
-        {Version(61), {{{Property::Unique}}, {Clause::OMPC_adjust_args}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_adjust_args}}},
       }
     ),
   },
@@ -2119,7 +2119,7 @@
     descriptor::Modifier(
       "optional-modifier",
       {
-        {Version(61), {{{Property::Unique}}, {Clause::OMPC_default, Clause::OMPC_defaultmap}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_default, Clause::OMPC_defaultmap}}},
       }
     ),
   },
@@ -2128,10 +2128,10 @@
     descriptor::Modifier(
       "order-modifier",
       {
-        {Version(51), {{{Property::Unique}}, {Clause::OMPC_order}}},
-        {Version(52), {{{Property::Unique}}, {Clause::OMPC_order}}},
-        {Version(60), {{{Property::Unique}}, {Clause::OMPC_order}}},
-        {Version(61), {{{Property::Unique}}, {Clause::OMPC_order}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_order}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_order}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_order}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_order}}},
       }
     ),
   },
@@ -2140,12 +2140,12 @@
     descriptor::Modifier(
       "ordering-modifier",
       {
-        {Version(45), {{{Property::Unique}}, {Clause::OMPC_schedule}}},
-        {Version(50), {{{Property::Unique}}, {Clause::OMPC_schedule}}},
-        {Version(51), {{{Property::Unique}}, {Clause::OMPC_schedule}}},
-        {Version(52), {{{Property::Unique}}, {Clause::OMPC_schedule}}},
-        {Version(60), {{{Property::Unique}}, {Clause::OMPC_schedule}}},
-        {Version(61), {{{Property::Unique}}, {Clause::OMPC_schedule}}},
+        {Version(45), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_schedule}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_schedule}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_schedule}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_schedule}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_schedule}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_schedule}}},
       }
     ),
   },
@@ -2154,8 +2154,8 @@
     descriptor::Modifier(
       "original-sharing-modifier",
       {
-        {Version(60), {{{Property::Unique}}, {Clause::OMPC_reduction}}},
-        {Version(61), {{{Property::Unique}}, {Clause::OMPC_reduction}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_reduction}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_reduction}}},
       }
     ),
   },
@@ -2164,7 +2164,7 @@
     descriptor::Modifier(
       "per-thread-modifier",
       {
-        {Version(61), {{{Property::Unique}}, {Clause::OMPC_reduction}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_reduction}}},
       }
     ),
   },
@@ -2173,8 +2173,8 @@
     descriptor::Modifier(
       "prefer-type",
       {
-        {Version(60), {{{Property::Complex, Property::Unique}}, {Clause::OMPC_init}}},
-        {Version(61), {{{Property::Complex, Property::Unique}}, {Clause::OMPC_init}}},
+        {Version(60), {{{Property::Compatible, Property::Complex, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_init}}},
+        {Version(61), {{{Property::Compatible, Property::Complex, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_init}}},
       }
     ),
   },
@@ -2183,10 +2183,10 @@
     descriptor::Modifier(
       "prescriptiveness",
       {
-        {Version(51), {{{Property::Unique}}, {Clause::OMPC_grainsize, Clause::OMPC_num_tasks}}},
-        {Version(52), {{{Property::Unique}}, {Clause::OMPC_grainsize, Clause::OMPC_num_tasks}}},
-        {Version(60), {{{Property::Unique}}, {Clause::OMPC_grainsize, Clause::OMPC_num_tasks, Clause::OMPC_num_threads}}},
-        {Version(61), {{{Property::Unique}}, {Clause::OMPC_grainsize, Clause::OMPC_num_tasks}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_grainsize, Clause::OMPC_num_tasks}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_grainsize, Clause::OMPC_num_tasks}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_grainsize, Clause::OMPC_num_tasks, Clause::OMPC_num_threads}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_grainsize, Clause::OMPC_num_tasks}}},
       }
     ),
   },
@@ -2195,7 +2195,7 @@
     descriptor::Modifier(
       "prescriptiveness-modifier",
       {
-        {Version(61), {{{Property::Unique}}, {Clause::OMPC_num_threads, Clause::OMPC_thread_limit}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_num_threads, Clause::OMPC_thread_limit}}},
       }
     ),
   },
@@ -2204,8 +2204,8 @@
     descriptor::Modifier(
       "present-modifier",
       {
-        {Version(60), {{{Property::MapTypeModifying, Property::Unique}}, {Clause::OMPC_from, Clause::OMPC_map, Clause::OMPC_to}}},
-        {Version(61), {{{Property::Unique}}, {Clause::OMPC_from, Clause::OMPC_map, Clause::OMPC_to}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::MapTypeModifying, Property::Optional, Property::Unique}}, {Clause::OMPC_from, Clause::OMPC_map, Clause::OMPC_to}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_from, Clause::OMPC_map, Clause::OMPC_to}}},
       }
     ),
   },
@@ -2214,12 +2214,12 @@
     descriptor::Modifier(
       "reduction-identifier",
       {
-        {Version(45), {{{Property::Required, Property::Ultimate, Property::Unique}}, {Clause::OMPC_reduction}}},
-        {Version(50), {{{Property::Required, Property::Ultimate, Property::Unique}}, {Clause::OMPC_in_reduction, Clause::OMPC_reduction, Clause::OMPC_task_reduction}}},
-        {Version(51), {{{Property::Required, Property::Ultimate, Property::Unique}}, {Clause::OMPC_in_reduction, Clause::OMPC_reduction, Clause::OMPC_task_reduction}}},
-        {Version(52), {{{Property::Required, Property::Ultimate, Property::Unique}}, {Clause::OMPC_in_reduction, Clause::OMPC_reduction, Clause::OMPC_task_reduction}}},
-        {Version(60), {{{Property::Required, Property::Ultimate, Property::Unique}}, {Clause::OMPC_in_reduction, Clause::OMPC_reduction, Clause::OMPC_task_reduction}}},
-        {Version(61), {{{Property::Required, Property::Ultimate, Property::Unique}}, {Clause::OMPC_in_reduction, Clause::OMPC_reduction, Clause::OMPC_task_reduction}}},
+        {Version(45), {{{Property::Compatible, Property::Required, Property::Ultimate, Property::Unique}}, {Clause::OMPC_reduction}}},
+        {Version(50), {{{Property::Compatible, Property::Required, Property::Ultimate, Property::Unique}}, {Clause::OMPC_in_reduction, Clause::OMPC_reduction, Clause::OMPC_task_reduction}}},
+        {Version(51), {{{Property::Compatible, Property::Required, Property::Ultimate, Property::Unique}}, {Clause::OMPC_in_reduction, Clause::OMPC_reduction, Clause::OMPC_task_reduction}}},
+        {Version(52), {{{Property::Compatible, Property::Required, Property::Ultimate, Property::Unique}}, {Clause::OMPC_in_reduction, Clause::OMPC_reduction, Clause::OMPC_task_reduction}}},
+        {Version(60), {{{Property::Compatible, Property::Required, Property::Ultimate, Property::Unique}}, {Clause::OMPC_in_reduction, Clause::OMPC_reduction, Clause::OMPC_task_reduction}}},
+        {Version(61), {{{Property::Compatible, Property::Required, Property::Ultimate, Property::Unique}}, {Clause::OMPC_in_reduction, Clause::OMPC_reduction, Clause::OMPC_task_reduction}}},
       }
     ),
   },
@@ -2228,10 +2228,10 @@
     descriptor::Modifier(
       "reduction-modifier",
       {
-        {Version(50), {{{Property::Unique}}, {Clause::OMPC_reduction}}},
-        {Version(51), {{{Property::Unique}}, {Clause::OMPC_reduction}}},
-        {Version(52), {{{Property::Unique}}, {Clause::OMPC_reduction}}},
-        {Version(60), {{{Property::Unique}}, {Clause::OMPC_reduction}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_reduction}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_reduction}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_reduction}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_reduction}}},
       }
     ),
   },
@@ -2240,8 +2240,8 @@
     descriptor::Modifier(
       "ref-modifier",
       {
-        {Version(60), {{{Property::Unique}}, {Clause::OMPC_map}}},
-        {Version(61), {{{Property::Unique}}, {Clause::OMPC_map}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_map}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_map}}},
       }
     ),
   },
@@ -2250,8 +2250,8 @@
     descriptor::Modifier(
       "saved",
       {
-        {Version(60), {{{Property::Unique}}, {Clause::OMPC_firstprivate}}},
-        {Version(61), {{{Property::Unique}}, {Clause::OMPC_firstprivate}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_firstprivate}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_firstprivate}}},
       }
     ),
   },
@@ -2260,7 +2260,7 @@
     descriptor::Modifier(
       "scaled-modifier",
       {
-        {Version(61), {{{Property::Unique}}, {Clause::OMPC_simdlen}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_simdlen}}},
       }
     ),
   },
@@ -2269,8 +2269,8 @@
     descriptor::Modifier(
       "self-modifier",
       {
-        {Version(60), {{{Property::MapTypeModifying, Property::Unique}}, {Clause::OMPC_map}}},
-        {Version(61), {{{Property::Unique}}, {Clause::OMPC_map}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::MapTypeModifying, Property::Optional, Property::Unique}}, {Clause::OMPC_map}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_map}}},
       }
     ),
   },
@@ -2279,7 +2279,7 @@
     descriptor::Modifier(
       "sizes-selector",
       {
-        {Version(61), {{{Property::Unique}}, {Clause::OMPC_sizes}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_sizes}}},
       }
     ),
   },
@@ -2288,9 +2288,9 @@
     descriptor::Modifier(
       "step-complex-modifier",
       {
-        {Version(52), {{{Property::Unique}}, {Clause::OMPC_linear}}},
-        {Version(60), {{{Property::Unique}}, {Clause::OMPC_linear}}},
-        {Version(61), {{{Property::Unique}}, {Clause::OMPC_linear}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_linear}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_linear}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_linear}}},
       }
     ),
   },
@@ -2299,8 +2299,8 @@
     descriptor::Modifier(
       "step-modifier",
       {
-        {Version(60), {{{Property::Required, Property::Unique}}, {Clause::OMPC_induction}}},
-        {Version(61), {{{Property::Required, Property::Unique}}, {Clause::OMPC_induction}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Required, Property::Unique}}, {Clause::OMPC_induction}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Required, Property::Unique}}, {Clause::OMPC_induction}}},
       }
     ),
   },
@@ -2309,9 +2309,9 @@
     descriptor::Modifier(
       "step-simple-modifier",
       {
-        {Version(52), {{{Property::Exclusive, Property::RegionInvariant, Property::Unique}}, {Clause::OMPC_linear}}},
-        {Version(60), {{{Property::Exclusive, Property::RegionInvariant, Property::Unique}}, {Clause::OMPC_linear}}},
-        {Version(61), {{{Property::Exclusive, Property::RegionInvariant, Property::Unique}}, {Clause::OMPC_linear}}},
+        {Version(52), {{{Property::Exclusive, Property::Free, Property::Optional, Property::RegionInvariant, Property::Unique}}, {Clause::OMPC_linear}}},
+        {Version(60), {{{Property::Exclusive, Property::Free, Property::Optional, Property::RegionInvariant, Property::Unique}}, {Clause::OMPC_linear}}},
+        {Version(61), {{{Property::Exclusive, Property::Free, Property::Optional, Property::RegionInvariant, Property::Unique}}, {Clause::OMPC_linear}}},
       }
     ),
   },
@@ -2320,7 +2320,7 @@
     descriptor::Modifier(
       "target-type",
       {
-        {Version(61), {{{Property::Unique}}, {Clause::OMPC_init}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_init}}},
       }
     ),
   },
@@ -2329,7 +2329,7 @@
     descriptor::Modifier(
       "targetsync-type",
       {
-        {Version(61), {{{Property::Unique}}, {Clause::OMPC_init}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_init}}},
       }
     ),
   },
@@ -2338,12 +2338,12 @@
     descriptor::Modifier(
       "task-dependence-type",
       {
-        {Version(45), {{{Property::Ultimate, Property::Unique}}, {Clause::OMPC_depend}}},
-        {Version(50), {{{Property::Ultimate, Property::Unique}}, {Clause::OMPC_depend}}},
-        {Version(51), {{{Property::Ultimate, Property::Unique}}, {Clause::OMPC_depend}}},
-        {Version(52), {{{Property::Required, Property::Ultimate, Property::Unique}}, {Clause::OMPC_depend}}},
-        {Version(60), {{{Property::Unique}}, {Clause::OMPC_depend, Clause::OMPC_update_depend_objects}}},
-        {Version(61), {{{Property::Unique}}, {Clause::OMPC_depend, Clause::OMPC_update_depend_objects}}},
+        {Version(45), {{{Property::Compatible, Property::Optional, Property::Ultimate, Property::Unique}}, {Clause::OMPC_depend}}},
+        {Version(50), {{{Property::Compatible, Property::Optional, Property::Ultimate, Property::Unique}}, {Clause::OMPC_depend}}},
+        {Version(51), {{{Property::Compatible, Property::Optional, Property::Ultimate, Property::Unique}}, {Clause::OMPC_depend}}},
+        {Version(52), {{{Property::Compatible, Property::Required, Property::Ultimate, Property::Unique}}, {Clause::OMPC_depend}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_depend, Clause::OMPC_update_depend_objects}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_depend, Clause::OMPC_update_depend_objects}}},
       }
     ),
   },
@@ -2352,7 +2352,7 @@
     descriptor::Modifier(
       "task-modifier",
       {
-        {Version(61), {{{Property::Unique}}, {Clause::OMPC_reduction}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_reduction}}},
       }
     ),
   },
@@ -2361,9 +2361,9 @@
     descriptor::Modifier(
       "traits-array",
       {
-        {Version(52), {{{Property::Unique}}, {Clause::OMPC_uses_allocators}}},
-        {Version(60), {{{Property::Unique}}, {Clause::OMPC_uses_allocators}}},
-        {Version(61), {{{Property::Unique}}, {Clause::OMPC_uses_allocators}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_uses_allocators}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_uses_allocators}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_uses_allocators}}},
       }
     ),
   },
@@ -2372,16 +2372,72 @@
     descriptor::Modifier(
       "variable-category",
       {
-        {Version(45), {{{Property::Required, Property::Unique}}, {Clause::OMPC_defaultmap}}},
-        {Version(50), {{{Property::Unique}}, {Clause::OMPC_default, Clause::OMPC_defaultmap}}},
-        {Version(51), {{{Property::Unique}}, {Clause::OMPC_default, Clause::OMPC_defaultmap}}},
-        {Version(52), {{{Property::Unique}}, {Clause::OMPC_default, Clause::OMPC_defaultmap}}},
-        {Version(60), {{{Property::Unique}}, {Clause::OMPC_default, Clause::OMPC_defaultmap}}},
-        {Version(61), {{{Property::Unique}}, {Clause::OMPC_default, Clause::OMPC_defaultmap}}},
+        {Version(45), {{{Property::Compatible, Property::Free, Property::Required, Property::Unique}}, {Clause::OMPC_defaultmap}}},
+        {Version(50), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_default, Clause::OMPC_defaultmap}}},
+        {Version(51), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_default, Clause::OMPC_defaultmap}}},
+        {Version(52), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_default, Clause::OMPC_defaultmap}}},
+        {Version(60), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_default, Clause::OMPC_defaultmap}}},
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Clause::OMPC_default, Clause::OMPC_defaultmap}}},
       }
     ),
   },
 #endif // GEN_OMP_MODIFIER_DESCRIPTORS
+#ifdef GEN_OMP_MODIFIER_GROUP_DESCRIPTORS
+  {
+    ModifierSet::AdjustOp,
+    descriptor::ModifierSet(
+      "adjust-op",
+      {
+        {Version(61), {{{Property::Exclusive, Property::Free, Property::Required, Property::Unique}}, {Modifier::NeedDeviceAddr, Modifier::NeedDevicePtr, Modifier::Nothing}, {Clause::OMPC_adjust_args}}},
+      }
+    ),
+  },
+  {
+    ModifierSet::DependListType,
+    descriptor::ModifierSet(
+      "depend-list-type",
+      {
+        {Version(61), {{{Property::Exclusive, Property::Free, Property::Optional, Property::Unique}}, {Modifier::DepobjModifier, Modifier::LocModifier}, {Clause::OMPC_depend}}},
+      }
+    ),
+  },
+  {
+    ModifierSet::InteropType,
+    descriptor::ModifierSet(
+      "interop-type",
+      {
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Modifier::TargetType, Modifier::TargetsyncType}, {Clause::OMPC_init}}},
+      }
+    ),
+  },
+  {
+    ModifierSet::MapTypeModifying,
+    descriptor::ModifierSet(
+      "map-type-modifying",
+      {
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Optional, Property::Unique}}, {Modifier::AlwaysModifier, Modifier::CloseModifier, Modifier::DeleteModifier, Modifier::PresentModifier, Modifier::SelfModifier}, {Clause::OMPC_map}}},
+      }
+    ),
+  },
+  {
+    ModifierSet::ReductionType,
+    descriptor::ModifierSet(
+      "reduction-type",
+      {
+        {Version(61), {{{Property::Exclusive, Property::Free, Property::Optional, Property::Unique}}, {Modifier::DefaultModifier, Modifier::InscanModifier, Modifier::NoncommutativeModifier, Modifier::TaskModifier}, {Clause::OMPC_reduction}}},
+      }
+    ),
+  },
+  {
+    ModifierSet::VariableSelector,
+    descriptor::ModifierSet(
+      "variable-selector",
+      {
+        {Version(61), {{{Property::Compatible, Property::Free, Property::Required, Property::Unique}}, {Modifier::OptionalModifier, Modifier::VariableCategory}, {Clause::OMPC_default, Clause::OMPC_defaultmap}}},
+      }
+    ),
+  },
+#endif // GEN_OMP_MODIFIER_GROUP_DESCRIPTORS
 #ifdef GEN_OMP_MODIFIER_SET_DESCRIPTORS
   {
     ModifierSet::DependModifierSet1,
@@ -2391,6 +2447,7 @@
         {Version(45), {{{Property::Exclusive, Property::Required}}, {Modifier::DependenceType, Modifier::TaskDependenceType}, {Clause::OMPC_depend}}},
         {Version(50), {{{Property::Exclusive, Property::Required}}, {Modifier::DependenceType, Modifier::TaskDependenceType}, {Clause::OMPC_depend}}},
         {Version(51), {{{Property::Exclusive, Property::Required}}, {Modifier::DependenceType, Modifier::TaskDependenceType}, {Clause::OMPC_depend}}},
+        {Version(61), {{{Property::Exclusive, Property::Free, Property::Optional, Property::Unique}}, {Modifier::DepobjModifier, Modifier::TaskDependenceType}, {Clause::OMPC_depend}}},
       }
     ),
   },
@@ -2399,7 +2456,7 @@
     descriptor::ModifierSet(
       "num_teams_modifier_set_1",
       {
-        {Version(61), {{{Property::Exclusive}}, {Modifier::DimsModifier, Modifier::LowerBound}, {Clause::OMPC_num_teams}}},
+        {Version(61), {{{Property::Exclusive, Property::Free, Property::Optional, Property::Unique}}, {Modifier::DimsModifier, Modifier::LowerBound}, {Clause::OMPC_num_teams}}},
       }
     ),
   },
@@ -2408,65 +2465,9 @@
     descriptor::ModifierSet(
       "reduction_modifier_set_1",
       {
-        {Version(61), {{{Property::Exclusive}}, {Modifier::InscanModifier, Modifier::NoncommutativeModifier, Modifier::PerThreadModifier}, {Clause::OMPC_reduction}}},
+        {Version(61), {{{Property::Exclusive, Property::Free, Property::Optional, Property::Unique}}, {Modifier::InscanModifier, Modifier::NoncommutativeModifier, Modifier::PerThreadModifier}, {Clause::OMPC_reduction}}},
       }
     ),
   },
 #endif // GEN_OMP_MODIFIER_SET_DESCRIPTORS
-#ifdef GEN_OMP_MODIFIER_GROUP_DESCRIPTORS
-  {
-    ModifierSet::AdjustOp,
-    descriptor::ModifierSet(
-      "adjust-op",
-      {
-        {Version(61), {{{Property::Exclusive, Property::Required}}, {Modifier::NeedDeviceAddr, Modifier::NeedDevicePtr, Modifier::Nothing}, {Clause::OMPC_adjust_args}}},
-      }
-    ),
-  },
-  {
-    ModifierSet::DependListType,
-    descriptor::ModifierSet(
-      "depend-list-type",
-      {
-        {Version(61), {{{Property::Exclusive}}, {Modifier::DepobjModifier, Modifier::LocModifier}, {Clause::OMPC_depend}}},
-      }
-    ),
-  },
-  {
-    ModifierSet::InteropType,
-    descriptor::ModifierSet(
-      "interop-type",
-      {
-        {Version(61), {{{Property::Unique}}, {Modifier::TargetType, Modifier::TargetsyncType}, {Clause::OMPC_init}}},
-      }
-    ),
-  },
-  {
-    ModifierSet::MapTypeModifying,
-    descriptor::ModifierSet(
-      "map-type-modifying",
-      {
-        {Version(61), {{{Property::Unique}}, {Modifier::AlwaysModifier, Modifier::CloseModifier, Modifier::DeleteModifier, Modifier::PresentModifier, Modifier::SelfModifier}, {Clause::OMPC_map}}},
-      }
-    ),
-  },
-  {
-    ModifierSet::ReductionType,
-    descriptor::ModifierSet(
-      "reduction-type",
-      {
-        {Version(61), {{{Property::Exclusive}}, {Modifier::DefaultModifier, Modifier::InscanModifier, Modifier::NoncommutativeModifier, Modifier::TaskModifier}, {Clause::OMPC_reduction}}},
-      }
-    ),
-  },
-  {
-    ModifierSet::VariableSelector,
-    descriptor::ModifierSet(
-      "variable-selector",
-      {
-        {Version(61), {{{Property::Required}}, {Modifier::OptionalModifier, Modifier::VariableCategory}, {Clause::OMPC_default, Clause::OMPC_defaultmap}}},
-      }
-    ),
-  },
-#endif // GEN_OMP_MODIFIER_GROUP_DESCRIPTORS
     // clang-format on


### PR DESCRIPTION
For clauses, modifiers, and modifier sets/groups, make sure that either the syntactic proprty or its inverse is explicitily listed, with the missing properties added according to the following table.
```
                       |                           Modifier
            Inverse    | Clause       Modifier     group
Property    property   | defaults     defaults     defaults
----------+------------+------------+------------+-----------
required    optional   | optional     optional     optional
unique      repeatable | repeatable   unique       unique
exclusive   compatible | compatible   compatible   compatible
ultimate    free       | free         free         free
```