### PR TITLE
[mlir][spirv] Fix assertion on non-signless integer memref memory spaces

### DIFF
--- a/mlir/lib/Conversion/MemRefToSPIRV/MapMemRefStorageClassPass.cpp
+++ b/mlir/lib/Conversion/MemRefToSPIRV/MapMemRefStorageClassPass.cpp
@@ -73,13 +73,17 @@ spirv::mapMemorySpaceToVulkanStorageClass(Attribute memorySpaceAttr) {
   auto intAttr = dyn_cast<IntegerAttr>(memorySpaceAttr);
   if (!intAttr)
     return std::nullopt;
-  unsigned memorySpace = intAttr.getInt();
+  // The integer may be signless, signed or unsigned and of any width; read
+  // the raw value instead of a typed accessor that asserts on a mismatch.
+  std::optional<uint64_t> memorySpace = intAttr.getValue().tryZExtValue();
+  if (!memorySpace)
+    return std::nullopt;
 
 #define STORAGE_SPACE_MAP_FN(storage, space)                                   \
   case space:                                                                  \
     return storage;
 
-  switch (memorySpace) {
+  switch (*memorySpace) {
     VULKAN_STORAGE_SPACE_MAP_LIST(STORAGE_SPACE_MAP_FN)
   default:
     break;
@@ -127,13 +131,17 @@ spirv::mapMemorySpaceToOpenCLStorageClass(Attribute memorySpaceAttr) {
   auto intAttr = dyn_cast<IntegerAttr>(memorySpaceAttr);
   if (!intAttr)
     return std::nullopt;
-  unsigned memorySpace = intAttr.getInt();
+  // The integer may be signless, signed or unsigned and of any width; read
+  // the raw value instead of a typed accessor that asserts on a mismatch.
+  std::optional<uint64_t> memorySpace = intAttr.getValue().tryZExtValue();
+  if (!memorySpace)
+    return std::nullopt;
 
 #define STORAGE_SPACE_MAP_FN(storage, space)                                   \
   case space:                                                                  \
     return storage;
 
-  switch (memorySpace) {
+  switch (*memorySpace) {
     OPENCL_STORAGE_SPACE_MAP_LIST(STORAGE_SPACE_MAP_FN)
   default:
     break;

--- a/mlir/test/Conversion/MemRefToSPIRV/map-storage-class.mlir
+++ b/mlir/test/Conversion/MemRefToSPIRV/map-storage-class.mlir
@@ -89,6 +89,22 @@ func.func @type_attribute() {
 
 // -----
 
+// Signed and unsigned integer memory spaces are mapped like signless ones.
+
+// VULKAN-LABEL: func @non_signless_memory_spaces
+// OPENCL-LABEL: func @non_signless_memory_spaces
+func.func @non_signless_memory_spaces() {
+  // VULKAN: memref<10xf32, #spirv.storage_class<Generic>>
+  // OPENCL: memref<10xf32, #spirv.storage_class<Generic>>
+  %0 = "dialect.memref_producer"() : () -> (memref<10xf32, 1 : ui64>)
+  // VULKAN: memref<4xi32, #spirv.storage_class<Workgroup>>
+  // OPENCL: memref<4xi32, #spirv.storage_class<Workgroup>>
+  %1 = "dialect.memref_producer"() : () -> (memref<4xi32, 3 : si32>)
+  return
+}
+
+// -----
+
 // VULKAN-LABEL: func.func @function_io
 // OPENCL-LABEL: func.func @function_io
 func.func @function_io
@@ -142,6 +158,15 @@ func.func @non_memref_types(%arg: f32) -> f32 {
 func.func @missing_mapping() {
   // expected-error @+1 {{failed to legalize}}
   %0 = "dialect.memref_producer"() : () -> (memref<f32, 2>)
+  return
+}
+
+// -----
+
+// Values wider than 64 bits used to trip an APInt assertion.
+func.func @memory_space_too_wide() {
+  // expected-error @+1 {{failed to legalize}}
+  %0 = "dialect.memref_producer"() : () -> (memref<f32, 18446744073709551616 : i128>)
   return
 }
 


### PR DESCRIPTION
The default memory space to storage class mappings in
MapMemRefStorageClassPass read the numeric memory space with
IntegerAttr::getInt(), which asserts unless the attribute type is signless
(or index). The memref verifier accepts any IntegerAttr as memory space, so
a type like memref<10xf32, 1 : ui64> makes map-memref-spirv-storage-class
(and convert-gpu-to-spirv, which reuses the same mappings) abort in an
assertions build:

```mlir
%alloc = memref.alloc() alignment = 64 : memref<10xf32, 1 : ui64>
```

Read the raw APInt with tryZExtValue() instead, so signed and unsigned
spellings map exactly like the signless one (1 : ui64 -> Generic, like 1);
the value is zero-extended from its bit pattern, like NVGPU does.
Values that do not fit in 64 bits, which used to trip a second assertion in
APInt::getSExtValue(), now return nullopt and get the usual "failed to
legalize memory space" error, and so do signless values above 2^32, which
were silently truncated to unsigned before.

This follows what NVGPUDialect::isSharedMemoryAddressSpace does for the
same input (#204676).

Fixes #217795