### PR TITLE
[clang][bytecode] Allow pointer type mismatch in SubPtr op

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.h
+++ b/clang/lib/AST/ByteCode/Interp.h
@@ -2847,7 +2847,8 @@ inline bool SubPtr(InterpState &S, CodePtr OpPC, uint32_t ElemSize) {
   if (!VR)
     return false;
 
-  assert(((int64_t)*VL - (int64_t)*VR) % ElemSize == 0);
+  // We allow (VL - VR) / Elemsize to have non-zero remainder. This happens for
+  // invalid expressions where LHS and RHS are of different types.
   int64_t R64 =
       (static_cast<int64_t>(*VL) - static_cast<int64_t>(*VR)) / ElemSize;
   if (static_cast<int64_t>(T::from(R64)) != R64)

--- a/clang/test/AST/ByteCode/invalid.cpp
+++ b/clang/test/AST/ByteCode/invalid.cpp
@@ -256,3 +256,14 @@ namespace UnknownSizeArrayInEvaluateString {
   }
   }
 } // both-error {{extraneous closing brace}}
+
+namespace SubPtrResultIs1 {
+  struct A {
+    char x;
+  };
+  struct B {
+    char y;
+  };
+  struct C : A, B {};
+  unsigned char x = ((char **)(B *)(C *)0x1000) - (char *)0x1000; // both-error {{not pointers to compatible types}}
+}


### PR DESCRIPTION
The result of the attached test case is 1, which then gets divided by 8 and the end result is 0. This should evaluate.