### PR TITLE
[ORC] Move ExecutorSharedMemoryMapperService names to sps_ci

### DIFF
--- a/clang/lib/Interpreter/IncrementalExecutor.cpp
+++ b/clang/lib/Interpreter/IncrementalExecutor.cpp
@@ -35,7 +35,7 @@
 #include "llvm/ExecutionEngine/Orc/JITTargetMachineBuilder.h"
 #include "llvm/ExecutionEngine/Orc/LLJIT.h"
 #include "llvm/ExecutionEngine/Orc/MapperJITLinkMemoryManager.h"
-#include "llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h"
+#include "llvm/ExecutionEngine/Orc/Shared/SPSCI/SharedMemoryMapperSPSCI.h"
 #include "llvm/ExecutionEngine/Orc/Shared/SimpleRemoteEPCUtils.h"
 #include "llvm/ExecutionEngine/Orc/SimpleRemoteEPC.h"
 
@@ -117,18 +117,15 @@ createSharedMemoryManager(llvm::orc::ExecutorProcessControl &EPC,
   llvm::orc::SharedMemoryMapper::SymbolAddrs SAs;
   if (auto Err = EPC.getBootstrapSymbols(
           {{SAs.Instance,
-            llvm::orc::rt::ExecutorSharedMemoryMapperServiceInstanceName},
+            llvm::orc::rt::sps_ci::SharedMemoryMapperInstanceName},
            {SAs.Reserve,
-            llvm::orc::rt::ExecutorSharedMemoryMapperServiceReserveWrapperName},
+            llvm::orc::rt::sps_ci::SharedMemoryMapperReserve::Name},
            {SAs.Initialize,
-            llvm::orc::rt::
-                ExecutorSharedMemoryMapperServiceInitializeWrapperName},
+            llvm::orc::rt::sps_ci::SharedMemoryMapperInitialize::Name},
            {SAs.Deinitialize,
-            llvm::orc::rt::
-                ExecutorSharedMemoryMapperServiceDeinitializeWrapperName},
+            llvm::orc::rt::sps_ci::SharedMemoryMapperDeinitialize::Name},
            {SAs.Release,
-            llvm::orc::rt::
-                ExecutorSharedMemoryMapperServiceReleaseWrapperName}}))
+            llvm::orc::rt::sps_ci::SharedMemoryMapperRelease::Name}}))
     return std::move(Err);
 
   size_t SlabSize;

--- a/llvm/include/llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h
@@ -28,14 +28,6 @@ LLVM_ABI extern const char *SimpleExecutorMemoryManagerInitializeWrapperName;
 LLVM_ABI extern const char *SimpleExecutorMemoryManagerDeinitializeWrapperName;
 LLVM_ABI extern const char *SimpleExecutorMemoryManagerReleaseWrapperName;
 
-LLVM_ABI extern const char *ExecutorSharedMemoryMapperServiceInstanceName;
-LLVM_ABI extern const char *ExecutorSharedMemoryMapperServiceReserveWrapperName;
-LLVM_ABI extern const char
-    *ExecutorSharedMemoryMapperServiceInitializeWrapperName;
-LLVM_ABI extern const char
-    *ExecutorSharedMemoryMapperServiceDeinitializeWrapperName;
-LLVM_ABI extern const char *ExecutorSharedMemoryMapperServiceReleaseWrapperName;
-
 LLVM_ABI extern const char *RegisterEHFrameSectionAllocActionName;
 LLVM_ABI extern const char *DeregisterEHFrameSectionAllocActionName;
 
@@ -66,21 +58,6 @@ using SPSSimpleExecutorMemoryManagerInitializeSignature =
 using SPSSimpleExecutorMemoryManagerDeinitializeSignature = shared::SPSError(
     shared::SPSExecutorAddr, shared::SPSSequence<shared::SPSExecutorAddr>);
 using SPSSimpleExecutorMemoryManagerReleaseSignature = shared::SPSError(
-    shared::SPSExecutorAddr, shared::SPSSequence<shared::SPSExecutorAddr>);
-
-// ExecutorSharedMemoryMapperService
-using SPSExecutorSharedMemoryMapperServiceReserveSignature =
-    shared::SPSExpected<
-        shared::SPSTuple<shared::SPSExecutorAddr, shared::SPSString>>(
-        shared::SPSExecutorAddr, uint64_t);
-using SPSExecutorSharedMemoryMapperServiceInitializeSignature =
-    shared::SPSExpected<shared::SPSExecutorAddr>(
-        shared::SPSExecutorAddr, shared::SPSExecutorAddr,
-        shared::SPSSharedMemoryFinalizeRequest);
-using SPSExecutorSharedMemoryMapperServiceDeinitializeSignature =
-    shared::SPSError(shared::SPSExecutorAddr,
-                     shared::SPSSequence<shared::SPSExecutorAddr>);
-using SPSExecutorSharedMemoryMapperServiceReleaseSignature = shared::SPSError(
     shared::SPSExecutorAddr, shared::SPSSequence<shared::SPSExecutorAddr>);
 
 } // end namespace rt

