### PR TITLE
[AArch64] Cache repeated subtarget queries (NFC)

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64TargetMachine.cpp
+++ b/llvm/lib/Target/AArch64/AArch64TargetMachine.cpp
@@ -296,7 +296,10 @@ bool AArch64TargetMachine::isGlobalISelOptNone() const {
           !GlobalISelFlag);
 }
 
-void AArch64TargetMachine::reset() { SubtargetMap.clear(); }
+void AArch64TargetMachine::reset() {
+  SubtargetMap.clear();
+  LastSubtarget = nullptr;
+}
 
 //===----------------------------------------------------------------------===//
 // AArch64 Lowering public interface.
@@ -436,6 +439,10 @@ AArch64TargetMachine::~AArch64TargetMachine() = default;
 
 const AArch64Subtarget *
 AArch64TargetMachine::getSubtargetImpl(const Function &F) const {
+  AttributeSet FnAttrs = F.getAttributes().getFnAttrs();
+  if (LastSubtarget && LastSubtargetAttrs == FnAttrs)
+    return LastSubtarget;
+
   Attribute CPUAttr = F.getFnAttribute("target-cpu");
   Attribute TuneAttr = F.getFnAttribute("tune-cpu");
   Attribute FSAttr = F.getFnAttribute("target-features");
@@ -503,7 +510,9 @@ AArch64TargetMachine::getSubtargetImpl(const Function &F) const {
   if (IsStreaming && !I->hasSME())
     reportFatalUsageError("streaming SVE functions require SME");
 
-  return I.get();
+  LastSubtargetAttrs = FnAttrs;
+  LastSubtarget = I.get();
+  return LastSubtarget;
 }
 
 // Encourage placing FORM_TRANSPOSED_REG immediately before the instruction that

--- a/llvm/lib/Target/AArch64/AArch64TargetMachine.cpp
+++ b/llvm/lib/Target/AArch64/AArch64TargetMachine.cpp
@@ -439,6 +439,8 @@ AArch64TargetMachine::~AArch64TargetMachine() = default;
 
 const AArch64Subtarget *
 AArch64TargetMachine::getSubtargetImpl(const Function &F) const {
+  // Constructing the subtarget key is not cheap, avoid rebuilding it for
+  // repeated queries with the same function attributes.
   AttributeSet FnAttrs = F.getAttributes().getFnAttrs();
   if (LastSubtarget && LastSubtargetAttrs == FnAttrs)
     return LastSubtarget;

--- a/llvm/lib/Target/AArch64/AArch64TargetMachine.h
+++ b/llvm/lib/Target/AArch64/AArch64TargetMachine.h
@@ -16,6 +16,7 @@
 #include "AArch64InstrInfo.h"
 #include "AArch64Subtarget.h"
 #include "llvm/CodeGen/CodeGenTargetMachineImpl.h"
+#include "llvm/IR/Attributes.h"
 #include "llvm/IR/DataLayout.h"
 #include <optional>
 
@@ -25,6 +26,8 @@ class AArch64TargetMachine : public CodeGenTargetMachineImpl {
 protected:
   std::unique_ptr<TargetLoweringObjectFile> TLOF;
   mutable StringMap<std::unique_ptr<AArch64Subtarget>> SubtargetMap;
+  mutable AttributeSet LastSubtargetAttrs;
+  mutable const AArch64Subtarget *LastSubtarget = nullptr;
 
   /// Reset internal state.
   void reset() override;


### PR DESCRIPTION
The existing SubtargetMap caches subtargets using a key built from a subset of
relevant function attributes. Add a single-entry cache keyed by the full
function attribute set to avoid rebuilding that key for repeated queries. This
covers both repeated queries for the same function and queries for different
functions with identical attributes.

Improves CTMark geomean -0.10% on aarch64-O3 and -0.17 on aarch64-O0-g.

https://llvm-compile-time-tracker.com/compare.php?from=87d9c3c24ff5941ac08799850a6549b561c98a81&to=544bb3d9ac28bc1a28248f6b03bcd95fa85b20e0&stat=instructions:u

Assisted-by: codex