### PR TITLE
[mlir][ROCDL] Split the dialect declaration to improve build time (NFC)

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/ROCDLDialect.h
+++ b/mlir/include/mlir/Dialect/LLVMIR/ROCDLDialect.h
@@ -24,7 +24,7 @@
 
 #include "mlir/Bytecode/BytecodeOpInterface.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
-#include "mlir/IR/Dialect.h"
+#include "mlir/Dialect/LLVMIR/ROCDLDialectDecl.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 
@@ -33,8 +33,6 @@
 ///// Ops /////
 #define GET_ATTRDEF_CLASSES
 #include "mlir/Dialect/LLVMIR/ROCDLOpsAttributes.h.inc"
-
-#include "mlir/Dialect/LLVMIR/ROCDLOpsDialect.h.inc"
 
 #define GET_OP_CLASSES
 #include "mlir/Dialect/LLVMIR/ROCDLOps.h.inc"

--- a/mlir/include/mlir/Dialect/LLVMIR/ROCDLDialectDecl.h
+++ b/mlir/include/mlir/Dialect/LLVMIR/ROCDLDialectDecl.h
@@ -1,0 +1,17 @@
+//===- ROCDLDialectDecl.h - ROCDL dialect declaration ---------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_DIALECT_LLVMIR_ROCDLDIALECTDECL_H
+#define MLIR_DIALECT_LLVMIR_ROCDLDIALECTDECL_H
+
+#include "mlir/IR/Dialect.h"
+#include "mlir/IR/Operation.h"
+
+#include "mlir/Dialect/LLVMIR/ROCDLOpsDialect.h.inc"
+
+#endif // MLIR_DIALECT_LLVMIR_ROCDLDIALECTDECL_H

--- a/mlir/lib/CAPI/Dialect/ROCDL.cpp
+++ b/mlir/lib/CAPI/Dialect/ROCDL.cpp
@@ -8,6 +8,6 @@
 
 #include "mlir-c/Dialect/ROCDL.h"
 #include "mlir/CAPI/Registration.h"
-#include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
+#include "mlir/Dialect/LLVMIR/ROCDLDialectDecl.h"
 
 MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(ROCDL, rocdl, mlir::ROCDL::ROCDLDialect)

--- a/mlir/lib/RegisterAllDialects.cpp
+++ b/mlir/lib/RegisterAllDialects.cpp
@@ -46,7 +46,7 @@
 #include "mlir/Dialect/Index/IR/IndexDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/LLVMIR/NVVMDialectDecl.h"
-#include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
+#include "mlir/Dialect/LLVMIR/ROCDLDialectDecl.h"
 #include "mlir/Dialect/LLVMIR/Transforms/InlinerInterfaceImpl.h"
 #include "mlir/Dialect/LLVMIR/XeVMDialect.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"

--- a/mlir/test/lib/Dialect/GPU/TestGpuRewrite.cpp
+++ b/mlir/test/lib/Dialect/GPU/TestGpuRewrite.cpp
@@ -16,7 +16,7 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/GPU/Transforms/Passes.h"
 #include "mlir/Dialect/Index/IR/IndexDialect.h"
-#include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
+#include "mlir/Dialect/LLVMIR/ROCDLDialectDecl.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/IR/PatternMatch.h"


### PR DESCRIPTION
Introduce a self-contained dialect declaration and use it in three consumers that need registration but not the generated operation umbrella.

Across three controlled rebuilds of the affected TUs, median instructions fell from 129.372B to 111.587B (-13.748%) and median wall time fell from 20.62s to 17.72s (-14.064%).

Assisted-by: Codex