### PR TITLE
Revert "[libc++] Remove __libcpp_allocate"

### DIFF
--- a/libcxx/include/CMakeLists.txt
+++ b/libcxx/include/CMakeLists.txt
@@ -651,6 +651,7 @@ set(files
   __mutex/tag_types.h
   __mutex/unique_lock.h
   __new/align_val_t.h
+  __new/allocate.h
   __new/destroying_delete_t.h
   __new/exceptions.h
   __new/global_new_delete.h

--- a/libcxx/include/__configuration/compiler.h
+++ b/libcxx/include/__configuration/compiler.h
@@ -71,12 +71,6 @@
 #    error "libc++ only supports C++03 with Clang-based compilers. Please enable C++11"
 #  endif
 
-#  ifdef __STDCPP_DEFAULT_NEW_ALIGNMENT__
-#    define _LIBCPP_DEFAULT_NEW_ALIGNMENT __STDCPP_DEFAULT_NEW_ALIGNMENT__
-#  else
-#    define _LIBCPP_DEFAULT_NEW_ALIGNMENT __BIGGEST_ALIGNMENT__
-#  endif
-
 #endif
 
 #endif // _LIBCPP___CONFIGURATION_COMPILER_H

--- a/libcxx/include/__memory/allocator.h
+++ b/libcxx/include/__memory/allocator.h
@@ -15,7 +15,7 @@
 #include <__cstddef/size_t.h>
 #include <__memory/addressof.h>
 #include <__memory/allocator_traits.h>
-#include <__new/align_val_t.h>
+#include <__new/allocate.h>
 #include <__new/exceptions.h>
 #include <__type_traits/is_const.h>
 #include <__type_traits/is_constant_evaluated.h>
@@ -86,12 +86,11 @@ public:
     static_assert(sizeof(_Tp) >= 0, "cannot allocate memory for an incomplete type");
     if (__n > allocator_traits<allocator>::max_size(*this))
       std::__throw_bad_array_new_length();
-#if _LIBCPP_HAS_ALIGNED_ALLOCATION
-    if _LIBCPP_CONSTEXPR (_LIBCPP_ALIGNOF(value_type) > _LIBCPP_DEFAULT_NEW_ALIGNMENT)
-      return static_cast<_Tp*>(
-          __builtin_operator_new(__n * sizeof(value_type), static_cast<align_val_t>(_LIBCPP_ALIGNOF(value_type))));
-#endif
-    return static_cast<_Tp*>(__builtin_operator_new(__n * sizeof(value_type)));
+    if (__libcpp_is_constant_evaluated()) {
+      return static_cast<_Tp*>(::operator new(__n * sizeof(_Tp)));
+    } else {
+      return std::__libcpp_allocate<_Tp>(__element_count(__n));
+    }
   }
 
 #if _LIBCPP_STD_VER >= 23
@@ -101,23 +100,13 @@ public:
   }
 #endif
 
