### PR TITLE
[BOLT] Fixed BOLT edge weight estimation in non-LBR mode.

### DIFF
--- a/bolt/lib/Passes/MCF.cpp
+++ b/bolt/lib/Passes/MCF.cpp
@@ -21,7 +21,7 @@
 #include <algorithm>
 #include <vector>
 
-#undef  DEBUG_TYPE
+#undef DEBUG_TYPE
 #define DEBUG_TYPE "mcf"
 
 using namespace llvm;
@@ -153,7 +153,7 @@ void computeEdgeWeights(BinaryBasicBlock *BB, EdgeWeightMap &EdgeWeights) {
                                           E = GraphT::child_end(BB);
        CI != E; ++CI) {
     typename GraphT::NodeRef Child = *CI;
-    double Weight = 1 / (GraphT::child_end(BB) - GraphT::child_begin(BB));
+    double Weight = 1.0 / (GraphT::child_end(BB) - GraphT::child_begin(BB));
     if (TotalChildrenCount != 0.0)
       Weight = ChildrenExecCount[ChildIndex] / TotalChildrenCount;
     updateEdgeWeight<NodeT>(EdgeWeights, BB, Child, Weight);

--- a/bolt/lib/Passes/MCF.cpp
+++ b/bolt/lib/Passes/MCF.cpp
@@ -21,7 +21,7 @@
 #include <algorithm>
 #include <vector>
 
-#undef DEBUG_TYPE
+#undef  DEBUG_TYPE
 #define DEBUG_TYPE "mcf"
 
 using namespace llvm;

--- a/bolt/test/AArch64/edge-weight-estimation-fixes.s
+++ b/bolt/test/AArch64/edge-weight-estimation-fixes.s
@@ -1,0 +1,61 @@
+## Check that edge weights are correctly distributed among CFG edges being
+## estimated by BOLT when TotalChildrenCount is zero and non-zero.
+
+# RUN: llvm-mc -filetype=obj -triple=aarch64-unknown-unknown %s -o %t.o
+# RUN: link_fdata --no-lbr %s %t.o %t.z.fdata FDATA_ZERO
+# RUN: link_fdata --no-lbr %s %t.o %t.nz.fdata FDATA_NONZERO
+# RUN: %clang %cflags -Wl,-q %t.o -o %t.exe
+# RUN: llvm-bolt %t.exe -o %t.z.bolt --print-estimate-edge-counts \
+# RUN:   --data=%t.z.fdata 2>&1 | FileCheck %s --check-prefix=ZERO
+# RUN: llvm-bolt %t.exe -o %t.nz.bolt --print-estimate-edge-counts \
+# RUN:   --data=%t.nz.fdata 2>&1 | FileCheck %s --check-prefix=NONZERO
+
+# ZERO-LABEL: Binary Function "main" after estimate-edge-counts
+# ZERO-LABEL: .LBB00 (
+# ZERO: Successors: .Ltmp0 (mispreds: 0, count: 3000)
+# ZERO-LABEL: .Ltmp1 (
+# ZERO: Successors: .Ltmp0 (mispreds: 0, count: 3000)
+
+# FDATA_ZERO: 1 main #LBB0_1# 6
+
+# NONZERO-LABEL: Binary Function "main" after estimate-edge-counts
+# NONZERO-LABEL: .LBB00 (
+# NONZERO: Successors: .Ltmp0 (mispreds: 0, count: 1000)
+# NONZERO-LABEL: .Ltmp1 (
+# NONZERO: Successors: .Ltmp0 (mispreds: 0, count: 5000)
+
+# FDATA_NONZERO: 1 main #main# 1
+# FDATA_NONZERO: 1 main #LBB0_1# 6
+# FDATA_NONZERO: 1 main #LBB0_2# 5
+# FDATA_NONZERO: 1 main #LBB0_3# 1
+
+        .file   "main.c"
+        .text
+        .globl  main
+        .p2align        2
+        .type   main,@function
+main:
+        sub     sp, sp, #16
+        str     wzr, [sp, #12]
+        mov     w8, #5
+        str     w8, [sp, #8]
+        b       LBB0_1
+LBB0_1:
+        ldr     w8, [sp, #8]
+        subs    w8, w8, #0
+        b.gt    LBB0_2
+        b       LBB0_3
+LBB0_2:
+        ldr     w8, [sp, #8]
+        subs    w8, w8, #1
+        str     w8, [sp, #8]
+        b       LBB0_1
+LBB0_3:
+        mov     w0, wzr
+        add     sp, sp, #16
+        ret
+Lfunc_end0:
+        .size   main, Lfunc_end0-main
+        .reloc 0, R_AARCH64_NONE
+        .section        ".note.GNU-stack","",@progbits
+        .addrsig


### PR DESCRIPTION
**Before**: When estimating edge weights within `computeEdgeWeights` in `MCF.cpp`, if the `TotalChildrenCount` is 0, the default edge weight is `1 / (GraphT::child_end(BB)_ - GraphT::child_begin(BB))` resulting in integer division and incorrect distribution of estimated edge weights. 

**After**: Correctly estimate edge weights with zero and non-zero values of `TotalChildrenCount` by enforcing floating point division. 