### PR TITLE
[libc++][test][shared] Add @CMAKE_DL_LIBS@ when needed

### DIFF
--- a/libcxx/test/configs/llvm-libc++-shared.cfg.in
+++ b/libcxx/test/configs/llvm-libc++-shared.cfg.in
@@ -7,8 +7,13 @@ config.substitutions.append(('%{flags}',
 config.substitutions.append(('%{compile_flags}',
     '-nostdinc++ -I %{target-include-dir} -I %{include-dir} -I %{libcxx-dir}/test/support'
 ))
+
+link_flags = []
+if '@CMAKE_DL_LIBS@':
+    link_flags.append('-l@CMAKE_DL_LIBS@')
 config.substitutions.append(('%{link_flags}',
-    '-nostdlib++ -L %{lib-dir} -Wl,-rpath,%{lib-dir} -lc++'
+    '-nostdlib++ -L %{{lib-dir}} -Wl,-rpath,%{{lib-dir}} '
+    '-lc++ {}'.format(' '.join(link_flags))
 ))
 config.substitutions.append(('%{exec}',
     '%{executor} --execdir %{temp} -- '


### PR DESCRIPTION
libcxx shared tests on systems with glibc older than 2.34 fail due to missing dynamic loading library provided symbols.
e.g. RHEL-8, Ubuntu-20.

Fix by leveraging @CMAKE_DL_LIBS@ to provide the list of required libraries.

Fixes #223108 