### PR TITLE
[MLIR][XeGPU] Update WG integration tests to strict property syntax

### DIFF
--- a/mlir/test/Integration/Dialect/XeGPU/WG/simple_3d_gemm.mlir
+++ b/mlir/test/Integration/Dialect/XeGPU/WG/simple_3d_gemm.mlir
@@ -22,34 +22,34 @@ gpu.module @test_kernel {
     %m = arith.muli %block_id_x, %c64 : index
     %n = arith.muli %block_id_y, %c64 : index
     %c_tdesc = xegpu.create_nd_tdesc %C : memref<4x64x64xf32> -> !xegpu.tensor_desc<4x64x64xf32, #c>
-    %c_init_value = xegpu.load_nd %c_tdesc[%block_id_z, %m, %n] {layout = #c} : !xegpu.tensor_desc<4x64x64xf32, #c> -> vector<4x64x64xf32>
+    %c_init_value = xegpu.load_nd %c_tdesc[%block_id_z, %m, %n] <{layout = #c}> : !xegpu.tensor_desc<4x64x64xf32, #c> -> vector<4x64x64xf32>
     %a_tdesc = xegpu.create_nd_tdesc %A : memref<4x64x256xf16> -> !xegpu.tensor_desc<4x64x32xf16, #a>
     %b_tdesc = xegpu.create_nd_tdesc %B : memref<4x256x64xf16> -> !xegpu.tensor_desc<4x32x64xf16, #b>
     // Prefetch A 3 times.
     %a_prefetch_tdesc = xegpu.create_nd_tdesc %A : memref<4x64x256xf16> -> !xegpu.tensor_desc<4x64x32xf16, #a_prefetch>
-    xegpu.prefetch_nd %a_prefetch_tdesc[%block_id_z, %m, %c0] {layout = #a_prefetch} : !xegpu.tensor_desc<4x64x32xf16, #a_prefetch>
-    xegpu.prefetch_nd %a_prefetch_tdesc[%block_id_z, %m, %c32] {layout = #a_prefetch} : !xegpu.tensor_desc<4x64x32xf16, #a_prefetch>
-    xegpu.prefetch_nd %a_prefetch_tdesc[%block_id_z, %m, %c64] {layout = #a_prefetch} : !xegpu.tensor_desc<4x64x32xf16, #a_prefetch>
+    xegpu.prefetch_nd %a_prefetch_tdesc[%block_id_z, %m, %c0] <{layout = #a_prefetch}> : !xegpu.tensor_desc<4x64x32xf16, #a_prefetch>
+    xegpu.prefetch_nd %a_prefetch_tdesc[%block_id_z, %m, %c32] <{layout = #a_prefetch}> : !xegpu.tensor_desc<4x64x32xf16, #a_prefetch>
+    xegpu.prefetch_nd %a_prefetch_tdesc[%block_id_z, %m, %c64] <{layout = #a_prefetch}> : !xegpu.tensor_desc<4x64x32xf16, #a_prefetch>
     // Prefetch B 3 times.
     %b_prefetch_tdesc = xegpu.create_nd_tdesc %B : memref<4x256x64xf16> -> !xegpu.tensor_desc<4x32x64xf16, #b_prefetch>
-    xegpu.prefetch_nd %b_prefetch_tdesc[%block_id_z, %c0, %n] {layout = #b_prefetch} : !xegpu.tensor_desc<4x32x64xf16, #b_prefetch>
-    xegpu.prefetch_nd %b_prefetch_tdesc[%block_id_z, %c32, %n] {layout = #b_prefetch} : !xegpu.tensor_desc<4x32x64xf16, #b_prefetch>
-    xegpu.prefetch_nd %b_prefetch_tdesc[%block_id_z, %c64, %n] {layout = #b_prefetch} : !xegpu.tensor_desc<4x32x64xf16, #b_prefetch>
+    xegpu.prefetch_nd %b_prefetch_tdesc[%block_id_z, %c0, %n] <{layout = #b_prefetch}> : !xegpu.tensor_desc<4x32x64xf16, #b_prefetch>
+    xegpu.prefetch_nd %b_prefetch_tdesc[%block_id_z, %c32, %n] <{layout = #b_prefetch}> : !xegpu.tensor_desc<4x32x64xf16, #b_prefetch>
+    xegpu.prefetch_nd %b_prefetch_tdesc[%block_id_z, %c64, %n] <{layout = #b_prefetch}> : !xegpu.tensor_desc<4x32x64xf16, #b_prefetch>
 
     %out = scf.for %k = %c0 to %c256 step %c32
       iter_args(%c_value = %c_init_value)
       -> (vector<4x64x64xf32>) {
-      %a_value = xegpu.load_nd %a_tdesc[%block_id_z, %m, %k] {layout = #a} : !xegpu.tensor_desc<4x64x32xf16, #a> -> vector<4x64x32xf16>
-      %b_value = xegpu.load_nd %b_tdesc[%block_id_z, %k, %n] {layout = #b} : !xegpu.tensor_desc<4x32x64xf16, #b> -> vector<4x32x64xf16>
+      %a_value = xegpu.load_nd %a_tdesc[%block_id_z, %m, %k] <{layout = #a}> : !xegpu.tensor_desc<4x64x32xf16, #a> -> vector<4x64x32xf16>
+      %b_value = xegpu.load_nd %b_tdesc[%block_id_z, %k, %n] <{layout = #b}> : !xegpu.tensor_desc<4x32x64xf16, #b> -> vector<4x32x64xf16>
       // Prefetch next tiles.
       %prefetch_offset = arith.addi %k, %c96 : index
-      xegpu.prefetch_nd %a_prefetch_tdesc[%block_id_z, %m, %prefetch_offset] {layout = #a_prefetch} : !xegpu.tensor_desc<4x64x32xf16, #a_prefetch>
-      xegpu.prefetch_nd %b_prefetch_tdesc[%block_id_z, %prefetch_offset, %n] {layout = #b_prefetch} : !xegpu.tensor_desc<4x32x64xf16, #b_prefetch>
-      %c_new_value = xegpu.dpas %a_value, %b_value, %c_value {layout_a = #a, layout_b = #b, layout_cd = #c}
+      xegpu.prefetch_nd %a_prefetch_tdesc[%block_id_z, %m, %prefetch_offset] <{layout = #a_prefetch}> : !xegpu.tensor_desc<4x64x32xf16, #a_prefetch>
+      xegpu.prefetch_nd %b_prefetch_tdesc[%block_id_z, %prefetch_offset, %n] <{layout = #b_prefetch}> : !xegpu.tensor_desc<4x32x64xf16, #b_prefetch>
+      %c_new_value = xegpu.dpas %a_value, %b_value, %c_value <{layout_a = #a, layout_b = #b, layout_cd = #c}>
         : vector<4x64x32xf16>, vector<4x32x64xf16>, vector<4x64x64xf32> -> vector<4x64x64xf32>
       scf.yield %c_new_value : vector<4x64x64xf32>
     }
-    xegpu.store_nd %out, %c_tdesc[%block_id_z, %m, %n] {layout = #c} : vector<4x64x64xf32>, !xegpu.tensor_desc<4x64x64xf32, #c>
+    xegpu.store_nd %out, %c_tdesc[%block_id_z, %m, %n] <{layout = #c}> : vector<4x64x64xf32>, !xegpu.tensor_desc<4x64x64xf32, #c>
     gpu.return
   }
 }

--- a/mlir/test/Integration/Dialect/XeGPU/WG/simple_3d_gemm.mlir
+++ b/mlir/test/Integration/Dialect/XeGPU/WG/simple_3d_gemm.mlir
@@ -1,7 +1,4 @@
-// RUN: mlir-opt %s --gpu-lower-to-xevm-pipeline="xegpu-op-level=workgroup" \
-// RUN: | FileCheck %s
-
-// XFAIL: *
+// RUN: mlir-opt %s --gpu-lower-to-xevm-pipeline="xegpu-op-level=workgroup"
 
 #a = #xegpu.layout<sg_layout = [1, 8, 4], sg_data = [4, 8, 32], inst_data = [1, 8, 16]>
 #b = #xegpu.layout<sg_layout = [1, 8, 4], sg_data = [4, 32, 16], inst_data = [1, 16, 16]>

--- a/mlir/test/Integration/Dialect/XeGPU/WG/simple_3d_mxfp_gemm.mlir
+++ b/mlir/test/Integration/Dialect/XeGPU/WG/simple_3d_mxfp_gemm.mlir
@@ -32,32 +32,32 @@ gpu.module @test {
     %n = arith.muli %block_id_y, %c128 : index
 
     %a_tdesc = xegpu.create_nd_tdesc %arg0 : memref<4x128x512xf4E2M1FN> -> !xegpu.tensor_desc<4x128x512xf4E2M1FN>
-    %a = xegpu.load_nd %a_tdesc[%block_id_z, %m, %c0] {layout = #a} : !xegpu.tensor_desc<4x128x512xf4E2M1FN> -> vector<4x128x512xf4E2M1FN>
+    %a = xegpu.load_nd %a_tdesc[%block_id_z, %m, %c0] <{layout = #a}> : !xegpu.tensor_desc<4x128x512xf4E2M1FN> -> vector<4x128x512xf4E2M1FN>
 
     %b_tdesc = xegpu.create_nd_tdesc %arg1 : memref<4x512x128xf4E2M1FN> -> !xegpu.tensor_desc<4x512x128xf4E2M1FN>
-    %b = xegpu.load_nd %b_tdesc[%block_id_z, %c0, %n] {layout = #b} : !xegpu.tensor_desc<4x512x128xf4E2M1FN> -> vector<4x512x128xf4E2M1FN>
+    %b = xegpu.load_nd %b_tdesc[%block_id_z, %c0, %n] <{layout = #b}> : !xegpu.tensor_desc<4x512x128xf4E2M1FN> -> vector<4x512x128xf4E2M1FN>
 
     %cd_tdesc = xegpu.create_nd_tdesc %arg4 : memref<4x128x128xf32> -> !xegpu.tensor_desc<4x128x128xf32, #c>
-    %c = xegpu.load_nd %cd_tdesc[%block_id_z, %m, %n] {layout = #c} : !xegpu.tensor_desc<4x128x128xf32, #c> -> vector<4x128x128xf32>
+    %c = xegpu.load_nd %cd_tdesc[%block_id_z, %m, %n] <{layout = #c}> : !xegpu.tensor_desc<4x128x128xf32, #c> -> vector<4x128x128xf32>
 
     %a_scale_tdesc = xegpu.create_nd_tdesc %arg2 : memref<4x128x16xf8E8M0FNU> -> !xegpu.tensor_desc<4x128x16xf8E8M0FNU>
-    %scale_a = xegpu.load_nd %a_scale_tdesc[%block_id_z, %m, %c0] {layout = #a_scale_load} : !xegpu.tensor_desc<4x128x16xf8E8M0FNU> -> vector<4x128x16xf8E8M0FNU>
+    %scale_a = xegpu.load_nd %a_scale_tdesc[%block_id_z, %m, %c0] <{layout = #a_scale_load}> : !xegpu.tensor_desc<4x128x16xf8E8M0FNU> -> vector<4x128x16xf8E8M0FNU>
 
     %b_scale_tdesc = xegpu.create_nd_tdesc %arg3 : memref<4x16x128xf8E8M0FNU> -> !xegpu.tensor_desc<4x16x128xf8E8M0FNU>
-    %scale_b = xegpu.load_nd %b_scale_tdesc[%block_id_z, %c0, %n] {layout = #b_scale_load} : !xegpu.tensor_desc<4x16x128xf8E8M0FNU> -> vector<4x16x128xf8E8M0FNU>
+    %scale_b = xegpu.load_nd %b_scale_tdesc[%block_id_z, %c0, %n] <{layout = #b_scale_load}> : !xegpu.tensor_desc<4x16x128xf8E8M0FNU> -> vector<4x16x128xf8E8M0FNU>
 
     %d = xegpu.dpas_mx %a, %b, %c scale_a = %scale_a scale_b = %scale_b
-          {layout_a = #a,
+          <{layout_a = #a,
            layout_b = #b,
            layout_cd = #c,
            layout_a_scale = #a_scale,
-           layout_b_scale = #b_scale}
+           layout_b_scale = #b_scale}>
         : (vector<4x128x512xf4E2M1FN>, vector<4x512x128xf4E2M1FN>,
           vector<4x128x128xf32>,
           vector<4x128x16xf8E8M0FNU>, vector<4x16x128xf8E8M0FNU>)
         -> vector<4x128x128xf32>
 
-    xegpu.store_nd %d, %cd_tdesc[%block_id_z, %m, %n] {layout = #c} : vector<4x128x128xf32>, !xegpu.tensor_desc<4x128x128xf32, #c>
+    xegpu.store_nd %d, %cd_tdesc[%block_id_z, %m, %n] <{layout = #c}> : vector<4x128x128xf32>, !xegpu.tensor_desc<4x128x128xf32, #c>
     gpu.return
   }
 }

--- a/mlir/test/Integration/Dialect/XeGPU/WG/simple_3d_mxfp_gemm.mlir
+++ b/mlir/test/Integration/Dialect/XeGPU/WG/simple_3d_mxfp_gemm.mlir
@@ -1,5 +1,4 @@
-// RUN: mlir-opt %s --gpu-lower-to-xevm-pipeline="xegpu-op-level=workgroup zebin-chip=cri" \
-// RUN: | FileCheck %s
+// RUN: mlir-opt %s --gpu-lower-to-xevm-pipeline="xegpu-op-level=workgroup zebin-chip=cri"
 
 // XFAIL: *
 

--- a/mlir/test/Integration/Dialect/XeGPU/WG/simple_mxfp_gemm.mlir
+++ b/mlir/test/Integration/Dialect/XeGPU/WG/simple_mxfp_gemm.mlir
@@ -43,13 +43,13 @@ module @gemm attributes {gpu.container_module} {
 
       // Load initial C
       %cd_tdesc = xegpu.create_nd_tdesc %arg4 : memref<256x256xf32> -> !xegpu.tensor_desc<32x32xf32, #c>
-      %c_init = xegpu.load_nd %cd_tdesc[%m, %n] {layout = #c}: !xegpu.tensor_desc<32x32xf32, #c> -> vector<32x32xf32>
+      %c_init = xegpu.load_nd %cd_tdesc[%m, %n] <{layout = #c}>: !xegpu.tensor_desc<32x32xf32, #c> -> vector<32x32xf32>
 
       %res:3 = scf.for %k = %c0 to %kbound step %kstep
         iter_args(%c_partial = %c_init, %kb = %c0, %kscale = %c0) -> (vector<32x32xf32>, index, index) {
         // load_nd with offset
-        %a = xegpu.load_nd %a_tdesc[%m, %k] {layout = #a}: !xegpu.tensor_desc<32x1024xf4E2M1FN> -> vector<32x1024xf4E2M1FN>
-        %bp = xegpu.load_nd %bp_tdesc[%kb, %n] {layout = #b_packed}: !xegpu.tensor_desc<512x32xi8> -> vector<512x32xi8>
+        %a = xegpu.load_nd %a_tdesc[%m, %k] <{layout = #a}>: !xegpu.tensor_desc<32x1024xf4E2M1FN> -> vector<32x1024xf4E2M1FN>
+        %bp = xegpu.load_nd %bp_tdesc[%kb, %n] <{layout = #b_packed}>: !xegpu.tensor_desc<512x32xi8> -> vector<512x32xi8>
 
         // Bitcast to fp4: 512x32 uint8 -> 512x64 fp4 (each uint8 holds 2 fp4 values)
         %b_bitcast = vector.bitcast %bp : vector<512x32xi8> to vector<512x64xf4E2M1FN>
@@ -66,15 +66,15 @@ module @gemm attributes {gpu.container_module} {
         %b_interleaved = vector.interleave %b_even_t, %b_odd_t : vector<32x512xf4E2M1FN> -> vector<32x1024xf4E2M1FN>
         %b = vector.transpose %b_interleaved, [1, 0] : vector<32x1024xf4E2M1FN> to vector<1024x32xf4E2M1FN>
 
-        %scale_a = xegpu.load_nd %a_scale_tdesc[%m, %kscale] {layout = #a_scale}: !xegpu.tensor_desc<32x32xf8E8M0FNU> -> vector<32x32xf8E8M0FNU>
+        %scale_a = xegpu.load_nd %a_scale_tdesc[%m, %kscale] <{layout = #a_scale}>: !xegpu.tensor_desc<32x32xf8E8M0FNU> -> vector<32x32xf8E8M0FNU>
 
-        %scale_b = xegpu.load_nd %b_scale_tdesc[%kscale, %n] {layout = #b_scale}: !xegpu.tensor_desc<32x32xf8E8M0FNU> -> vector<32x32xf8E8M0FNU>
+        %scale_b = xegpu.load_nd %b_scale_tdesc[%kscale, %n] <{layout = #b_scale}>: !xegpu.tensor_desc<32x32xf8E8M0FNU> -> vector<32x32xf8E8M0FNU>
         %new_c_partial = xegpu.dpas_mx %a, %b, %c_partial scale_a = %scale_a scale_b = %scale_b
-              {layout_a = #a,
+              <{layout_a = #a,
                layout_b = #b,
                layout_cd = #c,
                layout_a_scale = #dpas_a_scale,
-               layout_b_scale = #dpas_b_scale}
+               layout_b_scale = #dpas_b_scale}>
             : (vector<32x1024xf4E2M1FN>, vector<1024x32xf4E2M1FN>,
                vector<32x32xf32>,
                vector<32x32xf8E8M0FNU>, vector<32x32xf8E8M0FNU>)
@@ -88,7 +88,7 @@ module @gemm attributes {gpu.container_module} {
       }
 
       // store_nd with offset
-      xegpu.store_nd %res#0, %cd_tdesc[%m, %n] {layout = #c} : vector<32x32xf32>, !xegpu.tensor_desc<32x32xf32, #c>
+      xegpu.store_nd %res#0, %cd_tdesc[%m, %n] <{layout = #c}> : vector<32x32xf32>, !xegpu.tensor_desc<32x32xf32, #c>
       gpu.return
     }
   }

--- a/mlir/test/Integration/Dialect/XeGPU/WG/simple_mxfp_gemm.mlir
+++ b/mlir/test/Integration/Dialect/XeGPU/WG/simple_mxfp_gemm.mlir
@@ -1,10 +1,11 @@
-// RUN: mlir-opt %s --gpu-lower-to-xevm-pipeline="xegpu-op-level=workgroup zebin-chip=cri" \
+// RUN: mlir-opt %s --gpu-lower-to-xevm-pipeline="xegpu-op-level=workgroup zebin-chip=cri"
+// RUN-DISABLED: mlir-opt %s --gpu-lower-to-xevm-pipeline="xegpu-op-level=workgroup zebin-chip=cri" \
 // RUN-DISABLED: | mlir-runner \
 // RUN-DISABLED:   --shared-libs=%mlir_levelzero_runtime \
 // RUN-DISABLED:   --shared-libs=%mlir_runner_utils \
 // RUN-DISABLED:   --shared-libs=%mlir_c_runner_utils \
 // RUN-DISABLED:   --entry-point-result=void \
-// RUN-DISABLED: | FileCheck %s
+// RUN-DISABLED: | FileCheck --check-prefix=MISMATCH %s
 
 // Note: layouts used by dpas_mx need to match HW constaint. Otherwise dpas_mx is not unrolled.
 #a = #xegpu.layout<sg_layout = [2, 2], sg_data = [16, 1024], inst_data = [8, 64], lane_layout = [1, 16], lane_data = [1, 4]>
@@ -189,7 +190,7 @@ module @gemm attributes {gpu.container_module} {
     call @printI64(%diff) : (i64) -> ()
     //call @printMemrefF32(%C_cast) : (memref<*xf32>) -> ()
 
-    // CHECK: 0
+    // MISMATCH: 0
     memref.dealloc %A_flatbytes : memref<524288xi8>
     memref.dealloc %B : memref<2048x256xi8>
     memref.dealloc %A_scale : memref<256x128xf8E8M0FNU>

--- a/mlir/test/Integration/Dialect/XeGPU/WG/simple_mxfp_gemm_dequantizeB_F4.mlir
+++ b/mlir/test/Integration/Dialect/XeGPU/WG/simple_mxfp_gemm_dequantizeB_F4.mlir
@@ -1,10 +1,11 @@
 // RUN: mlir-opt %s --gpu-lower-to-xevm-pipeline="xegpu-op-level=workgroup zebin-chip=cri"
+// RUN-DISABLED: mlir-opt %s --gpu-lower-to-xevm-pipeline="xegpu-op-level=workgroup zebin-chip=cri" \
 // RUN-DISABLED: | mlir-runner \
 // RUN-DISABLED:   --shared-libs=%mlir_levelzero_runtime \
 // RUN-DISABLED:   --shared-libs=%mlir_runner_utils \
 // RUN-DISABLED:   --shared-libs=%mlir_c_runner_utils \
 // RUN-DISABLED:   --entry-point-result=void \
-// RUN-DISABLED: | FileCheck %s
+// RUN-DISABLED: | FileCheck --check-prefix=MISMATCH %s
 
 
 // Note: layouts used by dpas_mx need to match HW constaint. Otherwise dpas_mx is not unrolled.
@@ -187,7 +188,7 @@ module @gemm attributes {gpu.container_module} {
     call @printI64(%diff) : (i64) -> ()
     //call @printMemrefF32(%C_cast) : (memref<*xf32>) -> ()
 
-    // CHECK: 0
+    // MISMATCH: 0
     memref.dealloc %A : memref<256x4096xbf16>
     memref.dealloc %B : memref<2048x256xi8>
     memref.dealloc %B_scale : memref<128x256xf8E8M0FNU>

--- a/mlir/test/Integration/Dialect/XeGPU/WG/simple_mxfp_gemm_quantizeA_F4.mlir
+++ b/mlir/test/Integration/Dialect/XeGPU/WG/simple_mxfp_gemm_quantizeA_F4.mlir
@@ -47,12 +47,12 @@ module @gemm attributes {gpu.container_module} {
 
       // Load initial C
       %cd_tdesc = xegpu.create_nd_tdesc %arg4 : memref<256x256xf32> -> !xegpu.tensor_desc<32x32xf32, #c>
-      %c_init = xegpu.load_nd %cd_tdesc[%m, %n] {layout = #c}: !xegpu.tensor_desc<32x32xf32, #c> -> vector<32x32xf32>
+      %c_init = xegpu.load_nd %cd_tdesc[%m, %n] <{layout = #c}>: !xegpu.tensor_desc<32x32xf32, #c> -> vector<32x32xf32>
 
       %res:3 = scf.for %k = %c0 to %kbound step %kstep
         iter_args(%c_partial = %c_init, %kb = %c0, %kscale = %c0) -> (vector<32x32xf32>, index, index) {
         // -------- Load A (bf16) --------
-        %a_bf16 = xegpu.load_nd %a_tdesc[%m, %k] {layout = #a_ld}: !xegpu.tensor_desc<32x1024xbf16> -> vector<32x1024xbf16>
+        %a_bf16 = xegpu.load_nd %a_tdesc[%m, %k] <{layout = #a_ld}>: !xegpu.tensor_desc<32x1024xbf16> -> vector<32x1024xbf16>
 
         // -------- Quantize A: bf16 -> fp4 + f8E8M0 scale (block_size=32 along K) --------
         // 1) abs and reduce-max per block of 32 along K dim using vector ops.
@@ -90,7 +90,7 @@ module @gemm attributes {gpu.container_module} {
         %a = arith.scaling_truncf %a_bf16, %a_scale_full
             : vector<32x1024xbf16>, vector<32x1024xf8E8M0FNU> to vector<32x1024xf4E2M1FN>
 
-        %bp = xegpu.load_nd %bp_tdesc[%kb, %n] {layout = #b_packed}: !xegpu.tensor_desc<512x32xi8> -> vector<512x32xi8>
+        %bp = xegpu.load_nd %bp_tdesc[%kb, %n] <{layout = #b_packed}>: !xegpu.tensor_desc<512x32xi8> -> vector<512x32xi8>
 
         // Bitcast to fp4: 512x32 uint8 -> 512x64 fp4 (each uint8 holds 2 fp4 values)
         %b_bitcast = vector.bitcast %bp : vector<512x32xi8> to vector<512x64xf4E2M1FN>
@@ -108,13 +108,13 @@ module @gemm attributes {gpu.container_module} {
         %b = vector.transpose %b_interleaved, [1, 0] : vector<32x1024xf4E2M1FN> to vector<1024x32xf4E2M1FN>
 
 
-        %scale_b = xegpu.load_nd %b_scale_tdesc[%kscale, %n] {layout = #b_scale}: !xegpu.tensor_desc<32x32xf8E8M0FNU> -> vector<32x32xf8E8M0FNU>
+        %scale_b = xegpu.load_nd %b_scale_tdesc[%kscale, %n] <{layout = #b_scale}>: !xegpu.tensor_desc<32x32xf8E8M0FNU> -> vector<32x32xf8E8M0FNU>
         %new_c_partial = xegpu.dpas_mx %a, %b, %c_partial scale_a = %a_scale scale_b = %scale_b
-              {layout_a = #a,
+              <{layout_a = #a,
                layout_b = #b,
                layout_cd = #c,
                layout_a_scale = #dpas_a_scale,
-               layout_b_scale = #dpas_b_scale}
+               layout_b_scale = #dpas_b_scale}>
             : (vector<32x1024xf4E2M1FN>, vector<1024x32xf4E2M1FN>,
                vector<32x32xf32>,
                vector<32x32xf8E8M0FNU>, vector<32x32xf8E8M0FNU>)
@@ -128,7 +128,7 @@ module @gemm attributes {gpu.container_module} {
       }
 
       // store_nd with offset
-      xegpu.store_nd %res#0, %cd_tdesc[%m, %n] {layout = #c} : vector<32x32xf32>, !xegpu.tensor_desc<32x32xf32, #c>
+      xegpu.store_nd %res#0, %cd_tdesc[%m, %n] <{layout = #c}> : vector<32x32xf32>, !xegpu.tensor_desc<32x32xf32, #c>
       gpu.return
     }
   }

--- a/mlir/test/Integration/Dialect/XeGPU/WG/simple_mxfp_gemm_quantizeA_F4.mlir
+++ b/mlir/test/Integration/Dialect/XeGPU/WG/simple_mxfp_gemm_quantizeA_F4.mlir
@@ -1,12 +1,14 @@
-// RUN: mlir-opt %s --gpu-lower-to-xevm-pipeline="xegpu-op-level=workgroup zebin-chip=cri" \
-// RUN: | mlir-runner \
-// RUN:   --shared-libs=%mlir_levelzero_runtime \
-// RUN:   --shared-libs=%mlir_runner_utils \
-// RUN:   --shared-libs=%mlir_c_runner_utils \
-// RUN:   --entry-point-result=void \
-// RUN: | FileCheck %s
+// RUN: mlir-opt %s --gpu-lower-to-xevm-pipeline="xegpu-op-level=workgroup zebin-chip=cri"
+// RUN-DISABLED: mlir-opt %s --gpu-lower-to-xevm-pipeline="xegpu-op-level=workgroup zebin-chip=cri" \
+// RUN-DISABLED: | mlir-runner \
+// RUN-DISABLED:   --shared-libs=%mlir_levelzero_runtime \
+// RUN-DISABLED:   --shared-libs=%mlir_runner_utils \
+// RUN-DISABLED:   --shared-libs=%mlir_c_runner_utils \
+// RUN-DISABLED:   --entry-point-result=void \
+// RUN-DISABLED: | FileCheck --check-prefix=MISMATCH %s
 
 // XFAIL: *
+
 // Note: layouts used by dpas_mx need to match HW constaint. Otherwise dpas_mx is not unrolled.
 #a = #xegpu.layout<sg_layout = [2, 2], sg_data = [16, 1024], inst_data = [8, 64], lane_layout = [1, 16], lane_data = [1, 4]>
 #a_ld = #xegpu.layout<sg_layout = [2, 2], sg_data = [16, 1024], inst_data = [8, 16], lane_layout = [1, 16], lane_data = [1, 1]>
@@ -220,7 +222,7 @@ module @gemm attributes {gpu.container_module} {
     call @printI64(%diff) : (i64) -> ()
     //call @printMemrefF32(%C_cast) : (memref<*xf32>) -> ()
 
-    // CHECK: 0
+    // MISMATCH: 0
     memref.dealloc %A : memref<256x4096xbf16>
     memref.dealloc %B : memref<2048x256xi8>
     memref.dealloc %B_scale : memref<128x256xf8E8M0FNU>


### PR DESCRIPTION
XeGPU enabled strict properties in its assembly format (b73a8b8d8c17), so inherent attributes such as the `layout`/`layout_*` operands of load_nd, store_nd, prefetch_nd, dpas and dpas_mx must be spelled in a prop-dict (`<{...}>`) instead of the discardable attr-dict (`{...}`). Several workgroup level integration tests were missed by that update and now fail to parse.
