### PR TITLE
Fix Bazel build for 176ab01

### DIFF
--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
@@ -8702,6 +8702,7 @@ cc_library(
         ":ControlFlowDialect",
         ":ConversionPassIncGen",
         ":FuncDialect",
+        ":FunctionInterfaces",
         ":Pass",
         ":SCFDialect",
         ":TransformUtils",


### PR DESCRIPTION
Buildkite error link: https://buildkite.com/llvm-project/upstream-bazel/builds?commit=176ab0177fb9acf749b90634cae84936fcfac2c5