### PR TITLE
[DRAFT] X86 mc semantics

### DIFF
--- a/llvm/include/llvm/MC/MCInstrAnalysis.h
+++ b/llvm/include/llvm/MC/MCInstrAnalysis.h
@@ -19,8 +19,10 @@
 #include "llvm/MC/MCInstrDesc.h"
 #include "llvm/MC/MCInstrInfo.h"
 #include "llvm/MC/MCRegisterInfo.h"
+#include "llvm/MC/MCSemExpr.h"
 #include "llvm/Support/Compiler.h"
 #include <cstdint>
+#include <optional>
 #include <vector>
 
 namespace llvm {
@@ -197,6 +199,46 @@ public:
   /// returns the offset within the instruction of that relocation.
   virtual std::optional<uint64_t>
   getMemoryOperandRelocationOffset(const MCInst &Inst, uint64_t Size) const;
+
+  /// Return the value \p Inst assigns to \p Reg.
+  ///
+  /// The result is expressed in terms of the register and memory values
+  /// before inst executes. All values used to describe a future step
+  /// are read from the previous state, so the instructions are seen as
+  /// semantically order-independent. For example, on X86 `push %rax` is
+  /// described by
+  ///
+  ///  evaluateDefinedValue(Inst, RSP) == %rsp - 8
+  ///  evaluateStoreAddress(Inst)      == [%rsp - 8]
+  ///  getStoredValue(Inst)            == [%rax]
+  ///
+  /// Returns std::nullopt if Inst does not define Reg, or if the new
+  /// value cannot currently be represented by MCSemExpr. Callers must treat
+  /// std::nullopt as a conservative unknown result.
+  virtual std::optional<MCSemExpr> evaluateDefinedValue(const MCInst &Inst,
+                                                        MCRegister Reg) const {
+    return {};
+  }
+
+  /// Return the memory locations Inst writes to, in terms of the pre-state.
+  ///
+  /// Returns an empty list if Inst stores nothing, or if the addresses
+  /// cannot be represented by MCSemAddrExpr. Similar to evaluateDefinedValue,
+  /// an empty list is a conservative unknown result.
+  virtual std::vector<MCSemAddrExpr>
+  evaluateStoreAddress(const MCInst &Inst) const {
+    return {};
+  }
+
+  /// Return the values Inst stores, in terms of the pre-state.
+  ///
+  /// The result corresponds positionally to evaluateStoreAddress(), i'th
+  /// element is the value written to the i'th location in the StoreAddress
+  /// list, both having the same size. Returns an empty list if \p Inst stores
+  /// nothing, or if the values cannot be represented by MCSemExpr.
+  virtual std::vector<MCSemExpr> getStoredValue(const MCInst &Inst) const {
+    return {};
+  }
 
   /// Returns (PLT virtual address, GOT virtual address) pairs for PLT entries.
   virtual std::vector<std::pair<uint64_t, uint64_t>>

--- a/llvm/include/llvm/MC/MCSemExpr.h
+++ b/llvm/include/llvm/MC/MCSemExpr.h
@@ -1,0 +1,138 @@
+//===- MCSemExpr.h - Semantic Level Expressions -----------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_MC_MCSEMEXPR_H
+#define LLVM_MC_MCSEMEXPR_H
+
+#include "llvm/MC/MCRegister.h"
+#include "llvm/Support/Compiler.h"
+#include <cassert>
+#include <cstdint>
+
+namespace llvm {
+class MCRegisterInfo;
+class raw_ostream;
+
+/// Affine address expression: A * Reg + B
+/// Canonical form for unambiguous constant addresses:
+/// A == 0 <=> Reg == MCRegister()
+class MCSemAddrExpr {
+  int64_t A;
+  MCRegister Reg;
+  int64_t B;
+
+  MCSemAddrExpr(int64_t A, MCRegister Reg, int64_t B) : A(A), Reg(Reg), B(B) {}
+
+public:
+  static MCSemAddrExpr createConst(int64_t B) { return {0, MCRegister(), B}; }
+  static MCSemAddrExpr createReg(int64_t A, MCRegister Reg, int64_t B) {
+    assert(Reg.isValid() && A != 0 && "non-canonical MCSemAddrExpr");
+    return {A, Reg, B};
+  }
+
+  int64_t getScale() const { return A; }
+  /// Returns base register or MCRegister() if constant.
+  MCRegister getReg() const { return Reg; }
+  int64_t getOffset() const { return B; }
+  bool isConstant() const { return A == 0; }
+
+  bool operator==(const MCSemAddrExpr &RHS) const {
+    return A == RHS.A && Reg == RHS.Reg && B == RHS.B;
+  }
+  bool operator!=(const MCSemAddrExpr &RHS) const { return !(*this == RHS); }
+
+  LLVM_ABI void print(raw_ostream &OS,
+                      const MCRegisterInfo *MRI = nullptr) const;
+  LLVM_ABI void dump() const;
+};
+
+/// Leaf of a semantic expression must be either a register value or a memory
+/// dereference.
+class MCSemLeaf {
+  enum MCSemLeafType : uint8_t { Register, Memory };
+
+  MCSemLeafType Kind;
+  /// Register or memory dereference type
+  MCRegister Reg;
+  MCSemAddrExpr Addr;
+
+  MCSemLeaf(MCSemLeafType Kind, MCRegister Reg, MCSemAddrExpr Addr)
+      : Kind(Kind), Reg(Reg), Addr(Addr) {}
+
+public:
+  static MCSemLeaf createReg(MCRegister Reg) {
+    return {Register, Reg, MCSemAddrExpr::createConst(0)};
+  }
+  static MCSemLeaf createMem(MCSemAddrExpr Addr) {
+    return {Memory, MCRegister(), Addr};
+  }
+
+  bool isReg() const { return Kind == Register; }
+  bool isMem() const { return Kind == Memory; }
+
+  MCRegister getReg() const {
+    assert(isReg() && "not a register leaf");
+    return Reg;
+  }
+  const MCSemAddrExpr &getAddr() const {
+    assert(isMem() && "not a memory leaf");
+    return Addr;
+  }
+
+  bool operator==(const MCSemLeaf &RHS) const {
+    if (Kind != RHS.Kind)
+      return false;
+    return isReg() ? Reg == RHS.Reg : Addr == RHS.Addr;
+  }
+  bool operator!=(const MCSemLeaf &RHS) const { return !(*this == RHS); }
+
+  LLVM_ABI void print(raw_ostream &OS,
+                      const MCRegisterInfo *MRI = nullptr) const;
+  LLVM_ABI void dump() const;
+};
+
+/// Affine semantic value A * Leaf + B
+/// Canonical form: A == 0 <=> Leaf == MCSemLeaf::createReg(MCRegister())
+/// To prevent ambiguous expressions for the same constant.
+class MCSemExpr {
+  int64_t A;
+  MCSemLeaf Leaf;
+  int64_t B;
+
+  MCSemExpr(int64_t A, MCSemLeaf Leaf, int64_t B) : A(A), Leaf(Leaf), B(B) {}
+
+public:
+  static MCSemExpr createConst(int64_t B) {
+    return {0, MCSemLeaf::createReg(MCRegister()), B};
+  }
+  static MCSemExpr createReg(int64_t A, MCRegister Reg, int64_t B) {
+    assert(Reg.isValid() && A != 0 && "non-canonical MCSemExpr");
+    return {A, MCSemLeaf::createReg(Reg), B};
+  }
+  static MCSemExpr createMem(int64_t A, MCSemAddrExpr Addr, int64_t B) {
+    assert(A != 0 && "non-canonical MCSemExpr");
+    return {A, MCSemLeaf::createMem(Addr), B};
+  }
+
+  int64_t getScale() const { return A; }
+  const MCSemLeaf &getLeaf() const { return Leaf; }
+  int64_t getOffset() const { return B; }
+  bool isConstant() const { return A == 0; }
+
+  bool operator==(const MCSemExpr &RHS) const {
+    return A == RHS.A && B == RHS.B && Leaf == RHS.Leaf;
+  }
+  bool operator!=(const MCSemExpr &RHS) const { return !(*this == RHS); }
+
+  LLVM_ABI void print(raw_ostream &OS,
+                      const MCRegisterInfo *MRI = nullptr) const;
+  LLVM_ABI void dump() const;
+};
+
+} // namespace llvm
+#endif

--- a/llvm/lib/MC/CMakeLists.txt
+++ b/llvm/lib/MC/CMakeLists.txt
@@ -47,6 +47,7 @@ add_llvm_component_library(LLVMMC
   MCSchedule.cpp
   MCSection.cpp
   MCSectionMachO.cpp
+  MCSemExpr.cpp
   MCStreamer.cpp
   MCSFrame.cpp
   MCSPIRVStreamer.cpp

--- a/llvm/lib/MC/MCSemExpr.cpp
+++ b/llvm/lib/MC/MCSemExpr.cpp
@@ -1,0 +1,89 @@
+//===- MCSemExpr.cpp - Semantic Level Expressions -------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/MC/MCSemExpr.h"
+#include "llvm/MC/MCRegisterInfo.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace llvm;
+
+namespace {
+
+void printReg(raw_ostream &OS, MCRegister Reg, const MCRegisterInfo *MRI) {
+  if (!Reg.isValid()) {
+    OS << "$noreg";
+    return;
+  }
+  if (MRI)
+    OS << '$' << MRI->getName(Reg);
+  else
+    OS << "$physreg" << Reg.id();
+}
+
+void printScale(raw_ostream &OS, int64_t A) { OS << A << '*'; }
+
+/// Print offset, or nothing when B is 0.
+void printOffset(raw_ostream &OS, int64_t B) {
+  if (B == 0)
+    return;
+  if (B < 0)
+    OS << " - " << -(uint64_t)(B);
+  else
+    OS << " + " << B;
+}
+
+} // namespace
+
+void MCSemAddrExpr::print(raw_ostream &OS, const MCRegisterInfo *MRI) const {
+  if (isConstant()) {
+    OS << B;
+    return;
+  }
+  printScale(OS, A);
+  printReg(OS, Reg, MRI);
+  printOffset(OS, B);
+}
+
+void MCSemLeaf::print(raw_ostream &OS, const MCRegisterInfo *MRI) const {
+  if (isReg()) {
+    printReg(OS, Reg, MRI);
+    return;
+  }
+  assert(isMem() && "Invalid semantic leaf kind");
+  OS << "mem[";
+  Addr.print(OS, MRI);
+  OS << ']';
+}
+
+void MCSemExpr::print(raw_ostream &OS, const MCRegisterInfo *MRI) const {
+  if (isConstant()) {
+    OS << B;
+    return;
+  }
+  printScale(OS, A);
+  Leaf.print(OS, MRI);
+  printOffset(OS, B);
+}
+
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
+LLVM_DUMP_METHOD void MCSemAddrExpr::dump() const {
+  print(dbgs(), nullptr);
+  dbgs() << '\n';
+}
+
+LLVM_DUMP_METHOD void MCSemLeaf::dump() const {
+  print(dbgs(), nullptr);
+  dbgs() << '\n';
+}
+
+LLVM_DUMP_METHOD void MCSemExpr::dump() const {
+  print(dbgs(), nullptr);
+  dbgs() << '\n';
+}
+#endif

--- a/llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.cpp
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.cpp
@@ -608,6 +608,11 @@ public:
   std::optional<uint64_t>
   getMemoryOperandRelocationOffset(const MCInst &Inst,
                                    uint64_t Size) const override;
+  std::optional<MCSemExpr> evaluateDefinedValue(const MCInst &Inst,
+                                                MCRegister Reg) const override;
+  std::vector<MCSemAddrExpr>
+  evaluateStoreAddress(const MCInst &Inst) const override;
+  std::vector<MCSemExpr> getStoredValue(const MCInst &Inst) const override;
 };
 
 #define GET_STIPREDICATE_DEFS_FOR_MC_ANALYSIS
@@ -781,6 +786,125 @@ X86MCInstrAnalysis::getMemoryOperandRelocationOffset(const MCInst &Inst,
   // rip-relative ModR/M immediate is 32 bits.
   assert(Size > 4 && "invalid instruction size for rip-relative lea");
   return Size - 4;
+}
+
+/// Return a 64-bit memory address with at most one base or index register.
+/// Addresses requiring two register terms are not handled yet.
+static std::optional<MCSemAddrExpr>
+getSimpleMemoryAddress(const MCInst &Inst, const MCInstrInfo &Info) {
+  // Address-size overrides require truncation, which MCSemAddrExpr cannot
+  // express. The callers currently only handle 64-bit MOV instructions.
+  if (Inst.getFlags() & X86::IP_HAS_AD_SIZE)
+    return std::nullopt;
+
+  int MemOpStart = X86II::getMemoryOperandIdx(Info.get(Inst.getOpcode()));
+  if (MemOpStart < 0)
+    return std::nullopt;
+
+  const MCOperand &Base = Inst.getOperand(MemOpStart + X86::AddrBaseReg);
+  const MCOperand &Scale = Inst.getOperand(MemOpStart + X86::AddrScaleAmt);
+  const MCOperand &Index = Inst.getOperand(MemOpStart + X86::AddrIndexReg);
+  const MCOperand &Disp = Inst.getOperand(MemOpStart + X86::AddrDisp);
+  const MCOperand &Segment = Inst.getOperand(MemOpStart + X86::AddrSegmentReg);
+
+  if (!Base.isReg() || !Scale.isImm() || !Index.isReg() || !Disp.isImm() ||
+      !Segment.isReg() || Segment.getReg())
+    return std::nullopt;
+
+  MCRegister BaseReg = Base.getReg();
+  MCRegister IndexReg = Index.getReg();
+  const MCRegisterClass &GR64 = getX86MCRegisterClass(X86::GR64RegClassID);
+  // GR64 includes RIP, but RIP-relative addressing uses the next instruction's
+  // address. Exclude it explicitly, along with 32-bit address registers.
+  if (BaseReg == X86::RIP || IndexReg == X86::RIP ||
+      (BaseReg && !GR64.contains(BaseReg)) ||
+      (IndexReg && !GR64.contains(IndexReg)))
+    return std::nullopt;
+
+  if (BaseReg && IndexReg)
+    return std::nullopt;
+
+  if (IndexReg) {
+    int64_t IndexScale = Scale.getImm();
+    assert((IndexScale == 1 || IndexScale == 2 || IndexScale == 4 ||
+            IndexScale == 8) &&
+           "Invalid X86 index scale");
+    return MCSemAddrExpr::createReg(IndexScale, IndexReg, Disp.getImm());
+  }
+
+  // Without an index register, use the form 1 * BaseReg + Disp.
+  if (BaseReg)
+    return MCSemAddrExpr::createReg(1, BaseReg, Disp.getImm());
+  return MCSemAddrExpr::createConst(Disp.getImm());
+}
+
+std::optional<MCSemExpr>
+X86MCInstrAnalysis::evaluateDefinedValue(const MCInst &Inst,
+                                         MCRegister Reg) const {
+  switch (Inst.getOpcode()) {
+  case X86::PUSH64r:
+    if (Reg == X86::RSP)
+      return MCSemExpr::createReg(1, X86::RSP, -8);
+    return std::nullopt;
+  case X86::POP64r:
+    if (Reg == X86::RSP)
+      return MCSemExpr::createReg(1, X86::RSP, 8);
+    if (Inst.getOperand(0).isReg() && Reg == Inst.getOperand(0).getReg())
+      return MCSemExpr::createMem(1, MCSemAddrExpr::createReg(1, X86::RSP, 0),
+                                  0);
+    return std::nullopt;
+  case X86::MOV64rr:
+    if (Inst.getOperand(0).isReg() && Inst.getOperand(1).isReg() &&
+        Reg == Inst.getOperand(0).getReg())
+      return MCSemExpr::createReg(1, Inst.getOperand(1).getReg(), 0);
+    return std::nullopt;
+  case X86::MOV64rm:
+    if (Inst.getOperand(0).isReg() && Reg == Inst.getOperand(0).getReg()) {
+      if (std::optional<MCSemAddrExpr> Address =
+              getSimpleMemoryAddress(Inst, *Info))
+        return MCSemExpr::createMem(1, *Address, 0);
+    }
+    return std::nullopt;
+  }
+
+  return std::nullopt;
+}
+
+std::vector<MCSemAddrExpr>
+X86MCInstrAnalysis::evaluateStoreAddress(const MCInst &Inst) const {
+  switch (Inst.getOpcode()) {
+  case X86::PUSH64r:
+    return {MCSemAddrExpr::createReg(1, X86::RSP, -8)};
+  case X86::MOV64mr:
+    if (std::optional<MCSemAddrExpr> Address =
+            getSimpleMemoryAddress(Inst, *Info))
+      return {*Address};
+    return {};
+  }
+
+  return {};
+}
+
+std::vector<MCSemExpr>
+X86MCInstrAnalysis::getStoredValue(const MCInst &Inst) const {
+  switch (Inst.getOpcode()) {
+  case X86::PUSH64r:
+    if (Inst.getOperand(0).isReg())
+      return {MCSemExpr::createReg(1, Inst.getOperand(0).getReg(), 0)};
+    return {};
+  case X86::MOV64mr: {
+    int MemOpStart = X86II::getMemoryOperandIdx(Info->get(Inst.getOpcode()));
+    if (MemOpStart < 0 || !getSimpleMemoryAddress(Inst, *Info))
+      return {};
+    const MCOperand &Source =
+        Inst.getOperand(MemOpStart + X86::AddrNumOperands);
+    if (Source.isReg())
+      return {MCSemExpr::createReg(1, Source.getReg(), 0)};
+    return {};
+  }
+  }
+
+  return {};
 }
 
 } // end of namespace X86_MC

