### PR TITLE
Use Z3 (when available) for more complex cases in the clang dataflow framework

### DIFF
--- a/clang/include/clang/Analysis/FlowSensitive/DataflowAnalysis.h
+++ b/clang/include/clang/Analysis/FlowSensitive/DataflowAnalysis.h
@@ -209,8 +209,11 @@ template <typename AnalysisT, typename Diagnostic> struct DiagnosisCallbacks {
   DiagnosisCallback<AnalysisT, Diagnostic> After;
 };
 
-/// Default for the maximum number of SAT solver iterations during analysis.
-inline constexpr std::int64_t kDefaultMaxSATIterations = 1'000'000'000;
+/// A factory for creating a Solver.
+using SolverFactory = std::function<std::unique_ptr<Solver>()>;
+
+/// Default SolverFactory.
+std::unique_ptr<Solver> createDefaultSolver();
 
 /// Default for the maximum number of block visits during analysis.
 inline constexpr std::int32_t kDefaultMaxBlockVisits = 20'000;
@@ -307,12 +310,8 @@ auto createAnalysis(ASTContext &ASTCtx, Environment &Env)
 /// error. Currently, errors can occur (at least) because the analysis requires
 /// too many iterations over the CFG or the SAT solver times out.
 ///
-/// The default value of `MaxSATIterations` was chosen based on the following
-/// observations:
-/// - Non-pathological calls to the solver typically require only a few hundred
-///   iterations.
-/// - This limit is still low enough to keep runtimes acceptable (on typical
-///   machines) in cases where we hit the limit.
+/// `MakeSolver` allows the caller to inject a custom SAT solver (e.g.,
+/// it may have custom timeout settings, or use different algorithms).
 ///
 /// `MaxBlockVisits` caps the number of block visits during analysis. See
 /// `runDataflowAnalysis` for a full description and explanation of the default
