### PR TITLE
[BOLT][RISCV] Preserve distinct IPLT entries for IFUNC aliases and fix RISC-V call targets

### DIFF
--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -531,27 +531,6 @@ static bool shouldDisassemble(const BinaryFunction &BF) {
   return !BF.isIgnored();
 }
 
-static void createRISCVIFuncResolverFunctions(BinaryContext &BC) {
-  assert(BC.isRISCV() && "expected RISC-V target");
-
-  for (const BinarySection &Section : BC.allocatableSections()) {
-    for (const Relocation &Rel : Section.dynamicRelocations()) {
-      if (!Rel.isIRelative() || !Rel.Addend ||
-          BC.getBinaryFunctionAtAddress(Rel.Addend))
-        continue;
-
-      ErrorOr<BinarySection &> ResolverSection =
-          BC.getSectionForAddress(Rel.Addend);
-      assert(ResolverSection &&
-             "cannot get section for address from IFUNC resolver");
-
-      const std::string FunctionName =
-          "__BOLT_IFUNC_RESOLVERat" + Twine::utohexstr(Rel.Addend).str();
-      BC.createBinaryFunction(FunctionName, *ResolverSection, Rel.Addend, 0);
-    }
-  }
-}
-
 // Return if a section stored in the image falls into a segment address space.
 // If not, Set \p Overlap to true if there's a partial overlap.
 template <class ELFT>
