### PR TITLE
Promote BOLT from Office hours to Online Sync-Up

### DIFF
--- a/llvm/docs/GettingInvolved.md
+++ b/llvm/docs/GettingInvolved.md
@@ -257,6 +257,10 @@ what to add to your calendar invite.
      - Every week on Thursday
      -
      - [Meeting notes](https://github.com/llvm/wg-hlsl/tree/main/meetings)
+   * - BOLT
+     - Monthly, 2nd Wednesday of the month at 11:00am PT
+     - [gcal](https://calendar.google.com/calendar/u/0/event?eid=ZjIzMGRsOTFpdWZ0MWkxYjB0M2QzamxtcmRfMjAyNjA5MDlUMTgwMDAwWiBjYWxlbmRhckBsbHZtLm9yZw)
+     - [Meeting notes/agenda](https://docs.google.com/document/d/17Ivx8tyvUkRT3h78RJSQdDabAtBvpbtGQI-atdPmXE8/edit?usp=sharing)
 ```
 
 For event owners, our Discord bot also supports sending automated announcements
@@ -359,11 +363,6 @@ The {doc}`CodeOfConduct` applies to all office hours.
     - SYCL compiler, offload tools, OpenCL and SPIR-V, how to contribute.
     - Monthly, 2nd Monday of the month at 9:30am PT, for 30 minutes.
     - [GoogleMeet](https://meet.google.com/pdz-xhns-uus)
-    - English, Russian
-  * - Maksim Panchenko
-    - BOLT internals, IR, new passes, proposals, etc.
-    - Monthly, 2nd Wednesday of the month at 11:00am PT, for 30 minutes.
-    - [Zoom](https://fb.zoom.us/j/97358910859?pwd=FamcLANMN7umLlFTTTkqXUCAG81SH0.1)
     - English, Russian
   * - Quentin Colombet (he/him)
     - LLVM/MLIR; Codegen (Instruction selection (GlobalISel/SDISel), Machine IR,


### PR DESCRIPTION
Office hours are intended for chats with individual contributors:
> A number of experienced LLVM contributors make themselves available for a chat on a regular schedule, to anyone who is looking for some guidance.

BOLT community has outgrown office hours format and has been operating as sync-up.
Reflect that in the Getting Involved page.