### PR TITLE
[libunwind] Mark test as requiring Unix headers

### DIFF
--- a/libunwind/test/dwarf_expression_stack.pass.cpp
+++ b/libunwind/test/dwarf_expression_stack.pass.cpp
@@ -9,7 +9,7 @@
 
 // Ensure that evaluateExpression bounds checks its internal operand stack and
 // aborts on malformed DWARF expressions rather than overflowing the stack.
-// REQUIRES: target={{(aarch64|x86_64)-.+}}
+// REQUIRES: target={{(aarch64|x86_64)-.+}} && has-unix-headers
 // UNSUPPORTED: target={{.*-windows.*}}
 // UNSUPPORTED: target={{.*-apple.*}}
 


### PR DESCRIPTION
Test `libunwind/test/dwarf_expression_stack.pass.cpp` requires a POSIX environment because it uses `signal.h` and associated functions. Because of this, the test fails in baremetal targets.

This change adjusts the requirements of the test. `has-unix-headers` does not map exactly to the requirements here, but it seems to be enough for this case.