--- a/llvm/unittests/MC/CMakeLists.txt
+++ b/llvm/unittests/MC/CMakeLists.txt
@@ -22,6 +22,7 @@ add_llvm_unittest(MCTests
   DwarfLineTableHeaders.cpp
   DXContainerWriterTest.cpp
   MCInstPrinter.cpp
+  MCSemExprTest.cpp
   StringTableBuilderTest.cpp
   TargetRegistry.cpp
   MCDisassemblerTest.cpp

--- a/llvm/unittests/MC/MCSemExprTest.cpp
+++ b/llvm/unittests/MC/MCSemExprTest.cpp
@@ -1,0 +1,76 @@
+//===- llvm/unittests/MC/MCSemExprTest.cpp --------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/MC/MCSemExpr.h"
+#include "gtest/gtest.h"
+
+using namespace llvm;
+
+namespace {
+
+// Arbitrary physical register ids
+const MCRegister R1(51);
+const MCRegister R2(9);
+
+TEST(MCSemExprTest, ConstantIsCanonical) {
+  MCSemExpr E = MCSemExpr::createConst(5);
+  EXPECT_TRUE(E.isConstant());
+  EXPECT_EQ(E.getScale(), 0);
+  EXPECT_EQ(E.getOffset(), 5);
+  // A == 0 implies the invalid leaf reg, canonical for constant uniqueness.
+  ASSERT_TRUE(E.getLeaf().isReg());
+  EXPECT_FALSE(E.getLeaf().getReg().isValid());
+  EXPECT_EQ(E, MCSemExpr::createConst(5));
+
+  MCSemAddrExpr A = MCSemAddrExpr::createConst(0x1000);
+  EXPECT_TRUE(A.isConstant());
+  EXPECT_FALSE(A.getReg().isValid());
+  EXPECT_EQ(A, MCSemAddrExpr::createConst(0x1000));
+}
+
+TEST(MCSemExprTest, Equality) {
+  MCSemExpr E = MCSemExpr::createReg(1, R1, -16);
+  EXPECT_EQ(E, MCSemExpr::createReg(1, R1, -16));
+  EXPECT_NE(E, MCSemExpr::createReg(2, R1, -16));
+  EXPECT_NE(E, MCSemExpr::createReg(1, R2, -16));
+  EXPECT_NE(E, MCSemExpr::createReg(1, R1, 8));
+  EXPECT_NE(E, MCSemExpr::createConst(-8));
+  // Reading a register should be different from reading the memory it points
+  // at.
+  EXPECT_NE(E,
+            MCSemExpr::createMem(1, MCSemAddrExpr::createReg(1, R1, -16), 0));
+}
+
+TEST(MCSemLeafTest, KindsAreNeverEqual) {
+  // Leaf kind compared first, to prevent equality of inactive field in class.
+  EXPECT_NE(MCSemLeaf::createReg(MCRegister()),
+            MCSemLeaf::createMem(MCSemAddrExpr::createConst(0)));
+}
+
+#ifdef GTEST_HAS_DEATH_TEST
+#ifndef NDEBUG
+TEST(MCSemExprTest, NonCanonicalDeath) {
+  // A == 0 should be only used with createConst()
+  EXPECT_DEATH((void)MCSemExpr::createReg(0, R1, 8), "non-canonical MCSemExpr");
+  EXPECT_DEATH((void)MCSemAddrExpr::createReg(0, R1, 8),
+               "non-canonical MCSemAddrExpr");
+  // A register term requires a valid register.
+  EXPECT_DEATH((void)MCSemExpr::createReg(1, MCRegister(), 8),
+               "non-canonical MCSemExpr");
+  EXPECT_DEATH((void)MCSemAddrExpr::createReg(1, MCRegister(), 8),
+               "non-canonical MCSemAddrExpr");
+  // Assert on the inactive leaf field.
+  EXPECT_DEATH((void)MCSemLeaf::createReg(R1).getAddr(), "not a memory leaf");
+  EXPECT_DEATH(
+      (void)MCSemLeaf::createMem(MCSemAddrExpr::createConst(0)).getReg(),
+      "not a register leaf");
+}
+#endif
+#endif
+
+} // namespace

--- a/llvm/unittests/MC/X86/CMakeLists.txt
+++ b/llvm/unittests/MC/X86/CMakeLists.txt
@@ -1,3 +1,8 @@
+include_directories(
+  ${LLVM_MAIN_SRC_DIR}/lib/Target/X86
+  ${LLVM_BINARY_DIR}/lib/Target/X86
+  )
+
 set(LLVM_LINK_COMPONENTS
   MC
   MCDisassembler
@@ -8,5 +13,6 @@ set(LLVM_LINK_COMPONENTS
   )
 
 add_llvm_unittest(X86MCTests
+  X86MCInstrAnalysisTest.cpp
   X86MCDisassemblerTest.cpp
   )

--- a/llvm/unittests/MC/X86/X86MCInstrAnalysisTest.cpp
+++ b/llvm/unittests/MC/X86/X86MCInstrAnalysisTest.cpp
@@ -1,0 +1,226 @@
+//===- X86MCInstrAnalysisTest.cpp - Tests for X86 MC instruction semantics
+//-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "MCTargetDesc/X86BaseInfo.h"
+#include "MCTargetDesc/X86MCTargetDesc.h"
+#include "llvm/MC/MCInstBuilder.h"
+#include "llvm/MC/MCInstrAnalysis.h"
+#include "llvm/MC/MCInstrInfo.h"
+#include "llvm/MC/TargetRegistry.h"
+#include "llvm/Support/TargetSelect.h"
+#include "llvm/TargetParser/Triple.h"
+#include "gtest/gtest.h"
+
+#include <memory>
+
+using namespace llvm;
+
+namespace {
+
+struct Context {
+  static constexpr char TripleName[] = "x86_64-unknown-elf";
+  const Triple TheTriple;
+  std::unique_ptr<MCInstrInfo> Info;
+  std::unique_ptr<MCInstrAnalysis> Analysis;
+
+  Context() : TheTriple(TripleName) {
+    LLVMInitializeX86TargetInfo();
+    LLVMInitializeX86TargetMC();
+
+    std::string Error;
+    const Target *TheTarget = TargetRegistry::lookupTarget(TheTriple, Error);
+    if (!TheTarget)
+      return;
+
+    Info.reset(TheTarget->createMCInstrInfo());
+    Analysis.reset(TheTarget->createMCInstrAnalysis(Info.get()));
+  }
+};
+
+Context &getContext() {
+  static Context Ctxt;
+  return Ctxt;
+}
+
+} // namespace
+
+TEST(X86MCInstrAnalysisTest, PushRegister) {
+  const auto &Analysis = getContext().Analysis;
+  ASSERT_NE(Analysis, nullptr);
+  MCInst Inst = MCInstBuilder(X86::PUSH64r).addReg(X86::RDI);
+
+  EXPECT_EQ(*Analysis->evaluateDefinedValue(Inst, X86::RSP),
+            MCSemExpr::createReg(1, X86::RSP, -8));
+  EXPECT_FALSE(Analysis->evaluateDefinedValue(Inst, X86::RDI));
+
+  const auto Addresses = Analysis->evaluateStoreAddress(Inst);
+  ASSERT_EQ(Addresses.size(), 1u);
+  EXPECT_EQ(Addresses[0], MCSemAddrExpr::createReg(1, X86::RSP, -8));
+
+  const auto Values = Analysis->getStoredValue(Inst);
+  ASSERT_EQ(Values.size(), 1u);
+  EXPECT_EQ(Values[0], MCSemExpr::createReg(1, X86::RDI, 0));
+}
+
+TEST(X86MCInstrAnalysisTest, PopRegister) {
+  const auto &Analysis = getContext().Analysis;
+  ASSERT_NE(Analysis, nullptr);
+  MCInst Inst = MCInstBuilder(X86::POP64r).addReg(X86::RDI);
+
+  EXPECT_EQ(
+      *Analysis->evaluateDefinedValue(Inst, X86::RDI),
+      MCSemExpr::createMem(1, MCSemAddrExpr::createReg(1, X86::RSP, 0), 0));
+  EXPECT_EQ(*Analysis->evaluateDefinedValue(Inst, X86::RSP),
+            MCSemExpr::createReg(1, X86::RSP, 8));
+  EXPECT_FALSE(Analysis->evaluateDefinedValue(Inst, X86::RAX));
+  EXPECT_TRUE(Analysis->evaluateStoreAddress(Inst).empty());
+  EXPECT_TRUE(Analysis->getStoredValue(Inst).empty());
+}
+
+TEST(X86MCInstrAnalysisTest, RegisterMove) {
+  const auto &Analysis = getContext().Analysis;
+  ASSERT_NE(Analysis, nullptr);
+  MCInst Inst = MCInstBuilder(X86::MOV64rr).addReg(X86::RBP).addReg(X86::RSP);
+
+  EXPECT_EQ(*Analysis->evaluateDefinedValue(Inst, X86::RBP),
+            MCSemExpr::createReg(1, X86::RSP, 0));
+  EXPECT_FALSE(Analysis->evaluateDefinedValue(Inst, X86::RSP));
+}
+
+TEST(X86MCInstrAnalysisTest, StackStore) {
+  const auto &Analysis = getContext().Analysis;
+  ASSERT_NE(Analysis, nullptr);
+  MCInst Inst = MCInstBuilder(X86::MOV64mr)
+                    .addReg(X86::RSP)
+                    .addImm(1)
+                    .addReg(X86::NoRegister)
+                    .addImm(-16)
+                    .addReg(X86::NoRegister)
+                    .addReg(X86::RDI);
+
+  const auto Addresses = Analysis->evaluateStoreAddress(Inst);
+  ASSERT_EQ(Addresses.size(), 1u);
+  EXPECT_EQ(Addresses[0], MCSemAddrExpr::createReg(1, X86::RSP, -16));
+
+  const auto Values = Analysis->getStoredValue(Inst);
+  ASSERT_EQ(Values.size(), 1u);
+  EXPECT_EQ(Values[0], MCSemExpr::createReg(1, X86::RDI, 0));
+}
+
+TEST(X86MCInstrAnalysisTest, StackLoad) {
+  const auto &Analysis = getContext().Analysis;
+  ASSERT_NE(Analysis, nullptr);
+  MCInst Inst = MCInstBuilder(X86::MOV64rm)
+                    .addReg(X86::RDI)
+                    .addReg(X86::RBP)
+                    .addImm(1)
+                    .addReg(X86::NoRegister)
+                    .addImm(-24)
+                    .addReg(X86::NoRegister);
+
+  EXPECT_EQ(
+      *Analysis->evaluateDefinedValue(Inst, X86::RDI),
+      MCSemExpr::createMem(1, MCSemAddrExpr::createReg(1, X86::RBP, -24), 0));
+  EXPECT_FALSE(Analysis->evaluateDefinedValue(Inst, X86::RAX));
+}
+
+// Creates the specified memory inst loading into destination RDI
+static MCInst memoryInst(unsigned Opcode, MCRegister Base, int64_t Scale,
+                         MCRegister Index, int64_t Disp,
+                         MCRegister Segment = X86::NoRegister,
+                         unsigned Flags = 0) {
+  MCInstBuilder Builder(Opcode);
+  if (Opcode == X86::MOV64rm)
+    Builder.addReg(X86::RDI);
+  Builder.addReg(Base).addImm(Scale).addReg(Index).addImm(Disp).addReg(Segment);
+  if (Opcode == X86::MOV64mr)
+    Builder.addReg(X86::RDI);
+  MCInst Inst = Builder;
+  Inst.setFlags(Flags);
+  return Inst;
+}
+
+// Creates the memory inst from parameters and tests for correct SemExprs
+// Loads and stores are from/to RDI.
+static void expectMemoryAddress(MCRegister Base, int64_t Scale,
+                                MCRegister Index, int64_t Disp,
+                                MCSemAddrExpr Expected) {
+  const auto &Analysis = getContext().Analysis;
+  ASSERT_NE(Analysis, nullptr);
+  MCInst Load = memoryInst(X86::MOV64rm, Base, Scale, Index, Disp);
+  auto Value = Analysis->evaluateDefinedValue(Load, X86::RDI);
+  ASSERT_TRUE(Value);
+  EXPECT_EQ(*Value, MCSemExpr::createMem(1, Expected, 0));
+
+  MCInst Store = memoryInst(X86::MOV64mr, Base, Scale, Index, Disp);
+  auto Addresses = Analysis->evaluateStoreAddress(Store);
+  auto Values = Analysis->getStoredValue(Store);
+  ASSERT_EQ(Addresses.size(), 1u);
+  ASSERT_EQ(Values.size(), Addresses.size());
+  EXPECT_EQ(Addresses[0], Expected);
+  EXPECT_EQ(Values[0], MCSemExpr::createReg(1, X86::RDI, 0));
+}
+
+TEST(X86MCInstrAnalysisTest, BaseOnlyAddress) {
+  for (MCRegister Base : {X86::RSP, X86::RBP, X86::RAX, X86::RDI, X86::R12})
+    expectMemoryAddress(Base, 1, X86::NoRegister, -16,
+                        MCSemAddrExpr::createReg(1, Base, -16));
+}
+
+TEST(X86MCInstrAnalysisTest, ScaleIgnoredWithoutIndex) {
+  for (int64_t Scale : {1, 2, 4, 8})
+    expectMemoryAddress(X86::RAX, Scale, X86::NoRegister, 16,
+                        MCSemAddrExpr::createReg(1, X86::RAX, 16));
+}
+
+TEST(X86MCInstrAnalysisTest, IndexOnlyAddress) {
+  for (int64_t Scale : {1, 2, 4, 8})
+    for (int64_t Disp : {-16, 0, 16})
+      expectMemoryAddress(X86::NoRegister, Scale, X86::RCX, Disp,
+                          MCSemAddrExpr::createReg(Scale, X86::RCX, Disp));
+}
+
+TEST(X86MCInstrAnalysisTest, AbsoluteAddress) {
+  for (int64_t Disp : {-16, 0, 16})
+    expectMemoryAddress(X86::NoRegister, 1, X86::NoRegister, Disp,
+                        MCSemAddrExpr::createConst(Disp));
+}
+
+// To test cases that are not handled yet.
+// Loads and stores are from/to RDI as well.
+static void expectUnknownMemoryAddress(MCRegister Base, int64_t Scale,
+                                       MCRegister Index, int64_t Disp,
+                                       MCRegister Segment = X86::NoRegister,
+                                       unsigned Flags = 0) {
+  const auto &Analysis = getContext().Analysis;
+  ASSERT_NE(Analysis, nullptr);
+  MCInst Load =
+      memoryInst(X86::MOV64rm, Base, Scale, Index, Disp, Segment, Flags);
+  EXPECT_FALSE(Analysis->evaluateDefinedValue(Load, X86::RDI));
+
+  MCInst Store =
+      memoryInst(X86::MOV64mr, Base, Scale, Index, Disp, Segment, Flags);
+  EXPECT_TRUE(Analysis->evaluateStoreAddress(Store).empty());
+  EXPECT_TRUE(Analysis->getStoredValue(Store).empty());
+}
+
+TEST(X86MCInstrAnalysisTest, UnsupportedMemoryAddresses) {
+  // A base plus an index is outside the helper's supported subset for now.
+  expectUnknownMemoryAddress(X86::RBP, 8, X86::RCX, 16);
+  // Does not support RIP-relative addressing yet due to variable length inst
+  // encoding.
+  expectUnknownMemoryAddress(X86::RIP, 1, X86::NoRegister, 16);
+  // Does not support segment registers yet.
+  expectUnknownMemoryAddress(X86::RAX, 1, X86::NoRegister, 16, X86::FS);
+  // Does not support 32 bit address registers yet.
+  expectUnknownMemoryAddress(X86::EAX, 1, X86::NoRegister, 16);
+  expectUnknownMemoryAddress(X86::NoRegister, 8, X86::ECX, 16);
+  expectUnknownMemoryAddress(X86::NoRegister, 1, X86::NoRegister, -16,
+                             X86::NoRegister, X86::IP_HAS_AD_SIZE);
+}


### PR DESCRIPTION
Depends on PR #[221021](https://github.com/llvm/llvm-project/pull/221021). Adds semantics for a few memory/stack instructions into MC.