### PR TITLE
[mlir][DLTI] Handle builtin types when combining data layouts

### DIFF
--- a/mlir/lib/Dialect/DLTI/DLTI.cpp
+++ b/mlir/lib/Dialect/DLTI/DLTI.cpp
@@ -288,6 +288,44 @@ overwriteDuplicateEntries(SmallVectorImpl<DataLayoutEntryInterface> &oldEntries,
   }
 }
 
+static bool
+areBuiltinDataLayoutEntriesCompatible(DataLayoutEntryListRef oldEntries,
+                                      DataLayoutEntryListRef newEntries) {
+  for (DataLayoutEntryInterface newEntry : newEntries) {
+    const auto *oldEntry =
+        llvm::find_if(oldEntries, [&](DataLayoutEntryInterface entry) {
+          return entry.getKey() == newEntry.getKey();
+        });
+    if (oldEntry == oldEntries.end())
+      continue;
+
+    Type type = cast<Type>(newEntry.getKey());
+    if (isa<IndexType>(type)) {
+      uint64_t oldBitwidth =
+          cast<IntegerAttr>(oldEntry->getValue()).getValue().getZExtValue();
+      uint64_t newBitwidth =
+          cast<IntegerAttr>(newEntry.getValue()).getValue().getZExtValue();
+      if (oldBitwidth != newBitwidth)
+        return false;
+      continue;
+    }
+
+    assert(type.isIntOrFloat() &&
+           "unexpected data layout entry for unsupported built-in type");
+    auto oldValues =
+        cast<DenseIntElementsAttr>(oldEntry->getValue()).getValues<uint64_t>();
+    auto newValues =
+        cast<DenseIntElementsAttr>(newEntry.getValue()).getValues<uint64_t>();
+    uint64_t oldAbi = *oldValues.begin();
+    uint64_t newAbi = *newValues.begin();
+    if (oldAbi == newAbi)
+      continue;
+    if (oldAbi < newAbi || newAbi == 0 || oldAbi % newAbi != 0)
+      return false;
+  }
+  return true;
+}
+
 /// Combines a data layout spec into the given lists of entries organized by
 /// type class and identifier, overwriting them if necessary. Fails to combine
 /// if the two entries with identical keys are not compatible.
@@ -333,16 +371,20 @@ static LogicalResult combineOneSpec(
     }
 
     Type typeSample = cast<Type>(kvp.second.front().getKey());
-    assert(&typeSample.getDialect() !=
-               typeSample.getContext()->getLoadedDialect<BuiltinDialect>() &&
-           "unexpected data layout entry for built-in type");
-
-    auto interface = cast<DataLayoutTypeInterface>(typeSample);
-    // TODO: Revisit this method and call once
-    // https://github.com/llvm/llvm-project/issues/130321 gets resolved.
-    if (!interface.areCompatible(entriesForType.lookup(kvp.first), kvp.second,
-                                 spec, entriesForID))
-      return failure();
+    if (isa<BuiltinDialect>(&typeSample.getDialect())) {
+      assert((isa<IndexType>(typeSample) || typeSample.isIntOrFloat()) &&
+             "unexpected data layout entry for unsupported built-in type");
+      if (!areBuiltinDataLayoutEntriesCompatible(
+              entriesForType.lookup(kvp.first), kvp.second))
+        return failure();
+    } else {
+      auto interface = cast<DataLayoutTypeInterface>(typeSample);
+      // TODO: Revisit this method and call once
+      // https://github.com/llvm/llvm-project/issues/130321 gets resolved.
+      if (!interface.areCompatible(entriesForType.lookup(kvp.first), kvp.second,
+                                   spec, entriesForID))
+        return failure();
+    }
 
     overwriteDuplicateEntries(entriesForType[kvp.first], kvp.second);
   }

--- a/mlir/test/Dialect/DLTI/invalid.mlir
+++ b/mlir/test/Dialect/DLTI/invalid.mlir
@@ -111,6 +111,32 @@ module attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<"unknown.unknown
 
 // -----
 
+// expected-note@below {{enclosing op with data layout}}
+module attributes { dlti.dl_spec = #dlti.dl_spec<
+  i32 = dense<32> : vector<2xi64>
+>} {
+  // expected-error@below {{data layout does not combine with layouts of enclosing ops}}
+  module attributes { dlti.dl_spec = #dlti.dl_spec<
+    i32 = dense<64> : vector<2xi64>
+  >} {
+  }
+}
+
+// -----
+
+// expected-note@below {{enclosing op with data layout}}
+module attributes { dlti.dl_spec = #dlti.dl_spec<
+  index = 32
+>} {
+  // expected-error@below {{data layout does not combine with layouts of enclosing ops}}
+  module attributes { dlti.dl_spec = #dlti.dl_spec<
+    index = 64
+  >} {
+  }
+}
+
+// -----
+
 // expected-error@below {{'dlti.target_system_spec' is expected to be a #dlti.target_system_spec attribute}}
 "test.unknown_op"() { dlti.target_system_spec = 42 } : () -> ()
 

