### PR TITLE
[RISCV] Use run-pass instead of start-before in macrofusion tests. NFC

### DIFF
--- a/llvm/test/CodeGen/RISCV/macro-fusion-add-mem.mir
+++ b/llvm/test/CodeGen/RISCV/macro-fusion-add-mem.mir
@@ -1,6 +1,6 @@
 # REQUIRES: asserts
 # RUN: llc -mtriple=riscv64-linux-gnu -x=mir < %s \
-# RUN:   -debug-only=machine-scheduler -start-before=machine-scheduler 2>&1 \
+# RUN:   -debug-only=machine-scheduler -run-pass=machine-scheduler 2>&1 \
 # RUN:   -mattr=+fusion-add-mem | FileCheck %s
 
 # Test add-mem fusion: ADD + load/store with offset 0

--- a/llvm/test/CodeGen/RISCV/macro-fusion-logic-imm-reg.mir
+++ b/llvm/test/CodeGen/RISCV/macro-fusion-logic-imm-reg.mir
@@ -1,6 +1,6 @@
 # REQUIRES: asserts
 # RUN: llc -mtriple=riscv64-linux-gnu -x=mir < %s \
-# RUN:   -debug-only=machine-scheduler -start-before=machine-scheduler 2>&1 \
+# RUN:   -debug-only=machine-scheduler -run-pass=machine-scheduler 2>&1 \
 # RUN:   -mattr=+fusion-logic-imm-reg | FileCheck %s
 
 # Test logic immediate-register fusion: ANDI/ORI/XORI + AND/OR/XOR

--- a/llvm/test/CodeGen/RISCV/macro-fusion-logic-reg-imm.mir
+++ b/llvm/test/CodeGen/RISCV/macro-fusion-logic-reg-imm.mir
@@ -1,6 +1,6 @@
 # REQUIRES: asserts
 # RUN: llc -mtriple=riscv64-linux-gnu -x=mir < %s \
-# RUN:   -debug-only=machine-scheduler -start-before=machine-scheduler 2>&1 \
+# RUN:   -debug-only=machine-scheduler -run-pass=machine-scheduler 2>&1 \
 # RUN:   -mattr=+fusion-logic-reg-imm | FileCheck %s
 
 # Test logic register-immediate fusion: AND/OR/XOR + ANDI/ORI/XORI

--- a/llvm/test/CodeGen/RISCV/macro-fusion-logic-reg-reg.mir
+++ b/llvm/test/CodeGen/RISCV/macro-fusion-logic-reg-reg.mir
@@ -1,6 +1,6 @@
 # REQUIRES: asserts
 # RUN: llc -mtriple=riscv64-linux-gnu -x=mir < %s \
-# RUN:   -debug-only=machine-scheduler -start-before=machine-scheduler 2>&1 \
+# RUN:   -debug-only=machine-scheduler -run-pass=machine-scheduler 2>&1 \
 # RUN:   -mattr=+fusion-logic-reg-reg | FileCheck %s
 
 # Test logic register-register fusion: AND/OR/XOR + AND/OR/XOR

--- a/llvm/test/CodeGen/RISCV/macro-fusion-mul-add.mir
+++ b/llvm/test/CodeGen/RISCV/macro-fusion-mul-add.mir
@@ -1,6 +1,6 @@
 # REQUIRES: asserts
 # RUN: llc -mtriple=riscv64-linux-gnu -x=mir < %s \
-# RUN:   -debug-only=machine-scheduler -start-before=machine-scheduler 2>&1 \
+# RUN:   -debug-only=machine-scheduler -run-pass=machine-scheduler 2>&1 \
 # RUN:   -mattr=+m,+fusion-mul-add | FileCheck %s
 
 # Test mul-add fusion: MUL + ADD and MULW + ADDW

--- a/llvm/test/CodeGen/RISCV/macro-fusion-shift-bit-extract.mir
+++ b/llvm/test/CodeGen/RISCV/macro-fusion-shift-bit-extract.mir
@@ -1,6 +1,6 @@
 # REQUIRES: asserts
 # RUN: llc -mtriple=riscv64-linux-gnu -x=mir < %s \
-# RUN:   -debug-only=machine-scheduler -start-before=machine-scheduler 2>&1 \
+# RUN:   -debug-only=machine-scheduler -run-pass=machine-scheduler 2>&1 \
 # RUN:   -mattr=+fusion-shift-bit-extract | FileCheck %s
 
 # Test shift-bit-extract fusion: SLLI + SRLI/SRAI

--- a/llvm/test/CodeGen/RISCV/macro-fusions-xqci.mir
+++ b/llvm/test/CodeGen/RISCV/macro-fusions-xqci.mir
@@ -1,6 +1,6 @@
 # REQUIRES: asserts
 # RUN: llc -mtriple=riscv32-linux-gnu -x=mir < %s \
-# RUN:   -debug-only=machine-scheduler -start-before=machine-scheduler 2>&1 \
+# RUN:   -debug-only=machine-scheduler -run-pass=machine-scheduler 2>&1 \
 # RUN:   -mattr=+xqcilia,+xqcili,+xqcilo,+zmmul,+fusion-xqci-movimm-alu \
 # RUN:   -mattr=+fusion-xqci-movimm-mul,+fusion-xqci-movimm-ldst \
 # RUN:   -mattr=+fusion-xqci-movimm-jump \

--- a/llvm/test/CodeGen/RISCV/macro-fusions.mir
+++ b/llvm/test/CodeGen/RISCV/macro-fusions.mir
@@ -1,12 +1,12 @@
 # REQUIRES: asserts
 # RUN: llc -mtriple=riscv64-linux-gnu -x=mir < %s \
-# RUN:   -debug-only=machine-scheduler -start-before=machine-scheduler 2>&1 \
+# RUN:   -debug-only=machine-scheduler -run-pass=machine-scheduler 2>&1 \
 # RUN:   -mattr=+fusion-lui-addi,+fusion-auipc-addi,+fusion-zexth,+fusion-zextw,+fusion-shifted-zextw,+fusion-ld-add \
 # RUN:   -mattr=+fusion-add-load,+fusion-auipc-load,+fusion-lui-load,+fusion-addi-load \
 # RUN:   -mattr=+zba,+fusion-shxadd-load \
 # RUN:   | FileCheck %s
 # RUN: llc -mtriple=riscv64-linux-gnu -x=mir < %s \
-# RUN:   -debug-only=machine-scheduler -start-before=machine-scheduler 2>&1 \
+# RUN:   -debug-only=machine-scheduler -run-pass=machine-scheduler 2>&1 \
 # RUN:   -mattr=+zba,+fusion-bfext | FileCheck --check-prefixes=CHECK-BFEXT %s
 
 # CHECK: lui_addi:%bb.0

--- a/llvm/test/CodeGen/RISCV/xqci-macro-fusions.mir
+++ b/llvm/test/CodeGen/RISCV/xqci-macro-fusions.mir
@@ -1,6 +1,6 @@
 # REQUIRES: asserts
 # RUN: llc -mtriple=riscv32-linux-gnu -x=mir < %s \
-# RUN:   -debug-only=machine-scheduler -start-before=machine-scheduler -stop-after=machine-scheduler 2>&1 \
+# RUN:   -debug-only=machine-scheduler -run-pass=machine-scheduler 2>&1 \
 # RUN:   -mattr=+xqcili,+fusion-qc-e-li-load-store \
 # RUN:   | FileCheck %s
 


### PR DESCRIPTION
We're only checking the debug output from the scheduler pass, we don't need to more of the pipeline.