### PR TITLE
[InstCombine] Fold add-select-srem pattern to bitwise AND for power-of-2

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
@@ -1603,36 +1603,27 @@ Instruction *InstCombinerImpl::foldDivCeil(BinaryOperator &I) {
 
 /// Fold: add (select (icmp slt (srem X, N), 0), N, 0), (srem X, N)
 /// to: and X, (N - 1)
+/// when N is a power of 2 (checked per-element for vectors).
 static Instruction *foldAddwithSRemSelect(BinaryOperator &Add,
                                           InstCombiner::BuilderTy &Builder,
                                           const SimplifyQuery &SQ) {
-  Value *Sel, *Rem;
-  if (!match(&Add, m_c_Add(m_Value(Sel), m_Value(Rem))))
-    return nullptr;
-
-  Value *X, *Modulus;
-  if (!match(Rem, m_SRem(m_Value(X), m_Value(Modulus))))
-    return nullptr;
-
-  Value *Cmp, *TrueVal, *FalseVal;
-  if (!match(Sel, m_Select(m_Value(Cmp), m_Value(TrueVal), m_Value(FalseVal))))
-    return nullptr;
-
+  Value *Sel, *Rem, *X, *Modulus, *Cmp, *TrueVal, *FalseVal, *CmpLHS;
   CmpPredicate Pred;
-  Value *CmpLHS;
-  if (!match(Cmp, m_ICmp(Pred, m_Value(CmpLHS), m_Zero())) ||
-      Pred != ICmpInst::ICMP_SLT || CmpLHS != Rem)
-    return nullptr;
-
-  if (TrueVal != Modulus || !match(FalseVal, m_Zero()))
-    return nullptr;
-
-  if (!isKnownToBeAPowerOfTwo(Modulus, false, SQ))
-    return nullptr;
-
-  Value *ModulusMinusOne =
-      Builder.CreateAdd(Modulus, Constant::getAllOnesValue(Modulus->getType()));
-  return BinaryOperator::CreateAnd(X, ModulusMinusOne);
+  
+  if (match(&Add, m_c_Add(m_Value(Sel), m_Value(Rem))) &&
+      match(Rem, m_SRem(m_Value(X), m_Value(Modulus))) &&
+      match(Sel, m_Select(m_Value(Cmp), m_Value(TrueVal), m_Value(FalseVal))) &&
+      match(Cmp, m_ICmp(Pred, m_Value(CmpLHS), m_Zero())) &&
+      Pred == ICmpInst::ICMP_SLT && CmpLHS == Rem &&
+      TrueVal == Modulus && match(FalseVal, m_Zero()) &&
+      isKnownToBeAPowerOfTwo(Modulus, false, SQ)) {
+    
+    Value *ModulusMinusOne =
+        Builder.CreateAdd(Modulus, Constant::getAllOnesValue(Modulus->getType()));
+    return BinaryOperator::CreateAnd(X, ModulusMinusOne);
+  }
+  
+  return nullptr;
 }
 
 Instruction *InstCombinerImpl::visitAdd(BinaryOperator &I) {

--- a/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
@@ -1609,20 +1609,19 @@ static Instruction *foldAddwithSRemSelect(BinaryOperator &Add,
                                           const SimplifyQuery &SQ) {
   Value *Sel, *Rem, *X, *Modulus, *Cmp, *TrueVal, *FalseVal, *CmpLHS;
   CmpPredicate Pred;
-  
+
   if (match(&Add, m_c_Add(m_Value(Sel), m_Value(Rem))) &&
       match(Rem, m_SRem(m_Value(X), m_Value(Modulus))) &&
       match(Sel, m_Select(m_Value(Cmp), m_Value(TrueVal), m_Value(FalseVal))) &&
       match(Cmp, m_ICmp(Pred, m_Value(CmpLHS), m_Zero())) &&
-      Pred == ICmpInst::ICMP_SLT && CmpLHS == Rem &&
-      TrueVal == Modulus && match(FalseVal, m_Zero()) &&
-      isKnownToBeAPowerOfTwo(Modulus, false, SQ)) {
-    
-    Value *ModulusMinusOne =
-        Builder.CreateAdd(Modulus, Constant::getAllOnesValue(Modulus->getType()));
+      Pred == ICmpInst::ICMP_SLT && CmpLHS == Rem && TrueVal == Modulus &&
+      match(FalseVal, m_Zero()) && isKnownToBeAPowerOfTwo(Modulus, false, SQ)) {
+
+    Value *ModulusMinusOne = Builder.CreateAdd(
+        Modulus, Constant::getAllOnesValue(Modulus->getType()));
     return BinaryOperator::CreateAnd(X, ModulusMinusOne);
   }
-  
+
   return nullptr;
 }
 

--- a/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
@@ -1601,6 +1601,40 @@ Instruction *InstCombinerImpl::foldDivCeil(BinaryOperator &I) {
   return BinaryOperator::CreateUDiv(NUWAdd, Y);
 }
 
+/// Fold: add (select (icmp slt (srem X, N), 0), N, 0), (srem X, N)
+/// to: and X, (N - 1)
+static Instruction *foldAddwithSRemSelect(BinaryOperator &Add,
+                                          InstCombiner::BuilderTy &Builder,
+                                          const SimplifyQuery &SQ) {
+  Value *Sel, *Rem;
+  if (!match(&Add, m_c_Add(m_Value(Sel), m_Value(Rem))))
+    return nullptr;
+
+  Value *X, *Modulus;
+  if (!match(Rem, m_SRem(m_Value(X), m_Value(Modulus))))
+    return nullptr;
+
+  Value *Cmp, *TrueVal, *FalseVal;
+  if (!match(Sel, m_Select(m_Value(Cmp), m_Value(TrueVal), m_Value(FalseVal))))
+    return nullptr;
+
+  CmpPredicate Pred;
+  Value *CmpLHS;
+  if (!match(Cmp, m_ICmp(Pred, m_Value(CmpLHS), m_Zero())) ||
+      Pred != ICmpInst::ICMP_SLT || CmpLHS != Rem)
+    return nullptr;
+
+  if (TrueVal != Modulus || !match(FalseVal, m_Zero()))
+    return nullptr;
+
+  if (!isKnownToBeAPowerOfTwo(Modulus, false, SQ))
+    return nullptr;
+
+  Value *ModulusMinusOne =
+      Builder.CreateAdd(Modulus, Constant::getAllOnesValue(Modulus->getType()));
+  return BinaryOperator::CreateAnd(X, ModulusMinusOne);
+}
+
 Instruction *InstCombinerImpl::visitAdd(BinaryOperator &I) {
   if (Value *V = simplifyAddInst(I.getOperand(0), I.getOperand(1),
                                  I.hasNoSignedWrap(), I.hasNoUnsignedWrap(),
@@ -1630,6 +1664,9 @@ Instruction *InstCombinerImpl::visitAdd(BinaryOperator &I) {
     return X;
 
   if (Instruction *X = foldNoWrapAdd(I, Builder))
+    return X;
+
+  if (Instruction *X = foldAddwithSRemSelect(I, Builder, SQ))
     return X;
 
   if (Instruction *R = foldBinOpShiftWithShift(I))

--- a/llvm/test/Transforms/InstCombine/modulo.ll
+++ b/llvm/test/Transforms/InstCombine/modulo.ll
@@ -136,10 +136,7 @@ define <2 x i32> @modulo32_vec(<2 x i32> %x) {
 
 define <2 x i32> @modulo16_32_vec(<2 x i32> %x) {
 ; CHECK-LABEL: @modulo16_32_vec(
-; CHECK-NEXT:    [[REM_I:%.*]] = srem <2 x i32> [[X:%.*]], <i32 16, i32 32>
-; CHECK-NEXT:    [[CMP_I:%.*]] = icmp slt <2 x i32> [[REM_I]], zeroinitializer
-; CHECK-NEXT:    [[ADD_I:%.*]] = select <2 x i1> [[CMP_I]], <2 x i32> <i32 16, i32 32>, <2 x i32> zeroinitializer
-; CHECK-NEXT:    [[RET_I:%.*]] = add nsw <2 x i32> [[ADD_I]], [[REM_I]]
+; CHECK-NEXT:    [[RET_I:%.*]] = and <2 x i32> [[X:%.*]], <i32 15, i32 31>
 ; CHECK-NEXT:    ret <2 x i32> [[RET_I]]
 ;
   %rem.i = srem <2 x i32> %x, <i32 16, i32 32>


### PR DESCRIPTION
Fold `add (select (icmp slt (srem X, N), 0), N, 0), (srem X, N)`  into `and X, (N-1)` when N is a power of 2. This can handle both scalar and non-splat vector constants.

alive2: https://alive2.llvm.org/ce/z/qmo9k4
            https://alive2.llvm.org/ce/z/tiWq-J
