### PR TITLE
[compiler-rt][asan] Include intrin.h for MinGW GCC

### DIFF
--- a/compiler-rt/lib/asan/asan_globals_win.cpp
+++ b/compiler-rt/lib/asan/asan_globals_win.cpp
@@ -14,6 +14,10 @@
 #if SANITIZER_WINDOWS
 #  include "sanitizer_common/sanitizer_win_defs.h"
 
+#  if defined(__GNUC__) && !defined(__clang__)
+#    include <intrin.h>
+#  endif
+
 namespace __asan {
 
 #  pragma section(".ASAN$GA", read, write)


### PR DESCRIPTION
asan_globals_win.cpp calls __debugbreak in the runtime thunk configurations. Include MinGW's intrinsic header so the function is declared when this file is compiled with GCC.