### PR TITLE
[libc] Implement pthread_attr_[gs]etscope

### DIFF
--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -1120,12 +1120,14 @@ if(LLVM_LIBC_FULL_BUILD)
     libc.src.pthread.pthread_attr_getdetachstate
     libc.src.pthread.pthread_attr_getguardsize
     libc.src.pthread.pthread_attr_getschedpolicy
+    libc.src.pthread.pthread_attr_getscope
     libc.src.pthread.pthread_attr_getstack
     libc.src.pthread.pthread_attr_getstacksize
     libc.src.pthread.pthread_attr_init
     libc.src.pthread.pthread_attr_setdetachstate
     libc.src.pthread.pthread_attr_setguardsize
     libc.src.pthread.pthread_attr_setschedpolicy
+    libc.src.pthread.pthread_attr_setscope
     libc.src.pthread.pthread_attr_setstack
     libc.src.pthread.pthread_attr_setstacksize
     libc.src.pthread.pthread_condattr_destroy

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -1306,12 +1306,14 @@ if(LLVM_LIBC_FULL_BUILD)
     libc.src.pthread.pthread_attr_getdetachstate
     libc.src.pthread.pthread_attr_getguardsize
     libc.src.pthread.pthread_attr_getschedpolicy
+    libc.src.pthread.pthread_attr_getscope
     libc.src.pthread.pthread_attr_getstack
     libc.src.pthread.pthread_attr_getstacksize
     libc.src.pthread.pthread_attr_init
     libc.src.pthread.pthread_attr_setdetachstate
     libc.src.pthread.pthread_attr_setguardsize
     libc.src.pthread.pthread_attr_setschedpolicy
+    libc.src.pthread.pthread_attr_setscope
     libc.src.pthread.pthread_attr_setstack
     libc.src.pthread.pthread_attr_setstacksize
     libc.src.pthread.pthread_condattr_destroy

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -1317,12 +1317,14 @@ if(LLVM_LIBC_FULL_BUILD)
     libc.src.pthread.pthread_attr_getdetachstate
     libc.src.pthread.pthread_attr_getguardsize
     libc.src.pthread.pthread_attr_getschedpolicy
+    libc.src.pthread.pthread_attr_getscope
     libc.src.pthread.pthread_attr_getstack
     libc.src.pthread.pthread_attr_getstacksize
     libc.src.pthread.pthread_attr_init
     libc.src.pthread.pthread_attr_setdetachstate
     libc.src.pthread.pthread_attr_setguardsize
     libc.src.pthread.pthread_attr_setschedpolicy
+    libc.src.pthread.pthread_attr_setscope
     libc.src.pthread.pthread_attr_setstack
     libc.src.pthread.pthread_attr_setstacksize
     libc.src.pthread.pthread_condattr_destroy

--- a/libc/include/llvm-libc-macros/pthread-macros.h
+++ b/libc/include/llvm-libc-macros/pthread-macros.h
@@ -29,6 +29,9 @@
 #define PTHREAD_PROCESS_PRIVATE 0
 #define PTHREAD_PROCESS_SHARED 1
 
