### PR TITLE
[lldb] Add SBCompileUnit::GetIsOptimized

### DIFF
--- a/lldb/bindings/interface/SBCompileUnitDocstrings.i
+++ b/lldb/bindings/interface/SBCompileUnitDocstrings.i
@@ -63,3 +63,8 @@ See also :py:class:`SBSymbolContext` and :py:class:`SBLineEntry`"
      @return
         A list of types in this compile unit that match type_mask"
 ) lldb::SBCompileUnit::GetTypes;
+
+%feature("docstring", "
+    Returns true if this compile unit was compiled with optimization,
+    false if unoptimized or unknown."
+) lldb::SBCompileUnit::GetIsOptimized;

--- a/lldb/include/lldb/API/SBCompileUnit.h
+++ b/lldb/include/lldb/API/SBCompileUnit.h
@@ -68,6 +68,10 @@ public:
 
   lldb::LanguageType GetLanguage();
 
+  /// Returns true if this compile unit was compiled with optimization, false if
+  /// unoptimized or unknown.
+  bool GetIsOptimized();
+
   bool operator==(const lldb::SBCompileUnit &rhs) const;
 
   bool operator!=(const lldb::SBCompileUnit &rhs) const;

--- a/lldb/source/API/SBCompileUnit.cpp
+++ b/lldb/source/API/SBCompileUnit.cpp
@@ -185,6 +185,14 @@ lldb::LanguageType SBCompileUnit::GetLanguage() {
   return lldb::eLanguageTypeUnknown;
 }
 
+bool SBCompileUnit::GetIsOptimized() {
+  LLDB_INSTRUMENT_VA(this);
+
+  if (m_opaque_ptr)
+    return m_opaque_ptr->GetIsOptimized();
+  return false;
+}
+
 bool SBCompileUnit::IsValid() const {
   LLDB_INSTRUMENT_VA(this);
   return this->operator bool();

--- a/lldb/test/API/python_api/compile_unit/TestCompileUnitAPI.py
+++ b/lldb/test/API/python_api/compile_unit/TestCompileUnitAPI.py
@@ -9,6 +9,8 @@ from lldbsuite.test import lldbutil
 
 
 class CompileUnitAPITestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def test(self):
         """Exercise some SBCompileUnit APIs."""
         self.build()
@@ -51,3 +53,20 @@ class CompileUnitAPITestCase(TestBase):
                 0, line_entry.GetLine(), line_entry.GetFileSpec(), True
             ),
         )
+
+    def find_main_compile_unit(self) -> lldb.SBCompileUnit:
+        target = self.dbg.CreateTarget(self.getBuildArtifact("a.out"))
+        self.assertTrue(target, VALID_TARGET)
+        main_cu = target.FindModule(lldb.SBFileSpec("a.out")).compile_unit["main.c"]
+        self.assertTrue(main_cu.IsValid(), "Main executable CU is not valid")
+        return main_cu
+
+    def test_is_optimized(self):
+        """A compile unit built with optimization reports it."""
+        self.build(dictionary={"CFLAGS_EXTRAS": "-O1"})
+        self.assertTrue(self.find_main_compile_unit().GetIsOptimized())
+
+    def test_is_not_optimized(self):
+        """A compile unit built without optimization reports it."""
+        self.build()
+        self.assertFalse(self.find_main_compile_unit().GetIsOptimized())


### PR DESCRIPTION
Expose Module::GetIsOptimized through the SB API so clients can tell whether a compile unit was built with optimization. This change is motivated by lldb-dap, where I want to extend the protocol::CompileUnit with this information.

The new tests build the same source with and without -O1, so the test case can no longer share a build with the others.