### PR TITLE
[docs] Check for absolute self-documentation links

### DIFF
--- a/utils/docs/__main__.py
+++ b/utils/docs/__main__.py
@@ -7,20 +7,38 @@ Use this as e.g. `python utils/docs --test` to run docs smoke tests.
 
 import sys
 import argparse
-from llvm_sphinx.ext import ghlinks
+import subprocess
+from pathlib import Path
+
+from llvm_sphinx.ext import absolute_links, ghlinks
 from typing import List
 
 
 def main(argv: List[str]) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--test", action="store_true", help="run sphinx self-tests")
+    parser.add_argument(
+        "--test-component",
+        choices=("absolute-links", "ghlinks"),
+        help=argparse.SUPPRESS,
+    )
     args = parser.parse_args(argv)
 
     if args.test:
+        script = Path(__file__).resolve()
+        for component in ("absolute-links", "ghlinks"):
+            subprocess.run(
+                [sys.executable, str(script), "--test-component", component],
+                check=True,
+            )
+        print("llvm_sphinx: tests passed; next, rebuild the affected project docs")
+        return 0
+
+    if args.test_component == "absolute-links":
+        absolute_links.run_tests()
+        return 0
+    if args.test_component == "ghlinks":
         ghlinks.run_tests()
-        print(
-            "ghlinks.py: tests passed; next, rebuild docs-clang-html and spot check the release notes"
-        )
         return 0
 
     parser.print_help(sys.stderr)

--- a/utils/docs/llvm_sphinx/ext/absolute_links.py
+++ b/utils/docs/llvm_sphinx/ext/absolute_links.py
@@ -1,0 +1,152 @@
+# -*- coding: utf-8 -*-
+
+"""Check for absolute links to documents in the current Sphinx project."""
+
+import io
+import sys
+import tempfile
+from pathlib import Path
+from typing import Collection, Dict, Optional, Sequence, Tuple
+from urllib.parse import unquote, urlsplit
+
+from llvm_sphinx.help import venv_help
+
+try:
+    from docutils import nodes
+    from sphinx.application import Sphinx
+    from sphinx.util import logging
+except ImportError as err:
+    print(venv_help(err), file=sys.stderr)
+    raise
+
+__version__ = "1.0"
+
+logger = logging.getLogger("llvm_sphinx.ext.absolute_links")
+
+
+def setup(app: Sphinx) -> Dict[str, object]:
+    app.add_config_value("llvm_sphinx_doc_url_prefixes", (), "env", [list, tuple])
+    app.connect("doctree-read", check_absolute_doc_links)
+    return {
+        "version": __version__,
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }
+
+
+def _url_prefix_parts(prefix: str) -> Optional[Tuple[str, str]]:
+    try:
+        parsed = urlsplit(prefix)
+        port = parsed.port
+    except ValueError:
+        return None
+    if parsed.scheme not in ("http", "https") or not parsed.hostname:
+        return None
+    if port not in (None, 80, 443):
+        return None
+    path = parsed.path
+    if not path.endswith("/"):
+        path += "/"
+    return parsed.hostname.lower(), path
+
+
+def _docname_from_url(
+    uri: str, prefixes: Sequence[str], found_docs: Collection[str]
+) -> Optional[str]:
+    try:
+        parsed = urlsplit(uri)
+        port = parsed.port
+    except ValueError:
+        return None
+    if (
+        parsed.scheme not in ("http", "https")
+        or not parsed.hostname
+        or port not in (None, 80, 443)
+    ):
+        return None
+
+    hostname = parsed.hostname.lower()
+    path = unquote(parsed.path)
+    for prefix in prefixes:
+        prefix_parts = _url_prefix_parts(prefix)
+        if prefix_parts is None:
+            continue
+        prefix_hostname, prefix_path = prefix_parts
+        if hostname != prefix_hostname or not path.startswith(prefix_path):
+            continue
+
+        relative_path = path[len(prefix_path) :]
+        if not relative_path:
+            docname = "index"
+        elif relative_path.endswith(".html"):
+            docname = relative_path[: -len(".html")]
+        elif relative_path.endswith("/"):
+            docname = relative_path + "index"
+        else:
+            continue
+
+        if docname in found_docs:
+            return docname
+    return None
+
+
+def check_absolute_doc_links(app: Sphinx, doctree: nodes.document) -> None:
+    """Diagnose absolute URLs that name documents in this Sphinx project."""
+    prefixes = app.config.llvm_sphinx_doc_url_prefixes
+    if not prefixes:
+        return
+
+    for node in doctree.findall(nodes.reference):
+        uri = node.get("refuri")
+        if not uri:
+            continue
+        docname = _docname_from_url(uri, prefixes, app.env.found_docs)
+        if docname is None:
+            continue
+        logger.warning(
+            "absolute URL points to document %r in this Sphinx project; "
+            "use an internal 'doc' or 'ref' role instead: %s",
+            docname,
+            uri,
+            location=node,
+            type="llvm_sphinx",
+            subtype="absolute-doc-link",
+        )
+
+
+# -----------------------------------------------------------------------------
+# Test code only below:
+# -----------------------------------------------------------------------------
+def _build_test_docs() -> str:
+    """Build the reST and Markdown test inputs and return Sphinx warnings."""
+    srcdir = Path(__file__).resolve().parent / "absolute_links_test"
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        warnings = io.StringIO()
+        app = Sphinx(
+            srcdir=srcdir,
+            confdir=srcdir,
+            outdir=tmp_path / "out",
+            doctreedir=tmp_path / "doctrees",
+            buildername="html",
+            freshenv=True,
+            warningiserror=False,
+            status=None,
+            warning=warnings,
+        )
+        app.build()
+        return warnings.getvalue()
+
+
+def run_tests() -> None:
+    warnings = _build_test_docs()
+    expected_urls = (
+        "https://example.test/docs/target.html#target-section",
+        "https://example.test/docs/",
+        "http://www.example.test/docs/target.html?view=1#target-section",
+    )
+    for url in expected_urls:
+        if url not in warnings:
+            raise AssertionError(f"expected a warning for {url}")
+    if warnings.count("absolute URL points to document") != len(expected_urls):
+        raise AssertionError(f"unexpected Sphinx warnings:\n{warnings}")

