### PR TITLE
[compiler-rt] Retain sanitizer callbacks with MinGW GCC

### DIFF
--- a/compiler-rt/lib/asan/asan_globals_win.cpp
+++ b/compiler-rt/lib/asan/asan_globals_win.cpp
@@ -12,6 +12,7 @@
 
 #include "asan_interface_internal.h"
 #if SANITIZER_WINDOWS
+#  include "asan_win_common_runtime_thunk.h"
 #  include "sanitizer_common/sanitizer_win_defs.h"
 
 namespace __asan {

--- a/compiler-rt/lib/asan/asan_win.cpp
+++ b/compiler-rt/lib/asan/asan_win.cpp
@@ -414,6 +414,8 @@ static void NTAPI asan_thread_exit(void *module, DWORD reason, void *reserved) {
 IN_SECTION(".CRT$XLY")
 void(NTAPI* __asan_tls_exit)(void*, unsigned long, void*) = asan_thread_exit;
 
+extern "C" void (*const __asan_dso_reg_hook)();
+
 WIN_FORCE_LINK(__asan_dso_reg_hook)
 
 // }}}

--- a/compiler-rt/lib/asan/asan_win.cpp
+++ b/compiler-rt/lib/asan/asan_win.cpp
@@ -24,6 +24,7 @@
 #  include "asan_report.h"
 #  include "asan_stack.h"
 #  include "asan_thread.h"
+#  include "asan_win_common_runtime_thunk.h"
 #  include "sanitizer_common/sanitizer_libc.h"
 #  include "sanitizer_common/sanitizer_mutex.h"
 #  include "sanitizer_common/sanitizer_win.h"
@@ -413,8 +414,6 @@ static void NTAPI asan_thread_exit(void *module, DWORD reason, void *reserved) {
 #pragma section(".CRT$XLY", long, read)
 IN_SECTION(".CRT$XLY")
 void(NTAPI* __asan_tls_exit)(void*, unsigned long, void*) = asan_thread_exit;
-
-extern "C" void (*const __asan_dso_reg_hook)();
 
 WIN_FORCE_LINK(__asan_dso_reg_hook)
 

--- a/compiler-rt/lib/asan/asan_win_common_runtime_thunk.cpp
+++ b/compiler-rt/lib/asan/asan_win_common_runtime_thunk.cpp
@@ -105,6 +105,7 @@ extern "C" IN_SECTION(".CRT$XCAB") int (*__asan_seh_interceptor)() =
 WIN_FORCE_LINK(__asan_seh_interceptor)
 }
 
+extern "C" void (*const __asan_dso_reg_hook)();
 WIN_FORCE_LINK(__asan_dso_reg_hook)
 
 #endif  // defined(SANITIZER_DYNAMIC_RUNTIME_THUNK) ||

--- a/compiler-rt/lib/asan/asan_win_common_runtime_thunk.cpp
+++ b/compiler-rt/lib/asan/asan_win_common_runtime_thunk.cpp
@@ -105,7 +105,6 @@ extern "C" IN_SECTION(".CRT$XCAB") int (*__asan_seh_interceptor)() =
 WIN_FORCE_LINK(__asan_seh_interceptor)
 }
 
-extern "C" void (*const __asan_dso_reg_hook)();
 WIN_FORCE_LINK(__asan_dso_reg_hook)
 
 #endif  // defined(SANITIZER_DYNAMIC_RUNTIME_THUNK) ||

--- a/compiler-rt/lib/asan/asan_win_common_runtime_thunk.h
+++ b/compiler-rt/lib/asan/asan_win_common_runtime_thunk.h
@@ -14,6 +14,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+extern "C" void (*const __asan_dso_reg_hook)();
+
 #if defined(SANITIZER_STATIC_RUNTIME_THUNK) || \
     defined(SANITIZER_DYNAMIC_RUNTIME_THUNK)
 #  include "sanitizer_common/sanitizer_win_defs.h"

--- a/compiler-rt/lib/sanitizer_common/sanitizer_win_defs.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_win_defs.h
@@ -71,12 +71,18 @@
   __pragma(comment(linker, "/alternatename:" WIN_SYM_PREFIX STRINGIFY(Name) "="\
                                              WIN_SYM_PREFIX STRINGIFY(Default)))
 
-#define WIN_FORCE_LINK(Name)                                                   \
-  __pragma(comment(linker, "/include:" WIN_SYM_PREFIX STRINGIFY(Name)))
-
 #define WIN_EXPORT(ExportedName, Name)                                         \
   __pragma(comment(linker, "/export:" WIN_EXPORT_PREFIX STRINGIFY(ExportedName)\
                                   "=" WIN_EXPORT_PREFIX STRINGIFY(Name)))
+#    if !defined(__GNUC__) || defined(__clang__)
+#      define WIN_FORCE_LINK(Name) \
+        __pragma(comment(linker, "/include:" WIN_SYM_PREFIX STRINGIFY(Name)))
+#    else
+#      define WIN_FORCE_LINK(Name)                                           \
+        extern "C" __typeof__(Name) Name;                                    \
+        static __attribute__((used)) __typeof__(&Name) __force_link_##Name = \
+            &Name;
+#    endif
 
 // We cannot define weak functions on Windows, but we can use WIN_WEAK_ALIAS()
 // which defines an alias to a default implementation, and only works when

--- a/compiler-rt/lib/sanitizer_common/sanitizer_win_thunk_interception.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_win_thunk_interception.cpp
@@ -91,6 +91,7 @@ extern "C" int __sanitizer_thunk_init() {
 #  pragma section(".CRT$XIB", long, read)
 extern "C" IN_SECTION(".CRT$XIB") int (*__sanitizer_thunk_init_ptr)() =
     __sanitizer_thunk_init;
+WIN_FORCE_LINK(__sanitizer_thunk_init_ptr)
 
 static void WINAPI sanitizer_thunk_thread_init(void *mod, unsigned long reason,
                                                void *reserved) {
@@ -102,5 +103,6 @@ static void WINAPI sanitizer_thunk_thread_init(void *mod, unsigned long reason,
 extern "C" IN_SECTION(".CRT$XLAB") void(
     WINAPI* __sanitizer_thunk_thread_init_ptr)(void*, unsigned long, void*) =
     sanitizer_thunk_thread_init;
+WIN_FORCE_LINK(__sanitizer_thunk_thread_init_ptr)
 #endif  // defined(SANITIZER_STATIC_RUNTIME_THUNK) ||
         // defined(SANITIZER_DYNAMIC_RUNTIME_THUNK)

--- a/compiler-rt/lib/sanitizer_common/sanitizer_win_thunk_interception.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_win_thunk_interception.cpp
@@ -91,7 +91,9 @@ extern "C" int __sanitizer_thunk_init() {
 #  pragma section(".CRT$XIB", long, read)
 extern "C" IN_SECTION(".CRT$XIB") int (*__sanitizer_thunk_init_ptr)() =
     __sanitizer_thunk_init;
+#  if defined(__GNUC__) && !defined(__clang__)
 WIN_FORCE_LINK(__sanitizer_thunk_init_ptr)
+#  endif
 
 static void WINAPI sanitizer_thunk_thread_init(void *mod, unsigned long reason,
                                                void *reserved) {
@@ -103,6 +105,8 @@ static void WINAPI sanitizer_thunk_thread_init(void *mod, unsigned long reason,
 extern "C" IN_SECTION(".CRT$XLAB") void(
     WINAPI* __sanitizer_thunk_thread_init_ptr)(void*, unsigned long, void*) =
     sanitizer_thunk_thread_init;
+#  if defined(__GNUC__) && !defined(__clang__)
 WIN_FORCE_LINK(__sanitizer_thunk_thread_init_ptr)
+#  endif
 #endif  // defined(SANITIZER_STATIC_RUNTIME_THUNK) ||
         // defined(SANITIZER_DYNAMIC_RUNTIME_THUNK)


### PR DESCRIPTION
MSVC and clang-cl use /include directives emitted by WIN_FORCE_LINK. GNU tools need an ordinary used relocation instead. Keep the sanitizer initialization callbacks and ASan DSO registration object reachable when linking with MinGW GCC.