### PR TITLE
[BOLT] Zero all stale bytes in reused file region

### DIFF
--- a/bolt/include/bolt/Rewrite/RewriteInstance.h
+++ b/bolt/include/bolt/Rewrite/RewriteInstance.h
@@ -23,8 +23,10 @@
 #include "llvm/Support/Error.h"
 #include "llvm/Support/Regex.h"
 #include <map>
+#include <optional>
 #include <set>
 #include <unordered_map>
+#include <utility>
 
 namespace llvm {
 
@@ -241,10 +243,15 @@ private:
   /// Used by non-relocation mode and for patched functions.
   void rewriteFunctionsInPlace(raw_fd_ostream &OS);
 
-  /// When --use-old-text reuses input file regions, zero the alignment
-  /// padding after BOLT-written text sections so the output does not retain
-  /// stale bytes from the input binary.
-  void zeroPaddingForReusedSections(raw_fd_ostream &OS);
+  /// Return the input file range [Start, End) that BOLT reuses for new
+  /// content (like with --use-old-text). Return std::nullopt when no input
+  /// region is being reused.
+  std::optional<std::pair<uint64_t, uint64_t>> getReusedInputFileRange() const;
+
+  /// When certain input file region is reused (like with --use-old-text),
+  /// overwrite every byte of that region not covered by newly written content
+  /// so the output does not retain stale bytes from the input binary.
+  void zeroStaleBytesInReusedRegion(raw_fd_ostream &OS);
 
   /// Return address of a function in the new binary corresponding to
   /// \p OldAddress address in the original binary.

--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -6762,45 +6762,84 @@ void RewriteInstance::rewriteFunctionsInPlace(raw_fd_ostream &OS) {
   }
 }
 
