### PR TITLE
[lldb-dap] Fix logpoint to breakpoint conversion

### DIFF
--- a/lldb/test/API/tools/lldb-dap/breakpoint/TestDAP_logpoints.py
+++ b/lldb/test/API/tools/lldb-dap/breakpoint/TestDAP_logpoints.py
@@ -78,7 +78,9 @@ class TestDAP_logpoints(DAPTestCaseBase):
             )
         session.continue_to_exit()
 
-    def check_logpoint_to_breakpoint_conversion(self, log_message):
+    @skipIfWindows
+    def test_logmessage_claeared(self):
+        """Tests removing logMessage restores a stopping breakpoint."""
         session = self.build_and_create_session()
         initial_stop = self.stop_at_before_loop_line(session)
         loop_line = line_number("main.cpp", "// break loop")
@@ -97,7 +99,7 @@ class TestDAP_logpoints(DAPTestCaseBase):
         [breakpoint_id, _] = session.resolve_source_breakpoints(
             self.main_path,
             [
-                SourceBreakpoint(loop_line, logMessage=log_message),
+                SourceBreakpoint(loop_line, logMessage=None),
                 SourceBreakpoint(after_loop_line),
             ],
         )
@@ -130,16 +132,6 @@ class TestDAP_logpoints(DAPTestCaseBase):
         ]
         self.assertEqual(messages, [log_prefix + str(i) for i in range(1, 10)])
         session.continue_to_exit()
-
-    @skipIfWindows
-    def test_logmessage_none(self):
-        """Tests removing logMessage restores a stopping breakpoint."""
-        self.check_logpoint_to_breakpoint_conversion(None)
-
-    @skipIfWindows
-    def test_logmessage_empty(self):
-        """Tests clearing logMessage restores a stopping breakpoint."""
-        self.check_logpoint_to_breakpoint_conversion("")
 
     @skipIfWindows
     def test_logmessage_advanced(self):

--- a/lldb/test/API/tools/lldb-dap/breakpoint/TestDAP_logpoints.py
+++ b/lldb/test/API/tools/lldb-dap/breakpoint/TestDAP_logpoints.py
@@ -78,6 +78,69 @@ class TestDAP_logpoints(DAPTestCaseBase):
             )
         session.continue_to_exit()
 
+    def check_logpoint_to_breakpoint_conversion(self, log_message):
+        session = self.build_and_create_session()
+        initial_stop = self.stop_at_before_loop_line(session)
+        loop_line = line_number("main.cpp", "// break loop")
+        after_loop_line = line_number("main.cpp", "// after loop")
+        log_prefix = "This is log message for "
+
+        [logpoint_id, post_loop_breakpoint_id] = session.resolve_source_breakpoints(
+            self.main_path,
+            [
+                SourceBreakpoint(loop_line, logMessage=log_prefix + "{i}"),
+                SourceBreakpoint(after_loop_line),
+            ],
+        )
+
+        # Change logpoint to usual breakpoint and check that id preserved.
+        [breakpoint_id, _] = session.resolve_source_breakpoints(
+            self.main_path,
+            [
+                SourceBreakpoint(loop_line, logMessage=log_message),
+                SourceBreakpoint(after_loop_line),
+            ],
+        )
+        self.assertEqual(breakpoint_id, logpoint_id)
+
+        # Check that stop works as expected for updated logpoint.
+        loop_stop = session.continue_to_breakpoint(breakpoint_id)
+        frame = session.top_frame_from(loop_stop)
+        self.assertEqual(frame.locals["i"].value_as_int, 0)
+        captured = session.collect_console(after=initial_stop, until=loop_stop)
+        self.assertNotIn(log_prefix, captured.seen_texts)
+
+        # Change breakpoint to logpoint back.
+        [restored_id, _] = session.resolve_source_breakpoints(
+            self.main_path,
+            [
+                SourceBreakpoint(loop_line, logMessage=log_prefix + "{i}"),
+                SourceBreakpoint(after_loop_line),
+            ],
+        )
+        self.assertEqual(restored_id, logpoint_id)
+
+        # Check that logpoint prints messages.
+        post_loop_stop = session.continue_to_breakpoint(post_loop_breakpoint_id)
+        captured = session.collect_console(after=loop_stop, until=post_loop_stop)
+        messages = [
+            line
+            for line in captured.seen_texts.splitlines()
+            if line.startswith(log_prefix)
+        ]
+        self.assertEqual(messages, [log_prefix + str(i) for i in range(1, 10)])
+        session.continue_to_exit()
+
+    @skipIfWindows
+    def test_logmessage_none(self):
+        """Tests removing logMessage restores a stopping breakpoint."""
+        self.check_logpoint_to_breakpoint_conversion(None)
+
+    @skipIfWindows
+    def test_logmessage_empty(self):
+        """Tests clearing logMessage restores a stopping breakpoint."""
+        self.check_logpoint_to_breakpoint_conversion("")
+
     @skipIfWindows
     def test_logmessage_advanced(self):
         """Tests breakpoint logmessage functionality for complex expression."""

