### PR TITLE
[BOLT][AArch64][Android] Only the dumping thread can longjmp

### DIFF
--- a/bolt/runtime/common.h
+++ b/bolt/runtime/common.h
@@ -292,19 +292,22 @@ static bool scanUInt32(const char *&Buf, const char *End, uint32_t &Ret) {
 // process. Any failure in runtime should not terminate the host process with
 // __exit(1), which would turn a profiling-tool defect into a foreground app
 // crash. Instead, __bolt_instr_data_dump() installs a setjmp() recovery point
-// and any failed assert() or reportError() will record the failure and then
-// longjmp() back reporting failure to the caller.
+// and a failed assert() or reportError() on the dumping thread will record
+// the failure and then longjmp() back reporting failure to the caller.
 alignas(16) void *__bolt_instr_longjmp_buf[16];
-bool __bolt_instr_recovery_active = false;
+
+// Thread that installed the recovery point above, or 0 when there is none.
+uint64_t __bolt_instr_recovery_tid = 0;
+
 bool __bolt_instr_dump_failed = false;
 
 void boltHandleFatalAndRecover() {
   __atomic_store_n(&__bolt_instr_dump_failed, true, __ATOMIC_RELAXED);
-  if (__bolt_instr_recovery_active) {
-    __bolt_instr_recovery_active = false;
+  if (__atomic_load_n(&__bolt_instr_recovery_tid, __ATOMIC_RELAXED) ==
+      __gettid()) {
+    __atomic_store_n(&__bolt_instr_recovery_tid, 0, __ATOMIC_RELAXED);
     __bolt_longjmp(__bolt_instr_longjmp_buf, 1);
   }
-  __exit(1);
 }
 #endif // defined(ANDROID_AARCH64)
 

--- a/bolt/runtime/instr.cpp
+++ b/bolt/runtime/instr.cpp
@@ -1587,11 +1587,11 @@ extern "C" int ALIGN_ARG_POINTER __bolt_instr_data_dump(
   // of exiting the host app. We land here with the write mutex held; release
   // it and report failure.
   if (__bolt_setjmp(__bolt_instr_longjmp_buf)) {
-    __bolt_instr_recovery_active = false;
+    __atomic_store_n(&__bolt_instr_recovery_tid, 0, __ATOMIC_RELAXED);
     GlobalWriteProfileMutex->release();
     return 1;
   }
-  __bolt_instr_recovery_active = true;
+  __atomic_store_n(&__bolt_instr_recovery_tid, __gettid(), __ATOMIC_RELAXED);
 #endif
 
   int ret = __lseek(FD, 0, SEEK_SET);
@@ -1626,7 +1626,7 @@ extern "C" int ALIGN_ARG_POINTER __bolt_instr_data_dump(
   }
   HashAlloc.destroy();
 #if defined(ANDROID_AARCH64)
-  __bolt_instr_recovery_active = false;
+  __atomic_store_n(&__bolt_instr_recovery_tid, 0, __ATOMIC_RELAXED);
 #endif
   GlobalWriteProfileMutex->release();
   DEBUG(report("Finished writing profile.\n"));

--- a/bolt/runtime/sys_aarch64.h
+++ b/bolt/runtime/sys_aarch64.h
@@ -298,6 +298,17 @@ uint64_t __getpid() {
   return ret;
 }
 
+uint64_t __gettid() {
+  uint64_t ret;
+  register uint32_t w8 __asm__("w8") = 178;
+  __asm__ __volatile__("svc #0\n"
+                       "mov %0, x0"
+                       : "=r"(ret)
+                       : "r"(w8)
+                       : "cc", "memory", "x0", "x1");
+  return ret;
+}
+
 uint64_t __getppid() {
   uint64_t ret;
   register uint32_t w8 __asm__("w8") = 173;


### PR DESCRIPTION
`__bolt_instr_recovery_active` is a process global flag and the reader in
`boltHandleFatalAndRecover()` runs on any thread. When a dump is in flight,
another app thread that fails an `assert()` or exhausts `GlobalAlloc` in
`instrumentIndirectCall()` could see the flag set, longjmp with the dumping
thread's buffer and restore the dump thread's sp/fp/lr. This is wrong since
the thread would then run on the dumping thread's stack and later release a
mutex that it does not own or hold.

`GlobalWriteProfileMutex` already serializes the writers, so one buffer would
be sufficient; only the reader side needs to know who owns the buffer. Replace
the flag with `__bolt_instr_recovery_tid` holding the owner's thread ID, and
longjmp only when it matches `__gettid()`. Other threads will fall through to
just record the failure and return.

Added a `__gettid()` syscall wrapper, for aarch64 only.

Assited-by: opus