### PR TITLE
[RISCV] Remove deprecated hasStdExtCOrZcd/hasStdExtCOrZcfOrZce

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVSubtarget.h
+++ b/llvm/lib/Target/RISCV/RISCVSubtarget.h
@@ -176,10 +176,6 @@ public:
   bool GETTER() const { return ATTRIBUTE; }
 #include "RISCVGenSubtargetInfo.inc"
 
-  LLVM_DEPRECATED("Now Equivalent to hasStdExtZcd", "hasStdExtZcd")
-  bool hasStdExtCOrZcd() const { return HasStdExtZcd; }
-  LLVM_DEPRECATED("Now Equivalent to hasStdExtZcf", "hasStdExtZcf")
-  bool hasStdExtCOrZcfOrZce() const { return HasStdExtZcf; }
   bool hasStdExtZvl() const { return ZvlLen != 0; }
   bool hasStdExtFOrZfinx() const { return HasStdExtF || HasStdExtZfinx; }
   bool hasStdExtDOrZdinx() const { return HasStdExtD || HasStdExtZdinx; }


### PR DESCRIPTION
These two methods were marked LLVM_DEPRECATED in favor of hasStdExtZcd/hasStdExtZcf respectively 7 months ago. There are no remaining in tree callers, so remove them.