### PR TITLE
[mlir][GPU] Split the dialect declaration to improve build time (NFC)

### DIFF
--- a/mlir/include/mlir/Dialect/GPU/IR/GPUDialect.h
+++ b/mlir/include/mlir/Dialect/GPU/IR/GPUDialect.h
@@ -17,9 +17,9 @@
 #include "mlir/Bytecode/BytecodeOpInterface.h"
 #include "mlir/Dialect/DLTI/Traits.h"
 #include "mlir/Dialect/GPU/IR/CompilationInterfaces.h"
+#include "mlir/Dialect/GPU/IR/GPUDialectDecl.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
-#include "mlir/IR/Dialect.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/RegionKindInterface.h"
@@ -218,10 +218,6 @@ public:
 
 } // namespace gpu
 } // namespace mlir
-
-#include "mlir/Dialect/GPU/IR/GPUOpsEnums.h.inc"
-
-#include "mlir/Dialect/GPU/IR/GPUOpsDialect.h.inc"
 
 #include "mlir/Dialect/GPU/IR/GPUOpInterfaces.h.inc"
 

--- a/mlir/include/mlir/Dialect/GPU/IR/GPUDialectDecl.h
+++ b/mlir/include/mlir/Dialect/GPU/IR/GPUDialectDecl.h
@@ -1,0 +1,23 @@
+//===- GPUDialectDecl.h - GPU dialect declaration --------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_DIALECT_GPU_IR_GPUDIALECTDECL_H
+#define MLIR_DIALECT_GPU_IR_GPUDIALECTDECL_H
+
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Dialect.h"
+#include "mlir/IR/Operation.h"
+
+// Pull in enum definitions used by the generated dialect declaration.
+#include "mlir/Dialect/GPU/IR/GPUOpsEnums.h.inc"
+
+// Pull in the generated dialect declaration.
+#include "mlir/Dialect/GPU/IR/GPUOpsDialect.h.inc"
+
+#endif // MLIR_DIALECT_GPU_IR_GPUDIALECTDECL_H

--- a/mlir/lib/Dialect/Linalg/TransformOps/DialectExtension.cpp
+++ b/mlir/lib/Dialect/Linalg/TransformOps/DialectExtension.cpp
@@ -9,7 +9,7 @@
 #include "mlir/Dialect/Linalg/TransformOps/DialectExtension.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
-#include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/GPU/IR/GPUDialectDecl.h"
 #include "mlir/Dialect/Index/IR/IndexDialect.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/TransformOps/LinalgMatchOps.h"

--- a/mlir/test/lib/Dialect/Linalg/TestLinalgTransforms.cpp
+++ b/mlir/test/lib/Dialect/Linalg/TestLinalgTransforms.cpp
@@ -14,7 +14,7 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
-#include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/GPU/IR/GPUDialectDecl.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/Passes.h"
 #include "mlir/Dialect/Linalg/Transforms/Hoisting.h"


### PR DESCRIPTION
Introduce a self-contained dialect declaration and use it in two consumers that need registration but not the generated operation umbrella.

Across three controlled rebuilds of the affected TUs, median instructions fell from 82.473B to 75.865B (-8.012%) and median wall time fell from 12.51s to 11.34s (-9.353%).

Assisted-by: Codex