### PR TITLE
AMDGPU: Migrate R600 onto generated TargetParser bitset

### DIFF
--- a/clang/lib/Basic/Targets/AMDGPU.cpp
+++ b/clang/lib/Basic/Targets/AMDGPU.cpp
@@ -197,11 +197,7 @@ AMDGPUTargetInfo::AMDGPUTargetInfo(const llvm::Triple &Triple,
                   ? (Opts.CPU.empty() ? llvm::AMDGPU::getGPUKindFromSubArch(
                                             Triple.getSubArch())
                                       : llvm::AMDGPU::parseArchAMDGCN(Opts.CPU))
-                  : llvm::AMDGPU::parseArchR600(Opts.CPU)),
-      GPUFeatures(
-          Triple.isAMDGCN()
-              ? llvm::AMDGPU::FEATURE_NONE
-              : static_cast<unsigned>(llvm::AMDGPU::getArchAttrR600(GPUKind))) {
+                  : llvm::AMDGPU::parseArchR600(Opts.CPU)) {
   resetDataLayout();
 
   AddrSpaceMap = &AMDGPUAddrSpaceMap;

--- a/clang/lib/Basic/Targets/AMDGPU.h
+++ b/clang/lib/Basic/Targets/AMDGPU.h
@@ -33,7 +33,6 @@ class LLVM_LIBRARY_VISIBILITY AMDGPUTargetInfo final : public TargetInfo {
   static const LangASMap AMDGPUAddrSpaceMap;
 
   llvm::AMDGPU::GPUKind GPUKind;
-  unsigned GPUFeatures;
   unsigned WavefrontSize;
 
   /// Whether to use cumode or WGP mode. True for cumode. False for WGP mode.
@@ -64,7 +63,8 @@ class LLVM_LIBRARY_VISIBILITY AMDGPUTargetInfo final : public TargetInfo {
 
   bool hasFMAF() const {
     return getTriple().isAMDGCN() ||
-           !!(GPUFeatures & llvm::AMDGPU::R600_FEATURE_FMA);
+           llvm::AMDGPU::getFeatureBitsetR600(GPUKind).test(
+               llvm::AMDGPU::R600_FEAT_FMAF);
   }
 
   bool hasFullRateDenormalsF32() const {
@@ -282,13 +282,11 @@ public:
   bool setCPU(StringRef Name) override {
     if (getTriple().isAMDGCN()) {
       GPUKind = llvm::AMDGPU::parseArchAMDGCN(Name);
-      GPUFeatures = llvm::AMDGPU::FEATURE_NONE;
       return llvm::AMDGPU::isCPUValidForSubArch(getTriple().getSubArch(),
                                                 GPUKind) &&
              !llvm::AMDGPU::isPseudoTarget(GPUKind);
     }
     GPUKind = llvm::AMDGPU::parseArchR600(Name);
-    GPUFeatures = llvm::AMDGPU::getArchAttrR600(GPUKind);
     return GPUKind != llvm::AMDGPU::GK_NONE;
   }
 

--- a/llvm/include/llvm/TargetParser/AMDGPUTargetParser.h
+++ b/llvm/include/llvm/TargetParser/AMDGPUTargetParser.h
@@ -51,6 +51,15 @@ enum AMDGPUFeature : unsigned {
 
 using AMDGPUFeatureBitset = Bitset<NUM_FEATURES>;
 
+/// One enumerator per frontend-visible R600 feature bit; R600_NUM_FEATURES is
+/// the count.
+enum R600Feature : unsigned {
+#define GET_R600_FEATURE_ENUM
+#include "llvm/TargetParser/R600TargetParserDef.inc"
+};
+
+using R600FeatureBitset = Bitset<R600_NUM_FEATURES>;
+
 /// Instruction set architecture version.
 struct IsaVersion {
   uint8_t Major;
@@ -177,6 +186,9 @@ LLVM_ABI R600FeatureKind getArchAttrR600(GPUKind AK);
 
 /// Returns \p AK's feature bitset, or an empty bitset if unknown.
 LLVM_ABI const AMDGPUFeatureBitset &getFeatureBitset(GPUKind AK);
+
+/// Returns R600 GPU \p AK's feature bitset, or an empty bitset if unknown.
+LLVM_ABI const R600FeatureBitset &getFeatureBitsetR600(GPUKind AK);
 
 /// Appends the feature name of each bit set in \p Features to \p Names.
 LLVM_ABI void getFeatureNames(const AMDGPUFeatureBitset &Features,

--- a/llvm/lib/Target/AMDGPU/R600Processors.td
+++ b/llvm/lib/Target/AMDGPU/R600Processors.td
@@ -169,3 +169,8 @@ def : R600ProcessorModel<"cayman", R600_VLIW4_Itin,
 def : R600ProcessorModel<"turks", R600_VLIW5_Itin,
   [FeatureNorthernIslands, FeatureVertexCache, FeatureCFALUBug]
 >;
+
+// The subset of R600 SubtargetFeatures exposed outside of the backend.
+def R600FrontendVisibleFeatures {
+  list<SubtargetFeature> Features = [FeatureFMA];
+}

--- a/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
+++ b/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
@@ -49,6 +49,7 @@ struct GPUInfo {
 struct R600Info {
   StringTable::Offset Name;
   R600FeatureKind ArchFeatures;
+  R600FeatureBitset Features;
 };
 
 #define GET_AMDGPU_NAME_TABLE
@@ -62,6 +63,7 @@ struct R600Info {
 #define GET_R600_NAME_TABLE
 #define GET_R600_GPU_TABLE
 #define GET_R600_GPU_ALIAS_TABLE
+#define GET_R600_FEATURE_NAME_TABLE
 #include "llvm/TargetParser/R600TargetParserDef.inc"
 
 // The string tables holding GPU-name-derived strings as offsets. R600 and
@@ -328,6 +330,12 @@ R600FeatureKind AMDGPU::getArchAttrR600(GPUKind AK) {
 const AMDGPUFeatureBitset &AMDGPU::getFeatureBitset(GPUKind AK) {
   static constexpr AMDGPUFeatureBitset Empty{};
   const GPUInfo *Info = getAMDGPUInfo(AK);
+  return Info ? Info->Features : Empty;
+}
+
+const R600FeatureBitset &AMDGPU::getFeatureBitsetR600(GPUKind AK) {
+  static constexpr R600FeatureBitset Empty{};
+  const R600Info *Info = getR600Info(AK);
   return Info ? Info->Features : Empty;
 }
 

--- a/llvm/unittests/TargetParser/TargetParserTest.cpp
+++ b/llvm/unittests/TargetParser/TargetParserTest.cpp
@@ -2748,6 +2748,9 @@ TEST(TargetParserTest, testAMDGPUparseArchR600) {
     EXPECT_EQ(AMDGPU::parseArchR600(G.Name), G.Kind) << G.Name;
     EXPECT_EQ(AMDGPU::getArchNameR600(G.Kind), G.Name) << G.Name;
     EXPECT_EQ(AMDGPU::getArchAttrR600(G.Kind), G.Features) << G.Name;
+    EXPECT_EQ(AMDGPU::getFeatureBitsetR600(G.Kind).test(AMDGPU::R600_FEAT_FMAF),
+              G.Features == AMDGPU::R600_FEATURE_FMA)
+        << G.Name;
   }
 
   // Aliases resolve to the canonical GPUKind but are not returned by

--- a/llvm/utils/TableGen/Basic/AMDGPUTargetDefEmitter.cpp
+++ b/llvm/utils/TableGen/Basic/AMDGPUTargetDefEmitter.cpp
@@ -40,9 +40,9 @@ static void emitGPUKindEnum(raw_ostream &OS, StringRef Name) {
 // Feature string to enumerator, e.g. "16-bit-insts" -> "FEAT_16_BIT_INSTS". The
 // FEAT_ prefix (rather than FEATURE_) avoids colliding with the legacy
 // ArchFeatureKind enumerators (e.g. FEATURE_XNACK_ON_OFF_MODES) during the
-// migration off that bitfield.
-static void emitFeatureEnum(raw_ostream &OS, StringRef Name) {
-  OS << "FEAT_";
+// migration off that bitfield. R600 uses the "R600_FEAT_" prefix.
+static void emitFeatureEnum(raw_ostream &OS, StringRef Prefix, StringRef Name) {
+  OS << Prefix;
   for (char C : Name)
     OS << ((C == '-') ? '_' : toUpper(C));
 }
@@ -193,15 +193,20 @@ static void emitFeatureExpr(raw_ostream &OS, const Record *Rec,
     OS << NoneSpelling;
 }
 
-// The frontend-visible features, bit order matching the list. Empty for R600
-// (no AMDGPUFrontendVisibleFeatures def).
+// The frontend-visible features from def \p ListName, in bit order. Empty if
+// the def is absent.
 static std::vector<const Record *>
-collectFrontendFeatures(const RecordKeeper &RK) {
-  const Record *List = RK.getDef("AMDGPUFrontendVisibleFeatures");
+collectFrontendFeatures(const RecordKeeper &RK, StringRef ListName) {
+  const Record *List = RK.getDef(ListName);
   if (!List)
     return {};
   return List->getValueAsListOfDefs("Features");
 }
+
+static void
+emitFeatureBitset(raw_ostream &OS, StringRef BitsetType, StringRef EnumPrefix,
+                  const Record *GPU,
+                  const DenseMap<const Record *, unsigned> &FeatureIdx);
 
 // The transitive closure of a GPU's SubtargetFeatures, following the Implies
 // edges (a feature enables everything it implies).
@@ -305,8 +310,10 @@ static void emitR600Enum(raw_ostream &OS, const RecordKeeper &RK) {
 
 // Emit the R600Info table indexed by (GPUKind - R600FirstGPUKind). Names are
 // offsets into the shared \p Names table. Guarded by GET_R600_GPU_TABLE.
-static void emitR600Table(raw_ostream &OS, const RecordKeeper &RK,
-                          StringToOffsetTable &Names) {
+static void
+emitR600Table(raw_ostream &OS, const RecordKeeper &RK,
+              StringToOffsetTable &Names,
+              const DenseMap<const Record *, unsigned> &FeatureIdx) {
   std::vector<const Record *> Canon = collectR600Canonicals(RK);
   if (Canon.empty())
     return;
@@ -321,6 +328,8 @@ static void emitR600Table(raw_ostream &OS, const RecordKeeper &RK,
     OS << "  {" << Names.GetOrAddStringOffset(R->getValueAsString("Name"))
        << ", ";
     emitFeatureExpr(OS, R, "R600_FEATURE_NONE");
+    OS << ", ";
+    emitFeatureBitset(OS, "R600FeatureBitset", "R600_FEAT_", R, FeatureIdx);
     OS << "},\n";
   }
   OS << "};\n"
@@ -413,42 +422,62 @@ static void emitAMDGPUAliases(raw_ostream &OS, const RecordKeeper &RK,
         "#endif // GET_AMDGPU_GPU_ALIAS_TABLE\n\n";
 }
 
-// Emit the frontend feature enum (GET_AMDGPU_FEATURE_ENUM), interning each
-// feature name into \p Names. Returns the name offsets indexed by feature bit.
-static std::vector<unsigned>
-emitAMDGPUFeatureEnum(raw_ostream &OS, ArrayRef<const Record *> Features,
-                      StringToOffsetTable &Names) {
+// Per-family spellings for the generated feature enum and name table. R600 and
+// AMDGCN each get their own so the two headers coexist.
+struct FeatureNaming {
+  StringRef EnumGuard;
+  StringRef EnumPrefix;
+  StringRef CountEnumerator;
+  StringRef NameTableGuard;
+  StringRef NameTableSymbol;
+};
+
+static constexpr FeatureNaming AMDGPUFeatureNaming = {
+    "GET_AMDGPU_FEATURE_ENUM", "FEAT_", "NUM_FEATURES",
+    "GET_AMDGPU_FEATURE_NAME_TABLE", "AMDGPUFeatureNames"};
+
+static constexpr FeatureNaming R600FeatureNaming = {
+    "GET_R600_FEATURE_ENUM", "R600_FEAT_", "R600_NUM_FEATURES",
+    "GET_R600_FEATURE_NAME_TABLE", "R600FeatureNames"};
+
+// Emit the frontend feature enum for a family, interning each feature name into
+// \p Names. Returns the name offsets indexed by feature bit.
+static std::vector<unsigned> emitFeatureEnum(raw_ostream &OS,
+                                             const FeatureNaming &Naming,
+                                             ArrayRef<const Record *> Features,
+                                             StringToOffsetTable &Names) {
   std::vector<unsigned> Offsets;
   if (Features.empty())
     return Offsets;
   Offsets.reserve(Features.size());
 
-  OS << "#ifdef GET_AMDGPU_FEATURE_ENUM\n"
-        "#undef GET_AMDGPU_FEATURE_ENUM\n";
+  OS << "#ifdef " << Naming.EnumGuard << "\n"
+     << "#undef " << Naming.EnumGuard << "\n";
   for (const Record *F : Features) {
     StringRef Name = F->getValueAsString("Name");
     OS << "  ";
-    emitFeatureEnum(OS, Name);
+    emitFeatureEnum(OS, Naming.EnumPrefix, Name);
     OS << ",\n";
     Offsets.push_back(Names.GetOrAddStringOffset(Name));
   }
-  OS << "  NUM_FEATURES\n"
-        "#endif // GET_AMDGPU_FEATURE_ENUM\n\n";
+  OS << "  " << Naming.CountEnumerator << "\n"
+     << "#endif // " << Naming.EnumGuard << "\n\n";
   return Offsets;
 }
 
-// Emit AMDGPUFeatureNames (GET_AMDGPU_FEATURE_NAME_TABLE): bit -> name offset.
-static void emitAMDGPUFeatureNames(raw_ostream &OS,
-                                   ArrayRef<unsigned> Offsets) {
+// Emit a family's feature-name table (bit -> name offset).
+static void emitFeatureNames(raw_ostream &OS, const FeatureNaming &Naming,
+                             ArrayRef<unsigned> Offsets) {
   if (Offsets.empty())
     return;
-  OS << "#ifdef GET_AMDGPU_FEATURE_NAME_TABLE\n"
-        "#undef GET_AMDGPU_FEATURE_NAME_TABLE\n"
-        "static constexpr StringTable::Offset AMDGPUFeatureNames[] = {\n";
+  OS << "#ifdef " << Naming.NameTableGuard << "\n"
+     << "#undef " << Naming.NameTableGuard << "\n"
+     << "static constexpr StringTable::Offset " << Naming.NameTableSymbol
+     << "[] = {\n";
   for (unsigned O : Offsets)
     OS << "  " << O << ",\n";
   OS << "};\n"
-        "#endif // GET_AMDGPU_FEATURE_NAME_TABLE\n\n";
+     << "#endif // " << Naming.NameTableGuard << "\n\n";
 }
 
 // The set of frontend features that end up in the emitted bitset.
@@ -502,7 +531,8 @@ validateGenericFeatures(const Record *GPU,
 
 static void validateAMDGPU(const RecordKeeper &RK) {
   DenseMap<const Record *, unsigned> FeatureIdx;
-  for (const auto &[Idx, F] : enumerate(collectFrontendFeatures(RK)))
+  for (const auto &[Idx, F] :
+       enumerate(collectFrontendFeatures(RK, "AMDGPUFrontendVisibleFeatures")))
     FeatureIdx[F] = Idx;
 
   for (const Record *GPU : RK.getAllDerivedDefinitions("AMDGPUGPUInfo"))
@@ -511,9 +541,10 @@ static void validateAMDGPU(const RecordKeeper &RK) {
 
 // Emit a GPU's feature bitset initializer: its feature closure intersected with
 // the frontend-visible set \p FeatureIdx, e.g.
-// "AMDGPUFeatureBitset({FEATURE_DPP, FEATURE_CI_INSTS})".
+// "AMDGPUFeatureBitset({FEAT_DPP, FEAT_CI_INSTS})".
 static void
-emitFeatureBitset(raw_ostream &OS, const Record *GPU,
+emitFeatureBitset(raw_ostream &OS, StringRef BitsetType, StringRef EnumPrefix,
+                  const Record *GPU,
                   const DenseMap<const Record *, unsigned> &FeatureIdx) {
   SetVector<const Record *> Closure;
   collectFeatureClosure(GPU, Closure);
@@ -527,11 +558,11 @@ emitFeatureBitset(raw_ostream &OS, const Record *GPU,
   }
   sort(Bits);
 
-  OS << "AMDGPUFeatureBitset({";
+  OS << BitsetType << "({";
   ListSeparator LS(", ");
   for (const auto &[Idx, Name] : Bits) {
     OS << LS;
-    emitFeatureEnum(OS, Name);
+    emitFeatureEnum(OS, EnumPrefix, Name);
   }
   OS << "})";
 }
@@ -591,7 +622,7 @@ emitAMDGPUTable(raw_ostream &OS, const RecordKeeper &RK,
     OS << ", ";
     emitFeatureExpr(OS, R, "FEATURE_NONE");
     OS << ", ";
-    emitFeatureBitset(OS, R, FeatureIdx);
+    emitFeatureBitset(OS, "AMDGPUFeatureBitset", "FEAT_", R, FeatureIdx);
     OS << ", ";
     emitIsaVersion(OS, R, '{', '}');
     SmallString<16> Family;
@@ -761,7 +792,19 @@ static void emitAMDGPUTargetDef(const RecordKeeper &RK, raw_ostream &OS) {
     StringToOffsetTable Names;
     std::string Tables;
     raw_string_ostream TablesOS(Tables);
-    emitR600Table(TablesOS, RK, Names);
+
+    // The R600 frontend feature enum and per-GPU bitsets share the R600 string
+    // pool (feature names live alongside GPU names).
+    std::vector<const Record *> Features =
+        collectFrontendFeatures(RK, "R600FrontendVisibleFeatures");
+    DenseMap<const Record *, unsigned> FeatureIdx;
+    for (const auto &[Idx, F] : enumerate(Features))
+      FeatureIdx[F] = Idx;
+
+    std::vector<unsigned> FeatureOffsets =
+        emitFeatureEnum(TablesOS, R600FeatureNaming, Features, Names);
+    emitR600Table(TablesOS, RK, Names, FeatureIdx);
+    emitFeatureNames(TablesOS, R600FeatureNaming, FeatureOffsets);
     emitR600Aliases(TablesOS, RK, Names);
     if (!Tables.empty()) {
       OS << "#ifdef GET_R600_NAME_TABLE\n"
@@ -779,15 +822,16 @@ static void emitAMDGPUTargetDef(const RecordKeeper &RK, raw_ostream &OS) {
 
     // The frontend feature enum and per-GPU bitsets share the AMDGPU string
     // pool (feature names live alongside GPU names).
-    std::vector<const Record *> Features = collectFrontendFeatures(RK);
+    std::vector<const Record *> Features =
+        collectFrontendFeatures(RK, "AMDGPUFrontendVisibleFeatures");
     DenseMap<const Record *, unsigned> FeatureIdx;
     for (const auto &[Idx, F] : enumerate(Features))
       FeatureIdx[F] = Idx;
 
     std::vector<unsigned> FeatureOffsets =
-        emitAMDGPUFeatureEnum(TablesOS, Features, Names);
+        emitFeatureEnum(TablesOS, AMDGPUFeatureNaming, Features, Names);
     emitAMDGPUTable(TablesOS, RK, Names, FeatureIdx);
-    emitAMDGPUFeatureNames(TablesOS, FeatureOffsets);
+    emitFeatureNames(TablesOS, AMDGPUFeatureNaming, FeatureOffsets);
     emitAMDGPUAliases(TablesOS, RK, Names);
     emitAMDGPUSubArchNames(TablesOS, RK, Names);
     if (!Tables.empty()) {


### PR DESCRIPTION
Follow the new amdgcn system so we don't have to carry 2 different
forms of this infrastructure.

Co-authored-by: Claude (Opus 4.8) <noreply@anthropic.com>