### PR TITLE
[MLIR][CMake] Remove aggregate generated-header ordering

### DIFF
--- a/mlir/cmake/modules/AddMLIR.cmake
+++ b/mlir/cmake/modules/AddMLIR.cmake
@@ -780,25 +780,25 @@ endfunction()
 # Declare the library associated with a dialect.
 function(add_mlir_dialect_library name)
   set_property(GLOBAL APPEND PROPERTY MLIR_DIALECT_LIBS ${name})
-  add_mlir_library(${ARGV} DEPENDS mlir-headers)
+  add_mlir_library(${ARGV})
 endfunction(add_mlir_dialect_library)
 
 # Declare the library associated with a conversion.
 function(add_mlir_conversion_library name)
   set_property(GLOBAL APPEND PROPERTY MLIR_CONVERSION_LIBS ${name})
-  add_mlir_library(${ARGV} DEPENDS mlir-headers)
+  add_mlir_library(${ARGV})
 endfunction(add_mlir_conversion_library)
 
 # Declare the library associated with an extension.
 function(add_mlir_extension_library name)
   set_property(GLOBAL APPEND PROPERTY MLIR_EXTENSION_LIBS ${name})
-  add_mlir_library(${ARGV} DEPENDS mlir-headers)
+  add_mlir_library(${ARGV})
 endfunction(add_mlir_extension_library)
 
 # Declare the library associated with a translation.
 function(add_mlir_translation_library name)
   set_property(GLOBAL APPEND PROPERTY MLIR_TRANSLATION_LIBS ${name})
-  add_mlir_library(${ARGV} DEPENDS mlir-headers)
+  add_mlir_library(${ARGV})
 endfunction(add_mlir_translation_library)
 
 # Verification tools to aid debugging.

--- a/mlir/docs/ReleaseNotes.md
+++ b/mlir/docs/ReleaseNotes.md
@@ -8,6 +8,17 @@ specifically, it is a snapshot of the MLIR development at the time of the releas
 
 [TOC]
 
+## LLVM 24
+
+### Potentially Breaking Changes
+
+- MLIR dialect, conversion, extension, and translation libraries no longer
+  depend on the aggregate `mlir-headers` target. Downstream projects that
+  relied on that incidental ordering must model generated headers explicitly:
+  link the library that owns the header, use `HEADER_LIBS` with
+  `add_mlir_library` for a header-only or circular relationship, or retain
+  `DEPENDS mlir-headers` as a conservative compatibility escape hatch.
+
 ## LLVM 21
 
 ### GPU/NVVM Changes