--- a/lldb/tools/lldb-dap/Protocol/ProtocolTypes.cpp
+++ b/lldb/tools/lldb-dap/Protocol/ProtocolTypes.cpp
@@ -855,13 +855,10 @@ bool fromJSON(const llvm::json::Value &Params, Breakpoint &BP,
 bool fromJSON(const llvm::json::Value &Params, SourceBreakpoint &SB,
               llvm::json::Path P) {
   llvm::json::ObjectMapper O(Params, P);
-  std::optional<String> log_message;
-  if (!(O && O.mapOptional("logMessage", log_message)))
-    return false;
-  SB.logMessage = log_message.value_or("");
-  return O.map("line", SB.line) && O.mapOptional("column", SB.column) &&
+  return O && O.map("line", SB.line) && O.mapOptional("column", SB.column) &&
          O.mapOptional("condition", SB.condition) &&
          O.mapOptional("hitCondition", SB.hitCondition) &&
+         O.mapOptional("logMessage", SB.logMessage) &&
          O.mapOptional("mode", SB.mode);
 }
 

--- a/lldb/tools/lldb-dap/Protocol/ProtocolTypes.cpp
+++ b/lldb/tools/lldb-dap/Protocol/ProtocolTypes.cpp
@@ -855,10 +855,13 @@ bool fromJSON(const llvm::json::Value &Params, Breakpoint &BP,
 bool fromJSON(const llvm::json::Value &Params, SourceBreakpoint &SB,
               llvm::json::Path P) {
   llvm::json::ObjectMapper O(Params, P);
-  return O && O.map("line", SB.line) && O.mapOptional("column", SB.column) &&
+  std::optional<String> log_message;
+  if (!(O && O.mapOptional("logMessage", log_message)))
+    return false;
+  SB.logMessage = log_message.value_or("");
+  return O.map("line", SB.line) && O.mapOptional("column", SB.column) &&
          O.mapOptional("condition", SB.condition) &&
          O.mapOptional("hitCondition", SB.hitCondition) &&
-         O.mapOptional("logMessage", SB.logMessage) &&
          O.mapOptional("mode", SB.mode);
 }
 
@@ -871,8 +874,8 @@ llvm::json::Value toJSON(const SourceBreakpoint &SB) {
     result.insert({"condition", *SB.condition});
   if (SB.hitCondition)
     result.insert({"hitCondition", *SB.hitCondition});
-  if (SB.logMessage)
-    result.insert({"logMessage", *SB.logMessage});
+  if (!SB.logMessage.empty())
+    result.insert({"logMessage", SB.logMessage});
   if (SB.mode)
     result.insert({"mode", *SB.mode});
 

--- a/lldb/tools/lldb-dap/Protocol/ProtocolTypes.h
+++ b/lldb/tools/lldb-dap/Protocol/ProtocolTypes.h
@@ -689,7 +689,7 @@ struct SourceBreakpoint {
   /// capability `supportsLogPoints` is true.
   /// If either `hitCondition` or `condition` is specified, then the message
   /// should only be logged if those conditions are met.
-  std::optional<String> logMessage;
+  String logMessage;
 
   /// The mode of this breakpoint. If defined, this must be one of the
   /// `breakpointModes` the debug adapter advertised in its `Capabilities`.

--- a/lldb/tools/lldb-dap/SourceBreakpoint.cpp
+++ b/lldb/tools/lldb-dap/SourceBreakpoint.cpp
@@ -281,6 +281,11 @@ lldb::SBError SourceBreakpoint::FormatLogText(llvm::StringRef text,
 void SourceBreakpoint::SetLogMessage() {
   m_log_message_parts.clear();
 
+  if (m_log_message.empty()) {
+    m_bp.SetCallback(nullptr, nullptr);
+    return;
+  }
+
   // Contains unmatched open curly braces indices.
   std::vector<int> unmatched_curly_braces;
 

--- a/lldb/tools/lldb-dap/SourceBreakpoint.cpp
+++ b/lldb/tools/lldb-dap/SourceBreakpoint.cpp
@@ -33,8 +33,7 @@ namespace lldb_dap {
 SourceBreakpoint::SourceBreakpoint(DAP &dap,
                                    const protocol::SourceBreakpoint &breakpoint)
     : Breakpoint(dap, breakpoint.condition, breakpoint.hitCondition),
-      m_log_message(breakpoint.logMessage.value_or("")),
-      m_line(breakpoint.line),
+      m_log_message(breakpoint.logMessage), m_line(breakpoint.line),
       m_column(breakpoint.column.value_or(LLDB_INVALID_COLUMN_NUMBER)) {}
 
 llvm::Error SourceBreakpoint::SetBreakpoint(const protocol::Source &source) {

--- a/lldb/unittests/DAP/ProtocolTypesTest.cpp
+++ b/lldb/unittests/DAP/ProtocolTypesTest.cpp
@@ -163,6 +163,17 @@ TEST(ProtocolTypesTest, SourceBreakpoint) {
   EXPECT_EQ(source_breakpoint.mode, deserialized_source_breakpoint->mode);
 }
 
+TEST(ProtocolTypesTest, SourceBreakpointOptionalLogMessage) {
+  for (StringRef json : {R"({"line": 0, "logMessage": null})", R"({"line": 0})",
+                         R"({"line": 0, "logMessage": ""})"}) {
+    Expected<SourceBreakpoint> source_breakpoint =
+        parse<SourceBreakpoint>(json);
+    ASSERT_THAT_EXPECTED(source_breakpoint, Succeeded());
+    EXPECT_EQ(source_breakpoint->line, 0u);
+    EXPECT_TRUE(source_breakpoint->logMessage.empty());
+  }
+}
+
 TEST(ProtocolTypesTest, FunctionBreakpoint) {
   FunctionBreakpoint function_breakpoint;
   function_breakpoint.name = "myFunction";

--- a/lldb/unittests/DAP/ProtocolTypesTest.cpp
+++ b/lldb/unittests/DAP/ProtocolTypesTest.cpp
@@ -164,14 +164,17 @@ TEST(ProtocolTypesTest, SourceBreakpoint) {
 }
 
 TEST(ProtocolTypesTest, SourceBreakpointOptionalLogMessage) {
-  for (StringRef json : {R"({"line": 0, "logMessage": null})", R"({"line": 0})",
-                         R"({"line": 0, "logMessage": ""})"}) {
+  for (StringRef json :
+       {R"({"line": 0})", R"({"line": 0, "logMessage": ""})"}) {
     Expected<SourceBreakpoint> source_breakpoint =
         parse<SourceBreakpoint>(json);
     ASSERT_THAT_EXPECTED(source_breakpoint, Succeeded());
     EXPECT_EQ(source_breakpoint->line, 0u);
     EXPECT_TRUE(source_breakpoint->logMessage.empty());
   }
+
+  EXPECT_THAT_EXPECTED(
+      parse<SourceBreakpoint>(R"({"line": 0, "logMessage": null})"), Failed());
 }
 
 TEST(ProtocolTypesTest, FunctionBreakpoint) {


### PR DESCRIPTION
When user sets logpoint and after that removes `logMessage`, which implicitly converts it to usual breakpoint, breakpoint still has `BreakpointHitCallback`, which leads to missed stops.