### PR TITLE
[clang-tidy] Fix function-cognitive-complexity crash on aliases

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/FunctionCognitiveComplexityCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/FunctionCognitiveComplexityCheck.cpp
@@ -484,7 +484,7 @@ void FunctionCognitiveComplexityCheck::storeOptions(
 
 void FunctionCognitiveComplexityCheck::registerMatchers(MatchFinder *Finder) {
   Finder->addMatcher(
-      functionDecl(isDefinition(),
+      functionDecl(isDefinition(), hasBody(stmt()),
                    unless(anyOf(isDefaulted(), isDeleted(), isWeak())))
           .bind("func"),
       this);

--- a/clang-tools-extra/docs/ReleaseNotes.md
+++ b/clang-tools-extra/docs/ReleaseNotes.md
@@ -216,6 +216,10 @@ infrastructure are described first, followed by tool-specific sections.
   `INT09-C-EX1` exception, allowing enumerators initialized by referencing
   another enumerator in the same enum (e.g., `last = first`).
 
+- Improved {doc}`readability-function-cognitive-complexity
+  <clang-tidy/checks/readability/function-cognitive-complexity>` check by fixing
+  a crash when checking a function declared with the `alias` attribute.
+
 - Improved {doc}`readability-identifier-naming
   <clang-tidy/checks/readability/identifier-naming>` check:
 

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/function-cognitive-complexity-alias.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/function-cognitive-complexity-alias.cpp
@@ -1,0 +1,6 @@
+// RUN: %check_clang_tidy %s readability-function-cognitive-complexity %t -- \
+// RUN:   -- -target x86_64-unknown-linux-gnu
+
+extern "C" int function_alias_target() { return 42; }
+extern "C" int function_alias()
+    __attribute__((alias("function_alias_target")));


### PR DESCRIPTION
Only match function definitions that have a body, since declarations with the alias attribute satisfy `isDefinition()` without providing one.

Fixes #222958