### PR TITLE
[MLIR][XeVM] Hoist contiguous-slice shuffles through n-ary elementwise ops

### DIFF
--- a/mlir/lib/Conversion/XeVMToLLVM/XeVMToLLVM.cpp
+++ b/mlir/lib/Conversion/XeVMToLLVM/XeVMToLLVM.cpp
@@ -23,6 +23,7 @@
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Matchers.h"
 #include "mlir/IR/Types.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 #include "llvm/ADT/TypeSwitch.h"
@@ -1767,6 +1768,18 @@ static bool isExtractingContiguousSlice(LLVM::ShuffleVectorOp op) {
   return true;
 }
 
+// Clones `op` with new operands and result types, preserving its attributes
+// and properties (e.g. an `icmp` predicate or fastmath flags). Same idiom used
+// by the Vector dialect's unroll patterns.
+static Operation *cloneOpWithOperandsAndTypes(RewriterBase &rewriter,
+                                              Location loc, Operation *op,
+                                              ArrayRef<Value> operands,
+                                              ArrayRef<Type> resultTypes) {
+  OperationState state(loc, op->getName().getStringRef(), operands, resultTypes,
+                       op->getAttrs());
+  return rewriter.create(state);
+}
+
 // Input vector of a shuffle vector op extracting a contiguous slice is an
 // illegal vector in SPIRV kernel if the vector size is > 16 elements.
 // To legalize this case, keep applying the following transformations until no
@@ -1775,6 +1788,9 @@ static bool isExtractingContiguousSlice(LLVM::ShuffleVectorOp op) {
 //       start with fpext, fptrunc and bitcast for now.
 //   2. merge with another shuffle vector op
 //   3. merge with load as a smaller load
+//   4. hoist past n-ary element-wise operations (e.g. fdiv, select, icmp) by
+//      slicing every same-length vector operand with the same mask and cloning
+//      the op at the narrow width.
 class HandleVectorExtractPattern
     : public OpRewritePattern<LLVM::ShuffleVectorOp> {
   using OpRewritePattern<LLVM::ShuffleVectorOp>::OpRewritePattern;
@@ -1895,6 +1911,31 @@ class HandleVectorExtractPattern
           auto newLoad = LLVM::LoadOp::create(rewriter, loc, newVecTy, loadPtr);
           rewriter.replaceOp(op, newLoad);
         }
+      } else if (isMemoryEffectFree(srcOp) && srcOp->getNumResults() == 1 &&
+                 srcOp->getNumOperands() >= 1 &&
+                 llvm::all_of(srcOp->getOperands(), [&](Value operand) {
+                   auto operandTy = dyn_cast<VectorType>(operand.getType());
+                   auto srcTy = cast<VectorType>(src.getType());
+                   return operandTy && operandTy.getRank() == 1 &&
+                          operandTy.getNumElements() == srcTy.getNumElements();
+                 })) {
+        // 4. Hoist past an n-ary element-wise op: slice each same-length vector
+        //    operand with the same contiguous mask and clone the op narrow.
+        //    The freshly created operand shuffles keep the greedy driver going,
+        //    hoisting them further up (or merging via case 2 / into loads via
+        //    case 3) until they reach operands that are already legal width.
+        SmallVector<Value> newOperands;
+        newOperands.reserve(srcOp->getNumOperands());
+        for (Value operand : srcOp->getOperands()) {
+          auto operandTy = cast<VectorType>(operand.getType());
+          auto sliceTy =
+              VectorType::get(mask.size(), operandTy.getElementType());
+          newOperands.push_back(LLVM::ShuffleVectorOp::create(
+              rewriter, loc, sliceTy, operand, operand, mask));
+        }
+        Operation *newOp =
+            cloneOpWithOperandsAndTypes(rewriter, loc, srcOp, newOperands, ty);
+        rewriter.replaceOp(op, newOp->getResult(0));
       } else {
         return failure();
       }

--- a/mlir/test/Conversion/XeVMToLLVM/legalize_large_vector.mlir
+++ b/mlir/test/Conversion/XeVMToLLVM/legalize_large_vector.mlir
@@ -121,3 +121,59 @@ module @test_poison_second_operand {
     llvm.return
   }
 }
