### PR TITLE
Fix bazel build for clang/unittests:codegen_tests

### DIFF
--- a/utils/bazel/llvm-project-overlay/clang/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/clang/BUILD.bazel
@@ -2131,11 +2131,16 @@ cc_library(
 
 cc_library(
     name = "codegen",
-    srcs = glob([
-        "lib/CodeGen/**/*.cpp",
-        "lib/CodeGen/**/*.h",
-    ]),
-    hdrs = glob(["include/clang/CodeGen/*.h"]),
+    srcs = glob(
+        [
+            "lib/CodeGen/**/*.cpp",
+            "lib/CodeGen/**/*.h",
+        ],
+        exclude = ["lib/CodeGen/QualTypeMapper.h"],
+    ),
+    hdrs = glob(["include/clang/CodeGen/*.h"]) + [
+        "lib/CodeGen/QualTypeMapper.h",
+    ],
     copts = ["$(STACK_FRAME_UNLIMITED)"],
     includes = [
         "include",

--- a/utils/bazel/llvm-project-overlay/clang/unittests/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/clang/unittests/BUILD.bazel
@@ -252,6 +252,8 @@ cc_test(
         "//clang:lex",
         "//clang:parse",
         "//clang:sema",
+        "//clang:testing",
+        "//llvm:ABI",
         "//llvm:Core",
         "//llvm:Support",
         "//llvm:TargetParser",


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/pull/221375 (commit a1cd84100bd0) by exporting QualTypeMapper.h and adding missing dependencies.