### PR TITLE
[clang][WebAssembly] Add WebAssembly wasm-opt configuration option

### DIFF
--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -6028,6 +6028,10 @@ def mtail_call : Flag<["-"], "mtail-call">, Group<m_wasm_Features_Group>;
 def mno_tail_call : Flag<["-"], "mno-tail-call">, Group<m_wasm_Features_Group>;
 def mwide_arithmetic : Flag<["-"], "mwide-arithmetic">, Group<m_wasm_Features_Group>;
 def mno_wide_arithmetic : Flag<["-"], "mno-wide-arithmetic">, Group<m_wasm_Features_Group>;
+def mwasm_opt_args_EQ : Joined<["-"], "mwasm-opt-args=">,
+  Group<m_wasm_Features_Driver_Group>,
+  HelpText<"Pass <arg> to wasm-opt (WebAssembly only); may be specified multiple times">,
+  MetaVarName<"<arg>">;
 def mexec_model_EQ : Joined<["-"], "mexec-model=">, Group<m_wasm_Features_Driver_Group>,
                      Values<"command,reactor">,
                      HelpText<"Execution model (WebAssembly only)">,

--- a/clang/lib/Driver/ToolChains/WebAssembly.cpp
+++ b/clang/lib/Driver/ToolChains/WebAssembly.cpp
@@ -224,6 +224,9 @@ void wasm::Linker::ConstructJob(Compilation &C, const JobAction &JA,
     }
   }
 
+  ArgStringList WasmOptUserArgs;
+  Args.AddAllArgValues(WasmOptUserArgs, options::OPT_mwasm_opt_args_EQ);
+
   if (!WasmOptPath.empty()) {
     CmdArgs.push_back("--keep-section=target_features");
   }
@@ -248,6 +251,7 @@ void wasm::Linker::ConstructJob(Compilation &C, const JobAction &JA,
         ArgStringList OptArgs;
         OptArgs.push_back(Output.getFilename());
         OptArgs.push_back(Args.MakeArgString(llvm::Twine("-O") + OOpt));
+        OptArgs.append(WasmOptUserArgs.begin(), WasmOptUserArgs.end());
         OptArgs.push_back("-o");
         OptArgs.push_back(Output.getFilename());
         C.addCommand(std::make_unique<Command>(

--- a/clang/test/Driver/wasm-toolchain.c
+++ b/clang/test/Driver/wasm-toolchain.c
@@ -30,6 +30,19 @@
 // LINK_OPT: "-cc1" {{.*}} "-o" "[[temp:[^"]*]]"
 // LINK_OPT: wasm-ld{{.*}}" "-L/foo/lib" "crt1.o" "[[temp]]" "-lc" "{{.*[/\\]}}libclang_rt.builtins.a" "-o" "a.out"
 
+// -mwasm-opt-args= passes arguments to wasm-opt without passing them to wasm-ld.
+// UNSUPPORTED: system-windows
+// RUN: rm -rf %t-wasm-opt
+// RUN: mkdir -p %t-wasm-opt/bin
+// RUN: ln -s %clang %t-wasm-opt/bin/wasm-opt
+// RUN: %clang -### -O2 --target=wasm32-unknown-unknown --sysroot=/foo \
+// RUN:   -B%t-wasm-opt/bin %s -mwasm-opt-args=--disable-bulk-memory \
+// RUN:   -mwasm-opt-args=--converge 2>&1 \
+// RUN:   | FileCheck -check-prefix=WASM_OPT_ARGS %s
+// WASM_OPT_ARGS: wasm-ld{{.*}}" "-L/foo/lib" "crt1.o" {{.*}} "-o" "a.out"
+// WASM_OPT_ARGS-NOT: "--disable-bulk-memory"
+// WASM_OPT_ARGS: wasm-opt{{.*}}" "a.out" "-O2" "--disable-bulk-memory" "--converge" "-o" "a.out"
+
 // A basic C link command-line with known OS.
 
 // RUN: %clang -### --target=wasm32-wasi --sysroot=/foo %s 2>&1 \


### PR DESCRIPTION
Allow WebAssembly users to customize the wasm-opt stage invoked by Clang, including feature handling and optimization passes