### PR TITLE
[BOLT] Fix -Wunused-template

### DIFF
--- a/bolt/lib/Core/BinaryFunction.cpp
+++ b/bolt/lib/Core/BinaryFunction.cpp
@@ -169,10 +169,6 @@ bool shouldPrint(const BinaryFunction &Function) {
 namespace llvm {
 namespace bolt {
 
-template <typename R> static bool emptyRange(const R &Range) {
-  return Range.begin() == Range.end();
-}
-
 /// Gets debug line information for the instruction located at the given
 /// address in the original binary. Returns an optional DebugLineTableRowRef
 /// that references the corresponding row in the DWARF line table. Since binary

--- a/llvm/include/llvm/Support/GenericLoopInfoImpl.h
+++ b/llvm/include/llvm/Support/GenericLoopInfoImpl.h
@@ -881,8 +881,8 @@ void addInnerLoopsToHeadersMap(DenseMap<BlockT *, const LoopT *> &LoopHeaders,
 
 #ifndef NDEBUG
 template <class BlockT, class LoopT>
-static void compareLoops(const LoopT *L, const LoopT *OtherL,
-                         DenseMap<BlockT *, const LoopT *> &OtherLoopHeaders) {
+void compareLoops(const LoopT *L, const LoopT *OtherL,
+                  DenseMap<BlockT *, const LoopT *> &OtherLoopHeaders) {
   BlockT *H = L->getHeader();
   BlockT *OtherH = OtherL->getHeader();
   assert(H == OtherH &&


### PR DESCRIPTION
This was enabled by default in LLVM 23.1.0. It was disabled in LLVM 23.1.1, but it makes sense to fix the outstanding issues given they are real.