### PR TITLE
[compiler-rt][asan] Use native TLS for TSD on Windows

### DIFF
--- a/compiler-rt/lib/asan/asan_win.cpp
+++ b/compiler-rt/lib/asan/asan_win.cpp
@@ -228,7 +228,7 @@ void FlushUnneededASanShadowMemory(uptr p, uptr size) {
 // ---------------------- TSD ---------------- {{{
 static bool tsd_key_inited = false;
 
-static __declspec(thread) void *fake_tsd = 0;
+static THREADLOCAL void* fake_tsd = 0;
 
 // https://docs.microsoft.com/en-us/windows/desktop/api/winternl/ns-winternl-_teb
 // "[This structure may be altered in future versions of Windows. Applications


### PR DESCRIPTION
GCC 16 supports native Windows TLS. Use compiler-rt's THREADLOCAL abstraction for fake_tsd on all compilers instead of spelling the MSVC-specific storage-class syntax directly. GCC configurations using emulated TLS remain unsupported.