### PR TITLE
[libc++] Reword confusing warning message about AppleClang version

### DIFF
--- a/libcxx/include/__configuration/compiler.h
+++ b/libcxx/include/__configuration/compiler.h
@@ -38,7 +38,7 @@
 #    endif
 #  elif defined(_LIBCPP_APPLE_CLANG_VER)
 #    if _LIBCPP_APPLE_CLANG_VER < 2100
-#      warning "Libc++ only supports AppleClang 26.4 and later"
+#      warning "Libc++ only supports AppleClang 21.0 (from Xcode >= 26.4) and later"
 #    endif
 #  elif defined(_LIBCPP_GCC_VER)
 #    if _LIBCPP_GCC_VER < 1600


### PR DESCRIPTION
AppleClang 26.4 is not a thing -- it's AppleClang 21.0 that shipped with Xcode 26.4.