### PR TITLE
[mlir][DLTI] Stop using Operation::getAttrs  (NFC)

### DIFF
--- a/mlir/lib/Dialect/DLTI/DLTI.cpp
+++ b/mlir/lib/Dialect/DLTI/DLTI.cpp
@@ -525,7 +525,7 @@ getClosestQueryable(Operation *op) {
 
   // Search op and its ancestors for the first attached DLTIQueryInterface attr.
   do {
-    for (NamedAttribute attr : op->getAttrs())
+    for (NamedAttribute attr : op->getDiscardableAttrDictionary().getValue())
       if ((queryable = dyn_cast<DLTIQueryInterface>(attr.getValue())))
         break;
   } while (!queryable && (op = op->getParentOp()));


### PR DESCRIPTION
Inspect only discardable attributes when looking for DLTI query metadata.

This is part of a general migration to use the "new" properties-based APIs and stop mixing discardable/inherent attributes, see #155475

Assisted-by: Codex