### PR TITLE
[orc-rt] Generalize testcases for different target archs

### DIFF
--- a/orc-rt/test/regression/darwin/check-rt-process-info.test
+++ b/orc-rt/test/regression/darwin/check-rt-process-info.test
@@ -1,6 +1,6 @@
 # RUN: orc-rt-process-info-check --print-triple --print-cpu-features --print-page-size  \
-# RUN:   | FileCheck %s -DVERSION=%macos-product-version
+# RUN:   | FileCheck %s -DARCH=%target-arch -DVERSION=%macos-product-version
 
-# CHECK: {{arm64e?}}-apple-macosx[[VERSION]]
+# CHECK: [[ARCH]]-apple-macosx[[VERSION]]
 # CHECK-NEXT: {{4096|16384}}
-# CHECK-NEXT: {{(\+[a-z0-9_.]+,)*\+neon(,\+[a-z0-9_.]+)*}}
+# CHECK-NEXT: {{^\+[a-z0-9_.]+(,\+[a-z0-9_.]+)*$}}

--- a/orc-rt/test/regression/linux/check-rt-process-info.test
+++ b/orc-rt/test/regression/linux/check-rt-process-info.test
@@ -1,4 +1,5 @@
-# RUN: orc-rt-process-info-check --print-triple --print-page-size | FileCheck %s
+# RUN: orc-rt-process-info-check --print-triple --print-page-size \
+# RUN:   | FileCheck %s -DARCH=%target-arch
 
-# CHECK: -linux
+# CHECK: {{^}}[[ARCH]]-{{.*}}-linux
 # CHECK-NEXT: {{4096|16384}}

--- a/orc-rt/test/regression/lit.cfg.py
+++ b/orc-rt/test/regression/lit.cfg.py
@@ -93,5 +93,4 @@ config.substitutions.append(("%target_triple", config.target_triple))
 
 # The architecture the runtime was built for, so tests can check the triple it
 # reports against an independent source.
-config.substitutions.append(
-    ("%target-arch", config.target_triple.split("-")[0]))
+config.substitutions.append(("%target-arch", config.target_triple.split("-")[0]))

--- a/orc-rt/test/regression/lit.cfg.py
+++ b/orc-rt/test/regression/lit.cfg.py
@@ -90,3 +90,8 @@ for var in ("ORC_RT_LOG", "ORC_RT_LOG_OUTPUT"):
 if platform.system() == "Darwin":
     config.substitutions.append(("%macos-product-version", platform.mac_ver()[0]))
 config.substitutions.append(("%target_triple", config.target_triple))
+
+# The architecture the runtime was built for, so tests can check the triple it
+# reports against an independent source.
+config.substitutions.append(
+    ("%target-arch", config.target_triple.split("-")[0]))


### PR DESCRIPTION
Drop the hard-coded archs from the check-rt-process-info testcases. Instead, check against an arch value derived from the build's target triple.