+#define PTHREAD_SCOPE_SYSTEM 0
+#define PTHREAD_SCOPE_PROCESS 1
+
 #ifdef __linux__
 #define PTHREAD_MUTEX_INITIALIZER                                              \
   {                                                                            \

--- a/libc/include/pthread.yaml
+++ b/libc/include/pthread.yaml
@@ -28,6 +28,10 @@ macros:
     macro_header: pthread-macros.h
   - macro_name: "PTHREAD_PROCESS_SHARED"
     macro_header: pthread-macros.h
+  - macro_name: "PTHREAD_SCOPE_SYSTEM"
+    macro_header: pthread-macros.h
+  - macro_name: "PTHREAD_SCOPE_PROCESS"
+    macro_header: pthread-macros.h
   - macro_name: "PTHREAD_MUTEX_INITIALIZER"
     macro_header: pthread-macros.h
   - macro_name: "PTHREAD_COND_INITIALIZER"
@@ -102,6 +106,13 @@ functions:
     arguments:
       - type: const pthread_attr_t *__restrict
       - type: int *__restrict
+  - name: pthread_attr_getscope
+    standards:
+      - posix
+    return_type: int
+    arguments:
+      - type: const pthread_attr_t *__restrict
+      - type: int *__restrict
   - name: pthread_attr_getstack
     return_type: int
     arguments:
@@ -133,6 +144,13 @@ functions:
       - type: pthread_attr_t *__restrict
       - type: const struct sched_param *__restrict
   - name: pthread_attr_setschedpolicy
+    return_type: int
+    arguments:
+      - type: pthread_attr_t *
+      - type: int
+  - name: pthread_attr_setscope
+    standards:
+      - posix
     return_type: int
     arguments:
       - type: pthread_attr_t *

--- a/libc/src/pthread/CMakeLists.txt
+++ b/libc/src/pthread/CMakeLists.txt
@@ -85,6 +85,20 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
+  pthread_attr_getscope
+  SRCS
+    pthread_attr_getscope.cpp
+  HDRS
+    pthread_attr_getscope.h
+  DEPENDS
+    libc.hdr.pthread_macros
+    libc.hdr.types.pthread_attr_t
+    libc.src.__support.common
+    libc.src.__support.macros.config
+    libc.src.__support.macros.null_check
+)
+
+add_entrypoint_object(
   pthread_attr_setschedparam
   SRCS
     pthread_attr_setschedparam.cpp
@@ -101,6 +115,21 @@ add_entrypoint_object(
   HDRS
     pthread_attr_setschedpolicy.h
   DEPENDS
+    libc.hdr.types.pthread_attr_t
+    libc.src.__support.common
+    libc.src.__support.macros.config
+    libc.src.__support.macros.null_check
+)
+
+add_entrypoint_object(
+  pthread_attr_setscope
+  SRCS
+    pthread_attr_setscope.cpp
+  HDRS
+    pthread_attr_setscope.h
+  DEPENDS
+    libc.hdr.errno_macros
+    libc.hdr.pthread_macros
     libc.hdr.types.pthread_attr_t
     libc.src.__support.common
     libc.src.__support.macros.config

--- a/libc/src/pthread/pthread_attr_getscope.cpp
+++ b/libc/src/pthread/pthread_attr_getscope.cpp
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implementation of pthread_attr_getscope.
+///
+//===----------------------------------------------------------------------===//
+
+#include "src/pthread/pthread_attr_getscope.h"
+#include "hdr/pthread_macros.h"
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/null_check.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(int, pthread_attr_getscope,
+                   ([[maybe_unused]] const pthread_attr_t *__restrict attr,
+                    int *__restrict contentionscope)) {
+  LIBC_CRASH_ON_NULLPTR(attr);
+  LIBC_CRASH_ON_NULLPTR(contentionscope);
+
+  *contentionscope = PTHREAD_SCOPE_SYSTEM;
+  return 0;
+}
+
+} // namespace LIBC_NAMESPACE_DECL
+

--- a/libc/src/pthread/pthread_attr_getscope.cpp
+++ b/libc/src/pthread/pthread_attr_getscope.cpp
@@ -30,4 +30,3 @@ LLVM_LIBC_FUNCTION(int, pthread_attr_getscope,
 }
 
 } // namespace LIBC_NAMESPACE_DECL
-

--- a/libc/src/pthread/pthread_attr_getscope.h
+++ b/libc/src/pthread/pthread_attr_getscope.h
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implementation header for pthread_attr_getscope.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_PTHREAD_PTHREAD_ATTR_GETSCOPE_H
+#define LLVM_LIBC_SRC_PTHREAD_PTHREAD_ATTR_GETSCOPE_H
+
+#include "hdr/types/pthread_attr_t.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+int pthread_attr_getscope(const pthread_attr_t *__restrict attr,
+                          int *__restrict contentionscope);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_PTHREAD_PTHREAD_ATTR_GETSCOPE_H
+

--- a/libc/src/pthread/pthread_attr_getscope.h
+++ b/libc/src/pthread/pthread_attr_getscope.h
@@ -25,4 +25,3 @@ int pthread_attr_getscope(const pthread_attr_t *__restrict attr,
 } // namespace LIBC_NAMESPACE_DECL
 
 #endif // LLVM_LIBC_SRC_PTHREAD_PTHREAD_ATTR_GETSCOPE_H
-

--- a/libc/src/pthread/pthread_attr_setscope.cpp
+++ b/libc/src/pthread/pthread_attr_setscope.cpp
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implementation of pthread_attr_setscope.
+///
+//===----------------------------------------------------------------------===//
+
+#include "src/pthread/pthread_attr_setscope.h"
+#include "hdr/errno_macros.h"
+#include "hdr/pthread_macros.h"
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/null_check.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(int, pthread_attr_setscope,
+                   ([[maybe_unused]] pthread_attr_t *attr,
+                    int contentionscope)) {
+  LIBC_CRASH_ON_NULLPTR(attr);
+
+  switch (contentionscope) {
+  case PTHREAD_SCOPE_SYSTEM:
+    return 0;
+  case PTHREAD_SCOPE_PROCESS:
+    return ENOTSUP;
+  default:
+    return EINVAL;
+  }
+}
+
+} // namespace LIBC_NAMESPACE_DECL
+

--- a/libc/src/pthread/pthread_attr_setscope.cpp
+++ b/libc/src/pthread/pthread_attr_setscope.cpp
@@ -21,7 +21,7 @@
 namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(int, pthread_attr_setscope,
-                   ([[maybe_unused]] pthread_attr_t *attr,
+                   ([[maybe_unused]] pthread_attr_t * attr,
                     int contentionscope)) {
   LIBC_CRASH_ON_NULLPTR(attr);
 
@@ -36,4 +36,3 @@ LLVM_LIBC_FUNCTION(int, pthread_attr_setscope,
 }
 
 } // namespace LIBC_NAMESPACE_DECL
-

--- a/libc/src/pthread/pthread_attr_setscope.h
+++ b/libc/src/pthread/pthread_attr_setscope.h
@@ -24,4 +24,3 @@ int pthread_attr_setscope(pthread_attr_t *attr, int contentionscope);
 } // namespace LIBC_NAMESPACE_DECL
 
 #endif // LLVM_LIBC_SRC_PTHREAD_PTHREAD_ATTR_SETSCOPE_H
