### PR TITLE
[OpenMP][OMPD] Load `libompd` with LLVM dynamic lib

### DIFF
--- a/openmp/docs/Building.md
+++ b/openmp/docs/Building.md
@@ -379,7 +379,8 @@ This option is `OFF` if this feature is not supported for the platform.
 ### Options for `libompd`
 
 **LIBOMP_OMPD_SUPPORT**:BOOL
-: Enable building the libompd library.
+: Enable building the libompd library. The GDB plugin loads `libompd.so` with
+LLVM Support `DynamicLibrary` (not POSIX `dlopen`).
 
 **LIBOMPD_LD_STD_FLAGS**:STRING
 : Use `-stdlibc++` instead of `-libc++` library for C++.

--- a/openmp/libompd/gdb-plugin/CMakeLists.txt
+++ b/openmp/libompd/gdb-plugin/CMakeLists.txt
@@ -16,7 +16,7 @@ set (CMAKE_MODULE_PATH
 include_directories (${OMPD_INCLUDE_PATH})
 include_directories (${LIBOMP_INCLUDE_DIR})
 add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/python-module/ompd/__init__.py
-                   DEPENDS ompdModule.c ompdDLService.c ompdAPITests.c ompd/frame_filter.py ompd/__init__.py ompd/ompd_address_space.py ompd/ompd_callbacks.py ompd/ompd_handles.py ompd/ompd.py
+                   DEPENDS ompdModule.c ompdDLService.cpp ompdAPITests.c ompd/frame_filter.py ompd/__init__.py ompd/ompd_address_space.py ompd/ompd_callbacks.py ompd/ompd_handles.py ompd/ompd.py
                    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/ompd ${CMAKE_CURRENT_BINARY_DIR}/python-module/ompd/
                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
@@ -24,16 +24,28 @@ add_custom_target(ompd_gdb_plugin ALL
                   DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/python-module/ompd/__init__.py
                   COMMENT "Building the OMPD GDB plugin")
 
-add_library (ompdModule MODULE ompdModule.c ompdAPITests.c ompdDLService.c)
+add_library (ompdModule MODULE ompdModule.c ompdAPITests.c ompdDLService.cpp)
 include_directories (
         ${LIBOMP_INCLUDE_DIR}
         ${LIBOMP_SRC_DIR}
         ${Python3_INCLUDE_DIRS}
 )
+if(LLVM_INCLUDE_DIRS)
+    target_include_directories(ompdModule PRIVATE ${LLVM_INCLUDE_DIRS})
+else()
+    target_include_directories(ompdModule PRIVATE ${LLVM_INCLUDE_DIR} ${LLVM_MAIN_INCLUDE_DIR})
+endif()
 target_link_libraries (ompdModule ${Python3_LIBRARIES})
-target_link_libraries (ompdModule ${CMAKE_DL_LIBS})
+# Use LLVM Support's DynamicLibrary, not POSIX dlopen, and not libclang-cpp.
+if(LLVM_LINK_LLVM_DYLIB)
+    target_link_libraries(ompdModule LLVM)
+else()
+    llvm_map_components_to_libnames(ompd_llvm_libs Support)
+    target_link_libraries(ompdModule ${ompd_llvm_libs})
+endif()
 
 set_target_properties (ompdModule PROPERTIES PREFIX "")
+set_target_properties (ompdModule PROPERTIES LINKER_LANGUAGE CXX)
 set_target_properties (ompdModule PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/python-module/ompd/")
 
 openmp_register_meta_dep(ompd_gdb_plugin ompdModule)

--- a/openmp/libompd/gdb-plugin/README.txt
+++ b/openmp/libompd/gdb-plugin/README.txt
@@ -20,6 +20,7 @@ Instructions to use OpenMP specific debugging support for debugging C/C++ OpenMP
 
         - The gdb command 'help ompd' lists the subcommands available for OpenMP-specific debugging.
         - The command 'ompd init' needs to be run first to load the libompd.so available in the $LD_LIBRARY_PATH environment variable, and to initialize the OMPD library.
+        - The plugin uses LLVM Support to load libompd.so. Put the directory that contains libLLVMSupport.so (or libLLVM.so) on LD_LIBRARY_PATH if GDB cannot load the plugin.
         - The 'ompd init' command starts the program run, and the program stops at a temporary breakpoint at the OpenMP internal location ompd_dll_locations_valid().
         - The user can 'continue' from the temporary breakpoint for further debugging.
         - The user may place breakpoints at the OpenMP internal locations 'ompd_bp_thread_begin' and 'ompd_bp_thread_end' to catch the OpenMP thread begin and thread end events.

--- a/openmp/libompd/gdb-plugin/ompdDLService.cpp
+++ b/openmp/libompd/gdb-plugin/ompdDLService.cpp
@@ -41,11 +41,11 @@ int ompd_load_library(const char *name) {
     return -1;
   }
 
-  std::string errMsg;
+  std::string ErrMsg;
   llvm::sys::DynamicLibrary NewLib =
-      llvm::sys::DynamicLibrary::getLibrary(name, &errMsg);
+      llvm::sys::DynamicLibrary::getLibrary(name, &ErrMsg);
   if (!NewLib.isValid()) {
-    set_error(errMsg.empty() ? "failed to load OMPD library" : errMsg.c_str());
+    set_error(ErrMsg.empty() ? "failed to load OMPD library" : ErrMsg.c_str());
     return -1;
   }
 

--- a/openmp/libompd/gdb-plugin/ompdDLService.cpp
+++ b/openmp/libompd/gdb-plugin/ompdDLService.cpp
@@ -1,5 +1,5 @@
 /*
- * ompdDLService.c -- Load libompd and look up OMPD API symbols.
+ * ompdDLService.cpp -- Load libompd and look up OMPD API symbols.
  */
 
 //===----------------------------------------------------------------------===//
@@ -12,11 +12,15 @@
 
 #include "ompdDLService.h"
 
-#include <dlfcn.h>
-#include <string.h>
+#include "llvm/Support/DynamicLibrary.h"
+
+#include <cstdio>
+#include <cstring>
+#include <string>
 
 void *ompd_library = NULL;
 
+static llvm::sys::DynamicLibrary LoadedLib;
 static char last_error[256];
 
 static void set_error(const char *msg) {
@@ -28,41 +32,35 @@ static void set_error(const char *msg) {
   last_error[sizeof(last_error) - 1] = '\0';
 }
 
-static void clear_error(void) {
-  last_error[0] = '\0';
-  (void)dlerror();
-}
+static void clear_error(void) { last_error[0] = '\0'; }
 
 int ompd_load_library(const char *name) {
-  const char *dlerr;
-
   clear_error();
   if (!name || !name[0]) {
     set_error("OMPD library path is empty");
-    ompd_library = NULL;
     return -1;
   }
 
-  ompd_library = dlopen(name, RTLD_LAZY);
-  dlerr = dlerror();
-  if (dlerr) {
-    set_error(dlerr);
-    ompd_library = NULL;
+  std::string errMsg;
+  llvm::sys::DynamicLibrary NewLib =
+      llvm::sys::DynamicLibrary::getLibrary(name, &errMsg);
+  if (!NewLib.isValid()) {
+    set_error(errMsg.empty() ? "failed to load OMPD library" : errMsg.c_str());
     return -1;
   }
-  if (!ompd_library) {
-    set_error("dlopen returned NULL");
-    return -1;
-  }
+
+  if (LoadedLib.isValid())
+    llvm::sys::DynamicLibrary::closeLibrary(LoadedLib);
+  LoadedLib = NewLib;
+  ompd_library = LoadedLib.getOSSpecificHandle();
   return 0;
 }
 
 void *ompd_get_symbol(const char *name) {
-  const char *dlerr;
   void *sym;
 
   clear_error();
-  if (!ompd_library) {
+  if (!LoadedLib.isValid()) {
     set_error("OMPD library is not loaded");
     return NULL;
   }
@@ -71,10 +69,10 @@ void *ompd_get_symbol(const char *name) {
     return NULL;
   }
 
-  sym = dlsym(ompd_library, name);
-  dlerr = dlerror();
-  if (dlerr) {
-    set_error(dlerr);
+  sym = LoadedLib.getAddressOfSymbol(name);
+  if (!sym) {
+    snprintf(last_error, sizeof(last_error), "could not find symbol '%s'",
+             name);
     return NULL;
   }
   return sym;

--- a/openmp/libompd/test/lit.cfg
+++ b/openmp/libompd/test/lit.cfg
@@ -49,6 +49,8 @@ config.test_flags = " -I " + config.test_source_root + " -I " + config.ompt_incl
 
 append_dynamic_library_path(config.library_dir)
 append_dynamic_library_path(config.ompd_library_dir)
+if getattr(config, "llvm_library_dir", ""):
+    append_dynamic_library_path(config.llvm_library_dir)
 
 # Disable OMPT tests if FileCheck was not found
 if config.test_filecheck == "":
@@ -69,6 +71,9 @@ config.substitutions.append(("%gdb-compile-and-run", "%gdb-compile && %gdb-run")
 config.substitutions.append(("%gdb-compile",
     "%test_c_compiler -fopenmp -g -gdwarf-4 %s -o %t " + config.test_flags))
 config.substitutions.append(("%test_c_compiler", config.test_c_compiler))
+if not getattr(config, "test_cxx_compiler", ""):
+    config.test_cxx_compiler = config.test_c_compiler
+config.substitutions.append(("%test_cxx_compiler", config.test_cxx_compiler))
 config.substitutions.append(("%gdb-run",
     "env OMP_DEBUG=enabled gdb -x " + config.ompd_obj_root + "/../gdb-plugin/python-module/ompd/__init__.py -x " \
     + config.ompd_test_src + "/test.cmd %t "))
@@ -87,7 +92,9 @@ config.substitutions.append(
     (
         "%ompd-dl-src",
         os.path.normpath(
-            os.path.join(config.ompd_test_src, "..", "gdb-plugin", "ompdDLService.c")
+            os.path.join(
+                config.ompd_test_src, "..", "gdb-plugin", "ompdDLService.cpp"
+            )
         ),
     )
 )
@@ -97,4 +104,25 @@ config.substitutions.append(
         os.path.normpath(os.path.join(config.ompd_test_src, "..", "gdb-plugin")),
     )
 )
+
+ompd_llvm_flags = ""
+llvm_config = getattr(config, "llvm_config", "")
+if llvm_config and os.path.isfile(llvm_config):
+    try:
+        cxxflags = subprocess.check_output(
+            [llvm_config, "--cxxflags"], universal_newlines=True
+        ).strip()
+        ldflags = subprocess.check_output(
+            [llvm_config, "--ldflags"], universal_newlines=True
+        ).strip()
+        libs = subprocess.check_output(
+            [llvm_config, "--libs", "Support"], universal_newlines=True
+        ).strip()
+        syslibs = subprocess.check_output(
+            [llvm_config, "--system-libs"], universal_newlines=True
+        ).strip()
+        ompd_llvm_flags = " ".join([cxxflags, ldflags, libs, syslibs])
+    except subprocess.CalledProcessError:
+        ompd_llvm_flags = ""
+config.substitutions.append(("%ompd-llvm-flags", ompd_llvm_flags))
 

--- a/openmp/libompd/test/lit.cfg
+++ b/openmp/libompd/test/lit.cfg
@@ -71,8 +71,6 @@ config.substitutions.append(("%gdb-compile-and-run", "%gdb-compile && %gdb-run")
 config.substitutions.append(("%gdb-compile",
     "%test_c_compiler -fopenmp -g -gdwarf-4 %s -o %t " + config.test_flags))
 config.substitutions.append(("%test_c_compiler", config.test_c_compiler))
-if not getattr(config, "test_cxx_compiler", ""):
-    config.test_cxx_compiler = config.test_c_compiler
 config.substitutions.append(("%test_cxx_compiler", config.test_cxx_compiler))
 config.substitutions.append(("%gdb-run",
     "env OMP_DEBUG=enabled gdb -x " + config.ompd_obj_root + "/../gdb-plugin/python-module/ompd/__init__.py -x " \

--- a/openmp/libompd/test/lit.site.cfg.in
+++ b/openmp/libompd/test/lit.site.cfg.in
@@ -1,6 +1,7 @@
 @AUTO_GEN_COMMENT@
 
 config.test_c_compiler = "@OPENMP_TEST_C_COMPILER@"
+config.test_cxx_compiler = "@OPENMP_TEST_CXX_COMPILER@"
 config.test_compiler_features = @OPENMP_TEST_COMPILER_FEATURES@
 config.test_filecheck = "@OPENMP_FILECHECK_EXECUTABLE@"
 config.test_not = "@OPENMP_NOT_EXECUTABLE@"
@@ -17,6 +18,8 @@ config.target_triple = "@LLVM_TARGET_TRIPLE@"
 config.ompt_plugin = "@OMPT_PLUGIN@"
 config.ompt_include_dir = "@LIBOMP_INCLUDE_DIR@"
 config.ompd_module = "@CMAKE_CURRENT_BINARY_DIR@/../gdb-plugin/python-module/ompd/"
+config.llvm_config = "@LLVM_TOOLS_BINARY_DIR@/llvm-config"
+config.llvm_library_dir = "@LLVM_LIBRARY_DIR@"
 
 import lit.llvm
 lit.llvm.initialize(lit_config, config)

--- a/openmp/libompd/test/ompd_dl_service.c
+++ b/openmp/libompd/test/ompd_dl_service.c
@@ -1,4 +1,4 @@
-// RUN: %test_c_compiler %s %ompd-dl-src -I%ompd-dl-inc -ldl -o %t
+// RUN: %test_cxx_compiler %s %ompd-dl-src -I%ompd-dl-inc %ompd-llvm-flags -o %t
 // RUN: %t %ompd-lib | FileCheck %s
 // REQUIRES: linux
 


### PR DESCRIPTION
OMPD loads `libompd.so` through a small helper, but that helper still uses `dlopen/dlsym` under the hood. We have already laid the foundation by making libraries load behind helpers in the current state; this one is simply a cleanup that moves helpers to LLVM's loader, which is LLVM's standard.

The current state has few issues: 

1: Still tied to Unix-style APIs.
⁠2: Windows support has to separately deal with loader differences.
3: Future shared-lib work would need more loader changes later.

This patch keeps the same OMPD API and call sites, but replaces the implementation with LLVM's DynamicLibrary. Error handling remains unchanged.