### PR TITLE
[mlir][OpenACC] Restrict implicit data to compute constructs

### DIFF
--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCImplicitData.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCImplicitData.cpp
@@ -501,14 +501,8 @@ Operation *ACCImplicitData::generateDataClauseOpForCandidate(
       copyinOp.setDataClause(acc::DataClause::acc_reduction);
       return copyinOp.getOperation();
     }
-    if constexpr (std::is_same_v<OpT, acc::KernelsOp> ||
-                  std::is_same_v<OpT, acc::KernelEnvironmentOp>) {
+    if constexpr (std::is_same_v<OpT, acc::KernelsOp>) {
       // Scalars are implicit copyin in kernels construct.
-      // We also do the same for acc.kernel_environment because semantics
-      // of user variable mappings should be applied while ACC construct exists
-      // and at this point we should only be dealing with unmapped variables
-      // that were made live-in by the compiler.
-      // TODO: This may be revisited.
       auto copyinOp =
           acc::CopyinOp::create(builder, loc, var,
                                 /*structured=*/true, /*implicit=*/true,
@@ -764,8 +758,7 @@ void ACCImplicitData::generateImplicitDataOps(
 
   // 5) Generate private recipes which are required for properly attaching
   // private operands.
-  if constexpr (!std::is_same_v<OpT, acc::KernelsOp> &&
-                !std::is_same_v<OpT, acc::KernelEnvironmentOp>)
+  if constexpr (!std::is_same_v<OpT, acc::KernelsOp>)
     generateRecipes(module, builder, computeConstructOp, newPrivateOperands);
 
   // 6) Figure out insertion order for the new data clause operands.
@@ -778,8 +771,7 @@ void ACCImplicitData::generateImplicitDataOps(
   generateDataExitOperations(builder, computeConstructOp, newDataClauseOperands,
                              sortedDataClauseOperands);
   // 8) Add all of the new operands to the compute construct op.
-  if constexpr (!std::is_same_v<OpT, acc::KernelsOp> &&
-                !std::is_same_v<OpT, acc::KernelEnvironmentOp>)
+  if constexpr (!std::is_same_v<OpT, acc::KernelsOp>)
     addNewPrivateOperands(computeConstructOp, newPrivateOperands);
   computeConstructOp.getDataClauseOperandsMutable().assign(
       sortedDataClauseOperands);
@@ -791,15 +783,14 @@ void ACCImplicitData::runOnOperation() {
   acc::OpenACCSupport &accSupport = getAnalysis<acc::OpenACCSupport>();
 
   module.walk([&](Operation *op) {
-    if (isa<ACC_COMPUTE_CONSTRUCT_OPS, acc::KernelEnvironmentOp>(op)) {
+    if (isa<ACC_COMPUTE_CONSTRUCT_OPS>(op)) {
       assert(op->getNumRegions() == 1 && "must have 1 region");
 
       auto defaultClause = acc::getDefaultAttr(op);
       llvm::TypeSwitch<Operation *, void>(op)
-          .Case<ACC_COMPUTE_CONSTRUCT_OPS, acc::KernelEnvironmentOp>(
-              [&](auto op) {
-                generateImplicitDataOps(module, op, defaultClause, accSupport);
-              })
+          .Case<ACC_COMPUTE_CONSTRUCT_OPS>([&](auto op) {
+            generateImplicitDataOps(module, op, defaultClause, accSupport);
+          })
           .Default([&](Operation *) {});
     }
   });

--- a/mlir/test/Dialect/OpenACC/acc-implicit-data.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-implicit-data.mlir
@@ -2,6 +2,31 @@
 
 // -----
 
+// acc.kernel_environment is not a compute construct. Host-side preparation in
+// its body and operands captured by a nested acc.compute_region must not cause
+// implicit mappings.
+func.func @test_kernel_environment_is_not_compute_construct(
+    %arg: memref<f32>) {
+  acc.kernel_environment {
+    %host = memref.load %arg[] : memref<f32>
+    acc.compute_region ins(%deviceArg = %arg) : (memref<f32>) {
+      %device = memref.load %deviceArg[] : memref<f32>
+      acc.yield
+    } <{origin = "acc.parallel"}>
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @test_kernel_environment_is_not_compute_construct
+// CHECK-SAME: %[[ARG:.*]]: memref<f32>
+// CHECK-NOT: acc.copyin
+// CHECK-NOT: acc.firstprivate
+// CHECK: acc.kernel_environment {
+// CHECK: memref.load %[[ARG]][]
+// CHECK: acc.compute_region ins(%{{.*}} = %[[ARG]]) : (memref<f32>)
+
+// -----
+
 // Test scalar in serial construct - should generate firstprivate
 func.func @test_scalar_in_serial() {
   %alloc = memref.alloca() : memref<i64>


### PR DESCRIPTION
acc.kernel_environment contains host-side preparation around an outlined compute region; it is not itself an OpenACC compute construct. Treating all of its live-ins as implicit device mappings can map compiler-generated host operations and assign them kernels-style copy semantics.

Limit ACCImplicitData to parallel, kernels, and serial. In particular, do not process kernel_environment or the lowered compute_region form.

Assisted-by: Cursor