### PR TITLE
[Mips] Restrict rdhwr+synci to Linux on MIPS R6

### DIFF
--- a/compiler-rt/lib/builtins/clear_cache.c
+++ b/compiler-rt/lib/builtins/clear_cache.c
@@ -94,10 +94,10 @@ void __clear_cache(void *start, void *end) {
 #elif defined(__mips__)
   const uintptr_t start_int = (uintptr_t)start;
   const uintptr_t end_int = (uintptr_t)end;
+#if __mips_isa_rev >= 6 && defined(__linux__)
   uintptr_t synci_step;
   __asm__ volatile("rdhwr %0, $1" : "=r"(synci_step));
   if (synci_step != 0) {
-#if __mips_isa_rev >= 6
     for (uintptr_t p = start_int; p < end_int; p += synci_step)
       __asm__ volatile("synci 0(%0)" : : "r"(p));
 
@@ -108,6 +108,7 @@ void __clear_cache(void *start, void *end) {
                      "jr.hb $at\n"
                      "move $at, $0\n"
                      ".set at");
+  }
 #elif defined(__linux__) || defined(__OpenBSD__)
     // Pre-R6 may not be globalized. And some implementations may give strange
     // synci_step. So, let's use libc call for it.
@@ -117,7 +118,6 @@ void __clear_cache(void *start, void *end) {
     (void)end_int;
     compilerrt_abort();
 #endif
-  }
 #elif defined(__aarch64__) && !defined(__APPLE__)
   uint64_t xstart = (uint64_t)(uintptr_t)start;
   uint64_t xend = (uint64_t)(uintptr_t)end;


### PR DESCRIPTION
The rdhwr instruction reads synci_step, which is not allowed by OpenBSD and is not available for ISA older than mips{32/64}r2.

Restrict the rdhwr+synci to Linux on MIPS R6 and fall back to _flush_cache on all other MIPS targets including OpenBSD and pre-R6 Linux.

Fix #219896.