### PR TITLE
[BuildLibCalls] Apply ABI attributes to call-sites as well

### DIFF
--- a/llvm/lib/Transforms/Utils/BuildLibCalls.cpp
+++ b/llvm/lib/Transforms/Utils/BuildLibCalls.cpp
@@ -1503,6 +1503,21 @@ void llvm::markRegisterParameterAttributes(Function *F) {
   }
 }
 
+static void inheritABIAttributesFromCallee(CallBase *CB) {
+  Function *F = CB->getCalledFunction();
+  assert(F && "Cannot be indirect call");
+
+  auto CopyAtIndex = [&](unsigned Index) {
+    for (Attribute Attr : F->getAttributes().getAttributes(Index))
+      if (Attr.hasKindAsEnum() && Attribute::isABIAttr(Attr.getKindAsEnum()))
+        CB->addAttributeAtIndex(Index, Attr);
+  };
+
+  CopyAtIndex(AttributeList::ReturnIndex);
+  for (unsigned I = 0; I < F->arg_size(); I++)
+    CopyAtIndex(AttributeList::FirstArgIndex + I);
+}
+
 FunctionCallee llvm::getOrInsertLibFunc(Module *M, const TargetLibraryInfo &TLI,
                                         LibFunc TheLibFunc, FunctionType *T,
                                         AttributeList AttributeList) {
@@ -1663,6 +1678,7 @@ static Value *emitLibCall(LibFunc TheLibFunc, Type *ReturnType,
   FunctionCallee Callee = getOrInsertLibFunc(M, *TLI, TheLibFunc, FuncType);
   inferNonMandatoryLibFuncAttrs(M, FuncName, *TLI);
   CallInst *CI = B.CreateCall(Callee, Operands, FuncName);
+  inheritABIAttributesFromCallee(CI);
   if (const Function *F =
           dyn_cast<Function>(Callee.getCallee()->stripPointerCasts()))
     CI->setCallingConv(F->getCallingConv());
@@ -1756,6 +1772,7 @@ Value *llvm::emitMemCpyChk(Value *Dst, Value *Src, Value *Len, Value *ObjSize,
       AttributeList::get(M->getContext(), AS), VoidPtrTy,
       VoidPtrTy, VoidPtrTy, SizeTTy, SizeTTy);
   CallInst *CI = B.CreateCall(MemCpy, {Dst, Src, Len, ObjSize});
+  inheritABIAttributesFromCallee(CI);
   if (const Function *F =
           dyn_cast<Function>(MemCpy.getCallee()->stripPointerCasts()))
     CI->setCallingConv(F->getCallingConv());
@@ -1932,6 +1949,7 @@ static Value *emitUnaryFloatFnCallHelper(Value *Op, LibFunc TheLibFunc,
   // speculatable.
   CI->setAttributes(
       Attrs.removeFnAttribute(B.getContext(), Attribute::Speculatable));
+  inheritABIAttributesFromCallee(CI);
   if (const Function *F =
           dyn_cast<Function>(Callee.getCallee()->stripPointerCasts()))
     CI->setCallingConv(F->getCallingConv());
@@ -1980,6 +1998,7 @@ static Value *emitBinaryFloatFnCallHelper(Value *Op1, Value *Op2,
   // speculatable.
   CI->setAttributes(
       Attrs.removeFnAttribute(B.getContext(), Attribute::Speculatable));
+  inheritABIAttributesFromCallee(CI);
   if (const Function *F =
           dyn_cast<Function>(Callee.getCallee()->stripPointerCasts()))
     CI->setCallingConv(F->getCallingConv());
@@ -2080,6 +2099,7 @@ Value *llvm::emitHotColdSizeReturningNew(Value *Num, IRBuilderBase &B,
       M->getOrInsertFunction(Name, SizedPtrT, Num->getType(), B.getInt8Ty());
   inferNonMandatoryLibFuncAttrs(M, Name, *TLI);
   CallInst *CI = B.CreateCall(Func, {Num, HotCold}, "sized_ptr");
+  inheritABIAttributesFromCallee(CI);
 
   if (const Function *F = dyn_cast<Function>(Func.getCallee()))
     CI->setCallingConv(F->getCallingConv());
@@ -2105,6 +2125,7 @@ Value *llvm::emitHotColdSizeReturningNewAligned(Value *Num, Value *Align,
                                                Align->getType(), B.getInt8Ty());
   inferNonMandatoryLibFuncAttrs(M, Name, *TLI);
   CallInst *CI = B.CreateCall(Func, {Num, Align, HotCold}, "sized_ptr");
+  inheritABIAttributesFromCallee(CI);
 
   if (const Function *F = dyn_cast<Function>(Func.getCallee()))
     CI->setCallingConv(F->getCallingConv());
@@ -2124,6 +2145,7 @@ Value *llvm::emitHotColdNew(Value *Num, IRBuilderBase &B,
       M->getOrInsertFunction(Name, B.getPtrTy(), Num->getType(), B.getInt8Ty());
   inferNonMandatoryLibFuncAttrs(M, Name, *TLI);
   CallInst *CI = B.CreateCall(Func, {Num, HotCold}, Name);
+  inheritABIAttributesFromCallee(CI);
 
   if (const Function *F =
           dyn_cast<Function>(Func.getCallee()->stripPointerCasts()))
@@ -2144,6 +2166,7 @@ Value *llvm::emitHotColdNewNoThrow(Value *Num, Value *NoThrow, IRBuilderBase &B,
       Name, B.getPtrTy(), Num->getType(), NoThrow->getType(), B.getInt8Ty());
   inferNonMandatoryLibFuncAttrs(M, Name, *TLI);
   CallInst *CI = B.CreateCall(Func, {Num, NoThrow, HotCold}, Name);
+  inheritABIAttributesFromCallee(CI);
 
   if (const Function *F =
           dyn_cast<Function>(Func.getCallee()->stripPointerCasts()))
@@ -2164,6 +2187,7 @@ Value *llvm::emitHotColdNewAligned(Value *Num, Value *Align, IRBuilderBase &B,
       Name, B.getPtrTy(), Num->getType(), Align->getType(), B.getInt8Ty());
   inferNonMandatoryLibFuncAttrs(M, Name, *TLI);
   CallInst *CI = B.CreateCall(Func, {Num, Align, HotCold}, Name);
+  inheritABIAttributesFromCallee(CI);
 
   if (const Function *F =
           dyn_cast<Function>(Func.getCallee()->stripPointerCasts()))
@@ -2186,6 +2210,7 @@ Value *llvm::emitHotColdNewAlignedNoThrow(Value *Num, Value *Align,
       B.getInt8Ty());
   inferNonMandatoryLibFuncAttrs(M, Name, *TLI);
   CallInst *CI = B.CreateCall(Func, {Num, Align, NoThrow, HotCold}, Name);
+  inheritABIAttributesFromCallee(CI);
 
   if (const Function *F =
           dyn_cast<Function>(Func.getCallee()->stripPointerCasts()))

--- a/llvm/test/Transforms/InstCombine/RISCV/memcmp.ll
+++ b/llvm/test/Transforms/InstCombine/RISCV/memcmp.ll
@@ -5,7 +5,7 @@ declare signext i32 @memcmp(ptr, ptr, i64)
 ; Make sure we use signext attribute for the bcmp result.
 define signext i32 @test_bcmp(ptr %mem1, ptr %mem2, i64 %size) {
 ; CHECK-LABEL: define {{[^@]+}}@test_bcmp(
-; CHECK-NEXT:    [[BCMP:%.*]] = call i32 @bcmp(ptr [[MEM1:%.*]], ptr [[MEM2:%.*]], i64 [[SIZE:%.*]])
+; CHECK-NEXT:    [[BCMP:%.*]] = call signext i32 @bcmp(ptr [[MEM1:%.*]], ptr [[MEM2:%.*]], i64 [[SIZE:%.*]])
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i32 [[BCMP]], 0
 ; CHECK-NEXT:    [[ZEXT:%.*]] = zext i1 [[CMP]] to i32
 ; CHECK-NEXT:    ret i32 [[ZEXT]]

--- a/llvm/test/Transforms/InstCombine/SystemZ/libcall-arg-exts.ll
+++ b/llvm/test/Transforms/InstCombine/SystemZ/libcall-arg-exts.ll
@@ -12,7 +12,7 @@ declare fp128 @exp2l(fp128)
 define double @fun1(i32 %x) {
 ; CHECK-LABEL: define double @fun1(
 ; CHECK-SAME: i32 [[X:%.*]]) {
-; CHECK-NEXT:    [[LDEXP:%.*]] = call double @ldexp(double 1.000000e+00, i32 [[X]])
+; CHECK-NEXT:    [[LDEXP:%.*]] = call double @ldexp(double 1.000000e+00, i32 signext [[X]])
 ; CHECK-NEXT:    ret double [[LDEXP]]
 ;
   %conv = sitofp i32 %x to double
@@ -23,7 +23,7 @@ define double @fun1(i32 %x) {
 define float @fun2(i32 %x) {
 ; CHECK-LABEL: define float @fun2(
 ; CHECK-SAME: i32 [[X:%.*]]) {
-; CHECK-NEXT:    [[LDEXPF:%.*]] = call float @ldexpf(float 1.000000e+00, i32 [[X]])
+; CHECK-NEXT:    [[LDEXPF:%.*]] = call float @ldexpf(float 1.000000e+00, i32 signext [[X]])
 ; CHECK-NEXT:    ret float [[LDEXPF]]
 ;
   %conv = sitofp i32 %x to float
@@ -35,7 +35,7 @@ define fp128 @fun3(i8 zeroext %x) {
 ; CHECK-LABEL: define fp128 @fun3(
 ; CHECK-SAME: i8 zeroext [[X:%.*]]) {
 ; CHECK-NEXT:    [[TMP1:%.*]] = zext i8 [[X]] to i32
-; CHECK-NEXT:    [[LDEXPL:%.*]] = call fp128 @ldexpl(fp128 1.000000e+00, i32 [[TMP1]])
+; CHECK-NEXT:    [[LDEXPL:%.*]] = call fp128 @ldexpl(fp128 1.000000e+00, i32 signext [[TMP1]])
 ; CHECK-NEXT:    ret fp128 [[LDEXPL]]
 ;
   %conv = uitofp i8 %x to fp128
@@ -48,7 +48,7 @@ define fp128 @fun3(i8 zeroext %x) {
 declare ptr @__memccpy_chk(ptr, ptr, i32, i64, i64)
 define ptr @fun4() {
 ; CHECK-LABEL: define ptr @fun4() {
-; CHECK-NEXT:    [[MEMCCPY:%.*]] = call ptr @memccpy(ptr nonnull @a, ptr nonnull @b, i32 0, i64 60)
+; CHECK-NEXT:    [[MEMCCPY:%.*]] = call ptr @memccpy(ptr nonnull @a, ptr nonnull @b, i32 signext 0, i64 60)
 ; CHECK-NEXT:    ret ptr [[MEMCCPY]]
 ;
   %ret = call ptr @__memccpy_chk(ptr @a, ptr @b, i32 0, i64 60, i64 -1)
@@ -61,7 +61,7 @@ declare i32 @fputs(ptr, ptr)
 define void @fun5(ptr %fp) {
 ; CHECK-LABEL: define void @fun5(
 ; CHECK-SAME: ptr [[FP:%.*]]) {
-; CHECK-NEXT:    [[FPUTC:%.*]] = call i32 @fputc(i32 65, ptr [[FP]])
+; CHECK-NEXT:    [[FPUTC:%.*]] = call i32 @fputc(i32 signext 65, ptr [[FP]])
 ; CHECK-NEXT:    ret void
 ;
   call i32 @fputs(ptr @A, ptr %fp)
@@ -72,7 +72,7 @@ define void @fun5(ptr %fp) {
 declare i32 @puts(ptr)
 define void @fun6() {
 ; CHECK-LABEL: define void @fun6() {
-; CHECK-NEXT:    [[PUTCHAR:%.*]] = call i32 @putchar(i32 10)
+; CHECK-NEXT:    [[PUTCHAR:%.*]] = call i32 @putchar(i32 signext 10)
 ; CHECK-NEXT:    ret void
 ;
   call i32 @puts(ptr @empty)
@@ -84,7 +84,7 @@ declare ptr @strstr(ptr, ptr)
 define ptr @fun7(ptr %str) {
 ; CHECK-LABEL: define ptr @fun7(
 ; CHECK-SAME: ptr [[STR:%.*]]) {
-; CHECK-NEXT:    [[STRCHR:%.*]] = call ptr @strchr(ptr noundef nonnull dereferenceable(1) [[STR]], i32 97)
+; CHECK-NEXT:    [[STRCHR:%.*]] = call ptr @strchr(ptr noundef nonnull dereferenceable(1) [[STR]], i32 signext 97)
 ; CHECK-NEXT:    ret ptr [[STRCHR]]
 ;
   %ret = call ptr @strstr(ptr %str, ptr @.str1)
@@ -98,7 +98,7 @@ declare ptr @strchr(ptr, i32)
 define void @fun8(i32 %chr) {
 ; CHECK-LABEL: define void @fun8(
 ; CHECK-SAME: i32 [[CHR:%.*]]) {
-; CHECK-NEXT:    [[MEMCHR:%.*]] = call ptr @memchr(ptr noundef nonnull dereferenceable(1) @hello, i32 [[CHR]], i64 14)
+; CHECK-NEXT:    [[MEMCHR:%.*]] = call ptr @memchr(ptr noundef nonnull dereferenceable(1) @hello, i32 signext [[CHR]], i64 14)
 ; CHECK-NEXT:    store ptr [[MEMCHR]], ptr @chp, align 8
 ; CHECK-NEXT:    ret void
 ;


### PR DESCRIPTION
ABI attributes should be applied both at the function definition and the call-site.

I'm implementing this here via a helper that inherits ABI attributes from the callee to the call-site. I initially wanted to explicitly apply the attributes, but then figured that a generic copying utility is probably more useful, because it will be easy to apply in more places, without having to refactor things to be generic over Function vs CallBase.

This is to address the issue exposed by https://github.com/llvm/llvm-project/pull/207173. (At least partially, I expect there are more places like this.)