### PR TITLE
[CIR][X86] Emit cir.clz/cir.ctz for lzcnt/tzcnt builtins

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinX86.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinX86.cpp
@@ -1155,20 +1155,16 @@ CIRGenFunction::emitX86BuiltinExpr(unsigned builtinID, const CallExpr *expr) {
   }
   case X86::BI__builtin_ia32_lzcnt_u16:
   case X86::BI__builtin_ia32_lzcnt_u32:
-  case X86::BI__builtin_ia32_lzcnt_u64: {
-    mlir::Location loc = getLoc(expr->getExprLoc());
-    mlir::Value isZeroPoison = builder.getFalse(loc);
-    return builder.emitIntrinsicCallOp(loc, "ctlz", ops[0].getType(),
-                                       mlir::ValueRange{ops[0], isZeroPoison});
-  }
+  case X86::BI__builtin_ia32_lzcnt_u64:
+    return cir::BitClzOp::create(builder, getLoc(expr->getExprLoc()), ops[0],
+                                 /*poisonZero=*/false)
+        .getResult();
   case X86::BI__builtin_ia32_tzcnt_u16:
   case X86::BI__builtin_ia32_tzcnt_u32:
-  case X86::BI__builtin_ia32_tzcnt_u64: {
-    mlir::Location loc = getLoc(expr->getExprLoc());
-    mlir::Value isZeroPoison = builder.getFalse(loc);
-    return builder.emitIntrinsicCallOp(loc, "cttz", ops[0].getType(),
-                                       mlir::ValueRange{ops[0], isZeroPoison});
-  }
+  case X86::BI__builtin_ia32_tzcnt_u64:
+    return cir::BitCtzOp::create(builder, getLoc(expr->getExprLoc()), ops[0],
+                                 /*poisonZero=*/false)
+        .getResult();
   case X86::BI__builtin_ia32_undef128:
   case X86::BI__builtin_ia32_undef256:
   case X86::BI__builtin_ia32_undef512:

