### PR TITLE
[Clang][NFC] add additional test coverage for default argument parsing errors

### DIFF
--- a/clang/test/SemaCXX/blocks.cpp
+++ b/clang/test/SemaCXX/blocks.cpp
@@ -173,3 +173,13 @@ namespace test8{
 namespace gh189247 {
   template<void (^)()> struct A; // expected-error {{a non-type template parameter cannot have type 'void (^)()'}}
 }
+
+namespace GH115280 {
+struct s {
+  int i = 0;
+  int j = 0;
+  void m(int i = ^{ static int i = 0; return ++i; }(),  // expected-note {{'i' declared here}}
+         int j = ^{ #line 7                             // expected-error {{expected expression}}
+         static int i = 0; return ++i; }()) { }         // expected-error {{reference to local variable 'i' declared in enclosing function 'GH115280::s::m'}}
+};
+}


### PR DESCRIPTION
Fixes #115280 