### PR TITLE
[mlir][AMDGPU] Split the dialect declaration (NFC)

### DIFF
--- a/mlir/include/mlir/Dialect/AMDGPU/IR/AMDGPUDialect.h
+++ b/mlir/include/mlir/Dialect/AMDGPU/IR/AMDGPUDialect.h
@@ -15,6 +15,7 @@
 #define MLIR_DIALECT_AMDGPU_IR_AMDGPUDIALECT_H_
 
 #include "mlir/Bytecode/BytecodeOpInterface.h"
+#include "mlir/Dialect/AMDGPU/IR/AMDGPUDialectDecl.h"
 #include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Dialect.h"
@@ -22,8 +23,6 @@
 #include "mlir/Interfaces/InferTypeOpInterface.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "mlir/Interfaces/ViewLikeInterface.h"
-
-#include "mlir/Dialect/AMDGPU/IR/AMDGPUDialect.h.inc"
 
 #include "mlir/Dialect/AMDGPU/IR/AMDGPUEnums.h"
 

--- a/mlir/include/mlir/Dialect/AMDGPU/IR/AMDGPUDialectDecl.h
+++ b/mlir/include/mlir/Dialect/AMDGPU/IR/AMDGPUDialectDecl.h
@@ -1,0 +1,16 @@
+//===- AMDGPUDialectDecl.h - AMDGPU dialect declaration --------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_DIALECT_AMDGPU_IR_AMDGPUDIALECTDECL_H
+#define MLIR_DIALECT_AMDGPU_IR_AMDGPUDIALECTDECL_H
+
+#include "mlir/IR/Dialect.h"
+
+#include "mlir/Dialect/AMDGPU/IR/AMDGPUDialect.h.inc"
+
+#endif // MLIR_DIALECT_AMDGPU_IR_AMDGPUDIALECTDECL_H

--- a/mlir/lib/RegisterAllDialects.cpp
+++ b/mlir/lib/RegisterAllDialects.cpp
@@ -13,7 +13,7 @@
 
 #include "mlir/InitAllDialects.h"
 
-#include "mlir/Dialect/AMDGPU/IR/AMDGPUDialect.h"
+#include "mlir/Dialect/AMDGPU/IR/AMDGPUDialectDecl.h"
 #include "mlir/Dialect/AMDGPU/Transforms/MemoryAccessOpInterfacesImpl.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Affine/IR/ValueBoundsOpInterfaceImpl.h"


### PR DESCRIPTION
Introduce a self-contained dialect declaration so RegisterAllDialects does not need the generated AMDGPU operation umbrella.

Across five controlled rebuilds of the affected TU, median instructions fell from 71.757B to 70.331B (-1.987%) and median wall time fell from 11.01s to 10.77s (-2.180%).

Assisted-by: Codex