--- a/clang/test/CIR/CodeGenBuiltins/X86/bmi-builtins.c
+++ b/clang/test/CIR/CodeGenBuiltins/X86/bmi-builtins.c
@@ -18,7 +18,7 @@
 
 unsigned short test__tzcnt_u16(unsigned short __X) {
   // CIR-LABEL: __tzcnt_u16
-  // CIR: {{%.*}} = cir.call_llvm_intrinsic "cttz" {{%.*}} : (!u16i, !cir.bool) -> !u16i
+  // CIR: {{%.*}} = cir.ctz {{%.*}} : !u16i
   // LLVM-LABEL: __tzcnt_u16
   // LLVM: i16 @llvm.cttz.i16(i16 %{{.*}}, i1 false)
   // OGCG-LABEL: __tzcnt_u16
@@ -28,7 +28,7 @@ unsigned short test__tzcnt_u16(unsigned short __X) {
 
 unsigned int test__tzcnt_u32(unsigned int __X) {
   // CIR-LABEL: __tzcnt_u32
-  // CIR: {{%.*}} = cir.call_llvm_intrinsic "cttz" {{%.*}} : (!u32i, !cir.bool) -> !u32i
+  // CIR: {{%.*}} = cir.ctz {{%.*}} : !u32i
   // LLVM-LABEL: __tzcnt_u32
   // LLVM: i32 @llvm.cttz.i32(i32 %{{.*}}, i1 false)
   // OGCG-LABEL: __tzcnt_u32
@@ -39,7 +39,7 @@ unsigned int test__tzcnt_u32(unsigned int __X) {
 #ifdef __x86_64__
 unsigned long long test__tzcnt_u64(unsigned long long __X) {
   // CIR-LABEL: __tzcnt_u64
-  // CIR: {{%.*}} = cir.call_llvm_intrinsic "cttz" {{%.*}} : (!u64i, !cir.bool) -> !u64i
+  // CIR: {{%.*}} = cir.ctz {{%.*}} : !u64i
   // LLVM-LABEL: __tzcnt_u64
   // LLVM: i64 @llvm.cttz.i64(i64 %{{.*}}, i1 false)
   // OGCG-LABEL: __tzcnt_u64

--- a/clang/test/CIR/CodeGenBuiltins/X86/lzcnt-builtins.c
+++ b/clang/test/CIR/CodeGenBuiltins/X86/lzcnt-builtins.c
@@ -18,7 +18,7 @@
 
 unsigned int test__lzcnt16(unsigned short __X) {
   // CIR-LABEL: __lzcnt16
-  // CIR: {{%.*}} = cir.call_llvm_intrinsic "ctlz" {{%.*}} : (!u16i, !cir.bool) -> !u16i
+  // CIR: {{%.*}} = cir.clz {{%.*}} : !u16i
   // LLVM-LABEL: __lzcnt16
   // LLVM: @llvm.ctlz.i16(i16 %{{.*}}, i1 false)
   // OGCG-LABEL: __lzcnt16
@@ -28,7 +28,7 @@ unsigned int test__lzcnt16(unsigned short __X) {
 
 unsigned int test__lzcnt32(unsigned int __X) {
   // CIR-LABEL: __lzcnt32
-  // CIR: {{%.*}} = cir.call_llvm_intrinsic "ctlz" {{%.*}} : (!u32i, !cir.bool) -> !u32i
+  // CIR: {{%.*}} = cir.clz {{%.*}} : !u32i
   // LLVM-LABEL: __lzcnt32
   // LLVM: @llvm.ctlz.i32(i32 %{{.*}}, i1 false)
   // OGCG-LABEL: __lzcnt32
@@ -38,7 +38,7 @@ unsigned int test__lzcnt32(unsigned int __X) {
 
 unsigned long long test__lzcnt64(unsigned long long __X) {
   // CIR-LABEL: __lzcnt64
-  // CIR: {{%.*}} = cir.call_llvm_intrinsic "ctlz" {{%.*}} : (!u64i, !cir.bool) -> !u64i
+  // CIR: {{%.*}} = cir.clz {{%.*}} : !u64i
   // LLVM-LABEL: __lzcnt64
   // LLVM: @llvm.ctlz.i64(i64 %{{.*}}, i1 false)
   // OGCG-LABEL: __lzcnt64
@@ -48,7 +48,7 @@ unsigned long long test__lzcnt64(unsigned long long __X) {
 
 unsigned int test__lzcnt_u32(unsigned int __X) {
   // CIR-LABEL: _lzcnt_u32
-  // CIR: {{%.*}} = cir.call_llvm_intrinsic "ctlz" {{%.*}} : (!u32i, !cir.bool) -> !u32i
+  // CIR: {{%.*}} = cir.clz {{%.*}} : !u32i
   // LLVM-LABEL: _lzcnt_u32
   // LLVM: @llvm.ctlz.i32(i32 %{{.*}}, i1 false)
   // OGCG-LABEL: _lzcnt_u32
@@ -58,7 +58,7 @@ unsigned int test__lzcnt_u32(unsigned int __X) {
 
 unsigned long long test__lzcnt_u64(unsigned long long __X) {
   // CIR-LABEL: _lzcnt_u64
-  // CIR: {{%.*}} = cir.call_llvm_intrinsic "ctlz" {{%.*}} : (!u64i, !cir.bool) -> !u64i
+  // CIR: {{%.*}} = cir.clz {{%.*}} : !u64i
   // LLVM-LABEL: _lzcnt_u64
   // LLVM: @llvm.ctlz.i64(i64 %{{.*}}, i1 false)
   // OGCG-LABEL: _lzcnt_u64


### PR DESCRIPTION
These x86 builtins were lowered through cir.call_llvm_intrinsic even though dedicated CIR bit-count ops already exist.

Assisted-by: grok-4.6