### PR TITLE
[AMDGPU] Add missing attributes to llvm.amdgcn.init.whole.wave

### DIFF
--- a/llvm/include/llvm/IR/IntrinsicsAMDGPU.td
+++ b/llvm/include/llvm/IR/IntrinsicsAMDGPU.td
@@ -247,7 +247,7 @@ def int_amdgcn_init_exec_from_input : Intrinsic<[],
 // (mostly related to WWM CSR handling) that differentiate it from using
 // a plain `amdgcn.init.exec -1`.
 def int_amdgcn_init_whole_wave : Intrinsic<[llvm_i1_ty], [], [
-    IntrHasSideEffects, IntrNoMem, IntrConvergent]>;
+    IntrHasSideEffects, IntrNoMem, IntrConvergent, IntrNoCallback, IntrNoFree, IntrWillReturn]>;
 
 def int_amdgcn_wavefrontsize
     : ClangBuiltin<"__builtin_amdgcn_wavefrontsize">,


### PR DESCRIPTION
`llvm.amdgcn.init.whole.wave` only sets the EXEC mask and reports whether the lane was active on entry. It never calls into the module, never frees memory, and always returns, so it can carry `nocallback`, `nofree`, and `willreturn`.

The neighboring `llvm.amdgcn.init.exec` and `llvm.amdgcn.init.exec.from.input` already have all three; this brings `init.whole.wave` in line and lets the attributor propagate them to callers.