### PR TITLE
[Inline] Do not extend musttail call dispatch chains

### DIFF
--- a/llvm/lib/Analysis/InlineCost.cpp
+++ b/llvm/lib/Analysis/InlineCost.cpp
@@ -387,6 +387,7 @@ protected:
   bool ContainsNoDuplicateCall = false;
   bool HasReturn = false;
   bool HasIndirectBr = false;
+  bool HasIndirectMustTailCall = false;
   bool HasUninlineableIntrinsic = false;
   bool InitsVargArgs = false;
 
@@ -2494,6 +2495,11 @@ bool CallAnalyzer::visitCallBase(CallBase &Call) {
     Value *Callee = Call.getCalledOperand();
     F = getSimplifiedValue<Function>(Callee);
     if (!F || F->getFunctionType() != Call.getFunctionType()) {
+      // The callee ends in a tail call to an unknown target, so inlining it
+      // will not remove the call, it will only move it into the caller.
+      if (Call.isMustTailCall())
+        HasIndirectMustTailCall = true;
+
       onCallArgumentSetup(Call);
 
       if (!Call.onlyReadsMemory())
@@ -3044,6 +3050,18 @@ InlineResult CallAnalyzer::analyze() {
   // is not actually duplicated, just moved).
   if (!isSoleCallToLocalFunction(CandidateCall, F) && ContainsNoDuplicateCall)
     return InlineResult::failure("noduplicate");
+
+  // Inlining a musttail call whose callee ends in an indirect musttail call
+  // just extends a tail call dispatch chain: the caller keeps ending in the
+  // same indirect tail call it would have jumped to, so no call is removed,
+  // and the callee body is duplicated into every caller of the chain. Threaded
+  // interpreters, where PGO promotes the dispatch and the inliner then chains
+  // handler after handler, are the pathological case. Inlining the sole call
+  // to a local function is still fine, as that moves the body rather than
+  // duplicating it.
+  if (CandidateCall.isMustTailCall() && HasIndirectMustTailCall &&
+      !isSoleCallToLocalFunction(CandidateCall, F))
+    return InlineResult::failure("musttail dispatch chain");
 
   // If the callee's stack size exceeds the user-specified threshold,
   // do not let it be inlined.

--- a/llvm/test/Transforms/Inline/musttail-dispatch-chain.ll
+++ b/llvm/test/Transforms/Inline/musttail-dispatch-chain.ll
@@ -1,0 +1,102 @@
+; Check that a musttail call is not inlined when the callee itself ends in an
+; indirect musttail call, i.e. when inlining would only extend a tail call
+; dispatch chain, as found in threaded interpreters.
+
+; RUN: opt < %s -passes=inline -S | FileCheck %s
+
+declare ptr @get_handler(ptr)
+
+; The dispatch site has been promoted to a direct musttail call to @handler_b
+; guarded by a compare, with the original indirect call as the fallback.
+
+define i64 @handler_a(ptr %pc, ptr %regs) {
+; CHECK-LABEL: define i64 @handler_a(
+; CHECK-NOT: musttail call i64 @handler_c
+; CHECK: musttail call i64 @handler_b(
+entry:
+  %next = call ptr @get_handler(ptr %pc)
+  %cmp = icmp eq ptr %next, @handler_b
+  br i1 %cmp, label %direct, label %indirect
+
+direct:
+  %ret0 = musttail call i64 @handler_b(ptr %pc, ptr %regs)
+  ret i64 %ret0
+
+indirect:
+  %ret1 = musttail call i64 %next(ptr %pc, ptr %regs)
+  ret i64 %ret1
+}
+
+define i64 @handler_b(ptr %pc, ptr %regs) {
+; CHECK-LABEL: define i64 @handler_b(
+entry:
+  %next = call ptr @get_handler(ptr %pc)
+  %cmp = icmp eq ptr %next, @handler_c
+  br i1 %cmp, label %direct, label %indirect
+
+direct:
+  %ret0 = musttail call i64 @handler_c(ptr %pc, ptr %regs)
+  ret i64 %ret0
+
+indirect:
+  %ret1 = musttail call i64 %next(ptr %pc, ptr %regs)
+  ret i64 %ret1
+}
+
+define i64 @handler_c(ptr %pc, ptr %regs) {
+; CHECK-LABEL: define i64 @handler_c(
+entry:
+  %next = call ptr @get_handler(ptr %pc)
+  %ret = musttail call i64 %next(ptr %pc, ptr %regs)
+  ret i64 %ret
+}
+
+; A callee that ends in an indirect musttail call is still inlined into a call
+; site that is not itself a musttail call: no dispatch chain is extended there.
+
+define i64 @run(ptr %pc, ptr %regs) {
+; CHECK-LABEL: define i64 @run(
+; CHECK-NOT: call i64 @handler_c(
+entry:
+  %ret = call i64 @handler_c(ptr %pc, ptr %regs)
+  ret i64 %ret
+}
+
+; A musttail callee whose own tail call is direct is a bounded chain and is
+; still inlined.
+
+define i64 @tail_to_direct(ptr %pc, ptr %regs) {
+; CHECK-LABEL: define i64 @tail_to_direct(
+; CHECK-NOT: musttail call i64 @direct_leaf(
+; CHECK: musttail call i64 @leaf(
+entry:
+  %ret = musttail call i64 @direct_leaf(ptr %pc, ptr %regs)
+  ret i64 %ret
+}
+
+define i64 @direct_leaf(ptr %pc, ptr %regs) {
+entry:
+  %ret = musttail call i64 @leaf(ptr %pc, ptr %regs)
+  ret i64 %ret
+}
+
+declare i64 @leaf(ptr, ptr)
+
+; Inlining the sole call to a local function moves its body rather than
+; duplicating it, so the dispatch chain is not extended and inlining happens.
+
+define i64 @sole_caller(ptr %pc, ptr %regs) {
+; CHECK-LABEL: define i64 @sole_caller(
+; CHECK-NOT: musttail call i64 @local_dispatch(
+; CHECK: musttail call i64 %{{.*}}(ptr %pc, ptr %regs)
+entry:
+  %ret = musttail call i64 @local_dispatch(ptr %pc, ptr %regs)
+  ret i64 %ret
+}
+
+define internal i64 @local_dispatch(ptr %pc, ptr %regs) {
+entry:
+  %next = call ptr @get_handler(ptr %pc)
+  %ret = musttail call i64 %next(ptr %pc, ptr %regs)
+  ret i64 %ret
+}

--- a/llvm/test/Transforms/PGOProfile/icp_musttail_dispatch_chain.ll
+++ b/llvm/test/Transforms/PGOProfile/icp_musttail_dispatch_chain.ll
@@ -1,0 +1,47 @@
+; Indirect call promotion of a threaded interpreter dispatch site must not lead
+; to the promoted handler being inlined into its caller, which would chain
+; handler after handler into one function.
+
+; RUN: opt < %s -passes='pgo-icall-prom,inline' -S | FileCheck %s
+
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+@table = external global [256 x ptr]
+
+define i64 @handler_add(ptr %pc, ptr %regs) {
+; CHECK-LABEL: define i64 @handler_add(
+; CHECK: musttail call i64 @handler_xor(
+; CHECK-NOT: musttail call i64 @handler_add(
+entry:
+  %op = load i8, ptr %pc, align 1
+  %opz = zext i8 %op to i64
+  %v = load i64, ptr %regs, align 8
+  %nv = add i64 %v, 1
+  store i64 %nv, ptr %regs, align 8
+  %slot = getelementptr inbounds [256 x ptr], ptr @table, i64 0, i64 %opz
+  %next = load ptr, ptr %slot, align 8
+  %pc1 = getelementptr inbounds i8, ptr %pc, i64 4
+  %ret = musttail call i64 %next(ptr %pc1, ptr %regs), !prof !0
+  ret i64 %ret
+}
+
+define i64 @handler_xor(ptr %pc, ptr %regs) {
+; CHECK-LABEL: define i64 @handler_xor(
+; CHECK: musttail call i64 @handler_add(
+; CHECK-NOT: musttail call i64 @handler_xor(
+entry:
+  %op = load i8, ptr %pc, align 1
+  %opz = zext i8 %op to i64
+  %v = load i64, ptr %regs, align 8
+  %nv = xor i64 %v, 3
+  store i64 %nv, ptr %regs, align 8
+  %slot = getelementptr inbounds [256 x ptr], ptr @table, i64 0, i64 %opz
+  %next = load ptr, ptr %slot, align 8
+  %pc1 = getelementptr inbounds i8, ptr %pc, i64 4
+  %ret = musttail call i64 %next(ptr %pc1, ptr %regs), !prof !1
+  ret i64 %ret
+}
+
+!0 = !{!"VP", i32 0, i64 10000, i64 13351034563885857626, i64 9000}
+!1 = !{!"VP", i32 0, i64 10000, i64 8050033870388950925, i64 9000}


### PR DESCRIPTION
Partially addresses https://github.com/llvm/llvm-project/issues/222292.

Despite LLM wrote most of it under my guidance, I edited and audited the changes to the best of my ability.

---

### Problem

A threaded interpreter handler ends in `musttail return next(pc + 1, regs)` through a table of function pointers. With a profile, indirect call promotion turns the hot dispatch into a guarded direct `musttail` call, which hands the inliner a direct call edge. It inlines the promoted handler, the inlined body brings its own promoted dispatch along, that gets inlined too, and the chain keeps growing until the inlining budget runs out. Handlers end up carrying copies of each other and of the dispatch table, and the interpreter loop stops fitting in the instruction cache.

Inlining such a call site is not worth it in the first place. The call is already a tail call, a jump, with no frame to set up or tear down. The callee ends in an indirect `musttail` call of its own, so after inlining the caller still ends in exactly the same indirect tail jump it would have jumped to. No call is removed, the callee body is only duplicated into every caller in the chain.

### Fix

Reject a `musttail` call site in the inline cost analysis when the callee contains an indirect `musttail` call, unless it is the sole call to a local function, where inlining moves the callee body instead of duplicating it.

This is deliberately not conditioned on the call site having come from ICP (see linked issue), the same reasoning applies to a hand-written chain of `[[clang::musttail]]` calls. It is a hard rejection rather than a cost penalty because PGO raises the threshold on precisely these (hot) call sites, so a penalty large enough to matter would have to be arbitrary.

### Measurements

C threaded interpreter, 32 handlers, dispatch through an array of function pointers, `.text`:

| | plain | PGO | PGO with this patch |
|---|---|---|---|
| bytes | 5676 | 8616 | 6144 |

Run time on that benchmark is unchanged (43.2 vs 43.5 ms, best of 7): the patch removes ~85% of the ICP-driven code growth without giving up the speed PGO buys.

### Scope

This does not fix all of https://github.com/llvm/llvm-project/issues/222292. An interpreter whose dispatch is a `switch` returning a function pointer rather than an array of them has a second, larger source of PGO growth: the promotion guard is threaded back into the switch, the phi of handler addresses stops being foldable into a lookup table, and every handler ends up with its own copy of the dispatch table. That is a separate change on the ICP side, I'll open a separate PR for it.

`llvm/test/Transforms/Inline/musttail-dispatch-chain.ll` covers the mechanism plus three cases that must keep inlining (a non-`musttail` call site, a callee whose own tail call is direct, and the sole call to a local function). `llvm/test/Transforms/PGOProfile/icp_musttail_dispatch_chain.ll` covers the reported path end to end.
