### PR TITLE
[GitHub] Bump CI Container Runner Version to 2.337.0

### DIFF
--- a/.github/workflows/containers/github-action-ci-windows/Dockerfile
+++ b/.github/workflows/containers/github-action-ci-windows/Dockerfile
@@ -100,7 +100,7 @@ RUN powershell -Command \
     New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" \
     -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
 
-ARG RUNNER_VERSION=2.335.1
+ARG RUNNER_VERSION=2.337.0
 ENV RUNNER_VERSION=$RUNNER_VERSION
 
 RUN powershell -Command \

--- a/.github/workflows/containers/github-action-ci/Dockerfile
+++ b/.github/workflows/containers/github-action-ci/Dockerfile
@@ -104,7 +104,7 @@ WORKDIR /home/gha
 
 FROM ci-container AS ci-container-agent
 
-ENV GITHUB_RUNNER_VERSION=2.335.1
+ENV GITHUB_RUNNER_VERSION=2.337.0
 
 RUN mkdir actions-runner && \
     cd actions-runner && \


### PR DESCRIPTION
This is the latest version and keeps us ahead of the relatively short runner support horizon.