### PR TITLE
[AggressiveInstCombine] Require a definitive initializer for table folds

### DIFF
--- a/llvm/lib/Transforms/AggressiveInstCombine/AggressiveInstCombine.cpp
+++ b/llvm/lib/Transforms/AggressiveInstCombine/AggressiveInstCombine.cpp
@@ -1250,7 +1250,8 @@ static bool tryToRecognizeTableBasedCttzOrLog2(Instruction &I,
     return false;
 
   GlobalVariable *GVTable = dyn_cast<GlobalVariable>(GEP->getPointerOperand());
-  if (!GVTable || !GVTable->hasInitializer() || !GVTable->isConstant())
+  if (!GVTable || !GVTable->isConstant() ||
+      !GVTable->hasDefinitiveInitializer())
     return false;
 
   unsigned BW = DL.getIndexTypeSizeInBits(GEP->getType());

--- a/llvm/test/Transforms/AggressiveInstCombine/negative-lower-table-based-cttz.ll
+++ b/llvm/test/Transforms/AggressiveInstCombine/negative-lower-table-based-cttz.ll
@@ -136,3 +136,20 @@ entry:
   %0 = load i32, ptr %arrayidx, align 4
   ret i32 %0
 }
+
+;; Negative: an interposable (weak) constant table may be replaced at link time
+;; with a different constant, so its observed initializer cannot be trusted.
+
+@ctz_weak.table = weak unnamed_addr constant [32 x i32] [i32 0, i32 1, i32 2, i32 24, i32 3, i32 19, i32 6, i32 25, i32 22, i32 4, i32 20, i32 10, i32 16, i32 7, i32 12, i32 26, i32 31, i32 23, i32 18, i32 5, i32 21, i32 9, i32 15, i32 11, i32 30, i32 17, i32 8, i32 14, i32 29, i32 13, i32 28, i32 27], align 4
+
+define i32 @ctz_weak(i32 %x) {
+entry:
+  %sub = sub i32 0, %x
+  %and = and i32 %sub, %x
+  %mul = mul i32 %and, 81224991
+  %shr = lshr i32 %mul, 27
+  %idxprom = zext i32 %shr to i64
+  %arrayidx = getelementptr inbounds [32 x i32], ptr @ctz_weak.table, i64 0, i64 %idxprom
+  %0 = load i32, ptr %arrayidx, align 4
+  ret i32 %0
+}


### PR DESCRIPTION
tryToRecognizeTableBasedCttzOrLog2 accepted any global that isConstant() and hasInitializer(), but isConstant() only means the value does not change at run time -- it does not mean the initializer that is read is the one that gets linked. An interposable (weak/linkonce) constant, or an externally_initialized constant, can be replaced with a different constant table at link or load time, so folding tbl[i] against the observed initializer is unsound for those.

Assisted-by: Claude Code