### PR TITLE
[VPlan] Add doesGenerateSingleScalar and use where applicable. (NFCI)

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanLowering.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanLowering.cpp
@@ -851,7 +851,7 @@ void VPlanTransforms::materializePacksAndUnpacks(VPlan &Plan) {
         // TODO: The Defs skipped here may or may not be vector values.
         // Introduce Unpacks, and remove them later, if they are guaranteed to
         // produce scalar values.
-        if (vputils::isSingleScalar(Def))
+        if (vputils::doesGenerateSingleScalar(Def))
           continue;
 
         // Only introduce an Unpack if some, but not all, users use the first

--- a/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
@@ -3250,7 +3250,7 @@ void VPScalarIVStepsRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
 
 bool VPWidenGEPRecipe::usesFirstLaneOnly(const VPValue *Op) const {
   assert(is_contained(operands(), Op) && "Op must be an operand of the recipe");
-  return vputils::isSingleScalar(Op);
+  return vputils::doesGenerateSingleScalar(Op);
 }
 
 void VPWidenGEPRecipe::execute(VPTransformState &State) {

--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
@@ -2264,10 +2264,11 @@ struct VPCSEDenseMapInfo : public DenseMapInfo<VPSingleDefRecipe *> {
 
   /// Hash the underlying data of \p Def.
   static unsigned getHashValue(const VPSingleDefRecipe *Def) {
-    hash_code Result = hash_combine(
-        Def->getVPRecipeID(), vputils::getOpcodeOrIntrinsicID(Def),
-        getGEPSourceElementType(Def), Def->getScalarType(),
-        vputils::isSingleScalar(Def), hash_combine_range(Def->operands()));
+    hash_code Result =
+        hash_combine(Def->getVPRecipeID(), vputils::getOpcodeOrIntrinsicID(Def),
+                     getGEPSourceElementType(Def), Def->getScalarType(),
+                     vputils::doesGenerateSingleScalar(Def),
+                     hash_combine_range(Def->operands()));
     if (auto *RFlags = dyn_cast<VPRecipeWithIRFlags>(Def))
       if (RFlags->hasPredicate())
         return hash_combine(Result, RFlags->getPredicate());
@@ -2286,7 +2287,8 @@ struct VPCSEDenseMapInfo : public DenseMapInfo<VPSingleDefRecipe *> {
         vputils::getOpcodeOrIntrinsicID(L) !=
             vputils::getOpcodeOrIntrinsicID(R) ||
         getGEPSourceElementType(L) != getGEPSourceElementType(R) ||
-        vputils::isSingleScalar(L) != vputils::isSingleScalar(R) ||
+        vputils::doesGenerateSingleScalar(L) !=
+            vputils::doesGenerateSingleScalar(R) ||
         !equal(L->operands(), R->operands()))
       return false;
     assert(vputils::getOpcodeOrIntrinsicID(L) &&

--- a/llvm/lib/Transforms/Vectorize/VPlanUtils.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanUtils.cpp
@@ -431,7 +431,7 @@ bool vputils::isElementwise(const VPValue *V) {
   return Instruction::isUnaryOp(Opcode) || Instruction::isBinaryOp(Opcode);
 }
 
-bool vputils::isSingleScalar(const VPValue *VPV) {
+bool vputils::doesGenerateSingleScalar(const VPValue *VPV) {
   // Live-in, symbolic and canonical-IV region values are single-scalar.
   if (auto *RV = dyn_cast<VPRegionValue>(VPV))
     return RV == RV->getDefiningRegion()->getCanonicalIV();
@@ -445,19 +445,10 @@ bool vputils::isSingleScalar(const VPValue *VPV) {
     // lanes.
     if (RegionOfR && RegionOfR->isReplicator())
       return false;
-    return Rep->isSingleScalar() || (preservesUniformity(Rep->getOpcode()) &&
-                                     all_of(Rep->operands(), isSingleScalar));
-  }
-  if (isa<VPWidenGEPRecipe, VPBlendRecipe>(VPV))
-    return all_of(VPV->getDefiningRecipe()->operands(), isSingleScalar);
-  if (auto *WidenR = dyn_cast<VPWidenRecipe>(VPV)) {
-    return preservesUniformity(WidenR->getOpcode()) &&
-           all_of(WidenR->operands(), isSingleScalar);
+    return Rep->isSingleScalar();
   }
   if (auto *VPI = dyn_cast<VPInstruction>(VPV))
-    return VPI->isSingleScalar() || VPI->isVectorToScalar() ||
-           (preservesUniformity(VPI->getOpcode()) &&
-            all_of(VPI->operands(), isSingleScalar));
+    return VPI->isSingleScalar() || VPI->isVectorToScalar();
   if (auto *RR = dyn_cast<VPReductionRecipe>(VPV))
     return !RR->isPartialReduction();
   if (isa<VPVectorPointerRecipe, VPVectorEndPointerRecipe, VPDerivedIVRecipe>(
@@ -468,6 +459,26 @@ bool vputils::isSingleScalar(const VPValue *VPV) {
 
   // VPExpandSCEVRecipes must be placed in the entry and are always uniform.
   return isa<VPExpandSCEVRecipe>(VPV);
+}
+
+bool vputils::isSingleScalar(const VPValue *VPV) {
+  if (doesGenerateSingleScalar(VPV))
+    return true;
+
+  // A uniformity-preserving operation is single-scalar if all its operands are.
+  if (auto *Rep = dyn_cast<VPReplicateRecipe>(VPV)) {
+    const VPRegionBlock *RegionOfR = Rep->getRegion();
+    if (RegionOfR && RegionOfR->isReplicator())
+      return false;
+    return preservesUniformity(Rep->getOpcode()) &&
+           all_of(Rep->operands(), isSingleScalar);
+  }
+  if (isa<VPWidenGEPRecipe, VPBlendRecipe>(VPV))
+    return all_of(VPV->getDefiningRecipe()->operands(), isSingleScalar);
+
+  return isa<VPWidenRecipe, VPInstruction>(VPV) &&
+         preservesUniformity(vputils::getOpcode(VPV)) &&
+         all_of(VPV->getDefiningRecipe()->operands(), isSingleScalar);
 }
 
 bool vputils::isUniformAcrossVFsAndUFs(const VPValue *V) {

--- a/llvm/lib/Transforms/Vectorize/VPlanUtils.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanUtils.h
@@ -70,6 +70,10 @@ bool isElementwise(const VPValue *V);
 /// Returns true if \p R produces scalar values for all VF lanes.
 bool doesGeneratePerAllLanes(const VPRecipeBase *R);
 
+/// Returns true if \p VPV is defined by a recipe producing a single-scalar
+/// value or a live-in/symbolic value/single-scalar region value.
+bool doesGenerateSingleScalar(const VPValue *VPV);
+
 /// Returns the header block of the first, top-level loop, or null if none
 /// exist.
 VPBasicBlock *getFirstLoopHeader(VPlan &Plan, VPDominatorTree &VPDT);


### PR DESCRIPTION
Similar to #199047, factor out the non-recursive logic from isSingleScalar to doesGenerateSingleScalar to determine single-scalar-ness encoded by the recipe, without recursion.

Use the cheaper, non-recursive variant at sites where the recursive result cannot differ or is not needed:
 - VPCSEDenseMapInfo hash/equality: operands are compared separately, so the recursive classification is fully determined including operands in the hash
 - materializePacksAndUnpacks,  VPWidenGEPRecipe::usesFirstLaneOnly: narrowToSingleScalar already scalarizes all relevant cases explicitly.

Most other users cannot be converted yet without functional changes