### PR TITLE
[MLIR] Fix the MLIR build by properly adding external directory-

### DIFF
--- a/llvm/cmake/modules/CrossCompile.cmake
+++ b/llvm/cmake/modules/CrossCompile.cmake
@@ -42,6 +42,12 @@ function(llvm_create_cross_target project_name target_name toolchain buildtype)
   if (LLVM_USE_LINKER AND NOT CMAKE_CROSSCOMPILING)
     set(linker_flag "-DLLVM_USE_LINKER=${LLVM_USE_LINKER}")
   endif()
+  if (LLVM_EXTERNAL_MLIR_SOURCE_DIR AND LLVM_TOOL_MLIR_BUILD)
+    # Propagate MLIR source dir and enable flag so that mlir-tblgen can be built
+    set(external_mlir_dir
+        "-DLLVM_EXTERNAL_MLIR_SOURCE_DIR=${LLVM_EXTERNAL_MLIR_SOURCE_DIR}"
+        "-DLLVM_TOOL_MLIR_BUILD=TRUE")
+  endif()
   if (LLVM_EXTERNAL_CLANG_SOURCE_DIR)
     # Propagate LLVM_EXTERNAL_CLANG_SOURCE_DIR so that clang-tblgen can be built
     set(external_clang_dir "-DLLVM_EXTERNAL_CLANG_SOURCE_DIR=${LLVM_EXTERNAL_CLANG_SOURCE_DIR}")
@@ -111,6 +117,7 @@ function(llvm_create_cross_target project_name target_name toolchain buildtype)
         -DLLVM_TABLEGEN_FLAGS="${llvm_tablegen_flags}"
         ${python_executable_flag}
         ${build_type_flags} ${linker_flag} ${external_clang_dir}
+        ${external_mlir_dir}
         ${ARGN}
     WORKING_DIRECTORY ${${project_name}_${target_name}_BUILD}
     DEPENDS CREATE_${project_name}_${target_name}


### PR DESCRIPTION
I don't know where we broke this, but it seems this is is necessary when doing -DLLVM_OPTIMIZED_TABLEGEN=true.  I copied this off the clang-tablegen, and it fixes my local problem, which was

[1881/7447] Building native mlir-tblgen...
ninja: error: unknown target 'mlir-tblgen', did you mean 'llvm-tblgen'?