### PR TITLE
[libc] Implement umask

### DIFF
--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -350,6 +350,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.sys.stat.mkdir
     libc.src.sys.stat.mkdirat
     libc.src.sys.stat.stat
+    libc.src.sys.stat.umask
     libc.src.sys.stat.utimensat
 
     # sys/statfs.h entrypoints

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -381,6 +381,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.sys.stat.mkdir
     libc.src.sys.stat.mkdirat
     libc.src.sys.stat.stat
+    libc.src.sys.stat.umask
     libc.src.sys.stat.utimensat
 
     # sys/statfs.h entrypoints

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -386,6 +386,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.sys.stat.mkdir
     libc.src.sys.stat.mkdirat
     libc.src.sys.stat.stat
+    libc.src.sys.stat.umask
     libc.src.sys.stat.utimensat
 
     # sys/statfs.h entrypoints

--- a/libc/include/sys/stat.yaml
+++ b/libc/include/sys/stat.yaml
@@ -63,6 +63,10 @@ functions:
     arguments:
       - type: const char *__restrict
       - type: struct stat *__restrict
+  - name: umask
+    return_type: mode_t
+    arguments:
+      - type: mode_t
   - name: utimensat
     return_type: int
     arguments:

--- a/libc/src/__support/OSUtil/linux/syscall_wrappers/CMakeLists.txt
+++ b/libc/src/__support/OSUtil/linux/syscall_wrappers/CMakeLists.txt
@@ -1251,3 +1251,15 @@ add_header_library(
     libc.src.__support.macros.config
     libc.include.sys_syscall
 )
+
+add_header_library(
+  umask
+  HDRS
+    umask.h
+  DEPENDS
+    libc.hdr.types.mode_t
+    libc.include.sys_syscall
+    libc.src.__support.common
+    libc.src.__support.macros.config
+    libc.src.__support.OSUtil.osutil
+)

