### PR TITLE
[GlobalISel] Fast path exact LLT equality (NFC)

### DIFF
--- a/llvm/include/llvm/CodeGenTypes/LowLevelType.h
+++ b/llvm/include/llvm/CodeGenTypes/LowLevelType.h
@@ -538,6 +538,9 @@ public:
 #endif
 
   bool operator==(const LLT &RHS) const {
+    if (Info == RHS.Info && RawData == RHS.RawData)
+      return true;
+
     if (isAnyScalar() || RHS.isAnyScalar())
       return isScalar() == RHS.isScalar() &&
              getScalarSizeInBits() == RHS.getScalarSizeInBits();
@@ -546,7 +549,7 @@ public:
       return getElementType() == RHS.getElementType() &&
              getElementCount() == RHS.getElementCount();
 
-    return Info == RHS.Info && RawData == RHS.RawData;
+    return false;
   }
 
   bool operator!=(const LLT &RHS) const { return !(*this == RHS); }


### PR DESCRIPTION
Improves CTMark geomean -0.05% on aarch64-O0-g.

https://llvm-compile-time-tracker.com/compare.php?from=87d9c3c24ff5941ac08799850a6549b561c98a81&to=a5391cd5be815299b2cddcabf62a86369b247f72&stat=instructions:u

Assisted-by: codex