### PR TITLE
[CodeGen] Re-land reverted PR (#216510): "Use RegisterClassInfo for remaining allocation-order users" with additional PBQP fix. 

### DIFF
--- a/llvm/lib/CodeGen/RegAllocPBQP.cpp
+++ b/llvm/lib/CodeGen/RegAllocPBQP.cpp
@@ -56,6 +56,7 @@
 #include "llvm/CodeGen/PBQP/Solution.h"
 #include "llvm/CodeGen/PBQPRAConstraint.h"
 #include "llvm/CodeGen/RegAllocRegistry.h"
+#include "llvm/CodeGen/RegisterClassInfo.h"
 #include "llvm/CodeGen/SlotIndexes.h"
 #include "llvm/CodeGen/Spiller.h"
 #include "llvm/CodeGen/TargetRegisterInfo.h"
@@ -154,7 +155,8 @@ private:
   void findVRegIntervalsToAlloc(const MachineFunction &MF, LiveIntervals &LIS);
 
   /// Constructs an initial graph.
-  void initializeGraph(PBQPRAGraph &G, VirtRegMap &VRM, Spiller &VRegSpiller);
+  void initializeGraph(PBQPRAGraph &G, VirtRegMap &VRM, Spiller &VRegSpiller,
+                       const RegisterClassInfo &RCI);
 
   /// Spill the given VReg.
   void spillVReg(Register VReg, SmallVectorImpl<Register> &NewIntervals,
@@ -170,8 +172,8 @@ private:
 
   /// Postprocessing before final spilling. Sets basic block "live in"
   /// variables.
-  void finalizeAlloc(MachineFunction &MF, LiveIntervals &LIS,
-                     VirtRegMap &VRM) const;
+  void finalizeAlloc(MachineFunction &MF, LiveIntervals &LIS, VirtRegMap &VRM,
+                     const RegisterClassInfo &RCI) const;
 
   void postOptimization(Spiller &VRegSpiller, LiveIntervals &LIS);
 };
@@ -541,6 +543,7 @@ INITIALIZE_PASS_DEPENDENCY(LiveStacksWrapperLegacy)
 INITIALIZE_PASS_DEPENDENCY(MachineBlockFrequencyInfoWrapperPass)
 INITIALIZE_PASS_DEPENDENCY(MachineLoopInfoWrapperPass)
 INITIALIZE_PASS_DEPENDENCY(MachineDominatorTreeWrapperPass)
+INITIALIZE_PASS_DEPENDENCY(MachineRegisterClassInfoWrapperPass)
 INITIALIZE_PASS_DEPENDENCY(VirtRegMapWrapperLegacy)
 INITIALIZE_PASS_END(RegAllocPBQP, "regallocpbqp", "PBQP Register Allocator",
                     false, false)
@@ -561,6 +564,8 @@ void RegAllocPBQP::getAnalysisUsage(AnalysisUsage &au) const {
   au.addRequired<MachineBlockFrequencyInfoWrapperPass>();
   au.addRequired<MachineLoopInfoWrapperPass>();
   au.addRequired<MachineDominatorTreeWrapperPass>();
+  au.addRequired<MachineRegisterClassInfoWrapperPass>();
+  au.addPreserved<MachineRegisterClassInfoWrapperPass>();
   au.addRequired<VirtRegMapWrapperLegacy>();
   au.addPreserved<VirtRegMapWrapperLegacy>();
   MachineFunctionPass::getAnalysisUsage(au);
@@ -590,7 +595,8 @@ static bool isACalleeSavedRegister(MCRegister Reg,
 }
 
 void RegAllocPBQP::initializeGraph(PBQPRAGraph &G, VirtRegMap &VRM,
-                                   Spiller &VRegSpiller) {
+                                   Spiller &VRegSpiller,
+                                   const RegisterClassInfo &RCI) {
   MachineFunction &MF = G.getMetadata().MF;
 
   LiveIntervals &LIS = G.getMetadata().LIS;
@@ -624,8 +630,7 @@ void RegAllocPBQP::initializeGraph(PBQPRAGraph &G, VirtRegMap &VRM,
 
     // Compute an initial allowed set for the current vreg.
     std::vector<MCRegister> VRegAllowed;
-    ArrayRef<MCPhysReg> RawPRegOrder = TRI.getRawAllocationOrder(*TRC, MF);
-    for (MCPhysReg R : RawPRegOrder) {
+    for (MCPhysReg R : RCI.getOrder(TRC)) {
       MCRegister PReg(R);
       if (MRI.isReserved(PReg))
         continue;
@@ -754,10 +759,9 @@ bool RegAllocPBQP::mapPBQPToRegAlloc(const PBQPRAGraph &G,
   return !AnotherRoundNeeded;
 }
 
-void RegAllocPBQP::finalizeAlloc(MachineFunction &MF,
-                                 LiveIntervals &LIS,
-                                 VirtRegMap &VRM) const {
-  const TargetRegisterInfo &TRI = *MF.getSubtarget().getRegisterInfo();
+void RegAllocPBQP::finalizeAlloc(MachineFunction &MF, LiveIntervals &LIS,
+                                 VirtRegMap &VRM,
+                                 const RegisterClassInfo &RCI) const {
   MachineRegisterInfo &MRI = MF.getRegInfo();
 
   // First allocate registers for the empty intervals.
@@ -767,16 +771,10 @@ void RegAllocPBQP::finalizeAlloc(MachineFunction &MF,
     Register PReg = MRI.getSimpleHint(LI.reg());
 
     if (PReg == 0) {
-      const TargetRegisterClass &RC = *MRI.getRegClass(LI.reg());
-      ArrayRef<MCPhysReg> RawPRegOrder = TRI.getRawAllocationOrder(RC, MF);
-      for (MCRegister CandidateReg : RawPRegOrder) {
-        if (!VRM.getRegInfo().isReserved(CandidateReg)) {
-          PReg = CandidateReg;
-          break;
-        }
-      }
-      assert(PReg &&
+      ArrayRef<MCPhysReg> Order = RCI.getOrder(MRI.getRegClass(LI.reg()));
+      assert(!Order.empty() &&
              "No un-reserved physical registers in this register class");
+      PReg = Order.front();
     }
 
     VRM.assignVirt2Phys(LI.reg(), PReg);
@@ -818,6 +816,12 @@ bool RegAllocPBQP::runOnMachineFunction(MachineFunction &MF) {
 
   MF.getRegInfo().freezeReservedRegs();
 
+  RegisterClassInfo &RCI =
+      getAnalysis<MachineRegisterClassInfoWrapperPass>().getRCI();
+  // freezeReservedRegs() may add reservations the shared analysis has not seen
+  // yet (e.g. AArch64 WinEH). Refresh RCI so getOrder() excludes them.
+  RCI.updateReservedRegs(MF.getRegInfo().getReservedRegs());
+
   LLVM_DEBUG(dbgs() << "PBQP Register Allocating for " << MF.getName() << "\n");
 
   // Allocator main loop:
@@ -857,7 +861,7 @@ bool RegAllocPBQP::runOnMachineFunction(MachineFunction &MF) {
       (void) Round;
 
       PBQPRAGraph G(PBQPRAGraph::GraphMetadata(MF, LIS, MBFI));
-      initializeGraph(G, VRM, *VRegSpiller);
+      initializeGraph(G, VRM, *VRegSpiller, RCI);
       ConstraintsRoot->apply(G);
 
 #ifndef NDEBUG
@@ -881,7 +885,7 @@ bool RegAllocPBQP::runOnMachineFunction(MachineFunction &MF) {
   }
 
   // Finalise allocation, allocate empty ranges.
-  finalizeAlloc(MF, LIS, VRM);
+  finalizeAlloc(MF, LIS, VRM, RCI);
   postOptimization(*VRegSpiller, LIS);
   VRegsToAlloc.clear();
   EmptyIntervalVRegs.clear();

--- a/llvm/lib/CodeGen/RegAllocPBQP.cpp
+++ b/llvm/lib/CodeGen/RegAllocPBQP.cpp
@@ -818,8 +818,8 @@ bool RegAllocPBQP::runOnMachineFunction(MachineFunction &MF) {
 
   RegisterClassInfo &RCI =
       getAnalysis<MachineRegisterClassInfoWrapperPass>().getRCI();
-  // freezeReservedRegs() may add reservations the shared analysis has not seen
-  // yet (e.g. AArch64 WinEH). Refresh RCI so getOrder() excludes them.
+  // freezeReservedRegs() may add reservations the shared analysis has not seen.
+  // Refresh RCI so getOrder() excludes them.
   RCI.updateReservedRegs(MF.getRegInfo().getReservedRegs());
 
   LLVM_DEBUG(dbgs() << "PBQP Register Allocating for " << MF.getName() << "\n");

--- a/llvm/lib/Target/AMDGPU/AMDGPURewriteAGPRCopyMFMA.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURewriteAGPRCopyMFMA.cpp
@@ -33,6 +33,7 @@
 #include "llvm/CodeGen/MachineDominators.h"
 #include "llvm/CodeGen/MachineFrameInfo.h"
 #include "llvm/CodeGen/MachineFunctionPass.h"
+#include "llvm/CodeGen/RegisterClassInfo.h"
 #include "llvm/CodeGen/SlotIndexes.h"
 #include "llvm/CodeGen/VirtRegMap.h"
 #include "llvm/InitializePasses.h"
@@ -692,7 +693,6 @@ bool AMDGPURewriteAGPRCopyMFMAImpl::run(MachineFunction &MF) const {
 class AMDGPURewriteAGPRCopyMFMALegacy : public MachineFunctionPass {
 public:
   static char ID;
-  RegisterClassInfo RegClassInfo;
 
   AMDGPURewriteAGPRCopyMFMALegacy() : MachineFunctionPass(ID) {}
 
@@ -707,12 +707,14 @@ public:
     AU.addRequired<VirtRegMapWrapperLegacy>();
     AU.addRequired<LiveRegMatrixWrapperLegacy>();
     AU.addRequired<LiveStacksWrapperLegacy>();
+    AU.addRequired<MachineRegisterClassInfoWrapperPass>();
     AU.addRequired<MachineDominatorTreeWrapperPass>();
 
     AU.addPreserved<LiveIntervalsWrapperPass>();
     AU.addPreserved<VirtRegMapWrapperLegacy>();
     AU.addPreserved<LiveRegMatrixWrapperLegacy>();
     AU.addPreserved<LiveStacksWrapperLegacy>();
+    AU.addPreserved<MachineRegisterClassInfoWrapperPass>();
     AU.addPreserved<MachineDominatorTreeWrapperPass>();
 
     AU.setPreservesAll();
@@ -728,6 +730,7 @@ INITIALIZE_PASS_DEPENDENCY(LiveIntervalsWrapperPass)
 INITIALIZE_PASS_DEPENDENCY(VirtRegMapWrapperLegacy)
 INITIALIZE_PASS_DEPENDENCY(LiveRegMatrixWrapperLegacy)
 INITIALIZE_PASS_DEPENDENCY(LiveStacksWrapperLegacy)
+INITIALIZE_PASS_DEPENDENCY(MachineRegisterClassInfoWrapperPass)
 INITIALIZE_PASS_DEPENDENCY(MachineDominatorTreeWrapperPass)
 INITIALIZE_PASS_END(AMDGPURewriteAGPRCopyMFMALegacy, DEBUG_TYPE,
                     "AMDGPU Rewrite AGPR-Copy-MFMA", false, false)
@@ -742,14 +745,13 @@ bool AMDGPURewriteAGPRCopyMFMALegacy::runOnMachineFunction(
   if (skipFunction(MF.getFunction()))
     return false;
 
-  RegClassInfo.runOnMachineFunction(MF);
-
   auto &VRM = getAnalysis<VirtRegMapWrapperLegacy>().getVRM();
   auto &LRM = getAnalysis<LiveRegMatrixWrapperLegacy>().getLRM();
   auto &LIS = getAnalysis<LiveIntervalsWrapperPass>().getLIS();
   auto &LSS = getAnalysis<LiveStacksWrapperLegacy>().getLS();
+  auto &RCI = getAnalysis<MachineRegisterClassInfoWrapperPass>().getRCI();
   auto &MDT = getAnalysis<MachineDominatorTreeWrapperPass>().getDomTree();
-  AMDGPURewriteAGPRCopyMFMAImpl Impl(MF, VRM, LRM, LIS, LSS, RegClassInfo, MDT);
+  AMDGPURewriteAGPRCopyMFMAImpl Impl(MF, VRM, LRM, LIS, LSS, RCI, MDT);
   return Impl.run(MF);
 }
 
@@ -760,11 +762,10 @@ AMDGPURewriteAGPRCopyMFMAPass::run(MachineFunction &MF,
   LiveRegMatrix &LRM = MFAM.getResult<LiveRegMatrixAnalysis>(MF);
   LiveIntervals &LIS = MFAM.getResult<LiveIntervalsAnalysis>(MF);
   LiveStacks &LSS = MFAM.getResult<LiveStacksAnalysis>(MF);
+  RegisterClassInfo &RCI = MFAM.getResult<MachineRegisterClassAnalysis>(MF);
   MachineDominatorTree &MDT = MFAM.getResult<MachineDominatorTreeAnalysis>(MF);
-  RegisterClassInfo RegClassInfo;
-  RegClassInfo.runOnMachineFunction(MF);
 
-  AMDGPURewriteAGPRCopyMFMAImpl Impl(MF, VRM, LRM, LIS, LSS, RegClassInfo, MDT);
+  AMDGPURewriteAGPRCopyMFMAImpl Impl(MF, VRM, LRM, LIS, LSS, RCI, MDT);
   if (!Impl.run(MF))
     return PreservedAnalyses::all();
   auto PA = getMachineFunctionPassPreservedAnalyses();
@@ -773,6 +774,7 @@ AMDGPURewriteAGPRCopyMFMAPass::run(MachineFunction &MF,
       .preserve<VirtRegMapAnalysis>()
       .preserve<SlotIndexesAnalysis>()
       .preserve<LiveIntervalsAnalysis>()
-      .preserve<LiveRegMatrixAnalysis>();
+      .preserve<LiveRegMatrixAnalysis>()
+      .preserve<MachineRegisterClassAnalysis>();
   return PA;
 }

--- a/llvm/lib/Target/ARM/ARMLoadStoreOptimizer.cpp
+++ b/llvm/lib/Target/ARM/ARMLoadStoreOptimizer.cpp
@@ -106,13 +106,13 @@ struct ARMLoadStoreOpt {
   const TargetLowering *TL;
   ARMFunctionInfo *AFI;
   LiveRegUnits LiveRegs;
-  RegisterClassInfo RegClassInfo;
+  const RegisterClassInfo *RCI = nullptr;
   MachineBasicBlock::const_iterator LiveRegPos;
   bool LiveRegsValid;
-  bool RegClassInfoValid;
   bool isThumb1, isThumb2;
 
-  bool runOnMachineFunction(MachineFunction &Fn);
+  bool runOnMachineFunction(MachineFunction &Fn,
+                            const RegisterClassInfo &RegClassInfo);
 
 private:
   /// A set of load/store MachineInstrs with same base register sorted by
@@ -200,6 +200,7 @@ struct ARMLoadStoreOptLegacy : public MachineFunctionPass {
   StringRef getPassName() const override { return ARM_LOAD_STORE_OPT_NAME; }
 
   void getAnalysisUsage(AnalysisUsage &AU) const override {
+    AU.addRequired<MachineRegisterClassInfoWrapperPass>();
     AU.addPreserved<MachineRegisterClassInfoWrapperPass>();
     MachineFunctionPass::getAnalysisUsage(AU);
   }
@@ -209,8 +210,11 @@ char ARMLoadStoreOptLegacy::ID = 0;
 
 } // end anonymous namespace
 
-INITIALIZE_PASS(ARMLoadStoreOptLegacy, "arm-ldst-opt", ARM_LOAD_STORE_OPT_NAME,
-                false, false)
+INITIALIZE_PASS_BEGIN(ARMLoadStoreOptLegacy, "arm-ldst-opt",
+                      ARM_LOAD_STORE_OPT_NAME, false, false)
+INITIALIZE_PASS_DEPENDENCY(MachineRegisterClassInfoWrapperPass)
+INITIALIZE_PASS_END(ARMLoadStoreOptLegacy, "arm-ldst-opt",
+                    ARM_LOAD_STORE_OPT_NAME, false, false)
 
 static bool definesCPSR(const MachineInstr &MI) {
   for (const auto &MO : MI.operands()) {
@@ -592,13 +596,8 @@ void ARMLoadStoreOpt::UpdateBaseRegUses(MachineBasicBlock &MBB,
 
 /// Return the first register of class \p RegClass that is not in \p Regs.
 unsigned ARMLoadStoreOpt::findFreeReg(const TargetRegisterClass &RegClass) {
-  if (!RegClassInfoValid) {
-    RegClassInfo.runOnMachineFunction(*MF);
-    RegClassInfoValid = true;
-  }
-
-  for (unsigned Reg : RegClassInfo.getOrder(&RegClass))
-    if (LiveRegs.available(Reg) && !MF->getRegInfo().isReserved(Reg))
+  for (unsigned Reg : RCI->getOrder(&RegClass))
+    if (LiveRegs.available(Reg))
       return Reg;
   return 0;
 }
@@ -2107,15 +2106,16 @@ bool ARMLoadStoreOpt::CombineMovBx(MachineBasicBlock &MBB) {
   llvm_unreachable("tMOVr doesn't kill a reg before tBX_RET?");
 }
 
-bool ARMLoadStoreOpt::runOnMachineFunction(MachineFunction &Fn) {
+bool ARMLoadStoreOpt::runOnMachineFunction(
+    MachineFunction &Fn, const RegisterClassInfo &RegClassInfo) {
   MF = &Fn;
   STI = &Fn.getSubtarget<ARMSubtarget>();
   TL = STI->getTargetLowering();
   AFI = Fn.getInfo<ARMFunctionInfo>();
   TII = STI->getInstrInfo();
   TRI = STI->getRegisterInfo();
+  RCI = &RegClassInfo;
 
-  RegClassInfoValid = false;
   isThumb2 = AFI->isThumb2Function();
   isThumb1 = AFI->isThumbFunction() && !isThumb2;
 
@@ -2144,7 +2144,8 @@ bool ARMLoadStoreOptLegacy::runOnMachineFunction(MachineFunction &MF) {
   if (skipFunction(MF.getFunction()))
     return false;
   ARMLoadStoreOpt Impl;
-  return Impl.runOnMachineFunction(MF);
+  return Impl.runOnMachineFunction(
+      MF, getAnalysis<MachineRegisterClassInfoWrapperPass>().getRCI());
 }
 
 #define ARM_PREALLOC_LOAD_STORE_OPT_NAME                                       \
@@ -3344,11 +3345,13 @@ PreservedAnalyses
 ARMLoadStoreOptPass::run(MachineFunction &MF,
                          MachineFunctionAnalysisManager &MFAM) {
   ARMLoadStoreOpt Impl;
-  bool Changed = Impl.runOnMachineFunction(MF);
+  bool Changed = Impl.runOnMachineFunction(
+      MF, MFAM.getResult<MachineRegisterClassAnalysis>(MF));
   if (!Changed)
     return PreservedAnalyses::all();
   PreservedAnalyses PA = getMachineFunctionPassPreservedAnalyses();
   PA.preserveSet<CFGAnalyses>();
+  PA.preserve<MachineRegisterClassAnalysis>();
   return PA;
 }
 


### PR DESCRIPTION
Re-land PR #216510 which was reverted in #221749 and fixed by @mhalk in #221849. 

Additionally addresses the comment in the reversion PR to fix `/llvm/test/CodeGen/AArch64/wineh-try-catch.ll` with -regalloc=pbqp by refreshing RCI with updateReservedRegs from my previous PR. 

Assisted by composer 2.5