### PR TITLE
[AMDGPU] Update buildbot cmake cache files

### DIFF
--- a/offload/cmake/caches/AMDGPUBot.cmake
+++ b/offload/cmake/caches/AMDGPUBot.cmake
@@ -20,7 +20,8 @@ set(LLVM_LIT_ARGS "-v --show-unsupported --timeout 100 --show-xfail -j 16" CACHE
 set(LIBOMPTEST_BUILD_UNITTESTS ON CACHE BOOL "")
 
 set(CLANG_DEFAULT_LINKER "lld" CACHE STRING "")
-set(CLANG_DEFAULT_RTLIB "compiler-rt" STRING "")
+set(CLANG_DEFAULT_RTLIB "compiler-rt" CACHE STRING "")
+set(CLANG_DEFAULT_UNWINDLIB "libgcc" CACHE STRING "")
 
 set(LLVM_RUNTIME_TARGETS default;amdgpu-amd-amdhsa CACHE STRING "")
 set(RUNTIMES_amdgpu-amd-amdhsa_LLVM_ENABLE_RUNTIMES "openmp" CACHE STRING "")

--- a/offload/cmake/caches/AMDGPULibcBot.cmake
+++ b/offload/cmake/caches/AMDGPULibcBot.cmake
@@ -14,7 +14,8 @@ set(LLVM_ENABLE_PER_TARGET_RUNTIME_DIR ON CACHE BOOL "")
 set(LLVM_ENABLE_ASSERTIONS ON CACHE BOOL "")
 
 set(CLANG_DEFAULT_LINKER "lld" CACHE STRING "")
-set(CLANG_DEFAULT_RTLIB "compiler-rt" STRING "")
+set(CLANG_DEFAULT_RTLIB "compiler-rt" CACHE STRING "")
+set(CLANG_DEFAULT_UNWINDLIB "libgcc" CACHE STRING "")
 
 set(LLVM_RUNTIME_TARGETS default;amdgpu-amd-amdhsa CACHE STRING "")
 set(RUNTIMES_amdgpu-amd-amdhsa_CACHE_FILES "${CMAKE_SOURCE_DIR}/../compiler-rt/cmake/caches/AMDGPU.cmake;${CMAKE_SOURCE_DIR}/../libcxx/cmake/caches/AMDGPU.cmake" CACHE STRING "")


### PR DESCRIPTION
This fixes one issue where the compiler-rt entry was not propagated to the build.

We also want to select libgcc as the default unwindlib explicitly (as this is what we do downstream).