### PR TITLE
[libc] Add MAP_ANON as a synonym for MAP_ANONYMOUS.

### DIFF
--- a/libc/include/llvm-libc-macros/sys-mman-macros.h
+++ b/libc/include/llvm-libc-macros/sys-mman-macros.h
@@ -28,6 +28,12 @@
 #define MAP_FAILED ((void *)-1)
 #endif
 
+// MAP_ANON is a synonym for MAP_ANONYMOUS specified in POSIX,
+// but is not always provided by kernel headers.
+#if !defined(MAP_ANON) && defined(MAP_ANONYMOUS)
+#define MAP_ANON MAP_ANONYMOUS
+#endif
+
 // Posix memory advise flags. (posix_madvise)
 #ifndef POSIX_MADV_NORMAL
 #define POSIX_MADV_NORMAL MADV_NORMAL

--- a/libc/include/sys/mman.yaml
+++ b/libc/include/sys/mman.yaml
@@ -2,6 +2,8 @@ header: sys/mman.h
 standards:
   - posix
 macros:
+  - macro_name: MAP_ANON
+    macro_header: sys-mman-macros.h
   - macro_name: MAP_FAILED
     macro_header: sys-mman-macros.h
 types:


### PR DESCRIPTION
`MAP_ANON` is specified in POSIX, but may not be present in Linux kernel headers,
which we rely on to get the values of other `MAP_` values. Provide this macro
ourselves to ensure the user code including `<sys/mman.h>` can use it.