### PR TITLE
[Clang] Remove Decl::hasBody() and devirtualize {ObjCMethod,Function}Decl::hadBody()

### DIFF
--- a/clang/include/clang/AST/Decl.h
+++ b/clang/include/clang/AST/Decl.h
@@ -2364,7 +2364,7 @@ public:
   /// there is one).
   bool hasBody(const FunctionDecl *&Definition) const;
 
-  bool hasBody() const override {
+  bool hasBody() const {
     const FunctionDecl* Definition;
     return hasBody(Definition);
   }

--- a/clang/include/clang/AST/DeclBase.h
+++ b/clang/include/clang/AST/DeclBase.h
@@ -1103,12 +1103,6 @@ public:
   ///  top-level Stmt* of that body.  Otherwise this method returns null.
   virtual Stmt* getBody() const { return nullptr; }
 
-  /// Returns true if this \c Decl represents a declaration for a body of
-  /// code, such as a function or method definition.
-  /// Note that \c hasBody can also return true if any redeclaration of this
-  /// \c Decl represents a declaration for a body of code.
-  virtual bool hasBody() const { return getBody() != nullptr; }
-
   /// getBodyRBrace - Gets the right brace of the body, if a body exists.
   /// This works whether the body is a CompoundStmt or a CXXTryStmt.
   SourceLocation getBodyRBrace() const;

--- a/clang/include/clang/AST/DeclObjC.h
+++ b/clang/include/clang/AST/DeclObjC.h
@@ -523,7 +523,7 @@ public:
       const ObjCMethodDecl **InitMethod = nullptr) const;
 
   /// Determine whether this method has a body.
-  bool hasBody() const override { return Body.isValid(); }
+  bool hasBody() const { return Body.isValid(); }
 
   /// Retrieve the body of this method, if it has one.
   Stmt *getBody() const override;

--- a/clang/include/clang/Analysis/CallGraph.h
+++ b/clang/include/clang/Analysis/CallGraph.h
@@ -66,12 +66,6 @@ public:
     TraverseDecl(D);
   }
 
-  /// Determine if a declaration should be included in the graph.
-  static bool includeInGraph(const Decl *D);
-
-  /// Determine if a declaration should be included in the graph for the
-  /// purposes of being a callee. This is similar to includeInGraph except
-  /// it permits declarations, not just definitions.
   static bool includeCalleeInGraph(const Decl *D);
 
   /// Lookup the node for the given declaration.
