### PR TITLE
[Passes] Add DisableSimplifyLibCalls flag to runCodeGenPipeline

### DIFF
--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -1243,7 +1243,8 @@ void EmitAssemblyHelper::RunCodegenPipeline(
   TimeCodegenPasses([&]() {
     Error CodeGenError = runCodeGenPipeline(
         *TM, *TheModule, *OS, DwoOS, CGFT, PrintPipelinePasses.has_value(),
-        !CodeGenOpts.VerifyModule, CI.getVirtualFileSystemPtr());
+        !CodeGenOpts.VerifyModule, /*DisableSimplifyLibCalls=*/false,
+        CI.getVirtualFileSystemPtr());
     if (CodeGenError)
       Diags.Report(diag::err_fe_unable_to_interface_with_target);
   });

--- a/llvm/include/llvm/Passes/RunCodeGen.h
+++ b/llvm/include/llvm/Passes/RunCodeGen.h
@@ -20,6 +20,7 @@ Error runCodeGenPipeline(
     TargetMachine &TM, Module &M, raw_pwrite_stream &OS,
     std::unique_ptr<ToolOutputFile> &DwoOS, CodeGenFileType CGFT,
     bool PrintPipelinePasses = false, bool DisableVerify = true,
+    bool DisableSimplifyLibCalls = false,
     IntrusiveRefCntPtr<vfs::FileSystem> VFS = vfs::getRealFileSystem());
 
 } // namespace llvm

--- a/llvm/lib/Passes/RunCodeGen.cpp
+++ b/llvm/lib/Passes/RunCodeGen.cpp
@@ -31,17 +31,18 @@ static cl::opt<cl::boolOrDefault>
                         "option will default to what the target prefers."),
                cl::init(cl::boolOrDefault::BOU_UNSET));
 
-static Error runCodeGenPipelineLegacy(TargetMachine &TM, Module &M,
-                                      raw_pwrite_stream &OS,
-                                      std::unique_ptr<ToolOutputFile> &DwoOS,
-                                      CodeGenFileType CGFT,
-                                      bool PrintPipelinePasses,
-                                      bool DisableVerify) {
+static Error
+runCodeGenPipelineLegacy(TargetMachine &TM, Module &M, raw_pwrite_stream &OS,
+                         std::unique_ptr<ToolOutputFile> &DwoOS,
+                         CodeGenFileType CGFT, bool PrintPipelinePasses,
+                         bool DisableVerify, bool DisableSimplifyLibCalls) {
   legacy::PassManager CodeGenPasses;
   CodeGenPasses.add(
       createTargetTransformInfoWrapperPass(TM.getTargetIRAnalysis()));
   // Add LibraryInfo.
   TargetLibraryInfoImpl TLII(TM.getTargetTriple(), TM.Options.VecLib);
+  if (DisableSimplifyLibCalls)
+    TLII.disableAllFunctions();
   CodeGenPasses.add(new TargetLibraryInfoWrapperPass(TLII));
 
   const TargetOptions &Options = TM.Options;
@@ -98,7 +99,7 @@ Error llvm::runCodeGenPipeline(TargetMachine &TM, Module &M,
                                raw_pwrite_stream &OS,
                                std::unique_ptr<ToolOutputFile> &DwoOS,
                                CodeGenFileType CGFT, bool PrintPipelinePasses,
-                               bool DisableVerify,
+                               bool DisableVerify, bool DisableSimplifyLibCalls,
                                IntrusiveRefCntPtr<vfs::FileSystem> VFS) {
   if (ForceNewPM == cl::boolOrDefault::BOU_TRUE ||
       (TM.shouldDefaultToNewPM() &&
@@ -107,5 +108,5 @@ Error llvm::runCodeGenPipeline(TargetMachine &TM, Module &M,
   }
 
   return runCodeGenPipelineLegacy(TM, M, OS, DwoOS, CGFT, PrintPipelinePasses,
-                                  DisableVerify);
+                                  DisableVerify, DisableSimplifyLibCalls);
 }


### PR DESCRIPTION
This enables this abstraction to be a drop-in replacement for rustc
after some minor refactoring.
