### PR TITLE
[compiler-rt][profdata] Use x86 triple in instrprof-debug-info-correlate-warnings.ll

### DIFF
--- a/compiler-rt/test/profile/Linux/instrprof-debug-info-correlate-warnings.ll
+++ b/compiler-rt/test/profile/Linux/instrprof-debug-info-correlate-warnings.ll
@@ -1,5 +1,7 @@
+; REQUIRES: x86-64-registered-target
+
 ; RUN: split-file %s %t
-; RUN: %clang %t/a.ll -o %t/a.out
+; RUN: %clang --target=x86_64-unknown-linux-gnu%t/a.ll -o %t/a.out
 ; RUN: llvm-profdata merge --debug-info=%t/a.out %t/a.proftext --max-debug-info-correlation-warnings=2 -o %t/a.profdata 2>&1 | FileCheck %s --implicit-check-not=warning --check-prefixes=CHECK,LIMIT
 ; RUN: llvm-profdata merge --debug-info=%t/a.out %t/a.proftext --max-debug-info-correlation-warnings=0 -o %t/a.profdata 2>&1 | FileCheck %s --implicit-check-not=warning --check-prefixes=CHECK,NOLIMIT
 


### PR DESCRIPTION
Test added by #163254 / 28c048ec0f0a677115a0b00a88a7d013f925f2b8.

It has been failing in Armv8 (32-bit) builds since then. I'm only just getting to it.

warning: overriding the module target triple with armv8a-unknown-linux-gnueabihf [-Woverride-module] 
'x86-64' is not a recognized processor for this target (ignoring processor)
'+cmov' is not a recognized feature for this target (ignoring feature)
'+cx8' is not a recognized feature for this target (ignoring feature) <...>
error: a.c:1:0: in function main i32 (): calling convention is hard-float, but floating-point registers are unavailable

Happens on AArch64 too, but it's not fatal there. This happens because the ll has x86 options in it, but the RUN used whatever the host triple was.

I don't know what's critical in this file, so I'm adding a --target x86 option to the test to fix this, instead of cutting out all the x86 specific parts.