### PR TITLE
[AMDGPU][lld] Remove "using namespace llvm" from AMDGPU.cpp

### DIFF
--- a/lld/ELF/Arch/AMDGPU.cpp
+++ b/lld/ELF/Arch/AMDGPU.cpp
@@ -13,7 +13,6 @@
 #include "llvm/BinaryFormat/ELF.h"
 #include "llvm/Support/Endian.h"
 
-using namespace llvm;
 using namespace llvm::object;
 using namespace llvm::support::endian;
 using namespace llvm::ELF;


### PR DESCRIPTION
AMDGPU class in anonymous namespace collides with llvm::AMDGPU, causing an error with MSVC.