@@ -321,13 +320,13 @@ template <typename AnalysisT, typename Diagnostic>
 llvm::Expected<llvm::SmallVector<Diagnostic>>
 diagnoseFunction(const FunctionDecl &FuncDecl, ASTContext &ASTCtx,
                  DiagnosisCallbacks<AnalysisT, Diagnostic> Diagnoser,
-                 std::int64_t MaxSATIterations = kDefaultMaxSATIterations,
+                 const SolverFactory &MakeSolver = createDefaultSolver,
                  std::int32_t MaxBlockVisits = kDefaultMaxBlockVisits) {
   llvm::Expected<AdornedCFG> Context = AdornedCFG::build(FuncDecl);
   if (!Context)
     return Context.takeError();
 
-  auto Solver = std::make_unique<WatchedLiteralsSolver>(MaxSATIterations);
+  auto Solver = MakeSolver();
   DataflowAnalysisContext AnalysisContext(*Solver);
   Environment Env(AnalysisContext, FuncDecl);
   AnalysisT Analysis = createAnalysis<AnalysisT>(ASTCtx, Env);
@@ -382,10 +381,10 @@ template <typename AnalysisT, typename Diagnostic>
 llvm::Expected<llvm::SmallVector<Diagnostic>>
 diagnoseFunction(const FunctionDecl &FuncDecl, ASTContext &ASTCtx,
                  DiagnosisCallback<AnalysisT, Diagnostic> Diagnoser,
-                 std::int64_t MaxSATIterations = kDefaultMaxSATIterations,
+                 const SolverFactory &MakeSolver = createDefaultSolver,
                  std::int32_t MaxBlockVisits = kDefaultMaxBlockVisits) {
   DiagnosisCallbacks<AnalysisT, Diagnostic> Callbacks = {nullptr, Diagnoser};
-  return diagnoseFunction(FuncDecl, ASTCtx, Callbacks, MaxSATIterations,
+  return diagnoseFunction(FuncDecl, ASTCtx, Callbacks, MakeSolver,
                           MaxBlockVisits);
 }
 

--- a/clang/include/clang/Analysis/FlowSensitive/TieredSolver.h
+++ b/clang/include/clang/Analysis/FlowSensitive/TieredSolver.h
@@ -1,0 +1,64 @@
+//===- TieredSolver.h -------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file defines a SAT solver implementation that can be used by dataflow
+//  analyses.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_ANALYSIS_FLOWSENSITIVE_TIEREDSOLVER_H
+#define LLVM_CLANG_ANALYSIS_FLOWSENSITIVE_TIEREDSOLVER_H
+
+#include "clang/Analysis/FlowSensitive/Formula.h"
+#include "clang/Analysis/FlowSensitive/Solver.h"
+#include "llvm/ADT/ArrayRef.h"
+
+namespace clang {
+namespace dataflow {
+
+/// A `Solver` implementation that delegates to a sequence of other solvers.
+///
+/// The first solver that does not time out is used to produce the result.
+///
+/// The intent is that we can combine a solver that solves simple problems
+/// quickly but times out on harder problems (e.g. `WatchedLiteralsSolver`) with
+/// a solver that solves simple problems more slowly but can solve harder
+/// problems without timing out.
+class TieredSolver : public Solver {
+public:
+  explicit TieredSolver(llvm::SmallVector<std::unique_ptr<Solver>> Tiers)
+      : Tiers_(std::move(Tiers)) {
+    assert(!Tiers_.empty());
+  }
+
+  Result solve(llvm::ArrayRef<const Formula *> Constraints) override {
+    for (const auto &Tier : Tiers_) {
+      Result Res = Tier->solve(Constraints);
+      if (Res.getStatus() != Result::Status::TimedOut)
+        return Res;
+    }
+
+    return Result::TimedOut();
+  }
+
+  bool reachedLimit() const override {
+    for (const auto &Tier : Tiers_)
+      if (!Tier->reachedLimit())
+        return false;
+
+    return true;
+  }
+
+private:
+  llvm::SmallVector<std::unique_ptr<Solver>> Tiers_;
+};
+
+} // namespace dataflow
+} // namespace clang
+
+#endif // LLVM_CLANG_ANALYSIS_FLOWSENSITIVE_TIEREDSOLVER_H

--- a/clang/include/clang/Analysis/FlowSensitive/Z3Solver.h
+++ b/clang/include/clang/Analysis/FlowSensitive/Z3Solver.h
@@ -1,0 +1,58 @@
+//===- Z3Solver.h -----------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file defines a Z3-based SAT solver implementation that can be used by
+//  dataflow analyses.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_ANALYSIS_FLOWSENSITIVE_Z3SOLVER_H
+#define LLVM_CLANG_ANALYSIS_FLOWSENSITIVE_Z3SOLVER_H
+
+#include "clang/Analysis/FlowSensitive/Formula.h"
+#include "clang/Analysis/FlowSensitive/Solver.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/Support/SMTAPI.h"
+
+namespace clang {
+namespace dataflow {
+
+/// Wrapper around Z3 to use it as a SAT solver (not full SMT).
+class Z3Solver : public Solver {
+
+public:
+  Z3Solver() : Solver(llvm::CreateZ3Solver()) {
+    Solver->setBoolParam("model", true);
+  }
+
+  // Creates a Z3-based solver with the given "rlimit" (0 is unlimited).
+  // Rlimit is a count of operations, which may be more deterministic
+  // than time. However, it could change across Z3 versions:
+  // https://stackoverflow.com/questions/45457131/what-is-the-relation-between-options-rlimit-and-timeout/45458651#45458651
+  explicit Z3Solver(std::uint32_t Rlimit)
+      : Rlimit(Rlimit), Solver(llvm::CreateZ3Solver()) {
+    Solver->setBoolParam("model", true);
+  }
+
+  Result solve(llvm::ArrayRef<const Formula *> Vals) override;
+
+  bool reachedLimit() const override { return EverTimedOut; }
+
+private:
+  std::uint32_t Rlimit = 0;     // 0 is unlimited
+  std::uint32_t RlimitUsed = 0; // track rlimit used (if Rlimit is non-zero)
+  bool EverTimedOut = false;
+  llvm::SMTSolverRef Solver;
+
+  void updateRlimitUsed(const llvm::SMTSolverRef &Solver);
+};
+
+} // namespace dataflow
+} // namespace clang
+
+#endif // LLVM_CLANG_ANALYSIS_FLOWSENSITIVE_Z3SOLVER_H

--- a/clang/lib/Analysis/FlowSensitive/CMakeLists.txt
+++ b/clang/lib/Analysis/FlowSensitive/CMakeLists.txt
@@ -3,8 +3,10 @@ add_clang_library(clangAnalysisFlowSensitive
   Arena.cpp
   ASTOps.cpp
   CNFFormula.cpp
+  DataflowAnalysis.cpp
   DataflowAnalysisContext.cpp
   DataflowEnvironment.cpp
+  DebugSupport.cpp
   Formula.cpp
   FormulaSerialization.cpp
   HTMLLogger.cpp
@@ -16,7 +18,7 @@ add_clang_library(clangAnalysisFlowSensitive
   TypeErasedDataflowAnalysis.cpp
   Value.cpp
   WatchedLiteralsSolver.cpp
-  DebugSupport.cpp
+  Z3Solver.cpp
 
   DEPENDS
   clangAnalysisFlowSensitiveResources

--- a/clang/lib/Analysis/FlowSensitive/DataflowAnalysis.cpp
+++ b/clang/lib/Analysis/FlowSensitive/DataflowAnalysis.cpp
@@ -1,0 +1,50 @@
+//===-- DataflowAnalysis.cpp ------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file defines functions for the DataflowAnalysis entry points.
+//
+//===----------------------------------------------------------------------===//
+
+#include "clang/Analysis/FlowSensitive/DataflowAnalysis.h"
+#include "clang/Analysis/FlowSensitive/Solver.h"
+#include "clang/Analysis/FlowSensitive/TieredSolver.h"
+#include "clang/Analysis/FlowSensitive/WatchedLiteralsSolver.h"
+#include "clang/Analysis/FlowSensitive/Z3Solver.h"
+#include "llvm/ADT/SmallVector.h"
+
+namespace clang {
+namespace dataflow {
+
+std::unique_ptr<Solver> createDefaultSolver() {
+#ifdef LLVM_WITH_Z3
+  // When Z3 is available, do a tiering strategy:
+  // - a simple solver for simple functions
+  // - fall back to a production-grade solver for more complex functions.
+  llvm::SmallVector<std::unique_ptr<dataflow::Solver>> Tiers;
+  constexpr std::int64_t MaxSATIterations = 5'000'000;
+  Tiers.push_back(
+      std::make_unique<dataflow::WatchedLiteralsSolver>(MaxSATIterations));
+
+  constexpr std::uint32_t Z3Rlimit = 1'000'000'000;
+  Tiers.push_back(std::make_unique<dataflow::Z3Solver>(Z3Rlimit));
+  return std::make_unique<TieredSolver>(std::move(Tiers));
+#else
+  /// Default for the maximum number of SAT solver iterations during analysis.
+  /// The value was chosen based on the following observations:
+  /// - Non-pathological calls to the solver typically require only a few
+  /// hundred
+  ///   iterations.
+  /// - This limit is still low enough to keep runtimes acceptable (on typical
+  ///   machines) in cases where we hit the limit.
+  constexpr std::int64_t kDefaultMaxSATIterations = 1'000'000'000;
+  return std::make_unique<WatchedLiteralsSolver>(kDefaultMaxSATIterations);
+#endif
+}
+
+} // namespace dataflow
+} // namespace clang

--- a/clang/lib/Analysis/FlowSensitive/Z3Solver.cpp
+++ b/clang/lib/Analysis/FlowSensitive/Z3Solver.cpp
@@ -1,0 +1,135 @@
+//===- Z3Solver.cpp ---------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file defines a Z3-based SAT solver implementation that can be used by
+//  dataflow analyses.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cassert>
+#include <vector>
+
+#include "clang/Analysis/FlowSensitive/CNFFormula.h"
+#include "clang/Analysis/FlowSensitive/Formula.h"
+#include "clang/Analysis/FlowSensitive/Solver.h"
+#include "clang/Analysis/FlowSensitive/Z3Solver.h"
+#include "llvm/ADT/APInt.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallString.h"
+#include "llvm/Support/SMTAPI.h"
+
+namespace clang {
+namespace dataflow {
+
+static llvm::DenseMap<Atom, Solver::Result::Assignment>
+buildSolution(const llvm::SMTSolverRef &Solver,
+              const llvm::DenseMap<Variable, Atom> &Atomics,
+              llvm::ArrayRef<llvm::SMTExprRef> BoolVars) {
+  llvm::DenseMap<Atom, Solver::Result::Assignment> Solution;
+
+  for (auto &Atomic : Atomics) {
+    llvm::SMTExprRef Var = BoolVars[Atomic.first];
+    llvm::APSInt Result = llvm::APSInt(1);
+    if (!Solver->getInterpretation(Var, Result)) {
+      // Model doesn't assign a value -- just pick one.
+      Solution[Atomic.second] = Solver::Result::Assignment::AssignedTrue;
+    } else {
+      Solution[Atomic.second] = Result.getBoolValue()
+                                    ? Solver::Result::Assignment::AssignedTrue
+                                    : Solver::Result::Assignment::AssignedFalse;
+    }
+  }
+
+  return Solution;
+}
+
+void Z3Solver::updateRlimitUsed(const llvm::SMTSolverRef &Solver) {
+  if (Rlimit > 0) {
+    std::uint32_t NextRlimitUsed =
+        Solver->getStatistics()->getUnsigned("rlimit count");
+    std::uint32_t Next = RlimitUsed + NextRlimitUsed;
+    // If overflow, clamp
+    if (Next < RlimitUsed)
+      RlimitUsed = Rlimit;
+    // If going past Rlimit, clamp
+    else if (Next > Rlimit)
+      RlimitUsed = Rlimit;
+    else
+      RlimitUsed = Next;
+  }
+}
+
+Solver::Result Z3Solver::solve(llvm::ArrayRef<const Formula *> Constraints) {
+  if (Constraints.empty()) {
+    return Result::Satisfiable(llvm::DenseMap<Atom, Result::Assignment>());
+  }
+  if (Rlimit > 0 && RlimitUsed == Rlimit) {
+    return Result::TimedOut();
+  }
+
+  llvm::DenseMap<Variable, Atom> Atomics;
+  CNFFormula CNF = buildCNF(Constraints, Atomics);
+
+  if (CNF.knownContradictory())
+    return Result::Unsatisfiable();
+
+  Solver->reset();
+  Solver->setBoolParam("model", true);
+  if (Rlimit != 0) {
+    std::uint32_t Remaining = Rlimit - RlimitUsed;
+    Solver->setUnsignedParam("rlimit", Remaining);
+  }
+
+  std::vector<llvm::SMTExprRef> BoolVars;
+  BoolVars.resize(CNF.largestVar() + 1);
+  llvm::SmallString<16> Str;
+  llvm::raw_svector_ostream OS(Str);
+  llvm::SMTSortRef BoolSort = Solver->getBoolSort();
+  for (Variable V = 1; V <= CNF.largestVar(); ++V) {
+    OS << "v" << V;
+    BoolVars[V] = Solver->mkSymbol(Str.c_str(), BoolSort);
+    Str.clear();
+  }
+
+  for (size_t ClauseId = 1; ClauseId <= CNF.numClauses(); ++ClauseId) {
+    llvm::SMTExprRef Clause = nullptr;
+    for (Literal Lit : CNF.clauseLiterals(ClauseId)) {
+      llvm::SMTExprRef Var = BoolVars[var(Lit)];
+      if (isNegLit(Lit))
+        Var = Solver->mkNot(Var);
+      if (Clause == nullptr) {
+        Clause = Var;
+      } else {
+        Clause = Solver->mkOr(Clause, Var);
+      }
+    }
+    if (Clause == nullptr) {
+      Solver->addConstraint(Solver->mkBoolean(false));
+    } else {
+      Solver->addConstraint(Clause);
+    }
+  }
+
+  std::optional<bool> IsSat = Solver->check();
+
+  // Update rlimit
+  updateRlimitUsed(Solver);
+
+  if (IsSat.has_value()) {
+    if (IsSat.value()) {
+      return Result::Satisfiable(buildSolution(Solver, Atomics, BoolVars));
+    }
+    return Result::Unsatisfiable();
+  }
+  EverTimedOut = true;
+  return Result::TimedOut();
+}
+
+} // namespace dataflow
+} // namespace clang

--- a/clang/unittests/Analysis/FlowSensitive/CMakeLists.txt
+++ b/clang/unittests/Analysis/FlowSensitive/CMakeLists.txt
@@ -29,6 +29,7 @@ add_clang_unittest(ClangAnalysisFlowSensitiveTests
   UncheckedStatusOrAccessModelTestFixture.cpp
   ValueTest.cpp
   WatchedLiteralsSolverTest.cpp
+  Z3SolverTest.cpp
   CLANG_LIBS
   clangAST
   clangASTMatchers

--- a/clang/unittests/Analysis/FlowSensitive/TieredSolverTest.cpp
+++ b/clang/unittests/Analysis/FlowSensitive/TieredSolverTest.cpp
@@ -1,0 +1,84 @@
+#include "clang/Analysis/FlowSensitive/TieredSolver.h"
+
+#include <memory>
+
+#include "clang/Analysis/FlowSensitive/Formula.h"
+#include "clang/Analysis/FlowSensitive/Solver.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/SmallVector.h"
+#include "gtest/gtest.h"
+
+namespace clang::dataflow::test {
+
+namespace {
+
+using Result = Solver::Result;
+
+class MockSolver : public Solver {
+public:
+  explicit MockSolver(Result Res) : Res(Res) {}
+
+  Result solve(llvm::ArrayRef<const dataflow::Formula *>) override {
+    return Res;
+  }
+
+  bool reachedLimit() const override {
+    return Res.getStatus() == Result::Status::TimedOut;
+  }
+
+private:
+  Result Res;
+};
+
+static llvm::SmallVector<std::unique_ptr<Solver>>
+makeMockSolvers(llvm::ArrayRef<Result> Results) {
+  llvm::SmallVector<std::unique_ptr<dataflow::Solver>> Solvers;
+
+  for (const auto &Res : Results)
+    Solvers.push_back(std::make_unique<MockSolver>(Res));
+
+  return Solvers;
+}
+
+TEST(TieredSolverTest, SingleSatisfiableStage) {
+  TieredSolver Solver(makeMockSolvers({Result::Satisfiable({{}})}));
+  EXPECT_EQ(Solver.solve({}).getStatus(), Result::Status::Satisfiable);
+  EXPECT_FALSE(Solver.reachedLimit());
+}
+
+TEST(TieredSolverTest, SingleUnsatisfiableStage) {
+  TieredSolver Solver(makeMockSolvers({Result::Unsatisfiable()}));
+  EXPECT_EQ(Solver.solve({}).getStatus(), Result::Status::Unsatisfiable);
+  EXPECT_FALSE(Solver.reachedLimit());
+}
+
+TEST(TieredSolverTest, SingleTimedOutStage) {
+  TieredSolver Solver(makeMockSolvers({Result::TimedOut()}));
+  EXPECT_EQ(Solver.solve({}).getStatus(), Result::Status::TimedOut);
+  EXPECT_TRUE(Solver.reachedLimit());
+}
+
+TEST(TieredSolverTest, UnsatisfiableThenTimedOut) {
+  TieredSolver Solver(
+      makeMockSolvers({Result::Unsatisfiable(), Result::TimedOut()}));
+  EXPECT_EQ(Solver.solve({}).getStatus(), Result::Status::Unsatisfiable);
+  EXPECT_FALSE(Solver.reachedLimit());
+}
+
+TEST(TieredSolverTest, TimedOutThenUnsatisfiable) {
+  TieredSolver Solver(
+      makeMockSolvers({Result::TimedOut(), Result::Unsatisfiable()}));
+  EXPECT_EQ(Solver.solve({}).getStatus(), Result::Status::Unsatisfiable);
+  EXPECT_FALSE(Solver.reachedLimit());
+}
+
+TEST(TieredSolverTest, TwoTimedOutStages) {
+  TieredSolver Solver(
+      makeMockSolvers({Result::TimedOut(), Result::TimedOut()}));
+  EXPECT_EQ(Solver.solve({}).getStatus(), Result::Status::TimedOut);
+  EXPECT_TRUE(Solver.reachedLimit());
+}
+
+} // namespace
+
+} // namespace clang::dataflow::test

--- a/clang/unittests/Analysis/FlowSensitive/Z3SolverTest.cpp
+++ b/clang/unittests/Analysis/FlowSensitive/Z3SolverTest.cpp
@@ -1,0 +1,27 @@
+//===- unittests/Analysis/FlowSensitive/Z3SolverTest.cpp -----===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "clang/Analysis/FlowSensitive/Z3Solver.h"
+#include "SolverTest.h"
+
+namespace clang::dataflow::test {
+
+#ifdef LLVM_WITH_Z3
+template <> Z3Solver SolverTest<Z3Solver>::createSolverWithLowTimeout() {
+  return Z3Solver(1);
+}
+
+namespace {
+
+INSTANTIATE_TYPED_TEST_SUITE_P(Z3SolverTest, SolverTest, Z3Solver, );
+
+} // namespace
+
+#endif // LLVM_WITH_Z3
+
+} // namespace clang::dataflow::test


### PR DESCRIPTION
Adds a Solver factory that users can override at the entry point of the clang dataflow framework.

For issue #204593

Current approach implicitly/automatically uses Z3 if available in the build. If it is not available in the build, will just use
the current basic WatchedLiteralsSolver (no functionality change). For distributions like Ubuntu, it seems Clang is built with Z3 as a dependency.

Alternatively, we could gate this on a checker option similar to how CSA has `-crosscheck-with-z3=true`, which a user must request explicitly. Then, there is a runtime error if Z3 was not actually available. However, it is not clear users will know to enable this.

Uses the Z3 rlimit setting to try and limit time spent  (WatchedLiterals solver had an iteration limit).

Benchmark with ccache (issue #69369):
- before: 78.4121 seconds overall (24.9s for the slowest TU argprocessing.cpp -- including parsing, etc.)
- after:  4.9644 seconds overall (8.7s for the slowest TU argprocessing.cpp -- including parsing, etc.)

"Overall" time is from `run-clang-tidy.py ... -enable-check-profile` sum over the ccache project.
