### PR TITLE
[lldb-dap] Set stopped event text for signals and instrumentation

### DIFF
--- a/lldb/test/API/tools/lldb-dap/exception/TestDAP_exception.py
+++ b/lldb/test/API/tools/lldb-dap/exception/TestDAP_exception.py
@@ -19,7 +19,9 @@ class TestDAP_exception(DAPTestCaseBase):
         process_event = session.launch(LaunchArgs(program=program))
 
         stopped_event = session.verify_stopped_on_exception(
-            expected_description="signal SIGABRT", after=process_event
+            expected_description="signal SIGABRT",
+            expected_text=r"^SIGABRT$",
+            after=process_event,
         )
         thread_id = self.expect_not_none(stopped_event.body.threadId)
         exception_info = session.get_exception_info(thread_id)

--- a/lldb/test/API/tools/lldb-dap/exception/asan/TestDAP_asan.py
+++ b/lldb/test/API/tools/lldb-dap/exception/asan/TestDAP_asan.py
@@ -17,7 +17,9 @@ class TestDAP_asan(DAPTestCaseBase):
         session = self.build_and_create_session()
         process_event = session.launch(LaunchArgs(program))
         stop_event = session.verify_stopped_on_exception(
-            after=process_event, expected_description="Use of deallocated memory"
+            after=process_event,
+            expected_description="Use of deallocated memory",
+            expected_text=r"^AddressSanitizer$",
         )
 
         thread_id = self.expect_not_none(stop_event.body.threadId)

--- a/lldb/test/API/tools/lldb-dap/exception/cpp/TestDAP_exception_cpp.py
+++ b/lldb/test/API/tools/lldb-dap/exception/cpp/TestDAP_exception_cpp.py
@@ -21,7 +21,9 @@ class TestDAP_exception_cpp(DAPTestCaseBase):
         process_event = session.launch(LaunchArgs(program=program))
 
         stopped_event = session.verify_stopped_on_exception(
-            expected_description="signal SIGABRT", after=process_event
+            expected_description="signal SIGABRT",
+            expected_text=r"^SIGABRT$",
+            after=process_event,
         )
 
         thread_id = self.expect_not_none(stopped_event.body.threadId)
@@ -50,7 +52,9 @@ class TestDAP_exception_cpp(DAPTestCaseBase):
 
             session.set_exception_breakpoints(filters=cpp_filters)
 
-        stop_event = session.verify_stopped_on_exception(after=ctx.process_event)
+        stop_event = session.verify_stopped_on_exception(
+            after=ctx.process_event, expected_text=r"^C\+\+ Throw$"
+        )
         thread_ctx = session.thread_context_from(stop_event)
 
         def verify_stack_trace_contains(function: str, line: int):

--- a/lldb/test/API/tools/lldb-dap/exception/objc/TestDAP_exception_objc.py
+++ b/lldb/test/API/tools/lldb-dap/exception/objc/TestDAP_exception_objc.py
@@ -17,7 +17,9 @@ class TestDAP_exception_objc(DAPTestCaseBase):
         session = self.build_and_create_session()
         process_event = session.launch(LaunchArgs(program))
         stop_event = session.verify_stopped_on_exception(
-            after=process_event, expected_description="signal SIGABRT"
+            after=process_event,
+            expected_description="signal SIGABRT",
+            expected_text=r"^SIGABRT$",
         )
 
         thread_id = self.expect_not_none(stop_event.body.threadId)
@@ -66,7 +68,7 @@ class TestDAP_exception_objc(DAPTestCaseBase):
         # self.continue_to_exception_breakpoint("Objective-C Catch")
 
         stop_event = session.continue_to_exception_breakpoint(
-            expected_description="signal SIGABRT"
+            expected_description="signal SIGABRT", expected_text=r"^SIGABRT$"
         )
 
         thread_id = self.expect_not_none(stop_event.body.threadId)

