### PR TITLE
[OpenMP] Rename ClauseSet to Clauses and DirectiveSet to Directives, NFC

### DIFF
--- a/flang/include/flang/Semantics/openmp-directive-sets.h
+++ b/flang/include/flang/Semantics/openmp-directive-sets.h
@@ -21,15 +21,15 @@ namespace llvm::omp {
 //   compound construct.
 // - all<Directive>Set: All standalone or compound uses of the directive.
 
-static const llvm::omp::DirectiveSet topDistributeSet{
+static const llvm::omp::Directives topDistributeSet{
     Directive::OMPD_distribute,
     Directive::OMPD_distribute_parallel_do,
     Directive::OMPD_distribute_parallel_do_simd,
     Directive::OMPD_distribute_simd,
 };
 
-static const llvm::omp::DirectiveSet allDistributeSet{
-    llvm::omp::DirectiveSet{
+static const llvm::omp::Directives allDistributeSet{
+    llvm::omp::Directives{
         Directive::OMPD_target_teams_distribute,
         Directive::OMPD_target_teams_distribute_parallel_do,
         Directive::OMPD_target_teams_distribute_parallel_do_simd,
@@ -41,13 +41,13 @@ static const llvm::omp::DirectiveSet allDistributeSet{
     } | topDistributeSet,
 };
 
-static const llvm::omp::DirectiveSet topDoSet{
+static const llvm::omp::Directives topDoSet{
     Directive::OMPD_do,
     Directive::OMPD_do_simd,
 };
 
-static const llvm::omp::DirectiveSet allDoSet{
-    llvm::omp::DirectiveSet{
+static const llvm::omp::Directives allDoSet{
+    llvm::omp::Directives{
         Directive::OMPD_distribute_parallel_do,
         Directive::OMPD_distribute_parallel_do_simd,
         Directive::OMPD_parallel_do,
@@ -61,12 +61,12 @@ static const llvm::omp::DirectiveSet allDoSet{
     } | topDoSet,
 };
 
-static const llvm::omp::DirectiveSet topLoopSet{
+static const llvm::omp::Directives topLoopSet{
     Directive::OMPD_loop,
 };
 
-static const llvm::omp::DirectiveSet allLoopSet{
-    llvm::omp::DirectiveSet{
+static const llvm::omp::Directives allLoopSet{
+    llvm::omp::Directives{
         Directive::OMPD_parallel_loop,
         Directive::OMPD_target_parallel_loop,
         Directive::OMPD_target_teams_loop,
@@ -74,7 +74,7 @@ static const llvm::omp::DirectiveSet allLoopSet{
     } | topLoopSet,
 };
 
-static const llvm::omp::DirectiveSet topParallelSet{
+static const llvm::omp::Directives topParallelSet{
     Directive::OMPD_parallel,
     Directive::OMPD_parallel_do,
     Directive::OMPD_parallel_do_simd,
@@ -89,8 +89,8 @@ static const llvm::omp::DirectiveSet topParallelSet{
     Directive::OMPD_parallel_workshare,
 };
 
-static const llvm::omp::DirectiveSet allParallelSet{
-    llvm::omp::DirectiveSet{
+static const llvm::omp::Directives allParallelSet{
+    llvm::omp::Directives{
         Directive::OMPD_distribute_parallel_do,
         Directive::OMPD_distribute_parallel_do_simd,
         Directive::OMPD_target_parallel,
@@ -104,12 +104,12 @@ static const llvm::omp::DirectiveSet allParallelSet{
     } | topParallelSet,
 };
 
-static const llvm::omp::DirectiveSet topSimdSet{
+static const llvm::omp::Directives topSimdSet{
     Directive::OMPD_simd,
 };
 
-static const llvm::omp::DirectiveSet allSimdSet{
-    llvm::omp::DirectiveSet{
+static const llvm::omp::Directives allSimdSet{
+    llvm::omp::Directives{
         Directive::OMPD_distribute_parallel_do_simd,
         Directive::OMPD_distribute_simd,
         Directive::OMPD_do_simd,
@@ -128,7 +128,7 @@ static const llvm::omp::DirectiveSet allSimdSet{
     } | topSimdSet,
 };
 
-static const llvm::omp::DirectiveSet topTargetSet{
+static const llvm::omp::Directives topTargetSet{
     Directive::OMPD_target,
     Directive::OMPD_target_parallel,
     Directive::OMPD_target_parallel_do,
@@ -144,15 +144,15 @@ static const llvm::omp::DirectiveSet topTargetSet{
     Directive::OMPD_target_teams_workdistribute,
 };
 
-static const llvm::omp::DirectiveSet allTargetSet{topTargetSet};
+static const llvm::omp::Directives allTargetSet{topTargetSet};
 
-static const llvm::omp::DirectiveSet topTaskloopSet{
+static const llvm::omp::Directives topTaskloopSet{
     Directive::OMPD_taskloop,
     Directive::OMPD_taskloop_simd,
 };
 
-static const llvm::omp::DirectiveSet allTaskloopSet{
-    llvm::omp::DirectiveSet{
+static const llvm::omp::Directives allTaskloopSet{
+    llvm::omp::Directives{
         Directive::OMPD_masked_taskloop,
         Directive::OMPD_masked_taskloop_simd,
         Directive::OMPD_master_taskloop,
@@ -164,7 +164,7 @@ static const llvm::omp::DirectiveSet allTaskloopSet{
     } | topTaskloopSet,
 };
 
-static const llvm::omp::DirectiveSet topTeamsSet{
+static const llvm::omp::Directives topTeamsSet{
     Directive::OMPD_teams,
     Directive::OMPD_teams_distribute,
     Directive::OMPD_teams_distribute_parallel_do,
@@ -174,13 +174,13 @@ static const llvm::omp::DirectiveSet topTeamsSet{
     Directive::OMPD_teams_workdistribute,
 };
 
-static const llvm::omp::DirectiveSet bottomTeamsSet{
+static const llvm::omp::Directives bottomTeamsSet{
     Directive::OMPD_target_teams,
     Directive::OMPD_teams,
 };
 
-static const llvm::omp::DirectiveSet allTeamsSet{
-    llvm::omp::DirectiveSet{
+static const llvm::omp::Directives allTeamsSet{
+    llvm::omp::Directives{
         Directive::OMPD_target_teams,
         Directive::OMPD_target_teams_distribute,
         Directive::OMPD_target_teams_distribute_parallel_do,
@@ -196,17 +196,17 @@ static const llvm::omp::DirectiveSet allTeamsSet{
 //===----------------------------------------------------------------------===//
 
 // Composite constructs
-static const llvm::omp::DirectiveSet allDistributeParallelDoSet{
+static const llvm::omp::Directives allDistributeParallelDoSet{
     allDistributeSet & allParallelSet & allDoSet};
-static const llvm::omp::DirectiveSet allDistributeParallelDoSimdSet{
+static const llvm::omp::Directives allDistributeParallelDoSimdSet{
     allDistributeSet & allParallelSet & allDoSet & allSimdSet};
-static const llvm::omp::DirectiveSet allDistributeSimdSet{
+static const llvm::omp::Directives allDistributeSimdSet{
     allDistributeSet & allSimdSet};
-static const llvm::omp::DirectiveSet allDoSimdSet{allDoSet & allSimdSet};
-static const llvm::omp::DirectiveSet allTaskloopSimdSet{
+static const llvm::omp::Directives allDoSimdSet{allDoSet & allSimdSet};
+static const llvm::omp::Directives allTaskloopSimdSet{
     allTaskloopSet & allSimdSet};
 
-static const llvm::omp::DirectiveSet compositeConstructSet{
+static const llvm::omp::Directives compositeConstructSet{
     Directive::OMPD_distribute_parallel_do,
     Directive::OMPD_distribute_parallel_do_simd,
     Directive::OMPD_distribute_simd,
@@ -214,7 +214,7 @@ static const llvm::omp::DirectiveSet compositeConstructSet{
     Directive::OMPD_taskloop_simd,
 };
 
-static const llvm::omp::DirectiveSet blockConstructSet{
+static const llvm::omp::Directives blockConstructSet{
     Directive::OMPD_masked,
     Directive::OMPD_master,
     Directive::OMPD_ordered_blockassoc,
@@ -237,7 +237,7 @@ static const llvm::omp::DirectiveSet blockConstructSet{
     Directive::OMPD_workdistribute,
 };
 
-static const llvm::omp::DirectiveSet loopConstructSet{
+static const llvm::omp::Directives loopConstructSet{
     Directive::OMPD_distribute,
     Directive::OMPD_distribute_parallel_do,
     Directive::OMPD_distribute_parallel_do_simd,
@@ -280,28 +280,28 @@ static const llvm::omp::DirectiveSet loopConstructSet{
     Directive::OMPD_interchange,
 };
 
-static const llvm::omp::DirectiveSet loopTransformationSet{
+static const llvm::omp::Directives loopTransformationSet{
     Directive::OMPD_tile,
     Directive::OMPD_unroll,
     Directive::OMPD_fuse,
     Directive::OMPD_interchange,
 };
 
-static const llvm::omp::DirectiveSet nonPartialVarSet{
+static const llvm::omp::Directives nonPartialVarSet{
     Directive::OMPD_allocate,
     Directive::OMPD_allocators,
     Directive::OMPD_threadprivate,
     Directive::OMPD_declare_target,
 };
 
-static const llvm::omp::DirectiveSet taskGeneratingSet{
-    llvm::omp::DirectiveSet{
+static const llvm::omp::Directives taskGeneratingSet{
+    llvm::omp::Directives{
         Directive::OMPD_task,
     } | allTaskloopSet,
 };
 
-static const llvm::omp::DirectiveSet workShareSet{
-    llvm::omp::DirectiveSet{
+static const llvm::omp::Directives workShareSet{
+    llvm::omp::Directives{
         Directive::OMPD_workshare,
         Directive::OMPD_parallel_workshare,
         Directive::OMPD_parallel_sections,
@@ -315,15 +315,14 @@ static const llvm::omp::DirectiveSet workShareSet{
 // Directive sets for parent directives that do allow/not allow a construct
 //===----------------------------------------------------------------------===//
 
-static const llvm::omp::DirectiveSet scanParentAllowedSet{
-    allDoSet | allSimdSet};
+static const llvm::omp::Directives scanParentAllowedSet{allDoSet | allSimdSet};
 
 //===----------------------------------------------------------------------===//
 // Directive sets for allowed/not allowed nested directives
 //===----------------------------------------------------------------------===//
 
-static const llvm::omp::DirectiveSet nestedBarrierErrSet{
-    llvm::omp::DirectiveSet{
+static const llvm::omp::Directives nestedBarrierErrSet{
+    llvm::omp::Directives{
         Directive::OMPD_atomic,
         Directive::OMPD_critical,
         Directive::OMPD_master,
@@ -332,7 +331,7 @@ static const llvm::omp::DirectiveSet nestedBarrierErrSet{
         workShareSet,
 };
 
-static const llvm::omp::DirectiveSet nestedCancelDoAllowedSet{
+static const llvm::omp::Directives nestedCancelDoAllowedSet{
     Directive::OMPD_distribute_parallel_do,
     Directive::OMPD_do,
     Directive::OMPD_parallel_do,
@@ -341,35 +340,35 @@ static const llvm::omp::DirectiveSet nestedCancelDoAllowedSet{
     Directive::OMPD_teams_distribute_parallel_do,
 };
 
-static const llvm::omp::DirectiveSet nestedCancelParallelAllowedSet{
+static const llvm::omp::Directives nestedCancelParallelAllowedSet{
     Directive::OMPD_parallel,
     Directive::OMPD_target_parallel,
 };
 
-static const llvm::omp::DirectiveSet nestedCancelSectionsAllowedSet{
+static const llvm::omp::Directives nestedCancelSectionsAllowedSet{
     Directive::OMPD_parallel_sections,
     Directive::OMPD_sections,
 };
 
-static const llvm::omp::DirectiveSet nestedCancelTaskgroupAllowedSet{
+static const llvm::omp::Directives nestedCancelTaskgroupAllowedSet{
     Directive::OMPD_task,
     Directive::OMPD_taskloop,
 };
 
-static const llvm::omp::DirectiveSet nestedMasterErrSet{
-    llvm::omp::DirectiveSet{
+static const llvm::omp::Directives nestedMasterErrSet{
+    llvm::omp::Directives{
         Directive::OMPD_atomic,
     } | taskGeneratingSet |
         workShareSet,
 };
 
-static const llvm::omp::DirectiveSet nestedOrderedDoAllowedSet{
+static const llvm::omp::Directives nestedOrderedDoAllowedSet{
     Directive::OMPD_do,
     Directive::OMPD_parallel_do,
     Directive::OMPD_target_parallel_do,
 };
 
-static const llvm::omp::DirectiveSet nestedOrderedErrSet{
+static const llvm::omp::Directives nestedOrderedErrSet{
     Directive::OMPD_atomic,
     Directive::OMPD_critical,
     Directive::OMPD_ordered_blockassoc,
@@ -377,20 +376,20 @@ static const llvm::omp::DirectiveSet nestedOrderedErrSet{
     Directive::OMPD_taskloop,
 };
 
-static const llvm::omp::DirectiveSet nestedOrderedParallelErrSet{
+static const llvm::omp::Directives nestedOrderedParallelErrSet{
     Directive::OMPD_parallel,
     Directive::OMPD_parallel_sections,
     Directive::OMPD_parallel_workshare,
     Directive::OMPD_target_parallel,
 };
 
-static const llvm::omp::DirectiveSet nestedReduceWorkshareAllowedSet{
+static const llvm::omp::Directives nestedReduceWorkshareAllowedSet{
     Directive::OMPD_do,
     Directive::OMPD_do_simd,
     Directive::OMPD_sections,
 };
 
-static const llvm::omp::DirectiveSet nestedTeamsAllowedSet{
+static const llvm::omp::Directives nestedTeamsAllowedSet{
     Directive::OMPD_workdistribute,
     Directive::OMPD_distribute,
     Directive::OMPD_distribute_parallel_do,
@@ -408,8 +407,8 @@ static const llvm::omp::DirectiveSet nestedTeamsAllowedSet{
     Directive::OMPD_parallel_workshare,
 };
 
-static const llvm::omp::DirectiveSet nestedWorkshareErrSet{
-    llvm::omp::DirectiveSet{
+static const llvm::omp::Directives nestedWorkshareErrSet{
+    llvm::omp::Directives{
         Directive::OMPD_atomic,
         Directive::OMPD_critical,
         Directive::OMPD_master,
@@ -424,7 +423,7 @@ static const llvm::omp::DirectiveSet nestedWorkshareErrSet{
 //===----------------------------------------------------------------------===//
 
 // Simple standalone directives than can be erased by -fopenmp-simd.
-static const llvm::omp::DirectiveSet simpleStandaloneNonSimdOnlySet{
+static const llvm::omp::Directives simpleStandaloneNonSimdOnlySet{
     Directive::OMPD_taskyield,
     Directive::OMPD_barrier,
     Directive::OMPD_ordered_standalone,

--- a/flang/include/flang/Semantics/symbol.h
+++ b/flang/include/flang/Semantics/symbol.h
@@ -53,8 +53,8 @@ using MutableSymbolVector = std::vector<MutableSymbolRef>;
 // Mixin for details with OpenMP declarative constructs.
 class WithOmpDeclarative {
 public:
-  const llvm::omp::ClauseSet &ompRequires() const { return ompRequires_; }
-  void set_ompRequires(llvm::omp::ClauseSet clauses) { ompRequires_ = clauses; }
+  const llvm::omp::Clauses &ompRequires() const { return ompRequires_; }
+  void set_ompRequires(llvm::omp::Clauses clauses) { ompRequires_ = clauses; }
 
   const std::optional<common::OmpMemoryOrderType> &
   ompAtomicDefaultMemOrder() const {
@@ -64,8 +64,8 @@ public:
     ompAtomicDefaultMemOrder_ = flags;
   }
 
-  const llvm::omp::ClauseSet &ompDeclTarget() const { return ompDeclTarget_; }
-  void set_ompDeclTarget(llvm::omp::ClauseSet clauses) {
+  const llvm::omp::Clauses &ompDeclTarget() const { return ompDeclTarget_; }
+  void set_ompDeclTarget(llvm::omp::Clauses clauses) {
     ompDeclTarget_ = clauses;
   }
 
@@ -76,10 +76,10 @@ public:
     ompDeclTargetDeviceType_ = device;
   }
 
-  const llvm::omp::ClauseSet &ompGroupprivate() const {
+  const llvm::omp::Clauses &ompGroupprivate() const {
     return ompGroupprivate_;
   }
-  void set_ompGroupprivate(llvm::omp::ClauseSet clauses) {
+  void set_ompGroupprivate(llvm::omp::Clauses clauses) {
     ompGroupprivate_ = clauses;
   }
 
@@ -94,7 +94,7 @@ public:
   // \p dir indicates to which declarative directive the given clauses
   // belong to.
   void printClauseSet(llvm::raw_ostream &os,
-      const llvm::omp::ClauseSet &clauses, llvm::omp::Directive dir,
+      const llvm::omp::Clauses &clauses, llvm::omp::Directive dir,
       parser::CharBlock name = parser::CharBlock{}) const;
   friend llvm::raw_ostream &operator<<(
       llvm::raw_ostream &, const WithOmpDeclarative &);
@@ -107,18 +107,18 @@ private:
   // to program unit symbols (i.e. scopes of the REQUIRES directive).
   // The set of requirements for any program unit include requirements
   // from any module used in the program unit.
-  llvm::omp::ClauseSet ompRequires_;
+  llvm::omp::Clauses ompRequires_;
   // The argument to ATOMIC_DEFAULT_MEM_ORDER. Only needed when the ADMO
   // clause is present in the ompRequires_ set.
   std::optional<common::OmpMemoryOrderType> ompAtomicDefaultMemOrder_;
   // The set of clauses on DECLARE_TARGET directive that apply to this
   // symbol.
-  llvm::omp::ClauseSet ompDeclTarget_;
+  llvm::omp::Clauses ompDeclTarget_;
   // The argument to DEVICE_TYPE clause. Only needed when the clause is
   // present in the ompDeclTarget_ set.
   std::optional<common::OmpDeviceType> ompDeclTargetDeviceType_;
   // The set of clauses on a GROUPPRIVATE directive declaring this symbol.
-  llvm::omp::ClauseSet ompGroupprivate_;
+  llvm::omp::Clauses ompGroupprivate_;
   // The argument to a DEVICE_TYPE clause on a GROUPPRIVATE directive declaring
   // this symbol. Only needed when the clause is present in ompGroupprivate_.
   std::optional<common::OmpDeviceType> ompGroupprivateDeviceType_;

--- a/flang/include/flang/Semantics/symbol.h
+++ b/flang/include/flang/Semantics/symbol.h
@@ -76,9 +76,7 @@ public:
     ompDeclTargetDeviceType_ = device;
   }
 
-  const llvm::omp::Clauses &ompGroupprivate() const {
-    return ompGroupprivate_;
-  }
+  const llvm::omp::Clauses &ompGroupprivate() const { return ompGroupprivate_; }
   void set_ompGroupprivate(llvm::omp::Clauses clauses) {
     ompGroupprivate_ = clauses;
   }
@@ -93,8 +91,8 @@ public:
 
   // \p dir indicates to which declarative directive the given clauses
   // belong to.
-  void printClauseSet(llvm::raw_ostream &os,
-      const llvm::omp::Clauses &clauses, llvm::omp::Directive dir,
+  void printClauseSet(llvm::raw_ostream &os, const llvm::omp::Clauses &clauses,
+      llvm::omp::Directive dir,
       parser::CharBlock name = parser::CharBlock{}) const;
   friend llvm::raw_ostream &operator<<(
       llvm::raw_ostream &, const WithOmpDeclarative &);

--- a/flang/lib/Lower/OpenMP/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP/OpenMP.cpp
@@ -417,12 +417,12 @@ public:
 protected:
   /// Initializes the visitor and returns the set of initial directives of
   /// interest to be matched the beginning of the pattern.
-  virtual llvm::omp::DirectiveSet initialize() = 0;
+  virtual llvm::omp::Directives initialize() = 0;
 
   /// Visits a single directive and, based on it, returns the set of other
   /// directives of interest that would be part of the pattern if nested inside.
-  virtual llvm::omp::DirectiveSet visitDirective(lower::pft::Evaluation &eval,
-                                                 llvm::omp::Directive dir) = 0;
+  virtual llvm::omp::Directives visitDirective(lower::pft::Evaluation &eval,
+                                               llvm::omp::Directive dir) = 0;
 
   /// Obtain the list of clauses of the given OpenMP block or loop construct
   /// evaluation. If it's not an OpenMP construct, no modifications are made to
@@ -479,14 +479,14 @@ private:
       return;
 
     const auto &ompEval{eval.get<parser::OpenMPConstruct>()};
-    llvm::omp::DirectiveSet visitNested{
+    llvm::omp::Directives visitNested{
         visitDirective(eval, parser::omp::GetOmpDirectiveName(ompEval).v)};
 
     if (visitNested.none())
       return;
 
     if (lower::pft::Evaluation *nestedEval = extractOnlyOmpNestedEval(eval)) {
-      llvm::omp::DirectiveSet prevDirs{directivesOfInterest};
+      llvm::omp::Directives prevDirs{directivesOfInterest};
       directivesOfInterest = visitNested;
       visitEval(*nestedEval);
       directivesOfInterest = prevDirs;
@@ -497,7 +497,7 @@ protected:
   semantics::SemanticsContext &semaCtx;
 
 private:
-  llvm::omp::DirectiveSet directivesOfInterest;
+  llvm::omp::Directives directivesOfInterest;
 };
 
 /// Helper pattern to navigate target SPMD.
@@ -507,12 +507,12 @@ public:
   virtual ~TargetSPMDVisitor() = default;
 
 protected:
-  virtual llvm::omp::DirectiveSet initialize() override {
+  virtual llvm::omp::Directives initialize() override {
     teamsVisited = false;
     return llvm::omp::allTargetSet;
   }
 
-  virtual llvm::omp::DirectiveSet
+  virtual llvm::omp::Directives
   visitDirective(lower::pft::Evaluation &eval,
                  llvm::omp::Directive dir) override {
     using namespace llvm::omp;
@@ -586,7 +586,7 @@ public:
   virtual ~HostEvalVisitor() = default;
 
 protected:
-  virtual llvm::omp::DirectiveSet
+  virtual llvm::omp::Directives
   visitDirective(lower::pft::Evaluation &eval,
                  llvm::omp::Directive dir) override {
     using namespace llvm::omp;
@@ -712,7 +712,7 @@ public:
   }
 
 protected:
-  virtual llvm::omp::DirectiveSet
+  virtual llvm::omp::Directives
   visitDirective(lower::pft::Evaluation &eval,
                  llvm::omp::Directive dir) override {
     using namespace llvm::omp;
@@ -4006,12 +4006,8 @@ struct DynamicSubstringVisitor {
   explicit DynamicSubstringVisitor(semantics::SemanticsContext &ctx)
       : semaCtx(ctx) {}
 
-  template <typename T>
-  bool Pre(const T &) {
-    return true;
-  }
-  template <typename T>
-  void Post(const T &) {}
+  template <typename T> bool Pre(const T &) { return true; }
+  template <typename T> void Post(const T &) {}
 
   // Check each expression for substring access
   void Post(const parser::Expr &expr) {
@@ -5879,12 +5875,11 @@ genOMPDispatch(lower::AbstractConverter &converter, lower::SymMap &symTable,
       // statements or directives preventing them from being combined need the
       // attribute as well. Disallow block constructs that can only be outermost
       // leafs and loop transformation constructs.
-      llvm::omp::DirectiveSet combinableDirs =
+      llvm::omp::Directives combinableDirs =
           (llvm::omp::blockConstructSet &
-           ~llvm::omp::DirectiveSet{
-               llvm::omp::Directive::OMPD_ordered_blockassoc,
-               llvm::omp::Directive::OMPD_scope,
-               llvm::omp::Directive::OMPD_taskgroup}) |
+           ~llvm::omp::Directives{llvm::omp::Directive::OMPD_ordered_blockassoc,
+                                  llvm::omp::Directive::OMPD_scope,
+                                  llvm::omp::Directive::OMPD_taskgroup}) |
           (llvm::omp::loopConstructSet & ~llvm::omp::loopTransformationSet);
       const auto &ompEval = nestedEval->get<parser::OpenMPConstruct>();
       llvm::omp::Directive nestedDir =
@@ -8718,7 +8713,7 @@ void Fortran::lower::genOpenMPRequires(mlir::Operation *mod,
 
   if (auto offloadMod =
           llvm::dyn_cast<mlir::omp::OffloadModuleInterface>(mod)) {
-    llvm::omp::ClauseSet reqs;
+    llvm::omp::Clauses reqs;
     if (symbol) {
       common::visit(
           [&](const auto &details) {
@@ -8794,12 +8789,8 @@ struct ModuleDeclareTargetVisitor {
       semantics::SemanticsContext &ctx)
       : converter(converter), semaCtx(ctx) {}
 
-  template <typename T>
-  bool Pre(const T &) {
-    return true;
-  }
-  template <typename T>
-  void Post(const T &) {}
+  template <typename T> bool Pre(const T &) { return true; }
+  template <typename T> void Post(const T &) {}
 
   void Post(const parser::OmpDeclareTargetDirective &directive) {
     markDeclareTargetWithDirective(converter, semaCtx, std::nullopt, directive);

--- a/flang/lib/Lower/OpenMP/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP/OpenMP.cpp
@@ -4006,8 +4006,12 @@ struct DynamicSubstringVisitor {
   explicit DynamicSubstringVisitor(semantics::SemanticsContext &ctx)
       : semaCtx(ctx) {}
 
-  template <typename T> bool Pre(const T &) { return true; }
-  template <typename T> void Post(const T &) {}
+  template <typename T>
+  bool Pre(const T &) {
+    return true;
+  }
+  template <typename T>
+  void Post(const T &) {}
 
   // Check each expression for substring access
   void Post(const parser::Expr &expr) {
@@ -8789,8 +8793,12 @@ struct ModuleDeclareTargetVisitor {
       semantics::SemanticsContext &ctx)
       : converter(converter), semaCtx(ctx) {}
 
-  template <typename T> bool Pre(const T &) { return true; }
-  template <typename T> void Post(const T &) {}
+  template <typename T>
+  bool Pre(const T &) {
+    return true;
+  }
+  template <typename T>
+  void Post(const T &) {}
 
   void Post(const parser::OmpDeclareTargetDirective &directive) {
     markDeclareTargetWithDirective(converter, semaCtx, std::nullopt, directive);

--- a/flang/lib/Parser/openmp-parsers.cpp
+++ b/flang/lib/Parser/openmp-parsers.cpp
@@ -1949,7 +1949,7 @@ static inline constexpr auto IsDirective(llvm::omp::Directive dir) {
   return [dir](const OmpDirectiveName &name) -> bool { return dir == name.v; };
 }
 
-static inline constexpr auto IsMemberOf(const llvm::omp::DirectiveSet &dirs) {
+static inline constexpr auto IsMemberOf(const llvm::omp::Directives &dirs) {
   return [&dirs](const OmpDirectiveName &name) -> bool {
     return dirs.test(name.v);
   };
@@ -2175,7 +2175,7 @@ TYPE_PARSER(construct<OmpMetadirectiveDirective>(
 struct OmpDirectiveParser {
   using resultType = OmpDirectiveSpecification;
 
-  constexpr OmpDirectiveParser(llvm::omp::DirectiveSet dirs) : dirs_(dirs) {}
+  constexpr OmpDirectiveParser(llvm::omp::Directives dirs) : dirs_(dirs) {}
   constexpr OmpDirectiveParser(llvm::omp::Directive dir) : dirs_({dir}) {}
 
   std::optional<resultType> Parse(ParseState &state) const {
@@ -2185,7 +2185,7 @@ struct OmpDirectiveParser {
   }
 
 private:
-  llvm::omp::DirectiveSet dirs_;
+  llvm::omp::Directives dirs_;
 };
 
 // Parse the directive that begins a construct. In some cases the directive
@@ -2198,7 +2198,7 @@ struct OmpBeginDirectiveParser {
   using resultType = OmpDirectiveSpecification;
 
   constexpr OmpBeginDirectiveParser(
-      llvm::omp::DirectiveSet dirs, bool implicit = true)
+      llvm::omp::Directives dirs, bool implicit = true)
       : dparser_(dirs), implicit_(implicit) {}
   constexpr OmpBeginDirectiveParser(
       llvm::omp::Directive dir, bool implicit = true)
@@ -2237,7 +2237,7 @@ private:
 struct OmpEndDirectiveParser {
   using resultType = OmpDirectiveSpecification;
 
-  constexpr OmpEndDirectiveParser(llvm::omp::DirectiveSet dirs)
+  constexpr OmpEndDirectiveParser(llvm::omp::Directives dirs)
       : dparser_(dirs) {}
   constexpr OmpEndDirectiveParser(llvm::omp::Directive dir) : dparser_(dir) {}
 
@@ -2351,7 +2351,7 @@ struct OmpLoopConstructParser {
   using resultType = OpenMPLoopConstruct;
 
   constexpr OmpLoopConstructParser(
-      llvm::omp::DirectiveSet dirs, bool implicit = true)
+      llvm::omp::Directives dirs, bool implicit = true)
       : dirs_(dirs), implicit_(implicit) {}
 
   std::optional<resultType> Parse(ParseState &state) const {
@@ -2394,7 +2394,7 @@ struct OmpLoopConstructParser {
   }
 
 private:
-  llvm::omp::DirectiveSet dirs_;
+  llvm::omp::Directives dirs_;
   bool implicit_;
 };
 
@@ -2780,8 +2780,8 @@ TYPE_PARSER(sourced(
         llvm::omp::Directive::OMPD_metadirective, /*implicit=*/false})))
 
 // OMP SECTIONS Directive
-static constexpr llvm::omp::DirectiveSet GetSectionsDirectives() {
-  constexpr llvm::omp::DirectiveSet sectionsDirectives{
+static constexpr llvm::omp::Directives GetSectionsDirectives() {
+  constexpr llvm::omp::Directives sectionsDirectives{
       llvm::omp::Directive::OMPD_sections,
       llvm::omp::Directive::OMPD_parallel_sections,
   };
@@ -2841,9 +2841,9 @@ TYPE_CONTEXT_PARSER("OpenMP construct"_en_US,
                 construct<OpenMPConstruct>(
                     Parser<OmpDelimitedMetadirectiveDirective>{}))))
 
-static constexpr llvm::omp::DirectiveSet GetLoopDirectives() {
+static constexpr llvm::omp::Directives GetLoopDirectives() {
   using SourceLanguage = llvm::omp::SourceLanguage;
-  llvm::omp::DirectiveSet loopDirectives;
+  llvm::omp::Directives loopDirectives;
 
   for (auto dirId : llvm::omp::directives()) {
     auto assoc{getDirectiveAssociation(dirId)};
@@ -2861,8 +2861,8 @@ static constexpr llvm::omp::DirectiveSet GetLoopDirectives() {
 TYPE_PARSER(sourced(construct<OpenMPLoopConstruct>(
     OmpLoopConstructParser(GetLoopDirectives()))))
 
-static constexpr llvm::omp::DirectiveSet GetAllDirectives() {
-  return ~llvm::omp::DirectiveSet();
+static constexpr llvm::omp::Directives GetAllDirectives() {
+  return ~llvm::omp::Directives();
 }
 
 TYPE_PARSER(construct<OpenMPMisplacedEndDirective>(

--- a/flang/lib/Semantics/check-omp-loop.cpp
+++ b/flang/lib/Semantics/check-omp-loop.cpp
@@ -160,7 +160,7 @@ void OmpStructureChecker::HasInvalidLoopBinding(
         "strictly nested inside a `TEAMS` region."_err_en_US);
   }
 
-  if (llvm::omp::DirectiveSet{
+  if (llvm::omp::Directives{
           llvm::omp::OMPD_teams_loop, llvm::omp::OMPD_target_teams_loop}
           .test(beginName.v)) {
     teamsBindingChecker(

--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -65,7 +65,7 @@ using namespace Fortran::semantics::omp;
 using namespace Fortran::parser::omp;
 
 template <>
-void IterateOverMembers(const llvm::omp::ClauseSet &set,
+void IterateOverMembers(const llvm::omp::Clauses &set,
     std::function<void(llvm::omp::Clause)> visitor) {
   for (llvm::omp::Clause c : set) {
     visitor(c);
@@ -651,7 +651,7 @@ void OmpStructureChecker::ClearLabels() {
 }
 
 bool OmpStructureChecker::IsCloselyNestedRegion(
-    const llvm::omp::DirectiveSet &set) {
+    const llvm::omp::Directives &set) {
   // Definition of close nesting:
   //
   // `A region nested inside another region with no parallel region nested
@@ -984,8 +984,7 @@ void OmpStructureChecker::CheckDirectiveInPureProcedure(
 }
 
 std::pair<const parser::OmpClause *, const parser::OmpClause *>
-OmpStructureChecker::FindMutuallyExclusiveClauses(
-    llvm::omp::ClauseSet exclusive,
+OmpStructureChecker::FindMutuallyExclusiveClauses(llvm::omp::Clauses exclusive,
     const std::vector<const parser::OmpClause *> &clauses) {
   const parser::OmpClause *first{nullptr};
   for (const parser::OmpClause *clause : clauses) {
@@ -1036,7 +1035,7 @@ void OmpStructureChecker::CheckClauses(parser::OmpDirectiveName dirName,
     }
   }
 
-  llvm::omp::ClauseSet notAllowed;
+  llvm::omp::Clauses notAllowed;
 
   for (const parser::OmpClause *clause : allClauses) {
     llvm::omp::Clause clauseId{clause->Id()};
@@ -1061,7 +1060,7 @@ void OmpStructureChecker::CheckClauses(parser::OmpDirectiveName dirName,
   // Exclusive clauses aren't necessarily unique, but there is no way
   // to specify a clause in both sets right now, and all clauses currently
   // listed as exclusive also happen to be unique.
-  llvm::omp::ClauseSet uniqueSet{//
+  llvm::omp::Clauses uniqueSet{//
       directiveClausesMap_[dirId].allowedOnce |
       directiveClausesMap_[dirId].allowedExclusive};
 
@@ -1089,7 +1088,7 @@ void OmpStructureChecker::CheckClauses(parser::OmpDirectiveName dirName,
 
   bool requiredPresent{false};
   // Prepare the requiredSet relevant to the current OpenMP version.
-  llvm::omp::ClauseSet requiredSet;
+  llvm::omp::Clauses requiredSet;
   for (llvm::omp::Clause id : directiveClausesMap_[dirId].requiredOneOf) {
     if (IsAllowedClause(id)) {
       requiredSet.set(id);
@@ -1214,7 +1213,7 @@ bool OmpStructureChecker::IsCombinedParallelWorksharing(
 }
 
 bool OmpStructureChecker::HasInvalidWorksharingNesting(
-    const parser::OmpDirectiveName &name, const llvm::omp::DirectiveSet &set) {
+    const parser::OmpDirectiveName &name, const llvm::omp::Directives &set) {
   // set contains all the invalid closely nested directives
   // for the given directive (`source` here)
   if (IsCombinedParallelWorksharing(name.v)) {
@@ -3825,7 +3824,7 @@ void OmpStructureChecker::Leave(const parser::OmpClauseList &x) {
   };
 
   // [5.1] 2.21.2 Threadprivate Directive Restriction
-  llvm::omp::ClauseSet threadprivateAllowedSet{llvm::omp::Clause::OMPC_copyin,
+  llvm::omp::Clauses threadprivateAllowedSet{llvm::omp::Clause::OMPC_copyin,
       llvm::omp::Clause::OMPC_copyprivate, llvm::omp::Clause::OMPC_schedule,
       llvm::omp::Clause::OMPC_num_threads, llvm::omp::Clause::OMPC_thread_limit,
       llvm::omp::Clause::OMPC_if};
@@ -4520,10 +4519,10 @@ void OmpStructureChecker::Enter(const parser::OmpClause::Firstprivate &x) {
   // Check firstprivate variables in task and taskloop constructs
   dirClauseTriple.emplace(llvm::omp::Directive::OMPD_task,
       std::make_pair(llvm::omp::Directive::OMPD_parallel,
-          llvm::omp::ClauseSet{llvm::omp::Clause::OMPC_reduction}));
+          llvm::omp::Clauses{llvm::omp::Clause::OMPC_reduction}));
   dirClauseTriple.emplace(llvm::omp::Directive::OMPD_taskloop,
       std::make_pair(llvm::omp::Directive::OMPD_parallel,
-          llvm::omp::ClauseSet{llvm::omp::Clause::OMPC_reduction}));
+          llvm::omp::Clauses{llvm::omp::Clause::OMPC_reduction}));
 
   CheckPrivateSymbolsInOuterCxt(
       currSymbols, dirClauseTriple, llvm::omp::Clause::OMPC_firstprivate);
@@ -4645,7 +4644,7 @@ void OmpStructureChecker::Enter(const parser::OmpClause::If &x) {
           "%s is not a constituent of the %s directive"_err_en_US, subName,
           dirName);
     } else {
-      static llvm::omp::DirectiveSet valid45{
+      static llvm::omp::Directives valid45{
           llvm::omp::Directive::OMPD_cancel, //
           llvm::omp::Directive::OMPD_parallel, //
           llvm::omp::Directive::OMPD_target, //
@@ -4656,13 +4655,13 @@ void OmpStructureChecker::Enter(const parser::OmpClause::If &x) {
           llvm::omp::Directive::OMPD_task, //
           llvm::omp::Directive::OMPD_taskloop, //
       };
-      static llvm::omp::DirectiveSet valid50{
-          valid45 | llvm::omp::DirectiveSet{llvm::omp::Directive::OMPD_simd}};
+      static llvm::omp::Directives valid50{
+          valid45 | llvm::omp::Directives{llvm::omp::Directive::OMPD_simd}};
       // 5.1 is the same as 5.0.
-      static llvm::omp::DirectiveSet valid52{
-          valid50 | llvm::omp::DirectiveSet{llvm::omp::Directive::OMPD_teams}};
-      static llvm::omp::DirectiveSet valid60{valid52 |
-          llvm::omp::DirectiveSet{llvm::omp::Directive::OMPD_taskgraph,
+      static llvm::omp::Directives valid52{
+          valid50 | llvm::omp::Directives{llvm::omp::Directive::OMPD_teams}};
+      static llvm::omp::Directives valid60{valid52 |
+          llvm::omp::Directives{llvm::omp::Directive::OMPD_taskgraph,
               /*TODO llvm::omp::Directive::OMPD_task_iteration*/}};
 
       static auto minVersion{[&](llvm::omp::Directive d) {

--- a/flang/lib/Semantics/check-omp-structure.h
+++ b/flang/lib/Semantics/check-omp-structure.h
@@ -41,10 +41,10 @@
 #include "llvm/Frontend/OpenMP/OMP.inc"
 
 namespace llvm::omp {
-static ClauseSet privateSet{
+static Clauses privateSet{
     Clause::OMPC_private, Clause::OMPC_firstprivate, Clause::OMPC_lastprivate};
-static ClauseSet privateReductionSet{
-    ClauseSet{Clause::OMPC_reduction} | privateSet};
+static Clauses privateReductionSet{
+    Clauses{Clause::OMPC_reduction} | privateSet};
 } // namespace llvm::omp
 
 namespace Fortran::semantics {
@@ -74,14 +74,14 @@ using AppliedModifier = AppliedModifierInfo::ElementTy;
 using SymbolSourceMap = std::multimap<const Symbol *, parser::CharBlock>;
 // Multimap to check the triple <current_dir, enclosing_dir, enclosing_clause>
 using DirectivesClauseTriple = std::multimap<llvm::omp::Directive,
-    std::pair<llvm::omp::Directive, const llvm::omp::ClauseSet>>;
+    std::pair<llvm::omp::Directive, const llvm::omp::Clauses>>;
 
 using OmpStructureCheckerBase = DirectiveStructureChecker<llvm::omp::Directive,
-    llvm::omp::Clause, parser::OmpClause, llvm::omp::ClauseSet>;
+    llvm::omp::Clause, parser::OmpClause, llvm::omp::Clauses>;
 
 template <>
-void IterateOverMembers(const llvm::omp::ClauseSet &set,
-    std::function<void(llvm::omp::Clause)> func);
+void IterateOverMembers(
+    const llvm::omp::Clauses &set, std::function<void(llvm::omp::Clause)> func);
 
 class OmpStructureChecker : public OmpStructureCheckerBase {
 public:
@@ -386,7 +386,7 @@ private:
       llvm::iterator_range<ClauseIterator> endClauses);
   void AnalyzeObject(const parser::OmpObject &object);
   std::pair<const parser::OmpClause *, const parser::OmpClause *>
-  FindMutuallyExclusiveClauses(llvm::omp::ClauseSet exclusive,
+  FindMutuallyExclusiveClauses(llvm::omp::Clauses exclusive,
       const std::vector<const parser::OmpClause *> &clauses);
 
   const parser::OpenMPConstruct *GetCurrentConstruct() const;
@@ -403,9 +403,9 @@ private:
   void CheckStructureComponent(
       const parser::OmpObjectList &objects, llvm::omp::Clause clauseId);
   bool HasInvalidWorksharingNesting(
-      const parser::OmpDirectiveName &name, const llvm::omp::DirectiveSet &);
+      const parser::OmpDirectiveName &name, const llvm::omp::Directives &);
 
-  bool IsCloselyNestedRegion(const llvm::omp::DirectiveSet &set);
+  bool IsCloselyNestedRegion(const llvm::omp::Directives &set);
   bool IsNestedInDirective(llvm::omp::Directive directive);
   bool IsCombinedParallelWorksharing(llvm::omp::Directive directive) const;
   bool InTargetRegion();

--- a/flang/lib/Semantics/mod-file.cpp
+++ b/flang/lib/Semantics/mod-file.cpp
@@ -385,7 +385,7 @@ static void PutOpenMPRequirements(
   llvm::omp::Version version{semaCtx.langOptions().getOpenMPVersion()};
 
   if (const auto *decls{GetOmpDeclarative(symbol)}) {
-    if (const llvm::omp::ClauseSet &reqs{decls->ompRequires()}; reqs.count()) {
+    if (const llvm::omp::Clauses &reqs{decls->ompRequires()}; reqs.count()) {
       os << "!$omp "
          << parser::ToLowerCaseLetters(llvm::omp::getOpenMPDirectiveName(
                 llvm::omp::Directive::OMPD_requires, version));
@@ -401,7 +401,7 @@ static void PutOpenMPDeclarativeDirectives(llvm::raw_ostream &os,
 
   for (const Symbol &symbol : symbols) {
     if (const auto *decls{GetOmpDeclarative(symbol)}) {
-      if (const llvm::omp::ClauseSet &dtgt{decls->ompDeclTarget()};
+      if (const llvm::omp::Clauses &dtgt{decls->ompDeclTarget()};
           dtgt.count()) {
         os << "!$omp "
            << parser::ToLowerCaseLetters(llvm::omp::getOpenMPDirectiveName(
@@ -414,7 +414,7 @@ static void PutOpenMPDeclarativeDirectives(llvm::raw_ostream &os,
       // Re-emit `!$omp groupprivate` (and its device_type) so a TU that `use`s
       // this module recovers the directive from the .mod file. Common-block
       // names must be wrapped in slashes when reparsed.
-      if (const llvm::omp::ClauseSet &gp{decls->ompGroupprivate()};
+      if (const llvm::omp::Clauses &gp{decls->ompGroupprivate()};
           gp.count()) {
         os << "!$omp "
            << parser::ToLowerCaseLetters(llvm::omp::getOpenMPDirectiveName(

--- a/flang/lib/Semantics/mod-file.cpp
+++ b/flang/lib/Semantics/mod-file.cpp
@@ -414,8 +414,7 @@ static void PutOpenMPDeclarativeDirectives(llvm::raw_ostream &os,
       // Re-emit `!$omp groupprivate` (and its device_type) so a TU that `use`s
       // this module recovers the directive from the .mod file. Common-block
       // names must be wrapped in slashes when reparsed.
-      if (const llvm::omp::Clauses &gp{decls->ompGroupprivate()};
-          gp.count()) {
+      if (const llvm::omp::Clauses &gp{decls->ompGroupprivate()}; gp.count()) {
         os << "!$omp "
            << parser::ToLowerCaseLetters(llvm::omp::getOpenMPDirectiveName(
                   llvm::omp::Directive::OMPD_groupprivate, version))

--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -647,7 +647,7 @@ public:
     PushContext(x.source, llvm::omp::Directive::OMPD_requires);
 
     // Gather information from the clauses.
-    llvm::omp::ClauseSet reqs;
+    llvm::omp::Clauses reqs;
     std::optional<common::OmpMemoryOrderType> memOrder;
     for (const parser::OmpClause &clause : x.v.Clauses().v) {
       using OmpClause = parser::OmpClause;
@@ -655,7 +655,7 @@ public:
           common::visitors{
               [&](const OmpClause::AtomicDefaultMemOrder &admo) {
                 memOrder = admo.v.v;
-                return llvm::omp::ClauseSet{clause.Id()};
+                return llvm::omp::Clauses{clause.Id()};
               },
               [&](auto &&s) {
                 using TypeS = llvm::remove_cvref_t<decltype(s)>;
@@ -667,10 +667,10 @@ public:
                     std::is_same_v<TypeS, OmpClause::UnifiedAddress> ||
                     std::is_same_v<TypeS, OmpClause::UnifiedSharedMemory>) {
                   if (omp::GetLogicalArgument(s.v, context_).value_or(true)) {
-                    return llvm::omp::ClauseSet{clause.Id()};
+                    return llvm::omp::Clauses{clause.Id()};
                   }
                 }
-                return llvm::omp::ClauseSet{};
+                return llvm::omp::Clauses{};
               },
           },
           clause.u);
@@ -1043,7 +1043,7 @@ private:
   void CheckObjectIsPrivatizable(
       const parser::Name &, const Symbol &, Symbol::Flag);
 
-  void AddOmpRequiresToScope(Scope &, const llvm::omp::ClauseSet &,
+  void AddOmpRequiresToScope(Scope &, const llvm::omp::Clauses &,
       const std::optional<common::OmpMemoryOrderType> &);
 
   void CreateImplicitSymbols(const parser::Name &, const Symbol *symbol);
@@ -2308,7 +2308,7 @@ bool OmpAttributeVisitor::Pre(const parser::OmpGroupprivateDirective &x) {
   }
 
   llvm::omp::Version version{context_.langOptions().getOpenMPVersion()};
-  llvm::omp::ClauseSet clauses{llvm::omp::Clause::OMPC_device_type};
+  llvm::omp::Clauses clauses{llvm::omp::Clause::OMPC_device_type};
   for (const parser::OmpArgument &arg : x.v.Arguments().v) {
     if (const parser::OmpObject *object{parser::omp::GetArgumentObject(arg)}) {
       if (const Symbol *sym{omp::GetObjectSymbol(*object)}) {
@@ -2374,7 +2374,7 @@ bool OmpAttributeVisitor::Pre(const parser::OmpDeclareTargetDirective &x) {
       [&](const parser::OmpObject &object, llvm::omp::Clause clauseId) {
         if (const Symbol *sym{omp::GetObjectSymbol(object)}) {
           auto &clauseSet{
-              const_cast<llvm::omp::ClauseSet &>(details[sym].ompDeclTarget())};
+              const_cast<llvm::omp::Clauses &>(details[sym].ompDeclTarget())};
           clauseSet.set(clauseId);
         }
       }};
@@ -2403,7 +2403,7 @@ bool OmpAttributeVisitor::Pre(const parser::OmpDeclareTargetDirective &x) {
     if (auto *proc{const_cast<Symbol *>(scope.symbol())}) {
       proc->flags().set(Symbol::Flag::OmpDeclareTarget);
       auto &clauseSet{
-          const_cast<llvm::omp::ClauseSet &>(details[proc].ompDeclTarget())};
+          const_cast<llvm::omp::Clauses &>(details[proc].ompDeclTarget())};
       clauseSet.set(llvm::omp::Clause::OMPC_enter);
     }
   }
@@ -2417,7 +2417,7 @@ bool OmpAttributeVisitor::Pre(const parser::OmpDeclareTargetDirective &x) {
           if constexpr (std::is_base_of_v<WithOmpDeclarative, TypeD>) {
             d.set_version(version);
             auto &clauseSet{
-                const_cast<llvm::omp::ClauseSet &>(d.ompDeclTarget())};
+                const_cast<llvm::omp::Clauses &>(d.ompDeclTarget())};
             clauseSet |= decl.ompDeclTarget();
             if (device) {
               clauseSet.set(llvm::omp::Clause::OMPC_device_type);
@@ -3501,7 +3501,7 @@ void OmpAttributeVisitor::CheckObjectIsPrivatizable(
 }
 
 void OmpAttributeVisitor::AddOmpRequiresToScope(Scope &scope,
-    const llvm::omp::ClauseSet &reqs,
+    const llvm::omp::Clauses &reqs,
     const std::optional<common::OmpMemoryOrderType> &memOrder) {
   llvm::omp::Version version{context_.langOptions().getOpenMPVersion()};
   const Scope &programUnit{omp::GetProgramUnit(scope)};

--- a/flang/lib/Semantics/symbol.cpp
+++ b/flang/lib/Semantics/symbol.cpp
@@ -72,7 +72,7 @@ static void DumpList(llvm::raw_ostream &os, const char *label, const T &list) {
 }
 
 void WithOmpDeclarative::printClauseSet(llvm::raw_ostream &os,
-    const llvm::omp::ClauseSet &clauses, llvm::omp::Directive dir,
+    const llvm::omp::Clauses &clauses, llvm::omp::Directive dir,
     parser::CharBlock name) const {
   auto toLower = parser::ToLowerCaseLetters;
   size_t idx{0}, size{clauses.count()};
@@ -118,17 +118,17 @@ void WithOmpDeclarative::printClauseSet(llvm::raw_ostream &os,
 
 llvm::raw_ostream &operator<<(
     llvm::raw_ostream &os, const WithOmpDeclarative &x) {
-  if (const llvm::omp::ClauseSet &reqs{x.ompRequires()}; reqs.count()) {
+  if (const llvm::omp::Clauses &reqs{x.ompRequires()}; reqs.count()) {
     os << " OmpRequirements:(";
     x.printClauseSet(os, reqs, llvm::omp::Directive::OMPD_requires);
     os << ')';
   }
-  if (const llvm::omp::ClauseSet &dtgt{x.ompDeclTarget()}; dtgt.count()) {
+  if (const llvm::omp::Clauses &dtgt{x.ompDeclTarget()}; dtgt.count()) {
     os << " OmpDeclareTargetFlags:(";
     x.printClauseSet(os, dtgt, llvm::omp::Directive::OMPD_declare_target);
     os << ')';
   }
-  if (const llvm::omp::ClauseSet &gp{x.ompGroupprivate()}; gp.count()) {
+  if (const llvm::omp::Clauses &gp{x.ompGroupprivate()}; gp.count()) {
     os << " OmpGroupprivateFlags:(";
     x.printClauseSet(os, gp, llvm::omp::Directive::OMPD_groupprivate);
     os << ')';

--- a/llvm/include/llvm/Frontend/OpenMP/OMP.h
+++ b/llvm/include/llvm/Frontend/OpenMP/OMP.h
@@ -150,9 +150,8 @@ constexpr auto &EnumSetIterator<Enum, Size>::operator++() {
 }
 } // namespace detail
 
-using ClauseSet = EnumSet<llvm::omp::Clause, llvm::omp::Clause_enumSize>;
-using DirectiveSet =
-    EnumSet<llvm::omp::Directive, llvm::omp::Directive_enumSize>;
+using Clauses = EnumSet<llvm::omp::Clause, llvm::omp::Clause_enumSize>;
+using Directives = EnumSet<llvm::omp::Directive, llvm::omp::Directive_enumSize>;
 
 LLVM_ABI ArrayRef<Directive> getLeafConstructs(Directive D);
 LLVM_ABI ArrayRef<Directive> getLeafConstructsOrSelf(Directive D);

--- a/llvm/include/llvm/Frontend/OpenMP/OMP.td
+++ b/llvm/include/llvm/Frontend/OpenMP/OMP.td
@@ -24,7 +24,7 @@ def OpenMP : DirectiveLanguage {
   let loopModifierPrefix = "OMPLM_";
   let makeEnumAvailableInNamespace = true;
   let enableBitmaskEnumInNamespace = true;
-  let clauseEnumSetClass = "llvm::omp::ClauseSet";
+  let clauseEnumSetClass = "llvm::omp::Clauses";
   let flangClauseBaseClass = "OmpClause";
 }
 

--- a/llvm/include/llvm/Frontend/OpenMP/OMPDescriptors.h
+++ b/llvm/include/llvm/Frontend/OpenMP/OMPDescriptors.h
@@ -72,9 +72,6 @@ using Properties = EnumSet<Property, Property_enumSize>;
 using Modifiers = EnumSet<Modifier, Modifier_enumSize>;
 using ModifierSets = EnumSet<ModifierSet, ModifierSet_enumSize>;
 
-using Clauses = llvm::omp::ClauseSet;
-using Directives = llvm::omp::DirectiveSet;
-
 namespace descriptor {
 namespace details {
 struct Base {

--- a/llvm/unittests/Frontend/EnumSetTest.cpp
+++ b/llvm/unittests/Frontend/EnumSetTest.cpp
@@ -45,10 +45,10 @@ constexpr bool ElementsAre(Range &&R) {
 }
 } // namespace detail
 
-using ClauseSet = EnumSet<Clause, Clause_enumSize>;
+using Clauses = EnumSet<Clause, Clause_enumSize>;
 
 TEST(EnumSetTest, DefaultInitialization) {
-  constexpr ClauseSet S;
+  constexpr Clauses S;
   EXPECT_THAT(S, testing::IsEmpty());
   EXPECT_EQ(S.size(), static_cast<size_t>(0));
 
@@ -57,7 +57,7 @@ TEST(EnumSetTest, DefaultInitialization) {
 }
 
 TEST(EnumSetTest, ListInitialization) {
-  constexpr ClauseSet S{Clause::OMPC_private, Clause::OMPC_shared};
+  constexpr Clauses S{Clause::OMPC_private, Clause::OMPC_shared};
   EXPECT_THAT(S, testing::ElementsAre(OMPC_private, OMPC_shared));
 
   static_assert(
@@ -66,7 +66,7 @@ TEST(EnumSetTest, ListInitialization) {
 }
 
 TEST(EnumSetTest, CopyInitialization) {
-  constexpr ClauseSet S(ClauseSet{Clause::OMPC_private, Clause::OMPC_shared});
+  constexpr Clauses S(Clauses{Clause::OMPC_private, Clause::OMPC_shared});
   EXPECT_THAT(S, testing::ElementsAre(OMPC_private, OMPC_shared));
 
   static_assert(
@@ -75,38 +75,38 @@ TEST(EnumSetTest, CopyInitialization) {
 }
 
 TEST(EnumSetTest, Set) {
-  ClauseSet S;
+  Clauses S;
   S.set(Clause::OMPC_private);
   EXPECT_THAT(S, testing::ElementsAre(OMPC_private));
 
   static_assert(detail::ElementsAre<Clause, Clause::OMPC_private>(
-      ClauseSet{}.set(Clause::OMPC_private)));
+      Clauses{}.set(Clause::OMPC_private)));
 }
 
 TEST(EnumSetTest, Reset) {
-  ClauseSet S{Clause::OMPC_private, Clause::OMPC_shared};
+  Clauses S{Clause::OMPC_private, Clause::OMPC_shared};
   S.reset(Clause::OMPC_private);
   EXPECT_THAT(S, testing::ElementsAre(OMPC_shared));
 
   static_assert(detail::ElementsAre<Clause, Clause::OMPC_shared>(
-      ClauseSet{Clause::OMPC_private, Clause::OMPC_shared}.reset(
+      Clauses{Clause::OMPC_private, Clause::OMPC_shared}.reset(
           Clause::OMPC_private)));
 }
 
 TEST(EnumSetTest, Flip) {
-  ClauseSet S{Clause::OMPC_private};
+  Clauses S{Clause::OMPC_private};
   S.flip(Clause::OMPC_private);
   S.flip(Clause::OMPC_shared);
   EXPECT_THAT(S, testing::ElementsAre(OMPC_shared));
 
   static_assert(detail::ElementsAre<Clause, Clause::OMPC_shared>(
-      ClauseSet{Clause::OMPC_private}
+      Clauses{Clause::OMPC_private}
           .flip(Clause::OMPC_private)
           .flip(Clause::OMPC_shared)));
 }
 
 TEST(EnumSetTest, Test) {
-  constexpr ClauseSet S{Clause::OMPC_private};
+  constexpr Clauses S{Clause::OMPC_private};
   ASSERT_TRUE(S.test(Clause::OMPC_private));
   ASSERT_FALSE(S.test(Clause::OMPC_shared));
 
@@ -115,7 +115,7 @@ TEST(EnumSetTest, Test) {
 }
 
 TEST(EnumSetTest, SquareBracket) {
-  constexpr ClauseSet S{Clause::OMPC_private};
+  constexpr Clauses S{Clause::OMPC_private};
   ASSERT_TRUE(S[Clause::OMPC_private]);
   ASSERT_FALSE(S[Clause::OMPC_shared]);
 
@@ -124,18 +124,18 @@ TEST(EnumSetTest, SquareBracket) {
 }
 
 TEST(EnumSetTest, UnionUpdate) {
-  ClauseSet S{Clause::OMPC_private, OMPC_shared};
-  ClauseSet A{Clause::OMPC_nowait};
+  Clauses S{Clause::OMPC_private, OMPC_shared};
+  Clauses A{Clause::OMPC_nowait};
   S |= A;
   EXPECT_THAT(S, testing::ElementsAre(Clause::OMPC_nowait, Clause::OMPC_private,
                                       OMPC_shared));
 }
 
 TEST(EnumSetTest, Union) {
-  constexpr ClauseSet A{Clause::OMPC_private, OMPC_shared};
-  constexpr ClauseSet B{Clause::OMPC_nowait};
+  constexpr Clauses A{Clause::OMPC_private, OMPC_shared};
+  constexpr Clauses B{Clause::OMPC_nowait};
   constexpr auto S = A | B;
-  static_assert(std::is_same_v<llvm::remove_cvref_t<decltype(S)>, ClauseSet>);
+  static_assert(std::is_same_v<llvm::remove_cvref_t<decltype(S)>, Clauses>);
   EXPECT_THAT(S, testing::ElementsAre(Clause::OMPC_nowait, Clause::OMPC_private,
                                       OMPC_shared));
 
@@ -144,17 +144,17 @@ TEST(EnumSetTest, Union) {
 }
 
 TEST(EnumSetTest, IntersectionUpdate) {
-  ClauseSet S{Clause::OMPC_private, OMPC_shared};
-  ClauseSet A{Clause::OMPC_nowait, OMPC_shared};
+  Clauses S{Clause::OMPC_private, OMPC_shared};
+  Clauses A{Clause::OMPC_nowait, OMPC_shared};
   S &= A;
   EXPECT_THAT(S, testing::ElementsAre(OMPC_shared));
 }
 
 TEST(EnumSetTest, Intersection) {
-  constexpr ClauseSet A{Clause::OMPC_private, OMPC_shared};
-  constexpr ClauseSet B{Clause::OMPC_nowait, OMPC_shared};
+  constexpr Clauses A{Clause::OMPC_private, OMPC_shared};
+  constexpr Clauses B{Clause::OMPC_nowait, OMPC_shared};
   constexpr auto S = A & B;
-  static_assert(std::is_same_v<llvm::remove_cvref_t<decltype(S)>, ClauseSet>);
+  static_assert(std::is_same_v<llvm::remove_cvref_t<decltype(S)>, Clauses>);
   EXPECT_THAT(S, testing::ElementsAre(OMPC_shared));
 
   static_assert(detail::ElementsAre<Clause, OMPC_shared>(S));


### PR DESCRIPTION
The ClauseSet name was an alias of an EnumSet of clause ids. However, it
collides with a "clause set" concept in OpenMP, which is a set of clauses,
but with properties and additional information. To resolve the naming
conflict, rename ClauseSet to Clauses.

Although there is no "directive set" in OpenMP, rename DirectiveSet in
an analogous way for uniformity.