### PR TITLE
[lldb] Fix DIL losing StackFrame context after casting to pointer

### DIFF
--- a/lldb/source/ValueObject/DILEval.cpp
+++ b/lldb/source/ValueObject/DILEval.cpp
@@ -2057,11 +2057,9 @@ llvm::Expected<lldb::ValueObjectSP> Interpreter::Visit(const CastNode &node) {
                         ? operand->GetLoadAddress()
                         : (op_type.IsSigned() ? operand->GetValueAsSigned(0)
                                               : operand->GetValueAsUnsigned(0));
-    llvm::StringRef name = "result";
-    ExecutionContext exe_ctx(m_target.get(), false);
-    result = ValueObject::CreateValueObjectFromAddress(name, addr, exe_ctx,
-                                                       target_type,
-                                                       /* do_deref */ false);
+    result = ValueObject::CreateValueObjectFromAddress(
+        "result", addr, m_stack_frame, target_type,
+        /* do_deref */ false);
     break;
   }
   case CastKind::eNone: {

--- a/lldb/test/API/commands/frame/var-dil/expr/CreateValueFromExpression/TestCreateValueFromExpression.py
+++ b/lldb/test/API/commands/frame/var-dil/expr/CreateValueFromExpression/TestCreateValueFromExpression.py
@@ -33,17 +33,21 @@ class TestCreateValueFromExpression(TestBase):
         self.assertEqual(v1.GetValue(), "1")
         v2 = i.CreateValueFromExpression("v2", "static_cast<double>(i) + 2.5")
         self.assertEqual(v2.GetValue(), "2.5")
+        v3 = i.CreateValueFromExpression("v3", "(int *) 0")
+        self.assertEqual(v3.GetTypeName(), "int *")
+        v4 = v3.CreateValueFromExpression("v4", "i + 4")
+        self.assertEqual(v4.GetValue(), "4")
         expr_options = lldb.SBExpressionOptions()
-        v3 = i.CreateValueFromExpression("v3", "i + 3", expr_options)
-        self.assertEqual(v3.GetValue(), "3")
+        v5 = i.CreateValueFromExpression("v5", "i + 5", expr_options)
+        self.assertEqual(v5.GetValue(), "5")
         self.runCmd(
             "settings set target.experimental.use-DIL-for-creating-values false"
         )
-        v4 = i.CreateValueFromExpression("v4", "i + 4")
-        self.assertEqual(v4.GetValue(), "4")
+        v6 = i.CreateValueFromExpression("v6", "i + 6")
+        self.assertEqual(v6.GetValue(), "6")
         expr_options.SetTryDILFirst(True)
-        v5 = i.CreateValueFromExpression("v5", "i + 5", expr_options)
-        self.assertEqual(v5.GetValue(), "5")
+        v7 = i.CreateValueFromExpression("v7", "i + 7", expr_options)
+        self.assertEqual(v7.GetValue(), "7")
 
         with open(log_file, "r") as f:
             log = f.read()
@@ -53,9 +57,12 @@ class TestCreateValueFromExpression(TestBase):
         # Check that if DIL cannot evaluate the expression, it falls back to
         # full expression evaluation
         self.assertGreater(log.find("v2 = 2.5 (evaluated by: UserExpression)"), 0)
+        # Check that values can be created from values created by DIL
+        self.assertGreater(log.find("0000 (evaluated by: DIL)"), 0)
+        self.assertGreater(log.find("v4 = 4 (evaluated by: DIL)"), 0)
         # Check that trying DIL can be disabled through expression options parameter
-        self.assertGreater(log.find("v3 = 3 (evaluated by: UserExpression)"), 0)
+        self.assertGreater(log.find("v5 = 5 (evaluated by: UserExpression)"), 0)
         # Check that using DIL was disabled after disabling the lldb setting
-        self.assertGreater(log.find("v4 = 4 (evaluated by: UserExpression)"), 0)
+        self.assertGreater(log.find("v6 = 6 (evaluated by: UserExpression)"), 0)
         # Check that trying DIL can be enabled through expression options parameter
-        self.assertGreater(log.find("v5 = 5 (evaluated by: DIL)"), 0)
+        self.assertGreater(log.find("v7 = 7 (evaluated by: DIL)"), 0)


### PR DESCRIPTION
When casting to pointer type, `CreateValueObjectFromAddress` is called with Target context only, so the resulting `ValueObject` doesn't have StackFrame context anymore, which can cause problems when it is returned as a final result from DIL. This patch fixes the issue.