### PR TITLE
[llvm][IR] Add per-function code model attribute

### DIFF
--- a/llvm/docs/LangRef.md
+++ b/llvm/docs/LangRef.md
@@ -988,6 +988,7 @@ attributes <paramattrs>`), optional {ref}`function attributes <fnattrs>`,
 an optional address space, an optional section, an optional partition,
 an optional minimum alignment,
 an optional preferred alignment,
+an optional code model,
 an optional {ref}`comdat <langref_comdats>`,
 an optional {ref}`garbage collector name <gc>`, an optional {ref}`prefix <prefixdata>`,
 an optional {ref}`prologue <prologuedata>`,
@@ -1002,7 +1003,7 @@ define [linkage] [PreemptionSpecifier] [visibility] [DLLStorageClass]
        <ResultType> @<FunctionName> ([argument list])
        [(unnamed_addr|local_unnamed_addr)] [AddrSpace] [fn Attrs]
        [section "name"] [partition "name"] [comdat [($name)]] [align N]
-       [prefalign(N)] [gc] [prefix Constant] [prologue Constant]
+       [prefalign(N)] [code_model "model"] [gc] [prefix Constant] [prologue Constant]
        [personality Constant] (!name !N)* { ... }
 ```
 
@@ -1021,8 +1022,8 @@ optional {ref}`linkage type <linkage>`, an optional {ref}`visibility style
 optional {ref}`calling convention <callingconv>`, an optional `unnamed_addr`
 or `local_unnamed_addr` attribute, an optional address space, a return type,
 an optional {ref}`parameter attribute <paramattrs>` for the return type, a function name, a possibly
-empty list of arguments, an optional alignment, an optional {ref}`garbage
-collector name <gc>`, an optional {ref}`prefix <prefixdata>`, and an optional
+empty list of arguments, an optional alignment, an optional code model,
+an optional {ref}`garbage collector name <gc>`, an optional {ref}`prefix <prefixdata>`, and an optional
 {ref}`prologue <prologuedata>`.
 
 Syntax:
@@ -1031,7 +1032,7 @@ Syntax:
 declare [linkage] [visibility] [DLLStorageClass]
         [cconv] [ret attrs]
         <ResultType> @<FunctionName> ([argument list])
-        [(unnamed_addr|local_unnamed_addr)] [align N] [gc]
+        [(unnamed_addr|local_unnamed_addr)] [align N] [code_model "model"] [gc]
         [prefix Constant] [prologue Constant]
 ```
 

