### PR TITLE
[libc][Bazel] Add missing F16 math targets

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/test/src/math/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/math/BUILD.bazel
@@ -24,6 +24,8 @@ math_mpfr_test(name = "atan2")
 
 math_mpfr_test(name = "atan2f")
 
+math_mpfr_test(name = "atan2f16")
+
 math_mpfr_test(
     name = "atan2f128",
     deps = ["//libc:__support_fputil_float128"],
@@ -33,7 +35,13 @@ math_mpfr_test(name = "atan")
 
 math_mpfr_test(name = "atanf")
 
+math_mpfr_test(name = "atanf16")
+
 math_mpfr_test(name = "atanhf")
+
+math_mpfr_test(name = "atanhf16")
+
+math_mpfr_test(name = "atanpif16")
 
 math_mpfr_test(name = "cbrt")
 
@@ -122,6 +130,10 @@ math_mpfr_test(
 
 math_mpfr_test(name = "erff")
 
+math_mpfr_test(name = "erff16")
+
+math_mpfr_test(name = "erfcf16")
+
 math_mpfr_test(name = "exp")
 
 math_mpfr_test(name = "expf")
@@ -144,6 +156,8 @@ math_mpfr_test(
 math_mpfr_test(name = "expm1")
 
 math_mpfr_test(name = "expm1f")
+
+math_mpfr_test(name = "expm1f16")
 
 math_mpfr_test(
     name = "fabs",
@@ -251,13 +265,68 @@ math_mpfr_test(
 
 # TODO: Add fma, fmaf, fmal, fmul, fmull tests.  Missing stdlib/rand dependency.
 
-# math_mpfr_test(name = "f16mul")
-# math_mpfr_test(name = "f16mulf")
-# math_mpfr_test(name = "f16mull")
+math_mpfr_test(
+    name = "f16mul",
+    hdrs = ["MulTest.h"],
+    deps = [
+        "//libc:rand",
+        "//libc:srand",
+    ],
+)
 
-# math_mpfr_test(name = "f16fma")
-# math_mpfr_test(name = "f16fmaf")
-# math_mpfr_test(name = "f16fmal")
+math_mpfr_test(
+    name = "f16mulf",
+    hdrs = ["MulTest.h"],
+    deps = [
+        "//libc:rand",
+        "//libc:srand",
+    ],
+)
+
+math_mpfr_test(
+    name = "f16mull",
+    hdrs = ["MulTest.h"],
+    deps = [
+        "//libc:rand",
+        "//libc:srand",
+    ],
+)
+
+math_mpfr_test(
+    name = "f16fma",
+    hdrs = ["FmaTest.h"],
+    deps = [
+        "//libc:rand",
+        "//libc:srand",
+    ],
+)
+
+math_mpfr_test(
+    name = "f16fmaf",
+    hdrs = ["FmaTest.h"],
+    deps = [
+        "//libc:rand",
+        "//libc:srand",
+    ],
+)
+
+math_mpfr_test(
+    name = "f16fmal",
+    hdrs = ["FmaTest.h"],
+    deps = [
+        "//libc:rand",
+        "//libc:srand",
+    ],
+)
+
+math_mpfr_test(
+    name = "fmaf16",
+    hdrs = ["FmaTest.h"],
+    deps = [
+        "//libc:rand",
+        "//libc:srand",
+    ],
+)
 
 math_mpfr_test(
     name = "frexp",
@@ -655,6 +724,10 @@ math_mpfr_test(
     hdrs = ["SqrtTest.h"],
 )
 
+math_mpfr_test(name = "sqrtf16")
+
+math_mpfr_test(name = "rsqrtf16")
+
 math_mpfr_test(
     name = "f16sqrtl",
     hdrs = ["SqrtTest.h"],
@@ -731,7 +804,15 @@ math_mpfr_test(name = "exp10m1f16")
 
 math_mpfr_test(name = "asinf16")
 
+math_mpfr_test(name = "asinhf16")
+
+math_mpfr_test(name = "asinpif16")
+
 math_mpfr_test(name = "acosf16")
+
+math_mpfr_test(name = "acoshf16")
+
+math_mpfr_test(name = "acospif16")
 
 math_mpfr_test(name = "coshf16")
 
@@ -743,4 +824,10 @@ math_mpfr_test(name = "logf16")
 
 math_mpfr_test(name = "log2f16")
 
+math_mpfr_test(name = "log2p1f16")
+
 math_mpfr_test(name = "log10f16")
+
+math_mpfr_test(name = "log10p1f16")
+
+math_mpfr_test(name = "lgammaf16")

--- a/utils/bazel/llvm-project-overlay/libc/test/src/math/smoke/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/math/smoke/BUILD.bazel
@@ -16,11 +16,19 @@ math_test(name = "acoshf")
 
 math_test(name = "acosf16")
 
+math_test(name = "acoshf16")
+
+math_test(name = "acospif16")
+
 math_test(name = "asinf")
 
 math_test(name = "asinf16")
 
 math_test(name = "asinhf")
+
+math_test(name = "asinhf16")
+
+math_test(name = "asinpif16")
 
 math_test(name = "atan2")
 
@@ -41,6 +49,12 @@ math_test(name = "atan")
 math_test(name = "atanf")
 
 math_test(name = "atanhf")
+
+math_test(name = "atanf16")
+
+math_test(name = "atanhf16")
+
+math_test(name = "atanpif16")
 
 math_test(
     name = "canonicalize",
@@ -194,6 +208,11 @@ math_test(
 )
 
 math_test(
+    name = "f16addf128",
+    hdrs = ["AddTest.h"],
+)
+
+math_test(
     name = "f16addl",
     hdrs = ["AddTest.h"],
 )
@@ -215,6 +234,11 @@ math_test(
 
 math_test(
     name = "f16divf",
+    hdrs = ["DivTest.h"],
+)
+
+math_test(
+    name = "f16divf128",
     hdrs = ["DivTest.h"],
 )
 
@@ -244,6 +268,11 @@ math_test(
 )
 
 math_test(
+    name = "f16fmaf128",
+    hdrs = ["FmaTest.h"],
+)
+
+math_test(
     name = "f16fmal",
     hdrs = ["FmaTest.h"],
 )
@@ -265,6 +294,11 @@ math_test(
 
 math_test(
     name = "f16mulf",
+    hdrs = ["MulTest.h"],
+)
+
+math_test(
+    name = "f16mulf128",
     hdrs = ["MulTest.h"],
 )
 
@@ -333,9 +367,16 @@ math_test(
 )
 
 math_test(
+    name = "f16sqrtf128",
+    hdrs = ["SqrtTest.h"],
+)
+
+math_test(
     name = "sqrtf16",
     hdrs = ["SqrtTest.h"],
 )
+
+math_test(name = "rsqrtf16")
 
 math_test(
     name = "f16sqrtl",
@@ -363,11 +404,20 @@ math_test(
 )
 
 math_test(
+    name = "f16subf128",
+    hdrs = ["SubTest.h"],
+)
+
+math_test(
     name = "f16subl",
     hdrs = ["SubTest.h"],
 )
 
 math_test(name = "erff")
+
+math_test(name = "erfcf16")
+
+math_test(name = "erff16")
 
 math_test(name = "exp")
 
@@ -1067,6 +1117,11 @@ math_test(
     deps = [
         "//libc:__support_fputil_float128",
     ],
+)
+
+math_test(
+    name = "isnanf16",
+    hdrs = ["IsNanTest.h"],
 )
 
 math_test(
@@ -1820,7 +1875,13 @@ math_test(name = "log10f16")
 
 math_test(name = "log2f16")
 
+math_test(name = "log2p1f16")
+
+math_test(name = "log10p1f16")
+
 math_test(name = "logf16")
+
+math_test(name = "lgammaf16")
 
 math_test(
     name = "nanf16",


### PR DESCRIPTION
Addresses #221799 by adding all existing F16 tests that were missing Bazel targets.
Validated by running all 184 F16 tests with bazel test.
