### PR TITLE
[lldb][test] Disable TestConcurrentManySignals.py on AArch64 Linux

### DIFF
--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentManySignals.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentManySignals.py
@@ -11,6 +11,8 @@ class ConcurrentManySignals(ConcurrentEventsBase):
     # This test is flaky on Darwin.
     @skipIfDarwin
     @expectedFailureNetBSD
+    # Flakey in AArch64 Linux GitHub CI https://github.com/llvm/llvm-project/issues/171210.
+    @skipIf(oslist=["linux"], archs=["aarch64"])
     def test(self):
         """Test 100 signals from 100 threads."""
         self.build()


### PR DESCRIPTION
It is flakey in pre-commit CI (https://github.com/llvm/llvm-project/issues/171210) and blocking https://github.com/llvm/llvm-project/issues/171202 as a result.

No one is going to have time to dig into this soon, so disable it for now.