### PR TITLE
[sanitizer_common] Log a backtrace for unexpected format printf specifiers

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_common_interceptors_format.inc
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_common_interceptors_format.inc
@@ -15,6 +15,8 @@
 
 #include <stdarg.h>
 
+#include "sanitizer_stacktrace.h"
+
 static const char *parse_number(const char *p, int *out) {
   *out = internal_atoll(p);
   while (*p >= '0' && *p <= '9')
@@ -538,11 +540,16 @@ static void printf_common(void *ctx, const char *format, va_list aq) {
     int size = printf_get_value_size(&dir);
     if (size == FSS_INVALID) {
       static int ReportedOnce;
-      if (!ReportedOnce++)
+      if (!ReportedOnce++) {
         Report(
             "%s: WARNING: unexpected format specifier in printf "
             "interceptor: %.*s (reported once per process)\n",
             SanitizerToolName, static_cast<int>(dir.end - dir.begin), dir.begin);
+        BufferedStackTrace stack;
+        stack.Unwind(StackTrace::GetCurrentPc(), GET_CURRENT_FRAME(), nullptr,
+                     common_flags()->fast_unwind_on_fatal);
+        stack.Print();
+      }
       break;
     }
     if (dir.convSpecifier == 'n') {

--- a/compiler-rt/lib/sanitizer_common/sanitizer_common_interceptors_format.inc
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_common_interceptors_format.inc
@@ -15,6 +15,7 @@
 
 #include <stdarg.h>
 
+#include "sanitizer_allocator_internal.h"
 #include "sanitizer_stacktrace.h"
 
 static const char *parse_number(const char *p, int *out) {
@@ -545,10 +546,12 @@ static void printf_common(void *ctx, const char *format, va_list aq) {
             "%s: WARNING: unexpected format specifier in printf "
             "interceptor: %.*s (reported once per process)\n",
             SanitizerToolName, static_cast<int>(dir.end - dir.begin), dir.begin);
-        BufferedStackTrace stack;
-        stack.Unwind(StackTrace::GetCurrentPc(), GET_CURRENT_FRAME(), nullptr,
-                     common_flags()->fast_unwind_on_fatal);
-        stack.Print();
+        auto* stack = new (InternalAlloc(sizeof(BufferedStackTrace)))
+            BufferedStackTrace();
+        stack->Unwind(StackTrace::GetCurrentPc(), GET_CURRENT_FRAME(), nullptr,
+                      common_flags()->fast_unwind_on_fatal);
+        stack->Print();
+        InternalFree(stack);
       }
       break;
     }

--- a/compiler-rt/test/sanitizer_common/TestCases/printf-unknown-specifier.c
+++ b/compiler-rt/test/sanitizer_common/TestCases/printf-unknown-specifier.c
@@ -5,7 +5,7 @@
 // RUN: %run %t 2>&1 | FileCheck %s
 
 // The warning is only emitted by tools that use the common printf interceptor.
-// UNSUPPORTED: ubsan, lsan
+// UNSUPPORTED: ubsan, lsan, hwasan, msan, rtsan
 
 #include <stdio.h>
 

--- a/compiler-rt/test/sanitizer_common/TestCases/printf-unknown-specifier.c
+++ b/compiler-rt/test/sanitizer_common/TestCases/printf-unknown-specifier.c
@@ -1,0 +1,24 @@
+// Check that the "unexpected format specifier" warning from the printf
+// interceptor gives a backtrace
+
+// RUN: %clang %s -Wno-format -Wno-format-invalid-specifier -o %t
+// RUN: %run %t 2>&1 | FileCheck %s
+
+// The warning is only emitted by tools that use the common printf interceptor.
+// UNSUPPORTED: ubsan, lsan
+
+#include <stdio.h>
+
+__attribute__((noinline)) void log_it(const char *fmt, int v) {
+  printf(fmt, v);
+}
+
+int main(void) {
+  log_it("value=%y\n", 42);
+  // CHECK: WARNING: unexpected format specifier in printf interceptor: %y
+  // CHECK: {{ }}log_it
+  // CHECK: {{ }}main
+  printf("done\n");
+  // CHECK: done
+  return 0;
+}


### PR DESCRIPTION
Occasionally I find these warning messages in ASan logs, and it is not always easy to track down their source. This patch logs a backtrace along with the warning message in order to make them easier to locate.

rdar://34028569