### PR TITLE
[SelectionDAG] Remove dead accessors, variables, and init parameters (NFC)

### DIFF
--- a/llvm/include/llvm/CodeGen/SelectionDAG.h
+++ b/llvm/include/llvm/CodeGen/SelectionDAG.h
@@ -79,9 +79,7 @@ struct KnownBits;
 class LLVMContext;
 class MachineBasicBlock;
 class MachineConstantPoolValue;
-class MachineModuleInfo;
 class MCSymbol;
-class OptimizationRemarkEmitter;
 class ProfileSummaryInfo;
 class SDDbgValue;
 class SDDbgOperand;
@@ -231,26 +229,19 @@ class SelectionDAG {
   const SelectionDAGTargetInfo *TSI = nullptr;
   const TargetLowering *TLI = nullptr;
   const TargetLibraryInfo *LibInfo = nullptr;
-  const RTLIB::RuntimeLibcallsInfo *RuntimeLibcallInfo = nullptr;
   const LibcallLoweringInfo *Libcalls = nullptr;
 
   const FunctionVarLocs *FnVarLocs = nullptr;
   MachineFunction *MF;
   MachineFunctionAnalysisManager *MFAM = nullptr;
-  Pass *SDAGISelPass = nullptr;
   LLVMContext *Context;
   CodeGenOptLevel OptLevel;
 
   UniformityInfo *UA = nullptr;
   FunctionLoweringInfo * FLI = nullptr;
 
-  /// The function-level optimization remark emitter.  Used to emit remarks
-  /// whenever manipulating the DAG.
-  OptimizationRemarkEmitter *ORE;
-
   ProfileSummaryInfo *PSI = nullptr;
   BlockFrequencyInfo *BFI = nullptr;
-  MachineModuleInfo *MMI = nullptr;
 
   /// Uniquing of VT lists.  Each key aliases the EVT array that the returned
   /// SDVTList points at, allocated from \p Allocator.
@@ -488,21 +479,19 @@ public:
   LLVM_ABI ~SelectionDAG();
 
   /// Prepare this SelectionDAG to process code in the given MachineFunction.
-  LLVM_ABI void init(MachineFunction &NewMF, OptimizationRemarkEmitter &NewORE,
-                     Pass *PassPtr, const TargetLibraryInfo *LibraryInfo,
+  LLVM_ABI void init(MachineFunction &NewMF,
+                     const TargetLibraryInfo *LibraryInfo,
                      const LibcallLoweringInfo *LibcallsInfo,
                      UniformityInfo *UA, ProfileSummaryInfo *PSIin,
-                     BlockFrequencyInfo *BFIin, MachineModuleInfo &MMI,
+                     BlockFrequencyInfo *BFIin,
                      FunctionVarLocs const *FnVarLocs);
 
-  void init(MachineFunction &NewMF, OptimizationRemarkEmitter &NewORE,
-            MachineFunctionAnalysisManager &AM,
+  void init(MachineFunction &NewMF, MachineFunctionAnalysisManager &AM,
             const TargetLibraryInfo *LibraryInfo,
             const LibcallLoweringInfo *LibcallsInfo, UniformityInfo *UA,
             ProfileSummaryInfo *PSIin, BlockFrequencyInfo *BFIin,
-            MachineModuleInfo &MMI, FunctionVarLocs const *FnVarLocs) {
-    init(NewMF, NewORE, nullptr, LibraryInfo, LibcallsInfo, UA, PSIin, BFIin,
-         MMI, FnVarLocs);
+            FunctionVarLocs const *FnVarLocs) {
+    init(NewMF, LibraryInfo, LibcallsInfo, UA, PSIin, BFIin, FnVarLocs);
     MFAM = &AM;
   }
 
@@ -515,7 +504,6 @@ public:
   LLVM_ABI void clear();
 
   MachineFunction &getMachineFunction() const { return *MF; }
-  const Pass *getPass() const { return SDAGISelPass; }
   MachineFunctionAnalysisManager *getMFAM() { return MFAM; }
 
   bool hasSwiftErrorArg() const;
@@ -532,20 +520,14 @@ public:
 
   const LibcallLoweringInfo &getLibcalls() const { return *Libcalls; }
 
-  const RTLIB::RuntimeLibcallsInfo &getRuntimeLibcallInfo() const {
-    return *RuntimeLibcallInfo;
-  }
-
   const SelectionDAGTargetInfo &getSelectionDAGInfo() const { return *TSI; }
   const UniformityInfo *getUniformityInfo() const { return UA; }
   /// Returns the result of the AssignmentTrackingAnalysis pass if it's
   /// available, otherwise return nullptr.
   const FunctionVarLocs *getFunctionVarLocs() const { return FnVarLocs; }
   LLVMContext *getContext() const { return Context; }
-  OptimizationRemarkEmitter &getORE() const { return *ORE; }
   ProfileSummaryInfo *getPSI() const { return PSI; }
   BlockFrequencyInfo *getBFI() const { return BFI; }
-  MachineModuleInfo *getMMI() const { return MMI; }
 
   FlagInserter *getFlagInserter() { return Inserter; }
   void setFlagInserter(FlagInserter *FI) { Inserter = FI; }

--- a/llvm/include/llvm/CodeGen/SelectionDAGISel.h
+++ b/llvm/include/llvm/CodeGen/SelectionDAGISel.h
@@ -51,7 +51,6 @@ public:
   std::unique_ptr<FunctionLoweringInfo> FuncInfo;
   std::unique_ptr<SwiftErrorValueTracking> SwiftError;
   MachineFunction *MF;
-  MachineModuleInfo *MMI;
   MachineRegisterInfo *RegInfo;
   SelectionDAG *CurDAG;
   std::unique_ptr<SelectionDAGBuilder> SDB;

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -1458,15 +1458,12 @@ SelectionDAG::SelectionDAG(const TargetMachine &tm, CodeGenOptLevel OL)
 }
 
 void SelectionDAG::init(MachineFunction &NewMF,
-                        OptimizationRemarkEmitter &NewORE, Pass *PassPtr,
                         const TargetLibraryInfo *LibraryInfo,
                         const LibcallLoweringInfo *LibcallsInfo,
                         UniformityInfo *NewUA, ProfileSummaryInfo *PSIin,
-                        BlockFrequencyInfo *BFIin, MachineModuleInfo &MMIin,
+                        BlockFrequencyInfo *BFIin,
                         FunctionVarLocs const *VarLocs) {
   MF = &NewMF;
-  SDAGISelPass = PassPtr;
-  ORE = &NewORE;
   TLI = getSubtarget().getTargetLowering();
   TSI = getSubtarget().getSelectionDAGInfo();
   LibInfo = LibraryInfo;
@@ -1475,7 +1472,6 @@ void SelectionDAG::init(MachineFunction &NewMF,
   UA = NewUA;
   PSI = PSIin;
   BFI = BFIin;
-  MMI = &MMIin;
   FnVarLocs = VarLocs;
 }
 

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp
@@ -499,8 +499,6 @@ void SelectionDAGISel::initializeAnalysisResults(
     FnVarLocs = &FAM.getResult<DebugAssignmentTrackingAnalysis>(Fn);
 
   auto *UA = FAM.getCachedResult<UniformityInfoAnalysis>(Fn);
-  MachineModuleInfo &MMI =
-      MAMP.getCachedResult<MachineModuleAnalysis>(*Fn.getParent())->getMMI();
 
   const ModuleLibcallLoweringInfo *LibcallResult =
       MAMP.getCachedResult<LibcallLoweringModuleAnalysis>(*Fn.getParent());
@@ -510,8 +508,7 @@ void SelectionDAGISel::initializeAnalysisResults(
   }
 
   LibcallLowering = &getLibcallLowering(*LibcallResult, Subtarget);
-  CurDAG->init(*MF, *ORE, MFAM, LibInfo, LibcallLowering, UA, PSI, BFI, MMI,
-               FnVarLocs);
+  CurDAG->init(*MF, MFAM, LibInfo, LibcallLowering, UA, PSI, BFI, FnVarLocs);
 
   // Now get the optional analyzes if we want to.
   // This is based on the possibly changed OptLevel (after optnone is taken
@@ -569,15 +566,11 @@ void SelectionDAGISel::initializeAnalysisResults(MachineFunctionPass &MFP) {
   if (auto *UAPass = MFP.getAnalysisIfAvailable<UniformityInfoWrapperPass>())
     UA = &UAPass->getUniformityInfo();
 
-  MachineModuleInfo &MMI =
-      MFP.getAnalysis<MachineModuleInfoWrapperPass>().getMMI();
-
   LibcallLowering =
       &MFP.getAnalysis<LibcallLoweringInfoWrapper>().getLibcallLowering(
           *Fn.getParent(), Subtarget);
 
-  CurDAG->init(*MF, *ORE, &MFP, LibInfo, LibcallLowering, UA, PSI, BFI, MMI,
-               FnVarLocs);
+  CurDAG->init(*MF, LibInfo, LibcallLowering, UA, PSI, BFI, FnVarLocs);
 
   // Now get the optional analyzes if we want to.
   // This is based on the possibly changed OptLevel (after optnone is taken

--- a/llvm/unittests/CodeGen/SelectionDAGTestBase.h
+++ b/llvm/unittests/CodeGen/SelectionDAGTestBase.h
@@ -6,7 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "llvm/Analysis/OptimizationRemarkEmitter.h"
 #include "llvm/AsmParser/Parser.h"
 #include "llvm/CodeGen/MachineModuleInfo.h"
 #include "llvm/CodeGen/TargetLowering.h"
@@ -62,8 +61,8 @@ protected:
     AliasedG = M->getNamedAlias("g_alias");
     ASSERT_TRUE(AliasedG && "Could not get alias g_alias!");
 
-    // MMI and ORE must outlive SetUp(): MachineFunction stores MMI's MCContext
-    // by reference and SelectionDAG::init keeps raw pointers to both.
+    // MMI must outlive SetUp(): MachineFunction stores MMI's MCContext
+    // by reference.
     MMI = std::make_unique<MachineModuleInfo>(TM.get());
 
     MF = std::make_unique<MachineFunction>(*F, *TM, *TM->getSubtargetImpl(*F),
@@ -72,9 +71,7 @@ protected:
     DAG = std::make_unique<SelectionDAG>(*TM, CodeGenOptLevel::None);
     if (!DAG)
       reportFatalUsageError("Failed to create SelectionDAG?");
-    ORE = std::make_unique<OptimizationRemarkEmitter>(F);
-    DAG->init(*MF, *ORE, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
-              *MMI, nullptr);
+    DAG->init(*MF, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
   }
 
   TargetLoweringBase::LegalizeTypeAction getTypeAction(EVT VT) {
@@ -91,10 +88,8 @@ protected:
   Function *F;
   GlobalVariable *G;
   GlobalAlias *AliasedG;
-  // MMI and ORE must be declared before MF and DAG so they are destroyed
-  // after them.
+  // MMI must be declared before MF and DAG so it is destroyed after them.
   std::unique_ptr<MachineModuleInfo> MMI;
-  std::unique_ptr<OptimizationRemarkEmitter> ORE;
   std::unique_ptr<MachineFunction> MF;
   std::unique_ptr<SelectionDAG> DAG;
 };

--- a/llvm/unittests/Target/AArch64/AArch64SelectionDAGTest.cpp
+++ b/llvm/unittests/Target/AArch64/AArch64SelectionDAGTest.cpp
@@ -7,7 +7,6 @@
 
 #include "AArch64SelectionDAGInfo.h"
 #include "llvm/Analysis/MemoryLocation.h"
-#include "llvm/Analysis/OptimizationRemarkEmitter.h"
 #include "llvm/AsmParser/Parser.h"
 #include "llvm/CodeGen/MachineModuleInfo.h"
 #include "llvm/CodeGen/SelectionDAG.h"
@@ -64,9 +63,7 @@ protected:
     DAG = std::make_unique<SelectionDAG>(*TM, CodeGenOptLevel::None);
     if (!DAG)
       report_fatal_error("DAG?");
-    OptimizationRemarkEmitter ORE(F);
-    DAG->init(*MF, ORE, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
-              MMI, nullptr);
+    DAG->init(*MF, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
   }
 
   TargetLoweringBase::LegalizeTypeAction getTypeAction(EVT VT) {

--- a/llvm/unittests/Target/ARM/ARMSelectionDAGTest.cpp
+++ b/llvm/unittests/Target/ARM/ARMSelectionDAGTest.cpp
@@ -7,7 +7,6 @@
 
 #include "ARMSelectionDAGInfo.h"
 #include "MCTargetDesc/ARMAddressingModes.h"
-#include "llvm/Analysis/OptimizationRemarkEmitter.h"
 #include "llvm/AsmParser/Parser.h"
 #include "llvm/CodeGen/MachineModuleInfo.h"
 #include "llvm/CodeGen/SelectionDAG.h"
@@ -65,10 +64,9 @@ protected:
     if (!DAG)
       report_fatal_error("SelectionDAG allocation failed");
 
-    OptimizationRemarkEmitter ORE(F);
-    DAG->init(*MF, ORE, /*LibInfo=*/nullptr, /*LibcallsInfo=*/nullptr,
+    DAG->init(*MF, /*LibInfo=*/nullptr, /*LibcallsInfo=*/nullptr,
               /*AA=*/nullptr,
-              /*AC=*/nullptr, /*MDT=*/nullptr, /*MSDT=*/nullptr, MMI, nullptr);
+              /*AC=*/nullptr, /*MDT=*/nullptr, /*MSDT=*/nullptr);
   }
 
   TargetLoweringBase::LegalizeTypeAction getTypeAction(EVT VT) {

--- a/llvm/unittests/Target/RISCV/RISCVSelectionDAGTest.cpp
+++ b/llvm/unittests/Target/RISCV/RISCVSelectionDAGTest.cpp
@@ -7,7 +7,6 @@
 
 #include "RISCVISelLowering.h"
 #include "RISCVSelectionDAGInfo.h"
-#include "llvm/Analysis/OptimizationRemarkEmitter.h"
 #include "llvm/AsmParser/Parser.h"
 #include "llvm/CodeGen/MachineModuleInfo.h"
 #include "llvm/CodeGen/SelectionDAG.h"
@@ -65,10 +64,9 @@ protected:
     if (!DAG)
       report_fatal_error("SelectionDAG allocation failed");
 
-    OptimizationRemarkEmitter ORE(F);
-    DAG->init(*MF, ORE, /*LibInfo=*/nullptr, /*LibcallsInfo=*/nullptr,
+    DAG->init(*MF, /*LibInfo=*/nullptr, /*LibcallsInfo=*/nullptr,
               /*AA=*/nullptr,
-              /*AC=*/nullptr, /*MDT=*/nullptr, /*MSDT=*/nullptr, MMI, nullptr);
+              /*AC=*/nullptr, /*MDT=*/nullptr, /*MSDT=*/nullptr);
   }
 
   LLVMContext Context;

--- a/llvm/unittests/Target/X86/X86SelectionDAGTest.cpp
+++ b/llvm/unittests/Target/X86/X86SelectionDAGTest.cpp
@@ -7,7 +7,6 @@
 
 #include "X86ISelLowering.h"
 #include "llvm/Analysis/MemoryLocation.h"
-#include "llvm/Analysis/OptimizationRemarkEmitter.h"
 #include "llvm/AsmParser/Parser.h"
 #include "llvm/CodeGen/MachineModuleInfo.h"
 #include "llvm/CodeGen/SelectionDAG.h"
@@ -63,9 +62,7 @@ protected:
     DAG = std::make_unique<SelectionDAG>(*TM, CodeGenOptLevel::None);
     if (!DAG)
       report_fatal_error("DAG?");
-    OptimizationRemarkEmitter ORE(F);
-    DAG->init(*MF, ORE, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
-              MMI, nullptr);
+    DAG->init(*MF, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
   }
 
   LLVMContext Context;


### PR DESCRIPTION
This patch removes several dead accessors in SelectionDAG.  It also
adjusts init() and its callers to remove transitively dead variables
and parameters.

SDAGISelPass / getPass:
The last use of SelectionDAG::getPass was removed on February 23, 2026
in commit 9e6a6be8a84f32072e40b27e146fa9076560274e.

RuntimeLibcallInfo / getRuntimeLibcallInfo:
Introduced on January 16, 2026 in commit
01e6245af481dac4604e8a25be6bec0dbe36f99d without any callers, and never
initialized or assigned anywhere.

ORE / getORE:
Introduced on March 30, 2017 in commit
6dd6082472d11b1e1af21e4e4e0789e49de56537 without any callers
for getORE in or out of tree.

MMI / getMMI:
The last use of SelectionDAG::getMMI was removed on July 26, 2024 in
commit 6f83a031e452bb33c0ee23b8c5c4dee97ce2bf52.

Assisted-by: Antigravity