@@ -1374,13 +1353,6 @@ void RewriteInstance::discoverFileObjects() {
   // that is a subject to dynamic relocation processing.
   processDynamicRelocations();
 
-  // LLD may canonicalize the only RISC-V IFUNC symbol to its IPLT entry,
-  // leaving the resolver identifiable only by an R_RISCV_IRELATIVE addend.
-  // Register every such resolver before PLT disassembly so .iplt can use the
-  // normal PLT processing path.
-  if (BC->isRISCV())
-    createRISCVIFuncResolverFunctions(*BC);
-
   // Process PLT section.
   disassemblePLT();
 
@@ -1929,37 +1901,21 @@ void RewriteInstance::createPLTBinaryFunction(uint64_t TargetAddress,
     Symbol = TargetBF->getSymbol();
   }
 
+  // Distinct PLT/GOT entries must not reuse an MCSymbol, even when their
+  // IRELATIVE addends identify the same resolver.
+  std::string Name = Symbol->getName().str();
+  if (const BinaryData *BD = BC->getBinaryDataByName(Name + "@PLT"))
+    if (BD->getAddress() != EntryAddress)
+      Name += ".0x" + Twine::utohexstr(EntryAddress).str();
+
   ErrorOr<BinarySection &> Section = BC->getSectionForAddress(EntryAddress);
   assert(Section && "cannot get section for address");
   if (!BF)
-    BF = BC->createBinaryFunction(Symbol->getName().str() + "@PLT", *Section,
-                                  EntryAddress, 0, EntrySize,
-                                  Section->getAlignment());
+    BF = BC->createBinaryFunction(Name + "@PLT", *Section, EntryAddress, 0,
+                                  EntrySize, Section->getAlignment());
   else
-    BF->addAlternativeName(Symbol->getName().str() + "@PLT");
-  setPLTSymbol(BF, Symbol->getName());
-
-  // R_RISCV_IRELATIVE has no symbol, so the IPLT entry above is named after
-  // one BinaryFunction at the resolver address. Multiple STT_GNU_IFUNC
-  // symbols can alias that resolver, and R_RISCV_CALL_PLT relocations may use
-  // any of their names. Register every such name for the same IPLT entry so
-  // getPLTBinaryDataByName() can resolve those call sites.
-  if (BC->isRISCV() && Rel->isIRelative()) {
-    auto ResolverSyms = FileSymRefs.equal_range(Rel->Addend);
-    for (const SymbolRef &AliasSymbol : llvm::make_second_range(
-             llvm::make_range(ResolverSyms.first, ResolverSyms.second))) {
-      if (ELFSymbolRef(AliasSymbol).getELFType() != ELF::STT_GNU_IFUNC)
-        continue;
-      StringRef AliasName = cantFail(AliasSymbol.getName());
-      const std::string PLTName = AliasName.str() + "@PLT";
-      if (!BC->getBinaryDataByName(PLTName)) {
-        BF->addAlternativeName(PLTName);
-        BC->registerNameAtAddress(PLTName, EntryAddress, EntrySize,
-                                  Section->getAlignment());
-      }
-      setPLTSymbol(BF, AliasName);
-    }
-  }
+    BF->addAlternativeName(Name + "@PLT");
+  setPLTSymbol(BF, Name);
 }
 
 void RewriteInstance::disassemblePLTInstruction(const BinarySection &Section,
@@ -2860,15 +2816,18 @@ bool RewriteInstance::analyzeRelocation(
     SkipVerification = (cantFail(Symbol.getType()) == SymbolRef::ST_Other);
     // Section symbols are marked as ST_Debug.
     IsSectionRelocation = (cantFail(Symbol.getType()) == SymbolRef::ST_Debug);
-    // Check for PLT entry registered with symbol name
-    // LLD may give a defined RISC-V IFUNC symbol the .iplt entry address.
-    // R_RISCV_CALL_PLT must still resolve it through the registered @PLT
-    // BinaryData instead of treating that symbol value as a normal function.
-    const bool IsRISCVIFuncPLT =
-        IsRISCV && RType == ELF::R_RISCV_CALL_PLT &&
+    // An IFUNC symbol can name its resolver rather than the IPLT entry.
+    // Decode the linked call target: aliases sharing a resolver can have
+    // different IPLT entries, so the symbol name cannot identify the entry.
+    const bool IsRISCVIFuncCall =
+        IsRISCV &&
+        (RType == ELF::R_RISCV_CALL || RType == ELF::R_RISCV_CALL_PLT) &&
         ELFSymbolRef(Symbol).getELFType() == ELF::STT_GNU_IFUNC;
-    if ((!SymbolAddress || IsRISCVIFuncPLT) && !IsWeakReference(Symbol) &&
-        (IsAArch64 || IsRISCV)) {
+    if (IsRISCVIFuncCall) {
+      SymbolAddress = truncateToSize(ExtractedValue - Addend + Rel.getOffset(),
+                                     BC->AsmInfo->getCodePointerSize());
+    } else if (!SymbolAddress && !IsWeakReference(Symbol) &&
+               (IsAArch64 || IsRISCV)) {
       const BinaryData *BD = BC->getPLTBinaryDataByName(SymbolName);
       SymbolAddress = BD ? BD->getAddress() : 0;
     }

--- a/bolt/test/AArch64/ifunc-aliases.s
+++ b/bolt/test/AArch64/ifunc-aliases.s
@@ -1,0 +1,34 @@
+## Sharing an IFUNC resolver does not imply sharing an IPLT/GOT entry.
+
+# RUN: llvm-mc -filetype=obj -triple=aarch64 -o %t.o %s
+# RUN: ld.lld --emit-relocs -o %t %t.o
+# RUN: llvm-bolt %t -o %t.bolt --use-old-text=0 --lite=0
+# RUN: llvm-objdump -d --section=.iplt --no-show-raw-insn %t.bolt > %t.dump
+# RUN: llvm-objdump -d --disassemble-symbols=_start --no-show-raw-insn %t.bolt >> %t.dump
+# RUN: FileCheck %s --input-file=%t.dump
+
+# CHECK:       [[#%x,IPLT:]] <.iplt>:
+# CHECK-LABEL: <_start>:
+# CHECK:       bl 0x[[#IPLT]]
+# CHECK:       bl 0x[[#IPLT+16]]
+# CHECK:       b 0x[[#IPLT+16]]
+
+  .text
+  .globl _start
+  .type _start, @function
+_start:
+  bl ifunc0
+  bl ifunc1
+  b ifunc1
+  .size _start, .-_start
+
+  .type resolver, @function
+resolver:
+  ret
+  .size resolver, .-resolver
+
+  .globl ifunc0, ifunc1
+  .type ifunc0, @gnu_indirect_function
+  .set ifunc0, resolver
+  .type ifunc1, @gnu_indirect_function
+  .set ifunc1, resolver

--- a/bolt/test/RISCV/ifunc-aliases.s
+++ b/bolt/test/RISCV/ifunc-aliases.s
@@ -1,0 +1,41 @@
+## IFUNC aliases can share a resolver while using distinct IPLT/GOT entries.
+## Preserve the linked target of both CALL_PLT and CALL, including tail calls.
+
+# RUN: llvm-mc -filetype=obj -triple=riscv64 -o %t.o %s
+# RUN: ld.lld --emit-relocs -o %t %t.o
+# RUN: llvm-readelf -Wr %t | FileCheck %s --check-prefix=RELOCS
+# RUN: llvm-bolt %t -o %t.bolt --use-old-text=0 --lite=0
+# RUN: llvm-objdump -d --no-show-raw-insn %t.bolt | FileCheck %s --check-prefix=CALLS
+
+# RELOCS: R_RISCV_IRELATIVE {{ *}}[[#%x,RESOLVER:]]
+# RELOCS: R_RISCV_IRELATIVE {{ *}}[[#RESOLVER]]
+# RELOCS: R_RISCV_CALL_PLT {{0*}}[[#RESOLVER]] ifunc0 + 0
+# RELOCS: R_RISCV_CALL {{0*}}[[#RESOLVER]] ifunc1 + 0
+
+# CALLS-LABEL: <_start>:
+# CALLS:       jalr {{.*}} <.iplt>
+# CALLS:       jalr {{.*}} <.iplt+0x10>
+# CALLS:       jr {{.*}} <.iplt+0x10>
+
+  .text
+  .option norelax
+  .globl _start
+  .type _start, @function
+_start:
+  call ifunc0
+  .reloc ., R_RISCV_CALL, ifunc1
+  auipc ra, 0
+  jalr ra
+  tail ifunc1
+  .size _start, .-_start
+
+  .type resolver, @function
+resolver:
+  ret
+  .size resolver, .-resolver
+
+  .globl ifunc0, ifunc1
+  .type ifunc0, @gnu_indirect_function
+  .set ifunc0, resolver
+  .type ifunc1, @gnu_indirect_function
+  .set ifunc1, resolver

--- a/bolt/test/RISCV/ifunc.s
+++ b/bolt/test/RISCV/ifunc.s
@@ -1,12 +1,11 @@
-## Check that BOLT recognizes a non-preemptible IFUNC IPLT entry and tracks an
-## otherwise unnamed resolver after the linker canonicalizes the exported IFUNC
-## symbol to the IPLT entry. Function sizes model normal compiler output, while
-## discarding local symbols removes the resolver's remaining name. Moving the
-## synthesized resolver also verifies that the IRELATIVE addend is updated.
+## Check that BOLT recognizes a non-preemptible IFUNC IPLT entry after the
+## linker canonicalizes the exported IFUNC symbol to that entry. Retain a local
+## function symbol for the resolver, as in compiler-generated input. Moving the
+## resolver also verifies that the IRELATIVE addend is updated.
 
 # RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+relax -o %t.64.o %s
 # RUN: ld.lld -q -o %t.64 %t.64.o
-# RUN: llvm-objcopy --discard-all %t.64
+# RUN: llvm-readelf -Wr -Ws %t.64 | FileCheck %s --check-prefix=INPUT
 # RUN: llvm-bolt %t.64 -o %t.64.bolt --use-old-text=0 --lite=0 \
 # RUN:   --print-disasm --print-only=_start 2>&1 | FileCheck %s \
 # RUN:   --check-prefix=BOLT \
@@ -16,8 +15,12 @@
 # RUN: FileCheck %s --input-file=%t.64.dump \
 # RUN:   --check-prefixes=ELF,IPLT,RESOLVER
 
+# INPUT: R_RISCV_IRELATIVE {{ *}}[[#%x,INPUT_RESOLVER:]]
+# INPUT: {{0*}}[[#INPUT_RESOLVER]] 4 FUNC LOCAL DEFAULT {{[0-9]+}} resolver
+# INPUT: FUNC GLOBAL DEFAULT {{[0-9]+}} ifunc0
+
 # BOLT: Binary Function "_start
-# BOLT: auipc a0, %pcrel_hi(__BOLT_IFUNC_RESOLVERat{{[0-9a-f]+}}@PLT)
+# BOLT: auipc a0, %pcrel_hi("resolver/1@PLT")
 
 # ELF: R_RISCV_IRELATIVE {{ *}}[[#%x,RESOLVER:]]
 # ELF: {{[0-9a-f]+}} 4 FUNC {{.*}} func
@@ -36,6 +39,7 @@ _start:
 1:
   auipc a0, %pcrel_hi(ifunc0)
   addi a0, a0, %pcrel_lo(1b)
+  ret
   .size _start, .-_start
 
   .globl func
@@ -44,8 +48,11 @@ func:
   ret
   .size func, .-func
 
+  .type resolver, @function
+resolver:
+  ret
+  .size resolver, .-resolver
+
   .globl ifunc0
   .type ifunc0, @gnu_indirect_function
-ifunc0:
-  ret
-  .size ifunc0, .-ifunc0
+  .set ifunc0, resolver

--- a/bolt/test/X86/ifunc-aliases.s
+++ b/bolt/test/X86/ifunc-aliases.s
@@ -1,0 +1,34 @@
+## Sharing an IFUNC resolver does not imply sharing an IPLT/GOT entry.
+
+# RUN: llvm-mc -filetype=obj -triple=x86_64 -o %t.o %s
+# RUN: ld.lld --emit-relocs -o %t %t.o
+# RUN: llvm-bolt %t -o %t.bolt --use-old-text=0 --lite=0
+# RUN: llvm-objdump -d --section=.iplt --no-show-raw-insn %t.bolt > %t.dump
+# RUN: llvm-objdump -d --disassemble-symbols=_start --no-show-raw-insn %t.bolt >> %t.dump
+# RUN: FileCheck %s --input-file=%t.dump
+
+# CHECK:       [[#%x,IPLT:]] <.iplt>:
+# CHECK-LABEL: <_start>:
+# CHECK:       callq 0x[[#IPLT]]
+# CHECK:       callq 0x[[#IPLT+16]]
+# CHECK:       jmp 0x[[#IPLT+16]]
+
+  .text
+  .globl _start
+  .type _start, @function
+_start:
+  call ifunc0
+  call ifunc1
+  jmp ifunc1
+  .size _start, .-_start
+
+  .type resolver, @function
+resolver:
+  retq
+  .size resolver, .-resolver
+
+  .globl ifunc0, ifunc1
+  .type ifunc0, @gnu_indirect_function
+  .set ifunc0, resolver
+  .type ifunc1, @gnu_indirect_function
+  .set ifunc1, resolver


### PR DESCRIPTION
IFUNC aliases can share a resolver while using distinct IPLT/GOT entries. Reusing the same PLT symbol for these entries can cause BOLT to redirect calls to the wrong entry. 

This patch assigns unique names to distinct entries and resolves RISC-V `R_RISCV_CALL` and `R_RISCV_CALL_PLT` relocations against IFUNC symbols using the linked call target, preserving both regular and tail calls. 
It removes RISC-V-specific resolver synthesis and alias registration, and updates the existing IFUNC test to retain the resolver’s local function symbol. 

Regression tests for RISC-V, AArch64, and X86 cover aliases sharing a resolver while retaining separate IPLT entries.