### PR TITLE
[MISched] Dump SU node number on `tracePick`

### DIFF
--- a/llvm/lib/CodeGen/MachineScheduler.cpp
+++ b/llvm/lib/CodeGen/MachineScheduler.cpp
@@ -3500,9 +3500,12 @@ bool llvm::tryLatency(GenericSchedulerBase::SchedCandidate &TryCand,
   return false;
 }
 
-static void tracePick(GenericSchedulerBase::CandReason Reason, bool IsTop,
-                      bool IsPostRA = false) {
-  LLVM_DEBUG(dbgs() << "Pick " << (IsTop ? "Top " : "Bot ")
+static void tracePick(const SUnit *SU,
+                      const GenericSchedulerBase::CandReason Reason,
+                      const bool IsTop, const bool IsPostRA = false) {
+  assert(SU && "SU must not be null for tracing");
+  LLVM_DEBUG(dbgs() << "Pick " << (IsTop ? "Top " : "Bot ") << "Cand SU("
+                    << SU->NodeNum << ") "
                     << GenericSchedulerBase::getReasonStr(Reason) << " ["
                     << (IsPostRA ? "post-RA" : "pre-RA") << "]\n");
 
@@ -3629,8 +3632,8 @@ static void tracePick(GenericSchedulerBase::CandReason Reason, bool IsTop,
 }
 
 static void tracePick(const GenericSchedulerBase::SchedCandidate &Cand,
-                      bool IsPostRA = false) {
-  tracePick(Cand.Reason, Cand.AtTop, IsPostRA);
+                      const bool IsPostRA = false) {
+  tracePick(Cand.SU, Cand.Reason, Cand.AtTop, IsPostRA);
 }
 
 void GenericScheduler::initialize(ScheduleDAGMI *dag) {
@@ -4083,12 +4086,12 @@ SUnit *GenericScheduler::pickNodeBidirectional(bool &IsTopNode) {
   // efficient, but also provides the best heuristics for CriticalPSets.
   if (SUnit *SU = Bot.pickOnlyChoice()) {
     IsTopNode = false;
-    tracePick(Only1, /*IsTopNode=*/false);
+    tracePick(SU, Only1, /*IsTopNode=*/false);
     return SU;
   }
   if (SUnit *SU = Top.pickOnlyChoice()) {
     IsTopNode = true;
-    tracePick(Only1, /*IsTopNode=*/true);
+    tracePick(SU, Only1, /*IsTopNode=*/true);
     return SU;
   }
   // Set the bottom-up policy based on the state of the current bottom zone and
@@ -4447,12 +4450,12 @@ SUnit *PostGenericScheduler::pickNodeBidirectional(bool &IsTopNode) {
   // efficient, but also provides the best heuristics for CriticalPSets.
   if (SUnit *SU = Bot.pickOnlyChoice()) {
     IsTopNode = false;
-    tracePick(Only1, /*IsTopNode=*/false, /*IsPostRA=*/true);
+    tracePick(SU, Only1, /*IsTopNode=*/false, /*IsPostRA=*/true);
     return SU;
   }
   if (SUnit *SU = Top.pickOnlyChoice()) {
     IsTopNode = true;
-    tracePick(Only1, /*IsTopNode=*/true, /*IsPostRA=*/true);
+    tracePick(SU, Only1, /*IsTopNode=*/true, /*IsPostRA=*/true);
     return SU;
   }
   // Set the bottom-up policy based on the state of the current bottom zone and
@@ -4530,7 +4533,7 @@ SUnit *PostGenericScheduler::pickNode(bool &IsTopNode) {
   if (RegionPolicy.OnlyBottomUp) {
     SU = Bot.pickOnlyChoice();
     if (SU) {
-      tracePick(Only1, /*IsTopNode=*/true, /*IsPostRA=*/true);
+      tracePick(SU, Only1, /*IsTopNode=*/true, /*IsPostRA=*/true);
     } else {
       CandPolicy NoPolicy;
       BotCand.reset(NoPolicy);
@@ -4546,7 +4549,7 @@ SUnit *PostGenericScheduler::pickNode(bool &IsTopNode) {
   } else if (RegionPolicy.OnlyTopDown) {
     SU = Top.pickOnlyChoice();
     if (SU) {
-      tracePick(Only1, /*IsTopNode=*/true, /*IsPostRA=*/true);
+      tracePick(SU, Only1, /*IsTopNode=*/true, /*IsPostRA=*/true);
     } else {
       CandPolicy NoPolicy;
       TopCand.reset(NoPolicy);

--- a/llvm/test/CodeGen/AArch64/misched-detail-resource-booking-01.mir
+++ b/llvm/test/CodeGen/AArch64/misched-detail-resource-booking-01.mir
@@ -398,7 +398,7 @@ body:             |
 # CHECK-NEXT: Queue BotQ.P:
 # CHECK-NEXT: Queue BotQ.A: 12 11
 # CHECK-NEXT:   Cand SU(12) FIRST
-# CHECK-NEXT: Pick Bot FIRST
+# CHECK-NEXT: Pick Bot Cand SU(12) FIRST
 # CHECK-NEXT: Scheduling SU(12) $q1 = COPY %12:fpr128
 # CHECK-NEXT:   Ready @3c
 # CHECK-NEXT:   CortexA55UnitALU +1x1u
@@ -582,7 +582,7 @@ body:             |
 # CHECK-NEXT: Queue BotQ.P:
 # CHECK-NEXT: Queue BotQ.A: 10 8
 # CHECK-NEXT:   Cand SU(10) FIRST
-# CHECK-NEXT: Pick Bot FIRST
+# CHECK-NEXT: Pick Bot Cand SU(10) FIRST
 # CHECK-NEXT: Scheduling SU(10) %12:fpr128 = UMULLv4i16_v4i32 %3.dsub:fpr128, %11:fpr64
 # CHECK-NEXT:   Ready @7c
 # CHECK-NEXT:   CortexA55UnitFPALU +2x1u
@@ -871,7 +871,7 @@ body:             |
 # CHECK-NEXT: Queue BotQ.P: 3
 # CHECK-NEXT: Queue BotQ.A: 7 5
 # CHECK-NEXT:   Cand SU(7) FIRST
-# CHECK-NEXT: Pick Bot FIRST
+# CHECK-NEXT: Pick Bot Cand SU(7) FIRST
 # CHECK-NEXT: Scheduling SU(7) %9:fpr64 = XTNv4i16 %8:fpr128
 # CHECK-NEXT:   Ready @10c
 # CHECK-NEXT:   CortexA55UnitFPALU +1x1u
@@ -1094,7 +1094,7 @@ body:             |
 # CHECK-NEXT: Queue BotQ.A: 3 6
 # CHECK-NEXT:   Cand SU(3) FIRST
 # CHECK-NEXT:   Cand SU(6) ORDER
-# CHECK-NEXT: Pick Bot ORDER
+# CHECK-NEXT: Pick Bot Cand SU(6) ORDER
 # CHECK-NEXT: Scheduling SU(6) %8:fpr128 = ANDv16i8 %1:fpr128, %6:fpr128
 # CHECK-NEXT:   Ready @12c
 # CHECK-NEXT:   CortexA55UnitFPALU +2x1u
@@ -1216,7 +1216,7 @@ body:             |
 # CHECK-NEXT: Queue BotQ.P: 1 4
 # CHECK-NEXT: Queue BotQ.A: 3 0
 # CHECK-NEXT:   Cand SU(3) FIRST
-# CHECK-NEXT: Pick Bot PHYS-REG
+# CHECK-NEXT: Pick Bot Cand SU(3) PHYS-REG
 # CHECK-NEXT: Scheduling SU(3) %3:fpr128 = EXTv16i8 %0:fpr128, %0:fpr128, 8
 # CHECK-NEXT:   Ready @13c
 # CHECK-NEXT:   CortexA55UnitFPALU +2x1u
@@ -1484,7 +1484,7 @@ body:             |
 # CHECK-NEXT: Queue BotQ.A: 2 4
 # CHECK-NEXT:   Cand SU(2) FIRST
 # CHECK-NEXT:   Cand SU(4) PHYS-REG
-# CHECK-NEXT: Pick Bot PHYS-REG
+# CHECK-NEXT: Pick Bot Cand SU(4) PHYS-REG
 # CHECK-NEXT: Scheduling SU(4) %6:fpr128 = MOVIv2d_ns 17
 # CHECK-NEXT:   Ready @16c
 # CHECK-NEXT:   CortexA55UnitFPALU +2x1u

--- a/llvm/test/CodeGen/AArch64/misched-detail-resource-booking-02.mir
+++ b/llvm/test/CodeGen/AArch64/misched-detail-resource-booking-02.mir
@@ -231,7 +231,7 @@ body:             |
 # CHECK-NEXT: Queue BotQ.P:
 # CHECK-NEXT: Queue BotQ.A: 2 1 0
 # CHECK-NEXT:   Cand SU(2) FIRST
-# CHECK-NEXT: Pick Bot FIRST
+# CHECK-NEXT: Pick Bot Cand SU(2) FIRST
 # CHECK-NEXT: Scheduling SU(2) $x5 = ADDXrr $x2, $x2
 # CHECK-NEXT:   Ready @0c
 # CHECK-NEXT:   CortexA55UnitALU +1x1u
@@ -326,7 +326,7 @@ body:             |
 # CHECK-NEXT: Queue BotQ.A: 0 1
 # CHECK-NEXT:   Cand SU(0) FIRST
 # CHECK-NEXT:   Cand SU(1) ORDER
-# CHECK-NEXT: Pick Bot ORDER
+# CHECK-NEXT: Pick Bot Cand SU(1) ORDER
 # CHECK-NEXT: Scheduling SU(1) $x4 = ADDXrr $x1, $x1
 # CHECK-NEXT:   Ready @0c
 # CHECK-NEXT:   CortexA55UnitALU +1x1u

--- a/llvm/test/CodeGen/SystemZ/misched-prera-cmp-elim.mir
+++ b/llvm/test/CodeGen/SystemZ/misched-prera-cmp-elim.mir
@@ -12,7 +12,7 @@
 # CHECK:      Queue BotQ.A: 6 4
 # CHECK-NEXT:   Cand SU(6) FIRST
 # CHECK-NEXT:   Cand SU(4) WEAK
-# CHECK-NEXT: Pick Bot WEAK       [pre-RA]
+# CHECK-NEXT: Pick Bot Cand SU(4) WEAK       [pre-RA]
 # CHECK-NEXT: Scheduling SU(4) %7:gr32bit = NRK %6:gr32bit, %0:gr32bit, implicit-def dead $cc
 # CHECK:      *** Final schedule for %bb.1 ***
 # CHECK-NEXT: SU(0):   %5:gr32bit = NRK %2:gr32bit, %0:gr32bit, implicit-def dead $cc

--- a/llvm/test/CodeGen/SystemZ/misched-prera-latencies.mir
+++ b/llvm/test/CodeGen/SystemZ/misched-prera-latencies.mir
@@ -74,7 +74,7 @@ body:             |
 # Single block loop that should also have latency enabled.
 # CHECK:      Current Schedule Region
 # CHECK-NEXT: fun2:%bb.1
-# CHECK: Pick Bot BOT-HEIGHT [pre-RA]
+# CHECK: Pick Bot Cand SU(12) BOT-HEIGHT [pre-RA]
 ---
 name:            fun2
 tracksRegLiveness: true

--- a/llvm/test/CodeGen/SystemZ/misched-prera-loads.mir
+++ b/llvm/test/CodeGen/SystemZ/misched-prera-loads.mir
@@ -18,7 +18,7 @@
 # %3, but this is not done in small regions like this.
 # CHECK:      Current Schedule Region
 # CHECK-NEXT: fun0:%bb.0
-# CHECK-NOT:  Pick Bot REG-EXCESS [pre-RA]
+# CHECK-NOT:  REG-EXCESS [pre-RA]
 # CHECK:      *** Final schedule for %bb.0 ***
 # CHECK-NEXT: SU(0):   %0:gr64bit = COPY $r2d
 # CHECK-NEXT: SU(1):   %1:gr32bit = LHIMux 1
@@ -74,7 +74,7 @@ body:             |
 # CHECK:      Scheduling SU(39)
 #
 # CHECK:      Queue BotQ.A: 33 5
-# CHECK:      Pick Bot BOT-HEIGHT [pre-RA]
+# CHECK:      Pick Bot Cand SU(5) BOT-HEIGHT [pre-RA]
 # CHECK-NEXT: Scheduling SU(5)
 #
 # CHECK:      *** Final schedule for %bb.0 ***
@@ -171,10 +171,10 @@ body:             |
 # CHECK:      Queue BotQ.A: 36 2
 # CHECK-NOT:  Cand SU(2) REG-EXCESS
 # CHECK-NOT:  Scheduling SU(2)
-# CHECK:      Pick Bot FIRST [pre-RA]
+# CHECK:      Pick Bot Cand SU(36) FIRST [pre-RA]
 # CHECK-NEXT: Scheduling SU(36)
 # CHECK:      Queue BotQ.A: 2 32
-# CHECK:      Pick Bot REG-EXCESS [pre-RA]
+# CHECK:      Pick Bot Cand SU(2) REG-EXCESS [pre-RA]
 # CHECK-NEXT: Scheduling SU(2)
 #
 # CHECK:      *** Final schedule for %bb.0 ***
@@ -258,8 +258,8 @@ body:             |
 #
 # CHECK:      Queue BotQ.A: 37 3
 # CHECK:      Scheduling SU(37)
-# CHECK-NOT:  Pick Bot BOT-HEIGHT [pre-RA]
-# CHECK-NOT:  Pick Bot REG-EXCESS [pre-RA]
+# CHECK-NOT:  BOT-HEIGHT [pre-RA]
+# CHECK-NOT:  REG-EXCESS [pre-RA]
 #
 # CHECK:      *** Final schedule for %bb.0 ***
 # CHECK-NEXT: SU(0):   %0:gr64bit = COPY $r2d
@@ -345,13 +345,13 @@ body:             |
 # CHECK:      Height             : 6
 #
 # CHECK:      Queue BotQ.A: 27 38 36 34 33 32 31 30
-# CHECK:      Pick Bot ORDER      [pre-RA]
+# CHECK:      Pick Bot Cand SU(38) ORDER      [pre-RA]
 # CHECK-NEXT: Scheduling SU(38)
 # CHECK:      Queue BotQ.A: 27 30 36 34 33 32 31 37
-# CHECK:      Pick Bot BOT-HEIGHT [pre-RA]
+# CHECK:      Pick Bot Cand SU(36) BOT-HEIGHT [pre-RA]
 # CHECK-NEXT: Scheduling SU(36)
 # CHECK:      Queue BotQ.A: 27 30 37 34 33 32 31 35
-# CHECK:      Pick Bot REG-EXCESS [pre-RA]
+# CHECK:      Pick Bot Cand SU(30) REG-EXCESS [pre-RA]
 # CHECK-NEXT: Scheduling SU(30)
 #
 # CHECK:      *** Final schedule for %bb.0 ***
@@ -447,7 +447,7 @@ body:             |
 # CHECK:      Queue BotQ.A: 27 30 31 34 33 32 35
 # CHECK:      Scheduling SU(35)
 # CHECK:      Queue BotQ.A: 27 30 31 34 33 32
-# CHECK:      Pick Bot REG-EXCESS [pre-RA]
+# CHECK:      Pick Bot Cand SU(30) REG-EXCESS [pre-RA]
 # CHECK-NEXT: Scheduling SU(30)
 #
 # CHECK:      *** Final schedule for %bb.0 ***


### PR DESCRIPTION
Print picked SU node number inline in `tracePick` for convenience. Otherwise its may be a bit more confusing, for example if we have 2 best candidates with a similar reason under a single direction.

Printing node number directly as it cannot be an ExitSU (and EntrySU is effectively unused in-tree).