### PR TITLE
[CIR][NFC] Fix CIR build after #219195

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRDialect.h
+++ b/clang/include/clang/CIR/Dialect/IR/CIRDialect.h
@@ -81,6 +81,17 @@ private:
   }
 };
 
+/// The properties of \p Op with every ODS-declared default applied.  The
+/// aggregate op builders that take a `Properties` struct do not apply those
+/// defaults themselves, so callers of those builders have to do it here.
+template <typename Op>
+typename Op::Properties getDefaultProperties(mlir::MLIRContext *context) {
+  typename Op::Properties properties{};
+  Op::populateDefaultProperties(
+      mlir::OperationName(Op::getOperationName(), context), properties);
+  return properties;
+}
+
 /// Look up the RecordLayoutAttr for a named record in the module's
 /// cir.record_layouts dictionary.  Asserts if the entry is missing.
 RecordLayoutAttr getRecordLayout(mlir::ModuleOp mod, mlir::StringAttr name);

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -844,6 +844,21 @@ def CIR_LoadOp : CIR_Op<"load", [
     $addr `:` qualified(type($addr)) `,` type($result) attr-dict
   }];
 
+  let builders = [
+    OpBuilder<(ins "mlir::Value":$addr), [{
+      build($_builder, $_state, addr, /*isDeref=*/false,
+            /*is_volatile=*/false, /*is_nontemporal=*/false,
+            /*alignment=*/mlir::IntegerAttr{}, cir::SyncScopeKindAttr{},
+            cir::MemOrderAttr{}, /*invariant=*/false);
+    }]>,
+    OpBuilder<(ins "mlir::Type":$result, "mlir::Value":$addr), [{
+      build($_builder, $_state, result, addr, /*isDeref=*/false,
+            /*is_volatile=*/false, /*is_nontemporal=*/false,
+            /*alignment=*/mlir::IntegerAttr{}, cir::SyncScopeKindAttr{},
+            cir::MemOrderAttr{}, /*invariant=*/false);
+    }]>
+  ];
+
   // FIXME: add verifier.
 }
 

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -566,8 +566,7 @@ static RValue emitUnaryMaybeConstrainedFPBuiltin(CIRGenFunction &cgf,
 template <class Operation>
 static RValue emitUnaryFPBuiltin(CIRGenFunction &cgf, const CallExpr &e) {
   mlir::Value arg = cgf.emitScalarExpr(e.getArg(0));
-  auto call =
-      Operation::create(cgf.getBuilder(), arg.getLoc(), arg.getType(), arg);
+  auto call = Operation::create(cgf.getBuilder(), arg.getLoc(), arg);
   return RValue::get(call->getResult(0));
 }
 

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
@@ -205,7 +205,10 @@ emitNeonCallToOp(CIRGenModule &cgm, CIRGenBuilderTy &builder,
                              funcResTy, args)
         .getResult();
   } else {
-    return Operation::create(builder, loc, funcResTy, args).getResult();
+    return Operation::create(
+               builder, loc, mlir::TypeRange{funcResTy}, args,
+               cir::getDefaultProperties<Operation>(builder.getContext()))
+        .getResult();
   }
 }
 

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinAMDGPU.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinAMDGPU.cpp
@@ -94,7 +94,7 @@ static mlir::Value emitLogbBuiltin(CIRGenFunction &cgf, const CallExpr *e,
   mlir::Value siToFp = cir::CastOp::create(
       builder, loc, srcTy, cir::CastKind::int_to_float, expMinus1);
 
-  mlir::Value fabs = cir::FAbsOp::create(builder, loc, srcTy, src0);
+  mlir::Value fabs = cir::FAbsOp::create(builder, loc, src0);
 
   llvm::APFloat infVal = llvm::APFloat::getInf(fSem);
   mlir::Value inf = builder.getConstant(loc, cir::FPAttr::get(srcTy, infVal));

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinX86.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinX86.cpp
@@ -2367,7 +2367,7 @@ CIRGenFunction::emitX86BuiltinExpr(unsigned builtinID, const CallExpr *expr) {
   case X86::BI__builtin_ia32_sqrtpd512: {
     mlir::Location loc = getLoc(expr->getExprLoc());
     mlir::Value arg = ops[0];
-    return cir::SqrtOp::create(builder, loc, arg.getType(), arg).getResult();
+    return cir::SqrtOp::create(builder, loc, arg).getResult();
   }
   case X86::BI__builtin_ia32_pmuludq128:
   case X86::BI__builtin_ia32_pmuludq256:

--- a/clang/lib/CIR/CodeGen/CIRGenOpenACCRecipe.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenOpenACCRecipe.cpp
@@ -65,7 +65,7 @@ void OpenACCRecipeBuilderBase::makeAllocaCopy(mlir::Location loc,
           if (!numEltsToCopy)
             numEltsToCopy = builder.getConstInt(loc, itrTy, 1);
 
-          auto loadCur = cir::LoadOp::create(builder, loc, {itr});
+          auto loadCur = cir::LoadOp::create(builder, loc, itr.getResult());
           auto cmp = builder.createCompare(loc, cir::CmpOpKind::lt, loadCur,
                                            numEltsToCopy);
           builder.createCondition(cmp);
@@ -73,7 +73,7 @@ void OpenACCRecipeBuilderBase::makeAllocaCopy(mlir::Location loc,
         /*bodyBuilder=*/
         [&](mlir::OpBuilder &b, mlir::Location loc) {
           // destAlloca[itr] = srcAlloca[offsetPerSubArray * itr];
-          auto loadCur = cir::LoadOp::create(builder, loc, {itr});
+          auto loadCur = cir::LoadOp::create(builder, loc, itr.getResult());
           auto srcOffset = builder.createMul(loc, offsetPerSubarray, loadCur);
 
           auto ptrToOffsetIntoSrc = cir::PtrStrideOp::create(
@@ -90,7 +90,7 @@ void OpenACCRecipeBuilderBase::makeAllocaCopy(mlir::Location loc,
         /*stepBuilder=*/
         [&](mlir::OpBuilder &b, mlir::Location loc) {
           // Simple increment of the iterator.
-          auto load = cir::LoadOp::create(builder, loc, {itr});
+          auto load = cir::LoadOp::create(builder, loc, itr.getResult());
           auto inc = builder.createInc(loc, load);
           builder.CIRBaseBuilderTy::createStore(loc, inc, itr);
           builder.createYield(loc);
@@ -241,7 +241,7 @@ std::pair<mlir::Value, mlir::Value> OpenACCRecipeBuilderBase::createBoundsLoop(
 
     assert(isa<cir::PointerType>(eltTy));
 
-    auto eltLoad = cir::LoadOp::create(builder, loc, {subVal});
+    auto eltLoad = cir::LoadOp::create(builder, loc, subVal);
 
     return cir::PtrStrideOp::create(builder, loc, eltLoad.getType(), eltLoad,
                                     idxLoad);
@@ -282,7 +282,7 @@ std::pair<mlir::Value, mlir::Value> OpenACCRecipeBuilderBase::createBoundsLoop(
         loc,
         /*condBuilder=*/
         [&](mlir::OpBuilder &b, mlir::Location loc) {
-          auto loadCur = cir::LoadOp::create(builder, loc, {itr});
+          auto loadCur = cir::LoadOp::create(builder, loc, itr.getResult());
           // Use 'not equal' since we are just doing an increment/decrement.
           auto cmp = builder.createCompare(
               loc, inverse ? cir::CmpOpKind::ge : cir::CmpOpKind::lt, loadCur,
@@ -291,7 +291,7 @@ std::pair<mlir::Value, mlir::Value> OpenACCRecipeBuilderBase::createBoundsLoop(
         },
         /*bodyBuilder=*/
         [&](mlir::OpBuilder &b, mlir::Location loc) {
-          auto load = cir::LoadOp::create(builder, loc, {itr});
+          auto load = cir::LoadOp::create(builder, loc, itr.getResult());
 
           if (subscriptedValue)
             subscriptedValue = doSubscriptOp(subscriptedValue, load);
@@ -301,7 +301,7 @@ std::pair<mlir::Value, mlir::Value> OpenACCRecipeBuilderBase::createBoundsLoop(
         },
         /*stepBuilder=*/
         [&](mlir::OpBuilder &b, mlir::Location loc) {
-          auto load = cir::LoadOp::create(builder, loc, {itr});
+          auto load = cir::LoadOp::create(builder, loc, itr.getResult());
           auto unary = inverse ? builder.createDec(loc, load)
                                : builder.createInc(loc, load);
           builder.CIRBaseBuilderTy::createStore(loc, unary, itr);
@@ -623,7 +623,7 @@ void OpenACCRecipeBuilderBase::createReductionRecipeCombiner(
         loc,
         /*condBuilder=*/
         [&](mlir::OpBuilder &b, mlir::Location loc) {
-          auto loadItr = cir::LoadOp::create(builder, loc, {itr});
+          auto loadItr = cir::LoadOp::create(builder, loc, itr);
           mlir::Value arraySize = builder.getConstInt(
               loc, mlir::cast<cir::IntType>(cgf.ptrDiffTy), cat->getZExtSize());
           auto cmp = builder.createCompare(loc, cir::CmpOpKind::lt, loadItr,
@@ -632,7 +632,7 @@ void OpenACCRecipeBuilderBase::createReductionRecipeCombiner(
         },
         /*bodyBuilder=*/
         [&](mlir::OpBuilder &b, mlir::Location loc) {
-          auto loadItr = cir::LoadOp::create(builder, loc, {itr});
+          auto loadItr = cir::LoadOp::create(builder, loc, itr);
           auto lhsElt = builder.getArrayElement(
               loc, loc, lhsArg, cgf.convertType(cat->getElementType()), loadItr,
               /*shouldDecay=*/true);
@@ -645,7 +645,7 @@ void OpenACCRecipeBuilderBase::createReductionRecipeCombiner(
         },
         /*stepBuilder=*/
         [&](mlir::OpBuilder &b, mlir::Location loc) {
-          auto loadItr = cir::LoadOp::create(builder, loc, {itr});
+          auto loadItr = cir::LoadOp::create(builder, loc, itr);
           auto inc = builder.createInc(loc, loadItr);
           builder.CIRBaseBuilderTy::createStore(loc, inc, itr);
           builder.createYield(loc);

--- a/clang/lib/CIR/CodeGen/CIRGenStmtOpenACC.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenStmtOpenACC.cpp
@@ -29,7 +29,8 @@ mlir::LogicalResult CIRGenFunction::emitOpenACCOpAssociatedStmt(
 
   llvm::SmallVector<mlir::Type> retTy;
   llvm::SmallVector<mlir::Value> operands;
-  auto op = Op::create(builder, start, retTy, operands);
+  auto op = Op::create(builder, start, retTy, operands,
+                       cir::getDefaultProperties<Op>(builder.getContext()));
 
   emitOpenACCClauses(op, dirKind, clauses);
 
@@ -72,7 +73,9 @@ mlir::LogicalResult CIRGenFunction::emitOpenACCOpCombinedConstruct(
   llvm::SmallVector<mlir::Type> retTy;
   llvm::SmallVector<mlir::Value> operands;
 
-  auto computeOp = Op::create(builder, start, retTy, operands);
+  auto computeOp =
+      Op::create(builder, start, retTy, operands,
+                 cir::getDefaultProperties<Op>(builder.getContext()));
   computeOp.setCombinedAttr(builder.getUnitAttr());
   mlir::acc::LoopOp loopOp;
 
@@ -84,7 +87,9 @@ mlir::LogicalResult CIRGenFunction::emitOpenACCOpCombinedConstruct(
     builder.setInsertionPointToEnd(&block);
 
     LexicalScope ls{*this, start, builder.getInsertionBlock()};
-    auto loopOp = LoopOp::create(builder, start, retTy, operands);
+    auto loopOp =
+        LoopOp::create(builder, start, retTy, operands,
+                       cir::getDefaultProperties<LoopOp>(builder.getContext()));
     loopOp.setCombinedAttr(mlir::acc::CombinedConstructsTypeAttr::get(
         builder.getContext(), CombinedType<Op>::value));
 
@@ -118,7 +123,8 @@ Op CIRGenFunction::emitOpenACCOp(
     llvm::ArrayRef<const OpenACCClause *> clauses) {
   llvm::SmallVector<mlir::Type> retTy;
   llvm::SmallVector<mlir::Value> operands;
-  auto op = Op::create(builder, start, retTy, operands);
+  auto op = Op::create(builder, start, retTy, operands,
+                       cir::getDefaultProperties<Op>(builder.getContext()));
 
   emitOpenACCClauses(op, dirKind, clauses);
   return op;
@@ -363,7 +369,7 @@ emitAtomicUpdate(CIRGenFunction &cgf, CIRGenBuilderTy &builder,
     if (inf.WholeExpr)
       res = cgf.emitStmt(inf.WholeExpr, /*useCurrentScope=*/true);
 
-    auto load = cir::LoadOp::create(builder, start, {alloca});
+    auto load = cir::LoadOp::create(builder, start, alloca.getResult());
     mlir::acc::YieldOp::create(builder, end, {load});
   }
 

--- a/clang/lib/CIR/CodeGen/CIRGenStmtOpenACCLoop.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenStmtOpenACCLoop.cpp
@@ -58,7 +58,9 @@ CIRGenFunction::emitOpenACCLoopConstruct(const OpenACCLoopConstruct &s) {
   mlir::Location end = getLoc(s.getSourceRange().getEnd());
   llvm::SmallVector<mlir::Type> retTy;
   llvm::SmallVector<mlir::Value> operands;
-  auto op = LoopOp::create(builder, start, retTy, operands);
+  auto op =
+      LoopOp::create(builder, start, retTy, operands,
+                     cir::getDefaultProperties<LoopOp>(builder.getContext()));
 
   // TODO(OpenACC): In the future we are going to need to come up with a
   // transformation here that can teach the acc.loop how to figure out the

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -561,7 +561,9 @@ mlir::LogicalResult lowerConstrainableFPOp(
     return op->emitError("expected LLVM result type for floating-point op");
 
   if (!fenv) {
-    rewriter.replaceOpWithNewOp<LLVMOp>(op, llvmResTy, operands);
+    rewriter.replaceOpWithNewOp<LLVMOp>(
+        op, mlir::TypeRange{llvmResTy}, operands,
+        cir::getDefaultProperties<LLVMOp>(op->getContext()));
     return mlir::success();
   }
 

--- a/clang/utils/TableGen/CIRLoweringEmitter.cpp
+++ b/clang/utils/TableGen/CIRLoweringEmitter.cpp
@@ -222,14 +222,19 @@ void GenerateLLVMLoweringPattern(
         << "  mlir::LogicalResult matchAndRewrite(cir::" << OpName
         << " op, OpAdaptor adaptor, mlir::ConversionPatternRewriter &rewriter) "
            "const override {\n";
+    std::string Properties =
+        "cir::getDefaultProperties<mlir::LLVM::" + LLVMOp.str() +
+        ">(op.getContext())";
     if (HasZeroResult) {
       Code << "    rewriter.replaceOpWithNewOp<mlir::LLVM::" << LLVMOp
-           << ">(op, mlir::TypeRange{}, adaptor.getOperands());\n";
+           << ">(op, mlir::TypeRange{}, adaptor.getOperands(), " << Properties
+           << ");\n";
     } else {
       Code << "    mlir::Type resTy = "
               "typeConverter->convertType(op.getType());\n";
       Code << "    rewriter.replaceOpWithNewOp<mlir::LLVM::" << LLVMOp
-           << ">(op, resTy, adaptor.getOperands());\n";
+           << ">(op, mlir::TypeRange{resTy}, adaptor.getOperands(), "
+           << Properties << ");\n";
     }
     Code << "    return mlir::success();\n";
     Code << "  }\n";


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/219195 marked certain forms of the create function, and CIR was using those (most unintentionally/indirectly).

This change updates the CIR code to use non-deprecated forms

Assisted-by: Cursor / claude-opus-5