### PR TITLE
[Driver][test] Anchor msvc-link.c's lld/link.exe NOT checks on the quoted argument

### DIFF
--- a/clang/test/Driver/msvc-link.c
+++ b/clang/test/Driver/msvc-link.c
@@ -63,7 +63,7 @@
 // RUN: %clang --target=i686-pc-windows-msvc -g -fuse-ld=link -### %s 2>&1 | FileCheck --check-prefix=DEBUG-LINK %s
 // DEBUG-LINK: link.exe"
 // DEBUG-LINK-SAME: "-debug"
-// DEBUG-LINK-NOT: lld
+// DEBUG-LINK-NOT: "lld-link
 
 // RUN: %clang --target=i686-pc-windows-msvc -g -fuse-ld=lld -### %s 2>&1 | FileCheck --check-prefix=DEBUG-LLD %s
 // RUN: %clang --target=i686-pc-windows-msvc -g -fuse-ld=lld-link -### %s 2>&1 | FileCheck --check-prefix=DEBUG-LLD %s
@@ -75,4 +75,4 @@
 // RUN: %clang --target=i686-pc-windows-msvc -gdwarf-6 -fuse-ld= -### %s 2>&1 | FileCheck --check-prefix=DEBUG-LLD %s
 // DEBUG-LLD: lld-link{{(\.exe)?}}"
 // DEBUG-LLD-SAME: "-debug"
-// DEBUG-LLD-NOT: link.exe
+// DEBUG-LLD-NOT: "link.exe


### PR DESCRIPTION
Fixes #222872

Anchors `DEBUG-LINK-NOT`/`DEBUG-LLD-NOT` on the quoted argument (`"lld-link` /
`"link.exe`) instead of a bare substring, since a double quote is never part
of a directory name -- a bare `lld` can coincidentally appear inside lit's
randomly-generated scratch-directory name. Also fixed `DEBUG-LLD-NOT:
link.exe` the same way, for completeness -- much less likely to collide in
practice, but the same bug shape.

Assisted-By: AI