-#if defined(__cpp_sized_deallocation) && __cpp_sized_deallocation >= 201309L
-#  define _LIBCPP_ONLY_IF_SIZED_DEALLOCATION(...) __VA_ARGS__
-#else
-#  define _LIBCPP_ONLY_IF_SIZED_DEALLOCATION(...) /* nothing */
-#endif
-
-  _LIBCPP_HIDE_FROM_ABI
-  _LIBCPP_CONSTEXPR_SINCE_CXX20 void deallocate(_Tp* __p, [[__maybe_unused__]] size_t __n) _NOEXCEPT {
-#if _LIBCPP_HAS_ALIGNED_ALLOCATION
-    if (_LIBCPP_ALIGNOF(value_type) > _LIBCPP_DEFAULT_NEW_ALIGNMENT)
-      return __builtin_operator_delete(__p _LIBCPP_ONLY_IF_SIZED_DEALLOCATION(, __n * sizeof(value_type)),
-                                       static_cast<align_val_t>(_LIBCPP_ALIGNOF(value_type)));
-#endif
-    return __builtin_operator_delete(__p _LIBCPP_ONLY_IF_SIZED_DEALLOCATION(, __n * sizeof(value_type)));
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void deallocate(_Tp* __p, size_t __n) _NOEXCEPT {
+    if (__libcpp_is_constant_evaluated()) {
+      ::operator delete(__p);
+    } else {
+      std::__libcpp_deallocate<_Tp>(__p, __element_count(__n));
+    }
   }
-
-#undef _LIBCPP_ONLY_IF_SIZED_DEALLOCATION
 
   // C++20 Removed members
 #if _LIBCPP_STD_VER <= 17

--- a/libcxx/include/__memory/shared_ptr.h
+++ b/libcxx/include/__memory/shared_ptr.h
@@ -51,7 +51,6 @@
 #include <__type_traits/remove_extent.h>
 #include <__type_traits/remove_pointer.h>
 #include <__type_traits/remove_reference.h>
-#include <__type_traits/type_identity.h>
 #include <__type_traits/void_t.h>
 #include <__utility/declval.h>
 #include <__utility/exception_guard.h>

--- a/libcxx/include/__memory/unique_temporary_buffer.h
+++ b/libcxx/include/__memory/unique_temporary_buffer.h
@@ -16,6 +16,7 @@
 #include <__cstddef/ptrdiff_t.h>
 #include <__memory/allocator.h>
 #include <__memory/unique_ptr.h>
+#include <__new/allocate.h>
 #include <__new/global_new_delete.h>
 #include <__type_traits/is_constant_evaluated.h>
 
@@ -24,14 +25,6 @@
 #endif
 
 _LIBCPP_BEGIN_NAMESPACE_STD
-
-#ifdef __STDCPP_DEFAULT_NEW_ALIGNMENT__
-template <class _Tp>
-inline const bool __is_overaligned_for_new = _LIBCPP_ALIGNOF(_Tp) > __STDCPP_DEFAULT_NEW_ALIGNMENT__;
-#else
-template <class _Tp>
-inline const bool __is_overaligned_for_new = _LIBCPP_ALIGNOF(_Tp) > _LIBCPP_ALIGNOF(max_align_t);
-#endif
 
 template <class _Tp>
 struct __temporary_buffer_deleter {
@@ -47,11 +40,7 @@ struct __temporary_buffer_deleter {
       return;
     }
 
-#if _LIBCPP_HAS_ALIGNED_ALLOCATION
-    if _LIBCPP_CONSTEXPR (__is_overaligned_for_new<_Tp>)
-      return __builtin_operator_delete(__ptr, static_cast<align_val_t>(_LIBCPP_ALIGNOF(_Tp)));
-#endif
-    return __builtin_operator_delete(__ptr);
+    std::__libcpp_deallocate_unsized<_Tp>(__ptr);
   }
 };
 
