### PR TITLE
[libcxx][test] Stop testing signaling NaN in the constexpr comparison functions

### DIFF
--- a/libcxx/test/std/numerics/c.math/isgreater.pass.cpp
+++ b/libcxx/test/std/numerics/c.math/isgreater.pass.cpp
@@ -32,7 +32,8 @@ struct TestFloat {
     assert(!std::isgreater(lim::quiet_NaN(), T(0)));
     assert(!std::isgreater(T(0), lim::quiet_NaN()));
     assert(!std::isgreater(lim::quiet_NaN(), lim::quiet_NaN()));
-    assert(!std::isgreater(lim::signaling_NaN(), T(0)));
+    // Note: signaling NaN is intentionally not tested. Passing a signaling NaN to these macros may
+    // raise the "invalid" floating-point exception, which is not allowed during constant evaluation.
   }
 };
 

--- a/libcxx/test/std/numerics/c.math/isgreaterequal.pass.cpp
+++ b/libcxx/test/std/numerics/c.math/isgreaterequal.pass.cpp
@@ -31,7 +31,8 @@ struct TestFloat {
 
     assert(!std::isgreaterequal(lim::quiet_NaN(), T(0)));
     assert(!std::isgreaterequal(T(0), lim::quiet_NaN()));
-    assert(!std::isgreaterequal(lim::signaling_NaN(), T(0)));
+    // Note: signaling NaN is intentionally not tested. Passing a signaling NaN to these macros may
+    // raise the "invalid" floating-point exception, which is not allowed during constant evaluation.
   }
 };
 

--- a/libcxx/test/std/numerics/c.math/islessequal.pass.cpp
+++ b/libcxx/test/std/numerics/c.math/islessequal.pass.cpp
@@ -31,7 +31,8 @@ struct TestFloat {
 
     assert(!std::islessequal(lim::quiet_NaN(), T(0)));
     assert(!std::islessequal(T(0), lim::quiet_NaN()));
-    assert(!std::islessequal(lim::signaling_NaN(), T(0)));
+    // Note: signaling NaN is intentionally not tested. Passing a signaling NaN to these macros may
+    // raise the "invalid" floating-point exception, which is not allowed during constant evaluation.
   }
 };
 

--- a/libcxx/test/std/numerics/c.math/isunordered.pass.cpp
+++ b/libcxx/test/std/numerics/c.math/isunordered.pass.cpp
@@ -27,8 +27,9 @@ struct TestFloat {
     assert(std::isunordered(lim::quiet_NaN(), T(0)));
     assert(std::isunordered(T(0), lim::quiet_NaN()));
     assert(std::isunordered(lim::quiet_NaN(), lim::quiet_NaN()));
+    // Note: signaling NaN is intentionally not tested. Passing a signaling NaN to these macros may
+    // raise the "invalid" floating-point exception, which is not allowed during constant evaluation.
 
-    assert(std::isunordered(lim::signaling_NaN(), T(0)));
     assert(!std::isunordered(lim::infinity(), lim::infinity()));
     assert(!std::isunordered(lim::max(), lim::lowest()));
   }


### PR DESCRIPTION
std::isgreater, std::isgreaterequal, std::islessequal and std::isunordered behave like the corresponding C macros, which may raise the "invalid" floating-point exception when an operand is a signaling NaN ([c.math.fpclass]/1, C23 7.12.17). Raising a floating-point exception is not allowed during constant evaluation, so passing signaling_NaN() to these functions in a constexpr context is bogus; MSVC's implementation rejects it.

Remove the signaling NaN asserts from the four affected tests. The classification functions (isnan, isinf, fpclassify, ...) are affected: the standard guarantees they never raise for signaling NaN, so their existing sNaN tests remain valid.

Fixes #222431