### PR TITLE
[libcxx] Fix `long double` literals in <numbers>

### DIFF
--- a/libcxx/include/numbers
+++ b/libcxx/include/numbers
@@ -113,31 +113,31 @@ template <class _Tp>
 inline constexpr _Tp phi_v = __illformed<_Tp>{};
 
 template <floating_point _Tp>
-inline constexpr _Tp e_v<_Tp> = 2.718281828459045235360287471352662;
+inline constexpr _Tp e_v<_Tp> = 2.718281828459045235360287471352662498L;
 template <floating_point _Tp>
-inline constexpr _Tp log2e_v<_Tp> = 1.442695040888963407359924681001892;
+inline constexpr _Tp log2e_v<_Tp> = 1.442695040888963407359924681001892137L;
 template <floating_point _Tp>
-inline constexpr _Tp log10e_v<_Tp> = 0.434294481903251827651128918916605;
+inline constexpr _Tp log10e_v<_Tp> = 0.434294481903251827651128918916605082L;
 template <floating_point _Tp>
-inline constexpr _Tp pi_v<_Tp> = 3.141592653589793238462643383279502;
+inline constexpr _Tp pi_v<_Tp> = 3.141592653589793238462643383279502884L;
 template <floating_point _Tp>
-inline constexpr _Tp inv_pi_v<_Tp> = 0.318309886183790671537767526745028;
+inline constexpr _Tp inv_pi_v<_Tp> = 0.318309886183790671537767526745028724L;
 template <floating_point _Tp>
-inline constexpr _Tp inv_sqrtpi_v<_Tp> = 0.564189583547756286948079451560772;
+inline constexpr _Tp inv_sqrtpi_v<_Tp> = 0.564189583547756286948079451560772586L;
 template <floating_point _Tp>
-inline constexpr _Tp ln2_v<_Tp> = 0.693147180559945309417232121458176;
+inline constexpr _Tp ln2_v<_Tp> = 0.693147180559945309417232121458176568L;
 template <floating_point _Tp>
-inline constexpr _Tp ln10_v<_Tp> = 2.302585092994045684017991454684364;
+inline constexpr _Tp ln10_v<_Tp> = 2.302585092994045684017991454684364208L;
 template <floating_point _Tp>
-inline constexpr _Tp sqrt2_v<_Tp> = 1.414213562373095048801688724209698;
+inline constexpr _Tp sqrt2_v<_Tp> = 1.414213562373095048801688724209698079L;
 template <floating_point _Tp>
-inline constexpr _Tp sqrt3_v<_Tp> = 1.732050807568877293527446341505872;
+inline constexpr _Tp sqrt3_v<_Tp> = 1.732050807568877293527446341505872367L;
 template <floating_point _Tp>
-inline constexpr _Tp inv_sqrt3_v<_Tp> = 0.577350269189625764509148780501957;
+inline constexpr _Tp inv_sqrt3_v<_Tp> = 0.577350269189625764509148780501957456L;
 template <floating_point _Tp>
-inline constexpr _Tp egamma_v<_Tp> = 0.577215664901532860606512090082402;
+inline constexpr _Tp egamma_v<_Tp> = 0.577215664901532860606512090082402431L;
 template <floating_point _Tp>
-inline constexpr _Tp phi_v<_Tp> = 1.618033988749894848204586834365638;
+inline constexpr _Tp phi_v<_Tp> = 1.618033988749894848204586834365638118L;
 
 inline constexpr double e          = e_v<double>;
 inline constexpr double log2e      = log2e_v<double>;

--- a/libcxx/test/std/numerics/numbers/value.pass.cpp
+++ b/libcxx/test/std/numerics/numbers/value.pass.cpp
@@ -11,71 +11,126 @@
 #include <cassert>
 #include <numbers>
 
