### PR TITLE
[lldb] Add SBCompileUnit::GetIDInModule

### DIFF
--- a/lldb/include/lldb/API/SBCompileUnit.h
+++ b/lldb/include/lldb/API/SBCompileUnit.h
@@ -72,6 +72,11 @@ public:
   /// unoptimized or unknown.
   bool GetIsOptimized();
 
+  /// Return an ID that identifies this compile unit within its module, or
+  /// LLDB_INVALID_INDEX32 if invalid. SBModule::GetCompileUnitAtIndex maps it
+  /// back to this compile unit. The ID is not unique across modules.
+  uint32_t GetIDInModule() const;
+
   bool operator==(const lldb::SBCompileUnit &rhs) const;
 
   bool operator!=(const lldb::SBCompileUnit &rhs) const;

--- a/lldb/include/lldb/Symbol/CompileUnit.h
+++ b/lldb/include/lldb/Symbol/CompileUnit.h
@@ -339,6 +339,11 @@ public:
   ///     a NULL Function pointer.
   lldb::FunctionSP FindFunctionByUID(lldb::user_id_t uid);
 
+  /// Return the index of this compile unit in its module.
+  uint32_t GetIndex() const { return m_index; }
+
+  void SetIndex(uint32_t index) { m_index = index; }
+
   /// Set the line table for the compile unit.
   ///
   /// Called by the SymbolFile plug-in when if first parses the line table and
@@ -442,6 +447,8 @@ protected:
   /// eLazyBoolYes if this compile unit was compiled with
   /// optimization.
   lldb_private::LazyBool m_is_optimized;
+  /// Index of this compile unit in its module.
+  uint32_t m_index = LLDB_INVALID_INDEX32;
 
 private:
   enum {

--- a/lldb/source/API/SBCompileUnit.cpp
+++ b/lldb/source/API/SBCompileUnit.cpp
@@ -203,6 +203,14 @@ SBCompileUnit::operator bool() const {
   return m_opaque_ptr != nullptr;
 }
 
+uint32_t SBCompileUnit::GetIDInModule() const {
+  LLDB_INSTRUMENT_VA(this);
+
+  if (m_opaque_ptr)
+    return m_opaque_ptr->GetIndex();
+  return LLDB_INVALID_INDEX32;
+}
+
 bool SBCompileUnit::operator==(const SBCompileUnit &rhs) const {
   LLDB_INSTRUMENT_VA(this, rhs);
 

--- a/lldb/source/Symbol/SymbolFile.cpp
+++ b/lldb/source/Symbol/SymbolFile.cpp
@@ -210,8 +210,11 @@ CompUnitSP SymbolFileCommon::GetCompileUnitAtIndex(uint32_t idx) {
   if (idx >= num)
     return nullptr;
   lldb::CompUnitSP &cu_sp = (*m_compile_units)[idx];
-  if (!cu_sp)
+  if (!cu_sp) {
     cu_sp = ParseCompileUnitAtIndex(idx);
+    if (cu_sp)
+      cu_sp->SetIndex(idx);
+  }
   return cu_sp;
 }
 
@@ -229,6 +232,8 @@ void SymbolFileCommon::SetCompileUnitAtIndex(uint32_t idx,
   // unit.
   assert((*m_compile_units)[idx] == nullptr);
   (*m_compile_units)[idx] = cu_sp;
+  if (cu_sp)
+    cu_sp->SetIndex(idx);
 }
 
 llvm::Expected<TypeSystemSP>

--- a/lldb/test/API/python_api/compile_unit/Makefile
+++ b/lldb/test/API/python_api/compile_unit/Makefile
@@ -1,3 +1,3 @@
-C_SOURCES := main.c
+C_SOURCES := main.c other.c
 
 include Makefile.rules

--- a/lldb/test/API/python_api/compile_unit/TestCompileUnitAPI.py
+++ b/lldb/test/API/python_api/compile_unit/TestCompileUnitAPI.py
@@ -54,6 +54,17 @@ class CompileUnitAPITestCase(TestBase):
             ),
         )
 
+        self.assertNotEqual(main_cu.GetIDInModule(), lldb.LLDB_INVALID_INDEX32)
+        self.assertEqual(main_cu.GetIDInModule(), main_cu_by_name.GetIDInModule())
+        self.assertEqual(
+            main_cu.GetIDInModule(), frame0.GetCompileUnit().GetIDInModule()
+        )
+        self.assertEqual(
+            lldb.SBCompileUnit().GetIDInModule(), lldb.LLDB_INVALID_INDEX32
+        )
+
+        self.assertEqual(a_mod.GetCompileUnitAtIndex(main_cu.GetIDInModule()), main_cu)
+
     def find_main_compile_unit(self) -> lldb.SBCompileUnit:
         target = self.dbg.CreateTarget(self.getBuildArtifact("a.out"))
         self.assertTrue(target, VALID_TARGET)
@@ -70,3 +81,19 @@ class CompileUnitAPITestCase(TestBase):
         """A compile unit built without optimization reports it."""
         self.build()
         self.assertFalse(self.find_main_compile_unit().GetIsOptimized())
+
+    def test_id_is_unique_per_module(self):
+        self.build()
+        target = self.dbg.CreateTarget(self.getBuildArtifact("a.out"))
+        self.assertTrue(target, VALID_TARGET)
+        module = target.FindModule(lldb.SBFileSpec("a.out"))
+
+        num_cus = module.GetNumCompileUnits()
+        self.assertGreater(num_cus, 1, "test needs a module with several CUs")
+
+        ids = set()
+        for i in range(num_cus):
+            cu = module.GetCompileUnitAtIndex(i)
+            self.assertEqual(cu.GetIDInModule(), i)
+            ids.add(cu.GetIDInModule())
+        self.assertEqual(len(ids), num_cus, "IDs must be unique")

--- a/lldb/test/API/python_api/compile_unit/other.c
+++ b/lldb/test/API/python_api/compile_unit/other.c
@@ -1,0 +1,1 @@
+int other(int val) { return val + 1; }


### PR DESCRIPTION
Expose an ID that identifies a compile unit within its module so clients can name a CU across API calls and look it up again with SBModule::GetCompileUnitAtIndex. The user ID is not usable for this: with a Darwin debug map every compile unit reports uid 0.

CompileUnit stores the index, set by SymbolFileCommon when a CU is parsed or installed at a given slot.