### PR TITLE
[NVPTX] Diagnose an unsupported alias instead of aborting the compiler

### DIFF
--- a/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
@@ -67,6 +67,7 @@
 #include "llvm/IR/DebugInfoMetadata.h"
 #include "llvm/IR/DebugLoc.h"
 #include "llvm/IR/DerivedTypes.h"
+#include "llvm/IR/DiagnosticInfo.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/GlobalAlias.h"
 #include "llvm/IR/GlobalValue.h"
@@ -1045,18 +1046,50 @@ std::string NVPTXAsmPrinter::getVirtualRegisterName(Register Reg) const {
   return Name;
 }
 
+/// PTX's .alias directive states that "Both fAlias and fAliasee are non-entry
+/// function symbols", that the aliasee "must be defined in the same module",
+/// and that it "cannot have .weak linkage" (PTX ISA, Kernel and Function
+/// Directives: .alias). An alias outside those bounds therefore has no PTX
+/// lowering at all. Returns why the alias cannot be lowered, or nullptr if it
+/// can be.
+static const char *getAliasUnsupportedReason(const GlobalAlias &GA) {
+  const Function *F = dyn_cast_or_null<Function>(GA.getAliaseeObject());
+  if (!F)
+    return "PTX can only alias a function";
+  if (F->isDeclaration())
+    return "PTX requires the aliasee to be defined in the same module";
+  if (isKernelFunction(*F))
+    return "PTX .alias requires non-entry functions, so a kernel cannot be "
+           "aliased";
+  if (GA.hasLinkOnceLinkage() || GA.hasWeakLinkage() ||
+      GA.hasAvailableExternallyLinkage() || GA.hasCommonLinkage())
+    return "PTX forbids a .weak aliasee";
+  return nullptr;
+}
+
+/// Report an alias we cannot lower as a diagnostic rather than aborting. A
+/// frontend that emits an alias for every export (as the Zig compiler does)
+/// would otherwise lose the whole compilation to report_fatal_error, with no
+/// source location and no way to recover.
+static void reportUnsupportedAlias(const GlobalAlias &GA, const char *Reason) {
+  const std::string Msg =
+      ("unsupported alias '" + GA.getName() + "': " + Reason).str();
+  LLVMContext &Ctx = GA.getContext();
+  if (const auto *F = dyn_cast_or_null<Function>(GA.getAliaseeObject()))
+    Ctx.diagnose(DiagnosticInfoUnsupported(*F, Msg, F->getSubprogram()));
+  else
+    Ctx.emitError(Msg);
+}
+
 void NVPTXAsmPrinter::emitAliasDeclaration(const GlobalAlias *GA,
                                            raw_ostream &O) {
-  const Function *F = dyn_cast_or_null<Function>(GA->getAliaseeObject());
-  if (!F || isKernelFunction(*F) || F->isDeclaration())
-    report_fatal_error(
-        "NVPTX aliasee must be a non-kernel function definition");
+  if (const char *Reason = getAliasUnsupportedReason(*GA)) {
+    reportUnsupportedAlias(*GA, Reason);
+    return;
+  }
 
-  if (GA->hasLinkOnceLinkage() || GA->hasWeakLinkage() ||
-      GA->hasAvailableExternallyLinkage() || GA->hasCommonLinkage())
-    report_fatal_error("NVPTX aliasee must not be '.weak'");
-
-  emitDeclarationWithName(F, getSymbol(GA), O);
+  emitDeclarationWithName(cast<Function>(GA->getAliaseeObject()), getSymbol(GA),
+                          O);
 }
 
 void NVPTXAsmPrinter::emitDeclaration(const Function *F, raw_ostream &O) {
@@ -1311,6 +1344,11 @@ void NVPTXAsmPrinter::emitGlobals(const Module &M) {
 }
 
 void NVPTXAsmPrinter::emitGlobalAlias(const Module &M, const GlobalAlias &GA) {
+  // Already diagnosed by emitAliasDeclaration, which runs first. Emitting the
+  // directive anyway would name a declaration that was deliberately skipped.
+  if (getAliasUnsupportedReason(GA))
+    return;
+
   getTargetStreamer()->emitAliasDirective(getSymbol(&GA),
                                           getSymbol(GA.getAliaseeObject()));
 }

--- a/llvm/test/CodeGen/NVPTX/alias-errors.ll
+++ b/llvm/test/CodeGen/NVPTX/alias-errors.ll
@@ -1,9 +1,29 @@
 ; RUN: not --crash llc < %s -mtriple=nvptx64 -mcpu=sm_30 -mattr=+ptx43 2>&1 | FileCheck %s --check-prefix=ATTR
 ; RUN: not --crash llc < %s -mtriple=nvptx64 -mcpu=sm_20 -mattr=+ptx63 2>&1 | FileCheck %s --check-prefix=ATTR
-; RUN: not --crash llc < %s -mtriple=nvptx64 -mcpu=sm_30 -mattr=+ptx63 2>&1 | FileCheck %s --check-prefix=ALIAS
+; RUN: not llc < %s -mtriple=nvptx64 -mcpu=sm_30 -mattr=+ptx63 2>&1 | FileCheck %s --check-prefix=ALIAS
 
 ; ATTR: .alias requires PTX version >= 6.3 and sm_30
 
-; ALIAS: NVPTX aliasee must be a non-kernel function
+; PTX's .alias directive accepts "non-entry function symbols" only, and requires
+; the aliasee to be defined in the same module, so none of the aliases below can
+; be lowered. Report them instead of aborting: a frontend that emits an alias
+; for every export would otherwise lose the whole compilation to a crash.
+
+; ALIAS-DAG: error: unsupported alias 'not_a_function': PTX can only alias a function
+; ALIAS-DAG: error: {{.*}}unsupported alias 'kernel_alias': PTX .alias requires non-entry functions, so a kernel cannot be aliased
+; ALIAS-DAG: error: {{.*}}unsupported alias 'weak_alias': PTX forbids a .weak aliasee
+
 @a = global i32 42, align 8
-@b = internal alias i32, ptr @a
+@not_a_function = internal alias i32, ptr @a
+
+define ptx_kernel void @the_kernel(ptr %p) {
+  store i32 0, ptr %p
+  ret void
+}
+@kernel_alias = alias void (ptr), ptr @the_kernel
+
+define void @plain_func(ptr %p) {
+  store i32 1, ptr %p
+  ret void
+}
+@weak_alias = weak alias void (ptr), ptr @plain_func


### PR DESCRIPTION
## Purpose

Fixes #213504.

`emitAliasDeclaration()` rejected four shapes of `GlobalAlias` with `report_fatal_error`, so a module that is perfectly valid IR took the whole compilation down with an abort, no source location, and a "PLEASE submit a bug report" banner. The reporter hit it from the Zig compiler, which emits an alias for every exported object, so any exported kernel crashes the backend:

```llvm
@foo = alias void (ptr), ptr @example.foo
define private ptx_kernel void @example.foo(ptr %0) { store i32 0, ptr %0  ret void }
```
```
LLVM ERROR: NVPTX aliasee must be a non-kernel function definition
PLEASE submit a bug report to https://github.com/llvm/llvm-project/issues/ ...
```

The issue asks for the backend to emulate these aliases during lowering. I don't think it can, and it's worth saying why: PTX's own `.alias` directive rules them out. From the PTX ISA, *Kernel and Function Directives: `.alias`*:

> Both `fAlias` and `fAliasee` are **non-entry function symbols**. [...] Identifier `fAliasee` is a function symbol which **must be defined in the same module** as `.alias` declaration. Function `fAliasee` **cannot have `.weak` linkage**.

So a kernel alias has no PTX spelling at all — emulating it would mean emitting the kernel body a second time under another name, which changes what the module contains rather than lowering it. The restriction the backend enforces is correct. Only the way it was reported was wrong.

This reports them with `DiagnosticInfoUnsupported` — the same mechanism this file already uses for an unsupported `blocksareclusters` a few hundred lines up — and skips the `.alias` directive for an alias whose declaration was skipped, so the output never names a declaration that was deliberately not emitted. `llc` exits non-zero with a readable error instead of aborting.

The reason strings are split into `getAliasUnsupportedReason()` so that `emitAliasDeclaration` and `emitGlobalAlias` cannot disagree about what is lowerable.

The module-level `.alias requires PTX version >= 6.3 and sm_30` check in `doInitialization` is left as a `report_fatal_error`; it is a different check in a different place, and I did not want to widen this patch. Happy to convert it too if you'd like it in the same change.

## Test Plan

```
llvm-lit llvm/test/CodeGen/NVPTX/alias-errors.ll
llvm-lit llvm/test/CodeGen/NVPTX
```

`alias-errors.ll` already covered the "aliasee is not a function" case, and needed updating because that case no longer crashes: its third RUN line goes from `not --crash llc` to `not llc`. I extended the same module to cover the kernel aliasee from the issue and a `.weak` aliasee, since all three now report rather than abort. The two `ATTR` RUN lines are untouched — that check lives in `doInitialization` and is unaffected.

## Test Result

```
$ llc alias.ll -mcpu=sm_90 -o out.ptx      # before
LLVM ERROR: NVPTX aliasee must be a non-kernel function definition
PLEASE submit a bug report ... Stack dump: ...
Aborted (signal 6)

$ llc alias.ll -mcpu=sm_90 -o out.ptx      # after
error: <unknown>:0:0: in function example_$_foo void (ptr): unsupported alias 'foo': PTX .alias requires non-entry functions, so a kernel cannot be aliased
$ echo $?
1
```

All three reasons fire on the test module:

```
error: unsupported alias 'not_a_function': PTX can only alias a function
error: ... in function the_kernel void (ptr): unsupported alias 'kernel_alias': PTX .alias requires non-entry functions, so a kernel cannot be aliased
error: ... in function plain_func void (ptr): unsupported alias 'weak_alias': PTX forbids a .weak aliasee
```

`llvm/test/CodeGen/NVPTX`: **587/587 pass**. `git clang-format` reports no changes.

One judgement call worth flagging for review: `DiagnosticInfoUnsupported` needs a `Function`, so the diagnostic is attached to the *aliasee* rather than to the alias, which is what puts `in function the_kernel` in the message. That buys a source location when debug info is present, but it does name the wrong half of the relationship. If you would rather have a plain `Ctx.emitError` for all four cases, the messages get shorter and more uniform at the cost of that location — say the word and I'll switch it.

## AI tool use

Per the [LLVM AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html): this change was written with AI assistance (Claude Code), and the commit carries an `Assisted-by:` trailer. I have read and reviewed the whole patch and I am accountable for it. The PTX ISA constraint quoted above was read out of the current PTX ISA documentation rather than recalled, and the before/after transcripts are real runs of `llc` built from this tree.