--- a/llvm/include/llvm/ExecutionEngine/Orc/Shared/SPSCI/SharedMemoryMapperSPSCI.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Shared/SPSCI/SharedMemoryMapperSPSCI.h
@@ -1,0 +1,60 @@
+//===- SharedMemoryMapperSPSCI.h - SPS CI for shared-mem mapping *- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// SPS controller-interface descriptors for the executor's shared-memory mapper
+// service. See CallSPSCI.h for a description of the descriptor scheme.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_EXECUTIONENGINE_ORC_SHARED_SPSCI_SHAREDMEMORYMAPPERSPSCI_H
+#define LLVM_EXECUTIONENGINE_ORC_SHARED_SPSCI_SHAREDMEMORYMAPPERSPSCI_H
+
+#include "llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h"
+#include "llvm/ExecutionEngine/Orc/Shared/SimplePackedSerialization.h"
+#include "llvm/ExecutionEngine/Orc/Shared/TargetProcessControlTypes.h"
+
+#include <cstdint>
+
+namespace llvm::orc::rt::sps_ci {
+
+inline constexpr char SharedMemoryMapperInstanceName[] =
+    "__llvm_orc_ExecutorSharedMemoryMapperService_Instance";
+
+struct SharedMemoryMapperReserve {
+  static constexpr char Name[] =
+      "__llvm_orc_ExecutorSharedMemoryMapperService_Reserve";
+  using SPSSig = shared::SPSExpected<
+      shared::SPSTuple<shared::SPSExecutorAddr, shared::SPSString>>(
+      shared::SPSExecutorAddr, uint64_t);
+};
+
+struct SharedMemoryMapperInitialize {
+  static constexpr char Name[] =
+      "__llvm_orc_ExecutorSharedMemoryMapperService_Initialize";
+  using SPSSig = shared::SPSExpected<shared::SPSExecutorAddr>(
+      shared::SPSExecutorAddr, shared::SPSExecutorAddr,
+      shared::SPSSharedMemoryFinalizeRequest);
+};
+
+struct SharedMemoryMapperDeinitialize {
+  static constexpr char Name[] =
+      "__llvm_orc_ExecutorSharedMemoryMapperService_Deinitialize";
+  using SPSSig = shared::SPSError(shared::SPSExecutorAddr,
+                                  shared::SPSSequence<shared::SPSExecutorAddr>);
+};
+
+struct SharedMemoryMapperRelease {
+  static constexpr char Name[] =
+      "__llvm_orc_ExecutorSharedMemoryMapperService_Release";
+  using SPSSig = shared::SPSError(shared::SPSExecutorAddr,
+                                  shared::SPSSequence<shared::SPSExecutorAddr>);
+};
+
+} // namespace llvm::orc::rt::sps_ci
+
+#endif // LLVM_EXECUTIONENGINE_ORC_SHARED_SPSCI_SHAREDMEMORYMAPPERSPSCI_H

--- a/llvm/lib/ExecutionEngine/Orc/MemoryMapper.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/MemoryMapper.cpp
@@ -10,6 +10,7 @@
 
 #include "llvm/Config/llvm-config.h" // for LLVM_ON_UNIX
 #include "llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h"
+#include "llvm/ExecutionEngine/Orc/Shared/SPSCI/SharedMemoryMapperSPSCI.h"
 #include "llvm/Support/MSVCErrorWorkarounds.h"
 #include "llvm/Support/WindowsError.h"
 
