### PR TITLE
[libc] Implement pthread_attr_[gs]etschedpolicy

### DIFF
--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -1112,11 +1112,13 @@ if(LLVM_LIBC_FULL_BUILD)
     libc.src.pthread.pthread_attr_destroy
     libc.src.pthread.pthread_attr_getdetachstate
     libc.src.pthread.pthread_attr_getguardsize
+    libc.src.pthread.pthread_attr_getschedpolicy
     libc.src.pthread.pthread_attr_getstack
     libc.src.pthread.pthread_attr_getstacksize
     libc.src.pthread.pthread_attr_init
     libc.src.pthread.pthread_attr_setdetachstate
     libc.src.pthread.pthread_attr_setguardsize
+    libc.src.pthread.pthread_attr_setschedpolicy
     libc.src.pthread.pthread_attr_setstack
     libc.src.pthread.pthread_attr_setstacksize
     libc.src.pthread.pthread_condattr_destroy

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -1300,11 +1300,13 @@ if(LLVM_LIBC_FULL_BUILD)
     libc.src.pthread.pthread_attr_destroy
     libc.src.pthread.pthread_attr_getdetachstate
     libc.src.pthread.pthread_attr_getguardsize
+    libc.src.pthread.pthread_attr_getschedpolicy
     libc.src.pthread.pthread_attr_getstack
     libc.src.pthread.pthread_attr_getstacksize
     libc.src.pthread.pthread_attr_init
     libc.src.pthread.pthread_attr_setdetachstate
     libc.src.pthread.pthread_attr_setguardsize
+    libc.src.pthread.pthread_attr_setschedpolicy
     libc.src.pthread.pthread_attr_setstack
     libc.src.pthread.pthread_attr_setstacksize
     libc.src.pthread.pthread_condattr_destroy

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -1309,11 +1309,13 @@ if(LLVM_LIBC_FULL_BUILD)
     libc.src.pthread.pthread_attr_destroy
     libc.src.pthread.pthread_attr_getdetachstate
     libc.src.pthread.pthread_attr_getguardsize
+    libc.src.pthread.pthread_attr_getschedpolicy
     libc.src.pthread.pthread_attr_getstack
     libc.src.pthread.pthread_attr_getstacksize
     libc.src.pthread.pthread_attr_init
     libc.src.pthread.pthread_attr_setdetachstate
     libc.src.pthread.pthread_attr_setguardsize
+    libc.src.pthread.pthread_attr_setschedpolicy
     libc.src.pthread.pthread_attr_setstack
     libc.src.pthread.pthread_attr_setstacksize
     libc.src.pthread.pthread_condattr_destroy