--- a/utils/docs/llvm_sphinx/ext/absolute_links_test/conf.py
+++ b/utils/docs/llvm_sphinx/ext/absolute_links_test/conf.py
@@ -1,0 +1,11 @@
+extensions = ["llvm_sphinx.ext.absolute_links", "myst_parser"]
+master_doc = "index"
+project = "absolute links test"
+source_suffix = {
+    ".rst": "restructuredtext",
+    ".md": "markdown",
+}
+llvm_sphinx_doc_url_prefixes = (
+    "https://example.test/docs/",
+    "https://www.example.test/docs/",
+)

--- a/utils/docs/llvm_sphinx/ext/absolute_links_test/index.rst
+++ b/utils/docs/llvm_sphinx/ext/absolute_links_test/index.rst
@@ -1,0 +1,8 @@
+Absolute Link Tests
+===================
+
+.. toctree::
+
+   rest
+   markdown
+   target

--- a/utils/docs/llvm_sphinx/ext/absolute_links_test/markdown.md
+++ b/utils/docs/llvm_sphinx/ext/absolute_links_test/markdown.md
@@ -1,0 +1,10 @@
+# Markdown Absolute Link Tests
+
+This [absolute link](http://www.example.test/docs/target.html?view=1#target-section)
+points into this Sphinx project.
+
+These links should not warn:
+
+- [another project](https://other.example.test/docs/target.html)
+- [a nonexistent document](https://example.test/docs/missing.html)
+- [a non-document page](https://example.test/docs/downloads/package.tar.xz)

--- a/utils/docs/llvm_sphinx/ext/absolute_links_test/rest.rst
+++ b/utils/docs/llvm_sphinx/ext/absolute_links_test/rest.rst
@@ -1,0 +1,12 @@
+reST Absolute Link Tests
+========================
+
+This `absolute link <https://example.test/docs/target.html#target-section>`_
+points into this Sphinx project.
+The `project root <https://example.test/docs/>`_ does too.
+
+These links should not warn:
+
+* `another project <https://other.example.test/docs/target.html>`_
+* `a nonexistent document <https://example.test/docs/missing.html>`_
+* `a non-document page <https://example.test/docs/downloads/package.tar.xz>`_

--- a/utils/docs/llvm_sphinx/ext/absolute_links_test/target.md
+++ b/utils/docs/llvm_sphinx/ext/absolute_links_test/target.md
@@ -1,0 +1,5 @@
+# Target Document
+
+(target-section)=
+
+## Target Section

--- a/utils/docs/llvm_sphinx/ext/checks.py
+++ b/utils/docs/llvm_sphinx/ext/checks.py
@@ -2,18 +2,18 @@
 
 """Sphinx extension for llvm-project checks/lints.
 
-Enable by adding "llvm_sphinx.checks" to the sphinx `extensions` list.
+Enable by adding "llvm_sphinx.ext.checks" to the Sphinx `extensions` list.
 """
 
 import sys
 from typing import Dict, List
+
 from llvm_sphinx.help import venv_help
 
 try:
     from sphinx.application import Sphinx
     from sphinx.environment import BuildEnvironment
     from sphinx.util import logging
-    from sphinx.errors import ExtensionError
 except ImportError as err:
     print(venv_help(err), file=sys.stderr)
     raise


### PR DESCRIPTION
Add an opt-in llvm_sphinx check that diagnoses absolute links to
documents in the current Sphinx project. Operate on the parsed doctree
so the check works for both reStructuredText and MyST without flagging
examples in literal blocks.

For example, restoring one absolute link in the LLVM documentation makes
a warnings-as-errors build report:

    llvm/docs/ReleaseNotes.md:321: WARNING: absolute URL points to document
    'index' in this Sphinx project; use an internal 'doc' or 'ref' role
    instead: https://llvm.org/docs/ [llvm_sphinx.absolute-doc-link]

Part of #214861

Assisted-by: codex