+
+// -----
+
+// A wide *binary* element-wise op (fdiv) feeding a contiguous slice is
+// narrowed: the slice hoists through the binary op onto both operands, which
+// then terminate as legal-width slices of the (wide) arguments.
+module @test_binary_elementwise {
+  // CHECK-LABEL: llvm.func @test_binary_elementwise
+  // CHECK-NOT:     llvm.fdiv {{.*}} : vector<32xf32>
+  // CHECK:         %[[LO_A:.*]] = llvm.shufflevector %[[A:.*]], %[[A]] [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+  // CHECK:         %[[LO_B:.*]] = llvm.shufflevector %[[B:.*]], %[[B]] [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+  // CHECK:         llvm.fdiv %[[LO_A]], %[[LO_B]] : vector<16xf32>
+  llvm.func @test_binary_elementwise(%a: vector<32xf32>, %b: vector<32xf32>) -> vector<16xf32> {
+    %0 = llvm.fdiv %a, %b : vector<32xf32>
+    %1 = llvm.shufflevector %0, %0 [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] : vector<32xf32>
+    llvm.return %1 : vector<16xf32>
+  }
+}
+
+// -----
+
+// A ternary `select` fed by a binary `icmp`, both wide, narrowed through the
+// contiguous slice. The `icmp` predicate must be preserved by the clone.
+module @test_select_icmp {
+  // CHECK-LABEL: llvm.func @test_select_icmp
+  // CHECK-NOT:     llvm.icmp {{.*}} : vector<32xi32>
+  // CHECK-NOT:     llvm.select {{.*}} : vector<32xi1>, vector<32xi32>
+  // CHECK:         llvm.icmp "eq" {{.*}} : vector<16xi32>
+  // CHECK:         llvm.select {{.*}} : vector<16xi1>, vector<16xi32>
+  llvm.func @test_select_icmp(%a: vector<32xi32>, %b: vector<32xi32>,
+                              %t: vector<32xi32>, %f: vector<32xi32>) -> vector<16xi32> {
+    %c = llvm.icmp "eq" %a, %b : vector<32xi32>
+    %s = llvm.select %c, %t, %f : vector<32xi1>, vector<32xi32>
+    %r = llvm.shufflevector %s, %s [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] : vector<32xi32>
+    llvm.return %r : vector<16xi32>
+  }
+}
+
+// -----
+
+// Negative: the hoist only fires when every operand has the same length as the
+// result. A length-changing bitcast (which is how packed sub-byte payloads are
+// formed) is handled by the dedicated bitcast case, not the n-ary path; here a
+// non-elementwise, side-effecting producer (a call) must be left untouched so
+// the slice is not pushed through it.
+module @test_nary_no_hoist_through_call {
+  llvm.func @producer(vector<32xf32>) -> vector<32xf32>
+  // CHECK-LABEL: llvm.func @test_nary_no_hoist_through_call
+  // CHECK:         %[[C:.*]] = llvm.call @producer
+  // CHECK:         llvm.shufflevector %[[C]], %[[C]] [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] : vector<32xf32>
+  llvm.func @test_nary_no_hoist_through_call(%a: vector<32xf32>) -> vector<16xf32> {
+    %0 = llvm.call @producer(%a) : (vector<32xf32>) -> vector<32xf32>
+    %1 = llvm.shufflevector %0, %0 [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] : vector<32xf32>
+    llvm.return %1 : vector<16xf32>
+  }
+}