@@ -115,7 +109,7 @@ public:
   bool VisitFunctionDecl(FunctionDecl *FD) override {
     // We skip function template definitions, as their semantics is
     // only determined when they are instantiated.
-    if (includeInGraph(FD) && FD->isThisDeclarationADefinition()) {
+    if (FD->isThisDeclarationADefinition() && includeCalleeInGraph(FD)) {
       // Add all blocks declared inside this function to the graph.
       addNodesForBlocks(FD);
       // If this function has external linkage, anything could call it.
@@ -128,7 +122,7 @@ public:
 
   /// Part of recursive declaration visitation.
   bool VisitObjCMethodDecl(ObjCMethodDecl *MD) override {
-    if (includeInGraph(MD)) {
+    if (MD->hasBody()) {
       addNodesForBlocks(MD);
       addNodeForDecl(MD, true);
     }

--- a/clang/lib/Analysis/CallGraph.cpp
+++ b/clang/lib/Analysis/CallGraph.cpp
@@ -154,14 +154,6 @@ CallGraph::CallGraph() {
 
 CallGraph::~CallGraph() = default;
 
-bool CallGraph::includeInGraph(const Decl *D) {
-  assert(D);
-  if (!D->hasBody())
-    return false;
-
-  return includeCalleeInGraph(D);
-}
-
 bool CallGraph::includeCalleeInGraph(const Decl *D) {
   if (const FunctionDecl *FD = dyn_cast<FunctionDecl>(D)) {
     // We skip function template definitions, as their semantics is

--- a/clang/lib/Analysis/CloneDetection.cpp
+++ b/clang/lib/Analysis/CloneDetection.cpp
@@ -89,7 +89,7 @@ SourceRange StmtSequence::getSourceRange() const {
 
 void CloneDetector::analyzeCodeBody(const Decl *D) {
   assert(D);
-  assert(D->hasBody());
+  assert(D->getBody());
 
   Sequences.push_back(StmtSequence(D->getBody(), D));
 }

--- a/clang/lib/Analysis/PathDiagnostic.cpp
+++ b/clang/lib/Analysis/PathDiagnostic.cpp
@@ -1016,8 +1016,8 @@ std::shared_ptr<PathDiagnosticEventPiece>
 PathDiagnosticCallPiece::getCallEnterWithinCallerEvent() const {
   if (!callEnterWithin.asLocation().isValid())
     return nullptr;
-  if (Callee->isImplicit() || !Callee->hasBody())
-    return nullptr;
+  // if (Callee->isImplicit() || !Callee->hasBody())
+  //   return nullptr;
   if (const auto *MD = dyn_cast<CXXMethodDecl>(Callee))
     if (MD->isDefaulted())
       return nullptr;

--- a/clang/lib/CodeGen/CGStmt.cpp
+++ b/clang/lib/CodeGen/CGStmt.cpp
@@ -3484,7 +3484,7 @@ CodeGenFunction::GenerateCapturedStmtFunction(const CapturedStmt &S) {
   const CapturedDecl *CD = S.getCapturedDecl();
   const RecordDecl *RD = S.getCapturedRecordDecl();
   SourceLocation Loc = S.getBeginLoc();
-  assert(CD->hasBody() && "missing CapturedDecl body");
+  assert(CD->getBody() && "missing CapturedDecl body");
 
   // Build the argument list.
   ASTContext &Ctx = CGM.getContext();

--- a/clang/lib/CodeGen/CGStmtOpenMP.cpp
+++ b/clang/lib/CodeGen/CGStmtOpenMP.cpp
@@ -532,7 +532,7 @@ static llvm::Function *emitOutlinedFunctionPrologue(
     llvm::Value *&CXXThisValue, const FunctionOptions &FO) {
   const CapturedDecl *CD = FO.S->getCapturedDecl();
   const RecordDecl *RD = FO.S->getCapturedRecordDecl();
-  assert(CD->hasBody() && "missing CapturedDecl body");
+  assert(CD->getBody() && "missing CapturedDecl body");
 
   CXXThisValue = nullptr;
   // Build the argument list.

--- a/clang/lib/CodeGen/CodeGenPGO.cpp
+++ b/clang/lib/CodeGen/CodeGenPGO.cpp
@@ -921,7 +921,7 @@ uint64_t PGOHash::finalize() {
 
 void CodeGenPGO::assignRegionCounters(GlobalDecl GD, llvm::Function *Fn) {
   const Decl *D = GD.getDecl();
-  if (!D->hasBody())
+  if (!D->getBody())
     return;
 
   // Skip CUDA/HIP kernel launch stub functions.

--- a/clang/lib/Sema/SemaFunctionEffects.cpp
+++ b/clang/lib/Sema/SemaFunctionEffects.cpp
@@ -1479,10 +1479,9 @@ void Sema::diagnoseFunctionEffectMergeConflicts(
 // Decl should be a FunctionDecl or BlockDecl.
 void Sema::maybeAddDeclWithEffects(const Decl *D,
                                    const FunctionEffectsRef &FX) {
-  if (!D->hasBody()) {
-    if (const auto *FD = D->getAsFunction(); FD && !FD->willHaveBody())
-      return;
-  }
+  if (const auto *FD = D->getAsFunction();
+      FD && !FD->hasBody() && !FD->willHaveBody())
+    return;
 
   if (Diags.getIgnoreAllWarnings() ||
       (Diags.getSuppressSystemWarnings() &&

--- a/clang/lib/StaticAnalyzer/Core/BugReporter.cpp
+++ b/clang/lib/StaticAnalyzer/Core/BugReporter.cpp
@@ -518,7 +518,7 @@ static void removePopUpNotes(PathPieces &Path) {
 /// the analyzer or by the compiler proper.
 static bool hasImplicitBody(const Decl *D) {
   assert(D);
-  return D->isImplicit() || !D->hasBody();
+  return D->isImplicit() || !D->getBody();
 }
 
 /// Recursively scan through a path and make sure that all call pieces have
@@ -1167,7 +1167,7 @@ void PathDiagnosticBuilder::generatePathDiagnosticsForNode(
       // Objective-C. No need for a similar extra check for CallExit points
       // because the exit edge comes from a statement (i.e. return),
       // not from declaration.
-      if (D->hasBody())
+      if (D->getBody())
         addEdgeToPath(C.getActivePath(), PrevLoc,
                       PathDiagnosticLocation::createBegin(D, SM));
     }

--- a/clang/lib/StaticAnalyzer/Core/CallEvent.cpp
+++ b/clang/lib/StaticAnalyzer/Core/CallEvent.cpp
@@ -1221,8 +1221,8 @@ static const ObjCMethodDecl *findDefiningRedecl(const ObjCMethodDecl *MD) {
   // Find the redeclaration that defines the method.
   if (!MD->hasBody()) {
     for (auto *I : MD->redecls())
-      if (I->hasBody())
-        MD = cast<ObjCMethodDecl>(I);
+      if (auto * NewMD = cast<ObjCMethodDecl>(I); NewMD->hasBody())
+        MD = NewMD;
   }
   return MD;
 }

--- a/clang/lib/StaticAnalyzer/Core/CheckerManager.cpp
+++ b/clang/lib/StaticAnalyzer/Core/CheckerManager.cpp
@@ -83,7 +83,7 @@ void CheckerManager::runCheckersOnASTDecl(const Decl *D, AnalysisManager& mgr,
 
 void CheckerManager::runCheckersOnASTBody(const Decl *D, AnalysisManager& mgr,
                                           BugReporter &BR) {
-  assert(D && D->hasBody());
+  assert(D && D->getBody());
 
   for (const auto &BodyChecker : BodyCheckers)
     BodyChecker(D, mgr, BR);

--- a/clang/lib/StaticAnalyzer/Frontend/AnalysisConsumer.cpp
+++ b/clang/lib/StaticAnalyzer/Frontend/AnalysisConsumer.cpp
@@ -324,7 +324,7 @@ public:
     // We skip function template definitions, as their semantics is
     // only determined when they are instantiated.
     if (FD->isThisDeclarationADefinition() &&
-        !FD->isDependentContext()) {
+        !FD->isDependentContext() && FD->hasBody()) {
       assert(RecVisitorMode == AM_Syntax || Mgr->shouldInlineCall() == false);
       HandleCode(FD, RecVisitorMode);
     }
@@ -340,7 +340,7 @@ public:
   }
 
   bool VisitBlockDecl(BlockDecl *BD) override {
-    if (BD->hasBody()) {
+    if (BD->getBody()) {
       assert(RecVisitorMode == AM_Syntax || Mgr->shouldInlineCall() == false);
       // Since we skip function template definitions, we should skip blocks
       // declared in those functions as well.
@@ -525,8 +525,11 @@ void AnalysisConsumer::HandleDeclsCallGraph(const unsigned LocalTUDeclsSize) {
     // Analyze the function.
     SetOfConstDecls VisitedCallees;
 
-    HandleCode(D, AM_Path, getInliningModeForFunction(D, Visited),
-               (Mgr->options.InliningMode == All ? nullptr : &VisitedCallees));
+    if (D->getBody()) {
+      HandleCode(
+          D, AM_Path, getInliningModeForFunction(D, Visited),
+          (Mgr->options.InliningMode == All ? nullptr : &VisitedCallees));
+    }
 
     // Add the visited callees to the global visited set.
     for (const Decl *Callee : VisitedCallees)
@@ -719,8 +722,7 @@ void AnalysisConsumer::HandleCode(Decl *D, AnalysisMode Mode,
                                   SetOfConstDecls *VisitedCallees) {
   llvm::TimeTraceScope TCS(timeTraceScopeDeclName("HandleCode", D),
                            [D]() { return timeTraceScopeDeclMetadata(D); });
-  if (!D->hasBody())
-    return;
+  assert(D->getBody());
   Mode = getModeForDecl(D, Mode);
   if (Mode == AM_None)
     return;

--- a/clang/unittests/StaticAnalyzer/CallDescriptionTest.cpp
+++ b/clang/unittests/StaticAnalyzer/CallDescriptionTest.cpp
@@ -61,7 +61,7 @@ class CallDescriptionConsumer : public ExprEngineConsumer {
     using namespace ast_matchers;
     using T = MatchedExprT;
 
-    if (!D->hasBody())
+    if (!D->getBody())
       return;
 
     const StackFrame *SF =


### PR DESCRIPTION
In almost all cases we either already know that we have a `FunctionDecl` or `ObjCMethodDecl`, in which case we don't need a virtual function. In the rest of the cases we either `assert`, in which case we might as well use `getBody()` instead, or we'll need the body anyway.