### PR TITLE
[libc] Write LF line endings from cmake_format.py on every platform

### DIFF
--- a/libc/utils/cmake_format.py
+++ b/libc/utils/cmake_format.py
@@ -1377,7 +1377,10 @@ def process_file(
                 temp_file = target_path.with_name(
                     f".{target_path.name}.tmp_{os.getpid()}"
                 )
-                with open(temp_file, "w", encoding="utf-8") as f:
+                # newline="\n" disables the newline substitution a text-mode
+                # write does: format_cmake_content() emits "\n" endings and the
+                # file has to land on disk with those.
+                with open(temp_file, "w", encoding="utf-8", newline="\n") as f:
                     f.write(formatted)
                 os.replace(temp_file, target_path)
                 print(f"Formatted {filepath}")
@@ -1422,6 +1425,10 @@ def find_cmake_files(paths: list[str]) -> list[str]:
 
 def main() -> None:
     """Entry point: parses CLI arguments and drives file discovery, pre-scanning, and formatting."""
+    # Formatted output and diffs go to stdout verbatim, for the same reason
+    # process_file() writes files with newline="\n".
+    sys.stdout.reconfigure(newline="\n")
+
     parser = argparse.ArgumentParser(
         description="LLVM and LLVM-libc CMake Formatter Utility",
         formatter_class=argparse.RawDescriptionHelpFormatter,

--- a/libc/utils/cmake_format_test.py
+++ b/libc/utils/cmake_format_test.py
@@ -503,5 +503,48 @@ endfunction()
         self.assertEqual(cmake_format.format_cmake_content(code), expected)
 
 
+class TestFileWriting(unittest.TestCase):
+    """Regression tests for the bytes that land on disk, not the formatted string."""
+
+    def test_inplace_write_keeps_lf_endings(self):
+        """In-place formatting writes exactly the bytes format_cmake_content produced.
+
+        A text-mode write substitutes the platform line separator, which
+        rewrites every line of an LF file as CRLF on Windows.
+        """
+        import contextlib
+        import io
+        import tempfile
+
+        code = "add_library(foo  STATIC\n  a.c\n)\n"
+        expected = cmake_format.format_cmake_content(code).encode("utf-8")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "CMakeLists.txt")
+            with open(path, "w", encoding="utf-8", newline="") as f:
+                f.write(code)
+
+            with contextlib.redirect_stdout(io.StringIO()):
+                self.assertTrue(cmake_format.process_file(path, inplace=True))
+
+            with open(path, "rb") as f:
+                self.assertEqual(f.read(), expected)
+
+    def test_stdout_write_keeps_lf_endings(self):
+        """Formatting through stdin/stdout does not rewrite the line endings either."""
+        import subprocess
+
+        code = "add_library(foo  STATIC\n  a.c\n)\n"
+        expected = cmake_format.format_cmake_content(code).encode("utf-8")
+
+        proc = subprocess.run(
+            [sys.executable, os.path.join(SCRIPT_DIR, "cmake_format.py")],
+            input=code.encode("utf-8"),
+            stdout=subprocess.PIPE,
+            check=True,
+        )
+        self.assertEqual(proc.stdout, expected)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
I ran the libc CMake formatter on Windows and it gave back a file whose every line had changed:

```
$ printf 'add_library(foo  STATIC\n  a.c\n)\n' > CMakeLists.txt
$ python libc/utils/cmake_format.py -i CMakeLists.txt
Formatted CMakeLists.txt
$ python -c "print(open('CMakeLists.txt','rb').read())"
b'add_library(foo STATIC\r\n  a.c\r\n)\r\n'
```

`format_cmake_content()` joins its lines with `"\n"`, but `process_file()` hands that string to `open(temp_file, "w", encoding="utf-8")`, and a text-mode write substitutes the platform line separator. So on Windows, reformatting one command in a file rewrites the endings of the whole file. `.gitattributes` declares no `text`/`eol` rules and `llvm/docs/GettingStarted.md` tells people to clone with `core.autocrlf=false`, so nothing normalizes those endings back before the commit.

The read side already normalizes: `open(..., "r")` gives universal newlines, so a CRLF file is LF by the time the formatter sees it. Passing `newline="\n"` on the write makes both ends agree and gives the same bytes on every platform.

The same substitution applies to stdout, which affects the piped output and the `--diff` text (a CRLF diff does not apply against an LF file), so I configured stdout the same way in `main()`.

One behaviour change worth flagging: on Windows, a CMake file that currently has CRLF endings and needs reformatting now comes out with LF rather than CRLF. Files that are already formatted are not written at all, before or after, since the comparison is made on the LF-normalized read.

For the tests, everything in `cmake_format_test.py` today asserts on the string returned by `format_cmake_content()`, so nothing covers what lands on disk. I added two cases that compare the bytes on disk and on stdout against that string. They fail on Windows before this change (the assertion prints `b'...\r\n...' != b'...\n...'`) and pass after; on Linux and macOS they pass either way, since the separator is already LF. The file went from 47 to 49 tests, all passing under `python -m unittest cmake_format_test`.

I did not have `black` available on that machine, so the added code follows the surrounding style by hand rather than by running the formatter.

AI tools used
