### PR TITLE
X86: Mark EFLAGS dead on MOV32r0 emitted outside SelectionDAG

### DIFF
--- a/llvm/lib/Target/X86/GISel/X86InstructionSelector.cpp
+++ b/llvm/lib/Target/X86/GISel/X86InstructionSelector.cpp
@@ -1858,8 +1858,8 @@ bool X86InstructionSelector::selectMulDivRem(MachineInstr &I,
               TII.get(OpEntry.OpSignExtend));
     else {
       Register Zero32 = MRI.createVirtualRegister(&X86::GR32RegClass);
-      BuildMI(*I.getParent(), I, I.getDebugLoc(), TII.get(X86::MOV32r0),
-              Zero32);
+      BuildMI(*I.getParent(), I, I.getDebugLoc(), TII.get(X86::MOV32r0), Zero32)
+          .setOperandDead(1);
 
       // Copy the zero into the appropriate sub/super/identical physical
       // register. Unfortunately the operations needed are not uniform enough

--- a/llvm/lib/Target/X86/X86FastISel.cpp
+++ b/llvm/lib/Target/X86/X86FastISel.cpp
@@ -138,6 +138,8 @@ private:
 
   bool handleConstantAddresses(const Value *V, X86AddressMode &AM);
 
+  Register emitMOV32r0();
+
   Register X86MaterializeInt(const ConstantInt *CI, MVT VT);
   Register X86MaterializeFP(const ConstantFP *CFP, MVT VT);
   Register X86MaterializeGV(const GlobalValue *GV, MVT VT);
@@ -1455,9 +1457,7 @@ bool X86FastISel::X86SelectCmp(const Instruction *I) {
   switch (Predicate) {
   default: break;
   case CmpInst::FCMP_FALSE: {
-    ResultReg = createResultReg(&X86::GR32RegClass);
-    BuildMI(*FuncInfo.MBB, FuncInfo.InsertPt, MIMD, TII.get(X86::MOV32r0),
-            ResultReg);
+    ResultReg = emitMOV32r0();
     ResultReg = fastEmitInst_extractsubreg(MVT::i8, ResultReg, X86::sub_8bit);
     if (!ResultReg)
       return false;
@@ -1971,9 +1971,7 @@ bool X86FastISel::X86SelectDivRem(const Instruction *I) {
       BuildMI(*FuncInfo.MBB, FuncInfo.InsertPt, MIMD,
               TII.get(OpEntry.OpSignExtend));
     else {
-      Register Zero32 = createResultReg(&X86::GR32RegClass);
-      BuildMI(*FuncInfo.MBB, FuncInfo.InsertPt, MIMD,
-              TII.get(X86::MOV32r0), Zero32);
+      Register Zero32 = emitMOV32r0();
 
       // Copy the zero into the appropriate sub/super/identical physical
       // register. Unfortunately the operations needed are not uniform enough
@@ -3714,13 +3712,21 @@ X86FastISel::fastSelectInstruction(const Instruction *I)  {
   return false;
 }
 
+Register X86FastISel::emitMOV32r0() {
+  Register ResultReg = createResultReg(&X86::GR32RegClass);
+  BuildMI(*FuncInfo.MBB, FuncInfo.InsertPt, MIMD, TII.get(X86::MOV32r0),
+          ResultReg)
+      .setOperandDead(1);
+  return ResultReg;
+}
+
 Register X86FastISel::X86MaterializeInt(const ConstantInt *CI, MVT VT) {
   if (VT > MVT::i64)
     return Register();
 
   uint64_t Imm = CI->getZExtValue();
   if (Imm == 0) {
-    Register SrcReg = fastEmitInst_(X86::MOV32r0, &X86::GR32RegClass);
+    Register SrcReg = emitMOV32r0();
     switch (VT.SimpleTy) {
     default: llvm_unreachable("Unexpected value type");
     case MVT::i1:

--- a/llvm/lib/Target/X86/X86FixupSetCC.cpp
+++ b/llvm/lib/Target/X86/X86FixupSetCC.cpp
@@ -135,7 +135,8 @@ static bool fixupSetCC(MachineFunction &MF) {
       } else {
         // Initialize a register with 0. This must go before the eflags def
         BuildMI(MBB, FlagsDefMI, MI.getDebugLoc(), TII->get(X86::MOV32r0),
-                ZeroReg);
+                ZeroReg)
+            .setOperandDead(1);
       }
 
       BuildMI(*ZExt->getParent(), ZExt, ZExt->getDebugLoc(),


### PR DESCRIPTION
Currently these get set by LiveVariables after the fact, but
ideally we would not rely on that since it's long overdue for
deletion.

Co-authored-by: Claude (Opus 4.8) <noreply@anthropic.com>