### PR TITLE
[flang][cuda] Emit Mcuda_compiled sentinel for CUDA Fortran objects

### DIFF
--- a/flang-rt/lib/cuda/init.cpp
+++ b/flang-rt/lib/cuda/init.cpp
@@ -15,6 +15,8 @@
 
 extern "C" {
 
+char Mcuda_compiled;
+
 void RTDEF(CUFInit)() {
   // Perform ctx initialization based on execution environment if necessary.
   if (Fortran::runtime::executionEnvironment.cudaStackLimit) {

--- a/flang/include/flang/Optimizer/Transforms/Passes.td
+++ b/flang/include/flang/Optimizer/Transforms/Passes.td
@@ -605,7 +605,8 @@ def CUFDeviceGlobal :
 def CUFAddConstructor : Pass<"cuf-add-constructor", "mlir::ModuleOp"> {
   let summary = "Add constructor to register CUDA Fortran allocators";
   let dependentDialects = [
-    "cuf::CUFDialect", "mlir::func::FuncDialect", "mlir::DLTIDialect"
+    "cuf::CUFDialect", "mlir::func::FuncDialect", "mlir::DLTIDialect",
+    "mlir::LLVM::LLVMDialect"
   ];
   let options = [
     Option<"allocatorRegistrationFunction",
@@ -620,7 +621,11 @@ def CUFAddConstructor : Pass<"cuf-add-constructor", "mlir::ModuleOp"> {
            "time and HMM/ATS handles migration.">,
     Option<"priority", "priority", "int32_t", /*default=*/"0",
            "Priority for the CUDA Fortran global constructor in "
-           "llvm.mlir.global_ctors.">
+           "llvm.mlir.global_ctors.">,
+    Option<"emitCudaCompiled", "emit-cuda-compiled", "bool",
+           /*default=*/"false",
+           "Declare an undefined cuda_compiled symbol so linking without the "
+           "CUDA Fortran runtime fails with a clear diagnostic.">
   ];
 }
 

--- a/flang/lib/Optimizer/Transforms/CUDA/CUFAddConstructor.cpp
+++ b/flang/lib/Optimizer/Transforms/CUDA/CUFAddConstructor.cpp
@@ -41,6 +41,7 @@ namespace {
 static constexpr llvm::StringRef cudaFortranCtorName{
     "__cudaFortranConstructor"};
 static constexpr llvm::StringRef managedPtrSuffix{".managed.ptr"};
+static constexpr llvm::StringRef cudaCompiledSymbolName{"Mcuda_compiled"};
 
 /// Create an 8-byte pointer global in the __nv_managed_data__ section.
 /// The CUDA runtime populates this pointer with the unified memory address
@@ -319,6 +320,16 @@ struct CUFAddConstructor
 
     // Create the constructor function that call CUFRegisterAllocator.
     builder.setInsertionPointToEnd(mod.getBody());
+    mlir::LLVM::GlobalOp cudaCompiledGlobal;
+    if (emitCudaCompiled) {
+      // Undefined sentinel: objects compiled as CUDA Fortran reference this
+      // symbol so linking without the CUDA Fortran runtime produces
+      // "undefined reference to `Mcuda_compiled'".
+      cudaCompiledGlobal = mlir::LLVM::GlobalOp::create(
+          builder, loc, mlir::IntegerType::get(ctx, 8), /*isConstant=*/false,
+          mlir::LLVM::Linkage::External, cudaCompiledSymbolName,
+          mlir::Attribute{});
+    }
     auto func = mlir::LLVM::LLVMFuncOp::create(builder, loc,
                                                cudaFortranCtorName, funcTy);
     func.setLinkage(mlir::LLVM::Linkage::Internal);
@@ -466,6 +477,14 @@ struct CUFAddConstructor
           fir::CallOp::create(builder, loc, initFunc, initArgs);
         }
       }
+    }
+    if (emitCudaCompiled) {
+      // Keep the sentinel reference alive: an unused non-volatile load would
+      // be folded away before it reaches the object file.
+      auto addr =
+          mlir::LLVM::AddressOfOp::create(builder, loc, cudaCompiledGlobal);
+      mlir::LLVM::LoadOp::create(builder, loc, mlir::IntegerType::get(ctx, 8),
+                                 addr, /*alignment=*/0, /*isVolatile=*/true);
     }
     mlir::LLVM::ReturnOp::create(builder, loc, mlir::ValueRange{});
 

--- a/flang/test/Fir/CUDA/cuda-constructor-2.f90
+++ b/flang/test/Fir/CUDA/cuda-constructor-2.f90
@@ -1,5 +1,6 @@
-// RUN: fir-opt --split-input-file --cuf-add-constructor %s | FileCheck --check-prefixes=CHECK,NOUNIFIED %s
-// RUN: fir-opt --split-input-file --cuf-add-constructor="cuda-unified=true" %s | FileCheck %s --check-prefixes=CHECK,UNIFIED
+// RUN: fir-opt --split-input-file --cuf-add-constructor %s | FileCheck --check-prefixes=CHECK,NOUNIFIED,NOMARKER %s
+// RUN: fir-opt --split-input-file --cuf-add-constructor="cuda-unified=true" %s | FileCheck %s --check-prefixes=CHECK,UNIFIED,NOMARKER
+// RUN: fir-opt --split-input-file --cuf-add-constructor="emit-cuda-compiled=true" %s | FileCheck --check-prefixes=CHECK,NOUNIFIED,MARKER %s
 
 module attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<!llvm.ptr, dense<64> : vector<4xi64>>, #dlti.dl_entry<!llvm.ptr<271>, dense<32> : vector<4xi64>>, #dlti.dl_entry<!llvm.ptr<270>, dense<32> : vector<4xi64>>, #dlti.dl_entry<f128, dense<128> : vector<2xi64>>, #dlti.dl_entry<f64, dense<64> : vector<2xi64>>, #dlti.dl_entry<f80, dense<128> : vector<2xi64>>, #dlti.dl_entry<f16, dense<16> : vector<2xi64>>, #dlti.dl_entry<i32, dense<32> : vector<2xi64>>, #dlti.dl_entry<i16, dense<16> : vector<2xi64>>, #dlti.dl_entry<i128, dense<128> : vector<2xi64>>, #dlti.dl_entry<i8, dense<8> : vector<2xi64>>, #dlti.dl_entry<!llvm.ptr<272>, dense<64> : vector<4xi64>>, #dlti.dl_entry<i64, dense<64> : vector<2xi64>>, #dlti.dl_entry<i1, dense<8> : vector<2xi64>>, #dlti.dl_entry<"dlti.endianness", "little">, #dlti.dl_entry<"dlti.stack_alignment", 128 : i64>>, fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", gpu.container_module, llvm.data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128", llvm.ident = "flang version 20.0.0 (https://github.com/llvm/llvm-project.git cae351f3453a0a26ec8eb2ddaf773c24a29d929e)", llvm.target_triple = "x86_64-unknown-linux-gnu"} {
 
@@ -30,7 +31,10 @@ module attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<!llvm.ptr, dense<
 
 // CHECK: gpu.module @cuda_device_mod
 
+// MARKER: llvm.mlir.global external @Mcuda_compiled
+// NOMARKER-NOT: Mcuda_compiled
 // CHECK: llvm.func internal @__cudaFortranConstructor() {
+// MARKER-DAG: llvm.mlir.addressof @Mcuda_compiled
 // NOUNIFIED-DAG: %[[MODULE:.*]] = cuf.register_module @cuda_device_mod -> !llvm.ptr
 // NOUNIFIED-DAG: %[[VAR_NAME:.*]] = fir.address_of(@_QQ{{.*}}) : !fir.ref<!fir.char<1,12>>
 // NOUNIFIED-DAG: %[[VAR_ADDR:.*]] = fir.address_of(@_QMmtestsEn) : !fir.ref<!fir.array<5xi32>>
@@ -174,7 +178,10 @@ module attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<!llvm.ptr, dense<
 }
 
 // CHECK: llvm.func internal @__cudaFortranConstructor()
-// CHECK-NEXT: llvm.return
+// NOMARKER-NEXT: llvm.return
+// MARKER-NEXT: llvm.mlir.addressof @Mcuda_compiled
+// MARKER-NEXT: llvm.load volatile
+// MARKER-NEXT: llvm.return
 // CHECK: llvm.mlir.global_ctors ctors = [@__cudaFortranConstructor]
 
 // -----


### PR DESCRIPTION
Objects compiled as CUDA Fortran now declare an undefined Mcuda_compiled
symbol from CUFAddConstructor when emit-cuda-compiled is set. Linking
without the CUDA Fortran runtime then fails with a clear undefined
reference instead of only _FortranACUFInit, which is limited to PROGRAM
units.

The CUDA Fortran runtime defines the symbol so linking with the CUDA
Fortran runtime still succeeds.