### PR TITLE
[LLD][ELF] Reduce memory and file size of overlay thunk tests

### DIFF
--- a/lld/test/ELF/aarch64-thunk-bti-overlay-reuse.s
+++ b/lld/test/ELF/aarch64-thunk-bti-overlay-reuse.s
@@ -1,7 +1,7 @@
 // REQUIRES: aarch64
 // RUN: rm -rf %t && split-file %s %t && cd %t
 // RUN: llvm-mc -filetype=obj -triple=aarch64 a.s -o a.o
-// RUN: ld.lld --script=overlay.ld a.o -o overlay --pic-veneer --print-map
+// RUN: ld.lld --script=overlay.ld a.o -o overlay --pic-veneer
 // RUN: llvm-objdump -d --no-show-raw-insn overlay | FileCheck %s
 
 /// A range extension thunk in a different overlay should not be shared as we
@@ -59,12 +59,12 @@ far:
 //--- overlay.ld
 
 SECTIONS {
-  OVERLAY 0x1000 : {
+  OVERLAY 0x1000 : AT(0x1000) {
     .text.over.01   { *(.text.over.01) }
     .text.over.02   { *(.text.over.02) }
   }
 	.text 0x2000 : { *(.text) }
-  OVERLAY 0x80000000 : {
+  OVERLAY 0x80000000 : AT(0x80000000) {
     .text.far { *(.text.far) }
   }
 }

--- a/lld/test/ELF/arm-thunk-overlay-reuse.s
+++ b/lld/test/ELF/arm-thunk-overlay-reuse.s
@@ -79,11 +79,11 @@ far2:	bx lr
 //--- overlay.ld
 
 SECTIONS {
-  .text.01 0x1000 : { *(.text.00) }
+  .text.01 0x1000 : AT(0x1000) { *(.text.00) }
   OVERLAY 0x2000 : {
     .text.over.01   { *(.text.over.01) }
     .text.over.02   { *(.text.over.02) }
   }
   .text.02 0x3000 : { *(.text.02) }
-  .text.03 0x80000000 : { *(.text.far) }
+  .text.03 0x80000000 : AT(0x80000000) { *(.text.far) }
 }


### PR DESCRIPTION
Add AT(address) to linker script to force generation of a program header for each address. Without AT we get a single large program header that takes up a large amount of memory and causes a large file to be generated. This may prevent the test from running on a 32-bit machine without a lot of memory. See comment on #200415

Also removed a superfluous --print-map from
aarch64-thunk-bit-overlay-reuse.s. This was used when constructing the test but it is not needed.