@@ -223,8 +224,7 @@ void SharedMemoryMapper::reserve(size_t NumBytes,
 #if (defined(LLVM_ON_UNIX) && !defined(__ANDROID__)) || defined(_WIN32)
 
   int SharedMemoryId = -1;
-  EPC.callSPSWrapperAsync<
-      rt::SPSExecutorSharedMemoryMapperServiceReserveSignature>(
+  EPC.callSPSWrapperAsync<rt::sps_ci::SharedMemoryMapperReserve::SPSSig>(
       SAs.Reserve,
       [this, NumBytes, OnReserved = std::move(OnReserved), SharedMemoryId](
           Error SerializationErr,
@@ -355,8 +355,7 @@ void SharedMemoryMapper::initialize(MemoryMapper::AllocInfo &AI,
     FR.Segments.push_back(SegReq);
   }
 
-  EPC.callSPSWrapperAsync<
-      rt::SPSExecutorSharedMemoryMapperServiceInitializeSignature>(
+  EPC.callSPSWrapperAsync<rt::sps_ci::SharedMemoryMapperInitialize::SPSSig>(
       SAs.Initialize,
       [OnInitialized = std::move(OnInitialized)](
           Error SerializationErr, Expected<ExecutorAddr> Result) mutable {
@@ -373,8 +372,7 @@ void SharedMemoryMapper::initialize(MemoryMapper::AllocInfo &AI,
 void SharedMemoryMapper::deinitialize(
     ArrayRef<ExecutorAddr> Allocations,
     MemoryMapper::OnDeinitializedFunction OnDeinitialized) {
-  EPC.callSPSWrapperAsync<
-      rt::SPSExecutorSharedMemoryMapperServiceDeinitializeSignature>(
+  EPC.callSPSWrapperAsync<rt::sps_ci::SharedMemoryMapperDeinitialize::SPSSig>(
       SAs.Deinitialize,
       [OnDeinitialized = std::move(OnDeinitialized)](Error SerializationErr,
                                                      Error Result) mutable {
@@ -421,8 +419,7 @@ void SharedMemoryMapper::release(ArrayRef<ExecutorAddr> Bases,
     }
   }
 
-  EPC.callSPSWrapperAsync<
-      rt::SPSExecutorSharedMemoryMapperServiceReleaseSignature>(
+  EPC.callSPSWrapperAsync<rt::sps_ci::SharedMemoryMapperRelease::SPSSig>(
       SAs.Release,
       [OnReleased = std::move(OnReleased),
        Err = std::move(Err)](Error SerializationErr, Error Result) mutable {

--- a/llvm/lib/ExecutionEngine/Orc/Shared/OrcRTBridge.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/Shared/OrcRTBridge.cpp
@@ -23,17 +23,6 @@ const char *SimpleExecutorMemoryManagerDeinitializeWrapperName =
 const char *SimpleExecutorMemoryManagerReleaseWrapperName =
     "__llvm_orc_SimpleExecutorMemoryManager_release_wrapper";
 
-const char *ExecutorSharedMemoryMapperServiceInstanceName =
-    "__llvm_orc_ExecutorSharedMemoryMapperService_Instance";
-const char *ExecutorSharedMemoryMapperServiceReserveWrapperName =
-    "__llvm_orc_ExecutorSharedMemoryMapperService_Reserve";
-const char *ExecutorSharedMemoryMapperServiceInitializeWrapperName =
-    "__llvm_orc_ExecutorSharedMemoryMapperService_Initialize";
-const char *ExecutorSharedMemoryMapperServiceDeinitializeWrapperName =
-    "__llvm_orc_ExecutorSharedMemoryMapperService_Deinitialize";
-const char *ExecutorSharedMemoryMapperServiceReleaseWrapperName =
-    "__llvm_orc_ExecutorSharedMemoryMapperService_Release";
-
 const char *RegisterEHFrameSectionAllocActionName =
     "llvm_orc_registerEHFrameAllocAction";
 const char *DeregisterEHFrameSectionAllocActionName =

--- a/llvm/lib/ExecutionEngine/Orc/TargetProcess/ExecutorSharedMemoryMapperService.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/TargetProcess/ExecutorSharedMemoryMapperService.cpp
@@ -9,6 +9,7 @@
 #include "llvm/ExecutionEngine/Orc/TargetProcess/ExecutorSharedMemoryMapperService.h"
 #include "llvm/Config/llvm-config.h" // for LLVM_ON_UNIX
 #include "llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h"
+#include "llvm/ExecutionEngine/Orc/Shared/SPSCI/SharedMemoryMapperSPSCI.h"
 #include "llvm/Support/Process.h"
 #include "llvm/Support/WindowsError.h"
 #include <sstream>
@@ -309,24 +310,23 @@ Error ExecutorSharedMemoryMapperService::shutdown() {
 
 void ExecutorSharedMemoryMapperService::addBootstrapSymbols(
     StringMap<ExecutorAddr> &M) {
-  M[rt::ExecutorSharedMemoryMapperServiceInstanceName] =
-      ExecutorAddr::fromPtr(this);
-  M[rt::ExecutorSharedMemoryMapperServiceReserveWrapperName] =
+  M[rt::sps_ci::SharedMemoryMapperInstanceName] = ExecutorAddr::fromPtr(this);
+  M[rt::sps_ci::SharedMemoryMapperReserve::Name] =
       ExecutorAddr::fromPtr(&reserveWrapper);
-  M[rt::ExecutorSharedMemoryMapperServiceInitializeWrapperName] =
+  M[rt::sps_ci::SharedMemoryMapperInitialize::Name] =
       ExecutorAddr::fromPtr(&initializeWrapper);
-  M[rt::ExecutorSharedMemoryMapperServiceDeinitializeWrapperName] =
+  M[rt::sps_ci::SharedMemoryMapperDeinitialize::Name] =
       ExecutorAddr::fromPtr(&deinitializeWrapper);
-  M[rt::ExecutorSharedMemoryMapperServiceReleaseWrapperName] =
+  M[rt::sps_ci::SharedMemoryMapperRelease::Name] =
       ExecutorAddr::fromPtr(&releaseWrapper);
 }
 
 llvm::orc::shared::CWrapperFunctionBuffer
 ExecutorSharedMemoryMapperService::reserveWrapper(const char *ArgData,
                                                   size_t ArgSize) {
-  return shared::WrapperFunction<
-             rt::SPSExecutorSharedMemoryMapperServiceReserveSignature>::
-      handle(ArgData, ArgSize,
+  return shared::
+      WrapperFunction<rt::sps_ci::SharedMemoryMapperReserve::SPSSig>::handle(
+             ArgData, ArgSize,
              shared::makeMethodWrapperHandler(
                  &ExecutorSharedMemoryMapperService::reserve))
           .release();
@@ -335,9 +335,9 @@ ExecutorSharedMemoryMapperService::reserveWrapper(const char *ArgData,
 llvm::orc::shared::CWrapperFunctionBuffer
 ExecutorSharedMemoryMapperService::initializeWrapper(const char *ArgData,
                                                      size_t ArgSize) {
-  return shared::WrapperFunction<
-             rt::SPSExecutorSharedMemoryMapperServiceInitializeSignature>::
-      handle(ArgData, ArgSize,
+  return shared::
+      WrapperFunction<rt::sps_ci::SharedMemoryMapperInitialize::SPSSig>::handle(
+             ArgData, ArgSize,
              shared::makeMethodWrapperHandler(
                  &ExecutorSharedMemoryMapperService::initialize))
           .release();
@@ -347,7 +347,7 @@ llvm::orc::shared::CWrapperFunctionBuffer
 ExecutorSharedMemoryMapperService::deinitializeWrapper(const char *ArgData,
                                                        size_t ArgSize) {
   return shared::WrapperFunction<
-             rt::SPSExecutorSharedMemoryMapperServiceDeinitializeSignature>::
+             rt::sps_ci::SharedMemoryMapperDeinitialize::SPSSig>::
       handle(ArgData, ArgSize,
              shared::makeMethodWrapperHandler(
                  &ExecutorSharedMemoryMapperService::deinitialize))
@@ -357,9 +357,9 @@ ExecutorSharedMemoryMapperService::deinitializeWrapper(const char *ArgData,
 llvm::orc::shared::CWrapperFunctionBuffer
 ExecutorSharedMemoryMapperService::releaseWrapper(const char *ArgData,
                                                   size_t ArgSize) {
-  return shared::WrapperFunction<
-             rt::SPSExecutorSharedMemoryMapperServiceReleaseSignature>::
-      handle(ArgData, ArgSize,
+  return shared::
+      WrapperFunction<rt::sps_ci::SharedMemoryMapperRelease::SPSSig>::handle(
+             ArgData, ArgSize,
              shared::makeMethodWrapperHandler(
                  &ExecutorSharedMemoryMapperService::release))
           .release();

--- a/llvm/tools/llvm-jitlink/llvm-jitlink.cpp
+++ b/llvm/tools/llvm-jitlink/llvm-jitlink.cpp
@@ -40,6 +40,7 @@
 #include "llvm/ExecutionEngine/Orc/SectCreate.h"
 #include "llvm/ExecutionEngine/Orc/SelfExecutorProcessControl.h"
 #include "llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h"
+#include "llvm/ExecutionEngine/Orc/Shared/SPSCI/SharedMemoryMapperSPSCI.h"
 #include "llvm/ExecutionEngine/Orc/SimpleMemoryMapSPS.h"
 #include "llvm/ExecutionEngine/Orc/SimpleRemoteMemoryMapper.h"
 #include "llvm/ExecutionEngine/Orc/TargetProcess/JITLoaderGDB.h"
@@ -779,15 +780,11 @@ Expected<std::unique_ptr<jitlink::JITLinkMemoryManager>>
 createSharedMemoryManager(ExecutorProcessControl &EPC) {
   SharedMemoryMapper::SymbolAddrs SAs;
   if (auto Err = EPC.getBootstrapSymbols(
-          {{SAs.Instance, rt::ExecutorSharedMemoryMapperServiceInstanceName},
-           {SAs.Reserve,
-            rt::ExecutorSharedMemoryMapperServiceReserveWrapperName},
-           {SAs.Initialize,
-            rt::ExecutorSharedMemoryMapperServiceInitializeWrapperName},
-           {SAs.Deinitialize,
-            rt::ExecutorSharedMemoryMapperServiceDeinitializeWrapperName},
-           {SAs.Release,
-            rt::ExecutorSharedMemoryMapperServiceReleaseWrapperName}}))
+          {{SAs.Instance, rt::sps_ci::SharedMemoryMapperInstanceName},
+           {SAs.Reserve, rt::sps_ci::SharedMemoryMapperReserve::Name},
+           {SAs.Initialize, rt::sps_ci::SharedMemoryMapperInitialize::Name},
+           {SAs.Deinitialize, rt::sps_ci::SharedMemoryMapperDeinitialize::Name},
+           {SAs.Release, rt::sps_ci::SharedMemoryMapperRelease::Name}}))
     return std::move(Err);
 
 #ifdef _WIN32

--- a/llvm/unittests/ExecutionEngine/Orc/SharedMemoryMapperTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/SharedMemoryMapperTest.cpp
@@ -12,6 +12,7 @@
 #include "llvm/ExecutionEngine/Orc/MemoryMapper.h"
 #include "llvm/ExecutionEngine/Orc/SelfExecutorProcessControl.h"
 #include "llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h"
+#include "llvm/ExecutionEngine/Orc/Shared/SPSCI/SharedMemoryMapperSPSCI.h"
 #include "llvm/ExecutionEngine/Orc/TargetProcess/ExecutorSharedMemoryMapperService.h"
 #include "llvm/Testing/Support/Error.h"
 
@@ -47,13 +48,11 @@ TEST(SharedMemoryMapperTest, MemReserveInitializeDeinitializeRelease) {
   {
     StringMap<ExecutorAddr> Map;
     MapperService.addBootstrapSymbols(Map);
-    SAs.Instance = Map[rt::ExecutorSharedMemoryMapperServiceInstanceName];
-    SAs.Reserve = Map[rt::ExecutorSharedMemoryMapperServiceReserveWrapperName];
-    SAs.Initialize =
-        Map[rt::ExecutorSharedMemoryMapperServiceInitializeWrapperName];
-    SAs.Deinitialize =
-        Map[rt::ExecutorSharedMemoryMapperServiceDeinitializeWrapperName];
-    SAs.Release = Map[rt::ExecutorSharedMemoryMapperServiceReleaseWrapperName];
+    SAs.Instance = Map[rt::sps_ci::SharedMemoryMapperInstanceName];
+    SAs.Reserve = Map[rt::sps_ci::SharedMemoryMapperReserve::Name];
+    SAs.Initialize = Map[rt::sps_ci::SharedMemoryMapperInitialize::Name];
+    SAs.Deinitialize = Map[rt::sps_ci::SharedMemoryMapperDeinitialize::Name];
+    SAs.Release = Map[rt::sps_ci::SharedMemoryMapperRelease::Name];
   }
 
   std::string TestString = "Hello, World!";


### PR DESCRIPTION
Relocate the service's interface names and SPS signatures from rt:: in OrcRTBridge into a new Shared/SPSCI/SharedMemoryMapperSPSCI.h, matching the existing SPSCI descriptor convention. Name-neutral: the symbol strings are unchanged.