### PR TITLE
[flang][veclib] Add HVML target to fveclib

### DIFF
--- a/clang/lib/Driver/ToolChains/Flang.cpp
+++ b/clang/lib/Driver/ToolChains/Flang.cpp
@@ -763,6 +763,11 @@ void Flang::addTargetOptions(const ArgList &Args, ArgStringList &CmdArgs,
           Triple.getArch() != llvm::Triple::x86_64)
         D.Diag(diag::err_drv_unsupported_opt_for_target)
             << Name << Triple.getArchName();
+    } else if (Name == "HVML") {
+      // HVML is only available on x86_64 (Hygon CPUs are 64-bit only).
+      if (Triple.getArch() != llvm::Triple::x86_64)
+        D.Diag(diag::err_drv_unsupported_opt_for_target)
+            << Name << Triple.getArchName();
     } else if (Name == "libmvec") {
       if (Triple.getArch() != llvm::Triple::x86 &&
           Triple.getArch() != llvm::Triple::x86_64 &&

--- a/flang/lib/Frontend/CompilerInvocation.cpp
+++ b/flang/lib/Frontend/CompilerInvocation.cpp
@@ -241,6 +241,7 @@ static bool parseVectorLibArg(Fortran::frontend::CodeGenOptions &opts,
           .Case("Darwin_libsystem_m", VectorLibrary::Darwin_libsystem_m)
           .Case("ArmPL", VectorLibrary::ArmPL)
           .Case("AMDLIBM", VectorLibrary::AMDLIBM)
+          .Case("HVML", VectorLibrary::HVML)
           .Case("NoLibrary", VectorLibrary::NoLibrary)
           .Default(std::nullopt);
   if (!val.has_value()) {

--- a/flang/test/Driver/fveclib-codegen.f90
+++ b/flang/test/Driver/fveclib-codegen.f90
@@ -4,6 +4,7 @@
 ! RUN: %if aarch64-registered-target %{ %flang -S -Ofast -target aarch64-unknown-linux-gnu -fveclib=libmvec -march=armv8.2-a+nosve -o - %s | FileCheck %s --check-prefix=LIBMVEC-AARCH64-NEON %}
 ! RUN: %if aarch64-registered-target %{ %flang -S -Ofast -target aarch64-unknown-linux-gnu -fveclib=libmvec -march=armv8.2-a+sve -o - %s | FileCheck %s --check-prefix=LIBMVEC-AARCH64-SVE %}
 ! RUN: %if x86-registered-target %{ %flang -S -O3 -ffast-math -target x86_64-unknown-linux-gnu -fveclib=AMDLIBM -o - %s | FileCheck %s --check-prefix=AMDLIBM %}
+! RUN: %if x86-registered-target %{ %flang -S -O3 -ffast-math -target x86_64-unknown-linux-gnu -fveclib=HVML -o - %s | FileCheck %s --check-prefix=HVML %}
 ! RUN: %flang -S -Ofast -fveclib=NoLibrary -o - %s | FileCheck %s --check-prefix=NOLIB
 
 subroutine sb(a, b)
@@ -16,6 +17,7 @@ subroutine sb(a, b)
 ! LIBMVEC-AARCH64-NEON: _ZGVnN4vv_powf
 ! LIBMVEC-AARCH64-SVE: _ZGVsMxvv_powf
 ! AMDLIBM: amd_vrs4_powf
+! HVML: hvml_vs4_pow
 ! NOLIB: powf
     a(i) = a(i) ** b(i)
   end do

--- a/flang/test/Driver/fveclib.f90
+++ b/flang/test/Driver/fveclib.f90
@@ -7,6 +7,7 @@
 ! RUN: %flang -### -c --target=aarch64-none-none -fveclib=SLEEF %s 2>&1 | FileCheck -check-prefix CHECK-SLEEF %s
 ! RUN: %flang -### -c --target=aarch64-none-none -fveclib=ArmPL %s 2>&1 | FileCheck -check-prefix CHECK-ARMPL %s
 ! RUN: %flang -### -c --target=x86_64-unknown-linux-gnu -fveclib=AMDLIBM %s 2>&1 | FileCheck -check-prefix CHECK-AMDLIBM %s
+! RUN: %flang -### -c --target=x86_64-unknown-linux-gnu -fveclib=HVML %s 2>&1 | FileCheck -check-prefix CHECK-HVML %s
 ! RUN: %flang -### -c --target=aarch64-apple-darwin -fveclib=none %s 2>&1 | FileCheck -check-prefix CHECK-NOLIB-DARWIN %s
 ! RUN: not %flang -c -fveclib=something %s 2>&1 | FileCheck -check-prefix CHECK-INVALID %s
 
@@ -18,15 +19,18 @@
 ! CHECK-SLEEF: "-fveclib=SLEEF"
 ! CHECK-ARMPL: "-fveclib=ArmPL"
 ! CHECK-AMDLIBM: "-fveclib=AMDLIBM"
+! CHECK-HVML: "-fveclib=HVML"
 ! CHECK-NOLIB-DARWIN: "-fveclib=none"
 
 ! CHECK-INVALID: error: invalid value 'something' in '-fveclib=something'
 
 ! RUN: not %flang --target=x86-none-none -c -fveclib=SLEEF %s 2>&1 | FileCheck -check-prefix CHECK-ERROR %s
 ! RUN: not %flang --target=x86-none-none -c -fveclib=ArmPL %s 2>&1 | FileCheck -check-prefix CHECK-ERROR %s
+! RUN: not %flang --target=x86-none-none -c -fveclib=HVML %s 2>&1 | FileCheck -check-prefix CHECK-ERROR %s
 ! RUN: not %flang --target=riscv64-none-none -c -fveclib=libmvec %s 2>&1 | FileCheck -check-prefix CHECK-ERROR %s
 ! RUN: not %flang --target=aarch64-none-none -c -fveclib=SVML %s 2>&1 | FileCheck -check-prefix CHECK-ERROR %s
 ! RUN: not %flang --target=aarch64-none-none -c -fveclib=AMDLIBM %s 2>&1 | FileCheck -check-prefix CHECK-ERROR %s
+! RUN: not %flang --target=aarch64-none-none -c -fveclib=HVML %s 2>&1 | FileCheck -check-prefix CHECK-ERROR %s
 ! CHECK-ERROR: unsupported option {{.*}} for target
 
 ! RUN: %flang -fveclib=Accelerate %s -target arm64-apple-ios8.0.0 -### 2>&1 | FileCheck --check-prefix=CHECK-LINK %s


### PR DESCRIPTION
Add support for the HVML vector math library in flang's -fveclib option.

Wire HVML through the flang driver, restricted to x86_64.

This is the third of three incremental patches; depends on #222632.