### PR TITLE
Change string type of StackFrameRecognizer module names

### DIFF
--- a/lldb/include/lldb/Target/StackFrameRecognizer.h
+++ b/lldb/include/lldb/Target/StackFrameRecognizer.h
@@ -111,7 +111,7 @@ public:
   /// \param symbol_mangling controls whether the symbol name should be
   /// compared to the mangled or demangled name.
   void AddRecognizer(lldb::StackFrameRecognizerSP recognizer,
-                     ConstString module, llvm::ArrayRef<ConstString> symbols,
+                     std::string module, std::vector<ConstString> symbols,
                      Mangled::NamePreference symbol_mangling,
                      bool first_instruction_only = true);
 
@@ -152,7 +152,7 @@ private:
     uint32_t recognizer_id;
     lldb::StackFrameRecognizerSP recognizer;
     bool is_regexp;
-    ConstString module;
+    std::string module;
     lldb::RegularExpressionSP module_regexp;
     std::vector<ConstString> symbols;
     lldb::RegularExpressionSP symbol_regexp;

--- a/lldb/source/Commands/CommandObjectFrame.cpp
+++ b/lldb/source/Commands/CommandObjectFrame.cpp
@@ -1038,11 +1038,10 @@ void CommandObjectFrameRecognizerAdd::DoExecute(Args &command,
         recognizer_sp, module, func, Mangled::NamePreference::ePreferDemangled,
         m_options.m_first_instruction_only);
   } else {
-    auto module = ConstString(m_options.m_module);
     std::vector<ConstString> symbols(m_options.m_symbols.begin(),
                                      m_options.m_symbols.end());
     GetTarget()->GetFrameRecognizerManager().AddRecognizer(
-        recognizer_sp, module, symbols,
+        recognizer_sp, m_options.m_module, std::move(symbols),
         Mangled::NamePreference::ePreferDemangled,
         m_options.m_first_instruction_only);
   }

--- a/lldb/source/Plugins/DynamicLoader/Windows-DYLD/MSVCRTCFrameRecognizer.cpp
+++ b/lldb/source/Plugins/DynamicLoader/Windows-DYLD/MSVCRTCFrameRecognizer.cpp
@@ -23,7 +23,7 @@ namespace lldb_private {
 
 void RegisterMSVCRTCFrameRecognizer(Target &target) {
   target.GetFrameRecognizerManager().AddRecognizer(
-      std::make_shared<MSVCRTCFrameRecognizer>(), ConstString(""),
+      std::make_shared<MSVCRTCFrameRecognizer>(), "",
       {ConstString("failwithmessage")}, Mangled::ePreferDemangled,
       /*first_instruction_only=*/false);
 }

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
@@ -3664,7 +3664,7 @@ static void RegisterObjCExceptionRecognizer(Process *process) {
 
   process->GetTarget().GetFrameRecognizerManager().AddRecognizer(
       StackFrameRecognizerSP(new ObjCExceptionThrowFrameRecognizer()),
-      ConstString(module.GetFilename()), symbols,
+      module.GetFilename().str(), std::move(symbols),
       Mangled::NamePreference::ePreferDemangled,
       /*first_instruction_only*/ true);
 }

--- a/lldb/source/Plugins/SystemRuntime/MacOSX/AbortWithPayloadFrameRecognizer.cpp
+++ b/lldb/source/Plugins/SystemRuntime/MacOSX/AbortWithPayloadFrameRecognizer.cpp
@@ -29,15 +29,15 @@ void RegisterAbortWithPayloadFrameRecognizer(Process *process) {
   // There are two user-level API's that this recognizer captures,
   // abort_with_reason and abort_with_payload.  But they both call the private
   // __abort_with_payload, the abort_with_reason call fills in a null payload.
-  static ConstString module_name("libsystem_kernel.dylib");
   static ConstString sym_name("__abort_with_payload");
 
   if (!process)
     return;
 
+  std::string module_name("libsystem_kernel.dylib");
   process->GetTarget().GetFrameRecognizerManager().AddRecognizer(
       std::make_shared<AbortWithPayloadFrameRecognizer>(), module_name,
-      sym_name, Mangled::NamePreference::ePreferDemangled,
+      {sym_name}, Mangled::NamePreference::ePreferDemangled,
       /*first_instruction_only*/ false);
 }
 

--- a/lldb/source/Target/AssertFrameRecognizer.cpp
+++ b/lldb/source/Target/AssertFrameRecognizer.cpp
@@ -100,7 +100,7 @@ void RegisterAssertFrameRecognizer(Process *process) {
   if (!location.symbols_are_regex) {
     target.GetFrameRecognizerManager().AddRecognizer(
         std::make_shared<AssertFrameRecognizer>(),
-        ConstString(location.module_spec.GetFilename()), location.symbols,
+        location.module_spec.GetFilename().str(), location.symbols,
         Mangled::ePreferDemangled,
         /*first_instruction_only*/ false);
     return;

--- a/lldb/source/Target/StackFrameRecognizer.cpp
+++ b/lldb/source/Target/StackFrameRecognizer.cpp
@@ -111,13 +111,13 @@ void StackFrameRecognizerManager::BumpGeneration() {
 }
 
 void StackFrameRecognizerManager::AddRecognizer(
-    StackFrameRecognizerSP recognizer, ConstString module,
-    llvm::ArrayRef<ConstString> symbols,
-    Mangled::NamePreference symbol_mangling, bool first_instruction_only) {
+    StackFrameRecognizerSP recognizer, std::string module,
+    std::vector<ConstString> symbols, Mangled::NamePreference symbol_mangling,
+    bool first_instruction_only) {
   m_recognizers.push_front({(uint32_t)m_recognizers.size(), recognizer, false,
-                            module, RegularExpressionSP(), symbols,
-                            RegularExpressionSP(), symbol_mangling,
-                            first_instruction_only, true});
+                            std::move(module), RegularExpressionSP(),
+                            std::move(symbols), RegularExpressionSP(),
+                            symbol_mangling, first_instruction_only, true});
   BumpGeneration();
 }
 
@@ -126,7 +126,7 @@ void StackFrameRecognizerManager::AddRecognizer(
     RegularExpressionSP symbol, Mangled::NamePreference symbol_mangling,
     bool first_instruction_only) {
   m_recognizers.push_front({(uint32_t)m_recognizers.size(), recognizer, true,
-                            ConstString(), module, std::vector<ConstString>(),
+                            std::string(), module, std::vector<ConstString>(),
                             symbol, symbol_mangling, first_instruction_only,
                             true});
   BumpGeneration();
@@ -151,8 +151,7 @@ void StackFrameRecognizerManager::ForEach(
                entry.symbol_mangling, true);
     } else {
       callback(entry.recognizer_id, entry.enabled, entry.recognizer->GetName(),
-               entry.module.GetCString(), entry.symbols, entry.symbol_mangling,
-               false);
+               entry.module, entry.symbols, entry.symbol_mangling, false);
     }
   }
 }
@@ -216,9 +215,8 @@ StackFrameRecognizerManager::GetRecognizerForFrame(StackFrameSP frame) {
     if (!entry.enabled)
       continue;
 
-    if (entry.module)
-      if (entry.module != module_name)
-        continue;
+    if (!entry.module.empty() && entry.module != module_name)
+      continue;
 
     if (entry.module_regexp)
       if (!entry.module_regexp->Execute(module_name))


### PR DESCRIPTION
The majority of these come from FileSpec filenames (which are no longer ConstStrings). Instead of putting them into the StringPool, the StackFrameRecognizerManager can just hold onto the name in the RegisteredEntry.