### PR TITLE
[mlir][LLVM] Fix crash combining nested pointer data layouts

### DIFF
--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMTypes.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMTypes.cpp
@@ -419,8 +419,8 @@ bool LLVMPointerType::areCompatible(
       });
     }
     if (it != oldLayout.end()) {
-      size = *extractPointerSpecValue(*it, PtrDLEntryPos::Size);
-      abi = *extractPointerSpecValue(*it, PtrDLEntryPos::Abi);
+      size = *extractPointerSpecValue(it->getValue(), PtrDLEntryPos::Size);
+      abi = *extractPointerSpecValue(it->getValue(), PtrDLEntryPos::Abi);
     }
 
     Attribute newSpec = llvm::cast<DenseIntElementsAttr>(newEntry.getValue());

--- a/mlir/test/Dialect/LLVMIR/layout.mlir
+++ b/mlir/test/Dialect/LLVMIR/layout.mlir
@@ -173,6 +173,17 @@ module attributes { dlti.dl_spec = #dlti.dl_spec<
 
 // -----
 
+module attributes { dlti.dl_spec = #dlti.dl_spec<
+  #dlti.dl_entry<!llvm.ptr, dense<64> : vector<4xi64>>
+>} {
+  module attributes { dlti.dl_spec = #dlti.dl_spec<
+    #dlti.dl_entry<!llvm.ptr, dense<64> : vector<4xi64>>
+  >} {
+  }
+}
+
+// -----
+
 module {
     // CHECK: @no_spec
     func.func @no_spec() {


### PR DESCRIPTION
While investigating #222356, an LLVM pointer data layout compatibility crash was found when combining nested layouts.

`LLVMPointerType::areCompatible()` passed the `DataLayoutEntryInterface` itself to `extractPointerSpecValue()`, even though that helper expects the entry value as a `DenseIntElementsAttr`.

Use `getValue()` for the enclosing pointer entry, matching the handling of the nested entry and allowing compatible pointer layouts to be combined without asserting.

The separate builtin data layout combination issue found during the same investigation is handled independently.

Related to #222356.

AI-assisted tooling was used during development and validation.