### PR TITLE
[mlir-translate] Move InitLLVM ownership to the standalone tool

### DIFF
--- a/mlir/lib/Tools/mlir-translate/MlirTranslateMain.cpp
+++ b/mlir/lib/Tools/mlir-translate/MlirTranslateMain.cpp
@@ -13,7 +13,6 @@
 #include "mlir/Support/Timing.h"
 #include "mlir/Support/ToolUtilities.h"
 #include "mlir/Tools/mlir-translate/Translation.h"
-#include "llvm/Support/InitLLVM.h"
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/ToolOutputFile.h"
 
@@ -97,8 +96,6 @@ LogicalResult mlir::mlirTranslateMain(int argc, char **argv,
       "output-split-marker",
       llvm::cl::desc("Split marker to use for merging the ouput"),
       llvm::cl::init(""));
-
-  llvm::InitLLVM y(argc, argv);
 
   // Add flags for all the registered translations.
   llvm::cl::list<const Translation *, bool, TranslationParser>

--- a/mlir/tools/mlir-translate/mlir-translate.cpp
+++ b/mlir/tools/mlir-translate/mlir-translate.cpp
@@ -14,6 +14,7 @@
 #include "mlir/InitAllTranslations.h"
 #include "mlir/Support/LLVM.h"
 #include "mlir/Tools/mlir-translate/MlirTranslateMain.h"
+#include "llvm/Support/InitLLVM.h"
 
 using namespace mlir;
 
@@ -37,6 +38,7 @@ static void registerTestTranslations() {
 }
 
 int main(int argc, char **argv) {
+  llvm::InitLLVM y(argc, argv);
   registerAllTranslations();
   registerTestTranslations();
   return failed(mlirTranslateMain(argc, argv, "MLIR Translation Testing Tool"));


### PR DESCRIPTION
Please Read: [RFC: Embeddable LLVM tool drivers for long-lived hosts](https://discourse.llvm.org/t/rfc-embeddable-llvm-tool-drivers-for-long-lived-hosts/91754)  and [Why `InitLLVM` ownership matters section in the RFC](https://discourse.llvm.org/t/rfc-embeddable-llvm-tool-drivers-for-long-lived-hosts/91754#p-367966-why-initllvm-ownership-matters-7)

`mlirTranslateMain` currently constructs `InitLLVM` internally. This is fine when `mlir-translate` runs once as a standalone executable, but it does not work for an in-process setting where the host remains alive and invokes multiple LLVM tools. When `mlirTranslateMain` returns, the `InitLLVM` destructor calls `llvm_shutdown()` and destroys process-global `ManagedStatic` state that may still be needed by the host and subsequent tool invocations.

[WasmBolt](https://github.com/anutosh491/WasmBolt) (try [here](https://anutosh21.github.io/WasmBolt/)) is a concrete example of such a host. It runs Clang, `mlir-opt`, `opt`, `llc` and LLD inside one browser-hosted LLVM process, allowing users to inspect and transform code without a remote compilation server.

As described in the [MLIR section of the RFC](https://discourse.llvm.org/t/rfc-embeddable-llvm-tool-drivers-for-long-lived-hosts/91754#p-367966-mlir-13), the real `mlir-opt` driver already works in this environment. `MlirOptMain` does not own `InitLLVM`, so the surrounding host can control the process lifetime. `mlirTranslateMain` does not currently provide the same ownership boundary, which prevents us from integrating it in the same clean way.

The working `mlir-opt` pipeline can be seen here: https://www.youtube.com/watch?v=yga2lWelne4

This patch makes the two MLIR driver interfaces consistent by moving `InitLLVM` from the reusable `mlirTranslateMain` entry point into the standalone `mlir-translate` executable:

```text
standalone:
  main -> InitLLVM -> mlirTranslateMain -> process exit

embedded:
  host-owned InitLLVM / LLVMToolSession -> mlirTranslateMain
```

Standalone behaviour remains unchanged, while MLIRTranslateLib can now borrow the process lifetime owned by a long-lived host.