--- a/lldb/test/API/tools/lldb-dap/exception/ubsan/TestDAP_ubsan.py
+++ b/lldb/test/API/tools/lldb-dap/exception/ubsan/TestDAP_ubsan.py
@@ -17,7 +17,9 @@ class TestDAP_ubsan(DAPTestCaseBase):
         session = self.build_and_create_session()
         process_event = session.launch(LaunchArgs(program))
         stop_event = session.verify_stopped_on_exception(
-            after=process_event, expected_description=r"Out of bounds index"
+            after=process_event,
+            expected_description=r"Out of bounds index",
+            expected_text=r"^UndefinedBehaviorSanitizer$",
         )
 
         thread_id = self.expect_not_none(stop_event.body.threadId)

--- a/lldb/tools/lldb-dap/EventHelper.cpp
+++ b/lldb/tools/lldb-dap/EventHelper.cpp
@@ -25,14 +25,17 @@
 #include "lldb/API/SBFileSpec.h"
 #include "lldb/API/SBListener.h"
 #include "lldb/API/SBPlatform.h"
+#include "lldb/API/SBProcess.h"
 #include "lldb/API/SBStream.h"
 #include "lldb/API/SBThread.h"
+#include "lldb/API/SBUnixSignals.h"
 #include "lldb/Host/PosixApi.h"
 #include "lldb/lldb-defines.h"
 #include "lldb/lldb-types.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/FormatVariadic.h"
+#include "llvm/Support/JSON.h"
 #include "llvm/Support/Threading.h"
 #include "llvm/Support/raw_ostream.h"
 #include <mutex>
@@ -170,6 +173,36 @@ void SendProcessEvent(DAP &dap, LaunchMethod launch_method) {
   dap.SendJSON(llvm::json::Value(std::move(event)));
 }
 
+static std::string GetSignalName(lldb::SBThread &thread) {
+  if (thread.GetStopReasonDataCount() == 0)
+    return {};
+
+  const int32_t signo =
+      static_cast<int32_t>(thread.GetStopReasonDataAtIndex(0));
+  lldb::SBUnixSignals signals = thread.GetProcess().GetUnixSignals();
+  if (const char *name = signals.GetSignalAsCString(signo))
+    return name;
+  return llvm::formatv("signal {0}", signo).str();
+}
+
+static std::string GetInstrumentationRuntimeName(lldb::SBThread &thread) {
+  lldb::SBStream stream;
+  if (!thread.GetStopReasonExtendedInfoAsJSON(stream))
+    return {};
+
+  llvm::Expected<llvm::json::Value> report =
+      llvm::json::parse({stream.GetData(), stream.GetSize()});
+  if (!report) {
+    llvm::consumeError(report.takeError());
+    return {};
+  }
+
+  const llvm::json::Object *obj = report->getAsObject();
+  if (!obj)
+    return {};
+  return obj->getString("instrumentation_class").value_or("").str();
+}
+
 static void SendStoppedEvent(DAP &dap, lldb::SBThread &thread, bool on_entry,
                              bool all_threads_stopped, bool preserve_focus) {
   protocol::StoppedEventBody body;
@@ -212,10 +245,17 @@ static void SendStoppedEvent(DAP &dap, lldb::SBThread &thread, bool on_entry,
       body.hitBreakpointIds.push_back(bp_id);
       body.text = llvm::formatv("data breakpoint {0}", bp_id).str();
     } break;
+    // DAP lacks stopped reasons for signals and instrumentation.
     case lldb::eStopReasonSignal:
+      body.reason = protocol::eStoppedReasonException;
+      body.text = GetSignalName(thread);
+      break;
     case lldb::eStopReasonException:
+      body.reason = protocol::eStoppedReasonException;
+      break;
     case lldb::eStopReasonInstrumentation:
       body.reason = protocol::eStoppedReasonException;
+      body.text = GetInstrumentationRuntimeName(thread);
       break;
     case lldb::eStopReasonExec:
     case lldb::eStopReasonFork:


### PR DESCRIPTION
DAP maps signals and instrumentation to reason 'exception'. Populate 'text' with the signal or runtime name to distinguish stop types. For example, text contains the specific signal name (e.g., "SIGABRT") or instrumentation runtime name (e.g., "AddressSanitizer").