### PR TITLE
[LIT] Fix quadratic behavior collecting process output

### DIFF
--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -988,21 +988,21 @@ def formatOutput(title, data, limit=None):
         msg = ""
     ndashes = 30
     # fmt: off
-    out = f"# .---{title}{'-' * (ndashes - 4 - len(title))}\n"
+    parts = [f"# .---{title}{'-' * (ndashes - 4 - len(title))}\n"]
     curr_color = None
     for line in data.splitlines():
         if curr_color:
-            out += "\33[0m"
-        out += "# | "
+            parts.append("\33[0m")
+        parts.append("# | ")
         if curr_color:
-            out += curr_color
-        out += line + "\n"
+            parts.append(curr_color)
+        parts.append(line + "\n")
         curr_color = findColor(line, curr_color)
     if curr_color:
-        out += "\33[0m"  # prevent unterminated formatting from leaking
-    out += f"# `---{msg}{'-' * (ndashes - 4 - len(msg))}\n"
+        parts.append("\33[0m")  # prevent unterminated formatting from leaking
+    parts.append(f"# `---{msg}{'-' * (ndashes - 4 - len(msg))}\n")
     # fmt: on
-    return out
+    return "".join(parts)
 
 
 # Always either returns the tuple (out, err, exitCode, timeoutInfo) or raises a


### PR DESCRIPTION
Repeatedly appending to a string is quadratic.
This makes lit very slow when tests emit large amounts of output.

Fixing this speeds up one Swift compiler test by 36x (from 720s down to 20s).