--- a/libc/include/llvm-libc-types/pthread_attr_t.h
+++ b/libc/include/llvm-libc-types/pthread_attr_t.h
@@ -13,6 +13,7 @@
 
 typedef struct {
   int __detachstate;
+  int __schedpolicy;
   void *__stack;
   size_t __stacksize;
   size_t __guardsize;

--- a/libc/include/pthread.yaml
+++ b/libc/include/pthread.yaml
@@ -97,6 +97,11 @@ functions:
     arguments:
       - type: const pthread_attr_t *__restrict
       - type: struct sched_param *__restrict
+  - name: pthread_attr_getschedpolicy
+    return_type: int
+    arguments:
+      - type: const pthread_attr_t *__restrict
+      - type: int *__restrict
   - name: pthread_attr_getstack
     return_type: int
     arguments:
@@ -127,6 +132,11 @@ functions:
     arguments:
       - type: pthread_attr_t *__restrict
       - type: const struct sched_param *__restrict
+  - name: pthread_attr_setschedpolicy
+    return_type: int
+    arguments:
+      - type: pthread_attr_t *
+      - type: int
   - name: pthread_attr_setstack
     return_type: int
     arguments:

--- a/libc/src/pthread/CMakeLists.txt
+++ b/libc/src/pthread/CMakeLists.txt
@@ -6,6 +6,7 @@ add_entrypoint_object(
     pthread_attr_init.h
   DEPENDS
     libc.include.pthread
+    libc.hdr.sched_macros
 )
 
 add_entrypoint_object(
@@ -71,6 +72,19 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
+  pthread_attr_getschedpolicy
+  SRCS
+    pthread_attr_getschedpolicy.cpp
+  HDRS
+    pthread_attr_getschedpolicy.h
+  DEPENDS
+    libc.hdr.types.pthread_attr_t
+    libc.src.__support.common
+    libc.src.__support.macros.config
+    libc.src.__support.macros.null_check
+)
+
+add_entrypoint_object(
   pthread_attr_setschedparam
   SRCS
     pthread_attr_setschedparam.cpp
@@ -78,6 +92,19 @@ add_entrypoint_object(
     pthread_attr_setschedparam.h
   DEPENDS
     libc.include.pthread
+)
+
+add_entrypoint_object(
+  pthread_attr_setschedpolicy
+  SRCS
+    pthread_attr_setschedpolicy.cpp
+  HDRS
+    pthread_attr_setschedpolicy.h
+  DEPENDS
+    libc.hdr.types.pthread_attr_t
+    libc.src.__support.common
+    libc.src.__support.macros.config
+    libc.src.__support.macros.null_check
 )
 
 add_entrypoint_object(

--- a/libc/src/pthread/pthread_attr_getschedpolicy.cpp
+++ b/libc/src/pthread/pthread_attr_getschedpolicy.cpp
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implementation of pthread_attr_getschedpolicy.
+///
+//===----------------------------------------------------------------------===//
+
+#include "pthread_attr_getschedpolicy.h"
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/null_check.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(int, pthread_attr_getschedpolicy,
+                   (const pthread_attr_t *__restrict attr,
+                    int *__restrict policy)) {
+  LIBC_CRASH_ON_NULLPTR(attr);
+  LIBC_CRASH_ON_NULLPTR(policy);
+
+  *policy = attr->__schedpolicy;
+  return 0;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/pthread/pthread_attr_getschedpolicy.h
+++ b/libc/src/pthread/pthread_attr_getschedpolicy.h
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implementation header for pthread_attr_getschedpolicy.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_PTHREAD_PTHREAD_ATTR_GETSCHEDPOLICY_H
+#define LLVM_LIBC_SRC_PTHREAD_PTHREAD_ATTR_GETSCHEDPOLICY_H
+
+#include "hdr/types/pthread_attr_t.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+int pthread_attr_getschedpolicy(const pthread_attr_t *__restrict attr,
+                                int *__restrict policy);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_PTHREAD_PTHREAD_ATTR_GETSCHEDPOLICY_H

--- a/libc/src/pthread/pthread_attr_init.cpp
+++ b/libc/src/pthread/pthread_attr_init.cpp
@@ -8,6 +8,7 @@
 
 #include "pthread_attr_init.h"
 
+#include "hdr/sched_macros.h"
 #include "src/__support/common.h"
 #include "src/__support/macros/config.h"
 #include "src/__support/threads/thread.h" // For thread::DEFAULT_*
@@ -19,6 +20,7 @@ namespace LIBC_NAMESPACE_DECL {
 LLVM_LIBC_FUNCTION(int, pthread_attr_init, (pthread_attr_t * attr)) {
   *attr = pthread_attr_t{
       PTHREAD_CREATE_JOINABLE,   // Not detached
+      SCHED_OTHER,               // Default scheduling policy
       nullptr,                   // Let the thread manage its stack
       Thread::DEFAULT_STACKSIZE, // stack size.
       Thread::DEFAULT_GUARDSIZE, // Default page size for the guard size.

--- a/libc/src/pthread/pthread_attr_setschedpolicy.cpp
+++ b/libc/src/pthread/pthread_attr_setschedpolicy.cpp
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implementation of pthread_attr_setschedpolicy.
+///
+//===----------------------------------------------------------------------===//
+
+#include "pthread_attr_setschedpolicy.h"
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/null_check.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(int, pthread_attr_setschedpolicy,
+                   (pthread_attr_t * attr, int policy)) {
+  LIBC_CRASH_ON_NULLPTR(attr);
+  attr->__schedpolicy = policy;
+  return 0;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/pthread/pthread_attr_setschedpolicy.h
+++ b/libc/src/pthread/pthread_attr_setschedpolicy.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implementation header for pthread_attr_setschedpolicy.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_PTHREAD_PTHREAD_ATTR_SETSCHEDPOLICY_H
+#define LLVM_LIBC_SRC_PTHREAD_PTHREAD_ATTR_SETSCHEDPOLICY_H
+
+#include "hdr/types/pthread_attr_t.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+int pthread_attr_setschedpolicy(pthread_attr_t *attr, int policy);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_PTHREAD_PTHREAD_ATTR_SETSCHEDPOLICY_H

--- a/libc/test/src/pthread/CMakeLists.txt
+++ b/libc/test/src/pthread/CMakeLists.txt
@@ -18,7 +18,10 @@ add_libc_test(
     libc.src.pthread.pthread_attr_setguardsize
     libc.src.pthread.pthread_attr_setstacksize
     libc.src.pthread.pthread_attr_setstack
+    libc.src.pthread.pthread_attr_getschedpolicy
+    libc.src.pthread.pthread_attr_setschedpolicy
     libc.hdr.errno_macros
+    libc.hdr.sched_macros
 )
 
 add_libc_test(

--- a/libc/test/src/pthread/pthread_attr_test.cpp
+++ b/libc/test/src/pthread/pthread_attr_test.cpp
@@ -7,14 +7,17 @@
 //===----------------------------------------------------------------------===//
 
 #include "hdr/errno_macros.h"
+#include "hdr/sched_macros.h"
 #include "src/pthread/pthread_attr_destroy.h"
 #include "src/pthread/pthread_attr_getdetachstate.h"
 #include "src/pthread/pthread_attr_getguardsize.h"
+#include "src/pthread/pthread_attr_getschedpolicy.h"
 #include "src/pthread/pthread_attr_getstack.h"
 #include "src/pthread/pthread_attr_getstacksize.h"
 #include "src/pthread/pthread_attr_init.h"
 #include "src/pthread/pthread_attr_setdetachstate.h"
 #include "src/pthread/pthread_attr_setguardsize.h"
+#include "src/pthread/pthread_attr_setschedpolicy.h"
 #include "src/pthread/pthread_attr_setstack.h"
 #include "src/pthread/pthread_attr_setstacksize.h"
 
@@ -114,6 +117,39 @@ TEST(LlvmLibcPThreadattrTest, SetAndGetStack) {
   ASSERT_EQ(
       LIBC_NAMESPACE::pthread_attr_setstack(&attr, 0, PTHREAD_STACK_MIN / 2),
       EINVAL);
+
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_attr_destroy(&attr), 0);
+}
+
+TEST(LlvmLibcPThreadattrTest, SetAndGetSchedPolicy) {
+  pthread_attr_t attr;
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_attr_init(&attr), 0);
+
+  int policy;
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_attr_getschedpolicy(&attr, &policy), 0);
+  ASSERT_EQ(policy, SCHED_OTHER);
+
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_attr_setschedpolicy(&attr, SCHED_FIFO), 0);
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_attr_getschedpolicy(&attr, &policy), 0);
+  ASSERT_EQ(policy, SCHED_FIFO);
+
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_attr_setschedpolicy(&attr, SCHED_RR), 0);
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_attr_getschedpolicy(&attr, &policy), 0);
+  ASSERT_EQ(policy, SCHED_RR);
+
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_attr_setschedpolicy(&attr, SCHED_OTHER), 0);
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_attr_getschedpolicy(&attr, &policy), 0);
+  ASSERT_EQ(policy, SCHED_OTHER);
+
+  // We do not attempt to validate scheduling policies here. The OS will do that
+  // when starting a thread.
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_attr_setschedpolicy(&attr, 0xBAD), 0);
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_attr_getschedpolicy(&attr, &policy), 0);
+  ASSERT_EQ(policy, 0xBAD);
+
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_attr_setschedpolicy(&attr, -1), 0);
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_attr_getschedpolicy(&attr, &policy), 0);
+  ASSERT_EQ(policy, -1);
 
   ASSERT_EQ(LIBC_NAMESPACE::pthread_attr_destroy(&attr), 0);
 }


### PR DESCRIPTION
This patch implements pthread_attr_setschedpolicy and pthread_attr_getschedpolicy.

This commit only operates on the pthread_attr_t object. It does not attempt to install the scheduling policy when creating a new thread. I'm leaving that for a separate patch as it requires a moderately complicated startup dance to ensure that the scheduling policy takes effect before the startup code runs.

The validation of inputs in pthread_attr_setschedpolicy is an interesting question. Glibc accepts only policies explicitly declared in POSIX, while other implementations let the user pass anything, and rely on the kernel to validate the arguments. Interestingly, even glibc does not validate the arguments in pthread_setschedparam.

For llvm-libc, I chose not to validate the arguments either. This is *mostly* consistent with POSIX, which says (emphasis mine):
> The supported values of policy shall *include* SCHED_FIFO, SCHED_RR, and
> SCHED_OTHER, which are defined in the <sched.h> header.

I say mostly, because the spec does say we should return ENOTSUP if "an attempt was made to set the attribute to an unsupported value", but I'm not sure that's worthwhile, as it means we would need to update our list of supported policies whenever the kernel adds a new one (and anyway, we cannot be sure that our understanding of supported policies matches what the running kernel actually supports).

Assisted-by: Gemini