### PR TITLE
[lldb][Windows] Remove use of unstable ABI and fix SB API visibility

### DIFF
--- a/lldb/include/lldb/API/SBFile.h
+++ b/lldb/include/lldb/API/SBFile.h
@@ -35,7 +35,13 @@ public:
   SBFile(int fd, const char *mode, bool transfer_ownership);
   ~SBFile();
 
-#if defined(_WIN32) && !defined(SWIG)
+#ifndef SWIG
+  /// Open a file descriptor in liblldb from a Windows HANDLE.
+  ///
+  /// This is useful for builds that statically link to the C runtime (`/MT`),
+  /// because the fd -> HANDLE mapping is local to liblldb's CRT instance.
+  ///
+  /// On other platforms, this always returns -1.
   static int OpenFdFromHandle(intptr_t handle, int flags);
 #endif
 

--- a/lldb/source/API/SBFile.cpp
+++ b/lldb/source/API/SBFile.cpp
@@ -69,11 +69,15 @@ SBFile::SBFile(int fd, const char *mode, bool transfer_ownership) {
       std::make_shared<NativeFile>(fd, options.get(), transfer_ownership);
 }
 
-#ifdef _WIN32
 int SBFile::OpenFdFromHandle(intptr_t handle, int flags) {
+#if _WIN32
   return _open_osfhandle(handle, flags);
-}
+#else
+  (void)handle;
+  (void)flags;
+  return -1;
 #endif
+}
 
 SBError SBFile::Read(uint8_t *buf, size_t num_bytes, size_t *bytes_read) {
   LLDB_INSTRUMENT_VA(this, buf, num_bytes, bytes_read);

--- a/lldb/source/Plugins/ScriptInterpreter/Python/PythonDataObjects.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/PythonDataObjects.cpp
@@ -1027,12 +1027,13 @@ int PythonFile::TranslateFdToPython(int our_fd) {
   Py_XDECREF(open_osf);
   if (!fd_obj)
     return -1;
-  if (!PyLong_Check(fd_obj)) {
-    Py_XDECREF(fd_obj);
-    return -1;
-  }
+
   long theirs = PyLong_AsLong(fd_obj);
   Py_XDECREF(fd_obj);
+  if (PyErr_Occurred()) {
+    PyErr_Clear();
+    return -1;
+  }
   return (int)theirs;
 }
 
@@ -1048,12 +1049,14 @@ int PythonFile::TranslateFdFromPython(int their_fd) {
   Py_XDECREF(get_handle);
   if (!handle_obj)
     return -1;
-  if (!PyLong_Check(handle_obj)) {
-    Py_XDECREF(handle_obj);
-    return -1;
-  }
+
   size_t handle = PyLong_AsSize_t(handle_obj);
   Py_XDECREF(handle_obj);
+  if (PyErr_Occurred()) {
+    PyErr_Clear();
+    return -1;
+  }
+
   return _open_osfhandle((intptr_t)handle, 0);
 }
 #else


### PR DESCRIPTION
Addresses the post-commit review comments from the original PR (https://github.com/llvm/llvm-project/pull/217126#pullrequestreview-5162589053).

- `SBFile::OpenFdFromHandle` is now visible on all platforms (just `#ifndef SWIG`) and returns -1 by default.
- Removed non-stable `PyLong_Check` in favor of `PyErr_Occurred` and `PyErr_Clear`.