--- a/llvm/include/llvm/AsmParser/LLParser.h
+++ b/llvm/include/llvm/AsmParser/LLParser.h
@@ -346,7 +346,7 @@ namespace llvm {
     bool parseOptionalAlignment(MaybeAlign &Alignment,
                                 bool AllowParens = false);
     bool parseOptionalPrefAlignment(MaybeAlign &Alignment);
-    bool parseOptionalCodeModel(CodeModel::Model &model);
+    bool parseOptionalCodeModel(std::optional<CodeModel::Model> &model);
     bool parseOptionalAttrBytes(lltok::Kind AttrKind,
                                 std::optional<uint64_t> &Bytes,
                                 bool ErrorNoBytes = true);

--- a/llvm/include/llvm/IR/Function.h
+++ b/llvm/include/llvm/IR/Function.h
@@ -1040,7 +1040,28 @@ public:
   /// unknown.
   unsigned getVScaleValue() const;
 
+  /// Get the custom code model raw value of this function.
+  unsigned getCodeModelRaw() const {
+    unsigned Data = getGlobalValueSubClassData();
+    return (Data >> CodeModelShift) & CodeModelMask;
+  }
+
+  /// Get the custom code model of this function if it has one.
+  std::optional<CodeModel::Model> getCodeModel() const {
+    unsigned CodeModelData = getCodeModelRaw();
+    if (CodeModelData > 0)
+      return static_cast<CodeModel::Model>(CodeModelData - 1);
+    return {};
+  }
+
+  /// Change the code model for this function.
+  void setCodeModel(CodeModel::Model CM);
+
 private:
+  static const unsigned CodeModelBits = LastCodeModelBit - LastAlignmentBit;
+  static const unsigned CodeModelMask = (1 << CodeModelBits) - 1;
+  static const unsigned CodeModelShift = LastAlignmentBit + 1;
+
   void allocHungoffUselist();
   template<int Idx> void setHungoffOperand(Constant *C);
 

--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -1618,10 +1618,11 @@ bool LLParser::parseGlobal(const std::string &Name, unsigned NameID,
       if (Alignment)
         GV->setAlignment(*Alignment);
     } else if (Lex.getKind() == lltok::kw_code_model) {
-      CodeModel::Model CodeModel;
+      std::optional<CodeModel::Model> CodeModel;
       if (parseOptionalCodeModel(CodeModel))
         return true;
-      GV->setCodeModel(CodeModel);
+      if (CodeModel)
+        GV->setCodeModel(*CodeModel);
     } else if (Lex.getKind() == lltok::MetadataVar) {
       if (parseGlobalObjectMetadataAttachment(*GV))
         return true;
@@ -2644,10 +2645,12 @@ bool LLParser::parseOptionalPrefAlignment(MaybeAlign &Alignment) {
 /// parseOptionalCodeModel
 ///   ::= /* empty */
 ///   ::= 'code_model' "large"
-bool LLParser::parseOptionalCodeModel(CodeModel::Model &model) {
-  Lex.Lex();
+bool LLParser::parseOptionalCodeModel(std::optional<CodeModel::Model> &model) {
+  model = std::nullopt;
+  if (!EatIfPresent(lltok::kw_code_model))
+    return false;
   auto StrVal = Lex.getStrVal();
-  auto ErrMsg = "expected global code model string";
+  auto ErrMsg = "expected code model string";
   if (StrVal == "tiny")
     model = CodeModel::Tiny;
   else if (StrVal == "small")
@@ -7241,6 +7244,7 @@ bool LLParser::parseFunctionHeader(Function *&Fn, bool IsDefine,
   std::string Section;
   std::string Partition;
   MaybeAlign Alignment, PrefAlignment;
+  std::optional<CodeModel::Model> FnCodeModel;
   std::string GC;
   GlobalValue::UnnamedAddr UnnamedAddr = GlobalValue::UnnamedAddr::None;
   unsigned AddrSpace = 0;
@@ -7259,6 +7263,7 @@ bool LLParser::parseFunctionHeader(Function *&Fn, bool IsDefine,
       parseOptionalComdat(FunctionName, C) ||
       parseOptionalAlignment(Alignment) ||
       parseOptionalPrefAlignment(PrefAlignment) ||
+      parseOptionalCodeModel(FnCodeModel) ||
       (EatIfPresent(lltok::kw_gc) && parseStringConstant(GC)) ||
       (EatIfPresent(lltok::kw_prefix) && parseGlobalTypeAndValue(Prefix)) ||
       (EatIfPresent(lltok::kw_prologue) && parseGlobalTypeAndValue(Prologue)) ||
@@ -7361,6 +7366,8 @@ bool LLParser::parseFunctionHeader(Function *&Fn, bool IsDefine,
   if (Alignment)
     Fn->setAlignment(*Alignment);
   Fn->setPreferredAlignment(PrefAlignment);
+  if (FnCodeModel)
+    Fn->setCodeModel(*FnCodeModel);
   Fn->setSection(Section);
   Fn->setPartition(Partition);
   Fn->setComdat(C);

--- a/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
+++ b/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
@@ -4512,6 +4512,13 @@ Error BitcodeReader::parseFunctionRecord(ArrayRef<uint64_t> Record) {
     Func->setPreferredAlignment(PrefAlignment);
   }
 
+  if (Record.size() > 20 && Record[20]) {
+    if (auto CM = getDecodedCodeModel(Record[20]))
+      Func->setCodeModel(*CM);
+    else
+      return error("Invalid function code model");
+  }
+
   ValueList.push_back(Func, getVirtualTypeID(Func->getType(), FTyID));
 
   if (OperandInfo.PersonalityFn || OperandInfo.Prefix || OperandInfo.Prologue)

--- a/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
+++ b/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
@@ -1726,7 +1726,7 @@ void ModuleBitcodeWriter::writeModuleInfo() {
     //             linkage, paramattrs, alignment, section, visibility, gc,
     //             unnamed_addr, prologuedata, dllstorageclass, comdat,
     //             prefixdata, personalityfn, DSO_Local, addrspace,
-    //             partition_strtab, partition_size, prefalign]
+    //             partition_strtab, partition_size, prefalign, code_model]
     Vals.push_back(addToStrtab(F.getName()));
     Vals.push_back(F.getName().size());
     Vals.push_back(VE.getTypeID(F.getFunctionType()));
@@ -1754,6 +1754,7 @@ void ModuleBitcodeWriter::writeModuleInfo() {
     Vals.push_back(addToStrtab(F.getPartition()));
     Vals.push_back(F.getPartition().size());
     Vals.push_back(getEncodedAlign(F.getPreferredAlignment()));
+    Vals.push_back(F.getCodeModelRaw());
 
     unsigned AbbrevToUse = 0;
     Stream.EmitRecord(bitc::MODULE_CODE_FUNCTION, Vals, AbbrevToUse);

--- a/llvm/lib/IR/AsmWriter.cpp
+++ b/llvm/lib/IR/AsmWriter.cpp
@@ -4331,6 +4331,27 @@ void AssemblyWriter::printFunction(const Function *F) {
     Out << " align " << A->value();
   if (MaybeAlign A = F->getPreferredAlignment())
     Out << " prefalign(" << A->value() << ')';
+  if (auto CM = F->getCodeModel()) {
+    Out << " code_model \"";
+    switch (*CM) {
+    case CodeModel::Tiny:
+      Out << "tiny";
+      break;
+    case CodeModel::Small:
+      Out << "small";
+      break;
+    case CodeModel::Kernel:
+      Out << "kernel";
+      break;
+    case CodeModel::Medium:
+      Out << "medium";
+      break;
+    case CodeModel::Large:
+      Out << "large";
+      break;
+    }
+    Out << '"';
+  }
   if (F->hasGC())
     Out << " gc \"" << F->getGC() << '"';
   if (F->hasPrefixData()) {

--- a/llvm/lib/IR/Function.cpp
+++ b/llvm/lib/IR/Function.cpp
@@ -856,6 +856,8 @@ void Function::copyAttributesFrom(const Function *Src) {
     setPrefixData(Src->getPrefixData());
   if (Src->hasPrologueData())
     setPrologueData(Src->getPrologueData());
+  if (auto CM = Src->getCodeModel())
+    setCodeModel(*CM);
 }
 
 MemoryEffects Function::getMemoryEffects() const {
@@ -1232,4 +1234,13 @@ bool llvm::CallingConv::supportsNonVoidReturnType(CallingConv::ID CC) {
   }
 
   llvm_unreachable("covered callingconv switch");
+}
+
+void Function::setCodeModel(CodeModel::Model CM) {
+  unsigned CodeModelData = static_cast<unsigned>(CM) + 1;
+  unsigned OldData = getGlobalValueSubClassData();
+  unsigned NewData = (OldData & ~(CodeModelMask << CodeModelShift)) |
+                     (CodeModelData << CodeModelShift);
+  setGlobalValueSubClassData(NewData);
+  assert(getCodeModel() == CM && "Code model representation error!");
 }

--- a/llvm/test/Assembler/function-code-model.ll
+++ b/llvm/test/Assembler/function-code-model.ll
@@ -1,0 +1,26 @@
+; RUN: llvm-as < %s | llvm-dis | llvm-as | llvm-dis | FileCheck %s
+
+; CHECK: define void @f1() code_model "tiny" {
+define void @f1() code_model "tiny" {
+  ret void
+}
+
+; CHECK: define void @f2() code_model "small" {
+define void @f2() code_model "small" {
+  ret void
+}
+
+; CHECK: define void @f3() code_model "kernel" {
+define void @f3() code_model "kernel" {
+  ret void
+}
+
+; CHECK: define void @f4() code_model "medium" {
+define void @f4() code_model "medium" {
+  ret void
+}
+
+; CHECK: define void @f5() code_model "large" {
+define void @f5() code_model "large" {
+  ret void
+}


### PR DESCRIPTION
Adds an optional code model attribute to LLVM function definitions and declarations (e.g. `code_model "large"`):
- Adds getCodeModel(), getCodeModelRaw(), and setCodeModel() to llvm::Function,
  storing the value in GlobalObject subclass data bits.
- Updates Function::copyAttributesFrom to propagate code models.
- Updates LLParser and AsmWriter to parse and print code_model in function headers.
- Updates BitcodeReader and BitcodeWriter to serialize and deserialize function
  code models.
- Updates LangRef documentation and adds assembler round-trip tests.