### PR TITLE
[lldb][Darwin] Don't mark threads as having hit bp if not

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/gdbclientutils.py
+++ b/lldb/packages/Python/lldbsuite/test/gdbclientutils.py
@@ -292,6 +292,8 @@ class MockGDBServerResponder:
             return self.vAttach(int(pid, 16))
         if packet[0] == "Z":
             return self.setBreakpoint(packet)
+        if packet[0] == "z":
+            return self.clearBreakpoint(packet)
         if packet.startswith("qThreadStopInfo"):
             threadnum = int(packet[15:], 16)
             return self.threadStopInfo(threadnum)
@@ -299,6 +301,8 @@ class MockGDBServerResponder:
             return self.QThreadSuffixSupported()
         if packet == "QListThreadsInStopReply":
             return self.QListThreadsInStopReply()
+        if packet == "jThreadsInfo":
+            return self.jThreadsInfo()
         if packet.startswith("qMemoryRegionInfo:"):
             return self.qMemoryRegionInfo(int(packet.split(":")[1], 16))
         if packet == "qQueryGDBServer":
@@ -355,6 +359,9 @@ class MockGDBServerResponder:
         return "2f"
 
     def qOffsets(self) -> str:
+        return ""
+
+    def jThreadsInfo(self) -> str:
         return ""
 
     def qProcessInfo(self) -> str:
@@ -442,6 +449,9 @@ class MockGDBServerResponder:
         return "OK"
 
     def setBreakpoint(self, packet) -> str:
