### PR TITLE
[mlir][test] Fix RegionYieldOp builder adding a null operand

### DIFF
--- a/mlir/test/IR/invalid.mlir
+++ b/mlir/test/IR/invalid.mlir
@@ -699,3 +699,11 @@ func.func @drop_references_on_block_parse_error(){
   }) : () -> ()
   return
 }
+
+// -----
+
+// Auto-constructing a missing implicit terminator must not crash.
+func.func @cse_of_single_block_op_no_terminator() {
+  %0 = test.cse_of_single_block_op inputs() {
+  } // expected-error {{expected ':'}}
+}

--- a/mlir/test/lib/Dialect/Test/TestOps.td
+++ b/mlir/test/lib/Dialect/Test/TestOps.td
@@ -2653,9 +2653,7 @@ def RegionYieldOp : TEST_Op<"region_yield",
   let assemblyFormat = [{
     $result `:` type($result) attr-dict
   }];
-  let builders = [OpBuilder<(ins),
-    [{ build($_builder, $_state, {}); }]>
-  ];
+  let builders = [OpBuilder<(ins), [{ /* nothing to do */ }]>];
 }
 
 class BufferBasedOpBase<string mnemonic, list<Trait> traits>


### PR DESCRIPTION
The custom NoOperand build delegate of test::RegionYieldOp forwarded {} to build(), which overload resolution maps to the generated builder taking a single Value parameter, so a null Value was added as an operand. That only explodes once the op is actually created: parsing an op with the `SingleBlockImplicitTerminator` trait whose region lacks a terminator builds the implicit terminator, inserts the null operand and hits a null use-list
access in IROperandBase::insertInto.

Drop the delegate and use an empty builder body like scf.yield, and add a parser error test for the missing-terminator path.

Fixes #221638