### PR TITLE
[SystemZ][z/OS] Fix "relative immediate relocation section mismatch"

### DIFF
--- a/llvm/include/llvm/CodeGen/TargetLoweringObjectFileImpl.h
+++ b/llvm/include/llvm/CodeGen/TargetLoweringObjectFileImpl.h
@@ -333,6 +333,9 @@ public:
 
   bool shouldPutJumpTableInFunctionSection(bool UsesLabelDifference,
                                            const Function &F) const override;
+  MCSection *getSectionForConstant(const DataLayout &DL, SectionKind Kind,
+                                   const Constant *C, Align &Alignment,
+                                   const Function *F) const override;
   MCSection *SelectSectionForGlobal(const GlobalObject *GO, SectionKind Kind,
                                     const TargetMachine &TM) const override;
   MCSection *getExplicitSectionGlobal(const GlobalObject *GO, SectionKind Kind,

--- a/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
+++ b/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
@@ -2860,6 +2860,12 @@ bool TargetLoweringObjectFileGOFF::shouldPutJumpTableInFunctionSection(
   return true;
 }
 
+MCSection *TargetLoweringObjectFileGOFF::getSectionForConstant(
+    const DataLayout &DL, SectionKind Kind, const Constant *C, Align &Alignment,
+    const Function *F) const {
+  return TextSection;
+}
+
 MCSection *TargetLoweringObjectFileGOFF::getExplicitSectionGlobal(
     const GlobalObject *GO, SectionKind Kind, const TargetMachine &TM) const {
   return SelectSectionForGlobal(GO, Kind, TM);

--- a/llvm/test/CodeGen/SystemZ/zos-eh.ll
+++ b/llvm/test/CodeGen/SystemZ/zos-eh.ll
@@ -13,6 +13,11 @@ bb1:
   ret { ptr, i32 } zeroinitializer
 }
 
+define double @fn_with_const_pool() {
+start:
+  ret double 1.0   ; forces a constant pool entry (L#CPI1_0)
+}
+
 declare i32 @__zos_cxx_personality_v2(...)
 
 ; CHECK:      C_WSA64 CATTR ALIGN(2),FILL(0),NOTEXECUTABLE,RMODE(64),PART(.gcc_excepti


### PR DESCRIPTION
Constants should go inside the text section, but this is not explicitly coded. In the test case, the EH table is generated into a PR section. Then the constant pool of function `fn_with_const_pool()` is emitted, which goes into the PR section of the EH table instead of the code section. When the constant is later referenced in the code, the relative offset cannot be calculated because different sections are involved.
The fix is to explicitly return the text section for constants.