### PR TITLE
[CMake] Don't reference unexported targets from dependency-only configs

### DIFF
--- a/clang/cmake/modules/CMakeLists.txt
+++ b/clang/cmake/modules/CMakeLists.txt
@@ -30,10 +30,14 @@ endif()
 # Generate ClangConfig.cmake for the build tree.
 set(CLANG_CONFIG_CMAKE_DIR "${clang_cmake_builddir}")
 set(CLANG_CONFIG_LLVM_CMAKE_DIR "${llvm_cmake_builddir}")
-if(NOT "clang" IN_LIST LLVM_DEPENDENCY_ONLY_PROJECTS)
-  set(CLANG_CONFIG_INCLUDE_EXPORTS "include(\"${clang_cmake_builddir}/ClangTargets.cmake\")")
-else()
+if("clang" IN_LIST LLVM_DEPENDENCY_ONLY_PROJECTS)
+  # Clang is enabled only to satisfy another project's dependency, so its
+  # targets file is not exported above. Leave the include out of the config
+  # rather than referring to a file that is never generated, which would make
+  # every find_package(Clang) against this build tree fail.
   set(CLANG_CONFIG_INCLUDE_EXPORTS "")
+else()
+  set(CLANG_CONFIG_INCLUDE_EXPORTS "include(\"${clang_cmake_builddir}/ClangTargets.cmake\")")
 endif()
 set(CLANG_CONFIG_INCLUDE_DIRS
   "${CLANG_SOURCE_DIR}/include"

--- a/clang/cmake/modules/CMakeLists.txt
+++ b/clang/cmake/modules/CMakeLists.txt
@@ -30,7 +30,11 @@ endif()
 # Generate ClangConfig.cmake for the build tree.
 set(CLANG_CONFIG_CMAKE_DIR "${clang_cmake_builddir}")
 set(CLANG_CONFIG_LLVM_CMAKE_DIR "${llvm_cmake_builddir}")
-set(CLANG_CONFIG_INCLUDE_EXPORTS "include(\"${clang_cmake_builddir}/ClangTargets.cmake\")")
+if(NOT "clang" IN_LIST LLVM_DEPENDENCY_ONLY_PROJECTS)
+  set(CLANG_CONFIG_INCLUDE_EXPORTS "include(\"${clang_cmake_builddir}/ClangTargets.cmake\")")
+else()
+  set(CLANG_CONFIG_INCLUDE_EXPORTS "")
+endif()
 set(CLANG_CONFIG_INCLUDE_DIRS
   "${CLANG_SOURCE_DIR}/include"
   "${CLANG_BINARY_DIR}/include"

--- a/mlir/cmake/modules/CMakeLists.txt
+++ b/mlir/cmake/modules/CMakeLists.txt
@@ -52,10 +52,14 @@ get_property(MLIR_CAPI_LIBS GLOBAL PROPERTY MLIR_CAPI_LIBS)
 # Generate MlirConfig.cmake for the build tree.
 set(MLIR_CONFIG_CMAKE_DIR "${mlir_cmake_builddir}")
 set(MLIR_CONFIG_LLVM_CMAKE_DIR "${llvm_cmake_builddir}")
-if(NOT "mlir" IN_LIST LLVM_DEPENDENCY_ONLY_PROJECTS)
-  set(MLIR_CONFIG_INCLUDE_EXPORTS "include(\"\${MLIR_CMAKE_DIR}/MLIRTargets.cmake\")")
-else()
+if("mlir" IN_LIST LLVM_DEPENDENCY_ONLY_PROJECTS)
+  # MLIR is enabled only to satisfy another project's dependency, so its
+  # targets file is not exported above. Leave the include out of the config
+  # rather than referring to a file that is never generated, which would make
+  # every find_package(MLIR) against this build tree fail.
   set(MLIR_CONFIG_INCLUDE_EXPORTS "")
+else()
+  set(MLIR_CONFIG_INCLUDE_EXPORTS "include(\"\${MLIR_CMAKE_DIR}/MLIRTargets.cmake\")")
 endif()
 set(MLIR_CONFIG_INCLUDE_DIRS
   "${MLIR_SOURCE_DIR}/include"

--- a/mlir/cmake/modules/CMakeLists.txt
+++ b/mlir/cmake/modules/CMakeLists.txt
@@ -52,7 +52,11 @@ get_property(MLIR_CAPI_LIBS GLOBAL PROPERTY MLIR_CAPI_LIBS)
 # Generate MlirConfig.cmake for the build tree.
 set(MLIR_CONFIG_CMAKE_DIR "${mlir_cmake_builddir}")
 set(MLIR_CONFIG_LLVM_CMAKE_DIR "${llvm_cmake_builddir}")
-set(MLIR_CONFIG_INCLUDE_EXPORTS "include(\"\${MLIR_CMAKE_DIR}/MLIRTargets.cmake\")")
+if(NOT "mlir" IN_LIST LLVM_DEPENDENCY_ONLY_PROJECTS)
+  set(MLIR_CONFIG_INCLUDE_EXPORTS "include(\"\${MLIR_CMAKE_DIR}/MLIRTargets.cmake\")")
+else()
+  set(MLIR_CONFIG_INCLUDE_EXPORTS "")
+endif()
 set(MLIR_CONFIG_INCLUDE_DIRS
   "${MLIR_SOURCE_DIR}/include"
   "${MLIR_BINARY_DIR}/include"


### PR DESCRIPTION
#221724 stopped exporting a project's targets file when that project is enabled only as another project's dependency, but the build-tree `ClangConfig.cmake` and `MLIRConfig.cmake` still include it unconditionally. `find_package()` therefore finds the config and fails inside it:

```
CMake Error at build/lib/cmake/clang/ClangConfig.cmake:19 (include):
  include could not find requested file:
    build/lib/cmake/clang/ClangTargets.cmake
Call Stack (most recent call first):
  CMakeLists.txt:90 (find_package)
```

This breaks any configuration that enables Flang without also enabling Clang or MLIR explicitly: `runtimes/CMakeLists.txt` calls `find_package(Clang ...)`, which is deliberately not `REQUIRED` and is expected to tolerate an unavailable package — but a *half-generated* package is a hard error rather than a "not found". Concretely, `-DLLVM_ENABLE_PROJECTS=flang -DLLVM_ENABLE_RUNTIMES=flang-rt` fails at `runtimes-configure`, which is the configuration premerge uses for flang-rt changes.

This patch guards the include the same way the export itself is guarded, so a dependency-only project generates a config without a dangling include. The install-tree path already handles this through `get_config_exports_includes()`; only the build-tree path was missed.

MLIR has the same defect and is fixed here too. It is currently latent only because `runtimes/CMakeLists.txt` calls `find_package(Clang)` and not `find_package(MLIR)`; a `find_package(MLIR)` against a dependency-only build tree fails identically at `MLIRConfig.cmake:33`.

Assisted-by: AI