### PR TITLE
[CIR][NFC] Fix VectorElementType constraints

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRTypeConstraints.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypeConstraints.td
@@ -297,8 +297,8 @@ def CIR_PtrToArray : CIR_PtrToType<CIR_AnyArrayType>;
 def CIR_AnyVectorType : CIR_TypeBase<"::cir::VectorType", "vector type">;
 
 def CIR_VectorElementType
-    : AnyTypeOf<[CIR_AnyBoolType, CIR_AnyIntOrFloatType, CIR_AnyPtrType],
-                "any cir boolean, integer, floating point or pointer type"> {
+    : AnyTypeOf<[CIR_AnyBoolType, CIR_AnyIntOrFloatType],
+                "any cir boolean, integer, floating point"> {
   let cppFunctionName = "isValidVectorTypeElementType";
 }
 


### PR DESCRIPTION
Remove `CIR_AnyPtrType` from the supported types in VectorElementType constraints