### PR TITLE
[flang][acc] Update descriptor attach rules to only pointer/allocatable

### DIFF
--- a/flang/lib/Optimizer/OpenACC/Transforms/ACCMapInfoPrep.cpp
+++ b/flang/lib/Optimizer/OpenACC/Transforms/ACCMapInfoPrep.cpp
@@ -78,14 +78,29 @@ using namespace mlir;
 
 namespace {
 
-/// Returns the pointer slot holding the address of \p mapVar, which the runtime
-/// rewrites once the pointee has a device copy. Such a slot exists only when
-/// the clause maps a pointee obtained by dereferencing it; mapping the slot
-/// itself has no second indirection and therefore no attach point. Only slots
-/// reached through a Fortran descriptor are recognized here.
+/// True when \p boxValue is the descriptor of a POINTER or an ALLOCATABLE.
+/// OpenACC 3.4 §2.6.4 names Fortran pointers and allocatables alike as
+/// pointers: an attach action updates the device pointer to the device copy of
+/// the data and, for Fortran array pointers and allocatable arrays, copies any
+/// associated descriptor. Flang gives a descriptor to further entities -
+/// assumed-shape, assumed-rank and polymorphic among them - for which the
+/// specification prescribes no descriptor management, so the runtime keeps no
+/// device copy of one to attach. See
+/// flang/docs/OpenACC-descriptor-management.md.
+static bool isPointerOrAllocatableBox(Value boxValue) {
+  auto boxTy = dyn_cast<fir::BaseBoxType>(boxValue.getType());
+  return boxTy && boxTy.isPointerOrAllocatable();
+}
+
+/// Returns the pointer slot holding the address of \p mapVar, which the attach
+/// action rewrites once the pointee has a device copy. Such a slot exists only
+/// when the clause maps a pointee obtained by dereferencing it; mapping the
+/// slot itself has no second indirection and therefore no attach point. Only
+/// slots reached through a Fortran descriptor are recognized here.
 static Value findAttachPoint(Value mapVar) {
   if (auto boxAddr = mapVar.getDefiningOp<fir::BoxAddrOp>()) {
-    if (auto load = boxAddr.getVal().getDefiningOp<fir::LoadOp>())
+    auto load = boxAddr.getVal().getDefiningOp<fir::LoadOp>();
+    if (load && isPointerOrAllocatableBox(boxAddr.getVal()))
       return load.getMemref();
   }
   if (fir::isa_box_type(fir::unwrapRefType(mapVar.getType()))) {
@@ -130,12 +145,19 @@ findDescriptorFacts(Value mapVar, Type mappedObjectType, bool isImplicit) {
   if (fir::isa_box_type(fir::unwrapRefType(mapTy)))
     return {acc::DataDescKind::cfi, mapVar};
   // box_addr of a loaded box can be either the pointee of a nested descriptor
-  // map or a host data-base address derived from an already-mapped box. The
-  // latter is always an implicit clause; only treat the explicit case as CFI.
+  // map or a data base address derived from an already-mapped box. The latter
+  // is always an implicit clause; only treat the explicit case as CFI.
+  //
+  // Naming a descriptor asserts that it describes the mapped object wherever
+  // that object is used, so name only one that OpenACC 3.4 §2.6.4 requires to
+  // be maintained on the device: that of a POINTER or an ALLOCATABLE. Flang
+  // also forms descriptors for entities whose descriptor the specification
+  // leaves unmanaged, and those describe the object on the host alone. See
+  // flang/docs/OpenACC-descriptor-management.md.
   if (!isImplicit) {
     if (auto boxAddr = mapVar.getDefiningOp<fir::BoxAddrOp>()) {
       Value boxVal = boxAddr.getVal();
-      if (fir::isa_box_type(boxVal.getType()) &&
+      if (isPointerOrAllocatableBox(boxVal) &&
           boxVal.getDefiningOp<fir::LoadOp>())
         return {acc::DataDescKind::cfi, boxVal};
     }

--- a/flang/test/Fir/OpenACC/acc-fir-map-info-prep-attach.mlir
+++ b/flang/test/Fir/OpenACC/acc-fir-map-info-prep-attach.mlir
@@ -90,6 +90,134 @@ func.func @loaded_unmanaged_descriptor() {
   return
 }
 
+// An assumed-shape dummy arrives as a box parameter. Mapping that box is a
+// descriptor map recovered from var: no separate desc operand and no attach
+// slot, because the specification leaves this descriptor unmanaged on the
+// device.
+// CHECK-LABEL: func.func @assumed_shape_dummy
+// CHECK-SAME: %[[BOX:.*]]: !fir.box<!fir.array<?xf32>>
+// CHECK: acc.map_info var(%[[BOX]] : !fir.box<!fir.array<?xf32>>)
+// CHECK-NOT: varPtrPtr
+// CHECK-NOT: desc(
+// CHECK-SAME: elementSize(4)
+// CHECK-SAME: descKind(cfi)
+// CHECK-SAME: mapFlags(to)
+// CHECK-NOT: ptr_and_obj
+// IDEMP-LABEL: func.func @assumed_shape_dummy
+// IDEMP-COUNT-1: acc.map_info
+// IDEMP-NOT: acc.copyin
+func.func @assumed_shape_dummy(%box: !fir.box<!fir.array<?xf32>>) {
+  %copy = acc.copyin var(%box : !fir.box<!fir.array<?xf32>>)
+      dataClause(acc_copyin) name("a") -> !fir.box<!fir.array<?xf32>>
+  acc.data dataOperands(%copy : !fir.box<!fir.array<?xf32>>) {
+    acc.terminator
+  }
+  return
+}
+
+// The base address taken out of that same box parameter is a plain object map:
+// there is no descriptor slot to attach through, and the box itself is not
+// named. An explicit clause keeps the unknown size of a dynamic extent.
+// CHECK-LABEL: func.func @assumed_shape_base_address
+// CHECK-SAME: %[[BOX:.*]]: !fir.box<!fir.array<?xf32>>
+// CHECK: %[[DATA:.*]] = fir.box_addr %[[BOX]]
+// CHECK: %[[SIZE:.*]] = arith.constant -1 : i64
+// CHECK: acc.map_info varPtr(%[[DATA]] : !fir.ref<!fir.array<?xf32>>)
+// CHECK-NOT: varPtrPtr
+// CHECK-NOT: desc(
+// CHECK-SAME: size(%[[SIZE]] : i64)
+// CHECK-SAME: elementSize(4)
+// CHECK-SAME: descKind(none)
+// CHECK-SAME: mapFlags(to)
+// IDEMP-LABEL: func.func @assumed_shape_base_address
+// IDEMP-COUNT-1: acc.map_info
+// IDEMP-NOT: acc.copyin
+func.func @assumed_shape_base_address(%box: !fir.box<!fir.array<?xf32>>) {
+  %data = fir.box_addr %box : (!fir.box<!fir.array<?xf32>>) -> !fir.ref<!fir.array<?xf32>>
+  %copy = acc.copyin varPtr(%data : !fir.ref<!fir.array<?xf32>>)
+      dataClause(acc_copyin) name("a") -> !fir.ref<!fir.array<?xf32>>
+  acc.data dataOperands(%copy : !fir.ref<!fir.array<?xf32>>) {
+    acc.terminator
+  }
+  return
+}
+
+// A polymorphic dummy arrives as a class parameter. It behaves like the
+// assumed-shape box: mapping the class is a descriptor map recovered from var,
+// with no separate desc operand and no attach slot.
+// CHECK-LABEL: func.func @polymorphic_dummy
+// CHECK-SAME: %[[CLASS:.*]]: !fir.class<!fir.type<_QMtypesTbase{i:i32}>>
+// CHECK: acc.map_info var(%[[CLASS]] : !fir.class<!fir.type<_QMtypesTbase{i:i32}>>)
+// CHECK-NOT: varPtrPtr
+// CHECK-NOT: desc(
+// CHECK-SAME: elementSize(4)
+// CHECK-SAME: descKind(cfi)
+// CHECK-SAME: mapFlags(to)
+// CHECK-NOT: ptr_and_obj
+// IDEMP-LABEL: func.func @polymorphic_dummy
+// IDEMP-COUNT-1: acc.map_info
+// IDEMP-NOT: acc.copyin
+func.func @polymorphic_dummy(%class: !fir.class<!fir.type<_QMtypesTbase{i:i32}>>) {
+  %copy = acc.copyin var(%class : !fir.class<!fir.type<_QMtypesTbase{i:i32}>>)
+      dataClause(acc_copyin) name("p") -> !fir.class<!fir.type<_QMtypesTbase{i:i32}>>
+  acc.data dataOperands(%copy : !fir.class<!fir.type<_QMtypesTbase{i:i32}>>) {
+    acc.terminator
+  }
+  return
+}
+
+// The base address taken out of that class parameter is likewise a plain
+// object map, sized from the record type.
+// CHECK-LABEL: func.func @polymorphic_base_address
+// CHECK-SAME: %[[CLASS:.*]]: !fir.class<!fir.type<_QMtypesTbase{i:i32}>>
+// CHECK: %[[DATA:.*]] = fir.box_addr %[[CLASS]]
+// CHECK: %[[SIZE:.*]] = arith.constant 4 : i64
+// CHECK: acc.map_info varPtr(%[[DATA]] : !fir.ref<!fir.type<_QMtypesTbase{i:i32}>>)
+// CHECK-NOT: varPtrPtr
+// CHECK-NOT: desc(
+// CHECK-SAME: size(%[[SIZE]] : i64)
+// CHECK-SAME: descKind(none)
+// CHECK-SAME: mapFlags(to)
+// IDEMP-LABEL: func.func @polymorphic_base_address
+// IDEMP-COUNT-1: acc.map_info
+// IDEMP-NOT: acc.copyin
+func.func @polymorphic_base_address(%class: !fir.class<!fir.type<_QMtypesTbase{i:i32}>>) {
+  %data = fir.box_addr %class : (!fir.class<!fir.type<_QMtypesTbase{i:i32}>>) -> !fir.ref<!fir.type<_QMtypesTbase{i:i32}>>
+  %copy = acc.copyin varPtr(%data : !fir.ref<!fir.type<_QMtypesTbase{i:i32}>>)
+      dataClause(acc_copyin) name("p") -> !fir.ref<!fir.type<_QMtypesTbase{i:i32}>>
+  acc.data dataOperands(%copy : !fir.ref<!fir.type<_QMtypesTbase{i:i32}>>) {
+    acc.terminator
+  }
+  return
+}
+
+// A polymorphic ALLOCATABLE is a class whose descriptor the specification does
+// require to be maintained on the device, so the pointee map keeps its attach
+// slot and names the descriptor. The distinction is the entity, not whether
+// the descriptor is a box or a class.
+// CHECK-LABEL: func.func @polymorphic_allocatable
+// CHECK-SAME: %[[SLOT:.*]]: !fir.ref<!fir.class<!fir.heap<!fir.type<_QMtypesTbase{i:i32}>>>>
+// CHECK: %[[CLASS:.*]] = fir.load %[[SLOT]]
+// CHECK: %[[DATA:.*]] = fir.box_addr %[[CLASS]]
+// CHECK: acc.map_info varPtr(%[[DATA]] : !fir.heap<!fir.type<_QMtypesTbase{i:i32}>>)
+// CHECK-SAME: varPtrPtr(%[[SLOT]] : !fir.ref<!fir.class<!fir.heap<!fir.type<_QMtypesTbase{i:i32}>>>>)
+// CHECK-SAME: desc(%[[CLASS]] : !fir.class<!fir.heap<!fir.type<_QMtypesTbase{i:i32}>>>)
+// CHECK-SAME: descKind(cfi)
+// CHECK-SAME: mapFlags(to,ptr_and_obj)
+// IDEMP-LABEL: func.func @polymorphic_allocatable
+// IDEMP-COUNT-1: acc.map_info
+// IDEMP-NOT: acc.copyin
+func.func @polymorphic_allocatable(%slot: !fir.ref<!fir.class<!fir.heap<!fir.type<_QMtypesTbase{i:i32}>>>>) {
+  %box = fir.load %slot : !fir.ref<!fir.class<!fir.heap<!fir.type<_QMtypesTbase{i:i32}>>>>
+  %data = fir.box_addr %box : (!fir.class<!fir.heap<!fir.type<_QMtypesTbase{i:i32}>>>) -> !fir.heap<!fir.type<_QMtypesTbase{i:i32}>>
+  %copy = acc.copyin varPtr(%data : !fir.heap<!fir.type<_QMtypesTbase{i:i32}>>)
+      dataClause(acc_copyin) name("p") -> !fir.heap<!fir.type<_QMtypesTbase{i:i32}>>
+  acc.data dataOperands(%copy : !fir.heap<!fir.type<_QMtypesTbase{i:i32}>>) {
+    acc.terminator
+  }
+  return
+}
+
 // Mapping descriptor storage itself has no second indirection operand. The
 // descriptor is recovered from var and supplies both CFI and ptr_and_obj facts.
 // CHECK-LABEL: func.func @descriptor_storage

--- a/flang/test/Fir/OpenACC/acc-fir-map-info-prep-attach.mlir
+++ b/flang/test/Fir/OpenACC/acc-fir-map-info-prep-attach.mlir
@@ -60,6 +60,36 @@ func.func @existing_attach_point() {
   return
 }
 
+// A loaded descriptor of an entity that is neither POINTER nor ALLOCATABLE is
+// not named: the specification leaves such a descriptor unmanaged on the
+// device, so it does not describe the mapped object there. The entry is a plain
+// object map, sized from its type.
+// CHECK-LABEL: func.func @loaded_unmanaged_descriptor
+// CHECK: %[[BOX:.*]] = fir.load %{{.*}} : !fir.ref<!fir.box<!fir.array<100xf32>>>
+// CHECK: %[[DATA:.*]] = fir.box_addr %[[BOX]]
+// CHECK: %[[SIZE:.*]] = arith.constant 400 : i64
+// CHECK: acc.map_info varPtr(%[[DATA]] : !fir.ref<!fir.array<100xf32>>)
+// CHECK-NOT: varPtrPtr
+// CHECK-NOT: desc(
+// CHECK-SAME: size(%[[SIZE]] : i64)
+// CHECK-SAME: elementSize(4)
+// CHECK-SAME: descKind(none)
+// CHECK-SAME: mapFlags(to)
+// IDEMP-LABEL: func.func @loaded_unmanaged_descriptor
+// IDEMP-COUNT-1: acc.map_info
+// IDEMP-NOT: acc.copyin
+func.func @loaded_unmanaged_descriptor() {
+  %slot = fir.undefined !fir.ref<!fir.box<!fir.array<100xf32>>>
+  %box = fir.load %slot : !fir.ref<!fir.box<!fir.array<100xf32>>>
+  %data = fir.box_addr %box : (!fir.box<!fir.array<100xf32>>) -> !fir.ref<!fir.array<100xf32>>
+  %copy = acc.copyin varPtr(%data : !fir.ref<!fir.array<100xf32>>)
+      dataClause(acc_copyin) name("v") -> !fir.ref<!fir.array<100xf32>>
+  acc.data dataOperands(%copy : !fir.ref<!fir.array<100xf32>>) {
+    acc.terminator
+  }
+  return
+}
+
 // Mapping descriptor storage itself has no second indirection operand. The
 // descriptor is recovered from var and supplies both CFI and ptr_and_obj facts.
 // CHECK-LABEL: func.func @descriptor_storage


### PR DESCRIPTION
When a clause maps only a descriptor's data, ACCMapInfoPrep should infer an attach point and name the descriptor only for POINTER and ALLOCATABLE, which OpenACC requires to be maintained on the device. See flang/docs/OpenACC-descriptor-management.md.