### PR TITLE
[Clang][Driver] Link ASan into user binaries when the HIP runtime is ASan

### DIFF
--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -87,6 +87,16 @@ def err_drv_no_hipstdpar_prim_lib : Error<
   "cannot find rocPrim, which is required by the HIP Standard Parallelism "
   "Acceleration library; provide it via '--hipstdpar-prim-path'">;
 
+def warn_drv_hip_runtime_asan_ignoring_static_libsan : Warning<
+  "ignoring '%0': the HIP runtime is built with the address sanitizer and "
+  "requires the shared address sanitizer runtime">,
+  InGroup<DiagGroup<"hip-runtime-sanitizer">>;
+def warn_drv_hip_runtime_asan_needs_shared_rt : Warning<
+  "the HIP runtime is built with the address sanitizer and requires the shared "
+  "address sanitizer runtime; the static runtime selected here is not "
+  "compatible with it, consider '-shared-libasan'">,
+  InGroup<DiagGroup<"hip-runtime-sanitizer">>;
+
 def err_drv_no_hipspv_device_lib : Error<
   "cannot find HIP device library%select{| for %1}0; provide its path via "
   "'--hip-path' or '--hip-device-lib-path', or pass '-nogpulib' to build "

--- a/clang/include/clang/Driver/CommonArgs.h
+++ b/clang/include/clang/Driver/CommonArgs.h
@@ -59,6 +59,11 @@ void claimNoWarnArgs(const llvm::opt::ArgList &Args);
 bool addSanitizerRuntimes(const ToolChain &TC, const llvm::opt::ArgList &Args,
                           llvm::opt::ArgStringList &CmdArgs);
 
+bool addHIPRuntimeSanitizerRuntimes(const ToolChain &TC,
+                                    unsigned ActiveOffloadKinds,
+                                    const llvm::opt::ArgList &Args,
+                                    llvm::opt::ArgStringList &CmdArgs);
+
 void linkSanitizerRuntimeDeps(const ToolChain &TC,
                               const llvm::opt::ArgList &Args,
                               llvm::opt::ArgStringList &CmdArgs);

--- a/clang/include/clang/Driver/RocmInstallationDetector.h
+++ b/clang/include/clang/Driver/RocmInstallationDetector.h
@@ -91,6 +91,7 @@ private:
   bool HasHIPStdParLibrary = false;
   bool HasRocThrustLibrary = false;
   bool HasRocPrimLibrary = false;
+  bool HasHIPRuntimeAsan = false;
 
   // Default version if not detected or specified.
   const unsigned DefaultVersionMajor = 3;
@@ -196,6 +197,10 @@ public:
 
   /// Check whether we detected a valid HIP STDPAR Acceleration library.
   bool hasHIPStdParLibrary() const { return HasHIPStdParLibrary; }
+
+  /// Check whether the detected HIP runtime was built with the address
+  /// sanitizer enabled.
+  bool hasHIPRuntimeAsan() const { return HasHIPRuntimeAsan; }
 
   /// Print information about the detected ROCm installation.
   void print(raw_ostream &OS) const;

--- a/clang/include/clang/Driver/ToolChain.h
+++ b/clang/include/clang/Driver/ToolChain.h
@@ -881,6 +881,15 @@ public:
                                 const llvm::opt::ArgList &Args,
                                 llvm::opt::ArgStringList &CmdArgs) const {}
 