+#include "test_macros.h"
+
 constexpr bool tests() {
   assert(std::numbers::e == 0x1.5bf0a8b145769p+1);
   assert(std::numbers::e_v<double> == 0x1.5bf0a8b145769p+1);
-  assert(std::numbers::e_v<long double> == 0x1.5bf0a8b145769p+1l);
   assert(std::numbers::e_v<float> == 0x1.5bf0a8p+1f);
 
   assert(std::numbers::log2e == 0x1.71547652b82fep+0);
   assert(std::numbers::log2e_v<double> == 0x1.71547652b82fep+0);
-  assert(std::numbers::log2e_v<long double> == 0x1.71547652b82fep+0l);
   assert(std::numbers::log2e_v<float> == 0x1.715476p+0f);
 
   assert(std::numbers::log10e == 0x1.bcb7b1526e50ep-2);
   assert(std::numbers::log10e_v<double> == 0x1.bcb7b1526e50ep-2);
-  assert(std::numbers::log10e_v<long double> == 0x1.bcb7b1526e50ep-2l);
   assert(std::numbers::log10e_v<float> == 0x1.bcb7b15p-2f);
 
   assert(std::numbers::pi == 0x1.921fb54442d18p+1);
   assert(std::numbers::pi_v<double> == 0x1.921fb54442d18p+1);
-  assert(std::numbers::pi_v<long double> == 0x1.921fb54442d18p+1l);
   assert(std::numbers::pi_v<float> == 0x1.921fb54p+1f);
 
   assert(std::numbers::inv_pi == 0x1.45f306dc9c883p-2);
   assert(std::numbers::inv_pi_v<double> == 0x1.45f306dc9c883p-2);
-  assert(std::numbers::inv_pi_v<long double> == 0x1.45f306dc9c883p-2l);
   assert(std::numbers::inv_pi_v<float> == 0x1.45f306p-2f);
 
   assert(std::numbers::inv_sqrtpi == 0x1.20dd750429b6dp-1);
   assert(std::numbers::inv_sqrtpi_v<double> == 0x1.20dd750429b6dp-1);
-  assert(std::numbers::inv_sqrtpi_v<long double> == 0x1.20dd750429b6dp-1l);
   assert(std::numbers::inv_sqrtpi_v<float> == 0x1.20dd76p-1f);
 
   assert(std::numbers::ln2 == 0x1.62e42fefa39efp-1);
   assert(std::numbers::ln2_v<double> == 0x1.62e42fefa39efp-1);
-  assert(std::numbers::ln2_v<long double> == 0x1.62e42fefa39efp-1l);
   assert(std::numbers::ln2_v<float> == 0x1.62e42fp-1f);
 
   assert(std::numbers::ln10 == 0x1.26bb1bbb55516p+1);
   assert(std::numbers::ln10_v<double> == 0x1.26bb1bbb55516p+1);
-  assert(std::numbers::ln10_v<long double> == 0x1.26bb1bbb55516p+1l);
   assert(std::numbers::ln10_v<float> == 0x1.26bb1bp+1f);
 
   assert(std::numbers::sqrt2 == 0x1.6a09e667f3bcdp+0);
   assert(std::numbers::sqrt2_v<double> == 0x1.6a09e667f3bcdp+0);
-  assert(std::numbers::sqrt2_v<long double> == 0x1.6a09e667f3bcdp+0l);
   assert(std::numbers::sqrt2_v<float> == 0x1.6a09e6p+0f);
 
   assert(std::numbers::sqrt3 == 0x1.bb67ae8584caap+0);
   assert(std::numbers::sqrt3_v<double> == 0x1.bb67ae8584caap+0);
-  assert(std::numbers::sqrt3_v<long double> == 0x1.bb67ae8584caap+0l);
   assert(std::numbers::sqrt3_v<float> == 0x1.bb67aep+0f);
 
   assert(std::numbers::inv_sqrt3 == 0x1.279a74590331cp-1);
   assert(std::numbers::inv_sqrt3_v<double> == 0x1.279a74590331cp-1);
-  assert(std::numbers::inv_sqrt3_v<long double> == 0x1.279a74590331cp-1l);
   assert(std::numbers::inv_sqrt3_v<float> == 0x1.279a74p-1f);
 
   assert(std::numbers::egamma == 0x1.2788cfc6fb619p-1);
   assert(std::numbers::egamma_v<double> == 0x1.2788cfc6fb619p-1);
-  assert(std::numbers::egamma_v<long double> == 0x1.2788cfc6fb619p-1l);
   assert(std::numbers::egamma_v<float> == 0x1.2788cfp-1f);
 
   assert(std::numbers::phi == 0x1.9e3779b97f4a8p+0);
   assert(std::numbers::phi_v<double> == 0x1.9e3779b97f4a8p+0);
-  assert(std::numbers::phi_v<long double> == 0x1.9e3779b97f4a8p+0l);
   assert(std::numbers::phi_v<float> == 0x1.9e3779ap+0f);
+
+#if defined(TEST_LONG_DOUBLE_IS_DOUBLE)
+  assert(std::numbers::e_v<long double> == 0x1.5bf0a8b145769p+1L);
+  assert(std::numbers::log2e_v<long double> == 0x1.71547652b82fep+0L);
+  assert(std::numbers::log10e_v<long double> == 0x1.bcb7b1526e50ep-2L);
+  assert(std::numbers::pi_v<long double> == 0x1.921fb54442d18p+1L);
+  assert(std::numbers::inv_pi_v<long double> == 0x1.45f306dc9c883p-2L);
+  assert(std::numbers::inv_sqrtpi_v<long double> == 0x1.20dd750429b6dp-1L);
+  assert(std::numbers::ln2_v<long double> == 0x1.62e42fefa39efp-1L);
+  assert(std::numbers::ln10_v<long double> == 0x1.26bb1bbb55516p+1L);
+  assert(std::numbers::sqrt2_v<long double> == 0x1.6a09e667f3bcdp+0L);
+  assert(std::numbers::sqrt3_v<long double> == 0x1.bb67ae8584caap+0L);
+  assert(std::numbers::inv_sqrt3_v<long double> == 0x1.279a74590331cp-1L);
+  assert(std::numbers::egamma_v<long double> == 0x1.2788cfc6fb619p-1L);
+  assert(std::numbers::phi_v<long double> == 0x1.9e3779b97f4a8p+0L);
+#elif defined(TEST_LONG_DOUBLE_IS_80_BIT)
+  assert(std::numbers::e_v<long double> == 0x1.5bf0a8b145769536p+1L);
+  assert(std::numbers::log2e_v<long double> == 0x1.71547652b82fe178p+0L);
+  assert(std::numbers::log10e_v<long double> == 0x1.bcb7b1526e50e32ap-2L);
+  assert(std::numbers::pi_v<long double> == 0x1.921fb54442d1846ap+1L);
+  assert(std::numbers::inv_pi_v<long double> == 0x1.45f306dc9c882a54p-2L);
+  assert(std::numbers::inv_sqrtpi_v<long double> == 0x1.20dd750429b6d11ap-1L);
+  assert(std::numbers::ln2_v<long double> == 0x1.62e42fefa39ef358p-1L);
+  assert(std::numbers::ln10_v<long double> == 0x1.26bb1bbb5551582ep+1L);
+  assert(std::numbers::sqrt2_v<long double> == 0x1.6a09e667f3bcc908p+0L);
+  assert(std::numbers::sqrt3_v<long double> == 0x1.bb67ae8584caa73cp+0L);
+  assert(std::numbers::inv_sqrt3_v<long double> == 0x1.279a74590331c4d2p-1L);
+  assert(std::numbers::egamma_v<long double> == 0x1.2788cfc6fb618f4ap-1L);
+  assert(std::numbers::phi_v<long double> == 0x1.9e3779b97f4a7c16p+0L);
+#elif defined(TEST_LONG_DOUBLE_IS_BINARY128)
+  assert(std::numbers::e_v<long double> == 0x1.5bf0a8b1457695355fb8ac404e7ap+1L);
+  assert(std::numbers::log2e_v<long double> == 0x1.71547652b82fe1777d0ffda0d23ap+0L);
+  assert(std::numbers::log10e_v<long double> == 0x1.bcb7b1526e50e32a6ab7555f5a68p-2L);
+  assert(std::numbers::pi_v<long double> == 0x1.921fb54442d18469898cc51701b8p+1L);
+  assert(std::numbers::inv_pi_v<long double> == 0x1.45f306dc9c882a53f84eafa3ea6ap-2L);
+  assert(std::numbers::inv_sqrtpi_v<long double> == 0x1.20dd750429b6d11ae3a914fed7fep-1L);
+  assert(std::numbers::ln2_v<long double> == 0x1.62e42fefa39ef35793c7673007e6p-1L);
+  assert(std::numbers::ln10_v<long double> == 0x1.26bb1bbb5551582dd4adac5705a6p+1L);
+  assert(std::numbers::sqrt2_v<long double> == 0x1.6a09e667f3bcc908b2fb1366ea95p+0L);
+  assert(std::numbers::sqrt3_v<long double> == 0x1.bb67ae8584caa73b25742d7078b8p+0L);
+  assert(std::numbers::inv_sqrt3_v<long double> == 0x1.279a74590331c4d218f81e4afb25p-1L);
+  assert(std::numbers::egamma_v<long double> == 0x1.2788cfc6fb618f49a37c7f0202a6p-1L);
+  assert(std::numbers::phi_v<long double> == 0x1.9e3779b97f4a7c15f39cc0605ceep+0L);
+#elif defined(TEST_LONG_DOUBLE_IS_PPCDOUBLEDOUBLE)
+  // TODO: These values may be off by a few ULP since APFloat only uses 106 bits
+  // of precision for PPCDoubleDouble while PPCDoubleDouble requires 2098 bits
+  // (1023 - -1074 + 1) bits of precision for round trip conversion.
+  //
+  // TODO: Ideally we would extract the high and low halves for the
+  // PPCDoubleDouble and test those individually.
+  assert(std::numbers::e_v<long double> == 0x1.5bf0a8b1457695355fb8ac404e7ap+1L);
+  assert(std::numbers::log2e_v<long double> == 0x1.71547652b82fe1777d0ffda0d23ap+0L);
+  assert(std::numbers::log10e_v<long double> == 0x1.bcb7b1526e50e32a6ab7555f5a68p-2L);
+  assert(std::numbers::pi_v<long double> == 0x1.921fb54442d18469898cc51701b8p+1L);
+  assert(std::numbers::inv_pi_v<long double> == 0x1.45f306dc9c882a53f84eafa3ea6ap-2L);
+  assert(std::numbers::inv_sqrtpi_v<long double> == 0x1.20dd750429b6d11ae3a914fed7fep-1L);
+  assert(std::numbers::ln2_v<long double> == 0x1.62e42fefa39ef35793c7673007e6p-1L);
+  assert(std::numbers::ln10_v<long double> == 0x1.26bb1bbb5551582dd4adac5705a6p+1L);
+  assert(std::numbers::sqrt2_v<long double> == 0x1.6a09e667f3bcc908b2fb1366ea95p+0L);
+  assert(std::numbers::sqrt3_v<long double> == 0x1.bb67ae8584caa73b25742d7078b8p+0L);
+  assert(std::numbers::inv_sqrt3_v<long double> == 0x1.279a74590331c4d218f81e4afb25p-1L);
+  assert(std::numbers::egamma_v<long double> == 0x1.2788cfc6fb618f49a37c7f0202a6p-1L);
+  assert(std::numbers::phi_v<long double> == 0x1.9e3779b97f4a7c15f39cc0605ceep+0L);
+#else
+#  error "Unknown long double format"
+#endif
 
   return true;
 }

