### PR TITLE
Fix bazel build for libc:__support_wctype_utils

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -4501,6 +4501,7 @@ libc_support_library(
     hdrs = ["src/__support/wctype_utils.h"],
     deps = [
         ":__support_cpp_array",
+        ":__support_cpp_bit",
         ":__support_cpp_string_view",
         ":__support_macros_attributes",
         ":__support_macros_config",


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/pull/222154 (commit e47d10f55719cb5bc7dac81d49277938813b5ee4) by adding missing dependency.