### PR TITLE
[libc++][test] Remove non-functional `constexpr` in three-way comparison test for `variant`

### DIFF
--- a/libcxx/test/std/utilities/variant/variant.relops/three_way.pass.cpp
+++ b/libcxx/test/std/utilities/variant/variant.relops/three_way.pass.cpp
@@ -148,18 +148,18 @@ concept has_three_way_op = requires (T& t, U& u) { t <=> u; };
 using std::three_way_comparable;
 
 struct HasSimpleOrdering {
-  constexpr bool operator==(const HasSimpleOrdering&) const;
-  constexpr bool operator<(const HasSimpleOrdering&) const;
+  bool operator==(const HasSimpleOrdering&) const;
+  bool operator<(const HasSimpleOrdering&) const;
 };
 
 struct HasOnlySpaceship {
-  constexpr bool operator==(const HasOnlySpaceship&) const = delete;
-  constexpr std::weak_ordering operator<=>(const HasOnlySpaceship&) const;
+  bool operator==(const HasOnlySpaceship&) const = delete;
+  std::weak_ordering operator<=>(const HasOnlySpaceship&) const;
 };
 
 struct HasFullOrdering {
-  constexpr bool operator==(const HasFullOrdering&) const;
-  constexpr std::weak_ordering operator<=>(const HasFullOrdering&) const;
+  bool operator==(const HasFullOrdering&) const;
+  std::weak_ordering operator<=>(const HasFullOrdering&) const;
 };
 
 // operator<=> must resolve the return types of all its union types'


### PR DESCRIPTION
When we are just testing SFINAE and do not provide definitions for these comparison operators, or make them deleted, it is unhelpful to mark them `constexpr`.

If the implementation uses `std::compare_three_way`, which uses deduced return type in its `operator()`, in the `operator<=>` for `variant`, more things in the function body would be instantiated and detected. As a result, the `-Wundefined-inline` warning or something similar could be raised. Currently, MSVC STL is doing so.