### PR TITLE
[flang][acc] Let getVariableName choose mangled or source names

### DIFF
--- a/flang/include/flang/Optimizer/OpenACC/Analysis/FIROpenACCSupportAnalysis.h
+++ b/flang/include/flang/Optimizer/OpenACC/Analysis/FIROpenACCSupportAnalysis.h
@@ -39,7 +39,8 @@ class FIROpenACCSupportAnalysis {
 public:
   FIROpenACCSupportAnalysis() = default;
 
-  std::string getVariableName(mlir::Value v);
+  std::string getVariableName(mlir::Value v,
+                              mlir::acc::VariableNameConfig config);
 
   std::string getRecipeName(mlir::acc::RecipeKind kind, mlir::Type type,
                             mlir::Value var);

--- a/flang/include/flang/Optimizer/OpenACC/Support/FIROpenACCUtils.h
+++ b/flang/include/flang/Optimizer/OpenACC/Support/FIROpenACCUtils.h
@@ -27,7 +27,10 @@ namespace acc {
 /// FIR operations and looking for variable names.
 /// \param v The value to extract the variable name from
 /// \param preferDemangledName If true, prefers demangled/bindc names over
-///        mangled/unique names. If false, prefers mangled names.
+///        mangled/unique names. If false, prefers mangled names. A component
+///        or an element is named through a path whose root is the variable
+///        that holds it; only that root is uniqued, so only it is spelled
+///        differently by the two.
 /// Returns empty string if no name is found.
 std::string getVariableName(mlir::Value v, bool preferDemangledName = true);
 

--- a/flang/lib/Optimizer/OpenACC/Analysis/FIROpenACCSupportAnalysis.cpp
+++ b/flang/lib/Optimizer/OpenACC/Analysis/FIROpenACCSupportAnalysis.cpp
@@ -29,8 +29,9 @@ using namespace mlir;
 namespace fir {
 namespace acc {
 
-std::string FIROpenACCSupportAnalysis::getVariableName(Value v) {
-  return fir::acc::getVariableName(v, /*preferDemangledName=*/true);
+std::string FIROpenACCSupportAnalysis::getVariableName(
+    Value v, mlir::acc::VariableNameConfig config) {
+  return fir::acc::getVariableName(v, config.preferDemangledName);
 }
 
 std::string FIROpenACCSupportAnalysis::getRecipeName(mlir::acc::RecipeKind kind,

--- a/flang/lib/Optimizer/OpenACC/Support/FIROpenACCUtils.cpp
+++ b/flang/lib/Optimizer/OpenACC/Support/FIROpenACCUtils.cpp
@@ -77,11 +77,10 @@ std::string fir::acc::getVariableName(Value v, bool preferDemangledName) {
               return true;
             })
             .Case([&](fir::AddrOfOp op) {
-              // Only use address_of symbol if mangled name is preferred
-              if (!preferDemangledName) {
-                auto symRef = op.getSymbol();
-                srcName = symRef.getLeafReference().getValue().str();
-              }
+              // A global is reached through the symbol it is emitted under,
+              // which is uniqued and thus deconstructed below when the name
+              // the source spells is asked for.
+              srcName = op.getSymbol().getLeafReference().getValue().str();
               return false;
             })
             .Case([&](fir::ArrayCoorOp op) {
@@ -148,7 +147,19 @@ std::string fir::acc::getVariableName(Value v, bool preferDemangledName) {
               v = op.getViewSource();
               return true;
             })
-            .Default([](mlir::Operation *) { return false; });
+            .Default([&](mlir::Operation *op) {
+              // A data clause records the name the source spells. The name the
+              // object is emitted under is only held by the variable the
+              // clause states, so it is walked to when that name is asked for.
+              // A variable that has no name to recover leaves the name empty,
+              // which falls back to the one the clause records below.
+              if (preferDemangledName ||
+                  !isa<ACC_DATA_ENTRY_OPS, mlir::acc::MapInfoOp>(op))
+                return false;
+              if (Value var = mlir::acc::getVar(op))
+                srcName = getVariableName(var, preferDemangledName);
+              return false;
+            });
   }
 
   // Fallback to the default implementation.

--- a/flang/test/Fir/OpenACC/support-analysis-varname.mlir
+++ b/flang/test/Fir/OpenACC/support-analysis-varname.mlir
@@ -1,0 +1,143 @@
+// Use --mlir-disable-threading so that the printing is serialized.
+// RUN: fir-opt %s -pass-pipeline='builtin.module(test-fir-openacc-support)' -split-input-file --mlir-disable-threading 2>&1 | FileCheck %s
+
+// A local variable goes by the name the source spells and by the name it is
+// uniqued under.
+
+func.func @local_alloca() {
+  %0 = fir.alloca i32 {bindc_name = "x", uniq_name = "_QFlocal_allocaEx", test.var_name}
+  return
+}
+
+// CHECK: Visiting: %{{.*}} = fir.alloca i32
+// CHECK-NEXT: Demangled name: "x"
+// CHECK-NEXT: Mangled name: "_QFlocal_allocaEx"
+
+// -----
+
+// A declared variable states only its uniqued name, which is deconstructed
+// when the name the source spells is asked for.
+
+func.func @declared_variable() {
+  %0 = fir.alloca f32
+  %1 = fir.declare %0 {uniq_name = "_QMmodFdeclared_variableEy", test.var_name} : (!fir.ref<f32>) -> !fir.ref<f32>
+  return
+}
+
+// CHECK: Visiting: %{{.*}} = fir.declare
+// CHECK-NEXT: Demangled name: "y"
+// CHECK-NEXT: Mangled name: "_QMmodFdeclared_variableEy"
+
+// -----
+
+// A global is reached through the symbol it is addressed by. The declaration
+// of it holds the uniqued name, so both names are recovered through it.
+
+fir.global @_QMmodEglob : i32 {
+  %0 = fir.zero_bits i32
+  fir.has_value %0 : i32
+}
+
+func.func @global_through_declare() {
+  %0 = fir.address_of(@_QMmodEglob) : !fir.ref<i32>
+  %1 = fir.declare %0 {uniq_name = "_QMmodEglob", test.var_name} : (!fir.ref<i32>) -> !fir.ref<i32>
+  return
+}
+
+// CHECK: Visiting: %{{.*}} = fir.declare
+// CHECK-NEXT: Demangled name: "glob"
+// CHECK-NEXT: Mangled name: "_QMmodEglob"
+
+// -----
+
+// Even without a declaration to walk to, the symbol a global is addressed
+// through is uniqued, so the name the source spells is recovered from it.
+
+fir.global @_QMmodEglob : i32 {
+  %0 = fir.zero_bits i32
+  fir.has_value %0 : i32
+}
+
+func.func @global_address_of() {
+  %0 = fir.address_of(@_QMmodEglob) {test.var_name} : !fir.ref<i32>
+  return
+}
+
+// CHECK: Visiting: %{{.*}} = fir.address_of
+// CHECK-NEXT: Demangled name: "glob"
+// CHECK-NEXT: Mangled name: "_QMmodEglob"
+
+// -----
+
+// A data clause records the name the source spells, so the name the object is
+// emitted under is recovered from the variable the clause states.
+
+func.func @data_clause_name() {
+  %0 = fir.alloca i32 {bindc_name = "arr", uniq_name = "_QFdata_clause_nameEarr"}
+  %1 = acc.copyin varPtr(%0 : !fir.ref<i32>) name("arr") -> !fir.ref<i32> {test.var_name}
+  acc.data dataOperands(%1 : !fir.ref<i32>) {
+    acc.terminator
+  }
+  return
+}
+
+// CHECK: Visiting: %{{.*}} = acc.copyin
+// CHECK-NEXT: Demangled name: "arr"
+// CHECK-NEXT: Mangled name: "_QFdata_clause_nameEarr"
+
+// -----
+
+// A global mapped by a data clause is resolved against the symbols of the
+// binary by the symbol it is addressed through.
+
+fir.global @_QMmodEglob : i32 {
+  %0 = fir.zero_bits i32
+  fir.has_value %0 : i32
+}
+
+func.func @data_clause_global() {
+  %0 = fir.address_of(@_QMmodEglob) : !fir.ref<i32>
+  %1 = acc.copyin varPtr(%0 : !fir.ref<i32>) name("glob") -> !fir.ref<i32> {test.var_name}
+  acc.data dataOperands(%1 : !fir.ref<i32>) {
+    acc.terminator
+  }
+  return
+}
+
+// CHECK: Visiting: %{{.*}} = acc.copyin
+// CHECK-NEXT: Demangled name: "glob"
+// CHECK-NEXT: Mangled name: "_QMmodEglob"
+
+// -----
+
+// A data clause on a variable with no name to recover keeps the name the
+// clause records.
+
+func.func @data_clause_unnamed_variable() {
+  %0 = fir.alloca i32
+  %1 = acc.copyin varPtr(%0 : !fir.ref<i32>) name("unnamed") -> !fir.ref<i32> {test.var_name}
+  acc.data dataOperands(%1 : !fir.ref<i32>) {
+    acc.terminator
+  }
+  return
+}
+
+// CHECK: Visiting: %{{.*}} = acc.copyin
+// CHECK-NEXT: Demangled name: "unnamed"
+// CHECK-NEXT: Mangled name: "unnamed"
+
+// -----
+
+// A component is named through a path whose root is the variable that holds
+// it. Only that root is uniqued - a component is not emitted under a name of
+// its own - so only it is spelled differently by the two renderings.
+
+func.func @derived_component() {
+  %0 = fir.alloca !fir.type<_QMmodTpair{a:i32,b:i32}> {bindc_name = "p", uniq_name = "_QFderived_componentEp"}
+  %1 = fir.coordinate_of %0, b {test.var_name} : (!fir.ref<!fir.type<_QMmodTpair{a:i32,b:i32}>>) -> !fir.ref<i32>
+  return
+}
+
+// CHECK: Visiting: %{{.*}} = fir.coordinate_of
+// CHECK-NEXT: Demangled name: "p%b"
+// CHECK-NEXT: Mangled name: "_QFderived_componentEp%b"

--- a/flang/test/lib/OpenACC/CMakeLists.txt
+++ b/flang/test/lib/OpenACC/CMakeLists.txt
@@ -1,15 +1,18 @@
 add_flang_library(FIRTestOpenACCInterfaces
   TestOpenACCInterfaces.cpp
+  TestOpenACCSupport.cpp
 
   DEPENDS
   HLFIRDialect
   FIRDialect
+  FIROpenACCAnalysis
   FIROpenACCSupport
   FIRSupport
 
   LINK_LIBS
   HLFIRDialect
   FIRDialect
+  FIROpenACCAnalysis
   FIROpenACCSupport
   FIRSupport
 

--- a/flang/test/lib/OpenACC/TestOpenACCSupport.cpp
+++ b/flang/test/lib/OpenACC/TestOpenACCSupport.cpp
@@ -1,0 +1,70 @@
+//===- TestOpenACCSupport.cpp ---------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/OpenACC/Analysis/OpenACCSupport.h"
+#include "mlir/Dialect/OpenACC/OpenACC.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Support/LLVM.h"
+#include "flang/Optimizer/Dialect/FIRDialect.h"
+#include "flang/Optimizer/HLFIR/HLFIRDialect.h"
+#include "flang/Optimizer/OpenACC/Analysis/FIROpenACCSupportAnalysis.h"
+
+using namespace mlir;
+
+namespace {
+
+struct TestFIROpenACCSupport
+    : public PassWrapper<TestFIROpenACCSupport, OperationPass<ModuleOp>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(TestFIROpenACCSupport)
+
+  StringRef getArgument() const final { return "test-fir-openacc-support"; }
+  StringRef getDescription() const final {
+    return "Test FIR implementation of the OpenACCSupport analysis.";
+  }
+  void getDependentDialects(::mlir::DialectRegistry &registry) const override {
+    registry.insert<fir::FIROpsDialect, hlfir::hlfirDialect,
+        mlir::acc::OpenACCDialect>();
+  }
+
+  void runOnOperation() override {
+    auto &support = getAnalysis<mlir::acc::OpenACCSupport>();
+    support.setImplementation(fir::acc::FIROpenACCSupportAnalysis());
+
+    mlir::acc::VariableNameConfig demangled;
+    mlir::acc::VariableNameConfig mangled;
+    mangled.preferDemangledName = false;
+
+    getOperation().walk([&](Operation *op) {
+      // Only the operations marked with test.var_name are reported, so that a
+      // test states which value it asks the name of.
+      if (!op->hasAttr("test.var_name"))
+        return;
+      for (Value result : op->getResults()) {
+        llvm::errs() << "Visiting: " << *op << "\n";
+        llvm::errs() << "\tDemangled name: \""
+                     << support.getVariableName(result, demangled) << "\"\n";
+        llvm::errs() << "\tMangled name: \""
+                     << support.getVariableName(result, mangled) << "\"\n";
+      }
+    });
+  }
+};
+} // namespace
+
+//===----------------------------------------------------------------------===//
+// Pass Registration
+//===----------------------------------------------------------------------===//
+
+namespace fir {
+namespace test {
+void registerTestFIROpenACCSupportPass() {
+  PassRegistration<TestFIROpenACCSupport>();
+}
+} // namespace test
+} // namespace fir

--- a/flang/tools/fir-opt/fir-opt.cpp
+++ b/flang/tools/fir-opt/fir-opt.cpp
@@ -25,6 +25,7 @@ namespace fir {
 namespace test {
 void registerTestFIRAliasAnalysisPass();
 void registerTestFIROpenACCInterfacesPass();
+void registerTestFIROpenACCSupportPass();
 } // namespace test
 } // namespace fir
 
@@ -42,6 +43,7 @@ int main(int argc, char **argv) {
 #ifdef FLANG_INCLUDE_TESTS
   fir::test::registerTestFIRAliasAnalysisPass();
   fir::test::registerTestFIROpenACCInterfacesPass();
+  fir::test::registerTestFIROpenACCSupportPass();
   mlir::registerSideEffectTestPasses();
   mlir::test::registerTestOpenACC();
 #endif

--- a/mlir/include/mlir/Dialect/OpenACC/Analysis/OpenACCSupport.h
+++ b/mlir/include/mlir/Dialect/OpenACC/Analysis/OpenACCSupport.h
@@ -67,6 +67,17 @@
 namespace mlir {
 namespace acc {
 
+/// How the name of a variable is to be rendered.
+struct VariableNameConfig {
+  /// Render the name the source language spells, which is the name a message
+  /// to the user states. When false, the name the variable is emitted under is
+  /// rendered instead - for a global the symbol it is addressed through -
+  /// which is the name it is resolved against the symbols of a binary by. Only
+  /// a language that uniques or mangles the names of its variables spells the
+  /// two differently.
+  bool preferDemangledName = true;
+};
+
 namespace detail {
 /// This class contains internal trait classes used by OpenACCSupport.
 /// It follows the Concept-Model pattern used throughout MLIR (e.g., in
@@ -77,7 +88,8 @@ struct OpenACCSupportTraits {
     virtual ~Concept() = default;
 
     /// Get the variable name for a given MLIR value.
-    virtual std::string getVariableName(Value v) = 0;
+    virtual std::string getVariableName(Value v,
+                                        VariableNameConfig config) = 0;
 
     /// Get the recipe name for a given kind, type and value.
     virtual std::string getRecipeName(RecipeKind kind, Type type,
@@ -170,8 +182,8 @@ struct OpenACCSupportTraits {
     explicit Model(ImplT &&impl) : impl(std::forward<ImplT>(impl)) {}
     ~Model() override = default;
 
-    std::string getVariableName(Value v) final {
-      return impl.getVariableName(v);
+    std::string getVariableName(Value v, VariableNameConfig config) final {
+      return impl.getVariableName(v, config);
     }
 
     std::string getRecipeName(RecipeKind kind, Type type, Value var) final {
@@ -252,11 +264,15 @@ public:
         std::make_unique<Model<AnalysisT>>(std::forward<AnalysisT>(analysis));
   }
 
-  /// Get the variable name for a given value.
+  /// Get the variable name for a given value. Which of the names a variable
+  /// goes by is a question only an implementation that knows the source
+  /// language can answer, so the default implementation returns the one name
+  /// the IR states regardless of \p config.
   ///
   /// \param v The MLIR value to get the variable name for.
+  /// \param config Which of the names of the variable to return.
   /// \return The variable name, or an empty string if unavailable.
-  std::string getVariableName(Value v);
+  std::string getVariableName(Value v, VariableNameConfig config = {});
 
   /// Get the recipe name for a given type and value.
   ///

--- a/mlir/include/mlir/Dialect/OpenACC/Analysis/OpenACCSupport.h
+++ b/mlir/include/mlir/Dialect/OpenACC/Analysis/OpenACCSupport.h
@@ -88,8 +88,7 @@ struct OpenACCSupportTraits {
     virtual ~Concept() = default;
 
     /// Get the variable name for a given MLIR value.
-    virtual std::string getVariableName(Value v,
-                                        VariableNameConfig config) = 0;
+    virtual std::string getVariableName(Value v, VariableNameConfig config) = 0;
 
     /// Get the recipe name for a given kind, type and value.
     virtual std::string getRecipeName(RecipeKind kind, Type type,

--- a/mlir/include/mlir/Dialect/OpenACC/OpenACCUtils.h
+++ b/mlir/include/mlir/Dialect/OpenACC/OpenACCUtils.h
@@ -57,8 +57,9 @@ std::optional<ClauseDefaultValue> getDefaultAttr(mlir::Operation *op);
 mlir::acc::VariableTypeCategory getTypeCategory(mlir::Value var);
 
 /// Attempts to extract the variable name from a value by walking through
-/// view-like operations until an `acc.var_name` attribute is found. Returns
-/// empty string if no name is found.
+/// view-like operations until an `acc.var_name` attribute, the name of a data
+/// clause operation, or the symbol a global is addressed through is found.
+/// Returns empty string if no name is found.
 std::string getVariableName(mlir::Value v);
 
 /// Returns a placeholder string for use as an acc.var_name attribute value when

--- a/mlir/lib/Dialect/OpenACC/Analysis/OpenACCSupport.cpp
+++ b/mlir/lib/Dialect/OpenACC/Analysis/OpenACCSupport.cpp
@@ -18,9 +18,10 @@
 namespace mlir {
 namespace acc {
 
-std::string OpenACCSupport::getVariableName(Value v) {
+std::string OpenACCSupport::getVariableName(Value v,
+                                            VariableNameConfig config) {
   if (impl)
-    return impl->getVariableName(v);
+    return impl->getVariableName(v, config);
   return acc::getVariableName(v);
 }
 

--- a/mlir/lib/Dialect/OpenACC/Utils/OpenACCUtils.cpp
+++ b/mlir/lib/Dialect/OpenACC/Utils/OpenACCUtils.cpp
@@ -128,9 +128,13 @@ std::string mlir::acc::getVariableName(mlir::Value v) {
       return varNameAttr.getName().str();
 
     // If it is a data entry operation, get name via getVarName
-    if (isa<ACC_DATA_ENTRY_OPS>(definingOp))
+    if (isa<ACC_DATA_ENTRY_OPS, MapInfoOp>(definingOp))
       if (auto name = acc::getVarName(definingOp))
         return name->str();
+
+    // A global goes by the symbol it is addressed through.
+    if (auto addressOf = dyn_cast<AddressOfGlobalOpInterface>(definingOp))
+      return addressOf.getSymbol().getLeafReference().str();
 
     // If it's a view operation, continue to the source
     if (auto viewOp = dyn_cast<ViewLikeOpInterface>(definingOp)) {

--- a/mlir/test/Dialect/OpenACC/acc-implicit-data.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-implicit-data.mlir
@@ -256,7 +256,7 @@ func.func @test_device_global_in_parallel() {
 }
 
 // CHECK-LABEL: func.func @test_device_global_in_parallel
-// CHECK: acc.deviceptr varPtr({{.*}} : memref<10xf32, #gpu.address_space<global>>) implicit(true) name("") -> memref<10xf32, #gpu.address_space<global>>
+// CHECK: acc.deviceptr varPtr({{.*}} : memref<10xf32, #gpu.address_space<global>>) implicit(true) name("device_global") -> memref<10xf32, #gpu.address_space<global>>
 // CHECK-NOT: acc.copyin
 // CHECK-NOT: acc.copyout
 

--- a/mlir/test/Dialect/OpenACC/support-analysis-varname.mlir
+++ b/mlir/test/Dialect/OpenACC/support-analysis-varname.mlir
@@ -70,6 +70,44 @@ func.func @test_multiple_casts() {
 
 // -----
 
+// Test with acc.map_info operation
+func.func @test_map_info_name() {
+  %0 = memref.alloca() : memref<10xf32>
+  %size = arith.constant 40 : i64
+
+  %1 = acc.map_info varPtr(%0 : memref<10xf32>) varType(tensor<10xf32>)
+      size(%size : i64) elementSize(4) name("mapped_data")
+      descKind(none) mapFlags(to) -> memref<10xf32>
+
+  // Mark with test attribute - should find name from the map_info operation
+  %2 = memref.cast %1 {test.var_name} : memref<10xf32> to memref<?xf32>
+
+  // CHECK: op=%{{.*}} = memref.cast %{{.*}} {test.var_name} : memref<10xf32> to memref<?xf32>
+  // CHECK-NEXT: getVariableName="mapped_data"
+
+  return
+}
+
+// -----
+
+// A global has no name of its own to state, so it goes by the symbol it is
+// addressed through.
+memref.global @global_data : memref<10xf32>
+
+func.func @test_global_symbol() {
+  %0 = memref.get_global @global_data : memref<10xf32>
+
+  // Mark with test attribute - should find the symbol of the global
+  %1 = memref.cast %0 {test.var_name} : memref<10xf32> to memref<?xf32>
+
+  // CHECK: op=%{{.*}} = memref.cast %{{.*}} {test.var_name} : memref<10xf32> to memref<?xf32>
+  // CHECK-NEXT: getVariableName="global_data"
+
+  return
+}
+
+// -----
+
 // Test with acc.copyin operation
 func.func @test_copyin_name() {
   // Create a memref


### PR DESCRIPTION
OpenACCSupport can now ask for the name the source spells or the name the variable is emitted under. Recover names from acc.map_info and globals, and teach Flang to demangle FIR symbols while still walking the referenced variable for a mangled data-clause name.