### PR TITLE
[mlir] Outline registered operation-model allocation (NFC)

### DIFF
--- a/mlir/include/mlir/IR/OperationSupport.h
+++ b/mlir/include/mlir/IR/OperationSupport.h
@@ -711,7 +711,11 @@ public:
   /// of operations they contain.
   template <typename T>
   static void insert(Dialect &dialect) {
-    insert(std::make_unique<Model<T>>(&dialect), T::getAttributeNames());
+    static_assert(sizeof(Model<T>) == sizeof(Impl));
+    static_assert(alignof(Model<T>) == alignof(Impl));
+    std::unique_ptr<Impl> ownedModel(new (allocateModelStorage())
+                                         Model<T>(&dialect));
+    insert(std::move(ownedModel), T::getAttributeNames());
   }
   /// The use of this method is in general discouraged in favor of
   /// 'insert<CustomOp>(dialect)'.
@@ -729,6 +733,9 @@ public:
   }
 
 private:
+  /// Allocate storage for one type-erased operation model.
+  static void *allocateModelStorage();
+
   RegisteredOperationName(Impl *impl) : OperationName(impl) {}
 
   /// Allow access to the constructor.

--- a/mlir/lib/IR/MLIRContext.cpp
+++ b/mlir/lib/IR/MLIRContext.cpp
@@ -1120,6 +1120,10 @@ void RegisteredOperationName::insert(
       value);
 }
 
+void *RegisteredOperationName::allocateModelStorage() {
+  return ::operator new(sizeof(Impl));
+}
+
 //===----------------------------------------------------------------------===//
 // AbstractType
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Allocate operation-model storage through an out-of-line helper so every registration TU does not instantiate the allocation machinery.

Across three controlled -j16 rebuilds of 44 registration TUs, median instructions fell from 2.284T to 2.202T (-3.594%) and median wall time fell from 40.44s to 38.54s (-4.698%).

Assisted-by: Codex