### PR TITLE
[HLSL] Compatibility overloads for scalar min/max

### DIFF
--- a/clang/lib/Headers/hlsl/hlsl_compat_overloads.h
+++ b/clang/lib/Headers/hlsl/hlsl_compat_overloads.h
@@ -28,6 +28,10 @@ namespace hlsl {
   [[deprecated("In 202x mismatched vector/scalar lowering for " #fn " is "     \
                "deprecated. Explicitly cast parameters.")]]
 
+#define _DXC_DEPRECATED_SCALAR_FN(ty1, ty2, fn)                                \
+  [[deprecated("In 202x mismatched " #ty1 "/" #ty2 " lowering for " #fn " is " \
+               "deprecated. Explicitly cast parameters.")]]
+
 #define _DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(fn)                                 \
   _DXC_DEPRECATED_64BIT_FN(fn)                                                 \
   constexpr float fn(double V) { return fn((float)V); }                        \
@@ -517,6 +521,12 @@ constexpr __detail::enable_if_t<(N > 1 && N <= 4), vector<T, N>> max(
   return max((vector<T, N>)p0, p1);
 }
 
+_DXC_DEPRECATED_SCALAR_FN(float, int, max)
+constexpr float max(float p0, int p1) { return max(p0, (float)p1); }
+
+_DXC_DEPRECATED_SCALAR_FN(int, float, max)
+constexpr float max(int p0, float p1) { return max((float)p0, p1); }
+
 //===----------------------------------------------------------------------===//
 // min builtins overloads
 //===----------------------------------------------------------------------===//
@@ -534,6 +544,12 @@ constexpr __detail::enable_if_t<(N > 1 && N <= 4), vector<T, N>> min(
     T p0, vector<T, N> p1) {
   return min((vector<T, N>)p0, p1);
 }
+
+_DXC_DEPRECATED_SCALAR_FN(float, int, max)
+constexpr float min(float p0, int p1) { return min(p0, (float)p1); }
+
+_DXC_DEPRECATED_SCALAR_FN(int, float, max)
+constexpr float min(int p0, float p1) { return min((float)p0, p1); }
 
 //===----------------------------------------------------------------------===//
 // normalize builtins overloads

--- a/clang/test/CodeGenHLSL/builtins/max-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/max-overloads.hlsl
@@ -79,3 +79,15 @@ double4 test_max_double4_mismatch(double4 p0, double p1) { return max(p0, p1); }
 // CHECK: [[MAX:%.*]] = call reassoc nnan ninf nsz arcp afn noundef nofpclass(nan inf) <4 x double> @llvm.maxnum.v4f64(<4 x double> [[CONV1]], <4 x double> %{{.*}})
 // CHECK: ret <4 x double> [[MAX]]
 double4 test_max_double4_mismatch2(double4 p0, double p1) { return max(p1, p0); }
+
+// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_max_float_int_mismatch
+// CHECK: [[CONV:%.*]] = sitofp reassoc nnan ninf nsz arcp afn i32 %{{.*}} to float
+// CHECK: [[MAX:%.*]] = call reassoc nnan ninf nsz arcp afn noundef nofpclass(nan inf) float @llvm.maxnum.f32(float {{%.*}}, float [[CONV]])
+// CHECK: ret float [[MAX]]
+float test_max_float_int_mismatch(float p0, int p1) { return max(p0, 1); }
+
+// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_max_float_int_mismatch2
+// CHECK: [[CONV:%.*]] = sitofp reassoc nnan ninf nsz arcp afn i32 %{{.*}} to float
+// CHECK: [[MAX:%.*]] = call reassoc nnan ninf nsz arcp afn noundef nofpclass(nan inf) float @llvm.maxnum.f32(float [[CONV]], float %{{.*}})
+// CHECK: ret float [[MAX]]
+float test_max_float_int_mismatch2(float p0, int p1) { return max(p1, p0); }

--- a/clang/test/CodeGenHLSL/builtins/min-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/min-overloads.hlsl
@@ -79,3 +79,15 @@ double4 test_min_double4_mismatch(double4 p0, double p1) { return min(p0, p1); }
 // CHECK: [[MIN:%.*]] = call reassoc nnan ninf nsz arcp afn noundef nofpclass(nan inf) <4 x double> @llvm.minnum.v4f64(<4 x double> [[CONV1]], <4 x double> %{{.*}})
 // CHECK: ret <4 x double> [[MIN]]
 double4 test_min_double4_mismatch2(double4 p0, double p1) { return min(p1, p0); }
+
+// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_min_float_int_mismatch
+// CHECK: [[CONV:%.*]] = sitofp reassoc nnan ninf nsz arcp afn i32 %{{.*}} to float
+// CHECK: [[MIN:%.*]] = call reassoc nnan ninf nsz arcp afn noundef nofpclass(nan inf) float @llvm.minnum.f32(float {{%.*}}, float [[CONV]])
+// CHECK: ret float [[MIN]]
+float test_min_float_int_mismatch(float p0, int p1) { return min(p0, p1); }
+
+// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_min_float_int_mismatch2
+// CHECK: [[CONV:%.*]] = sitofp reassoc nnan ninf nsz arcp afn i32 %{{.*}} to float
+// CHECK: [[MIN:%.*]] = call reassoc nnan ninf nsz arcp afn noundef nofpclass(nan inf) float @llvm.minnum.f32(float [[CONV]], float %{{.*}})
+// CHECK: ret float [[MIN]]
+float test_min_float_int_mismatch2(float p0, int p1) { return min(p1, p0); }


### PR DESCRIPTION
A lot of shaders fail with ambiguous overloads using int and float together in min or max calls. This just adds the usual compatibility overload with the usual warning for those including testing