### PR TITLE
[SizeOpts] Remove dead struct BasicBlockBFIAdapter (NFC)

### DIFF
--- a/llvm/lib/Transforms/Utils/SizeOpts.cpp
+++ b/llvm/lib/Transforms/Utils/SizeOpts.cpp
@@ -58,44 +58,6 @@ cl::opt<int> llvm::PgsoCutoffSampleProf(
     cl::desc("The profile guided size optimization profile summary cutoff "
              "for sample profile."));
 
-namespace {
-struct BasicBlockBFIAdapter {
-  static bool isFunctionColdInCallGraph(const Function *F,
-                                        ProfileSummaryInfo *PSI,
-                                        BlockFrequencyInfo &BFI) {
-    return PSI->isFunctionColdInCallGraph(F, BFI);
-  }
-  static bool isFunctionHotInCallGraphNthPercentile(int CutOff,
-                                                    const Function *F,
-                                                    ProfileSummaryInfo *PSI,
-                                                    BlockFrequencyInfo &BFI) {
-    return PSI->isFunctionHotInCallGraphNthPercentile(CutOff, F, BFI);
-  }
-  static bool isFunctionColdInCallGraphNthPercentile(int CutOff,
-                                                     const Function *F,
-                                                     ProfileSummaryInfo *PSI,
-                                                     BlockFrequencyInfo &BFI) {
-    return PSI->isFunctionColdInCallGraphNthPercentile(CutOff, F, BFI);
-  }
-  static bool isColdBlock(const BasicBlock *BB,
-                          ProfileSummaryInfo *PSI,
-                          BlockFrequencyInfo *BFI) {
-    return PSI->isColdBlock(BB, BFI);
-  }
-  static bool isHotBlockNthPercentile(int CutOff,
-                                      const BasicBlock *BB,
-                                      ProfileSummaryInfo *PSI,
-                                      BlockFrequencyInfo *BFI) {
-    return PSI->isHotBlockNthPercentile(CutOff, BB, BFI);
-  }
-  static bool isColdBlockNthPercentile(int CutOff, const BasicBlock *BB,
-                                       ProfileSummaryInfo *PSI,
-                                       BlockFrequencyInfo *BFI) {
-    return PSI->isColdBlockNthPercentile(CutOff, BB, BFI);
-  }
-};
-} // end anonymous namespace
-
 bool llvm::shouldOptimizeForSize(const Function *F, ProfileSummaryInfo *PSI,
                                  BlockFrequencyInfo *BFI,
                                  PGSOQueryType QueryType) {


### PR DESCRIPTION
The last uses were removed on June 28, 2023 in commit
80155cbf0be1744953edf68b9729c24bd0de79c4 when hotness/coldness queries
were refactored into templated ProfileSummaryInfo member functions.

Assisted-by: Antigravity
