### PR TITLE
[mlir][Tensor] Split out the dialect declaration to improve build time (NFC)

### DIFF
--- a/mlir/include/mlir/Dialect/Tensor/IR/Tensor.h
+++ b/mlir/include/mlir/Dialect/Tensor/IR/Tensor.h
@@ -10,9 +10,9 @@
 #define MLIR_DIALECT_TENSOR_IR_TENSOR_H_
 
 #include "mlir/Bytecode/BytecodeOpInterface.h"
+#include "mlir/Dialect/Tensor/IR/TensorDialect.h"
 #include "mlir/Dialect/Utils/ReshapeOpsUtils.h"
 #include "mlir/IR/BuiltinTypes.h"
-#include "mlir/IR/Dialect.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/Interfaces/CastInterfaces.h"
@@ -43,12 +43,6 @@ SmallVector<Range, 8> getOrCreateRanges(OffsetSizeAndStrideOpInterface op,
                                         OpBuilder &b, Location loc);
 
 } // namespace mlir
-
-//===----------------------------------------------------------------------===//
-// Tensor Dialect
-//===----------------------------------------------------------------------===//
-
-#include "mlir/Dialect/Tensor/IR/TensorOpsDialect.h.inc"
 
 //===----------------------------------------------------------------------===//
 // Tensor Dialect Operations

--- a/mlir/include/mlir/Dialect/Tensor/IR/TensorDialect.h
+++ b/mlir/include/mlir/Dialect/Tensor/IR/TensorDialect.h
@@ -1,0 +1,16 @@
+//===- TensorDialect.h - Tensor dialect declaration ------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_DIALECT_TENSOR_IR_TENSORDIALECT_H_
+#define MLIR_DIALECT_TENSOR_IR_TENSORDIALECT_H_
+
+#include "mlir/IR/Dialect.h"
+
+#include "mlir/Dialect/Tensor/IR/TensorOpsDialect.h.inc"
+
+#endif // MLIR_DIALECT_TENSOR_IR_TENSORDIALECT_H_

--- a/mlir/lib/CAPI/Dialect/Tensor.cpp
+++ b/mlir/lib/CAPI/Dialect/Tensor.cpp
@@ -6,9 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir-c/Dialect/Tensor.h"
 #include "mlir/CAPI/Registration.h"
+#include "mlir/Dialect/Tensor/IR/TensorDialect.h"
 
 MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(Tensor, tensor,
                                       mlir::tensor::TensorDialect)

--- a/mlir/lib/Conversion/TosaToSCF/TosaToSCFPass.cpp
+++ b/mlir/lib/Conversion/TosaToSCF/TosaToSCFPass.cpp
@@ -14,7 +14,7 @@
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
-#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Tensor/IR/TensorDialect.h"
 #include "mlir/Dialect/Tosa/IR/TosaOps.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/PassManager.h"


### PR DESCRIPTION
Move TensorDialect to a self-contained declaration header and use it in the two consumers that only need the dialect class.

Across three controlled rebuilds of the affected TUs, median instructions fell from 25.499B to 21.072B (-17.363%) and median wall time fell from 3.55s to 2.81s (-20.845%).

Assisted-by: Codex