### PR TITLE
[orc-rt] Wrap C API implementation in `extern "C" {..}` blocks

### DIFF
--- a/orc-rt/lib/bedrock/Session.cpp
+++ b/orc-rt/lib/bedrock/Session.cpp
@@ -431,15 +431,20 @@ void Session::wrapperReturn(orc_rt_SessionRef S,
 
 // --- C API Implementation ---
 
-extern "C" void orc_rt_Session_callController(
-    orc_rt_SessionRef S, orc_rt_ControllerHandlerTag T,
-    orc_rt_WrapperFunctionBuffer ArgBytes,
-    orc_rt_Session_CallControllerReturn Return, void *ReturnCtx) {
+extern "C" {
+
+void orc_rt_Session_callController(orc_rt_SessionRef S,
+                                   orc_rt_ControllerHandlerTag T,
+                                   orc_rt_WrapperFunctionBuffer ArgBytes,
+                                   orc_rt_Session_CallControllerReturn Return,
+                                   void *ReturnCtx) {
   unwrap(S)->callController(
       [S, Return, ReturnCtx](WrapperFunctionBuffer ResultBytes) {
         Return(S, ResultBytes.release(), ReturnCtx);
       },
       T, WrapperFunctionBuffer(ArgBytes));
 }
+
+} // extern "C"
 
 } // namespace orc_rt

--- a/orc-rt/lib/support/Error.cpp
+++ b/orc-rt/lib/support/Error.cpp
@@ -48,35 +48,37 @@ std::string ExceptionError::toString() const noexcept {
 
 #endif // ORC_RT_ENABLE_EXCEPTIONS
 
-extern "C" orc_rt_Error_TypeId
-orc_rt_Error_getTypeId(orc_rt_ErrorRef Err) noexcept {
+// --- C API Implementation ---
+
+extern "C" {
+
+orc_rt_Error_TypeId orc_rt_Error_getTypeId(orc_rt_ErrorRef Err) noexcept {
   assert(Err && "Err must not be null");
   return reinterpret_cast<ErrorInfoBase *>(Err)->dynamicClassID();
 }
 
-extern "C" void orc_rt_Error_consume(orc_rt_ErrorRef Err) noexcept {
+void orc_rt_Error_consume(orc_rt_ErrorRef Err) noexcept {
   consumeError(unwrap(Err));
 }
 
-extern "C" void orc_rt_Error_cantFail(orc_rt_ErrorRef Err) noexcept {
+void orc_rt_Error_cantFail(orc_rt_ErrorRef Err) noexcept {
   cantFail(unwrap(Err));
 }
 
-extern "C" char *orc_rt_Error_toString(orc_rt_ErrorRef Err) noexcept {
+char *orc_rt_Error_toString(orc_rt_ErrorRef Err) noexcept {
   return strdup(toString(unwrap(Err)).c_str());
 }
 
-extern "C" void orc_rt_Error_freeErrorMessage(char *ErrMsg) noexcept {
-  free(ErrMsg);
-}
+void orc_rt_Error_freeErrorMessage(char *ErrMsg) noexcept { free(ErrMsg); }
 
-extern "C" orc_rt_Error_TypeId orc_rt_StringError_getTypeId(void) noexcept {
+orc_rt_Error_TypeId orc_rt_StringError_getTypeId(void) noexcept {
   return StringError::classID();
 }
 
-extern "C" orc_rt_ErrorRef
-orc_rt_StringError_create(const char *ErrMsg) noexcept {
+orc_rt_ErrorRef orc_rt_StringError_create(const char *ErrMsg) noexcept {
   return wrap(make_error<StringError>(ErrMsg));
 }
+
+} // extern "C"
 
 } // namespace orc_rt

--- a/orc-rt/lib/support/Logging.cpp
+++ b/orc-rt/lib/support/Logging.cpp
@@ -27,6 +27,10 @@ static const char *LevelNames[] = {
 static_assert(std::size(LevelNames) == ORC_RT_LOG_LEVEL_COUNT,
               "LevelNames array is the wrong size");
 
+// --- C API Implementation ---
+
+extern "C" {
+
 const char *orc_rt_log_Category_getName(orc_rt_log_Category Cat) noexcept {
   if (Cat < 0 || Cat >= orc_rt_log_Category_Count)
     return nullptr;
@@ -60,3 +64,5 @@ orc_rt_log_Level orc_rt_log_Level_parse(const char *Str) noexcept {
 
   return -1;
 }
+
+} // extern "C"

--- a/orc-rt/lib/support/Logging_oslog.cpp
+++ b/orc-rt/lib/support/Logging_oslog.cpp
@@ -20,12 +20,15 @@
 
 #include <os/log.h>
 
+// --- C API Implementation ---
+
+extern "C" {
+
 // Cache for the inline accessor (declared in Logging.h). Zero-initialized, so
 // no static constructor runs; slots are filled lazily by the cold path below.
 os_log_t orc_rt_log_OSLogHandles[orc_rt_log_Category_Count];
 
-extern "C" os_log_t
-orc_rt_log_osLogHandleSlow(orc_rt_log_Category Category) noexcept {
+os_log_t orc_rt_log_osLogHandleSlow(orc_rt_log_Category Category) noexcept {
   // Category is already range-checked by the inline caller.
   //
   // ORC rt logs to the "org.llvm.orc-rt" subsystem.
@@ -43,3 +46,5 @@ orc_rt_log_osLogHandleSlow(orc_rt_log_Category Category) noexcept {
                    __ATOMIC_RELEASE);
   return Handle;
 }
+
+} // extern "C"

--- a/orc-rt/lib/support/Logging_printf.cpp
+++ b/orc-rt/lib/support/Logging_printf.cpp
@@ -85,9 +85,12 @@ constexpr size_t LogBufferSize = 1024;
 
 } // namespace
 
-extern "C" void orc_rt_log_printf(orc_rt_log_Level Level,
-                                  orc_rt_log_Category Category, const char *Fmt,
-                                  ...) noexcept {
+// --- C API Implementation ---
+
+extern "C" {
+
+void orc_rt_log_printf(orc_rt_log_Level Level, orc_rt_log_Category Category,
+                       const char *Fmt, ...) noexcept {
   if (Level < runtimeLevel())
     return;
 
@@ -120,3 +123,5 @@ extern "C" void orc_rt_log_printf(orc_rt_log_Level Level,
   // written atomically with respect to other threads logging to the same sink.
   std::fwrite(Buf, 1, Len, sink());
 }
+
+} // extern "C"


### PR DESCRIPTION
Adopt a consistent style for C API implementation: A banner comment and an `extern "C" { ... }` block around the definitions.