@@ -75,14 +64,14 @@ __allocate_unique_temporary_buffer(ptrdiff_t __count) {
     __count = __max_count;
   while (__count > 0) {
 #if _LIBCPP_HAS_ALIGNED_ALLOCATION
-    if _LIBCPP_CONSTEXPR (_LIBCPP_ALIGNOF(_Tp) > _LIBCPP_DEFAULT_NEW_ALIGNMENT) {
+    if (__is_overaligned_for_new(_LIBCPP_ALIGNOF(_Tp))) {
       align_val_t __al = align_val_t(_LIBCPP_ALIGNOF(_Tp));
       __ptr            = static_cast<_Tp*>(::operator new(__count * sizeof(_Tp), __al, nothrow));
     } else {
       __ptr = static_cast<_Tp*>(::operator new(__count * sizeof(_Tp), nothrow));
     }
 #else
-    if _LIBCPP_CONSTEXPR (_LIBCPP_ALIGNOF(_Tp) > _LIBCPP_DEFAULT_NEW_ALIGNMENT) {
+    if (__is_overaligned_for_new(_LIBCPP_ALIGNOF(_Tp))) {
       // Since aligned operator new is unavailable, constructs an empty buffer rather than one with invalid alignment.
       return __unique_buffer_type();
     }

--- a/libcxx/include/__new/allocate.h
+++ b/libcxx/include/__new/allocate.h
@@ -1,0 +1,78 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCPP___NEW_ALLOCATE_H
+#define _LIBCPP___NEW_ALLOCATE_H
+
+#include <__config>
+#include <__cstddef/max_align_t.h>
+#include <__cstddef/size_t.h>
+#include <__new/align_val_t.h>
+#include <__type_traits/type_identity.h>
+#include <__utility/element_count.h>
+
+#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#  pragma GCC system_header
+#endif
+
+_LIBCPP_BEGIN_NAMESPACE_STD
+
+_LIBCPP_CONSTEXPR inline _LIBCPP_HIDE_FROM_ABI bool __is_overaligned_for_new(size_t __align) _NOEXCEPT {
+#ifdef __STDCPP_DEFAULT_NEW_ALIGNMENT__
+  return __align > __STDCPP_DEFAULT_NEW_ALIGNMENT__;
+#else
+  return __align > _LIBCPP_ALIGNOF(max_align_t);
+#endif
+}
+
+template <class _Tp>
+inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_NO_CFI _Tp*
+__libcpp_allocate(__element_count __n, [[__maybe_unused__]] size_t __align = _LIBCPP_ALIGNOF(_Tp)) {
+  size_t __size = static_cast<size_t>(__n) * sizeof(_Tp);
+#if _LIBCPP_HAS_ALIGNED_ALLOCATION
+  if (__is_overaligned_for_new(__align))
+    return static_cast<_Tp*>(__builtin_operator_new(__size, static_cast<align_val_t>(__align)));
+#endif
+
+  return static_cast<_Tp*>(__builtin_operator_new(__size));
+}
+
+#if defined(__cpp_sized_deallocation) && __cpp_sized_deallocation >= 201309L
+#  define _LIBCPP_ONLY_IF_SIZED_DEALLOCATION(...) __VA_ARGS__
+#else
+#  define _LIBCPP_ONLY_IF_SIZED_DEALLOCATION(...) /* nothing */
+#endif
+
+template <class _Tp>
+inline _LIBCPP_HIDE_FROM_ABI void
+__libcpp_deallocate(__type_identity_t<_Tp>* __ptr,
+                    __element_count __n,
+                    [[__maybe_unused__]] size_t __align = _LIBCPP_ALIGNOF(_Tp)) _NOEXCEPT {
+  [[__maybe_unused__]] size_t __size = static_cast<size_t>(__n) * sizeof(_Tp);
+#if _LIBCPP_HAS_ALIGNED_ALLOCATION
+  if (__is_overaligned_for_new(__align))
+    return __builtin_operator_delete(
+        __ptr _LIBCPP_ONLY_IF_SIZED_DEALLOCATION(, __size), static_cast<align_val_t>(__align));
+#endif
+  return __builtin_operator_delete(__ptr _LIBCPP_ONLY_IF_SIZED_DEALLOCATION(, __size));
+}
+
+#undef _LIBCPP_ONLY_IF_SIZED_DEALLOCATION
+
+template <class _Tp>
+inline _LIBCPP_HIDE_FROM_ABI void __libcpp_deallocate_unsized(
+    __type_identity_t<_Tp>* __ptr, [[__maybe_unused__]] size_t __align = _LIBCPP_ALIGNOF(_Tp)) _NOEXCEPT {
+#if _LIBCPP_HAS_ALIGNED_ALLOCATION
+  if (__is_overaligned_for_new(__align))
+    return __builtin_operator_delete(__ptr, static_cast<align_val_t>(__align));
+#endif
+  return __builtin_operator_delete(__ptr);
+}
+_LIBCPP_END_NAMESPACE_STD
+
+#endif // _LIBCPP___NEW_ALLOCATE_H

--- a/libcxx/include/__utility/small_buffer.h
+++ b/libcxx/include/__utility/small_buffer.h
@@ -12,8 +12,8 @@
 #include <__config>
 #include <__cstddef/byte.h>
 #include <__cstddef/size_t.h>
-#include <__memory/allocator.h>
 #include <__memory/construct_at.h>
+#include <__new/allocate.h>
 #include <__new/launder.h>
 #include <__type_traits/decay.h>
 #include <__type_traits/is_trivially_constructible.h>
@@ -68,7 +68,7 @@ public:
     if constexpr (__fits_in_buffer<_Stored>) {
       return std::launder(reinterpret_cast<_Stored*>(__buffer_));
     } else {
-      byte* __allocation = reinterpret_cast<byte*>(std::allocator<_Stored>().allocate(1));
+      byte* __allocation = reinterpret_cast<byte*>(std::__libcpp_allocate<_Stored>(__element_count(1)));
       std::construct_at(reinterpret_cast<byte**>(__buffer_), __allocation);
       return std::launder(reinterpret_cast<_Stored*>(__allocation));
     }
@@ -77,7 +77,7 @@ public:
   template <class _Stored>
   _LIBCPP_HIDE_FROM_ABI void __dealloc() noexcept {
     if constexpr (!__fits_in_buffer<_Stored>)
-      std::allocator<_Stored>().deallocate(__get<_Stored>(), 1);
+      std::__libcpp_deallocate<_Stored>(__get<_Stored>(), __element_count(1));
   }
 
   template <class _Stored, class... _Args>

--- a/libcxx/include/module.modulemap.in
+++ b/libcxx/include/module.modulemap.in
@@ -1782,6 +1782,11 @@ module std {
   module new {
     header "new"
     module align_val_t          { header "__new/align_val_t.h" }
+    module allocate {
+      header "__new/allocate.h"
+      export std.utility.element_count // used as part of the API
+      export * // TODO: Workaround for https://llvm.org/PR120108
+    }
     module destroying_delete_t  { header "__new/destroying_delete_t.h" }
     module exceptions           { header "__new/exceptions.h" }
     module global_new_delete    {

--- a/libcxx/include/new
+++ b/libcxx/include/new
@@ -91,6 +91,7 @@ void  operator delete[](void* ptr, void*) noexcept;                     // const
 #else
 #  include <__config>
 #  include <__new/align_val_t.h>
+#  include <__new/allocate.h>
 #  include <__new/exceptions.h>
 #  include <__new/global_new_delete.h>
 #  include <__new/new_handler.h>

--- a/libcxx/src/include/aligned_alloc.h
+++ b/libcxx/src/include/aligned_alloc.h
@@ -23,7 +23,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 // Low-level helpers to call the aligned allocation and deallocation functions
 // on the target platform. This is used to implement libc++'s own memory
 // allocation routines -- if you need to allocate memory inside the library,
-// chances are that you want to use `allocator::allocate` instead.
+// chances are that you want to use `__libcpp_allocate` instead.
 //
 // Returns the allocated memory, or `nullptr` on failure.
 inline _LIBCPP_HIDE_FROM_ABI void* __libcpp_aligned_alloc(std::size_t __alignment, std::size_t __size) {

--- a/libcxx/test/libcxx/language.support/support.dynamic/libcpp_deallocate.sh.cpp
+++ b/libcxx/test/libcxx/language.support/support.dynamic/libcpp_deallocate.sh.cpp
@@ -1,0 +1,252 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Test libc++'s implementation of align_val_t, and the relevant new/delete
+// overloads in all dialects when -faligned-allocation is present.
+
+// Libc++ when built for z/OS doesn't contain the aligned allocation functions,
+// nor does the dynamic library shipped with z/OS.
+// XFAIL: target={{.+}}-zos{{.*}}
+
+// XFAIL: sanitizer-new-delete && !hwasan
+
+// TODO: Investigate this failure
+// UNSUPPORTED: ubsan
+
+// GCC doesn't support the aligned-allocation flags.
+// XFAIL: gcc
+
+// ADDITIONAL_COMPILE_FLAGS: -I %{libcxx-dir}/src -Wno-macro-redefined
+
+// RUN: %{build} -faligned-allocation -fsized-deallocation
+// RUN: %{run}
+// RUN: %{build} -faligned-allocation -fno-sized-deallocation -DNO_SIZE
+// RUN: %{run}
+// RUN: %{build} -fno-aligned-allocation -fsized-deallocation -DNO_ALIGN
+// RUN: %{run}
+// RUN: %{build} -fno-aligned-allocation -fno-sized-deallocation -DNO_ALIGN -DNO_SIZE
+// RUN: %{run}
+
+#include <cassert>
+#include <cstdlib>
+#include <new>
+
+#include "test_macros.h"
+
+#include "include/aligned_alloc.h"
+
+struct alloc_stats {
+  alloc_stats() { reset(); }
+
+  int aligned_sized_called;
+  int aligned_called;
+  int sized_called;
+  int plain_called;
+  int last_size;
+  int last_align;
+
+  void reset() {
+    aligned_sized_called = aligned_called = sized_called = plain_called = 0;
+    last_align = last_size = -1;
+  }
+
+  bool expect_plain() const {
+    assert(aligned_sized_called == 0);
+    assert(aligned_called == 0);
+    assert(sized_called == 0);
+    assert(last_size == -1);
+    assert(last_align == -1);
+    return plain_called == 1;
+  }
+
+  bool expect_size(int n) const {
+    assert(plain_called == 0);
+    assert(aligned_sized_called == 0);
+    assert(aligned_called == 0);
+    assert(last_size == n);
+    assert(last_align == -1);
+    return sized_called == 1;
+  }
+
+  bool expect_align(int a) const {
+    assert(plain_called == 0);
+    assert(aligned_sized_called == 0);
+    assert(sized_called == 0);
+    assert(last_size == -1);
+    assert(last_align == a);
+    return aligned_called == 1;
+  }
+
+  bool expect_size_align(int n, int a) const {
+    assert(plain_called == 0);
+    assert(sized_called == 0);
+    assert(aligned_called == 0);
+    assert(last_size == n);
+    assert(last_align == a);
+    return aligned_sized_called == 1;
+  }
+};
+alloc_stats stats;
+
+void operator delete(void* p) TEST_NOEXCEPT {
+  ::free(p);
+  stats.plain_called++;
+  stats.last_size = stats.last_align = -1;
+}
+
+#ifndef NO_SIZE
+void operator delete(void* p, std::size_t n) TEST_NOEXCEPT {
+  ::free(p);
+  stats.sized_called++;
+  stats.last_size  = n;
+  stats.last_align = -1;
+}
+#endif
+
+#ifndef NO_ALIGN
+void operator delete(void* p, std::align_val_t a) TEST_NOEXCEPT {
+  std::__libcpp_aligned_free(p);
+  stats.aligned_called++;
+  stats.last_align = static_cast<int>(a);
+  stats.last_size  = -1;
+}
+
+void operator delete(void* p, std::size_t n, std::align_val_t a) TEST_NOEXCEPT {
+  std::__libcpp_aligned_free(p);
+  stats.aligned_sized_called++;
+  stats.last_align = static_cast<int>(a);
+  stats.last_size  = n;
+}
+#endif
+
+void test_libcpp_dealloc() {
+  void* p = nullptr;
+#ifdef __STDCPP_DEFAULT_NEW_ALIGNMENT__
+  std::size_t over_align_val = __STDCPP_DEFAULT_NEW_ALIGNMENT__ * 2;
+#else
+  std::size_t over_align_val = TEST_ALIGNOF(std::max_align_t) * 2;
+#endif
+  std::size_t under_align_val = TEST_ALIGNOF(int);
+  std::size_t with_size_val   = 2;
+
+  {
+    std::__libcpp_deallocate_unsized<char>(static_cast<char*>(p), under_align_val);
+    assert(stats.expect_plain());
+  }
+  stats.reset();
+
+#if defined(NO_SIZE) && defined(NO_ALIGN)
+  {
+    std::__libcpp_deallocate<char>(static_cast<char*>(p), std::__element_count(with_size_val), over_align_val);
+    assert(stats.expect_plain());
+  }
+  stats.reset();
+#elif defined(NO_SIZE)
+  {
+    std::__libcpp_deallocate<char>(static_cast<char*>(p), std::__element_count(with_size_val), over_align_val);
+    assert(stats.expect_align(over_align_val));
+  }
+  stats.reset();
+#elif defined(NO_ALIGN)
+  {
+    std::__libcpp_deallocate<char>(static_cast<char*>(p), std::__element_count(with_size_val), over_align_val);
+    assert(stats.expect_size(with_size_val));
+  }
+  stats.reset();
+#else
+  {
+    std::__libcpp_deallocate<char>(static_cast<char*>(p), std::__element_count(with_size_val), over_align_val);
+    assert(stats.expect_size_align(with_size_val, over_align_val));
+  }
+  stats.reset();
+  {
+    std::__libcpp_deallocate_unsized<char>(static_cast<char*>(p), over_align_val);
+    assert(stats.expect_align(over_align_val));
+  }
+  stats.reset();
+  {
+    std::__libcpp_deallocate<char>(static_cast<char*>(p), std::__element_count(with_size_val), under_align_val);
+    assert(stats.expect_size(with_size_val));
+  }
+  stats.reset();
+#endif
+}
+
+struct TEST_ALIGNAS(128) AlignedType {
+  AlignedType() : elem(0) {}
+  TEST_ALIGNAS(128) char elem;
+};
+
+void test_allocator_and_new_match() {
+  stats.reset();
+#if defined(NO_SIZE) && defined(NO_ALIGN)
+  {
+    int* x = DoNotOptimize(new int(42));
+    delete x;
+    assert(stats.expect_plain());
+  }
+  stats.reset();
+  {
+    AlignedType* a = DoNotOptimize(new AlignedType());
+    delete a;
+    assert(stats.expect_plain());
+  }
+  stats.reset();
+#elif defined(NO_SIZE)
+  stats.reset();
+#  if TEST_STD_VER >= 11
+  {
+    int* x = DoNotOptimize(new int(42));
+    delete x;
+    assert(stats.expect_plain());
+  }
+#  endif
+  stats.reset();
+  {
+    AlignedType* a = DoNotOptimize(new AlignedType());
+    delete a;
+    assert(stats.expect_align(TEST_ALIGNOF(AlignedType)));
+  }
+  stats.reset();
+#elif defined(NO_ALIGN)
+  stats.reset();
+  {
+    int* x = DoNotOptimize(new int(42));
+    delete x;
+    assert(stats.expect_size(sizeof(int)));
+  }
+  stats.reset();
+  {
+    AlignedType* a = DoNotOptimize(new AlignedType());
+    delete a;
+    assert(stats.expect_size(sizeof(AlignedType)));
+  }
+  stats.reset();
+#else
+  stats.reset();
+  {
+    int* x = DoNotOptimize(new int(42));
+    delete x;
+    assert(stats.expect_size(sizeof(int)));
+  }
+  stats.reset();
+  {
+    AlignedType* a = DoNotOptimize(new AlignedType());
+    delete a;
+    assert(stats.expect_size_align(sizeof(AlignedType), TEST_ALIGNOF(AlignedType)));
+  }
+  stats.reset();
+#endif
+}
+
+int main(int, char**) {
+  test_libcpp_dealloc();
+  test_allocator_and_new_match();
+
+  return 0;
+}

--- a/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.capacity/max_size.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.capacity/max_size.pass.cpp
@@ -13,7 +13,6 @@
 // size_type max_size() const noexcept;
 
 #include <cassert>
-#include <cstddef>
 #include <deque>
 #include <flat_map>
 #include <functional>
@@ -51,7 +50,7 @@ constexpr bool test() {
     LIBCPP_ASSERT(c.max_size() == 10);
   }
   {
-    using A = limited_allocator<int, (std::size_t)-1>;
+    using A = limited_allocator<int, (size_t)-1>;
     using C = std::flat_map<int, int, std::less<int>, std::vector<int, A>, std::vector<int, A>>;
     ASSERT_SAME_TYPE(C::difference_type, std::ptrdiff_t);
     ASSERT_SAME_TYPE(C::size_type, std::size_t);

--- a/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.capacity/max_size.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.capacity/max_size.pass.cpp
@@ -15,7 +15,6 @@
 // size_type max_size() const noexcept;
 
 #include <cassert>
-#include <cstddef>
 #include <deque>
 #include <flat_map>
 #include <functional>
@@ -53,7 +52,7 @@ constexpr bool test() {
     LIBCPP_ASSERT(c.max_size() == 10);
   }
   {
-    using A = limited_allocator<int, (std::size_t)-1>;
+    using A = limited_allocator<int, (size_t)-1>;
     using C = std::flat_multimap<int, int, std::less<int>, std::vector<int, A>, std::vector<int, A>>;
     ASSERT_SAME_TYPE(C::difference_type, std::ptrdiff_t);
     ASSERT_SAME_TYPE(C::size_type, std::size_t);

--- a/libcxx/test/std/containers/container.adaptors/flat.multiset/flat.multiset.capacity/max_size.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.multiset/flat.multiset.capacity/max_size.pass.cpp
@@ -13,7 +13,6 @@
 // size_type max_size() const noexcept;
 
 #include <cassert>
-#include <cstddef>
 #include <deque>
 #include <flat_set>
 #include <functional>
@@ -38,7 +37,7 @@ constexpr bool test() {
     LIBCPP_ASSERT(c.max_size() == 10);
   }
   {
-    using A = limited_allocator<int, (std::size_t)-1>;
+    using A = limited_allocator<int, (size_t)-1>;
     using C = std::flat_multiset<int, std::less<int>, std::vector<int, A>>;
     ASSERT_SAME_TYPE(C::difference_type, std::ptrdiff_t);
     ASSERT_SAME_TYPE(C::size_type, std::size_t);

--- a/libcxx/test/std/containers/container.adaptors/flat.set/flat.set.capacity/max_size.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.set/flat.set.capacity/max_size.pass.cpp
@@ -13,7 +13,6 @@
 // size_type max_size() const noexcept;
 
 #include <cassert>
-#include <cstddef>
 #include <deque>
 #include <flat_set>
 #include <functional>
@@ -38,7 +37,7 @@ constexpr bool test() {
     LIBCPP_ASSERT(c.max_size() == 10);
   }
   {
-    using A = limited_allocator<int, (std::size_t)-1>;
+    using A = limited_allocator<int, (size_t)-1>;
     using C = std::flat_set<int, std::less<int>, std::vector<int, A>>;
     ASSERT_SAME_TYPE(C::difference_type, std::ptrdiff_t);
     ASSERT_SAME_TYPE(C::size_type, std::size_t);

--- a/libcxx/test/std/language.support/support.dynamic/hardware_inference_size.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.dynamic/hardware_inference_size.compile.pass.cpp
@@ -8,7 +8,6 @@
 
 // UNSUPPORTED: c++03, c++11, c++14
 
-#include <cstddef>
 #include <new>
 
 #include "test_macros.h"

--- a/libcxx/test/std/numerics/numarray/template.valarray/valarray.cons/size.pass.cpp
+++ b/libcxx/test/std/numerics/numarray/template.valarray/valarray.cons/size.pass.cpp
@@ -12,9 +12,8 @@
 
 // explicit valarray(size_t);
 
-#include <cassert>
-#include <cstdint>
 #include <valarray>
+#include <cassert>
 
 #include "test_macros.h"
 
@@ -25,7 +24,7 @@ struct S {
     static std::size_t cnt_dtor;
 };
 
-std::size_t S::cnt_dtor = 0;
+size_t S::cnt_dtor = 0;
 
 int main(int, char**)
 {

--- a/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/pointer_destruction.pass.cpp
+++ b/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/pointer_destruction.pass.cpp
@@ -15,13 +15,12 @@
 // XFAIL: FROZEN-CXX03-HEADERS-FIXME
 
 #include <cassert>
-#include <cstddef>
 #include <memory>
 #include <utility>
 
 #include "test_macros.h"
 
-static std::size_t pointer_count = 0;
+static size_t pointer_count = 0;
 
 template <class T>
 struct Pointer {


### PR DESCRIPTION
Reverts llvm/llvm-project#220981

This is breaking premerge. See comments on the original PR.