-void RewriteInstance::zeroPaddingForReusedSections(raw_fd_ostream &OS) {
-  // The output starts as a byte-for-byte copy of the input, so alignment
-  // padding after BOLT-written sections could retain stale data from the
-  // original binary. Zero the padding as if we were writing sections onto
-  // new file offset (i.e., not reusing old existing sections).
+std::optional<std::pair<uint64_t, uint64_t>>
+RewriteInstance::getReusedInputFileRange() const {
+  auto makeRange =
+      [this](uint64_t Start,
+             uint64_t Size) -> std::optional<std::pair<uint64_t, uint64_t>> {
+    const uint64_t End = std::min(Start + Size, FirstNonAllocatableOffset);
+    if (End <= Start)
+      return std::nullopt;
+    return std::make_pair(Start, End);
+  };
 
-  // Collect file offsets of all sections (allocatable and non-allocatable)
-  // that occupy file bytes.
-  SmallVector<uint64_t, 16> SectionStarts;
-  for (BinarySection &Section : BC->sections()) {
-    if (Section.isVirtual())
-      continue;
-    uint64_t Offset = Section.getOutputFileOffset();
-    if (!Offset)
-      Offset = Section.getInputFileOffset();
-    if (Offset)
-      SectionStarts.push_back(Offset);
-  }
-  llvm::sort(SectionStarts);
+  if (opts::UseOldText)
+    return makeRange(BC->OldTextSectionOffset, BC->OldTextSectionSize);
 
-  uint64_t SavedPos = OS.tell();
+  return std::nullopt;
+}
+
+void RewriteInstance::zeroStaleBytesInReusedRegion(raw_fd_ostream &OS) {
+  // The output starts as a byte-for-byte copy of the input, so every byte of a
+  // reused input region that the new layout does not cover would otherwise
+  // retain stale data from the original binary. Holes could appear on both
+  // sides of the new content:
+  //
+  //   * trailing - the new content is more compact than the input it replaces;
+  //
+  //   * leading  - the region does not start at the alignment boundary
+  //                required by the new code (--align-text), or the code was
+  //                packed against the end of the region
+  //                (--hot-functions-at-end).
+  //
+  // Overwrite all of them, as if the content had been written to a fresh file
+  // offset instead of onto existing sections.
+  std::optional<std::pair<uint64_t, uint64_t>> Range =
+      getReusedInputFileRange();
+  if (!Range)
+    return;
+  const uint64_t RegionStart = Range->first;
+  const uint64_t RegionEnd = Range->second;
+
+  // Collect the file extents holding content that has to be preserved, i.e.
+  // every section that occupies bytes in the output.
+  SmallVector<std::pair<uint64_t, uint64_t>, 16> Preserved;
   for (BinarySection &Section : BC->allocatableSections()) {
-    if (!Section.isFinalized() || !Section.getOutputData())
+    if (Section.isLinkOnly() || Section.isVirtual() || !Section.getOutputSize())
       continue;
-    if (Section.isLinkOnly() || !Section.getOutputSize())
+    const uint64_t Start = Section.getOutputFileOffset();
+    const uint64_t End = Start + Section.getOutputSize();
+    if (End <= RegionStart || Start >= RegionEnd)
       continue;
-    if (!(Section.getELFFlags() & ELF::SHF_EXECINSTR))
-      continue;
-    uint64_t SecEnd = Section.getOutputFileOffset() + Section.getOutputSize();
-    auto It = llvm::upper_bound(SectionStarts, SecEnd - 1);
-    if (It != SectionStarts.end()) {
-      uint64_t NextStart = *It;
-      if (NextStart > SecEnd) {
-        OS.seek(SecEnd);
-        OS.write_zeros(NextStart - SecEnd);
-      }
-    }
+    Preserved.emplace_back(std::max(Start, RegionStart),
+                           std::min(End, RegionEnd));
   }
+  llvm::sort(Preserved);
+
+  const uint64_t SavedPos = OS.tell();
+  uint64_t Cursor = RegionStart;
+  uint64_t NumBytesZeroed = 0;
+  auto zeroUpTo = [&](uint64_t To) {
+    if (To <= Cursor)
+      return;
+    NumBytesZeroed += To - Cursor;
+    OS.seek(Cursor);
+    OS.write_zeros(To - Cursor);
+    Cursor = To;
+  };
+
+  for (const std::pair<uint64_t, uint64_t> &Extent : Preserved) {
+    zeroUpTo(Extent.first);
+    Cursor = std::max(Cursor, Extent.second);
+  }
+  zeroUpTo(RegionEnd);
   OS.seek(SavedPos);
+
+  if (opts::Verbosity >= 1 && NumBytesZeroed)
+    BC->outs() << "BOLT-INFO: zeroed " << NumBytesZeroed
+               << " stale bytes in reused input region (file offset) [0x"
+               << Twine::utohexstr(RegionStart) << ", 0x"
+               << Twine::utohexstr(RegionEnd) << ")\n";
 }
 
 void RewriteInstance::rewriteFile() {
@@ -6893,7 +6932,7 @@ void RewriteInstance::rewriteFile() {
   rewriteNoteSections();
 
   if (opts::UseOldText)
-    zeroPaddingForReusedSections(OS);
+    zeroStaleBytesInReusedRegion(OS);
 
   if (BC->HasRelocations) {
     patchELFAllocatableRelaSections();

--- a/bolt/test/AArch64/use-old-text-zero-padding.c
+++ b/bolt/test/AArch64/use-old-text-zero-padding.c
@@ -30,6 +30,50 @@
 
 // PADDING: {{[0-9a-f]+}} 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 
+// The new .text is aligned to --align-text, which can push it past the start
+// of the old .text and leave unused space in front of the new code. That space
+// is what is left of .bolt.org.text in the output, and it has to be zeroed.
+
+// Build a second copy that starts .text at an address which is not a multiple
+// of the --align-text used below, so BOLT has to skip past it. Functions are
+// padded to 256 bytes on input, which leaves enough room for the more compact
+// output plus the skipped bytes.
+
+// RUN: %clang %cflags -falign-functions=256 -fasynchronous-unwind-tables \
+// RUN:   -Wl,--section-start=.text=0x10100 %t/test.c -o %t/test.misaligned \
+// RUN:   -Wl,-q
+// RUN: llvm-bolt %t/test.misaligned -o %t/test.misaligned.bolt --use-old-text \
+// RUN:   --align-text=512
+
+// RUN: llvm-readelf -S %t/test.misaligned.bolt | sed 's/\[ *[0-9]*\]//' \
+// RUN:   | awk '$1==".bolt.org.text"{print $4, $5}' > %t/lead-loc
+// RUN: bash -c "read O S < %t/lead-loc; \
+// RUN:   od -A n -v -t x1 -N \$((0x\$S)) -j \$((0x\$O)) \
+// RUN:     %t/test.misaligned.bolt" \
+// RUN:   > %t/lead-bytes
+// RUN: FileCheck %s --check-prefix=LEADING-NONEMPTY --input-file=%t/lead-bytes
+// RUN: FileCheck %s --check-prefix=LEADING --input-file=%t/lead-bytes
+
+// LEADING-NONEMPTY: 00 00 00 00
+// LEADING-NOT: {{[^ 0]}}
+
+// --hot-functions-at-end packs the new code against the end of the old .text,
+// leaving the whole front of the reused region unused. Same requirement.
+
+// RUN: llvm-bolt %t/test -o %t/test.hfe --use-old-text --align-text=4 \
+// RUN:   --hot-functions-at-end
+
+// RUN: llvm-readelf -S %t/test.hfe | sed 's/\[ *[0-9]*\]//' \
+// RUN:   | awk '$1==".bolt.org.text"{print $4, $5}' > %t/hfe-loc
+// RUN: bash -c "read O S < %t/hfe-loc; \
+// RUN:   od -A n -v -t x1 -N \$((0x\$S)) -j \$((0x\$O)) %t/test.hfe" \
+// RUN:   > %t/hfe-bytes
+// RUN: FileCheck %s --check-prefix=HOTEND-NONEMPTY --input-file=%t/hfe-bytes
+// RUN: FileCheck %s --check-prefix=HOTEND --input-file=%t/hfe-bytes
+
+// HOTEND-NONEMPTY: 00 00 00 00
+// HOTEND-NOT: {{[^ 0]}}
+
 //--- script.ld
 SECTIONS {
   .rodata : { *(.rodata) *(.rodata.*) }


### PR DESCRIPTION
`--use-old-text` reuses an input file region for new content. We have only zeroed the padding that followed each newly written section in #202375, which may leave stale bytes from input in front of the new content. This could happen if the region is not on the new alignment boundary, or when `--hot-functions-at-end` is used.

Replace the section name based forward scan with an interval coverage over the region - collect the file extents of sections that contain output bytes and then zero all the remaining holes.

Assisted-by: opus