--- a/mlir/test/Dialect/DLTI/valid.mlir
+++ b/mlir/test/Dialect/DLTI/valid.mlir
@@ -1,4 +1,5 @@
 // RUN: mlir-opt -split-input-file %s | FileCheck %s
+// RUN: mlir-opt -split-input-file --test-data-layout-query %s | FileCheck %s --check-prefix=BUILTIN
 
 
 // CHECK:      module attributes {
@@ -252,3 +253,90 @@ module attributes {
 // CHECK: }) {dlti.map = #dlti.map<i32 = 42 : i64>}
 "test.op_with_dlti_map"() ({
 }) { dlti.map = #dlti.map<#dlti.dl_entry<i32, 42>> } : () -> ()
+
+// -----
+
+// BUILTIN-LABEL: module @builtin_integer_entries
+module @builtin_integer_entries attributes { dlti.dl_spec = #dlti.dl_spec<
+  i32 = dense<32> : vector<2xi64>
+>} {
+  func.func @query() {
+    "test.op_with_data_layout"() ({
+        // BUILTIN: alignment = 4
+        "test.data_layout_query"() : () -> i32
+        // BUILTIN: alignment = 8
+        "test.data_layout_query"() : () -> i64
+        "test.maybe_terminator"() : () -> ()
+      }) { dlti.dl_spec = #dlti.dl_spec<
+        i32 = dense<32> : vector<2xi64>,
+        i64 = dense<64> : vector<2xi64>
+      >} : () -> ()
+    return
+  }
+}
+
+// -----
+
+// BUILTIN-LABEL: module @builtin_integer_compatible_abi
+module @builtin_integer_compatible_abi attributes { dlti.dl_spec = #dlti.dl_spec<
+  i32 = dense<64> : vector<2xi64>
+>} {
+  func.func @query() {
+    "test.op_with_data_layout"() ({
+      // BUILTIN: alignment = 4
+      "test.data_layout_query"() : () -> i32
+      "test.maybe_terminator"() : () -> ()
+    }) { dlti.dl_spec = #dlti.dl_spec<
+      i32 = dense<32> : vector<2xi64>
+    >} : () -> ()
+    return
+  }
+}
+
+// -----
+
+// BUILTIN-LABEL: module @builtin_index_entry
+module @builtin_index_entry attributes { dlti.dl_spec = #dlti.dl_spec<
+  index = 32
+>} {
+  func.func @query() {
+    "test.op_with_data_layout"() ({
+      // BUILTIN: bitsize = 32
+      // BUILTIN: index = 32
+      "test.data_layout_query"() : () -> index
+      "test.maybe_terminator"() : () -> ()
+    }) { dlti.dl_spec = #dlti.dl_spec<
+      index = 32
+    >} : () -> ()
+    return
+  }
+}
+
+// -----
+
+module attributes { dlti.dl_spec = #dlti.dl_spec<
+  i32 = dense<0> : vector<2xi64>
+>} {
+  module attributes { dlti.dl_spec = #dlti.dl_spec<
+    i32 = dense<0> : vector<2xi64>
+  >} {
+  }
+}
+
+// -----
+
+// BUILTIN-LABEL: module @builtin_float_entry
+module @builtin_float_entry attributes { dlti.dl_spec = #dlti.dl_spec<
+  f32 = dense<32> : vector<2xi64>
+>} {
+  func.func @query() {
+    "test.op_with_data_layout"() ({
+      // BUILTIN: alignment = 4
+      "test.data_layout_query"() : () -> f32
+      "test.maybe_terminator"() : () -> ()
+    }) { dlti.dl_spec = #dlti.dl_spec<
+      f32 = dense<32> : vector<2xi64>
+    >} : () -> ()
+    return
+  }
+}


### PR DESCRIPTION
While investigating #222356, nested data layouts containing builtin type entries were found to assert in combineOneSpec().

`bucketEntriesByType()` groups entries by `TypeID`, so parametric builtin types such as `i32` and `i64` share the same IntegerType bucket. `combineOneSpec()` assumed that an existing bucket could not belong to the builtin dialect, causing supported nested builtin layouts to hit an assertion instead of being combined.

Handle index, integer, and floating-point entries explicitly. Integer and floating-point compatibility is checked only for matching concrete type keys, while distinct types in the same bucket can coexist. The existing ABI alignment nesting rule is preserved, and index entries must keep the same bitwidth.

Also avoid modulo by zero when ABI alignment is zero, which is currently accepted by the verifier.

#222855 addresses the separate LLVM pointer data-layout crash found during the same investigation.

Related to #222356.

AI-assisted tooling was used during implementation and validation. The final design, review, changes, and verification were performed by me.