### PR TITLE
[mlir][Tosa] Optimize compliance initialization for size to improve build time (NFC)

### DIFF
--- a/mlir/lib/Dialect/Tosa/Transforms/TosaProfileCompliance.cpp
+++ b/mlir/lib/Dialect/Tosa/Transforms/TosaProfileCompliance.cpp
@@ -8,12 +8,13 @@
 
 #include "mlir/Dialect/Tosa/IR/TosaProfileCompliance.h"
 #include "llvm/ADT/StringExtras.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/raw_ostream.h"
 
 using namespace mlir;
 using namespace mlir::tosa;
 
-TosaProfileCompliance::TosaProfileCompliance() {
+LLVM_ATTRIBUTE_MINSIZE TosaProfileCompliance::TosaProfileCompliance() {
   const TypeInfo boolT = {mlir::IntegerType::getTypeID(), 1};
   const TypeInfo i4T = {mlir::IntegerType::getTypeID(), 4};
   const TypeInfo i8T = {mlir::IntegerType::getTypeID(), 8};


### PR DESCRIPTION
The compliance-map constructor includes a 4,920-line generated initializer. Mark it minsize because it runs only when creating the validation pass and optimizing this single large function at -O3 is expensive.

LLVM pass timing attributes most of the saving to code generation. Greedy register allocation fell from 7.070s to 1.348s as global live-range splitting fell from 6.403s to 0.021s after the constructor became 47.6% smaller.

Across five controlled rebuilds of the affected TU, median instructions fell from 205.087B to 66.157B (-67.742%) and median wall time fell from 19.83s to 7.95s (-59.909%).

Assisted-by: Codex