### PR TITLE
[lldb][Windows] Make RM_RF actually delete files

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -44,7 +44,7 @@ ifeq "$(OS)" "Windows_NT"
 	CP_R = xcopy $(subst /,\,$(1)) $(subst /,\,$(2)) /s /e /y
 	RM = del $(subst /,\,$(1)) > nul 2>&1 || (exit 0)
 	RM_F = del /f /q $(subst /,\,$(1))
-	RM_RF = $(if $(strip $(1)),rd /s /q $(subst /,\,$(1)) > nul 2>&1 || (exit 0))
+	RM_RF = $(if $(strip $(1)),(del /f /q $(subst /,\,$(1)) > nul 2>&1 & rd /s /q $(subst /,\,$(1)) > nul 2>&1) || (exit 0))
 	LN_SF = mklink /D "$(subst /,\,$(2))" "$(subst /,\,$(1))"
 	ECHO = echo $(1);
 	ECHO_TO_FILE = echo $(subst ',,$(1))> "$(subst /,\,$(2))"


### PR DESCRIPTION
On Windows `RM_RF` was `rd /s /q`, which only removes directories — so any `$(call RM_RF,...)` naming files silently did nothing, and `|| (exit 0)` hid it. POSIX gets `rm -rf`, which removes both.

`clean::` recipes pass file globs and usually run before the build (`all: clean ...`), so stale artifacts survived into the next run. Hits upstream `functionalities/disassembler-variables` too.

Fix adds `del /f /q`, joined with `&` not `&&` so `rd` still runs when the glob matched no files.

This is a follow up to 7d42028e806ab2b17af22ddb8417432e4781d4aa