--- a/mlir/test/Conversion/XeVMToLLVM/mxfp_scale_binary_hoist.mlir
+++ b/mlir/test/Conversion/XeVMToLLVM/mxfp_scale_binary_hoist.mlir
@@ -1,0 +1,86 @@
+// RUN: mlir-opt --convert-xevm-to-llvm --split-input-file %s | FileCheck %s
+
+// Driver for extending HandleVectorExtractPattern to hoist contiguous-slice
+// shuffles through n-ary elementwise ops (here the binary `llvm.fdiv`).
+//
+// This is the exact code sequence taken from the WG-level mxfp GEMM
+// (simple_mxfp_gemm_quantizeA_F4.mlir) at the point it is fed to
+// convert-xevm-to-llvm: the f8E8M0 scale is expanded into wide integer/float
+// arithmetic (zext/shl/icmp/select/bitcast/fptrunc/fpext/fdiv/fptrunc on
+// vector<32x...>), then sliced into two contiguous vector<16xbf16> halves that
+// feed `xevm.truncf` (bf16 -> e2m1), which are assembled into the `a` operand
+// of `xevm.mma_mx`.
+//
+// The `[0..15]`/`[16..31]` slices already sit below the wide chain; the
+// existing pattern hoists them through the unary `fptrunc` but gets stuck at
+// the binary `fdiv`, so the wide vector<32x...> compute survives and the
+// SPIR-V backend later fails to legalize the wide `fpext`/`fdiv`.
+//
+// Once the pattern hoists through n-ary elementwise ops, the whole scale chain
+// must narrow to the 16-wide slice width and no vector<32x...> compute op may
+// remain.
+
+// CHECK-LABEL: llvm.func @mxfp_scale_binary_hoist
+// The wide f8E8M0 scale chain must be narrowed to the 16-wide slice: no wide
+// (vector<32x...>) elementwise compute op may survive. Wide function arguments,
+// constants, the packed `b` payload and data-movement shuffles are unaffected.
+// CHECK-NOT:     llvm.fdiv {{.*}} : vector<32xf32>
+// CHECK-NOT:     llvm.fpext {{.*}} : vector<32xbf16>
+// CHECK-NOT:     llvm.fptrunc {{.*}} : vector<32xf32>
+// CHECK-NOT:     llvm.zext {{.*}} : vector<32xi8> to vector<32xi32>
+// CHECK-NOT:     llvm.shl {{.*}} : vector<32xi32>
+// CHECK-NOT:     llvm.select {{.*}} : vector<32xi1>, vector<32xi32>
+// CHECK-NOT:     llvm.icmp {{.*}} : vector<32xi8>
+// CHECK:         llvm.fdiv {{.*}} : vector<16xf32>
+llvm.func @mxfp_scale_binary_hoist(
+    %scale_src: vector<32xi8>,
+    %num: vector<32xf32>,
+    %b: vector<32xi8>,
+    %scale_a: vector<2xi8>,
+    %scale_b: vector<2xi8>,
+    %c: vector<8xf32>) -> vector<8xf32> {
+  %shl_amt   = llvm.mlir.constant(dense<23> : vector<32xi32>) : vector<32xi32>
+  %ones_i8   = llvm.mlir.constant(dense<-1> : vector<32xi8>)  : vector<32xi8>
+  %ones_i32  = llvm.mlir.constant(dense<-1> : vector<32xi32>) : vector<32xi32>
+
+  // f8E8M0 scale expansion into wide arithmetic.
+  %e         = llvm.zext %scale_src : vector<32xi8> to vector<32xi32>
+  %sh        = llvm.shl %e, %shl_amt : vector<32xi32>
+  %cmp       = llvm.icmp "eq" %scale_src, %ones_i8 : vector<32xi8>
+  %sel       = llvm.select %cmp, %ones_i32, %sh : vector<32xi1>, vector<32xi32>
+  %scale_f32 = llvm.bitcast %sel : vector<32xi32> to vector<32xf32>
+  %scale_bf  = llvm.fptrunc %scale_f32 : vector<32xf32> to vector<32xbf16>
+  %scale_ext = llvm.fpext %scale_bf fastmath<contract> : vector<32xbf16> to vector<32xf32>
+  %div       = llvm.fdiv %num, %scale_ext : vector<32xf32>
+  %div_bf    = llvm.fptrunc %div fastmath<contract> : vector<32xf32> to vector<32xbf16>
+
+  // Two contiguous 16-wide slices feeding xevm.truncf (bf16 -> e2m1/fp4).
+  %lo  = llvm.shufflevector %div_bf, %div_bf [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] : vector<32xbf16>
+  %lo4 = xevm.truncf %lo {src_etype = bf16, dst_etype = e2m1} : (vector<16xbf16>) -> vector<8xi8>
+  %hi  = llvm.shufflevector %div_bf, %div_bf [16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31] : vector<32xbf16>
+  %hi4 = xevm.truncf %hi {src_etype = bf16, dst_etype = e2m1} : (vector<16xbf16>) -> vector<8xi8>
+
+  // Assemble the packed fp4 `a` operand (16xi8) and feed the scaled MMA.
+  %a = llvm.shufflevector %lo4, %hi4 [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] : vector<8xi8>
+  %r = xevm.mma_mx %a, %b, %scale_a, %scale_b, %c
+        {shape = <m = 8, n = 16, k = 64>, types = <d = f32, a = e2m1, b = e2m1, c = f32>}
+        : (vector<16xi8>, vector<32xi8>, vector<2xi8>, vector<2xi8>, vector<8xf32>) -> vector<8xf32>
+  llvm.return %r : vector<8xf32>
+}
+
+// -----
+
+// Negative: a contiguous slice of a packed sub-byte `xevm.truncf` result must
+// NOT be hoisted into the truncf. The truncf changes the element count
+// (16 bf16 -> 8 packed i8) and is not a same-length elementwise op, so the
+// n-ary guard rejects it: the bf16 input is never fragmented into narrower
+// bf16 compute (the slice stays in the packed representation instead).
+// CHECK-LABEL: llvm.func @packed_subbyte_not_split
+// CHECK-NOT:     vector<4xbf16>
+// CHECK-NOT:     vector<8xbf16>
+// CHECK:         llvm.return
+llvm.func @packed_subbyte_not_split(%src: vector<16xbf16>) -> vector<4xi8> {
+  %p = xevm.truncf %src {src_etype = bf16, dst_etype = e2m1} : (vector<16xbf16>) -> vector<8xi8>
+  %s = llvm.shufflevector %p, %p [0, 1, 2, 3] : vector<8xi8>
+  llvm.return %s : vector<4xi8>
+}


### PR DESCRIPTION
XeGPU expresses vector operands in their logical element type, so per-lane compute chains can end up wider than the SPIR-V backend can legalize as a single operand. HandleVectorExtractPattern already narrows such chains by hoisting a contiguous-slice shufflevector upward through unary element-wise ops (fpext/fptrunc/bitcast), merging shuffle chains, and folding into smaller loads. But it stops at n-ary ops, so a chain like

  %0 = llvm.fdiv %a, %b : vector<32xf32>                    // wide, binary
  %1 = llvm.shufflevector %0, %0 [0..15] : vector<32xf32>   // legal 16-wide slice

keeps a wide vector<32xf32> compute that the backend rejects.

This extends the pattern to hoist a contiguous slice through n-ary element-wise ops as well: slice each same-length vector operand with the same mask and re-create the op at the narrow width. The freshly created operand slices keep hoisting upward (merging, or folding into loads) until they reach operands that are already legal width, so the whole compute chain collapses to the slice width - with no target-specific width limit, since the width is inherited from the slice. Length-changing and packed-payload ops (e.g. bitcast, truncf) are left untouched.