### PR TITLE
[Flang][OpenMP] Fix use_device_addr descriptor types

### DIFF
--- a/flang/lib/Optimizer/OpenMP/MapInfoFinalization.cpp
+++ b/flang/lib/Optimizer/OpenMP/MapInfoFinalization.cpp
@@ -1175,6 +1175,43 @@ class MapInfoFinalizationPass
       deferrableDesc.push_back(std::make_pair(newMapInfoOp, attachMap));
   }
 
+  /// Use the materialized descriptor's address for target data block arguments.
+  /// Lowering initially binds assumed-shape arguments to box values, whereas
+  /// their maps return the type of the box's base address. The use_device_addr
+  /// and use_device_ptr clauses require the map result and block argument types
+  /// to agree. Load the box inside the region to preserve its existing uses.
+  void updateUseDeviceDescriptorArgs(mlir::omp::MapInfoOp map,
+                                     mlir::Value descriptor,
+                                     mlir::Operation *target,
+                                     fir::FirOpBuilder &builder) {
+    auto targetData = mlir::dyn_cast<mlir::omp::TargetDataOp>(target);
+    if (!targetData)
+      return;
+
+    auto argIface = mlir::cast<mlir::omp::BlockArgOpenMPOpInterface>(target);
+    auto updateArgs = [&](mlir::ValueRange maps,
+                          llvm::ArrayRef<mlir::BlockArgument> args) {
+      for (auto [mapValue, blockArg] : llvm::zip_equal(maps, args)) {
+        mlir::BlockArgument arg = blockArg;
+        if (mapValue != map.getResult() ||
+            !mlir::isa<fir::BaseBoxType>(arg.getType()))
+          continue;
+
+        mlir::OpBuilder::InsertionGuard guard(builder);
+        builder.setInsertionPointToStart(arg.getOwner());
+        arg.setType(descriptor.getType());
+        auto load = fir::LoadOp::create(builder, arg.getLoc(), arg);
+        arg.replaceAllUsesExcept(load.getResult(), load);
+        map.getResult().setType(
+            mlir::cast<mlir::omp::PointerLikeType>(descriptor.getType()));
+      }
+    };
+    updateArgs(targetData.getUseDeviceAddrVars(),
+               argIface.getUseDeviceAddrBlockArgs());
+    updateArgs(targetData.getUseDevicePtrVars(),
+               argIface.getUseDevicePtrBlockArgs());
+  }
+
   // This function handles the splitting of allocatable/pointer maps in
   // Fortran into descriptor, pointer and attach map components, as
   // well as the handling of ref_ptr, ref_ptee, ref_ptr_ptee and attach
@@ -1210,6 +1247,7 @@ class MapInfoFinalizationPass
 
     mlir::Value descriptor = getDescriptorFromBoxMap(
         op, builder, descCanBeDeferred, canOptimizeDescViaPrivatization);
+    updateUseDeviceDescriptorArgs(op, descriptor, target, builder);
     mlir::FlatSymbolRefAttr mapperId = op.getMapperIdAttr();
 
     // Exclude irregular maps from optimization via privatization; at least for