--- a/libcxx/test/support/test_macros.h
+++ b/libcxx/test/support/test_macros.h
@@ -576,6 +576,14 @@ inline Tp const& DoNotOptimize(Tp const& value) {
 #  define TEST_LONG_DOUBLE_IS_80_BIT
 #endif
 
+#if defined(__LDBL_MANT_DIG__) && __LDBL_MANT_DIG__ == 106
+#  define TEST_LONG_DOUBLE_IS_PPCDOUBLEDOUBLE
+#endif
+
+#if defined(__LDBL_MANT_DIG__) && __LDBL_MANT_DIG__ == 113
+#  define TEST_LONG_DOUBLE_IS_BINARY128
+#endif
+
 // Align benchmark functions and never inline them to reduce changes in performance in unrelated benchmarks
 #define TEST_ALIGN_BENCHMARK __attribute__((aligned(128), noinline))
 


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/188079

`<numbers>` now uses `long double` literals instead of `double` literals. I also increased the number of digits for each literal to be of sufficient precision for `ieee_binary128`, this also makes it use the exact same number of digits as GCC's `<numbers>` header. I also made sure to round the literals (e.g. `0.145 --> 0.15`), since the previous literals used were truncated towards zero.

Also added `TEST_LONG_DOUBLE_IS_BINARY128` and `TEST_LONG_DOUBLE_IS_PPCDOUBLEDOUBLE` to `test_macros.h`.

I cannot properly test `PPCDoubleDouble` because I cannot safely extract the low/high `double` https://github.com/llvm/llvm-project/issues/222495.