-

--- a/libc/src/pthread/pthread_attr_setscope.h
+++ b/libc/src/pthread/pthread_attr_setscope.h
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implementation header for pthread_attr_setscope.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_PTHREAD_PTHREAD_ATTR_SETSCOPE_H
+#define LLVM_LIBC_SRC_PTHREAD_PTHREAD_ATTR_SETSCOPE_H
+
+#include "hdr/types/pthread_attr_t.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+int pthread_attr_setscope(pthread_attr_t *attr, int contentionscope);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_PTHREAD_PTHREAD_ATTR_SETSCOPE_H
+

--- a/libc/test/src/pthread/CMakeLists.txt
+++ b/libc/test/src/pthread/CMakeLists.txt
@@ -20,7 +20,10 @@ add_libc_test(
     libc.src.pthread.pthread_attr_setstack
     libc.src.pthread.pthread_attr_getschedpolicy
     libc.src.pthread.pthread_attr_setschedpolicy
+    libc.src.pthread.pthread_attr_getscope
+    libc.src.pthread.pthread_attr_setscope
     libc.hdr.errno_macros
+    libc.hdr.pthread_macros
     libc.hdr.sched_macros
 )
 

--- a/libc/test/src/pthread/pthread_attr_test.cpp
+++ b/libc/test/src/pthread/pthread_attr_test.cpp
@@ -1,23 +1,31 @@
-//===-- Unittests for pthread_attr_t --------------------------------------===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+///
+/// \file
+/// Unittests for pthread_attr_t.
+///
+//===----------------------------------------------------------------------===//
 
 #include "hdr/errno_macros.h"
+#include "hdr/pthread_macros.h"
 #include "hdr/sched_macros.h"
 #include "src/pthread/pthread_attr_destroy.h"
 #include "src/pthread/pthread_attr_getdetachstate.h"
 #include "src/pthread/pthread_attr_getguardsize.h"
 #include "src/pthread/pthread_attr_getschedpolicy.h"
+#include "src/pthread/pthread_attr_getscope.h"
 #include "src/pthread/pthread_attr_getstack.h"
 #include "src/pthread/pthread_attr_getstacksize.h"
 #include "src/pthread/pthread_attr_init.h"
 #include "src/pthread/pthread_attr_setdetachstate.h"
 #include "src/pthread/pthread_attr_setguardsize.h"
 #include "src/pthread/pthread_attr_setschedpolicy.h"
+#include "src/pthread/pthread_attr_setscope.h"
 #include "src/pthread/pthread_attr_setstack.h"
 #include "src/pthread/pthread_attr_setstacksize.h"
 
@@ -150,6 +158,35 @@ TEST(LlvmLibcPThreadattrTest, SetAndGetSchedPolicy) {
   ASSERT_EQ(LIBC_NAMESPACE::pthread_attr_setschedpolicy(&attr, -1), 0);
   ASSERT_EQ(LIBC_NAMESPACE::pthread_attr_getschedpolicy(&attr, &policy), 0);
   ASSERT_EQ(policy, -1);
+
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_attr_destroy(&attr), 0);
+}
+
+TEST(LlvmLibcPThreadAttrTest, SetAndGetScope) {
+  pthread_attr_t attr;
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_attr_init(&attr), 0);
+
+  int scope;
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_attr_getscope(&attr, &scope), 0);
+  ASSERT_EQ(scope, PTHREAD_SCOPE_SYSTEM);
+
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_attr_setscope(&attr, PTHREAD_SCOPE_SYSTEM),
+            0);
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_attr_getscope(&attr, &scope), 0);
+  ASSERT_EQ(scope, PTHREAD_SCOPE_SYSTEM);
+
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_attr_setscope(&attr, PTHREAD_SCOPE_PROCESS),
+            ENOTSUP);
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_attr_getscope(&attr, &scope), 0);
+  ASSERT_EQ(scope, PTHREAD_SCOPE_SYSTEM);
+
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_attr_setscope(&attr, 0xBAD), EINVAL);
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_attr_getscope(&attr, &scope), 0);
+  ASSERT_EQ(scope, PTHREAD_SCOPE_SYSTEM);
+
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_attr_setscope(&attr, -1), EINVAL);
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_attr_getscope(&attr, &scope), 0);
+  ASSERT_EQ(scope, PTHREAD_SCOPE_SYSTEM);
 
   ASSERT_EQ(LIBC_NAMESPACE::pthread_attr_destroy(&attr), 0);
 }


### PR DESCRIPTION
This patch implements pthread_attr_getscope and pthread_attr_setscope.

Same as other libraries, we only support the system contention scope (PTHREAD_SCOPE_SYSTEM). Process contention scope (PTHREAD_SCOPE_PROCESS) is not supported, and would basically require a userspace N:M threading implementation. Since this value cannot be checked in the kernel, I reject it directly during the attribute set operation, and don't even bother storing it in the attribute object.

Assisted-by: Gemini