### PR TITLE
[Sema][Test] Add c++17 standard specifier to diagnostic test.

### DIFF
--- a/clang/test/SemaTemplate/instantiate-member-initializers.cpp
+++ b/clang/test/SemaTemplate/instantiate-member-initializers.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsyntax-only -Wall -verify %s
+// RUN: %clang_cc1 -std=c++17 -fsyntax-only -Wall -verify %s
 
 template<typename T> struct A {
   A() : a(1) { } // expected-error{{cannot initialize a member subobject of type 'void *' with an rvalue of type 'int'}}


### PR DESCRIPTION
Test additions introduced in 1ec7a13fb238 caused later than c++17 defaulting configurations to fail for this specific test due to CTAD rules enabling initialization and instantiation of the added templates in the test.

This causes some of the expected diagnostics to go missing and has others appear.

The change adds a c++17 specifier to the run line to avoid the test failing for later c++ standard defaults.

Changes to be committed:
  modified:   clang/test/SemaTemplate/instantiate-member-initializers.cpp