### PR TITLE
[RISCV] Remove TuneHasSingleElementVecFP64 has a configurable tune feature for sifive-x180.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVProcessors.td
+++ b/llvm/lib/Target/RISCV/RISCVProcessors.td
@@ -448,9 +448,7 @@ def SIFIVE_X180 : RISCVProcessorModel<"sifive-x180",
                                        FeatureStdExtZicfilp,
                                        FeatureStdExtZvdot4a8i,
                                        FeatureStdExtZvfbfa],
-                                       SiFiveIntelligenceTuneFeatures> {
-  let ConfigurableTuneFeatures = [TuneHasSingleElementVecFP64];
-}
+                                       SiFiveIntelligenceTuneFeatures>;
 
 defvar SiFiveP400TuneFeatures = [TuneNoDefaultUnroll,
                                  TuneConditionalCompressedMoveFusion,

--- a/llvm/unittests/TargetParser/RISCVTargetParserTest.cpp
+++ b/llvm/unittests/TargetParser/RISCVTargetParserTest.cpp
@@ -238,12 +238,6 @@ TEST(RISCVTuneFeature, AllProcConfigurableFeatures) {
   EXPECT_EQ(Result.size(), 2U);
 
   Result.clear();
-  RISCV::getCPUConfigurableTuneFeatures("sifive-x180", Result);
-  EXPECT_TRUE(is_contained(Result, "single-element-vec-fp64"));
-  EXPECT_TRUE(is_contained(Result, "full-vec-fp64"));
-  EXPECT_EQ(Result.size(), 2U);
-
-  Result.clear();
   RISCV::getCPUConfigurableTuneFeatures("rocket", Result);
   EXPECT_TRUE(Result.empty());
 }


### PR DESCRIPTION
X180 is a DLEN=64 CPU with 1 vector ALU. By definition it is always single element FP64.