### PR TITLE
[lldb] Parse XML files without the deprecated SAX1 API

### DIFF
--- a/lldb/source/Host/common/XML.cpp
+++ b/lldb/source/Host/common/XML.cpp
@@ -45,7 +45,7 @@ bool XMLDocument::ParseFile(const char *path) {
 #if LLDB_ENABLE_LIBXML2
   Clear();
   xmlSetGenericErrorFunc((void *)this, XMLDocument::ErrorCallback);
-  m_document = xmlParseFile(path);
+  m_document = xmlReadFile(path, nullptr, 0);
   xmlSetGenericErrorFunc(nullptr, nullptr);
 #endif
   return IsValid();


### PR DESCRIPTION
SAX1 is deprecated, switch to SAX2 instead.