--- a/flang/test/Lower/OpenMP/target-data-use-device-addr-descriptor.f90
+++ b/flang/test/Lower/OpenMP/target-data-use-device-addr-descriptor.f90
@@ -1,0 +1,59 @@
+! RUN: %flang_fc1 -fopenmp -fopenmp-version=50 -emit-fir %s -o - | fir-opt | FileCheck %s
+! RUN: %flang_fc1 -fopenmp -fopenmp-version=50 -emit-hlfir %s -o - | fir-opt -o /dev/null
+
+! Descriptor map results and target data block arguments must have matching
+! types, including when the descriptor is passed by value to the subroutine.
+! Reparse textual FIR and HLFIR to catch mismatches between the types printed
+! in the use_device_addr clause and those used inside the region.
+
+subroutine device_addr_default(x)
+  integer, target, intent(in) :: x(:)
+  !$omp target data use_device_addr(x)
+  !$omp end target data
+end subroutine
+
+! CHECK-LABEL: func.func @_QPdevice_addr_default(
+! CHECK: omp.target_data {{.*}}use_device_addr(%{{.*}} -> %[[ARG:.*]], %{{.*}} -> %{{.*}} : !fir.ref<!fir.box<!fir.array<?xi32>>>, !fir.llvm_ptr<!fir.ref<!fir.array<?xi32>>>) {
+! CHECK-NEXT: %[[BOX:.*]] = fir.load %[[ARG]] : !fir.ref<!fir.box<!fir.array<?xi32>>>
+! CHECK-NEXT: %{{.*}} = fir.declare %[[BOX]] {{.*}} : (!fir.box<!fir.array<?xi32>>) -> !fir.box<!fir.array<?xi32>>
+
+subroutine device_addr_rank_two(x)
+  integer, target, intent(in) :: x(:, :)
+  interface
+    subroutine consume_rank_two(x)
+      integer, intent(in) :: x(:, :)
+    end subroutine
+  end interface
+  !$omp target data use_device_addr(x)
+    call consume_rank_two(x)
+  !$omp end target data
+end subroutine
+
+! CHECK-LABEL: func.func @_QPdevice_addr_rank_two(
+! CHECK: omp.target_data {{.*}}use_device_addr(%{{.*}} -> %[[ARG:.*]], %{{.*}} -> %{{.*}} : !fir.ref<!fir.box<!fir.array<?x?xi32>>>, !fir.llvm_ptr<!fir.ref<!fir.array<?x?xi32>>>) {
+! CHECK-NEXT: %[[BOX:.*]] = fir.load %[[ARG]] : !fir.ref<!fir.box<!fir.array<?x?xi32>>>
+! CHECK-NEXT: %{{.*}} = fir.declare %[[BOX]] {{.*}} : (!fir.box<!fir.array<?x?xi32>>) -> !fir.box<!fir.array<?x?xi32>>
+! CHECK: fir.call @_QPconsume_rank_two(%{{.*}}) {{.*}} : (!fir.box<!fir.array<?x?xi32>>) -> ()
+
+! OpenMP 5.0 treats a non-C_PTR use_device_ptr item as use_device_addr.
+subroutine device_ptr_promoted(x)
+  integer, target, intent(in) :: x(:)
+  !$omp target data use_device_ptr(x)
+  !$omp end target data
+end subroutine
+
+! CHECK-LABEL: func.func @_QPdevice_ptr_promoted(
+! CHECK: omp.target_data {{.*}}use_device_addr(%{{.*}} -> %[[ARG:.*]], %{{.*}} -> %{{.*}} : !fir.ref<!fir.box<!fir.array<?xi32>>>, !fir.llvm_ptr<!fir.ref<!fir.array<?xi32>>>) {
+! CHECK-NEXT: %[[BOX:.*]] = fir.load %[[ARG]] : !fir.ref<!fir.box<!fir.array<?xi32>>>
+! CHECK-NEXT: %{{.*}} = fir.declare %[[BOX]] {{.*}} : (!fir.box<!fir.array<?xi32>>) -> !fir.box<!fir.array<?xi32>>
+
+subroutine device_addr_optional(x)
+  integer, target, optional, intent(in) :: x(:)
+  !$omp target data use_device_addr(x)
+  !$omp end target data
+end subroutine
+
+! CHECK-LABEL: func.func @_QPdevice_addr_optional(
+! CHECK: omp.target_data {{.*}}use_device_addr(%{{.*}} -> %[[ARG:.*]], %{{.*}} -> %{{.*}} : !fir.ref<!fir.box<!fir.array<?xi32>>>, !fir.llvm_ptr<!fir.ref<!fir.array<?xi32>>>) {
+! CHECK-NEXT: %[[BOX:.*]] = fir.load %[[ARG]] : !fir.ref<!fir.box<!fir.array<?xi32>>>
+! CHECK-NEXT: %{{.*}} = fir.declare %[[BOX]] {{.*}} : (!fir.box<!fir.array<?xi32>>) -> !fir.box<!fir.array<?xi32>>


### PR DESCRIPTION
Fix invalid FIR for assumed-shape arrays in use_device_addr by using matching descriptor-reference types and loading the descriptor inside the region. Added tests.

Co-authored-by: Codex <codex@openai.com>