+  /// If this link pulls in a HIP runtime that was itself built
+  /// with the address sanitizer, return true.
+  ///
+  /// Only meaningful when HIP is among the active offload kinds.
+  virtual bool
+  hipRuntimeRequiresAddressSanitizer(const llvm::opt::ArgList &Args) const {
+    return false;
+  }
+
   /// Return sanitizers which are available in this toolchain.
   virtual SanitizerMask
   getSupportedSanitizers(BoundArch BA,

--- a/clang/lib/Driver/ToolChains/AMDGPU.cpp
+++ b/clang/lib/Driver/ToolChains/AMDGPU.cpp
@@ -16,6 +16,7 @@
 #include "clang/Driver/InputInfo.h"
 #include "clang/Driver/SanitizerArgs.h"
 #include "clang/Options/Options.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Option/ArgList.h"
@@ -163,6 +164,8 @@ bool RocmInstallationDetector::parseHIPVersionFile(llvm::StringRef V) {
   V.split(VersionParts, '\n');
   unsigned Major = ~0U;
   unsigned Minor = ~0U;
+  // Assume no runtime sanitizer unless the version file says otherwise.
+  HasHIPRuntimeAsan = false;
   for (auto Part : VersionParts) {
     auto Splits = Part.rtrim().split('=');
     if (Splits.first == "HIP_VERSION_MAJOR") {
@@ -173,6 +176,11 @@ bool RocmInstallationDetector::parseHIPVersionFile(llvm::StringRef V) {
         return true;
     } else if (Splits.first == "HIP_VERSION_PATCH")
       VersionPatch = Splits.second.str();
+    else if (Splits.first == "HIP_RUNTIME_SANITIZER") {
+      SmallVector<StringRef, 4> Sanitizers;
+      Splits.second.split(Sanitizers, ',');
+      HasHIPRuntimeAsan = llvm::is_contained(Sanitizers, "address");
+    }
   }
   if (Major == ~0U || Minor == ~0U)
     return true;
@@ -523,9 +531,12 @@ void RocmInstallationDetector::detectHIPRuntime(
 }
 
 void RocmInstallationDetector::print(raw_ostream &OS) const {
-  if (hasHIPRuntime())
+  if (hasHIPRuntime()) {
     OS << "Found HIP installation: " << InstallPath << ", version "
        << DetectedVersion << '\n';
+    if (hasHIPRuntimeAsan())
+      OS << "HIP runtime is built with the address sanitizer enabled\n";
+  }
 }
 
 void RocmInstallationDetector::AddHIPIncludeArgs(const ArgList &DriverArgs,

--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -1583,6 +1583,38 @@ void tools::addOpenMPHostOffloadingArgs(const Compilation &C,
       Args.MakeArgString(Twine(Targets) + llvm::join(Triples, ",")));
 }
 
+static bool hasRPathEntry(const ArgStringList &CmdArgs, StringRef Path) {
+  for (size_t I = 1, E = CmdArgs.size(); I != E; ++I)
+    if (StringRef(CmdArgs[I - 1]) == "-rpath" && StringRef(CmdArgs[I]) == Path)
+      return true;
+  return false;
+}
+
+/// Add an RPATH entry for the directory holding the selected shared sanitizer
+/// runtime.
+///
+/// That directory depends on the compiler-rt layout, so it's derived
+/// from the given file rather than guessed from the triple the way
+/// addArchSpecificRPath() does.
+static void addSanitizerRuntimeRPath(const ToolChain &TC, const ArgList &Args,
+                                     ArgStringList &CmdArgs,
+                                     StringRef Sanitizer) {
+  if (!Args.hasFlag(options::OPT_frtlib_add_rpath,
+                    options::OPT_fno_rtlib_add_rpath, false))
+    return;
+
+  if (TC.getTriple().isOSAIX()) // TODO: AIX doesn't support -rpath option.
+    return;
+
+  std::string RT = TC.getCompilerRT(Args, Sanitizer, ToolChain::FT_Shared);
+  StringRef Dir = llvm::sys::path::parent_path(RT);
+  if (Dir.empty() || !TC.getVFS().exists(Dir) || hasRPathEntry(CmdArgs, Dir))
+    return;
+
+  CmdArgs.push_back("-rpath");
+  CmdArgs.push_back(Args.MakeArgString(Dir));
+}
+
 static void addSanitizerRuntime(const ToolChain &TC, const ArgList &Args,
                                 ArgStringList &CmdArgs, StringRef Sanitizer,
                                 bool IsShared, bool IsWhole) {
@@ -1593,6 +1625,9 @@ static void addSanitizerRuntime(const ToolChain &TC, const ArgList &Args,
       Args, Sanitizer, IsShared ? ToolChain::FT_Shared : ToolChain::FT_Static));
   if (IsWhole)
     CmdArgs.push_back("--no-whole-archive");
+
+  if (IsShared)
+    addSanitizerRuntimeRPath(TC, Args, CmdArgs, Sanitizer);
 }
 
 // Tries to use a file with the list of dynamic symbols that need to be exported
@@ -1898,6 +1933,48 @@ bool tools::addSanitizerRuntimes(const ToolChain &TC, const ArgList &Args,
 
   return !StaticRuntimes.empty() || !NonWholeStaticRuntimes.empty() ||
          FuzzerNeedsSanitizerDeps;
+}
+
+// Links the ASan runtime an ASan-instrumented HIP runtime needs. That
+// requirement comes from the link rather than from how the user's sources were
+// compiled, so it must not imply '-fsanitize=address' for the compile jobs.
+//
+// Returns true if sanitizer system deps need to be linked in.
+bool tools::addHIPRuntimeSanitizerRuntimes(const ToolChain &TC,
+                                           unsigned ActiveOffloadKinds,
+                                           const ArgList &Args,
+                                           ArgStringList &CmdArgs) {
+  if (!(ActiveOffloadKinds & Action::OFK_HIP))
+    return false;
+
+  if (!TC.hipRuntimeRequiresAddressSanitizer(Args))
+    return false;
+
+  const SanitizerArgs &SanArgs = TC.getSanitizerArgs(Args);
+  // Already handled by addSanitizerRuntimes(), except that a static runtime
+  // cannot serve the instrumented HIP runtime and there is nothing to fix up
+  // at this point.
+  if (SanArgs.needsAsanRt()) {
+    if (!SanArgs.needsSharedRt())
+      TC.getDriver().Diag(diag::warn_drv_hip_runtime_asan_needs_shared_rt);
+    return false;
+  }
+
+  // The HIP runtime is a shared library, so only the shared ASan runtime can
+  // serve it.
+  if (const Arg *A = Args.getLastArg(options::OPT_static_libsan))
+    TC.getDriver().Diag(diag::warn_drv_hip_runtime_asan_ignoring_static_libsan)
+        << A->getAsString(Args);
+
+  addSanitizerRuntime(TC, Args, CmdArgs, "asan", /*IsShared=*/true,
+                      /*IsWhole=*/false);
+  // Same split collectSanitizerRuntimes() makes between executables and DSOs.
+  if (!Args.hasArg(options::OPT_shared) && !TC.getTriple().isAndroid())
+    addSanitizerRuntime(TC, Args, CmdArgs, "asan-preinit", /*IsShared=*/false,
+                        /*IsWhole=*/true);
+  addSanitizerRuntime(TC, Args, CmdArgs, "asan_static", /*IsShared=*/false,
+                      /*IsWhole=*/true);
+  return true;
 }
 
 bool tools::addXRayRuntime(const ToolChain&TC, const ArgList &Args, ArgStringList &CmdArgs) {

--- a/clang/lib/Driver/ToolChains/Gnu.cpp
+++ b/clang/lib/Driver/ToolChains/Gnu.cpp
@@ -446,6 +446,8 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
     CmdArgs.push_back("--no-demangle");
 
   bool NeedsSanitizerDeps = addSanitizerRuntimes(ToolChain, Args, CmdArgs);
+  NeedsSanitizerDeps |= addHIPRuntimeSanitizerRuntimes(
+      ToolChain, C.getActiveOffloadKinds(), Args, CmdArgs);
   bool NeedsXRayDeps = addXRayRuntime(ToolChain, Args, CmdArgs);
   addLinkerCompressDebugSectionsOption(ToolChain, Args, CmdArgs);
   AddLinkerInputs(ToolChain, Inputs, Args, CmdArgs, JA);

--- a/clang/lib/Driver/ToolChains/Linux.cpp
+++ b/clang/lib/Driver/ToolChains/Linux.cpp
@@ -881,14 +881,20 @@ void Linux::AddHIPIncludeArgs(const ArgList &DriverArgs,
   RocmInstallation->AddHIPIncludeArgs(DriverArgs, CC1Args);
 }
 
+/// Whether a link with these arguments gets the offloading runtime libraries
+/// appended to it.
+static bool linksOffloadRTLibs(const ArgList &Args) {
+  return Args.hasFlag(options::OPT_offloadlib, options::OPT_no_offloadlib,
+                      true) &&
+         !Args.hasArg(options::OPT_nostdlib) &&
+         !Args.hasArg(options::OPT_no_hip_rt) && !Args.hasArg(options::OPT_r) &&
+         !Args.hasFlag(options::OPT_foffload_via_llvm,
+                       options::OPT_fno_offload_via_llvm, false);
+}
+
 void Linux::addOffloadRTLibs(unsigned ActiveKinds, const ArgList &Args,
                              ArgStringList &CmdArgs) const {
-  if (!Args.hasFlag(options::OPT_offloadlib, options::OPT_no_offloadlib,
-                    true) ||
-      Args.hasArg(options::OPT_nostdlib) ||
-      Args.hasArg(options::OPT_no_hip_rt) || Args.hasArg(options::OPT_r) ||
-      Args.hasFlag(options::OPT_foffload_via_llvm,
-                   options::OPT_fno_offload_via_llvm, false))
+  if (!linksOffloadRTLibs(Args))
     return;
 
   llvm::SmallVector<std::pair<StringRef, StringRef>> Libraries;
@@ -928,6 +934,10 @@ void Linux::addOffloadRTLibs(unsigned ActiveKinds, const ArgList &Args,
     CmdArgs.push_back("-u");
     CmdArgs.push_back("__llvm_profile_offload_register_dynamic_module");
   }
+}
+
+bool Linux::hipRuntimeRequiresAddressSanitizer(const ArgList &Args) const {
+  return linksOffloadRTLibs(Args) && RocmInstallation->hasHIPRuntimeAsan();
 }
 
 void Linux::AddIAMCUIncludeArgs(const ArgList &DriverArgs,

--- a/clang/lib/Driver/ToolChains/Linux.h
+++ b/clang/lib/Driver/ToolChains/Linux.h
@@ -44,6 +44,8 @@ public:
 
   void addOffloadRTLibs(unsigned ActiveKinds, const llvm::opt::ArgList &Args,
                         llvm::opt::ArgStringList &CmdArgs) const override;
+  bool hipRuntimeRequiresAddressSanitizer(
+      const llvm::opt::ArgList &Args) const override;
   RuntimeLibType GetDefaultRuntimeLibType() const override;
   unsigned GetDefaultDwarfVersion() const override;
   CXXStdlibType GetDefaultCXXStdlibType() const override;

--- a/clang/test/Driver/hip-runtime-asan-linux.hip
+++ b/clang/test/Driver/hip-runtime-asan-linux.hip
@@ -1,0 +1,114 @@
+// UNSUPPORTED: system-windows
+
+// An ASan-instrumented libamdhip64.so only works if the matching ASan runtime
+// is in the process and initialized before it.
+
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: touch %t/in.o
+
+// A HIP runtime without the HIP_RUNTIME_SANITIZER field.
+// RUN: cp -R %S/Inputs/rocm %t/rocm
+
+// The same runtime, built with the address sanitizer.
+// RUN: cp -R %S/Inputs/rocm %t/rocm-asan
+// RUN: printf 'HIP_RUNTIME_SANITIZER=address\n' >> %t/rocm-asan/bin/.hipVersion
+
+// The ASan runtime components are linked, in the order Clang uses for a
+// shared-ASan executable, and ahead of libamdhip64.so so that the ASan
+// runtime precedes it in DT_NEEDED.
+// RUN: %clang -### --hip-link --target=x86_64-linux-gnu \
+// RUN:   --rocm-path=%t/rocm-asan %t/in.o 2>&1 \
+// RUN:   | FileCheck -check-prefix=ASAN %s
+
+// ASAN:      "{{.*}}libclang_rt.asan{{[^"]*}}.so"
+// ASAN-SAME: "--whole-archive" "{{.*}}libclang_rt.asan-preinit{{[^"]*}}.a" "--no-whole-archive"
+// ASAN-SAME: "--whole-archive" "{{.*}}libclang_rt.asan_static{{[^"]*}}.a" "--no-whole-archive"
+// ASAN-SAME: "{{.*}}in.o"
+// ASAN-SAME: "{{.*}}libamdhip64.so"
+// ASAN-SAME: "--no-as-needed" "-lpthread" "-lrt" "-lm" "-ldl" "-lresolv"
+
+// Nothing is added for a HIP runtime that was not built with the sanitizer.
+// RUN: %clang -### --hip-link --target=x86_64-linux-gnu \
+// RUN:   --rocm-path=%t/rocm %t/in.o 2>&1 \
+// RUN:   | FileCheck -check-prefix=NOASAN %s
+
+// NOASAN-NOT: libclang_rt.asan
+
+// Nothing is added when libamdhip64.so is not linked in the first place.
+// RUN: %clang -### --hip-link -nostdlib --target=x86_64-linux-gnu \
+// RUN:   --rocm-path=%t/rocm-asan %t/in.o 2>&1 \
+// RUN:   | FileCheck -check-prefix=NOASAN %s
+// RUN: %clang -### --hip-link -no-hip-rt --target=x86_64-linux-gnu \
+// RUN:   --rocm-path=%t/rocm-asan %t/in.o 2>&1 \
+// RUN:   | FileCheck -check-prefix=NOASAN %s
+// RUN: %clang -### --hip-link --no-offloadlib --target=x86_64-linux-gnu \
+// RUN:   --rocm-path=%t/rocm-asan %t/in.o 2>&1 \
+// RUN:   | FileCheck -check-prefix=NOASAN %s
+// RUN: %clang -### --hip-link -r --target=x86_64-linux-gnu \
+// RUN:   --rocm-path=%t/rocm-asan %t/in.o 2>&1 \
+// RUN:   | FileCheck -check-prefix=NOASAN %s
+
+// Nor for a link that does not involve HIP at all.
+// RUN: %clang -### --target=x86_64-linux-gnu \
+// RUN:   --rocm-path=%t/rocm-asan %t/in.o 2>&1 \
+// RUN:   | FileCheck -check-prefix=NOASAN %s
+
+// An explicit '-fsanitize=address -shared-libsan' already emits the runtime,
+// so it shouldn't be emitted a second time.
+// RUN: %clang -### --hip-link --target=x86_64-linux-gnu \
+// RUN:   --rocm-path=%t/rocm-asan -fsanitize=address -shared-libsan \
+// RUN:   %t/in.o 2>&1 | FileCheck -check-prefix=EXPLICIT %s
+
+// EXPLICIT:     "{{.*}}libclang_rt.asan{{[^"]*}}.so"
+// EXPLICIT-NOT: "{{.*}}libclang_rt.asan{{[^"]*}}.so"
+
+// The HIP runtime is a shared library, so an explicit request for the static
+// ASan runtime cannot be honored and is diagnosed.
+// RUN: %clang -### --hip-link --target=x86_64-linux-gnu \
+// RUN:   --rocm-path=%t/rocm-asan -static-libsan %t/in.o 2>&1 \
+// RUN:   | FileCheck -check-prefix=STATIC-LIBSAN %s
+
+// STATIC-LIBSAN: warning: ignoring '-static-libsan': the HIP runtime is built with the address sanitizer and requires the shared address sanitizer runtime [-Whip-runtime-sanitizer]
+// STATIC-LIBSAN: "{{.*}}libclang_rt.asan{{[^"]*}}.so"
+
+// The warning is suppressible.
+// RUN: %clang -### --hip-link --target=x86_64-linux-gnu \
+// RUN:   --rocm-path=%t/rocm-asan -static-libsan -Wno-hip-runtime-sanitizer \
+// RUN:   %t/in.o 2>&1 | FileCheck -check-prefix=NOWARN %s
+
+// NOWARN-NOT: warning:
+
+// '-fsanitize=address' defaults to the static runtime, which is not compatible
+// with an ASan-instrumented shared HIP runtime.
+// RUN: %clang -### --hip-link --target=x86_64-linux-gnu \
+// RUN:   --rocm-path=%t/rocm-asan -fsanitize=address %t/in.o 2>&1 \
+// RUN:   | FileCheck -check-prefix=STATIC-RT %s
+
+// STATIC-RT: warning: the HIP runtime is built with the address sanitizer and requires the shared address sanitizer runtime; the static runtime selected here is not compatible with it, consider '-shared-libasan' [-Whip-runtime-sanitizer]
+
+// The RPATH must point at the directory the selected runtime actually lives in.
+// RUN: mkdir -p %t/rd/lib/linux
+// RUN: touch %t/rd/lib/linux/libclang_rt.asan-x86_64.so
+// RUN: %clang -### --hip-link --target=x86_64-linux-gnu \
+// RUN:   --rocm-path=%t/rocm-asan -resource-dir=%t/rd -frtlib-add-rpath \
+// RUN:   %t/in.o 2>&1 | FileCheck -check-prefix=RPATH %s
+
+// RPATH: "{{.*}}/rd/lib/linux/libclang_rt.asan-x86_64.so"
+// RPATH-SAME: "-rpath" "{{.*}}/rd/lib/linux"
+
+// No RPATH without -frtlib-add-rpath.
+// RUN: %clang -### --hip-link --target=x86_64-linux-gnu \
+// RUN:   --rocm-path=%t/rocm-asan -resource-dir=%t/rd %t/in.o 2>&1 \
+// RUN:   | FileCheck -check-prefix=NORPATH %s
+
+// NORPATH-NOT: "-rpath" "{{.*}}/rd/lib/linux"
+
+//
+// The user's translation units are not instrumented: this only fixes the
+// loader contract, it does not imply '-fsanitize=address' for compile jobs.
+//
+// RUN: %clang -### -c --target=x86_64-linux-gnu --offload-arch=gfx908 \
+// RUN:   -nogpuinc -nogpulib --rocm-path=%t/rocm-asan %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=NOINSTR %s
+
+// NOINSTR-NOT: "-fsanitize=address"

--- a/clang/test/Driver/hip-version.hip
+++ b/clang/test/Driver/hip-version.hip
@@ -78,3 +78,46 @@
 // RUN:   | FileCheck -check-prefixes=INVALID %s
 
 // INVALID: error: invalid value 'x.y' in '--hip-version=x.y'
+
+// Test that the HIP_RUNTIME_SANITIZER field of the HIP version file is
+// parsed with -fsanitize= semantics. A missing field, or a "none" value,
+// means the runtime has no sanitizer. A comma-separated list containing
+// "address" means the runtime was built with the address sanitizer.
+
+// RUN: rm -rf %t/Inputs
+// RUN: mkdir -p %t/Inputs
+
+// No HIP_RUNTIME_SANITIZER field at all.
+// RUN: cp -R %S/Inputs/rocm %t/Inputs/rocm-no-field
+// RUN: %clang -v --rocm-path=%t/Inputs/rocm-no-field 2>&1 \
+// RUN:   | FileCheck -check-prefixes=NOASAN %s
+
+// HIP_RUNTIME_SANITIZER=none.
+// RUN: cp -R %S/Inputs/rocm %t/Inputs/rocm-none
+// RUN: printf 'HIP_RUNTIME_SANITIZER=none\n' >> %t/Inputs/rocm-none/bin/.hipVersion
+// RUN: %clang -v --rocm-path=%t/Inputs/rocm-none 2>&1 \
+// RUN:   | FileCheck -check-prefixes=NOASAN %s
+
+// HIP_RUNTIME_SANITIZER set to a sanitizer other than address.
+// RUN: cp -R %S/Inputs/rocm %t/Inputs/rocm-other
+// RUN: printf 'HIP_RUNTIME_SANITIZER=undefined\n' >> %t/Inputs/rocm-other/bin/.hipVersion
+// RUN: %clang -v --rocm-path=%t/Inputs/rocm-other 2>&1 \
+// RUN:   | FileCheck -check-prefixes=NOASAN %s
+
+// HIP_RUNTIME_SANITIZER=address.
+// RUN: cp -R %S/Inputs/rocm %t/Inputs/rocm-address
+// RUN: printf 'HIP_RUNTIME_SANITIZER=address\n' >> %t/Inputs/rocm-address/bin/.hipVersion
+// RUN: %clang -v --rocm-path=%t/Inputs/rocm-address 2>&1 \
+// RUN:   | FileCheck -check-prefixes=ASAN %s
+
+// HIP_RUNTIME_SANITIZER as a comma-separated list including address.
+// RUN: cp -R %S/Inputs/rocm %t/Inputs/rocm-multi
+// RUN: printf 'HIP_RUNTIME_SANITIZER=undefined,address\n' >> %t/Inputs/rocm-multi/bin/.hipVersion
+// RUN: %clang -v --rocm-path=%t/Inputs/rocm-multi 2>&1 \
+// RUN:   | FileCheck -check-prefixes=ASAN %s
+
+// ASAN: Found HIP installation: {{.*}}
+// ASAN-NEXT: HIP runtime is built with the address sanitizer enabled
+
+// NOASAN: Found HIP installation: {{.*}}
+// NOASAN-NOT: HIP runtime is built with the address sanitizer enabled


### PR DESCRIPTION
Change the GNU toolchain to add sanitizer dependencies when compiling a HIP offload, if the detected HIP runtime reports it's been compiled ASan. Also, change the HIP version detector to parse a HIP_RUNTIME_SANITIZER field.

Currently, if you compile an offload binary with an ASan HIP runtime, but no explicit ASan flags, you'll receive an error about a missing dependency (since ASan must be in the initial list of loaded dependencies). This is a concurrent change with the HIP runtime (see https://github.com/ROCm/rocm-systems/pull/9614).

Also, I want to page @arsenm about MacOS HIP, since this introduces a small change on the GNU toolchain, and I'm not sure if this has potential implications there.