+        raise self.UnexpectedPacketException()
+
+    def clearBreakpoint(self, packet) -> str:
         raise self.UnexpectedPacketException()
 
     def threadStopInfo(self, threadnum) -> str:

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -1842,14 +1842,18 @@ bool ProcessGDBRemote::CalculateThreadStopInfo(ThreadGDBRemote *thread) {
   if (GetThreadStopInfoFromJSON(thread, m_jthreadsinfo_sp))
     return true;
 
-  // See if we got thread stop info for any threads valid stop info reasons
-  // threads via the "jstopinfo" packet stop reply packet key/value pair?
   if (m_jstopinfo_sp) {
-    // If we have "jstopinfo" then we have stop descriptions for all threads
-    // that have stop reasons, and if there is no entry for a thread, then it
-    // has no stop reason.
-    if (!GetThreadStopInfoFromJSON(thread, m_jstopinfo_sp))
+    // If we have "jstopinfo" from the stop packet, then we have stop 
+    // descriptions for all threads that have stop reasons, and if there 
+    // is no entry for a thread, then it has no stop reason.
+    if (!GetThreadStopInfoFromJSON(thread, m_jstopinfo_sp)) {
+      addr_t pc = thread->GetRegisterContext()->GetPC();
+      BreakpointSiteSP bp_site_sp =
+          thread->GetProcess()->GetBreakpointSiteList().FindByAddress(pc);
+      if (bp_site_sp && IsBreakpointSitePhysicallyEnabled(*bp_site_sp))
+        thread->SetThreadStoppedAtUnexecutedBP(pc);
       thread->SetStopInfo(StopInfoSP());
+    }
     return true;
   }
 

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -1846,8 +1846,9 @@ bool ProcessGDBRemote::CalculateThreadStopInfo(ThreadGDBRemote *thread) {
   // with a mach exception description for any thread that has a stop reason.
   if (m_jstopinfo_sp) {
     // Any thread not described in `jstopinfo` has no stop reason.
-    // Mark if it's at a breakpoint site that hasn't been hit yet, and
-    // then filll in a no-reason StopInfo.
+    // If a no-stop-reason thread is stopped at a breakpoint site (but
+    // hasn't yet hit the breakpoint instruction), note that in the
+    // Thread state so we will hit the breakpoint when we resume execution.
     if (!GetThreadStopInfoFromJSON(thread, m_jstopinfo_sp)) {
       addr_t pc = thread->GetRegisterContext()->GetPC();
       BreakpointSiteSP bp_site_sp =

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -1838,14 +1838,16 @@ bool ProcessGDBRemote::GetThreadStopInfoFromJSON(
 
 bool ProcessGDBRemote::CalculateThreadStopInfo(ThreadGDBRemote *thread) {
   // See if we got thread stop infos for all threads via the "jThreadsInfo"
-  // packet
+  // packet (we're at a public stop).
   if (GetThreadStopInfoFromJSON(thread, m_jthreadsinfo_sp))
     return true;
 
+  // See if the stop-reply packet (T05 etc) included a `jstopinfo` key
+  // with a mach exception description for any thread that has a stop reason.
   if (m_jstopinfo_sp) {
-    // If we have "jstopinfo" from the stop packet, then we have stop 
-    // descriptions for all threads that have stop reasons, and if there 
-    // is no entry for a thread, then it has no stop reason.
+    // Any thread not described in `jstopinfo` has no stop reason.
+    // Mark if it's at a breakpoint site that hasn't been hit yet, and
+    // then filll in a no-reason StopInfo.
     if (!GetThreadStopInfoFromJSON(thread, m_jstopinfo_sp)) {
       addr_t pc = thread->GetRegisterContext()->GetPC();
       BreakpointSiteSP bp_site_sp =

--- a/lldb/test/API/functionalities/gdb_remote_client/TestBatchedBreakpointStepOver.py
+++ b/lldb/test/API/functionalities/gdb_remote_client/TestBatchedBreakpointStepOver.py
@@ -62,6 +62,9 @@ class TestBatchedBreakpointStepOver(GDBRemoteTestBase):
             def setBreakpoint(self, packet):
                 return "OK"
 
+            def clearBreakpoint(self, packet):
+                return "OK"
+
             def readRegisters(self):
                 return "00" * 160
 
@@ -106,8 +109,6 @@ class TestBatchedBreakpointStepOver(GDBRemoteTestBase):
                     return "vCont;c;C;s;S"
                 if packet.startswith("vCont;"):
                     return self._handle_vCont(packet)
-                if packet.startswith("z"):
-                    return "OK"
                 return ""
 
             def _handle_vCont(self, packet):

--- a/lldb/test/API/functionalities/gdb_remote_client/TestBreakpointNotHit.py
+++ b/lldb/test/API/functionalities/gdb_remote_client/TestBreakpointNotHit.py
@@ -1,0 +1,247 @@
+"""
+Multiple threads stop at a code address where there is a breakpoint
+at the same time.  Some threads have executed the breakpoint
+instruction and have a stop reason.  Other threads have not yet hit
+the breakpoint instruction.  When lldb resumes execution, only the
+threads that have hit the breakpoint should instruction-step past
+the breakpoint before resuming.
+"""
+
+import re
+import json
+
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+from lldbsuite.test.gdbclientutils import *
+from lldbsuite.test.lldbgdbclient import GDBRemoteTestBase
+
+
+class TestBreakpointNotHit(GDBRemoteTestBase):
+    @skipIfXmlSupportMissing
+    def test(self):
+        BP_ADDR = 0x1004
+        NUM_THREADS = 4
+
+        class MyResponder(MockGDBServerResponder):
+            def __init__(self):
+                MockGDBServerResponder.__init__(self)
+                self.bp_addr = BP_ADDR
+                self.tids = [0x101 + i for i in range(NUM_THREADS)]
+                self.pcs = [0x1000 for _ in range(NUM_THREADS)]
+                self.selected_thread = 0x101
+                self.breakpoints = set()
+                self.second_stop_at_bp_addr = False
+
+                # Threads that have just hit a breakpoint.
+                self.tids_hit_bp = []
+                # Threads that have just completed an instruction step.
+                self.tids_completed_stepi = []
+
+            def qSupported(self, client_supported):
+                return (
+                    "PacketSize=3fff;QStartNoAckMode+;"
+                    "qXfer:features:read+;swbreak+;hwbreak+"
+                )
+
+            def qXferRead(self, obj, annex, offset, length):
+                if annex == "target.xml":
+                    return (
+                        """<?xml version="1.0"?>
+                        <target version="1.0">
+                          <feature name="com.apple.debugserver.arm64">
+                            <reg name="fp" regnum="29" bitsize="64" group="general" generic="fp"/>
+                            <reg name="lr" regnum="30" bitsize="64" group="general" generic="ra"/>
+                            <reg name="sp" regnum="31" bitsize="64" group="general" generic="sp"/>
+                            <reg name="pc" regnum="32" bitsize="64" group="general" generic="pc"/>
+                          </feature>
+                        </target>""",
+                        False,
+                    )
+                return None, False
+
+            def cont(self):
+                # Clear the tid states.
+                self.tids_completed_stepi = []
+                self.tids_hit_bp = []
+                new_pcs = []
+                for idx, tid in enumerate(self.tids):
+                    pc = self.pcs[idx]
+                    # Thread 0x104
+                    #    (1) first stops at BP_ADDR but hasn't hit it.
+                    #       then on next continue,
+                    #    (2) hits the breakpoint at BP_ADDR (pc does not advance).
+                    if (
+                        tid == 0x104
+                        and pc == BP_ADDR
+                        and not self.second_stop_at_bp_addr
+                    ):
+                        self.tids_hit_bp.append(tid)
+                        self.second_stop_at_bp_addr = True
+                        new_pcs.append(pc)
+                    else:
+                        new_pcs.append(pc + 4)
+                    if (pc + 4) == BP_ADDR and tid != 0x104:
+                        self.tids_hit_bp.append(tid)
+                self.pcs = new_pcs
+                return self.haltReason()
+
+            def setBreakpoint(self, packet):
+                bp_data = packet[1:].split(",")
+                self.breakpoints.add(int(bp_data[1], 16))
+                return "OK"
+
+            def clearBreakpoint(self, packet):
+                bp_data = packet[1:].split(",")
+                self.breakpoints.remove(int(bp_data[1], 16))
+                return "OK"
+
+            def qHostInfo(self):
+                return "cputype:16777228;cpusubtype:2;addressing_bits:47;ostype:macosx;watchpoint_exceptions_received:before;vendor:apple;os_version:27.0.0;triple:61726D36342D6170706C652D6D61636F7378;"
+
+            def haltReason(self):
+                threads_str = ",".join("{:x}".format(t) for t in self.tids)
+                pcs_str = ",".join("{:x}".format(p) for p in self.pcs)
+                jstopinfos = []
+                for idx, tid in enumerate(self.tids):
+                    if tid in self.tids_completed_stepi or tid in self.tids_hit_bp:
+                        medata = 0
+                        if tid in self.tids_hit_bp:
+                            medata = self.pcs[idx]
+                        jstopinfos.append(
+                            '{"tid":%d,"metype":6,"medata":[1,%d],"reason":"exception"}'
+                            % (tid, medata)
+                        )
+                response = "T05thread:{:x};threads:{};thread-pcs:{};".format(
+                    self.tids[0], threads_str, pcs_str
+                )
+                if len(jstopinfos) > 0:
+                    json_str = "[%s]" % ",".join(jstopinfos)
+                    response += "jstopinfo:%s;" % json_str.encode().hex()
+                if self.tids[0] in self.tids_hit_bp:
+                    response += "metype:6;mecount:2;medata:1;medata:%x;" % (self.pcs[0])
+                else:
+                    if self.tids[0] in self.tids_completed_stepi:
+                        response += "metype:6;mecount:2;medata:1;medata:0;"
+
+                response += "20:%016x;" % (self.swap64(self.pcs[0]))
+                response += "1d:0000000000000000;"
+                response += "1f:0000000000000000;"
+                return response
+
+            # Register values need to be sent in native-endian (little)
+            def swap64(self, x):
+                return (
+                    ((x << 56) & 0xFF00000000000000)
+                    | ((x << 40) & 0x00FF000000000000)
+                    | ((x << 24) & 0x0000FF0000000000)
+                    | ((x << 8) & 0x000000FF00000000)
+                    | ((x >> 8) & 0x00000000FF000000)
+                    | ((x >> 24) & 0x0000000000FF0000)
+                    | ((x >> 40) & 0x000000000000FF00)
+                    | ((x >> 56) & 0x00000000000000FF)
+                )
+
+            def jThreadsInfo(self):
+                response_array = []
+                for idx, tid in enumerate(self.tids):
+                    this = {}
+                    this["tid"] = tid
+                    if tid in self.tids_hit_bp:
+                        this["metype"] = 6
+                        this["medata"] = [1, self.pcs[idx]]
+                        this["reason"] = "exception"
+                    if tid in self.tids_completed_stepi:
+                        this["metype"] = 6
+                        this["medata"] = [1, 0]
+                        this["reason"] = "exception"
+                    this["registers"] = {
+                        "20": "%016x" % (self.swap64(self.pcs[idx])),
+                        "1d": "0000000000000000",
+                        "1f": "0000000000000000",
+                    }
+                    response_array.append(this)
+                return json.dumps(response_array, indent=2)
+
+            def _handle_vCont(self, packet):
+                self.tids_completed_stepi = []
+                stepping_tids = []
+                tids_hit_a_bp = []
+                # Parse step actions from vCont.
+                for action in packet[6:].split(";"):
+                    if not action:
+                        continue
+                    if action.startswith("s:"):
+                        tid_str = action[2:]
+                        if "." in tid_str:
+                            tid_str = tid_str.split(".")[1]
+                        stepping_tids.append(int(tid_str, 16))
+
+                for idx, tid in enumerate(self.tids):
+                    # If a thread is _at_ a breakpoint instruction
+                    # but hasn't hit yet it, mark it as a breakpoint
+                    # hit and don't advance.
+                    if tid in stepping_tids:
+                        if (
+                            self.pcs[idx] in self.breakpoints
+                            and tid not in self.tids_hit_bp
+                        ):
+                            tids_hit_a_bp.append(tid)
+                        else:
+                            self.pcs[idx] += 4
+                            self.tids_completed_stepi.append(tid)
+                self.tids_hit_bp = tids_hit_a_bp
+
+                return self.haltReason()
+
+            def readRegisters(self):
+                return "00" * (8 * 4)
+
+            def readRegister(self, regno):
+                if self.selected_thread in self.tids and regno == 32:
+                    for idx, tid in enumerate(self.tids):
+                        if tid == self.selected_thread:
+                            return "%016x" % self.swap64(self.pcs[idx])
+                return "00" * 8
+
+            def selectThread(self, op, thread_id):
+                self.selected_thread = thread_id
+                return "OK"
+
+            def other(self, packet):
+                if packet == "vCont?":
+                    return "vCont;c;C;s;S"
+                if packet.startswith("vCont;"):
+                    return self._handle_vCont(packet)
+                return ""
+
+        self.server.responder = MyResponder()
+        if self.TraceOn():
+            self.runCmd("log enable gdb-remote packets")
+            # self.runCmd("log enable -v lldb break")
+            # self.runCmd("log enable -v lldb step")
+            # self.runCmd("log enable -v lldb temp")
+        target = self.dbg.CreateTarget("")
+        process = self.connect(target)
+        self.assertEqual(process.GetNumThreads(), NUM_THREADS)
+
+        bkpt = target.BreakpointCreateByAddress(BP_ADDR)
+        self.assertTrue(bkpt.IsValid())
+        self.runCmd("break list")
+        self.runCmd("thread list")
+
+        # Continue to the breakpoint hit on 3 threads; not on 4th
+        process.Continue()
+
+        self.runCmd("break list")
+        self.runCmd("thread list")
+        self.assertEqual(bkpt.GetHitCount(), 3)
+
+        # Continue the process, which must instruction step
+        # the three threads that have hit the breakpoint, then
+        # resume all threads (and the 4th thread will hit the breakpoint)
+        process.Continue()
+
+        self.runCmd("break list")
+        self.runCmd("thread list")
+        self.assertEqual(bkpt.GetHitCount(), 4)

--- a/lldb/test/API/functionalities/gdb_remote_client/TestMSP430MSPDebug.py
+++ b/lldb/test/API/functionalities/gdb_remote_client/TestMSP430MSPDebug.py
@@ -15,6 +15,9 @@ class MyResponder(MockGDBServerResponder):
     def setBreakpoint(self, packet):
         return "OK"
 
+    def clearBreakpoint(self, packet):
+        return "OK"
+
     def stopPackets():
         # Registers 3 to 15 are empty
         regs3to15 = "".join("%02x:%s;" % (i, "00000000") for i in range(3, 16))

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentManyBreakpoints.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentManyBreakpoints.py
@@ -5,7 +5,6 @@ from lldbsuite.test.lldbtest import TestBase
 
 @requireThreadSupport
 @skipIfWindows
-@skipIf  # See llvm/llvm-project/#205297
 class ConcurrentManyBreakpoints(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.
     @skipIf(triple="^mips")


### PR DESCRIPTION
When a multithreaded program stops exeuction with a mach exception on more than one thread, if one of the threads is *at* a breakpoint site, but hasn't *hit* the breakpoint yet, lldb was incorrectly stepping over the breakpoint instruction when it resumed execution. This would result in TestConcurrentManyBreakpoints reporting that a breakpoint hit on 100 threads was only hit 99 times, because one of the breakpoints was silently stepped past without being counted.

The bug happened because on Darwin/debugserver systems the stop info packet includes a `jstopinfo` which is a JSON dictionary of all threads that have an exception.  When `jstopinfo` is present, ProcessGDBRemote was initializing any thread not included in `jstopinfo` as having an empty StopInfo.  It did this without checking if we are _at_ a breakpoint site, and marking the thread as "Stopped at unexecuted breakpoint instruction".  Because the threads now had an empty StopInfo already, the other places where we might check "if stopped at unexecuted breakpoint instruction" were never executed.

I created a gdb_remote_client API test with a synthetic test case where four threads stop at a breakpoint; three of them have hit the breakpoint, one has not.  And confirm that lldb only registers 3 breakpoint hits initially, and then the 4th as we resume.  Debugging the "99 breakpoints hit instead of 100" failures was tricky and involved running the test in a loop on a heavily loaded machine to get the necessary timing, and it was easy to give up, so I wanted a much simpler synthetic case to show the problem if we might regress.

rdar://180565704