### PR TITLE
[SPARC] Add LEON5 processor

### DIFF
--- a/clang/lib/Basic/Targets/Sparc.cpp
+++ b/clang/lib/Basic/Targets/Sparc.cpp
@@ -106,6 +106,7 @@ static constexpr SparcCPUInfo CPUInfo[] = {
     {{"gr712rc"}, SparcTargetInfo::CK_LEON3_GR712RC, SparcTargetInfo::CG_V8},
     {{"leon4"}, SparcTargetInfo::CK_LEON4, SparcTargetInfo::CG_V8},
     {{"gr740"}, SparcTargetInfo::CK_LEON4_GR740, SparcTargetInfo::CG_V8},
+    {{"leon5"}, SparcTargetInfo::CK_LEON5, SparcTargetInfo::CG_V8},
 };
 
 SparcTargetInfo::CPUGeneration

--- a/clang/lib/Basic/Targets/Sparc.h
+++ b/clang/lib/Basic/Targets/Sparc.h
@@ -118,7 +118,8 @@ public:
     CK_LEON3_UT699,
     CK_LEON3_GR712RC,
     CK_LEON4,
-    CK_LEON4_GR740
+    CK_LEON4_GR740,
+    CK_LEON5,
   } CPU = CK_GENERIC;
 
   enum CPUGeneration {

--- a/clang/lib/Driver/ToolChains/Arch/Sparc.cpp
+++ b/clang/lib/Driver/ToolChains/Arch/Sparc.cpp
@@ -79,6 +79,7 @@ const char *sparc::getSparcAsmModeForCPU(StringRef Name,
         .Case("gr712rc", "-Aleon")
         .Case("leon4", "-Aleon")
         .Case("gr740", "-Aleon")
+        .Case("leon5", "-Aleon")
         .Default(DefV8CPU);
   }
 }

--- a/clang/test/Driver/sparc-as.c
+++ b/clang/test/Driver/sparc-as.c
@@ -152,6 +152,10 @@
 // RUN: -no-integrated-as --sysroot=%S/Inputs/basic_netbsd_tree -### %s 2>&1 \
 // RUN: | FileCheck -check-prefix=SPARC-LEON %s
 
+// RUN: %clang -mcpu=leon5 --target=sparc \
+// RUN: -no-integrated-as --sysroot=%S/Inputs/basic_netbsd_tree -### %s 2>&1 \
+// RUN: | FileCheck -check-prefix=SPARC-LEON %s
+
 // SPARC: as{{.*}}" "-32" "-Av8" "-o"
 // SPARC-V8: as{{.*}}" "-32" "-Av8" "-o"
 // SPARC-LEON: as{{.*}}" "-32" "-Aleon" "-o"

--- a/clang/test/Misc/target-invalid-cpu-note/sparc.c
+++ b/clang/test/Misc/target-invalid-cpu-note/sparc.c
@@ -39,6 +39,7 @@
 // SPARC-SAME: {{^}}, gr712rc
 // SPARC-SAME: {{^}}, leon4
 // SPARC-SAME: {{^}}, gr740
+// SPARC-SAME: {{^}}, leon5
 // SPARC-SAME: {{$}}
 
 // RUN: not %clang_cc1 -triple sparcv9--- -target-cpu not-a-cpu -fsyntax-only %s 2>&1 | FileCheck %s --check-prefix SPARCV9

--- a/llvm/lib/Target/Sparc/Sparc.td
+++ b/llvm/lib/Target/Sparc/Sparc.td
@@ -264,6 +264,10 @@ def : Processor<"gr740", LEON4Itineraries,
                 [FeatureLeon, UMACSMACSupport, LeonCASA, LeonCycleCounter,
                  FeaturePWRPSR]>;
 
+// LEON 5 generic
+def : ProcessorModel<"leon5", NoSchedModel,
+                     [FeatureLeon, LeonCASA, LeonCycleCounter, FeaturePWRPSR]>;
+
 //===----------------------------------------------------------------------===//
 // Declare the target which we are implementing
 //===----------------------------------------------------------------------===//

--- a/llvm/test/CodeGen/SPARC/LeonCASAInstructionUT.ll
+++ b/llvm/test/CodeGen/SPARC/LeonCASAInstructionUT.ll
@@ -2,6 +2,7 @@
 ; RUN: llc %s -O0 -mtriple=sparc -mcpu=gr712rc -o - | FileCheck %s
 ; RUN: llc %s -O0 -mtriple=sparc -mcpu=leon4 -o - | FileCheck %s
 ; RUN: llc %s -O0 -mtriple=sparc -mcpu=gr740 -o - | FileCheck %s
+; RUN: llc %s -O0 -mtriple=sparc -mcpu=leon5 -o - | FileCheck %s
 ; RUN: llc %s -O0 -mtriple=sparc -mcpu=myriad2 -o - | FileCheck %s
 ; RUN: llc %s -O0 -mtriple=sparc -mcpu=myriad2.1 -o - | FileCheck %s
 ; RUN: llc %s -O0 -mtriple=sparc -mcpu=myriad2.2 -o - | FileCheck %s

--- a/llvm/test/CodeGen/SPARC/readcycle.ll
+++ b/llvm/test/CodeGen/SPARC/readcycle.ll
@@ -1,4 +1,5 @@
 ; RUN: llc < %s -mtriple=sparc -mcpu=gr740 -verify-machineinstrs | FileCheck %s
+; RUN: llc < %s -mtriple=sparc -mcpu=leon5 -verify-machineinstrs | FileCheck %s
 ; CHECK: rd %asr23, %o1
 ; CHECK: mov %g0, %o0
 

--- a/llvm/test/MC/Sparc/leon-pwrpsr-instruction.s
+++ b/llvm/test/MC/Sparc/leon-pwrpsr-instruction.s
@@ -1,4 +1,5 @@
 ! RUN: llvm-mc %s -triple=sparc -mcpu=gr740 -show-encoding | FileCheck %s
+! RUN: llvm-mc %s -triple=sparc -mcpu=leon5 -show-encoding | FileCheck %s
 
     ! CHECK: pwr %g0, 0, %psr                ! encoding: [0x83,0x88,0x20,0x00]
     pwr 0, %psr


### PR DESCRIPTION
Same target exists in GCC. Instruction scheduling model will be added in later patch.