--- a/mlir/lib/Analysis/CMakeLists.txt
+++ b/mlir/lib/Analysis/CMakeLists.txt
@@ -47,9 +47,6 @@ add_mlir_library(MLIRAnalysis
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Analysis
 
-  DEPENDS
-  mlir-headers
-
   LINK_LIBS PUBLIC
   MLIRCallInterfaces
   MLIRControlFlowInterfaces

--- a/mlir/lib/CAPI/Conversion/CMakeLists.txt
+++ b/mlir/lib/CAPI/Conversion/CMakeLists.txt
@@ -2,9 +2,6 @@ get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
 add_mlir_upstream_c_api_library(MLIRCAPIConversion
   Passes.cpp
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   ${conversion_libs}
 )

--- a/mlir/lib/CAPI/Dialect/CMakeLists.txt
+++ b/mlir/lib/CAPI/Dialect/CMakeLists.txt
@@ -3,8 +3,6 @@ add_mlir_upstream_c_api_library(MLIRCAPIAffine
   AffinePasses.cpp
 
   PARTIAL_SOURCES_INTENDED
-  DEPENDS
-  MLIRAffinePassIncGen
 
   LINK_LIBS PUBLIC
   MLIRCAPIIR
@@ -17,8 +15,6 @@ add_mlir_upstream_c_api_library(MLIRCAPIAMDGPU
   AMDGPUPasses.cpp
 
   PARTIAL_SOURCES_INTENDED
-  DEPENDS
-  MLIRNVGPUPassIncGen
 
   LINK_LIBS PUBLIC
   MLIRCAPIIR
@@ -63,8 +59,6 @@ add_mlir_upstream_c_api_library(MLIRCAPIArmSVE
   ArmSVEPasses.cpp
 
   PARTIAL_SOURCES_INTENDED
-  DEPENDS
-  MLIRArmSVEPassIncGen
 
   LINK_LIBS PUBLIC
   MLIRCAPIIR
@@ -77,8 +71,6 @@ add_mlir_upstream_c_api_library(MLIRCAPIAsync
   AsyncPasses.cpp
 
   PARTIAL_SOURCES_INTENDED
-  DEPENDS
-  MLIRAsyncPassIncGen
 
   LINK_LIBS PUBLIC
   MLIRCAPIIR
@@ -92,8 +84,6 @@ add_mlir_upstream_c_api_library(MLIRCAPIBufferization
   BufferizationPasses.cpp
 
   PARTIAL_SOURCES_INTENDED
-  DEPENDS
-  MLIRBufferizationPassIncGen
 
   LINK_LIBS PUBLIC
   MLIRCAPIIR
@@ -156,8 +146,6 @@ add_mlir_upstream_c_api_library(MLIRCAPIGPU
   GPUPasses.cpp
 
   PARTIAL_SOURCES_INTENDED
-  DEPENDS
-  MLIRGPUPassIncGen
 
   LINK_LIBS PUBLIC
   MLIRCAPIIR
@@ -188,8 +176,6 @@ add_mlir_upstream_c_api_library(MLIRCAPILinalg
   LinalgPasses.cpp
 
   PARTIAL_SOURCES_INTENDED
-  DEPENDS
-  MLIRLinalgPassIncGen
 
   LINK_LIBS PUBLIC
   MLIRCAPIIR
@@ -226,8 +212,6 @@ add_mlir_upstream_c_api_library(MLIRCAPIMemRef
 
   PARTIAL_SOURCES_INTENDED
   PARTIAL_SOURCES_INTENDED
-  DEPENDS
-  MLIRMemRefPassIncGen
 
   LINK_LIBS PUBLIC
   MLIRCAPIIR
@@ -240,8 +224,6 @@ add_mlir_upstream_c_api_library(MLIRCAPIMLProgram
   MLProgramPasses.cpp
 
   PARTIAL_SOURCES_INTENDED
-  DEPENDS
-  MLIRMLProgramPassIncGen
 
   LINK_LIBS PUBLIC
   MLIRCAPIIR
@@ -263,8 +245,6 @@ add_mlir_upstream_c_api_library(MLIRCAPINVGPU
   NVGPUPasses.cpp
 
   PARTIAL_SOURCES_INTENDED
-  DEPENDS
-  MLIRNVGPUPassIncGen
 
   LINK_LIBS PUBLIC
   MLIRCAPIIR
@@ -286,8 +266,6 @@ add_mlir_upstream_c_api_library(MLIRCAPIOpenACC
   OpenACCPasses.cpp
 
   PARTIAL_SOURCES_INTENDED
-  DEPENDS
-  MLIROpenACCPassIncGen
 
   LINK_LIBS PUBLIC
   MLIRCAPIIR
@@ -354,8 +332,6 @@ add_mlir_upstream_c_api_library(MLIRCAPISCF
   SCFPasses.cpp
 
   PARTIAL_SOURCES_INTENDED
-  DEPENDS
-  MLIRSCFPassIncGen
 
   LINK_LIBS PUBLIC
   MLIRCAPIIR
@@ -379,8 +355,6 @@ add_mlir_upstream_c_api_library(MLIRCAPIShard
   ShardPasses.cpp
 
   PARTIAL_SOURCES_INTENDED
-  DEPENDS
-  MLIRShardPassIncGen
 
   LINK_LIBS PUBLIC
   MLIRCAPIIR
@@ -402,8 +376,6 @@ add_mlir_upstream_c_api_library(MLIRCAPISparseTensor
   SparseTensorPasses.cpp
 
   PARTIAL_SOURCES_INTENDED
-  DEPENDS
-  MLIRSparseTensorPassIncGen
 
   LINK_LIBS PUBLIC
   MLIRCAPIIR
@@ -416,8 +388,6 @@ add_mlir_upstream_c_api_library(MLIRCAPISPIRV
   SPIRVPasses.cpp
 
   PARTIAL_SOURCES_INTENDED
-  DEPENDS
-  MLIRSPIRVPassIncGen
 
   LINK_LIBS PUBLIC
   MLIRCAPIIR
@@ -441,8 +411,6 @@ add_mlir_upstream_c_api_library(MLIRCAPITosa
   TosaPasses.cpp
 
   PARTIAL_SOURCES_INTENDED
-  DEPENDS
-  MLIRTosaPassIncGen
 
   LINK_LIBS PUBLIC
   MLIRCAPIIR

--- a/mlir/lib/CMakeLists.txt
+++ b/mlir/lib/CMakeLists.txt
@@ -41,12 +41,6 @@ add_mlir_library(MLIRRegisterAllPasses
 
   PARTIAL_SOURCES_INTENDED
 
-  # This TU includes dialect pass registration headers that depend on
-  # TableGen outputs (e.g. Passes.h.inc) wired into mlir-headers. Without this
-  # dependency it may compile before those headers are regenerated.
-  DEPENDS
-  mlir-headers
-
   LINK_LIBS PUBLIC
   ${dialect_libs} # Some passes are part of the dialect libs
   ${conversion_libs}

--- a/mlir/lib/Conversion/AMDGPUToROCDL/CMakeLists.txt
+++ b/mlir/lib/Conversion/AMDGPUToROCDL/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRAMDGPUToROCDL
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/AMDGPUToROCDL
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/AffineToStandard/CMakeLists.txt
+++ b/mlir/lib/Conversion/AffineToStandard/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRAffineToStandard
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/AffineToStandard
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRAffineDialect
   MLIRAffineTransforms

--- a/mlir/lib/Conversion/ArithAndMathToAPFloat/CMakeLists.txt
+++ b/mlir/lib/Conversion/ArithAndMathToAPFloat/CMakeLists.txt
@@ -14,9 +14,6 @@ add_mlir_conversion_library(MLIRArithToAPFloat
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/ArithToLLVM
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 
@@ -35,9 +32,6 @@ add_mlir_conversion_library(MLIRMathToAPFloat
 
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/MathToLLVM
-
-  DEPENDS
-  MLIRConversionPassIncGen
 
   LINK_COMPONENTS
   Core

--- a/mlir/lib/Conversion/ArithToAMDGPU/CMakeLists.txt
+++ b/mlir/lib/Conversion/ArithToAMDGPU/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRArithToAMDGPU
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/ArithToAMDGPU
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/ArithToArmSME/CMakeLists.txt
+++ b/mlir/lib/Conversion/ArithToArmSME/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRArithToArmSME
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/ArithToArmSME
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/ArithToEmitC/CMakeLists.txt
+++ b/mlir/lib/Conversion/ArithToEmitC/CMakeLists.txt
@@ -5,9 +5,6 @@ add_mlir_conversion_library(MLIRArithToEmitC
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/ArithToEmitC
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRArithDialect
   MLIREmitCCommonConversion

--- a/mlir/lib/Conversion/ArithToLLVM/CMakeLists.txt
+++ b/mlir/lib/Conversion/ArithToLLVM/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRArithToLLVM
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/ArithToLLVM
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/ArithToSPIRV/CMakeLists.txt
+++ b/mlir/lib/Conversion/ArithToSPIRV/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRArithToSPIRV
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/ArithToSPIRV
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/ArmNeon2dToIntr/CMakeLists.txt
+++ b/mlir/lib/Conversion/ArmNeon2dToIntr/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRArmNeon2dToIntr
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/ArmNeon2dToIntr
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/ArmSMEToLLVM/CMakeLists.txt
+++ b/mlir/lib/Conversion/ArmSMEToLLVM/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRArmSMEToLLVM
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/ArmSMEToLLVM
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRArmSMETransforms
   MLIRArmSMEDialect

--- a/mlir/lib/Conversion/ArmSMEToSCF/CMakeLists.txt
+++ b/mlir/lib/Conversion/ArmSMEToSCF/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRArmSMEToSCF
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/ArmSMEToSCF
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRArmSMEDialect
   MLIRTransforms

--- a/mlir/lib/Conversion/AsyncToLLVM/CMakeLists.txt
+++ b/mlir/lib/Conversion/AsyncToLLVM/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRAsyncToLLVM
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/AsyncToLLVM
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/BufferizationToMemRef/CMakeLists.txt
+++ b/mlir/lib/Conversion/BufferizationToMemRef/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRBufferizationToMemRef
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/BufferizationToMemRef
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRBufferizationDialect
   MLIRBufferizationTransforms

--- a/mlir/lib/Conversion/ComplexToLLVM/CMakeLists.txt
+++ b/mlir/lib/Conversion/ComplexToLLVM/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRComplexToLLVM
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/ComplexToLLVM
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/ComplexToLibm/CMakeLists.txt
+++ b/mlir/lib/Conversion/ComplexToLibm/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRComplexToLibm
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/ComplexToLibm
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/ComplexToROCDLLibraryCalls/CMakeLists.txt
+++ b/mlir/lib/Conversion/ComplexToROCDLLibraryCalls/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRComplexToROCDLLibraryCalls
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/ComplexToROCDLLibraryCalls
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/ComplexToSPIRV/CMakeLists.txt
+++ b/mlir/lib/Conversion/ComplexToSPIRV/CMakeLists.txt
@@ -6,9 +6,6 @@ add_mlir_conversion_library(MLIRComplexToSPIRV
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/SPIRV
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/IR
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRComplexDialect
   MLIRIR

--- a/mlir/lib/Conversion/ComplexToStandard/CMakeLists.txt
+++ b/mlir/lib/Conversion/ComplexToStandard/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRComplexToStandard
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/ComplexToStandard
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRArithDialect
   MLIRComplexDivisionConversion

--- a/mlir/lib/Conversion/ControlFlowToLLVM/CMakeLists.txt
+++ b/mlir/lib/Conversion/ControlFlowToLLVM/CMakeLists.txt
@@ -5,7 +5,6 @@ add_mlir_conversion_library(MLIRControlFlowToLLVM
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/ControlFlowToLLVM
 
   DEPENDS
-  MLIRConversionPassIncGen
   intrinsics_gen
 
   LINK_COMPONENTS

--- a/mlir/lib/Conversion/ControlFlowToSCF/CMakeLists.txt
+++ b/mlir/lib/Conversion/ControlFlowToSCF/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRControlFlowToSCF
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/ControlFlowToSCF
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRAnalysis
   MLIRArithDialect

--- a/mlir/lib/Conversion/ControlFlowToSPIRV/CMakeLists.txt
+++ b/mlir/lib/Conversion/ControlFlowToSPIRV/CMakeLists.txt
@@ -6,9 +6,6 @@ add_mlir_conversion_library(MLIRControlFlowToSPIRV
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/SPIRV
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/IR
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRIR
   MLIRControlFlowDialect

--- a/mlir/lib/Conversion/ConvertToEmitC/CMakeLists.txt
+++ b/mlir/lib/Conversion/ConvertToEmitC/CMakeLists.txt
@@ -5,7 +5,6 @@ add_mlir_conversion_library(MLIRConvertToEmitC
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/ConvertToEmitC
 
   DEPENDS
-  MLIRConversionPassIncGen
   MLIRConvertToEmitCPatternInterfaceIncGen
 
   LINK_LIBS PUBLIC

--- a/mlir/lib/Conversion/ConvertToLLVM/CMakeLists.txt
+++ b/mlir/lib/Conversion/ConvertToLLVM/CMakeLists.txt
@@ -17,9 +17,6 @@ add_mlir_conversion_library(MLIRConvertToLLVMInterface
 add_mlir_conversion_library(MLIRConvertToLLVMPass
   ConvertToLLVMPass.cpp
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRIR
   MLIRConvertToLLVMInterface

--- a/mlir/lib/Conversion/FuncToEmitC/CMakeLists.txt
+++ b/mlir/lib/Conversion/FuncToEmitC/CMakeLists.txt
@@ -5,9 +5,6 @@ add_mlir_conversion_library(MLIRFuncToEmitC
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/FuncToEmitC
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIREmitCCommonConversion
   MLIREmitCDialect

--- a/mlir/lib/Conversion/FuncToLLVM/CMakeLists.txt
+++ b/mlir/lib/Conversion/FuncToLLVM/CMakeLists.txt
@@ -5,7 +5,6 @@ add_mlir_conversion_library(MLIRFuncToLLVM
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/FuncToLLVM
 
   DEPENDS
-  MLIRConversionPassIncGen
   intrinsics_gen
 
   LINK_COMPONENTS

--- a/mlir/lib/Conversion/FuncToSPIRV/CMakeLists.txt
+++ b/mlir/lib/Conversion/FuncToSPIRV/CMakeLists.txt
@@ -6,9 +6,6 @@ add_mlir_conversion_library(MLIRFuncToSPIRV
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/SPIRV
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/IR
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRFuncDialect
   MLIRIR

--- a/mlir/lib/Conversion/GPUCommon/CMakeLists.txt
+++ b/mlir/lib/Conversion/GPUCommon/CMakeLists.txt
@@ -21,7 +21,6 @@ add_mlir_conversion_library(MLIRGPUToGPURuntimeTransforms
   IndexIntrinsicsOpLowering.cpp
 
   DEPENDS
-  MLIRConversionPassIncGen
   intrinsics_gen
 
   LINK_COMPONENTS

--- a/mlir/lib/Conversion/GPUToLLVMSPV/CMakeLists.txt
+++ b/mlir/lib/Conversion/GPUToLLVMSPV/CMakeLists.txt
@@ -1,9 +1,6 @@
 add_mlir_conversion_library(MLIRGPUToLLVMSPV
   GPUToLLVMSPV.cpp
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRGPUDialect
   MLIRGPUToGPURuntimeTransforms

--- a/mlir/lib/Conversion/GPUToNVVM/CMakeLists.txt
+++ b/mlir/lib/Conversion/GPUToNVVM/CMakeLists.txt
@@ -2,9 +2,6 @@ add_mlir_conversion_library(MLIRGPUToNVVMTransforms
   LowerGpuOpsToNVVMOps.cpp
   WmmaOpsToNvvm.cpp
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRArithToLLVM
   MLIRFuncToLLVM

--- a/mlir/lib/Conversion/GPUToROCDL/CMakeLists.txt
+++ b/mlir/lib/Conversion/GPUToROCDL/CMakeLists.txt
@@ -6,7 +6,6 @@ add_mlir_conversion_library(MLIRGPUToROCDLTransforms
   LowerGpuOpsToROCDLOps.cpp
 
   DEPENDS
-  MLIRConversionPassIncGen
   MLIRGPUToROCDLIncGen
 
   LINK_LIBS PUBLIC

--- a/mlir/lib/Conversion/GPUToSPIRV/CMakeLists.txt
+++ b/mlir/lib/Conversion/GPUToSPIRV/CMakeLists.txt
@@ -3,9 +3,6 @@ add_mlir_conversion_library(MLIRGPUToSPIRV
   GPUToSPIRVPass.cpp
   WmmaOpsToSPIRV.cpp
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRArithToSPIRV
   MLIRGPUDialect

--- a/mlir/lib/Conversion/IndexToLLVM/CMakeLists.txt
+++ b/mlir/lib/Conversion/IndexToLLVM/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRIndexToLLVM
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/IndexToLLVM
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/IndexToSPIRV/CMakeLists.txt
+++ b/mlir/lib/Conversion/IndexToSPIRV/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRIndexToSPIRV
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/IndexToSPIRV
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/LinalgToStandard/CMakeLists.txt
+++ b/mlir/lib/Conversion/LinalgToStandard/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRLinalgToStandard
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/LinalgToStandard
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/MPIToLLVM/CMakeLists.txt
+++ b/mlir/lib/Conversion/MPIToLLVM/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRMPIToLLVM
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/MPIToLLVM
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/MathToEmitC/CMakeLists.txt
+++ b/mlir/lib/Conversion/MathToEmitC/CMakeLists.txt
@@ -5,9 +5,6 @@ add_mlir_conversion_library(MLIRMathToEmitC
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/MathToEmitC
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/MathToFuncs/CMakeLists.txt
+++ b/mlir/lib/Conversion/MathToFuncs/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRMathToFuncs
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/MathToFuncs
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/MathToLLVM/CMakeLists.txt
+++ b/mlir/lib/Conversion/MathToLLVM/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRMathToLLVM
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/MathToLLVM
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/MathToLibm/CMakeLists.txt
+++ b/mlir/lib/Conversion/MathToLibm/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRMathToLibm
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/MathToLibm
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/MathToNVVM/CMakeLists.txt
+++ b/mlir/lib/Conversion/MathToNVVM/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRMathToNVVM
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/MathToNVVM
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/MathToROCDL/CMakeLists.txt
+++ b/mlir/lib/Conversion/MathToROCDL/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRMathToROCDL
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/MathToROCDL
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/MathToSPIRV/CMakeLists.txt
+++ b/mlir/lib/Conversion/MathToSPIRV/CMakeLists.txt
@@ -6,9 +6,6 @@ add_mlir_conversion_library(MLIRMathToSPIRV
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/SPIRV
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/IR
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRIR
   MLIRMathDialect

--- a/mlir/lib/Conversion/MathToXeVM/CMakeLists.txt
+++ b/mlir/lib/Conversion/MathToXeVM/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRMathToXeVM
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/MathToXeVM
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/MemRefToEmitC/CMakeLists.txt
+++ b/mlir/lib/Conversion/MemRefToEmitC/CMakeLists.txt
@@ -5,9 +5,6 @@ add_mlir_conversion_library(MLIRMemRefToEmitC
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/MemRefToEmitC
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/MemRefToLLVM/CMakeLists.txt
+++ b/mlir/lib/Conversion/MemRefToLLVM/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRMemRefToLLVM
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/MemRefToLLVM
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/MemRefToSPIRV/CMakeLists.txt
+++ b/mlir/lib/Conversion/MemRefToSPIRV/CMakeLists.txt
@@ -7,9 +7,6 @@ add_mlir_conversion_library(MLIRMemRefToSPIRV
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/SPIRV
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/IR
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRFunctionInterfaces
   MLIRIR

--- a/mlir/lib/Conversion/NVGPUToNVVM/CMakeLists.txt
+++ b/mlir/lib/Conversion/NVGPUToNVVM/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRNVGPUToNVVM
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/NVGPUToNVVM
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/NVVMToLLVM/CMakeLists.txt
+++ b/mlir/lib/Conversion/NVVMToLLVM/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRNVVMToLLVM
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/NVVMToLLVM
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/OpenACCToLLVM/CMakeLists.txt
+++ b/mlir/lib/Conversion/OpenACCToLLVM/CMakeLists.txt
@@ -7,9 +7,6 @@ add_mlir_conversion_library(MLIROpenACCToLLVM
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/OpenACCToLLVM
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRArithToLLVM
   MLIRComplexDialect

--- a/mlir/lib/Conversion/OpenACCToSCF/CMakeLists.txt
+++ b/mlir/lib/Conversion/OpenACCToSCF/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIROpenACCToSCF
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/OpenACCToSCF
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRArithDialect
   MLIRIR

--- a/mlir/lib/Conversion/OpenMPToLLVM/CMakeLists.txt
+++ b/mlir/lib/Conversion/OpenMPToLLVM/CMakeLists.txt
@@ -5,7 +5,6 @@ add_mlir_conversion_library(MLIROpenMPToLLVM
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/OpenMPToLLVM
 
   DEPENDS
-  MLIRConversionPassIncGen
   intrinsics_gen
 
   LINK_COMPONENTS

--- a/mlir/lib/Conversion/PDLToPDLInterp/CMakeLists.txt
+++ b/mlir/lib/Conversion/PDLToPDLInterp/CMakeLists.txt
@@ -7,9 +7,6 @@ add_mlir_conversion_library(MLIRPDLToPDLInterp
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/PDLToPDLInterp
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRIR
   MLIRInferTypeOpInterface

--- a/mlir/lib/Conversion/PtrToLLVM/CMakeLists.txt
+++ b/mlir/lib/Conversion/PtrToLLVM/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRPtrToLLVM
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/PtrToLLVM
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/RaiseWasm/CMakeLists.txt
+++ b/mlir/lib/Conversion/RaiseWasm/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRWasmRaise
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/RaiseWasm
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRArithDialect
   MLIRControlFlowDialect

--- a/mlir/lib/Conversion/ReconcileUnrealizedCasts/CMakeLists.txt
+++ b/mlir/lib/Conversion/ReconcileUnrealizedCasts/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRReconcileUnrealizedCasts
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/ReconcileUnrealizedCasts
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/SCFToAffine/CMakeLists.txt
+++ b/mlir/lib/Conversion/SCFToAffine/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRSCFToAffine
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/SCFToAffine
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRAffineDialect
   MLIRArithDialect

--- a/mlir/lib/Conversion/SCFToControlFlow/CMakeLists.txt
+++ b/mlir/lib/Conversion/SCFToControlFlow/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRSCFToControlFlow
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/SCFToControlFlow
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRArithDialect
   MLIRControlFlowDialect

--- a/mlir/lib/Conversion/SCFToEmitC/CMakeLists.txt
+++ b/mlir/lib/Conversion/SCFToEmitC/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRSCFToEmitC
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/SCFToEmitC
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/SCFToGPU/CMakeLists.txt
+++ b/mlir/lib/Conversion/SCFToGPU/CMakeLists.txt
@@ -5,9 +5,6 @@ add_mlir_conversion_library(MLIRSCFToGPU
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/SCFToGPU
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRAffineDialect
   MLIRAffineToStandard

--- a/mlir/lib/Conversion/SCFToOpenMP/CMakeLists.txt
+++ b/mlir/lib/Conversion/SCFToOpenMP/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRSCFToOpenMP
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/SCFToStandard
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/SCFToSPIRV/CMakeLists.txt
+++ b/mlir/lib/Conversion/SCFToSPIRV/CMakeLists.txt
@@ -5,9 +5,6 @@ add_mlir_conversion_library(MLIRSCFToSPIRV
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/SCFToSPIRV
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRArithToSPIRV
   MLIRFuncToSPIRV

--- a/mlir/lib/Conversion/SPIRVCommon/CMakeLists.txt
+++ b/mlir/lib/Conversion/SPIRVCommon/CMakeLists.txt
@@ -1,9 +1,6 @@
 add_mlir_conversion_library(MLIRSPIRVAttrToLLVMConversion
   AttrToLLVMConverter.cpp
 
-  DEPENDS
-  MLIRSPIRVEnumsIncGen
-
   # AttrToLLVMConverter.h includes the generated SPIRVEnums.h.
   HEADER_LIBS
   MLIRSPIRVDialect

--- a/mlir/lib/Conversion/SPIRVToLLVM/CMakeLists.txt
+++ b/mlir/lib/Conversion/SPIRVToLLVM/CMakeLists.txt
@@ -7,7 +7,6 @@ add_mlir_conversion_library(MLIRSPIRVToLLVM
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/SPIRVToLLVM
 
   DEPENDS
-  MLIRConversionPassIncGen
   intrinsics_gen
 
   LINK_LIBS PUBLIC

--- a/mlir/lib/Conversion/ShapeToStandard/CMakeLists.txt
+++ b/mlir/lib/Conversion/ShapeToStandard/CMakeLists.txt
@@ -10,7 +10,6 @@ add_mlir_conversion_library(MLIRShapeToStandard
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/ShapeToStandard
 
   DEPENDS
-  MLIRConversionPassIncGen
   ShapeToStandardIncGen
 
   LINK_COMPONENTS

--- a/mlir/lib/Conversion/ShardToMPI/CMakeLists.txt
+++ b/mlir/lib/Conversion/ShardToMPI/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRShardToMPI
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/ShardToMPI
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/TensorToLinalg/CMakeLists.txt
+++ b/mlir/lib/Conversion/TensorToLinalg/CMakeLists.txt
@@ -6,9 +6,6 @@ add_mlir_conversion_library(MLIRTensorToLinalg
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/Linalg
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/IR
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRIR
   MLIRPass

--- a/mlir/lib/Conversion/TensorToSPIRV/CMakeLists.txt
+++ b/mlir/lib/Conversion/TensorToSPIRV/CMakeLists.txt
@@ -6,9 +6,6 @@ add_mlir_conversion_library(MLIRTensorToSPIRV
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/SPIRV
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/IR
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRArithToSPIRV
   MLIRFuncToSPIRV

--- a/mlir/lib/Conversion/TosaToArith/CMakeLists.txt
+++ b/mlir/lib/Conversion/TosaToArith/CMakeLists.txt
@@ -6,9 +6,6 @@ add_mlir_conversion_library(MLIRTosaToArith
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/Tosa
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/IR
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRArithDialect
   MLIRIR

--- a/mlir/lib/Conversion/TosaToLinalg/CMakeLists.txt
+++ b/mlir/lib/Conversion/TosaToLinalg/CMakeLists.txt
@@ -8,9 +8,6 @@ add_mlir_conversion_library(MLIRTosaToLinalg
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/Tosa
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/IR
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRArithDialect
   MLIRDialectUtils

--- a/mlir/lib/Conversion/TosaToMLProgram/CMakeLists.txt
+++ b/mlir/lib/Conversion/TosaToMLProgram/CMakeLists.txt
@@ -6,9 +6,6 @@ add_mlir_conversion_library(MLIRTosaToMLProgram
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/Tosa
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/IR
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRIR
   MLIRMLProgramDialect

--- a/mlir/lib/Conversion/TosaToSCF/CMakeLists.txt
+++ b/mlir/lib/Conversion/TosaToSCF/CMakeLists.txt
@@ -6,9 +6,6 @@ add_mlir_conversion_library(MLIRTosaToSCF
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/Tosa
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/IR
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRIR
   MLIRSCFDialect

--- a/mlir/lib/Conversion/TosaToSPIRVTosa/CMakeLists.txt
+++ b/mlir/lib/Conversion/TosaToSPIRVTosa/CMakeLists.txt
@@ -9,9 +9,6 @@ add_mlir_conversion_library(MLIRTosaToSPIRVTosa
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/Tosa
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/IR
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRFuncDialect
   MLIRIR

--- a/mlir/lib/Conversion/TosaToTensor/CMakeLists.txt
+++ b/mlir/lib/Conversion/TosaToTensor/CMakeLists.txt
@@ -6,9 +6,6 @@ add_mlir_conversion_library(MLIRTosaToTensor
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/Tosa
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/IR
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRTensorDialect
   MLIRTensorUtils

--- a/mlir/lib/Conversion/UBToLLVM/CMakeLists.txt
+++ b/mlir/lib/Conversion/UBToLLVM/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRUBToLLVM
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/UBToLLVM
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/UBToSPIRV/CMakeLists.txt
+++ b/mlir/lib/Conversion/UBToSPIRV/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRUBToSPIRV
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/UBToSPIRV
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/VectorToAMX/CMakeLists.txt
+++ b/mlir/lib/Conversion/VectorToAMX/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRVectorToAMX
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/VectorToAMX
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRAffineUtils
   MLIRArithDialect

--- a/mlir/lib/Conversion/VectorToArmSME/CMakeLists.txt
+++ b/mlir/lib/Conversion/VectorToArmSME/CMakeLists.txt
@@ -5,9 +5,6 @@ add_mlir_conversion_library(MLIRVectorToArmSME
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/VectorToArmSME
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRArmSMEDialect
   MLIRArmSVEDialect

--- a/mlir/lib/Conversion/VectorToLLVM/CMakeLists.txt
+++ b/mlir/lib/Conversion/VectorToLLVM/CMakeLists.txt
@@ -6,7 +6,6 @@ add_mlir_conversion_library(MLIRVectorToLLVM
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/VectorToLLVM
 
   DEPENDS
-  MLIRConversionPassIncGen
   intrinsics_gen
 
   LINK_COMPONENTS

--- a/mlir/lib/Conversion/VectorToSPIRV/CMakeLists.txt
+++ b/mlir/lib/Conversion/VectorToSPIRV/CMakeLists.txt
@@ -6,7 +6,6 @@ add_mlir_conversion_library(MLIRVectorToSPIRV
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/VectorToSPIRV
 
   DEPENDS
-  MLIRConversionPassIncGen
   intrinsics_gen
 
   LINK_LIBS PUBLIC

--- a/mlir/lib/Conversion/VectorToXeGPU/CMakeLists.txt
+++ b/mlir/lib/Conversion/VectorToXeGPU/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRVectorToXeGPU
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/VectorToXeGPU
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_LIBS PUBLIC
   MLIRArithDialect
   MLIRMemRefDialect

--- a/mlir/lib/Conversion/XeGPUToXeVM/CMakeLists.txt
+++ b/mlir/lib/Conversion/XeGPUToXeVM/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRXeGPUToXeVM
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/XeGPUToXeVM
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Conversion/XeVMToLLVM/CMakeLists.txt
+++ b/mlir/lib/Conversion/XeVMToLLVM/CMakeLists.txt
@@ -4,9 +4,6 @@ add_mlir_conversion_library(MLIRXeVMToLLVM
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/XeVMToLLVM
 
-  DEPENDS
-  MLIRConversionPassIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Dialect/Affine/Analysis/CMakeLists.txt
+++ b/mlir/lib/Dialect/Affine/Analysis/CMakeLists.txt
@@ -8,9 +8,6 @@ add_mlir_dialect_library(MLIRAffineAnalysis
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/Affine
 
-  DEPENDS
-  MLIRFuncOpsIncGen
-
   LINK_LIBS PUBLIC
   MLIRAffineDialect
   MLIRAnalysis

--- a/mlir/lib/Dialect/Affine/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/Affine/Transforms/CMakeLists.txt
@@ -25,9 +25,7 @@ add_mlir_dialect_library(MLIRAffineTransforms
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/Affine
 
   DEPENDS
-  MLIRAffineOpsIncGen
   MLIRAffinePassIncGen
-  MLIRLoopLikeInterfaceIncGen
 
   LINK_LIBS PUBLIC
   MLIRAffineDialect

--- a/mlir/lib/Dialect/ArmNeon/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/ArmNeon/Transforms/CMakeLists.txt
@@ -1,9 +1,6 @@
 add_mlir_dialect_library(MLIRArmNeonTransforms
   LowerContractToNeonPatterns.cpp
 
-  DEPENDS
-  MLIRArmNeonIncGen
-
   LINK_LIBS PUBLIC
   MLIRArmNeonDialect
   MLIRFuncDialect

--- a/mlir/lib/Dialect/ArmSVE/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/ArmSVE/Transforms/CMakeLists.txt
@@ -4,7 +4,6 @@ add_mlir_dialect_library(MLIRArmSVETransforms
   LowerContractToSVEPatterns.cpp
 
   DEPENDS
-  MLIRArmSVEConversionsIncGen
   MLIRArmSVEPassIncGen
 
   LINK_LIBS PUBLIC

--- a/mlir/lib/Dialect/Bufferization/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/Bufferization/Transforms/CMakeLists.txt
@@ -24,7 +24,6 @@ add_mlir_dialect_library(MLIRBufferizationTransforms
 
   DEPENDS
   MLIRBufferizationPassIncGen
-  MLIRBufferizationEnumsIncGen
 
   LINK_LIBS PUBLIC
   MLIRArithDialect

--- a/mlir/lib/Dialect/DLTI/TransformOps/CMakeLists.txt
+++ b/mlir/lib/Dialect/DLTI/TransformOps/CMakeLists.txt
@@ -6,7 +6,6 @@ add_mlir_dialect_library(MLIRDLTITransformOps
 
   DEPENDS
   MLIRDLTITransformOpsIncGen
-  MLIRDLTIDialect
 
   LINK_LIBS PUBLIC
   MLIRDLTIDialect

--- a/mlir/lib/Dialect/GPU/CMakeLists.txt
+++ b/mlir/lib/Dialect/GPU/CMakeLists.txt
@@ -58,7 +58,6 @@ add_mlir_dialect_library(MLIRGPUTransforms
 
   DEPENDS
   MLIRGPUPassIncGen
-  MLIRParallelLoopMapperEnumsGen
 
   LINK_LIBS PUBLIC
   MLIRAMDGPUDialect

--- a/mlir/lib/Dialect/GPU/TransformOps/CMakeLists.txt
+++ b/mlir/lib/Dialect/GPU/TransformOps/CMakeLists.txt
@@ -8,8 +8,6 @@ add_mlir_dialect_library(MLIRGPUTransformOps
 
   DEPENDS
   MLIRGPUTransformOpsIncGen
-  MLIRDeviceMappingInterfacesIncGen
-  MLIRGPUDeviceMapperEnumsGen
 
   LINK_LIBS PUBLIC
   MLIRGPUDialect

--- a/mlir/lib/Dialect/LLVMIR/CMakeLists.txt
+++ b/mlir/lib/Dialect/LLVMIR/CMakeLists.txt
@@ -38,9 +38,7 @@ add_mlir_dialect_library(MLIRLLVMDialect
   MLIRLLVMAllOpsIncGen
   MLIRLLVMOpsIncGen
   MLIRLLVMOpsShardGen
-  MLIRLLVMTranslationDialectInterfaceIncGen
   MLIRLLVMTypesIncGen
-  MLIROpenMPOpsIncGen
   intrinsics_gen
   MLIRLLVMConversionsIncGen
   MLIRLLVMIntrinsicConversionsIncGen
@@ -86,7 +84,6 @@ add_mlir_dialect_library(MLIRNVVMDialect
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/LLVMIR
 
   DEPENDS
-  MLIRGPUCompilationAttrInterfacesIncGen
   MLIRNVVMOpsIncGen
   MLIRNVVMOpsShardGen
   MLIRNVVMConversionsIncGen

--- a/mlir/lib/Dialect/Linalg/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/Linalg/IR/CMakeLists.txt
@@ -14,7 +14,6 @@ add_mlir_dialect_library(MLIRLinalgDialect
   MLIRLinalgOpsIncGen
   MLIRLinalgStructuredOpsIncGen
   MLIRLinalgRelayoutOpsIncGen
-  MLIRShardingInterfaceIncGen
   MLIRRelayoutOpInterfaceIncGen
 
   # LinalgDialect.cpp includes ShardingInterface.h for promised interfaces.

--- a/mlir/lib/Dialect/OpenACC/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/OpenACC/IR/CMakeLists.txt
@@ -9,7 +9,6 @@ add_mlir_dialect_library(MLIROpenACCDialect
   MLIROpenACCOpsIncGen
   MLIROpenACCEnumsIncGen
   MLIROpenACCAttributesIncGen
-  MLIROpenACCMPOpsInterfacesIncGen
   MLIROpenACCOpsInterfacesIncGen
   MLIROpenACCTypeInterfacesIncGen
 

--- a/mlir/lib/Dialect/OpenACC/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/OpenACC/Transforms/CMakeLists.txt
@@ -27,12 +27,6 @@ add_mlir_dialect_library(MLIROpenACCTransforms
 
   DEPENDS
   MLIROpenACCPassIncGen
-  MLIROpenACCOpsIncGen
-  MLIROpenACCEnumsIncGen
-  MLIROpenACCAttributesIncGen
-  MLIROpenACCMPOpsInterfacesIncGen
-  MLIROpenACCOpsInterfacesIncGen
-  MLIROpenACCTypeInterfacesIncGen
 
   LINK_LIBS PUBLIC
   MLIRAnalysis

--- a/mlir/lib/Dialect/OpenACC/Utils/CMakeLists.txt
+++ b/mlir/lib/Dialect/OpenACC/Utils/CMakeLists.txt
@@ -11,15 +11,6 @@ add_mlir_dialect_library(MLIROpenACCUtils
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/OpenACC
 
-  DEPENDS
-  MLIROpenACCPassIncGen
-  MLIROpenACCOpsIncGen
-  MLIROpenACCEnumsIncGen
-  MLIROpenACCAttributesIncGen
-  MLIROpenACCMPOpsInterfacesIncGen
-  MLIROpenACCOpsInterfacesIncGen
-  MLIROpenACCTypeInterfacesIncGen
-
   LINK_LIBS PUBLIC
   MLIRArithDialect
   MLIRArithUtils

--- a/mlir/lib/Dialect/OpenMP/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/OpenMP/IR/CMakeLists.txt
@@ -8,7 +8,6 @@ add_mlir_dialect_library(MLIROpenMPDialect
   omp_gen
   MLIROpenMPOpsIncGen
   MLIROpenMPOpsInterfacesIncGen
-  MLIROpenMPTypeInterfacesIncGen
 
   LINK_COMPONENTS
   TargetParser

--- a/mlir/lib/Dialect/OpenMP/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/OpenMP/Transforms/CMakeLists.txt
@@ -11,9 +11,6 @@ add_mlir_dialect_library(MLIROpenMPTransforms
   DEPENDS
   omp_gen
   MLIROpenMPPassIncGen
-  MLIROpenMPOpsIncGen
-  MLIROpenMPOpsInterfacesIncGen
-  MLIROpenMPTypeInterfacesIncGen
 
   LINK_LIBS PUBLIC
   MLIRFunctionInterfaces

--- a/mlir/lib/Dialect/Ptr/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/Ptr/IR/CMakeLists.txt
@@ -26,7 +26,7 @@ add_mlir_dialect_library(
   MLIRPtrOpsAttributesIncGen
   MLIRPtrOpsIncGen
   MLIRPtrOpsEnumsGen
-  MLIRPtrMemorySpaceInterfacesIncGen
+
   LINK_LIBS
   PUBLIC
   MLIRIR

--- a/mlir/lib/Dialect/SMT/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/SMT/IR/CMakeLists.txt
@@ -21,7 +21,3 @@ add_mlir_dialect_library(MLIRSMT
   MLIRSideEffectInterfaces
   MLIRControlFlowInterfaces
 )
-
-add_dependencies(mlir-headers
-  MLIRSMTIncGen
-)

--- a/mlir/lib/Dialect/SPIRV/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/SPIRV/IR/CMakeLists.txt
@@ -51,7 +51,6 @@ add_mlir_dialect_library(MLIRSPIRVDialect
   MLIRSPIRVCanonicalizationIncGen
   MLIRSPIRVEnumAvailabilityIncGen
   MLIRSPIRVEnumsIncGen
-  MLIRSPIRVImageInterfacesIncGen
   MLIRSPIRVOpsIncGen
   MLIRSPIRVOpsShardGen
   MLIRSPIRVSerializationGen

--- a/mlir/lib/Dialect/Shard/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/Shard/Transforms/CMakeLists.txt
@@ -9,7 +9,6 @@ add_mlir_dialect_library(MLIRShardTransforms
 
   DEPENDS
   MLIRShardPassIncGen
-  MLIRShardingInterface
 
   LINK_LIBS PUBLIC
   MLIRAffineDialect

--- a/mlir/lib/Dialect/Tosa/CMakeLists.txt
+++ b/mlir/lib/Dialect/Tosa/CMakeLists.txt
@@ -14,7 +14,6 @@ add_mlir_dialect_library(MLIRTosaDialect
   MLIRTosaOpsIncGen
   MLIRTosaInterfacesIncGen
   MLIRTosaEnumsIncGen
-  MLIRShardingInterfaceIncGen
 
   # TosaOps.cpp includes ShardingInterface.h for promised interfaces.
   HEADER_LIBS

--- a/mlir/lib/Dialect/Vector/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/Vector/IR/CMakeLists.txt
@@ -7,8 +7,6 @@ add_mlir_dialect_library(MLIRVectorDialect
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/Vector/IR
 
   DEPENDS
-  MLIRMaskableOpInterfaceIncGen
-  MLIRMaskingOpInterfaceIncGen
   MLIRVectorOpsIncGen
   MLIRVectorAttributesIncGen
   MLIRVectorIncGen

--- a/mlir/lib/IR/CMakeLists.txt
+++ b/mlir/lib/IR/CMakeLists.txt
@@ -63,14 +63,10 @@ add_mlir_library(MLIRIR
   MLIRBuiltinTypesIncGen
   MLIRBuiltinTypeConstraintsIncGen
   MLIRBuiltinTypeInterfacesIncGen
-  MLIRCallInterfacesIncGen
-  MLIRCastInterfacesIncGen
-  MLIRDataLayoutInterfacesIncGen
   MLIRDialectFoldInterfaceIncGen
   MLIROpAsmInterfaceIncGen
   MLIRQuantStorageTypeInterfaceIncGen
   MLIRRegionKindInterfaceIncGen
-  MLIRSideEffectInterfacesIncGen
   MLIRSymbolInterfacesIncGen
   MLIRTensorEncodingIncGen
   MLIROpAsmDialectInterfaceIncGen

--- a/mlir/lib/Interfaces/CMakeLists.txt
+++ b/mlir/lib/Interfaces/CMakeLists.txt
@@ -115,9 +115,7 @@ add_mlir_library(MLIRSubsetOpInterface
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Interfaces
 
   DEPENDS
-  MLIRDestinationStyleOpInterface
   MLIRSubsetOpInterfaceIncGen
-  MLIRValueBoundsOpInterface
 
   LINK_LIBS PUBLIC
   MLIRDestinationStyleOpInterface
@@ -148,9 +146,7 @@ add_mlir_library(MLIRValueBoundsOpInterface
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Interfaces
 
   DEPENDS
-  MLIRDestinationStyleOpInterface
   MLIRValueBoundsOpInterfaceIncGen
-  MLIRViewLikeInterface
 
   LINK_LIBS PUBLIC
   MLIRAnalysis

--- a/mlir/lib/Interfaces/Utils/CMakeLists.txt
+++ b/mlir/lib/Interfaces/Utils/CMakeLists.txt
@@ -9,9 +9,6 @@ add_mlir_library(MLIRInferIntRangeCommon
     ADDITIONAL_HEADER_DIRS
     ${MLIR_MAIN_INCLUDE_DIR}/mlir/Interfaces/Utils
 
-    DEPENDS
-    MLIRInferIntRangeInterfaceIncGen
-
     LINK_LIBS PUBLIC
     MLIRShapedOpInterfaces
     MLIRInferIntRangeInterface

--- a/mlir/lib/Rewrite/CMakeLists.txt
+++ b/mlir/lib/Rewrite/CMakeLists.txt
@@ -14,7 +14,6 @@ add_mlir_library(MLIRRewrite
 
   DEPENDS
   mlir-generic-headers
-  MLIRConversionPassIncGen
 
   # FrozenRewritePatternSet.cpp includes PDLInterp and PDL when enabled.
   # PDLInterp's public interface also provides the PDL generated headers.

--- a/mlir/lib/Target/LLVMIR/Dialect/ArmNeon/CMakeLists.txt
+++ b/mlir/lib/Target/LLVMIR/Dialect/ArmNeon/CMakeLists.txt
@@ -1,9 +1,6 @@
 add_mlir_translation_library(MLIRArmNeonToLLVMIRTranslation
   ArmNeonToLLVMIRTranslation.cpp
 
-  DEPENDS
-  MLIRArmNeonConversionsIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Target/LLVMIR/Dialect/ArmSME/CMakeLists.txt
+++ b/mlir/lib/Target/LLVMIR/Dialect/ArmSME/CMakeLists.txt
@@ -1,9 +1,6 @@
 add_mlir_translation_library(MLIRArmSMEToLLVMIRTranslation
   ArmSMEToLLVMIRTranslation.cpp
 
-  DEPENDS
-  MLIRArmSMEConversionsIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Target/LLVMIR/Dialect/ArmSVE/CMakeLists.txt
+++ b/mlir/lib/Target/LLVMIR/Dialect/ArmSVE/CMakeLists.txt
@@ -1,9 +1,6 @@
 add_mlir_translation_library(MLIRArmSVEToLLVMIRTranslation
   ArmSVEToLLVMIRTranslation.cpp
 
-  DEPENDS
-  MLIRArmSVEConversionsIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Target/LLVMIR/Dialect/NVVM/CMakeLists.txt
+++ b/mlir/lib/Target/LLVMIR/Dialect/NVVM/CMakeLists.txt
@@ -19,9 +19,6 @@ add_mlir_translation_library(MLIRLLVMIRToNVVMTranslation
 add_mlir_translation_library(MLIRNVVMToLLVMIRTranslation
   NVVMToLLVMIRTranslation.cpp
 
-  DEPENDS
-  MLIRNVVMConversionsIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Target/LLVMIR/Dialect/ROCDL/CMakeLists.txt
+++ b/mlir/lib/Target/LLVMIR/Dialect/ROCDL/CMakeLists.txt
@@ -1,9 +1,6 @@
 add_mlir_translation_library(MLIRROCDLToLLVMIRTranslation
   ROCDLToLLVMIRTranslation.cpp
 
-  DEPENDS
-  MLIRROCDLConversionsIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Target/LLVMIR/Dialect/VCIX/CMakeLists.txt
+++ b/mlir/lib/Target/LLVMIR/Dialect/VCIX/CMakeLists.txt
@@ -1,9 +1,6 @@
 add_mlir_translation_library(MLIRVCIXToLLVMIRTranslation
   VCIXToLLVMIRTranslation.cpp
 
-  DEPENDS
-  MLIRVCIXConversionsIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Target/LLVMIR/Dialect/XeVM/CMakeLists.txt
+++ b/mlir/lib/Target/LLVMIR/Dialect/XeVM/CMakeLists.txt
@@ -5,9 +5,6 @@ set(LLVM_OPTIONAL_SOURCES
 add_mlir_translation_library(MLIRXeVMToLLVMIRTranslation
   XeVMToLLVMIRTranslation.cpp
 
-  DEPENDS
-  MLIRXeVMConversionsIncGen
-
   LINK_COMPONENTS
   Core
 

--- a/mlir/lib/Target/SPIRV/Deserialization/CMakeLists.txt
+++ b/mlir/lib/Target/SPIRV/Deserialization/CMakeLists.txt
@@ -3,9 +3,6 @@ add_mlir_translation_library(MLIRSPIRVDeserialization
   Deserializer.cpp
   Deserialization.cpp
 
-  DEPENDS
-  MLIRSPIRVSerializationGen
-
   LINK_LIBS PUBLIC
   MLIRIR
   MLIRSPIRVDialect

--- a/mlir/lib/Target/SPIRV/Serialization/CMakeLists.txt
+++ b/mlir/lib/Target/SPIRV/Serialization/CMakeLists.txt
@@ -3,9 +3,6 @@ add_mlir_translation_library(MLIRSPIRVSerialization
   Serializer.cpp
   SerializeOps.cpp
 
-  DEPENDS
-  MLIRSPIRVSerializationGen
-
   LINK_LIBS PUBLIC
   MLIRIR
   MLIRSPIRVDialect

--- a/mlir/test/lib/Dialect/Test/CMakeLists.txt
+++ b/mlir/test/lib/Dialect/Test/CMakeLists.txt
@@ -68,7 +68,6 @@ add_mlir_library(MLIRTestDialect
   MLIRTestOpsIncGen
   MLIRTestOpsSyntaxIncGen
   MLIRTestOpsShardGen
-  MLIRConvertToEmitCPatternInterfaceIncGen
   )
 mlir_target_link_libraries(MLIRTestDialect PUBLIC
   MLIRControlFlowInterfaces

--- a/mlir/test/lib/Dialect/Tosa/CMakeLists.txt
+++ b/mlir/test/lib/Dialect/Tosa/CMakeLists.txt
@@ -6,9 +6,6 @@ add_mlir_library(MLIRTosaTestPasses
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/Tosa/Transforms
 
-  DEPENDS
-  mlir-headers
-  MLIRTosaPassIncGen
   )
 mlir_target_link_libraries(MLIRTosaTestPasses PUBLIC
   MLIRFuncDialect

--- a/mlir/test/python/lib/CMakeLists.txt
+++ b/mlir/test/python/lib/CMakeLists.txt
@@ -21,9 +21,6 @@ mlir_target_link_libraries(MLIRPythonTestDialect PUBLIC
 add_mlir_public_c_api_library(MLIRCAPIPythonTestDialect
   PythonTestCAPI.cpp
 
-  DEPENDS
-  MLIRPythonTestIncGen
-
   LINK_LIBS PUBLIC
   MLIRCAPIInterfaces
   MLIRCAPIIR

--- a/mlir/unittests/IR/CMakeLists.txt
+++ b/mlir/unittests/IR/CMakeLists.txt
@@ -26,9 +26,6 @@ add_mlir_unittest(MLIRIRTests
   ValueTest.cpp
   VerifierTest.cpp
   BlobManagerTest.cpp
-
-  DEPENDS
-  MLIRTestInterfaceIncGen
 )
 target_include_directories(MLIRIRTests PRIVATE "${MLIR_BINARY_DIR}/test/lib/Dialect/Test")
 mlir_target_link_libraries(MLIRIRTests PRIVATE MLIRIR)

--- a/mlir/unittests/Interfaces/CMakeLists.txt
+++ b/mlir/unittests/Interfaces/CMakeLists.txt
@@ -5,9 +5,6 @@ add_mlir_unittest(MLIRInterfacesTests
   MemorySlotUtilsTest.cpp
   SideEffectInterfacesTest.cpp
   InferTypeOpInterfaceTest.cpp
-
-  DEPENDS
-  MLIRTestInterfaceIncGen
 )
 target_include_directories(MLIRInterfacesTests PRIVATE "${MLIR_BINARY_DIR}/test/lib/Dialect/Test")
 

--- a/mlir/unittests/Parser/CMakeLists.txt
+++ b/mlir/unittests/Parser/CMakeLists.txt
@@ -1,9 +1,6 @@
 add_mlir_unittest(MLIRParserTests
   ParserTest.cpp
   ResourceTest.cpp
-
-  DEPENDS
-  MLIRTestInterfaceIncGen
 )
 target_include_directories(MLIRParserTests PRIVATE "${MLIR_BINARY_DIR}/test/lib/Dialect/Test")
 


### PR DESCRIPTION
Remove the broad mlir-headers prerequisites now that direct links and HEADER_LIBS relationships provide generated-header ordering.

Keep own generators and intentional source-generation dependencies explicit. Document migration options for downstream projects that relied on aggregate ordering.

Assisted-by: Codex
Assisted-by: Claude Code