### PR TITLE
[llvm][GlobalOpt] Preserve COMDATs for Dead GVs

### DIFF
--- a/llvm/lib/Transforms/IPO/GlobalOpt.cpp
+++ b/llvm/lib/Transforms/IPO/GlobalOpt.cpp
@@ -1331,9 +1331,13 @@ deleteIfDead(GlobalValue &GV,
   if (!GV.isDiscardableIfUnused() && !GV.isDeclaration())
     return false;
 
-  if (const Comdat *C = GV.getComdat())
-    if (!GV.hasLocalLinkage() && NotDiscardableComdats.count(C))
+  if (auto *C = GV.getComdat()) {
+    auto IsComdatLeaderWithUses =
+        C->getName() == GV.getName() && C->getUsers().size() > 1;
+    if (IsComdatLeaderWithUses ||
+        (!GV.hasInternalLinkage() && NotDiscardableComdats.count(C)))
       return false;
+  }
 
   bool Dead;
   if (auto *F = dyn_cast<Function>(&GV))

--- a/llvm/lib/Transforms/IPO/GlobalOpt.cpp
+++ b/llvm/lib/Transforms/IPO/GlobalOpt.cpp
@@ -1333,7 +1333,8 @@ deleteIfDead(GlobalValue &GV,
 
   if (auto *C = GV.getComdat()) {
     auto IsComdatLeaderWithUses =
-        C->getName() == GV.getName() && C->getUsers().size() > 1;
+        GV.getParent()->getComdatSymbolTable().contains(GV.getName()) &&
+        C->getUsers().size() > 1;
     if (IsComdatLeaderWithUses ||
         (!GV.hasInternalLinkage() && NotDiscardableComdats.count(C)))
       return false;

--- a/llvm/test/Transforms/GlobalOpt/deadfunction-comdat.ll
+++ b/llvm/test/Transforms/GlobalOpt/deadfunction-comdat.ll
@@ -1,0 +1,38 @@
+; RUN: opt < %s -passes=globalopt -S | FileCheck %s
+
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-windows-msvc"
+
+$foo = comdat any
+$trulydead = comdat any
+
+; CHECK: @foo
+define internal void @foo() comdat {
+  ret void
+}
+
+; CHECK: @bar
+define internal void @bar() #0 comdat($foo) {
+  ret void
+}
+
+define void @zed()  {
+  call void @bar()
+  ret void
+}
+
+; CHECK-NOT: @trulydead
+define internal void @trulydead() comdat {
+  ret void
+}
+
+; CHECK-NOT: @trulydead2
+define internal void @trulydead2() comdat($trulydead) {
+  ret void
+}
+
+define i32 @main() {
+  ret i32 0
+}
+
+attributes #0 = { noinline }

--- a/llvm/test/Transforms/GlobalOpt/deadglobal-comdat.ll
+++ b/llvm/test/Transforms/GlobalOpt/deadglobal-comdat.ll
@@ -1,0 +1,22 @@
+; RUN: opt < %s -passes=globalopt -S | FileCheck %s
+
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-windows-msvc"
+
+; CHECK: $x
+$x = comdat any
+
+; CHECK-NOT: $trulydeadg
+$trulydeadg = comdat any
+
+; CHECK: @g
+@g = internal global i32 0, comdat($x)
+; CHECK: @g2
+@g2 = global i32 0, comdat($x)
+; CHECK: @x
+@x = internal alias i32, ptr @g
+
+; CHECK-NOT: @trulydeadg
+@trulydeadg = internal alias i32, ptr @deadg
+; CHECK-NOT: @deadg
+@deadg = internal global i32 0, comdat($trulydeadg)


### PR DESCRIPTION
* This PR preserves COMDATs under the following case:
  * Dead functions
    * Even though a function is dead, its COMDAT may still be referenced.
      * On ELF, it is valid to have a "freestanding" COMDAT. 
        * _Note_: AFAIK this change in behavior should have no consequences for ELF (or MachO) though someone with more experience can chime in. As there wasn't prior precedent to having platform specific code in `GlobalOpt`, for now I've refrained from guarding this logic to be specific to COFF.
      * On COFF, this results in an Associative COMDAT error: `LLVM ERROR: Associative COMDAT symbol 'foo' does not exist.` 

* Replaces https://github.com/llvm/llvm-project/pull/220737 to create stacked PR.