### PR TITLE
[InstCombine] Add select to worklist when demanded FP class adds nsz

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
@@ -3056,7 +3056,19 @@ Value *InstCombinerImpl::SimplifyDemandedUseFPClass(Instruction *I,
       }
 
       if (InferredFMF != FMF) {
+        bool AddedNSZ = !FMF.noSignedZeros() && InferredFMF.noSignedZeros();
         CI->setFastMathFlags(InferredFMF);
+        
+        // BUG FIX: If we just added the nsz (No Signed Zero) flag, the demanded 
+        // FP class for our operands has changed. If an operand is a select, 
+        // it may now be foldable into a maxnum/minnum. Push it to the worklist!
+        if (AddedNSZ) {
+          for (Use &Op : CI->operands()) {
+            if (auto *Sel = dyn_cast<SelectInst>(Op.get()))
+              Worklist.push(Sel);
+          }
+        }
+        
         return FPOp;
       }
 

--- a/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-maximum.ll
+++ b/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-maximum.ll
@@ -2192,3 +2192,24 @@ define nofpclass(snan) float @qnan_result_demands_snan_rhs(i1 %cond, float %unkn
 
 attributes #0 = { denormal_fpenv(preservesign) }
 attributes #1 = { denormal_fpenv(dynamic) }
+
+
+; nsf flag or something
+
+; Adapted from ret_always_positive_nonzero__maximum__not_zero_select_positive_or_unknown
+; in file Transforms/InstCombine/simplify-demanded-fpclass-maximum.ll
+
+define nofpclass(pinf pnorm psub) float @test_nofpclass_worklist_bug(float %unknown, float nofpclass(zero) %not.zero) {
+; CHECK-LABEL: define nofpclass(pinf psub pnorm) float @test_nofpclass_worklist_bug(
+; CHECK-SAME: float [[UNKNOWN:%.*]], float nofpclass(zero) [[NOT_ZERO:%.*]]) {
+; CHECK-NEXT:    [[ALWAYS_POSITIVE:%.*]] = call float @returns_positive()
+; CHECK-NEXT:    [[SELECT_RHS:%.*]] = call nnan nsz float @llvm.maxnum.f32(float [[ALWAYS_POSITIVE]], float [[UNKNOWN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximum.f32(float [[NOT_ZERO]], float [[SELECT_RHS]])
+; CHECK-NEXT:    ret float [[RESULT]]
+;
+  %always.positive = call float @returns_positive()
+  %cond = fcmp nnan ogt float %always.positive, %unknown
+  %select.rhs = select i1 %cond, float %always.positive, float %unknown
+  %result = call float @llvm.maximum.f32(float %not.zero, float %select.rhs)
+  ret float %result
+}


### PR DESCRIPTION
When InstCombine simplifies a demanded FP class and applies the nsz fast-math flag to an instruction, it previously failed to push the instruction's operands back onto the worklist.

If one of those operands was a select representing a hand-rolled min/max, this bookkeeping failure caused the select to be optimized during the fixpoint verification pass, resulting in a fatal compiler crash.

This patch ensures that when nsz is inferred and added, any select operands are explicitly pushed to the worklist for re-evaluation.

Fixes #222343