### PR TITLE
AMDGPU: Remove deprecated getArchAttr and ArchFeatures TableGen

### DIFF
--- a/clang/test/CodeGenOpenCL/amdgpu-xnack-any-only.cl
+++ b/clang/test/CodeGenOpenCL/amdgpu-xnack-any-only.cl
@@ -1,5 +1,5 @@
 // Test that xnack module flags are emitted for all targets, regardless of support.
-// Targets without FEATURE_XNACK_ON_OFF_MODES (like gfx12-5-generic, gfx1250, gfx1251)
+// Targets without xnack on/off mode support (like gfx12-5-generic, gfx1250, gfx1251)
 // will ignore the module flag during codegen, but it is still emitted by clang.
 // TODO: In the future, clang should not emit the flag for targets that don't support
 // xnack control.

--- a/llvm/include/llvm/TargetParser/AMDGPUTargetParser.h
+++ b/llvm/include/llvm/TargetParser/AMDGPUTargetParser.h
@@ -73,43 +73,6 @@ struct IsaVersion {
   bool operator!=(const IsaVersion &Other) const { return !(*this == Other); }
 };
 
-// This isn't comprehensive for now, just things that are needed from the
-// frontend driver.
-enum R600FeatureKind : uint32_t {
-  R600_FEATURE_NONE = 0,
-
-  // Has fma instructions.
-  R600_FEATURE_FMA = 1 << 0,
-};
-
-// GFX6+ features. This isn't comprehensive for now, just things that are needed
-// from the frontend driver.
-enum ArchFeatureKind : uint32_t {
-  FEATURE_NONE = 0,
-
-  // Common features.
-  FEATURE_FAST_FMA_F32 = 1 << 0,
-  FEATURE_FAST_DENORMAL_F32 = 1 << 1,
-
-  // Wavefront 32 is available.
-  FEATURE_WAVE32 = 1 << 2,
-
-  // Xnack is available.
-  FEATURE_XNACK = 1 << 3,
-
-  // Sram-ecc is available.
-  FEATURE_SRAMECC = 1 << 4,
-
-  // WGP mode is supported.
-  FEATURE_WGP = 1 << 5,
-
-  // Xnack on/off modes are supported.
-  FEATURE_XNACK_ON_OFF_MODES = 1 << 6,
-
-  // VI SGPR initialization bug requiring a fixed SGPR allocation size.
-  FEATURE_SGPR_INIT_BUG = 1 << 7
-};
-
 enum FeatureError : uint32_t {
   NO_ERROR = 0,
   INVALID_FEATURE_COMBINATION,
@@ -176,13 +139,6 @@ LLVM_ABI StringRef getCanonicalArchName(const Triple &T, StringRef Arch);
 LLVM_ABI GPUKind parseArchAMDGCN(StringRef CPU);
 LLVM_ABI GPUKind parseArchR600(StringRef CPU);
 LLVM_ABI GPUKind getGPUKindFromSubArch(Triple::SubArchType SubArch);
-/// \deprecated Use getFeatureBitset and test the relevant FEAT_* bits instead.
-/// The legacy ArchFeatureKind bitfield is being removed.
-LLVM_DEPRECATED("use getFeatureBitset instead", "getFeatureBitset")
-LLVM_ABI unsigned getArchAttrAMDGCN(GPUKind AK);
-LLVM_DEPRECATED("use getFeatureBitset instead", "getFeatureBitset")
-LLVM_ABI unsigned getArchAttrAMDGCN(Triple::SubArchType SubArch);
-LLVM_ABI R600FeatureKind getArchAttrR600(GPUKind AK);
 
 /// Returns \p AK's feature bitset, or an empty bitset if unknown.
 LLVM_ABI const AMDGPUFeatureBitset &getFeatureBitset(GPUKind AK);

--- a/llvm/lib/Target/AMDGPU/AMDGPUTargetParser.td
+++ b/llvm/lib/Target/AMDGPU/AMDGPUTargetParser.td
@@ -11,32 +11,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-// FIXME: These duplicate real SubtargetFeatures and should be unified
-// (e.g. R600_FEATURE_FMA mirrors FeatureFMA).
-class AMDGPUArchFeature<string spelling> {
-  string Spelling = spelling;
-}
-
-// R600-only.
-def R600_FEATURE_FMA : AMDGPUArchFeature<"R600_FEATURE_FMA">;
-
-// AMDGCN.
-def FEATURE_FAST_FMA_F32       : AMDGPUArchFeature<"FEATURE_FAST_FMA_F32">;
-def FEATURE_FAST_DENORMAL_F32  : AMDGPUArchFeature<"FEATURE_FAST_DENORMAL_F32">;
-def FEATURE_WAVE32             : AMDGPUArchFeature<"FEATURE_WAVE32">;
-def FEATURE_XNACK              : AMDGPUArchFeature<"FEATURE_XNACK">;
-def FEATURE_SRAMECC            : AMDGPUArchFeature<"FEATURE_SRAMECC">;
-def FEATURE_WGP                : AMDGPUArchFeature<"FEATURE_WGP">;
-def FEATURE_XNACK_ON_OFF_MODES : AMDGPUArchFeature<"FEATURE_XNACK_ON_OFF_MODES">;
-def FEATURE_SGPR_INIT_BUG      : AMDGPUArchFeature<"FEATURE_SGPR_INIT_BUG">;
-
 // Marks a Processor/ProcessorModel record as a canonical GPU.
 //
 // \p isa is the ISA version [major, minor, stepping]. Empty for R600 (no AMDGCN
 // ISA version); required for AMDGCN GPUs. Not derivable from the name.
 class AMDGPUGPUInfo<list<int> isa = []> {
-  list<AMDGPUArchFeature> ArchFeatures = [];
-
   list<int> IsaVersion = isa;
 
   // List of targets which are compatible with this target. This

--- a/llvm/lib/Target/AMDGPU/GCNProcessors.td
+++ b/llvm/lib/Target/AMDGPU/GCNProcessors.td
@@ -6,17 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// Shared ArchFeature lists. Grouped by wavefront mode and the XNACK/SRAMECC/WGP
-// features that recur across many GPUs in a generation.
-defvar ArchFeaturesW64Xnack = [FEATURE_FAST_FMA_F32, FEATURE_FAST_DENORMAL_F32,
-                              FEATURE_XNACK, FEATURE_XNACK_ON_OFF_MODES];
-defvar ArchFeaturesW64XnackSramEcc = ArchFeaturesW64Xnack # [FEATURE_SRAMECC];
-defvar ArchFeaturesW32XnackWgp = [FEATURE_FAST_FMA_F32, FEATURE_FAST_DENORMAL_F32,
-                                 FEATURE_WAVE32, FEATURE_XNACK,
-                                 FEATURE_XNACK_ON_OFF_MODES, FEATURE_WGP];
-defvar ArchFeaturesW32Wgp = [FEATURE_FAST_FMA_F32, FEATURE_FAST_DENORMAL_F32,
-                            FEATURE_WAVE32, FEATURE_WGP];
-
 // The code produced for "generic" is only useful for tests and cannot
 // be expected to execute on any target.
 def : AMDGPUProcessorModel<"generic", NoSchedModel, [], [6, 0, 0]> {
@@ -33,9 +22,8 @@ def : AMDGPUProcessorModel<"generic-hsa", NoSchedModel,
 //===------------------------------------------------------------===//
 
 def GFX600 : AMDGPUProcessorModel<"gfx600", SIFullSpeedModel,
-  FeatureISAVersion6_0_0.Features, [6, 0, 0]> {
-  let ArchFeatures = [FEATURE_FAST_FMA_F32];
-}
+  FeatureISAVersion6_0_0.Features, [6, 0, 0]
+>;
 
 def : ProcessorAlias<"tahiti", "gfx600">;
 
@@ -64,16 +52,14 @@ def GFX700 : AMDGPUProcessorModel<"gfx700", SIQuarterSpeedModel,
 def : ProcessorAlias<"kaveri", "gfx700">;
 
 def GFX701 : AMDGPUProcessorModel<"gfx701", SIFullSpeedModel,
-  FeatureISAVersion7_0_1.Features, [7, 0, 1]> {
-  let ArchFeatures = [FEATURE_FAST_FMA_F32];
-}
+  FeatureISAVersion7_0_1.Features, [7, 0, 1]
+>;
 
 def : ProcessorAlias<"hawaii", "gfx701">;
 
 def GFX702 : AMDGPUProcessorModel<"gfx702", SIQuarterSpeedModel,
-  FeatureISAVersion7_0_2.Features, [7, 0, 2]> {
-  let ArchFeatures = [FEATURE_FAST_FMA_F32];
-}
+  FeatureISAVersion7_0_2.Features, [7, 0, 2]
+>;
 
 def GFX703 : AMDGPUProcessorModel<"gfx703", SIQuarterSpeedModel,
   FeatureISAVersion7_0_3.Features, [7, 0, 3]
@@ -97,40 +83,35 @@ def GFX705 : AMDGPUProcessorModel<"gfx705", SIQuarterSpeedModel,
 //===------------------------------------------------------------===//
 
 def GFX801 : AMDGPUProcessorModel<"gfx801", SIQuarterSpeedModel,
-  FeatureISAVersion8_0_1.Features, [8, 0, 1]> {
-  let ArchFeatures = ArchFeaturesW64Xnack;
-}
+  FeatureISAVersion8_0_1.Features, [8, 0, 1]
+>;
 
 def : ProcessorAlias<"carrizo", "gfx801">;
 
 def GFX802 : AMDGPUProcessorModel<"gfx802", SIQuarterSpeedModel,
-  FeatureISAVersion8_0_2.Features, [8, 0, 2]> {
-  let ArchFeatures = [FEATURE_FAST_DENORMAL_F32, FEATURE_SGPR_INIT_BUG];
-}
+  FeatureISAVersion8_0_2.Features, [8, 0, 2]
+>;
 
 def : ProcessorAlias<"iceland", "gfx802">;
 def : ProcessorAlias<"tonga", "gfx802">;
 
 def GFX803 : AMDGPUProcessorModel<"gfx803", SIQuarterSpeedModel,
-  FeatureISAVersion8_0_3.Features, [8, 0, 3]> {
-  let ArchFeatures = [FEATURE_FAST_DENORMAL_F32];
-}
+  FeatureISAVersion8_0_3.Features, [8, 0, 3]
+>;
 
 def : ProcessorAlias<"fiji", "gfx803">;
 def : ProcessorAlias<"polaris10", "gfx803">;
 def : ProcessorAlias<"polaris11", "gfx803">;
 
 def GFX805 : AMDGPUProcessorModel<"gfx805", SIQuarterSpeedModel,
-  FeatureISAVersion8_0_5.Features, [8, 0, 5]> {
-  let ArchFeatures = [FEATURE_FAST_DENORMAL_F32, FEATURE_SGPR_INIT_BUG];
-}
+  FeatureISAVersion8_0_5.Features, [8, 0, 5]
+>;
 
 def : ProcessorAlias<"tongapro", "gfx805">;
 
 def GFX810 : AMDGPUProcessorModel<"gfx810", SIQuarterSpeedModel,
-  FeatureISAVersion8_1_0.Features, [8, 1, 0]> {
-  let ArchFeatures = [FEATURE_FAST_DENORMAL_F32, FEATURE_XNACK, FEATURE_XNACK_ON_OFF_MODES];
-}
+  FeatureISAVersion8_1_0.Features, [8, 1, 0]
+>;
 
 def : ProcessorAlias<"stoney", "gfx810">;
 
@@ -139,64 +120,52 @@ def : ProcessorAlias<"stoney", "gfx810">;
 //===------------------------------------------------------------===//
 
 def GFX900 : AMDGPUProcessorModel<"gfx900", SIQuarterSpeedModel,
-  FeatureISAVersion9_0_0.Features, [9, 0, 0]> {
-  let ArchFeatures = ArchFeaturesW64Xnack;
-}
+  FeatureISAVersion9_0_0.Features, [9, 0, 0]
+>;
 
 def GFX902 : AMDGPUProcessorModel<"gfx902", SIQuarterSpeedModel,
-  FeatureISAVersion9_0_2.Features, [9, 0, 2]> {
-  let ArchFeatures = ArchFeaturesW64Xnack;
-}
+  FeatureISAVersion9_0_2.Features, [9, 0, 2]
+>;
 
 def GFX904 : AMDGPUProcessorModel<"gfx904", SIQuarterSpeedModel,
-  FeatureISAVersion9_0_4.Features, [9, 0, 4]> {
-  let ArchFeatures = ArchFeaturesW64Xnack;
-}
+  FeatureISAVersion9_0_4.Features, [9, 0, 4]
+>;
 
 def GFX906 : AMDGPUProcessorModel<"gfx906", SIQuarterSpeedModel,
-  FeatureISAVersion9_0_6.Features, [9, 0, 6]> {
-  let ArchFeatures = ArchFeaturesW64XnackSramEcc;
-}
+  FeatureISAVersion9_0_6.Features, [9, 0, 6]
+>;
 
 def GFX908 : AMDGPUProcessorModel<"gfx908", SIQuarterSpeedModel,
-  FeatureISAVersion9_0_8.Features, [9, 0, 8]> {
-  let ArchFeatures = ArchFeaturesW64XnackSramEcc;
-}
+  FeatureISAVersion9_0_8.Features, [9, 0, 8]
+>;
 
 def GFX909 : AMDGPUProcessorModel<"gfx909", SIQuarterSpeedModel,
-  FeatureISAVersion9_0_9.Features, [9, 0, 9]> {
-  let ArchFeatures = ArchFeaturesW64Xnack;
-}
+  FeatureISAVersion9_0_9.Features, [9, 0, 9]
+>;
 
 def GFX90A : AMDGPUProcessorModel<"gfx90a", SIDPFullSpeedModel,
-  FeatureISAVersion9_0_A.Features, [9, 0, 0xa]> {
-  let ArchFeatures = ArchFeaturesW64XnackSramEcc;
-}
+  FeatureISAVersion9_0_A.Features, [9, 0, 0xa]
+>;
 
 def GFX90C : AMDGPUProcessorModel<"gfx90c", SIQuarterSpeedModel,
-  FeatureISAVersion9_0_C.Features, [9, 0, 0xc]> {
-  let ArchFeatures = ArchFeaturesW64Xnack;
-}
+  FeatureISAVersion9_0_C.Features, [9, 0, 0xc]
+>;
 
 def GFX942 : AMDGPUProcessorModel<"gfx942", SIDPGFX942FullSpeedModel,
-  FeatureISAVersion9_4_2.Features, [9, 4, 2]> {
-  let ArchFeatures = ArchFeaturesW64XnackSramEcc;
-}
+  FeatureISAVersion9_4_2.Features, [9, 4, 2]
+>;
 
 def GFX950 : AMDGPUProcessorModel<"gfx950", SIDPGFX950FullSpeedModel,
-  FeatureISAVersion9_5_0.Features, [9, 5, 0]> {
-  let ArchFeatures = ArchFeaturesW64XnackSramEcc;
-}
+  FeatureISAVersion9_5_0.Features, [9, 5, 0]
+>;
 
 def GFX9_GENERIC : AMDGPUProcessorModel<"gfx9-generic", SIQuarterSpeedModel,
   FeatureISAVersion9_Generic.Features, [9, 0, 0]> {
-  let ArchFeatures = ArchFeaturesW64Xnack;
   let CoveredGPUs = [GFX900, GFX902, GFX904, GFX906, GFX909, GFX90C];
 }
 
 def GFX9_4_GENERIC : AMDGPUProcessorModel<"gfx9-4-generic", SIDPGFX942FullSpeedModel,
   FeatureISAVersion9_4_Generic.Features, [9, 4, 0]> {
-  let ArchFeatures = ArchFeaturesW64XnackSramEcc;
   let CoveredGPUs = [GFX942, GFX950];
 }
 
@@ -205,69 +174,56 @@ def GFX9_4_GENERIC : AMDGPUProcessorModel<"gfx9-4-generic", SIDPGFX942FullSpeedM
 //===----------------------------------------------------------------------===//
 
 def GFX1010 : AMDGPUProcessorModel<"gfx1010", GFX10SpeedModel,
-  FeatureISAVersion10_1_0.Features, [10, 1, 0]> {
-  let ArchFeatures = ArchFeaturesW32XnackWgp;
-}
+  FeatureISAVersion10_1_0.Features, [10, 1, 0]
+>;
 
 def GFX1011 : AMDGPUProcessorModel<"gfx1011", GFX10SpeedModel,
-  FeatureISAVersion10_1_1.Features, [10, 1, 1]> {
-  let ArchFeatures = ArchFeaturesW32XnackWgp;
-}
+  FeatureISAVersion10_1_1.Features, [10, 1, 1]
+>;
 
 def GFX1012 : AMDGPUProcessorModel<"gfx1012", GFX10SpeedModel,
-  FeatureISAVersion10_1_2.Features, [10, 1, 2]> {
-  let ArchFeatures = ArchFeaturesW32XnackWgp;
-}
+  FeatureISAVersion10_1_2.Features, [10, 1, 2]
+>;
 
 def GFX1013 : AMDGPUProcessorModel<"gfx1013", GFX10SpeedModel,
-  FeatureISAVersion10_1_3.Features, [10, 1, 3]> {
-  let ArchFeatures = ArchFeaturesW32XnackWgp;
-}
+  FeatureISAVersion10_1_3.Features, [10, 1, 3]
+>;
 
 def GFX1030 : AMDGPUProcessorModel<"gfx1030", GFX10SpeedModel,
-  FeatureISAVersion10_3_0.Features, [10, 3, 0]> {
-  let ArchFeatures = ArchFeaturesW32Wgp;
-}
+  FeatureISAVersion10_3_0.Features, [10, 3, 0]
+>;
 
 def GFX1031 : AMDGPUProcessorModel<"gfx1031", GFX10SpeedModel,
-  FeatureISAVersion10_3_0.Features, [10, 3, 1]> {
-  let ArchFeatures = ArchFeaturesW32Wgp;
-}
+  FeatureISAVersion10_3_0.Features, [10, 3, 1]
+>;
 
 def GFX1032 : AMDGPUProcessorModel<"gfx1032", GFX10SpeedModel,
-  FeatureISAVersion10_3_0.Features, [10, 3, 2]> {
-  let ArchFeatures = ArchFeaturesW32Wgp;
-}
+  FeatureISAVersion10_3_0.Features, [10, 3, 2]
+>;
 
 def GFX1033 : AMDGPUProcessorModel<"gfx1033", GFX10SpeedModel,
-  FeatureISAVersion10_3_0.Features, [10, 3, 3]> {
-  let ArchFeatures = ArchFeaturesW32Wgp;
-}
+  FeatureISAVersion10_3_0.Features, [10, 3, 3]
+>;
 
 def GFX1034 : AMDGPUProcessorModel<"gfx1034", GFX10SpeedModel,
-  FeatureISAVersion10_3_0.Features, [10, 3, 4]> {
-  let ArchFeatures = ArchFeaturesW32Wgp;
-}
+  FeatureISAVersion10_3_0.Features, [10, 3, 4]
+>;
 
 def GFX1035 : AMDGPUProcessorModel<"gfx1035", GFX10SpeedModel,
-  FeatureISAVersion10_3_0.Features, [10, 3, 5]> {
-  let ArchFeatures = ArchFeaturesW32Wgp;
-}
+  FeatureISAVersion10_3_0.Features, [10, 3, 5]
+>;
 
 def GFX1036 : AMDGPUProcessorModel<"gfx1036", GFX10SpeedModel,
-  FeatureISAVersion10_3_0.Features, [10, 3, 6]> {
-  let ArchFeatures = ArchFeaturesW32Wgp;
-}
+  FeatureISAVersion10_3_0.Features, [10, 3, 6]
+>;
 
 def GFX10_1_GENERIC : AMDGPUProcessorModel<"gfx10-1-generic", GFX10SpeedModel,
   FeatureISAVersion10_1_Generic.Features, [10, 1, 0]> {
-  let ArchFeatures = ArchFeaturesW32XnackWgp;
   let CoveredGPUs = [GFX1010, GFX1011, GFX1012, GFX1013];
 }
 
 def GFX10_3_GENERIC : AMDGPUProcessorModel<"gfx10-3-generic", GFX10SpeedModel,
   FeatureISAVersion10_3_Generic.Features, [10, 3, 0]> {
-  let ArchFeatures = ArchFeaturesW32Wgp;
   let CoveredGPUs = [GFX1030, GFX1031, GFX1032, GFX1033, GFX1034, GFX1035, GFX1036];
 }
 
@@ -276,75 +232,61 @@ def GFX10_3_GENERIC : AMDGPUProcessorModel<"gfx10-3-generic", GFX10SpeedModel,
 //===----------------------------------------------------------------------===//
 
 def GFX1100 : AMDGPUProcessorModel<"gfx1100", GFX11SpeedModel,
-  FeatureISAVersion11_0_0.Features, [11, 0, 0]> {
-  let ArchFeatures = ArchFeaturesW32Wgp;
-}
+  FeatureISAVersion11_0_0.Features, [11, 0, 0]
+>;
 
 def GFX1101 : AMDGPUProcessorModel<"gfx1101", GFX11SpeedModel,
-  FeatureISAVersion11_0_1.Features, [11, 0, 1]> {
-  let ArchFeatures = ArchFeaturesW32Wgp;
-}
+  FeatureISAVersion11_0_1.Features, [11, 0, 1]
+>;
 
 def GFX1102 : AMDGPUProcessorModel<"gfx1102", GFX11SpeedModel,
-  FeatureISAVersion11_0_2.Features, [11, 0, 2]> {
-  let ArchFeatures = ArchFeaturesW32Wgp;
-}
+  FeatureISAVersion11_0_2.Features, [11, 0, 2]
+>;
 
 def GFX1103 : AMDGPUProcessorModel<"gfx1103", GFX11SpeedModel,
-  FeatureISAVersion11_0_3.Features, [11, 0, 3]> {
-  let ArchFeatures = ArchFeaturesW32Wgp;
-}
+  FeatureISAVersion11_0_3.Features, [11, 0, 3]
+>;
 
 def GFX1150 : AMDGPUProcessorModel<"gfx1150", GFX11SpeedModel,
-  FeatureISAVersion11_5_0.Features, [11, 5, 0]> {
-  let ArchFeatures = ArchFeaturesW32Wgp;
-}
+  FeatureISAVersion11_5_0.Features, [11, 5, 0]
+>;
 
 def GFX1151 : AMDGPUProcessorModel<"gfx1151", GFX11SpeedModel,
-  FeatureISAVersion11_5_1.Features, [11, 5, 1]> {
-  let ArchFeatures = ArchFeaturesW32Wgp;
-}
+  FeatureISAVersion11_5_1.Features, [11, 5, 1]
+>;
 
 def GFX1152 : AMDGPUProcessorModel<"gfx1152", GFX11SpeedModel,
-  FeatureISAVersion11_5_2.Features, [11, 5, 2]> {
-  let ArchFeatures = ArchFeaturesW32Wgp;
-}
+  FeatureISAVersion11_5_2.Features, [11, 5, 2]
+>;
 
 def GFX1153 : AMDGPUProcessorModel<"gfx1153", GFX11SpeedModel,
-  FeatureISAVersion11_5_Common.Features, [11, 5, 3]> {
-  let ArchFeatures = ArchFeaturesW32Wgp;
-}
+  FeatureISAVersion11_5_Common.Features, [11, 5, 3]
+>;
 
 def GFX1154 : AMDGPUProcessorModel<"gfx1154", GFX11SpeedModel,
-  FeatureISAVersion11_5_Common.Features, [11, 5, 4]> {
-  let ArchFeatures = ArchFeaturesW32Wgp;
-}
+  FeatureISAVersion11_5_Common.Features, [11, 5, 4]
+>;
 
 def GFX1170 : AMDGPUProcessorModel<"gfx1170", GFX11SpeedModel,
-  FeatureISAVersion11_7_Common.Features, [11, 7, 0]> {
-  let ArchFeatures = ArchFeaturesW32Wgp;
-}
+  FeatureISAVersion11_7_Common.Features, [11, 7, 0]
+>;
 
 def GFX1171 : AMDGPUProcessorModel<"gfx1171", GFX11SpeedModel,
-  FeatureISAVersion11_7_Common.Features, [11, 7, 1]> {
-  let ArchFeatures = ArchFeaturesW32Wgp;
-}
+  FeatureISAVersion11_7_Common.Features, [11, 7, 1]
+>;
 
 def GFX1172 : AMDGPUProcessorModel<"gfx1172", GFX11SpeedModel,
-  FeatureISAVersion11_7_Common.Features, [11, 7, 2]> {
-  let ArchFeatures = ArchFeaturesW32Wgp;
-}
+  FeatureISAVersion11_7_Common.Features, [11, 7, 2]
+>;
 
 def GFX11_GENERIC : AMDGPUProcessorModel<"gfx11-generic", GFX11SpeedModel,
   FeatureISAVersion11_Generic.Features, [11, 0, 3]> {
-  let ArchFeatures = ArchFeaturesW32Wgp;
   let CoveredGPUs = [GFX1100, GFX1101, GFX1102, GFX1103, GFX1150, GFX1151, GFX1152, GFX1153,
                      GFX1154];
 }
 
 def GFX11_7_GENERIC : AMDGPUProcessorModel<"gfx11-7-generic", GFX11SpeedModel,
   FeatureISAVersion11_7_Generic.Features, [11, 7, 0]> {
-  let ArchFeatures = ArchFeaturesW32Wgp;
   let CoveredGPUs = [GFX1170, GFX1171, GFX1172];
 }
 
@@ -353,40 +295,33 @@ def GFX11_7_GENERIC : AMDGPUProcessorModel<"gfx11-7-generic", GFX11SpeedModel,
 //===----------------------------------------------------------------------===//
 
 def GFX1200 : AMDGPUProcessorModel<"gfx1200", GFX12SpeedModel,
-  FeatureISAVersion12.Features, [12, 0, 0]> {
-  let ArchFeatures = ArchFeaturesW32Wgp;
-}
+  FeatureISAVersion12.Features, [12, 0, 0]
+>;
 
 def GFX1201 : AMDGPUProcessorModel<"gfx1201", GFX12SpeedModel,
-  FeatureISAVersion12.Features, [12, 0, 1]> {
-  let ArchFeatures = ArchFeaturesW32Wgp;
-}
+  FeatureISAVersion12.Features, [12, 0, 1]
+>;
 
 def GFX12_GENERIC : AMDGPUProcessorModel<"gfx12-generic", GFX12SpeedModel,
   FeatureISAVersion12_Generic.Features, [12, 0, 0]> {
-  let ArchFeatures = ArchFeaturesW32Wgp;
   let CoveredGPUs = [GFX1200, GFX1201];
 }
 
 def GFX1250_STRICT : AMDGPUProcessorModel<"gfx1250-strict", GFX1250SpeedModel,
   FeatureISAVersion12_50_STRICT.Features, [12, 5, 0]> {
-  let ArchFeatures = [FEATURE_FAST_FMA_F32, FEATURE_FAST_DENORMAL_F32, FEATURE_WAVE32, FEATURE_XNACK, FEATURE_SRAMECC];
   let SubArchSpelling = "12.50s";
 }
 
 def GFX1250 : AMDGPUProcessorModel<"gfx1250", GFX1250SpeedModel,
-  FeatureISAVersion12_50.Features, [12, 5, 0]> {
-  let ArchFeatures = [FEATURE_FAST_FMA_F32, FEATURE_FAST_DENORMAL_F32, FEATURE_WAVE32, FEATURE_XNACK, FEATURE_SRAMECC];
-}
+  FeatureISAVersion12_50.Features, [12, 5, 0]
+>;
 
 def GFX1251 : AMDGPUProcessorModel<"gfx1251", GFX1251SpeedModel,
-  FeatureISAVersion12_51.Features, [12, 5, 1]> {
-  let ArchFeatures = [FEATURE_FAST_FMA_F32, FEATURE_FAST_DENORMAL_F32, FEATURE_WAVE32, FEATURE_XNACK, FEATURE_SRAMECC];
-}
+  FeatureISAVersion12_51.Features, [12, 5, 1]
+>;
 
 def GFX12_5_GENERIC : AMDGPUProcessorModel<"gfx12-5-generic", GFX125xGenericSpeedModel,
   FeatureISAVersion12_5_Generic.Features, [12, 5, 0]> {
-  let ArchFeatures = [FEATURE_FAST_FMA_F32, FEATURE_FAST_DENORMAL_F32, FEATURE_WAVE32, FEATURE_XNACK, FEATURE_SRAMECC];
   let CoveredGPUs = [GFX1250, GFX1251];
 }
 
@@ -395,13 +330,11 @@ def GFX12_5_GENERIC : AMDGPUProcessorModel<"gfx12-5-generic", GFX125xGenericSpee
 //===----------------------------------------------------------------------===//
 
 def GFX1310 : AMDGPUProcessorModel<"gfx1310", GFX12SpeedModel,
-  FeatureISAVersion13.Features, [13, 1, 0]> {
-  let ArchFeatures = ArchFeaturesW32Wgp;
-}
+  FeatureISAVersion13.Features, [13, 1, 0]
+>;
 
 def GFX13_GENERIC : AMDGPUProcessorModel<"gfx13-generic", GFX12SpeedModel,
   FeatureISAVersion13_Generic.Features, [13, 1, 0]> {
-  let ArchFeatures = ArchFeaturesW32Wgp;
   let CoveredGPUs = [GFX1310];
 }
 

--- a/llvm/lib/Target/AMDGPU/R600Processors.td
+++ b/llvm/lib/Target/AMDGPU/R600Processors.td
@@ -126,9 +126,8 @@ def : R600ProcessorModel<"cedar", R600_VLIW5_Itin,
 def : ProcessorAlias<"palm", "cedar">;
 
 def : R600ProcessorModel<"cypress", R600_VLIW5_Itin,
-  [FeatureEvergreen, FeatureWavefrontSize64, FeatureVertexCache, FeatureFMA]> {
-  let ArchFeatures = [R600_FEATURE_FMA];
-}
+  [FeatureEvergreen, FeatureWavefrontSize64, FeatureVertexCache, FeatureFMA]
+>;
 
 def : ProcessorAlias<"hemlock", "cypress">;
 
@@ -162,9 +161,8 @@ def : R600ProcessorModel<"caicos", R600_VLIW5_Itin,
 def : ProcessorAlias<"aruba", "cayman">;
 
 def : R600ProcessorModel<"cayman", R600_VLIW4_Itin,
-  [FeatureNorthernIslands, FeatureCaymanISA, FeatureFMA]> {
-  let ArchFeatures = [R600_FEATURE_FMA];
-}
+  [FeatureNorthernIslands, FeatureCaymanISA, FeatureFMA]
+>;
 
 def : R600ProcessorModel<"turks", R600_VLIW5_Itin,
   [FeatureNorthernIslands, FeatureVertexCache, FeatureCFALUBug]

--- a/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
+++ b/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
@@ -36,7 +36,6 @@ struct GPUNameAlias {
 struct GPUInfo {
   StringTable::Offset Name;
   Triple::SubArchType SubArch;
-  unsigned ArchFeatures;
   AMDGPUFeatureBitset Features;
   IsaVersion Version;
   StringTable::Offset FamilyName;
@@ -48,7 +47,6 @@ struct GPUInfo {
 // Per-GPU data for the R600 GPUKinds.
 struct R600Info {
   StringTable::Offset Name;
-  R600FeatureKind ArchFeatures;
   R600FeatureBitset Features;
 };
 
@@ -310,21 +308,6 @@ AMDGPU::GPUKind llvm::AMDGPU::parseArchAMDGCN(StringRef CPU) {
 AMDGPU::GPUKind llvm::AMDGPU::parseArchR600(StringRef CPU) {
   return parseArchImpl(CPU, R600GPUTable, R600FirstGPUKind, R600NameStrTab,
                        R600GPUAliases);
-}
-
-unsigned AMDGPU::getArchAttrAMDGCN(GPUKind AK) {
-  const GPUInfo *Info = getAMDGPUInfo(AK);
-  return Info ? Info->ArchFeatures : FEATURE_NONE;
-}
-
-unsigned AMDGPU::getArchAttrAMDGCN(Triple::SubArchType SubArch) {
-  const GPUInfo *Info = getAMDGPUInfo(getGPUKindFromSubArch(SubArch));
-  return Info ? Info->ArchFeatures : FEATURE_NONE;
-}
-
-R600FeatureKind AMDGPU::getArchAttrR600(GPUKind AK) {
-  const R600Info *Info = getR600Info(AK);
-  return Info ? Info->ArchFeatures : R600_FEATURE_NONE;
 }
 
 const AMDGPUFeatureBitset &AMDGPU::getFeatureBitset(GPUKind AK) {

--- a/llvm/test/CodeGen/AMDGPU/module-flag-xnack-no-on-off-modes.ll
+++ b/llvm/test/CodeGen/AMDGPU/module-flag-xnack-no-on-off-modes.ll
@@ -1,6 +1,6 @@
 ; Test targets without xnack on/off mode support ignore module flags
-; Targets with only FEATURE_XNACK (but not FEATURE_XNACK_ON_OFF_MODES)
-; have xnack always on and ignore module flag settings.
+; Targets that support xnack but not xnack on/off modes have xnack always on
+; and ignore module flag settings.
 ; The target ID should not contain the xnack specifier.
 
 ; RUN: split-file %s %t

--- a/llvm/test/TableGen/AMDGPUTargetDefErrors.td
+++ b/llvm/test/TableGen/AMDGPUTargetDefErrors.td
@@ -25,9 +25,7 @@
 //--- bad-alias.td
 include "llvm/Target/Target.td"
 def MyTarget : Target;
-class AMDGPUArchFeature<string spelling> { string Spelling = spelling; }
 class AMDGPUGPUInfo<list<int> isa = []> {
-  list<AMDGPUArchFeature> ArchFeatures = [];
   list<int> IsaVersion = isa;
   list<Processor> CoveredGPUs = [];
   bit IsPseudoTarget = false;
@@ -41,9 +39,7 @@ def : ProcessorAlias<"foo", "gfx-missing">;
 //--- dup-processor.td
 include "llvm/Target/Target.td"
 def MyTarget : Target;
-class AMDGPUArchFeature<string spelling> { string Spelling = spelling; }
 class AMDGPUGPUInfo<list<int> isa = []> {
-  list<AMDGPUArchFeature> ArchFeatures = [];
   list<int> IsaVersion = isa;
   list<Processor> CoveredGPUs = [];
   bit IsPseudoTarget = false;
@@ -57,9 +53,7 @@ def DupB : ProcessorModel<"gfx900", NoSchedModel, []>, AMDGPUGPUInfo<[9, 0, 0]>;
 //--- alias-shadows-processor.td
 include "llvm/Target/Target.td"
 def MyTarget : Target;
-class AMDGPUArchFeature<string spelling> { string Spelling = spelling; }
 class AMDGPUGPUInfo<list<int> isa = []> {
-  list<AMDGPUArchFeature> ArchFeatures = [];
   list<int> IsaVersion = isa;
   list<Processor> CoveredGPUs = [];
   bit IsPseudoTarget = false;
@@ -73,9 +67,7 @@ def : ProcessorAlias<"gfx900", "gfx900">;
 //--- bad-isa-version.td
 include "llvm/Target/Target.td"
 def MyTarget : Target;
-class AMDGPUArchFeature<string spelling> { string Spelling = spelling; }
 class AMDGPUGPUInfo<list<int> isa = []> {
-  list<AMDGPUArchFeature> ArchFeatures = [];
   list<int> IsaVersion = isa;
   list<Processor> CoveredGPUs = [];
   bit IsPseudoTarget = false;
@@ -88,9 +80,7 @@ def : ProcessorModel<"gfx900", NoSchedModel, []>, AMDGPUGPUInfo<[9, 0]>;
 //--- oversized-major.td
 include "llvm/Target/Target.td"
 def MyTarget : Target;
-class AMDGPUArchFeature<string spelling> { string Spelling = spelling; }
 class AMDGPUGPUInfo<list<int> isa = []> {
-  list<AMDGPUArchFeature> ArchFeatures = [];
   list<int> IsaVersion = isa;
   list<Processor> CoveredGPUs = [];
   bit IsPseudoTarget = false;
@@ -103,9 +93,7 @@ def : ProcessorModel<"gfx900", NoSchedModel, []>, AMDGPUGPUInfo<[256, 0, 0]>;
 //--- oversized-minor.td
 include "llvm/Target/Target.td"
 def MyTarget : Target;
-class AMDGPUArchFeature<string spelling> { string Spelling = spelling; }
 class AMDGPUGPUInfo<list<int> isa = []> {
-  list<AMDGPUArchFeature> ArchFeatures = [];
   list<int> IsaVersion = isa;
   list<Processor> CoveredGPUs = [];
   bit IsPseudoTarget = false;
@@ -117,9 +105,7 @@ def : ProcessorModel<"gfx900", NoSchedModel, []>, AMDGPUGPUInfo<[9, 256, 0]>;
 //--- oversized-stepping.td
 include "llvm/Target/Target.td"
 def MyTarget : Target;
-class AMDGPUArchFeature<string spelling> { string Spelling = spelling; }
 class AMDGPUGPUInfo<list<int> isa = []> {
-  list<AMDGPUArchFeature> ArchFeatures = [];
   list<int> IsaVersion = isa;
   list<Processor> CoveredGPUs = [];
   bit IsPseudoTarget = false;
@@ -132,9 +118,7 @@ def : ProcessorModel<"gfx900", NoSchedModel, []>, AMDGPUGPUInfo<[9, 0, 256]>;
 //--- negative-component.td
 include "llvm/Target/Target.td"
 def MyTarget : Target;
-class AMDGPUArchFeature<string spelling> { string Spelling = spelling; }
 class AMDGPUGPUInfo<list<int> isa = []> {
-  list<AMDGPUArchFeature> ArchFeatures = [];
   list<int> IsaVersion = isa;
   list<Processor> CoveredGPUs = [];
   bit IsPseudoTarget = false;
@@ -146,9 +130,7 @@ def : ProcessorModel<"gfx900", NoSchedModel, []>, AMDGPUGPUInfo<[9, 0, -1]>;
 //--- bad-stepping.td
 include "llvm/Target/Target.td"
 def MyTarget : Target;
-class AMDGPUArchFeature<string spelling> { string Spelling = spelling; }
 class AMDGPUGPUInfo<list<int> isa = []> {
-  list<AMDGPUArchFeature> ArchFeatures = [];
   list<int> IsaVersion = isa;
   list<Processor> CoveredGPUs = [];
   bit IsPseudoTarget = false;
@@ -161,9 +143,7 @@ def : ProcessorModel<"gfx900", NoSchedModel, []>, AMDGPUGPUInfo<[9, 0, 16]>;
 //--- generic-feature-superset.td
 include "llvm/Target/Target.td"
 def MyTarget : Target;
-class AMDGPUArchFeature<string spelling> { string Spelling = spelling; }
 class AMDGPUGPUInfo<list<int> isa = []> {
-  list<AMDGPUArchFeature> ArchFeatures = [];
   list<int> IsaVersion = isa;
   list<Processor> CoveredGPUs = [];
   bit IsPseudoTarget = false;

--- a/llvm/test/TableGen/AMDGPUTargetDefSubArchSpelling.td
+++ b/llvm/test/TableGen/AMDGPUTargetDefSubArchSpelling.td
@@ -4,9 +4,7 @@
 
 include "llvm/Target/Target.td"
 def MyTarget : Target;
-class AMDGPUArchFeature<string spelling> { string Spelling = spelling; }
 class AMDGPUGPUInfo<list<int> isa = []> {
-  list<AMDGPUArchFeature> ArchFeatures = [];
   list<int> IsaVersion = isa;
   list<Processor> CoveredGPUs = [];
   bit IsPseudoTarget = false;

--- a/llvm/unittests/TargetParser/TargetParserTest.cpp
+++ b/llvm/unittests/TargetParser/TargetParserTest.cpp
@@ -2724,32 +2724,31 @@ TEST(TargetParserTest, testAMDGPUparseArchR600) {
   struct CanonicalGPU {
     StringRef Name;
     AMDGPU::GPUKind Kind;
-    AMDGPU::R600FeatureKind Features;
+    bool HasFMA;
   };
   static const CanonicalGPU Canonicals[] = {
-      {"r600", AMDGPU::GK_R600, AMDGPU::R600_FEATURE_NONE},
-      {"r630", AMDGPU::GK_R630, AMDGPU::R600_FEATURE_NONE},
-      {"rs880", AMDGPU::GK_RS880, AMDGPU::R600_FEATURE_NONE},
-      {"rv670", AMDGPU::GK_RV670, AMDGPU::R600_FEATURE_NONE},
-      {"rv710", AMDGPU::GK_RV710, AMDGPU::R600_FEATURE_NONE},
-      {"rv730", AMDGPU::GK_RV730, AMDGPU::R600_FEATURE_NONE},
-      {"rv770", AMDGPU::GK_RV770, AMDGPU::R600_FEATURE_NONE},
-      {"cedar", AMDGPU::GK_CEDAR, AMDGPU::R600_FEATURE_NONE},
-      {"cypress", AMDGPU::GK_CYPRESS, AMDGPU::R600_FEATURE_FMA},
-      {"juniper", AMDGPU::GK_JUNIPER, AMDGPU::R600_FEATURE_NONE},
-      {"redwood", AMDGPU::GK_REDWOOD, AMDGPU::R600_FEATURE_NONE},
-      {"sumo", AMDGPU::GK_SUMO, AMDGPU::R600_FEATURE_NONE},
-      {"barts", AMDGPU::GK_BARTS, AMDGPU::R600_FEATURE_NONE},
-      {"caicos", AMDGPU::GK_CAICOS, AMDGPU::R600_FEATURE_NONE},
-      {"cayman", AMDGPU::GK_CAYMAN, AMDGPU::R600_FEATURE_FMA},
-      {"turks", AMDGPU::GK_TURKS, AMDGPU::R600_FEATURE_NONE},
+      {"r600", AMDGPU::GK_R600, false},
+      {"r630", AMDGPU::GK_R630, false},
+      {"rs880", AMDGPU::GK_RS880, false},
+      {"rv670", AMDGPU::GK_RV670, false},
+      {"rv710", AMDGPU::GK_RV710, false},
+      {"rv730", AMDGPU::GK_RV730, false},
+      {"rv770", AMDGPU::GK_RV770, false},
+      {"cedar", AMDGPU::GK_CEDAR, false},
+      {"cypress", AMDGPU::GK_CYPRESS, true},
+      {"juniper", AMDGPU::GK_JUNIPER, false},
+      {"redwood", AMDGPU::GK_REDWOOD, false},
+      {"sumo", AMDGPU::GK_SUMO, false},
+      {"barts", AMDGPU::GK_BARTS, false},
+      {"caicos", AMDGPU::GK_CAICOS, false},
+      {"cayman", AMDGPU::GK_CAYMAN, true},
+      {"turks", AMDGPU::GK_TURKS, false},
   };
   for (const CanonicalGPU &G : Canonicals) {
     EXPECT_EQ(AMDGPU::parseArchR600(G.Name), G.Kind) << G.Name;
     EXPECT_EQ(AMDGPU::getArchNameR600(G.Kind), G.Name) << G.Name;
-    EXPECT_EQ(AMDGPU::getArchAttrR600(G.Kind), G.Features) << G.Name;
     EXPECT_EQ(AMDGPU::getFeatureBitsetR600(G.Kind).test(AMDGPU::R600_FEAT_FMAF),
-              G.Features == AMDGPU::R600_FEATURE_FMA)
+              G.HasFMA)
         << G.Name;
   }
 
@@ -3310,8 +3309,8 @@ TEST(TargetParserTest, testAMDGPUParseTargetIDString) {
       "amdgcn-amd-amdhsa-unknown-gfx900:sramecc+"));
 
   // xnack is only a valid modifier when the processor supports on/off modes.
-  // gfx1250 has xnack permanently enabled (FEATURE_XNACK without
-  // FEATURE_XNACK_ON_OFF_MODES), so an xnack modifier is rejected.
+  // gfx1250 has xnack permanently enabled (xnack supported but without
+  // on/off modes), so an xnack modifier is rejected.
   EXPECT_FALSE(TargetID::parseTargetIDString(
       "amdgcn-amd-amdhsa-unknown-gfx1250:xnack+"));
   EXPECT_FALSE(TargetID::parseTargetIDString(

--- a/llvm/utils/TableGen/Basic/AMDGPUTargetDefEmitter.cpp
+++ b/llvm/utils/TableGen/Basic/AMDGPUTargetDefEmitter.cpp
@@ -37,10 +37,8 @@ static void emitGPUKindEnum(raw_ostream &OS, StringRef Name) {
     OS << ((C == '-') ? '_' : toUpper(C));
 }
 
-// Feature string to enumerator, e.g. "16-bit-insts" -> "FEAT_16_BIT_INSTS". The
-// FEAT_ prefix (rather than FEATURE_) avoids colliding with the legacy
-// ArchFeatureKind enumerators (e.g. FEATURE_XNACK_ON_OFF_MODES) during the
-// migration off that bitfield. R600 uses the "R600_FEAT_" prefix.
+// Feature string to enumerator, e.g. "16-bit-insts" -> "FEAT_16_BIT_INSTS".
+// AMDGCN uses the "FEAT_" prefix, R600 the "R600_FEAT_" prefix.
 static void emitFeatureEnum(raw_ostream &OS, StringRef Prefix, StringRef Name) {
   OS << Prefix;
   for (char C : Name)
@@ -178,21 +176,6 @@ struct GPUEntry {
 };
 } // namespace
 
-// Emit the ArchFeature spellings joined with '|', or \p NoneSpelling when
-// empty.
-static void emitFeatureExpr(raw_ostream &OS, const Record *Rec,
-                            StringRef NoneSpelling) {
-  ListSeparator LS("|");
-  bool Any = false;
-  for (const Record *F : Rec->getValueAsListOfDefs("ArchFeatures")) {
-    OS << LS << F->getValueAsString("Spelling");
-    Any = true;
-  }
-
-  if (!Any)
-    OS << NoneSpelling;
-}
-
 // The frontend-visible features from def \p ListName, in bit order. Empty if
 // the def is absent.
 static std::vector<const Record *>
@@ -327,8 +310,6 @@ emitR600Table(raw_ostream &OS, const RecordKeeper &RK,
   for (const Record *R : Canon) {
     OS << "  {" << Names.GetOrAddStringOffset(R->getValueAsString("Name"))
        << ", ";
-    emitFeatureExpr(OS, R, "R600_FEATURE_NONE");
-    OS << ", ";
     emitFeatureBitset(OS, "R600FeatureBitset", "R600_FEAT_", R, FeatureIdx);
     OS << "},\n";
   }
@@ -619,8 +600,6 @@ emitAMDGPUTable(raw_ostream &OS, const RecordKeeper &RK,
     StringRef Name = R->getValueAsString("Name");
     OS << "  {" << Names.GetOrAddStringOffset(Name) << ", ";
     emitSubArch(OS, R);
-    OS << ", ";
-    emitFeatureExpr(OS, R, "FEATURE_NONE");
     OS << ", ";
     emitFeatureBitset(OS, "AMDGPUFeatureBitset", "FEAT_", R, FeatureIdx);
     OS << ", ";


### PR DESCRIPTION
Everything should now use getFeatureBitset*

Co-authored-by: Claude (Opus 4.8) <noreply@anthropic.com>