--- a/libc/src/__support/OSUtil/linux/syscall_wrappers/umask.h
+++ b/libc/src/__support/OSUtil/linux/syscall_wrappers/umask.h
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Syscall wrapper for umask.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_UMASK_H
+#define LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_UMASK_H
+
+#include "hdr/types/mode_t.h"
+#include "src/__support/OSUtil/linux/syscall.h" // syscall_impl
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+#include <sys/syscall.h> // For syscall numbers
+
+namespace LIBC_NAMESPACE_DECL {
+namespace linux_syscalls {
+
+LIBC_INLINE mode_t umask(mode_t cmask) {
+  // umask is expected to always succeed, thus no error checking here.
+  return syscall_impl<mode_t>(SYS_umask, cmask);
+}
+
+} // namespace linux_syscalls
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_UMASK_H

--- a/libc/src/sys/stat/CMakeLists.txt
+++ b/libc/src/sys/stat/CMakeLists.txt
@@ -59,6 +59,13 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
+  umask
+  ALIAS
+  DEPENDS
+    .${LIBC_TARGET_OS}.umask
+)
+
+add_entrypoint_object(
   utimensat
   ALIAS
   DEPENDS

--- a/libc/src/sys/stat/linux/CMakeLists.txt
+++ b/libc/src/sys/stat/linux/CMakeLists.txt
@@ -127,3 +127,15 @@ add_entrypoint_object(
     libc.src.__support.common
     libc.src.errno.errno
 )
+
+add_entrypoint_object(
+  umask
+  SRCS
+    umask.cpp
+  HDRS
+    ../umask.h
+  DEPENDS
+    libc.hdr.types.mode_t
+    libc.src.__support.OSUtil.linux.syscall_wrappers.umask
+    libc.src.__support.common
+)

--- a/libc/src/sys/stat/linux/umask.cpp
+++ b/libc/src/sys/stat/linux/umask.cpp
@@ -1,0 +1,22 @@
+//===-- Linux implementation of umask -------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/sys/stat/umask.h"
+
+#include "hdr/types/mode_t.h"
+#include "src/__support/OSUtil/linux/syscall_wrappers/umask.h"
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(mode_t, umask, (mode_t cmask)) {
+  return linux_syscalls::umask(cmask);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/sys/stat/linux/umask.cpp
+++ b/libc/src/sys/stat/linux/umask.cpp
@@ -1,9 +1,14 @@
-//===-- Linux implementation of umask -------------------------------------===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+//===----------------------------------------------------------------------===//
+///
+/// ile
+/// Linux implementation of umask.
+///
 //===----------------------------------------------------------------------===//
 
 #include "src/sys/stat/umask.h"

--- a/libc/src/sys/stat/umask.h
+++ b/libc/src/sys/stat/umask.h
@@ -1,9 +1,14 @@
-//===-- Implementation header for umask -------------------------*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+//===----------------------------------------------------------------------===//
+///
+/// ile
+/// Implementation header for umask.
+///
 //===----------------------------------------------------------------------===//
 
 #ifndef LLVM_LIBC_SRC_SYS_STAT_UMASK_H

--- a/libc/src/sys/stat/umask.h
+++ b/libc/src/sys/stat/umask.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for umask -------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_SYS_STAT_UMASK_H
+#define LLVM_LIBC_SRC_SYS_STAT_UMASK_H
+
+#include "hdr/types/mode_t.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+mode_t umask(mode_t cmask);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_SYS_STAT_UMASK_H

--- a/libc/test/src/sys/stat/CMakeLists.txt
+++ b/libc/test/src/sys/stat/CMakeLists.txt
@@ -184,16 +184,9 @@ add_libc_test(
   SRCS
     umask_test.cpp
   DEPENDS
-    libc.hdr.fcntl_macros
     libc.hdr.sys_stat_macros
     libc.hdr.types.mode_t
-    libc.hdr.types.struct_stat
     libc.src.errno.errno
     libc.src.sys.stat.umask
-    libc.src.sys.stat.fstat
-    libc.src.fcntl.open
-    libc.src.unistd.close
-    libc.src.unistd.unlink
     libc.test.UnitTest.ErrnoCheckingTest
-    libc.test.UnitTest.ErrnoSetterMatcher
 )

--- a/libc/test/src/sys/stat/CMakeLists.txt
+++ b/libc/test/src/sys/stat/CMakeLists.txt
@@ -176,3 +176,24 @@ add_libc_test(
     libc.test.UnitTest.ErrnoCheckingTest
     libc.test.UnitTest.ErrnoSetterMatcher
 )
+
+add_libc_test(
+  umask_test
+  SUITE
+    libc_sys_stat_unittests
+  SRCS
+    umask_test.cpp
+  DEPENDS
+    libc.hdr.fcntl_macros
+    libc.hdr.sys_stat_macros
+    libc.hdr.types.mode_t
+    libc.hdr.types.struct_stat
+    libc.src.errno.errno
+    libc.src.sys.stat.umask
+    libc.src.sys.stat.fstat
+    libc.src.fcntl.open
+    libc.src.unistd.close
+    libc.src.unistd.unlink
+    libc.test.UnitTest.ErrnoCheckingTest
+    libc.test.UnitTest.ErrnoSetterMatcher
+)

--- a/libc/test/src/sys/stat/umask_test.cpp
+++ b/libc/test/src/sys/stat/umask_test.cpp
@@ -1,0 +1,93 @@
+//===-- Unittests for umask -----------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "hdr/fcntl_macros.h"
+#include "hdr/sys_stat_macros.h"
+#include "hdr/types/mode_t.h"
+#include "hdr/types/struct_stat.h"
+#include "src/fcntl/open.h"
+#include "src/sys/stat/fstat.h"
+#include "src/sys/stat/umask.h"
+#include "src/unistd/close.h"
+#include "src/unistd/unlink.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
+#include "test/UnitTest/ErrnoSetterMatcher.h"
+#include "test/UnitTest/Test.h"
+
+using namespace LIBC_NAMESPACE::testing::ErrnoSetterMatcher;
+using LlvmLibcUmaskTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
+
+// umask cannot fail (POSIX: "shall always be successful"), so there is no
+// error-path test here.
+
+TEST_F(LlvmLibcUmaskTest, SetAndGetPrevious) {
+  // Each call must return the mask installed by the previous one. Three
+  // distinct values are used so that no assertion degenerates into a tautology
+  // if the inherited umask happens to equal one of them.
+  mode_t original = LIBC_NAMESPACE::umask(S_IRWXG | S_IRWXO);
+  EXPECT_EQ(LIBC_NAMESPACE::umask(S_IWGRP | S_IWOTH),
+            static_cast<mode_t>(S_IRWXG | S_IRWXO));
+  EXPECT_EQ(LIBC_NAMESPACE::umask(S_IRWXO),
+            static_cast<mode_t>(S_IWGRP | S_IWOTH));
+
+  // umask must not touch errno.
+  libc_errno = EDOM;
+  LIBC_NAMESPACE::umask(original); // also restores the inherited mask
+  ASSERT_ERRNO_EQ(EDOM);           // ASSERT_ERRNO_EQ resets errno afterwards
+}
+
+TEST_F(LlvmLibcUmaskTest, AffectsCreatedFilePermissions) {
+  // Both cases are required: a single mask can coincide with the process's
+  // inherited umask, letting an implementation that ignores its argument pass.
+  constexpr mode_t ALL_PERMS = S_IRWXU | S_IRWXG | S_IRWXO;
+
+  { // umask 0022 -> 0755
+    auto TEST_FILE = libc_make_test_file_path("testdata/umask_0022.test");
+    LIBC_NAMESPACE::unlink(TEST_FILE); // best-effort: drop a stale file
+    libc_errno = 0;
+
+    mode_t old_mask = LIBC_NAMESPACE::umask(S_IWGRP | S_IWOTH);
+    int fd =
+        LIBC_NAMESPACE::open(TEST_FILE, O_CREAT | O_EXCL | O_WRONLY, ALL_PERMS);
+    LIBC_NAMESPACE::umask(old_mask); // restore right after the file is created
+    ASSERT_GE(fd, 0);
+    ASSERT_ERRNO_SUCCESS();
+
+    struct stat statbuf;
+    ASSERT_THAT(LIBC_NAMESPACE::fstat(fd, &statbuf), Succeeds(0));
+    EXPECT_EQ(
+        statbuf.st_mode & ALL_PERMS,
+        static_cast<mode_t>(S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH));
+    EXPECT_EQ(statbuf.st_mode & static_cast<mode_t>(S_IFMT),
+              static_cast<mode_t>(S_IFREG));
+
+    ASSERT_THAT(LIBC_NAMESPACE::close(fd), Succeeds(0));
+    ASSERT_THAT(LIBC_NAMESPACE::unlink(TEST_FILE), Succeeds(0));
+  }
+  { // umask 0077 -> 0700
+    auto TEST_FILE = libc_make_test_file_path("testdata/umask_0077.test");
+    LIBC_NAMESPACE::unlink(TEST_FILE); // best-effort: drop a stale file
+    libc_errno = 0;
+
+    mode_t old_mask = LIBC_NAMESPACE::umask(S_IRWXG | S_IRWXO);
+    int fd =
+        LIBC_NAMESPACE::open(TEST_FILE, O_CREAT | O_EXCL | O_WRONLY, ALL_PERMS);
+    LIBC_NAMESPACE::umask(old_mask); // restore right after the file is created
+    ASSERT_GE(fd, 0);
+    ASSERT_ERRNO_SUCCESS();
+
+    struct stat statbuf;
+    ASSERT_THAT(LIBC_NAMESPACE::fstat(fd, &statbuf), Succeeds(0));
+    EXPECT_EQ(statbuf.st_mode & ALL_PERMS, static_cast<mode_t>(S_IRWXU));
+    EXPECT_EQ(statbuf.st_mode & static_cast<mode_t>(S_IFMT),
+              static_cast<mode_t>(S_IFREG));
+
+    ASSERT_THAT(LIBC_NAMESPACE::close(fd), Succeeds(0));
+    ASSERT_THAT(LIBC_NAMESPACE::unlink(TEST_FILE), Succeeds(0));
+  }
+}

--- a/libc/test/src/sys/stat/umask_test.cpp
+++ b/libc/test/src/sys/stat/umask_test.cpp
@@ -1,93 +1,28 @@
-//===-- Unittests for umask -----------------------------------------------===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+///
+/// \file
+/// Unittests for umask.
+///
+//===----------------------------------------------------------------------===//
 
-#include "hdr/fcntl_macros.h"
 #include "hdr/sys_stat_macros.h"
 #include "hdr/types/mode_t.h"
-#include "hdr/types/struct_stat.h"
-#include "src/fcntl/open.h"
-#include "src/sys/stat/fstat.h"
 #include "src/sys/stat/umask.h"
-#include "src/unistd/close.h"
-#include "src/unistd/unlink.h"
 #include "test/UnitTest/ErrnoCheckingTest.h"
-#include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
 
-using namespace LIBC_NAMESPACE::testing::ErrnoSetterMatcher;
 using LlvmLibcUmaskTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
-// umask cannot fail (POSIX: "shall always be successful"), so there is no
-// error-path test here.
-
-TEST_F(LlvmLibcUmaskTest, SetAndGetPrevious) {
-  // Each call must return the mask installed by the previous one. Three
-  // distinct values are used so that no assertion degenerates into a tautology
-  // if the inherited umask happens to equal one of them.
-  mode_t original = LIBC_NAMESPACE::umask(S_IRWXG | S_IRWXO);
-  EXPECT_EQ(LIBC_NAMESPACE::umask(S_IWGRP | S_IWOTH),
+TEST_F(LlvmLibcUmaskTest, SmokeTest) {
+  // umask() always succeeds and returns the previous mask. Set a mask, then
+  // restore the original one and check that the mask we set is handed back.
+  mode_t old_mask = LIBC_NAMESPACE::umask(S_IRWXG | S_IRWXO);
+  EXPECT_EQ(LIBC_NAMESPACE::umask(old_mask),
             static_cast<mode_t>(S_IRWXG | S_IRWXO));
-  EXPECT_EQ(LIBC_NAMESPACE::umask(S_IRWXO),
-            static_cast<mode_t>(S_IWGRP | S_IWOTH));
-
-  // umask must not touch errno.
-  libc_errno = EDOM;
-  LIBC_NAMESPACE::umask(original); // also restores the inherited mask
-  ASSERT_ERRNO_EQ(EDOM);           // ASSERT_ERRNO_EQ resets errno afterwards
-}
-
-TEST_F(LlvmLibcUmaskTest, AffectsCreatedFilePermissions) {
-  // Both cases are required: a single mask can coincide with the process's
-  // inherited umask, letting an implementation that ignores its argument pass.
-  constexpr mode_t ALL_PERMS = S_IRWXU | S_IRWXG | S_IRWXO;
-
-  { // umask 0022 -> 0755
-    auto TEST_FILE = libc_make_test_file_path("testdata/umask_0022.test");
-    LIBC_NAMESPACE::unlink(TEST_FILE); // best-effort: drop a stale file
-    libc_errno = 0;
-
-    mode_t old_mask = LIBC_NAMESPACE::umask(S_IWGRP | S_IWOTH);
-    int fd =
-        LIBC_NAMESPACE::open(TEST_FILE, O_CREAT | O_EXCL | O_WRONLY, ALL_PERMS);
-    LIBC_NAMESPACE::umask(old_mask); // restore right after the file is created
-    ASSERT_GE(fd, 0);
-    ASSERT_ERRNO_SUCCESS();
-
-    struct stat statbuf;
-    ASSERT_THAT(LIBC_NAMESPACE::fstat(fd, &statbuf), Succeeds(0));
-    EXPECT_EQ(
-        statbuf.st_mode & ALL_PERMS,
-        static_cast<mode_t>(S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH));
-    EXPECT_EQ(statbuf.st_mode & static_cast<mode_t>(S_IFMT),
-              static_cast<mode_t>(S_IFREG));
-
-    ASSERT_THAT(LIBC_NAMESPACE::close(fd), Succeeds(0));
-    ASSERT_THAT(LIBC_NAMESPACE::unlink(TEST_FILE), Succeeds(0));
-  }
-  { // umask 0077 -> 0700
-    auto TEST_FILE = libc_make_test_file_path("testdata/umask_0077.test");
-    LIBC_NAMESPACE::unlink(TEST_FILE); // best-effort: drop a stale file
-    libc_errno = 0;
-
-    mode_t old_mask = LIBC_NAMESPACE::umask(S_IRWXG | S_IRWXO);
-    int fd =
-        LIBC_NAMESPACE::open(TEST_FILE, O_CREAT | O_EXCL | O_WRONLY, ALL_PERMS);
-    LIBC_NAMESPACE::umask(old_mask); // restore right after the file is created
-    ASSERT_GE(fd, 0);
-    ASSERT_ERRNO_SUCCESS();
-
-    struct stat statbuf;
-    ASSERT_THAT(LIBC_NAMESPACE::fstat(fd, &statbuf), Succeeds(0));
-    EXPECT_EQ(statbuf.st_mode & ALL_PERMS, static_cast<mode_t>(S_IRWXU));
-    EXPECT_EQ(statbuf.st_mode & static_cast<mode_t>(S_IFMT),
-              static_cast<mode_t>(S_IFREG));
-
-    ASSERT_THAT(LIBC_NAMESPACE::close(fd), Succeeds(0));
-    ASSERT_THAT(LIBC_NAMESPACE::unlink(TEST_FILE), Succeeds(0));
-  }
 }


### PR DESCRIPTION
Implement the POSIX umask() entrypoint for Linux and register it for
aarch64, riscv and x86_64. umask cannot fail, so the syscall wrapper
returns mode_t directly and the entrypoint does not touch errno.

Fixes #220759

Assisted-by: Claude Code
