### PR TITLE
[InstCombine] Share common binop folds between icmp and [su]cmp

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -2540,10 +2540,20 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
     if (Value *V = foldCmpIntrinsicOfExtended(II, Builder, DL))
       return replaceInstUsesWith(CI, V);
 
+    auto *Cmp = cast<CmpIntrinsic>(II);
+    Value *I0 = Cmp->getLHS(), *I1 = Cmp->getRHS();
+    Value *LHS, *RHS;
+    CmpInst::Predicate Pred = Cmp->getLTPredicate();
+    if (matchCommonBinOpOperands(I0, I1, Pred, LHS, RHS,
+                                 SQ.getWithInstruction(II))) {
+      if (ICmpInst::isGT(Pred))
+        std::swap(LHS, RHS);
+      return replaceInstUsesWith(
+          CI, Builder.CreateIntrinsic(II->getType(), IID, {LHS, RHS}));
+    }
+
     if (IID == Intrinsic::ucmp)
       break;
-
-    Value *I0 = II->getArgOperand(0), *I1 = II->getArgOperand(1);
 
     // scmp(X, 0) -> sext_or_trunc(X) if X is known to be one of -1, 0, 1.
     if (match(I1, m_Zero())) {
@@ -2553,7 +2563,6 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
         return replaceInstUsesWith(
             CI, Builder.CreateSExtOrTrunc(I0, II->getType()));
     }
-    Value *LHS, *RHS;
     if (match(I0, m_NSWSub(m_Value(LHS), m_Value(RHS))) && match(I1, m_Zero()))
       return replaceInstUsesWith(
           CI,

--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -21,6 +21,7 @@
 #include "llvm/Analysis/InstructionSimplify.h"
 #include "llvm/Analysis/Loads.h"
 #include "llvm/Analysis/Utils/Local.h"
+#include "llvm/Analysis/ValueTracking.h"
 #include "llvm/Analysis/VectorUtils.h"
 #include "llvm/IR/ConstantRange.h"
 #include "llvm/IR/Constants.h"
@@ -5288,6 +5289,154 @@ static bool isMultipleOf(Value *X, const APInt &C, const SimplifyQuery &Q) {
   return MaskedValueIsZero(X, C - 1, Q);
 }
 
+static bool hasNoWrapProblem(const BinaryOperator &BO, CmpInst::Predicate Pred,
+                             bool &HasNSW, bool &HasNUW) {
+  if (isa<OverflowingBinaryOperator>(BO)) {
+    HasNUW = BO.hasNoUnsignedWrap();
+    HasNSW = BO.hasNoSignedWrap();
+    return ICmpInst::isEquality(Pred) ||
+           (CmpInst::isUnsigned(Pred) && HasNUW) ||
+           (CmpInst::isSigned(Pred) && HasNSW);
+  }
+  if (BO.getOpcode() == Instruction::Or) {
+    // The callers only use this result for an or matched by m_AddLike, which
+    // must be an or disjoint and is equivalent to an add nuw nsw.
+    HasNUW = true;
+    HasNSW = true;
+    return true;
+  }
+  return false;
+}
+
+bool InstCombinerImpl::matchCommonBinOpOperands(Value *Op0, Value *Op1,
+                                                CmpInst::Predicate &Pred,
+                                                Value *&LHS, Value *&RHS,
+                                                const SimplifyQuery &Q) {
+  auto *BO0 = dyn_cast<BinaryOperator>(Op0);
+  auto *BO1 = dyn_cast<BinaryOperator>(Op1);
+  if (!BO0 || !BO1)
+    return false;
+
+  bool IsEquality = ICmpInst::isEquality(Pred);
+  bool IsSigned = ICmpInst::isSigned(Pred);
+
+  bool Op0HasNSW = false, Op0HasNUW = false;
+  bool Op1HasNSW = false, Op1HasNUW = false;
+  bool NoOp0WrapProblem = hasNoWrapProblem(*BO0, Pred, Op0HasNSW, Op0HasNUW);
+  bool NoOp1WrapProblem = hasNoWrapProblem(*BO1, Pred, Op1HasNSW, Op1HasNUW);
+
+  Value *A, *B, *C, *D;
+
+  // Handle all add-like operations.
+  if (match(BO0, m_AddLike(m_Value(A), m_Value(B))) &&
+      match(BO1, m_AddLike(m_Value(C), m_Value(D)))) {
+    if (!NoOp0WrapProblem || !NoOp1WrapProblem)
+      return false;
+
+    if (A == C) {
+      // (A + B) cmp (A + D) -> B cmp D
+      LHS = B;
+      RHS = D;
+      return true;
+    }
+    if (A == D) {
+      // (A + B) cmp (C + A) -> B cmp C
+      LHS = B;
+      RHS = C;
+      return true;
+    }
+    if (B == C) {
+      // (A + B) cmp (B + D) -> A cmp D
+      LHS = A;
+      RHS = D;
+      return true;
+    }
+    if (B == D) {
+      // (A + B) cmp (C + B) -> A cmp C
+      LHS = A;
+      RHS = C;
+      return true;
+    }
+    return false;
+  }
+
+  if (BO0->getOpcode() != BO1->getOpcode())
+    return false;
+
+  A = BO0->getOperand(0);
+  B = BO0->getOperand(1);
+  C = BO1->getOperand(0);
+  D = BO1->getOperand(1);
+
+  switch (BO0->getOpcode()) {
+  case Instruction::Sub:
+    if (!NoOp0WrapProblem || !NoOp1WrapProblem)
+      return false;
+
+    // (A - B) cmp (C - B) -> A cmp C
+    if (B == D) {
+      LHS = A;
+      RHS = C;
+      return true;
+    }
+    // (A - B) cmp (A - D) -> D cmp B
+    if (A == C) {
+      LHS = D;
+      RHS = B;
+      return true;
+    }
+    return false;
+
+  case Instruction::Mul: {
+    // Equality comparisons have additional modular-arithmetic folds and are
+    // handled by the existing multiplication logic in foldICmpBinOp().
+    if (IsEquality || !NoOp0WrapProblem || !NoOp1WrapProblem)
+      return false;
+
+    Value *Z;
+
+    if (A == C) {
+      // (A * B) cmp (A * D) -> B cmp D
+      Z = A;
+      LHS = B;
+      RHS = D;
+    } else if (A == D) {
+      // (A * B) cmp (C * A) -> B cmp C
+      Z = A;
+      LHS = B;
+      RHS = C;
+    } else if (B == C) {
+      // (A * B) cmp (B * D) -> A cmp D
+      Z = B;
+      LHS = A;
+      RHS = D;
+    } else if (B == D) {
+      // (A * B) cmp (C * B) -> A cmp C
+      Z = B;
+      LHS = A;
+      RHS = C;
+    } else {
+      return false;
+    }
+
+    if (!IsSigned)
+      return isKnownNonZero(Z, Q);
+
+    if (isKnownPositive(Z, Q))
+      return true;
+
+    if (isKnownNegative(Z, Q)) {
+      Pred = ICmpInst::getSwappedPredicate(Pred);
+      return true;
+    }
+
+    return false;
+  }
+  default:
+    return false;
+  }
+}
+
 /// Try to fold icmp (binop), X or icmp X, (binop).
 /// TODO: A large part of this logic is duplicated in InstSimplify's
 /// simplifyICmpWithBinOp(). We should be able to share that and avoid the code
@@ -5393,24 +5542,6 @@ Instruction *InstCombinerImpl::foldICmpBinOp(ICmpInst &I,
   bool Op0HasNSW = false, Op1HasNSW = false;
   // Analyze the case when either Op0 or Op1 is an add instruction.
   // Op0 = A + B (or A and B are null); Op1 = C + D (or C and D are null).
-  auto hasNoWrapProblem = [](const BinaryOperator &BO, CmpInst::Predicate Pred,
-                             bool &HasNSW, bool &HasNUW) -> bool {
-    if (isa<OverflowingBinaryOperator>(BO)) {
-      HasNUW = BO.hasNoUnsignedWrap();
-      HasNSW = BO.hasNoSignedWrap();
-      return ICmpInst::isEquality(Pred) ||
-             (CmpInst::isUnsigned(Pred) && HasNUW) ||
-             (CmpInst::isSigned(Pred) && HasNSW);
-    } else if (BO.getOpcode() == Instruction::Or) {
-      // The invariant here is that we are handling m_AddLike instructions,
-      // which can only be a or disjoint, which is equivalent to an add nuw nsw.
-      HasNUW = true;
-      HasNSW = true;
-      return true;
-    } else {
-      return false;
-    }
-  };
   Value *A = nullptr, *B = nullptr, *C = nullptr, *D = nullptr;
 
   if (BO0) {
@@ -5434,31 +5565,12 @@ Instruction *InstCombinerImpl::foldICmpBinOp(ICmpInst &I,
     return new ICmpInst(Pred, Constant::getNullValue(Op0->getType()),
                         C == Op0 ? D : C);
 
-  // icmp (A+B), (A+D) -> icmp B, D for equalities or if there is no overflow.
-  if (A && C && (A == C || A == D || B == C || B == D) && NoOp0WrapProblem &&
-      NoOp1WrapProblem) {
-    // Determine Y and Z in the form icmp (X+Y), (X+Z).
-    Value *Y, *Z;
-    if (A == C) {
-      // C + B == C + D  ->  B == D
-      Y = B;
-      Z = D;
-    } else if (A == D) {
-      // D + B == C + D  ->  B == C
-      Y = B;
-      Z = C;
-    } else if (B == C) {
-      // A + C == C + D  ->  A == D
-      Y = A;
-      Z = D;
-    } else {
-      assert(B == D);
-      // A + D == C + D  ->  A == C
-      Y = A;
-      Z = C;
-    }
-    return new ICmpInst(Pred, Y, Z);
-  }
+  // Fold comparisons of binops with a removable common operand.
+  Value *LHS;
+  Value *RHS;
+  CmpInst::Predicate NewPred = Pred;
+  if (matchCommonBinOpOperands(Op0, Op1, NewPred, LHS, RHS, Q))
+    return new ICmpInst(NewPred, LHS, RHS);
 
   if (ICmpInst::isRelational(Pred)) {
     // Return if both X and Y is divisible by Z/-Z.
@@ -5600,14 +5712,6 @@ Instruction *InstCombinerImpl::foldICmpBinOp(ICmpInst &I,
       isKnownNonZero(D, Q))
     return new ICmpInst(CmpInst::getFlippedStrictnessPredicate(Pred), C, D);
 
-  // icmp (A-B), (C-B) -> icmp A, C for equalities or if there is no overflow.
-  if (B && D && B == D && NoOp0WrapProblem && NoOp1WrapProblem)
-    return new ICmpInst(Pred, A, C);
-
-  // icmp (A-B), (A-D) -> icmp D, B for equalities or if there is no overflow.
-  if (A && C && A == C && NoOp0WrapProblem && NoOp1WrapProblem)
-    return new ICmpInst(Pred, D, B);
-
   // icmp (0-X) < cst --> x > -cst
   if (NoOp0WrapProblem && ICmpInst::isSigned(Pred)) {
     Value *X;
@@ -5633,11 +5737,6 @@ Instruction *InstCombinerImpl::foldICmpBinOp(ICmpInst &I,
          match(Op1, m_c_Mul(m_Specific(Z), m_Value(Y))))) {
       if (ICmpInst::isSigned(Pred)) {
         if (Op0HasNSW && Op1HasNSW) {
-          KnownBits ZKnown = computeKnownBits(Z, &I);
-          if (ZKnown.isStrictlyPositive())
-            return new ICmpInst(Pred, X, Y);
-          if (ZKnown.isNegative())
-            return new ICmpInst(ICmpInst::getSwappedPredicate(Pred), X, Y);
           Value *LessThan = simplifyICmpInst(ICmpInst::ICMP_SLT, X, Y,
                                              SQ.getWithInstruction(&I));
           if (LessThan && match(LessThan, m_One()))
@@ -5648,30 +5747,27 @@ Instruction *InstCombinerImpl::foldICmpBinOp(ICmpInst &I,
           if (GreaterThan && match(GreaterThan, m_One()))
             return new ICmpInst(Pred, Z, Constant::getNullValue(Z->getType()));
         }
-      } else {
-        bool NonZero;
-        if (ICmpInst::isEquality(Pred)) {
-          // If X != Y, fold (X *nw Z) eq/ne (Y *nw Z) -> Z eq/ne 0
-          if (((Op0HasNSW && Op1HasNSW) || (Op0HasNUW && Op1HasNUW)) &&
-              isKnownNonEqual(X, Y, SQ))
-            return new ICmpInst(Pred, Z, Constant::getNullValue(Z->getType()));
+      } else if (ICmpInst::isEquality(Pred)) {
+        // Handle equality folds beyond direct multiplier cancellation.
+        // If X != Y, fold (X *nw Z) eq/ne (Y *nw Z) -> Z eq/ne 0
+        if (((Op0HasNSW && Op1HasNSW) || (Op0HasNUW && Op1HasNUW)) &&
+            isKnownNonEqual(X, Y, SQ))
+          return new ICmpInst(Pred, Z, Constant::getNullValue(Z->getType()));
 
-          KnownBits ZKnown = computeKnownBits(Z, &I);
-          // if Z % 2 != 0
-          //    X * Z eq/ne Y * Z -> X eq/ne Y
-          if (ZKnown.countMaxTrailingZeros() == 0)
-            return new ICmpInst(Pred, X, Y);
-          NonZero = !ZKnown.One.isZero() || isKnownNonZero(Z, Q);
-          // if Z != 0 and nsw(X * Z) and nsw(Y * Z)
-          //    X * Z eq/ne Y * Z -> X eq/ne Y
-          if (NonZero && BO0 && BO1 && Op0HasNSW && Op1HasNSW)
-            return new ICmpInst(Pred, X, Y);
-        } else
-          NonZero = isKnownNonZero(Z, Q);
+        KnownBits ZKnown = computeKnownBits(Z, &I);
+        // if Z % 2 != 0
+        //    X * Z eq/ne Y * Z -> X eq/ne Y
+        if (ZKnown.countMaxTrailingZeros() == 0)
+          return new ICmpInst(Pred, X, Y);
+        bool NonZero = !ZKnown.One.isZero() || isKnownNonZero(Z, Q);
+        // if Z != 0 and nsw(X * Z) and nsw(Y * Z)
+        //    X * Z eq/ne Y * Z -> X eq/ne Y
+        if (NonZero && Op0HasNSW && Op1HasNSW)
+          return new ICmpInst(Pred, X, Y);
 
         // If Z != 0 and nuw(X * Z) and nuw(Y * Z)
-        //    X * Z u{lt/le/gt/ge}/eq/ne Y * Z -> X u{lt/le/gt/ge}/eq/ne Y
-        if (NonZero && BO0 && BO1 && Op0HasNUW && Op1HasNUW)
+        //    X * Z eq/ne Y * Z -> X eq/ne Y
+        if (NonZero && Op0HasNUW && Op1HasNUW)
           return new ICmpInst(Pred, X, Y);
       }
     }

--- a/llvm/lib/Transforms/InstCombine/InstCombineInternal.h
+++ b/llvm/lib/Transforms/InstCombine/InstCombineInternal.h
@@ -744,6 +744,11 @@ public:
   Instruction *foldICmpInstWithConstantNotInt(ICmpInst &Cmp);
   Instruction *foldICmpInstWithConstantAllowPoison(ICmpInst &Cmp,
                                                    const APInt &C);
+  /// Match comparisons of binops with a removable common operand. Pred is
+  /// updated when removing the common operand reverses the comparison order.
+  bool matchCommonBinOpOperands(Value *Op0, Value *Op1,
+                                CmpInst::Predicate &Pred, Value *&LHS,
+                                Value *&RHS, const SimplifyQuery &Q);
   Instruction *foldICmpBinOp(ICmpInst &Cmp, const SimplifyQuery &SQ);
   Instruction *foldICmpWithMinMax(Instruction &I, MinMaxIntrinsic *MinMax,
                                   Value *Z, CmpPredicate Pred);

--- a/llvm/test/Transforms/InstCombine/scmp.ll
+++ b/llvm/test/Transforms/InstCombine/scmp.ll
@@ -1197,3 +1197,180 @@ define i8 @scmp_zero_of_sext_memcmp(ptr %x, ptr %y) {
 
 declare void @use64(i64 %value)
 declare i32 @memcmp(ptr, ptr, i64)
+
+define i8 @scmp_add_common_op(i32 %a, i32 %b, i32 %n) {
+; CHECK-LABEL: define i8 @scmp_add_common_op(
+; CHECK-SAME: i32 [[A:%.*]], i32 [[B:%.*]], i32 [[N:%.*]]) {
+; CHECK-NEXT:    [[R:%.*]] = call i8 @llvm.scmp.i8.i32(i32 [[A]], i32 [[B]])
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  %an = add nsw i32 %a, %n
+  %bn = add nsw i32 %b, %n
+  %r = call i8 @llvm.scmp(i32 %an, i32 %bn)
+  ret i8 %r
+}
+
+define i8 @scmp_addlike_common_op(i32 %a, i32 %b, i32 %n) {
+; CHECK-LABEL: define i8 @scmp_addlike_common_op(
+; CHECK-SAME: i32 [[A:%.*]], i32 [[B:%.*]], i32 [[N:%.*]]) {
+; CHECK-NEXT:    [[R:%.*]] = call i8 @llvm.scmp.i8.i32(i32 [[A]], i32 [[B]])
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  %an = add nsw i32 %n, %a
+  %bn = or disjoint i32 %b, %n
+  %r = call i8 @llvm.scmp(i32 %an, i32 %bn)
+  ret i8 %r
+}
+
+; Negative test: signed ordering cannot be preserved without nsw.
+define i8 @scmp_add_common_op_no_nsw(i32 %a, i32 %b, i32 %n) {
+; CHECK-LABEL: define i8 @scmp_add_common_op_no_nsw(
+; CHECK-SAME: i32 [[A:%.*]], i32 [[B:%.*]], i32 [[N:%.*]]) {
+; CHECK-NEXT:    [[AN:%.*]] = add i32 [[A]], [[N]]
+; CHECK-NEXT:    [[BN:%.*]] = add i32 [[B]], [[N]]
+; CHECK-NEXT:    [[R:%.*]] = call i8 @llvm.scmp.i8.i32(i32 [[AN]], i32 [[BN]])
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  %an = add i32 %a, %n
+  %bn = add i32 %b, %n
+  %r = call i8 @llvm.scmp(i32 %an, i32 %bn)
+  ret i8 %r
+}
+
+; Negative test: nuw does not preserve signed ordering.
+define i8 @scmp_add_common_op_nuw(i32 %a, i32 %b, i32 %n) {
+; CHECK-LABEL: define i8 @scmp_add_common_op_nuw(
+; CHECK-SAME: i32 [[A:%.*]], i32 [[B:%.*]], i32 [[N:%.*]]) {
+; CHECK-NEXT:    [[AN:%.*]] = add nuw i32 [[A]], [[N]]
+; CHECK-NEXT:    [[BN:%.*]] = add nuw i32 [[B]], [[N]]
+; CHECK-NEXT:    [[R:%.*]] = call i8 @llvm.scmp.i8.i32(i32 [[AN]], i32 [[BN]])
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  %an = add nuw i32 %a, %n
+  %bn = add nuw i32 %b, %n
+  %r = call i8 @llvm.scmp(i32 %an, i32 %bn)
+  ret i8 %r
+}
+
+define i8 @scmp_sub_common_rhs(i32 %a, i32 %b, i32 %n) {
+; CHECK-LABEL: define i8 @scmp_sub_common_rhs(
+; CHECK-SAME: i32 [[A:%.*]], i32 [[B:%.*]], i32 [[N:%.*]]) {
+; CHECK-NEXT:    [[R:%.*]] = call i8 @llvm.scmp.i8.i32(i32 [[A]], i32 [[B]])
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  %an = sub nsw i32 %a, %n
+  %bn = sub nsw i32 %b, %n
+  %r = call i8 @llvm.scmp(i32 %an, i32 %bn)
+  ret i8 %r
+}
+
+define i8 @scmp_sub_common_lhs(i32 %n, i32 %a, i32 %b) {
+; CHECK-LABEL: define i8 @scmp_sub_common_lhs(
+; CHECK-SAME: i32 [[N:%.*]], i32 [[A:%.*]], i32 [[B:%.*]]) {
+; CHECK-NEXT:    [[R:%.*]] = call i8 @llvm.scmp.i8.i32(i32 [[B]], i32 [[A]])
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  %na = sub nsw i32 %n, %a
+  %nb = sub nsw i32 %n, %b
+  %r = call i8 @llvm.scmp(i32 %na, i32 %nb)
+  ret i8 %r
+}
+
+; Negative test: signed subtraction needs nsw on both operations.
+define i8 @scmp_sub_common_rhs_no_nsw(i32 %a, i32 %b, i32 %n) {
+; CHECK-LABEL: define i8 @scmp_sub_common_rhs_no_nsw(
+; CHECK-SAME: i32 [[A:%.*]], i32 [[B:%.*]], i32 [[N:%.*]]) {
+; CHECK-NEXT:    [[AN:%.*]] = sub i32 [[A]], [[N]]
+; CHECK-NEXT:    [[BN:%.*]] = sub nsw i32 [[B]], [[N]]
+; CHECK-NEXT:    [[R:%.*]] = call i8 @llvm.scmp.i8.i32(i32 [[AN]], i32 [[BN]])
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  %an = sub i32 %a, %n
+  %bn = sub nsw i32 %b, %n
+  %r = call i8 @llvm.scmp(i32 %an, i32 %bn)
+  ret i8 %r
+}
+
+define i8 @scmp_mul_common_positive(i32 %a, i32 %b,
+; CHECK-LABEL: define i8 @scmp_mul_common_positive(
+; CHECK-SAME: i32 [[A:%.*]], i32 [[B:%.*]], i32 range(i32 1, 10) [[N:%.*]]) {
+; CHECK-NEXT:    [[R:%.*]] = call i8 @llvm.scmp.i8.i32(i32 [[A]], i32 [[B]])
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  i32 range(i32 1, 10) %n) {
+  %an = mul nsw i32 %a, %n
+  %bn = mul nsw i32 %b, %n
+  %r = call i8 @llvm.scmp(i32 %an, i32 %bn)
+  ret i8 %r
+}
+
+define i8 @scmp_mul_common_negative(i32 %a, i32 %b,
+; CHECK-LABEL: define i8 @scmp_mul_common_negative(
+; CHECK-SAME: i32 [[A:%.*]], i32 [[B:%.*]], i32 range(i32 -10, 0) [[N:%.*]]) {
+; CHECK-NEXT:    [[R:%.*]] = call i8 @llvm.scmp.i8.i32(i32 [[B]], i32 [[A]])
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  i32 range(i32 -10, 0) %n) {
+  %an = mul nsw i32 %a, %n
+  %bn = mul nsw i32 %b, %n
+  %r = call i8 @llvm.scmp(i32 %an, i32 %bn)
+  ret i8 %r
+}
+
+define i8 @scmp_mul_common_negative_commuted(i32 %a, i32 %b,
+; CHECK-LABEL: define i8 @scmp_mul_common_negative_commuted(
+; CHECK-SAME: i32 [[A:%.*]], i32 [[B:%.*]], i32 range(i32 -10, 0) [[N:%.*]]) {
+; CHECK-NEXT:    [[R:%.*]] = call i8 @llvm.scmp.i8.i32(i32 [[B]], i32 [[A]])
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  i32 range(i32 -10, 0) %n) {
+  %an = mul nsw i32 %n, %a
+  %bn = mul nsw i32 %b, %n
+  %r = call i8 @llvm.scmp(i32 %an, i32 %bn)
+  ret i8 %r
+}
+
+; Negative test: a nonzero multiplier with unknown sign may reverse ordering.
+define i8 @scmp_mul_common_unknown_sign(i32 %a, i32 %b,
+; CHECK-LABEL: define i8 @scmp_mul_common_unknown_sign(
+; CHECK-SAME: i32 [[A:%.*]], i32 [[B:%.*]], i32 range(i32 1, 0) [[N:%.*]]) {
+; CHECK-NEXT:    [[AN:%.*]] = mul nsw i32 [[A]], [[N]]
+; CHECK-NEXT:    [[BN:%.*]] = mul nsw i32 [[B]], [[N]]
+; CHECK-NEXT:    [[R:%.*]] = call i8 @llvm.scmp.i8.i32(i32 [[AN]], i32 [[BN]])
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  i32 range(i32 1, 0) %n) {
+  %an = mul nsw i32 %a, %n
+  %bn = mul nsw i32 %b, %n
+  %r = call i8 @llvm.scmp(i32 %an, i32 %bn)
+  ret i8 %r
+}
+
+; Negative test: signed multiplication needs nsw on both operations.
+define i8 @scmp_mul_common_positive_no_nsw(
+; CHECK-LABEL: define i8 @scmp_mul_common_positive_no_nsw(
+; CHECK-SAME: i32 [[A:%.*]], i32 [[B:%.*]], i32 range(i32 1, 10) [[N:%.*]]) {
+; CHECK-NEXT:    [[AN:%.*]] = mul i32 [[A]], [[N]]
+; CHECK-NEXT:    [[BN:%.*]] = mul nsw i32 [[B]], [[N]]
+; CHECK-NEXT:    [[R:%.*]] = call i8 @llvm.scmp.i8.i32(i32 [[AN]], i32 [[BN]])
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  i32 %a, i32 %b, i32 range(i32 1, 10) %n) {
+  %an = mul i32 %a, %n
+  %bn = mul nsw i32 %b, %n
+  %r = call i8 @llvm.scmp(i32 %an, i32 %bn)
+  ret i8 %r
+}
+
+define <2 x i8> @scmp_add_common_op_vec(<2 x i32> %a, <2 x i32> %b,
+; CHECK-LABEL: define <2 x i8> @scmp_add_common_op_vec(
+; CHECK-SAME: <2 x i32> [[A:%.*]], <2 x i32> [[B:%.*]], <2 x i32> [[N:%.*]]) {
+; CHECK-NEXT:    [[R:%.*]] = call <2 x i8> @llvm.scmp.v2i8.v2i32(<2 x i32> [[A]], <2 x i32> [[B]])
+; CHECK-NEXT:    ret <2 x i8> [[R]]
+;
+  <2 x i32> %n) {
+  %an = add nsw <2 x i32> %a, %n
+  %bn = add nsw <2 x i32> %b, %n
+  %r = call <2 x i8> @llvm.scmp(<2 x i32> %an, <2 x i32> %bn)
+  ret <2 x i8> %r
+}

--- a/llvm/test/Transforms/InstCombine/ucmp.ll
+++ b/llvm/test/Transforms/InstCombine/ucmp.ll
@@ -771,3 +771,178 @@ define <2 x i8> @ucmp_zext_const_vec_not_narrowable(<2 x i8> %x) {
 }
 
 declare void @use64(i64 %value)
+
+define i8 @ucmp_add_common_op(i32 %a, i32 %b, i32 %n) {
+; CHECK-LABEL: define i8 @ucmp_add_common_op(
+; CHECK-SAME: i32 [[A:%.*]], i32 [[B:%.*]], i32 [[N:%.*]]) {
+; CHECK-NEXT:    [[R:%.*]] = call i8 @llvm.ucmp.i8.i32(i32 [[A]], i32 [[B]])
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  %an = add nuw i32 %a, %n
+  %bn = add nuw i32 %b, %n
+  %r = call i8 @llvm.ucmp(i32 %an, i32 %bn)
+  ret i8 %r
+}
+
+define i8 @ucmp_add_common_op_commuted(i32 %a, i32 %b, i32 %n) {
+; CHECK-LABEL: define i8 @ucmp_add_common_op_commuted(
+; CHECK-SAME: i32 [[A:%.*]], i32 [[B:%.*]], i32 [[N:%.*]]) {
+; CHECK-NEXT:    [[R:%.*]] = call i8 @llvm.ucmp.i8.i32(i32 [[A]], i32 [[B]])
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  %an = add nuw i32 %n, %a
+  %bn = add nuw i32 %b, %n
+  %r = call i8 @llvm.ucmp(i32 %an, i32 %bn)
+  ret i8 %r
+}
+
+define i8 @ucmp_addlike_common_op(i32 %a, i32 %b, i32 %n) {
+; CHECK-LABEL: define i8 @ucmp_addlike_common_op(
+; CHECK-SAME: i32 [[A:%.*]], i32 [[B:%.*]], i32 [[N:%.*]]) {
+; CHECK-NEXT:    [[R:%.*]] = call i8 @llvm.ucmp.i8.i32(i32 [[A]], i32 [[B]])
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  %an = add nuw i32 %a, %n
+  %bn = or disjoint i32 %b, %n
+  %r = call i8 @llvm.ucmp(i32 %an, i32 %bn)
+  ret i8 %r
+}
+
+; Negative test: unsigned ordering cannot be preserved without nuw.
+define i8 @ucmp_add_common_op_no_nuw(i32 %a, i32 %b, i32 %n) {
+; CHECK-LABEL: define i8 @ucmp_add_common_op_no_nuw(
+; CHECK-SAME: i32 [[A:%.*]], i32 [[B:%.*]], i32 [[N:%.*]]) {
+; CHECK-NEXT:    [[AN:%.*]] = add i32 [[A]], [[N]]
+; CHECK-NEXT:    [[BN:%.*]] = add i32 [[B]], [[N]]
+; CHECK-NEXT:    [[R:%.*]] = call i8 @llvm.ucmp.i8.i32(i32 [[AN]], i32 [[BN]])
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  %an = add i32 %a, %n
+  %bn = add i32 %b, %n
+  %r = call i8 @llvm.ucmp(i32 %an, i32 %bn)
+  ret i8 %r
+}
+
+; Negative test: nsw does not preserve unsigned ordering.
+define i8 @ucmp_add_common_op_nsw(i32 %a, i32 %b, i32 %n) {
+; CHECK-LABEL: define i8 @ucmp_add_common_op_nsw(
+; CHECK-SAME: i32 [[A:%.*]], i32 [[B:%.*]], i32 [[N:%.*]]) {
+; CHECK-NEXT:    [[AN:%.*]] = add nsw i32 [[A]], [[N]]
+; CHECK-NEXT:    [[BN:%.*]] = add nsw i32 [[B]], [[N]]
+; CHECK-NEXT:    [[R:%.*]] = call i8 @llvm.ucmp.i8.i32(i32 [[AN]], i32 [[BN]])
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  %an = add nsw i32 %a, %n
+  %bn = add nsw i32 %b, %n
+  %r = call i8 @llvm.ucmp(i32 %an, i32 %bn)
+  ret i8 %r
+}
+
+define i8 @ucmp_sub_common_rhs(i32 %a, i32 %b, i32 %n) {
+; CHECK-LABEL: define i8 @ucmp_sub_common_rhs(
+; CHECK-SAME: i32 [[A:%.*]], i32 [[B:%.*]], i32 [[N:%.*]]) {
+; CHECK-NEXT:    [[R:%.*]] = call i8 @llvm.ucmp.i8.i32(i32 [[A]], i32 [[B]])
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  %an = sub nuw i32 %a, %n
+  %bn = sub nuw i32 %b, %n
+  %r = call i8 @llvm.ucmp(i32 %an, i32 %bn)
+  ret i8 %r
+}
+
+define i8 @ucmp_sub_common_lhs(i32 %n, i32 %a, i32 %b) {
+; CHECK-LABEL: define i8 @ucmp_sub_common_lhs(
+; CHECK-SAME: i32 [[N:%.*]], i32 [[A:%.*]], i32 [[B:%.*]]) {
+; CHECK-NEXT:    [[R:%.*]] = call i8 @llvm.ucmp.i8.i32(i32 [[B]], i32 [[A]])
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  %na = sub nuw i32 %n, %a
+  %nb = sub nuw i32 %n, %b
+  %r = call i8 @llvm.ucmp(i32 %na, i32 %nb)
+  ret i8 %r
+}
+
+; Negative test: unsigned subtraction needs nuw on both operations.
+define i8 @ucmp_sub_common_rhs_no_nuw(i32 %a, i32 %b, i32 %n) {
+; CHECK-LABEL: define i8 @ucmp_sub_common_rhs_no_nuw(
+; CHECK-SAME: i32 [[A:%.*]], i32 [[B:%.*]], i32 [[N:%.*]]) {
+; CHECK-NEXT:    [[AN:%.*]] = sub i32 [[A]], [[N]]
+; CHECK-NEXT:    [[BN:%.*]] = sub nuw i32 [[B]], [[N]]
+; CHECK-NEXT:    [[R:%.*]] = call i8 @llvm.ucmp.i8.i32(i32 [[AN]], i32 [[BN]])
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  %an = sub i32 %a, %n
+  %bn = sub nuw i32 %b, %n
+  %r = call i8 @llvm.ucmp(i32 %an, i32 %bn)
+  ret i8 %r
+}
+
+define i8 @ucmp_mul_common_nonzero(i32 %a, i32 %b,
+; CHECK-LABEL: define i8 @ucmp_mul_common_nonzero(
+; CHECK-SAME: i32 [[A:%.*]], i32 [[B:%.*]], i32 range(i32 1, 0) [[N:%.*]]) {
+; CHECK-NEXT:    [[R:%.*]] = call i8 @llvm.ucmp.i8.i32(i32 [[A]], i32 [[B]])
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  i32 range(i32 1, 0) %n) {
+  %an = mul nuw i32 %a, %n
+  %bn = mul nuw i32 %b, %n
+  %r = call i8 @llvm.ucmp(i32 %an, i32 %bn)
+  ret i8 %r
+}
+
+define i8 @ucmp_mul_common_nonzero_commuted(i32 %a, i32 %b,
+; CHECK-LABEL: define i8 @ucmp_mul_common_nonzero_commuted(
+; CHECK-SAME: i32 [[A:%.*]], i32 [[B:%.*]], i32 range(i32 1, 0) [[N:%.*]]) {
+; CHECK-NEXT:    [[R:%.*]] = call i8 @llvm.ucmp.i8.i32(i32 [[A]], i32 [[B]])
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  i32 range(i32 1, 0) %n) {
+  %an = mul nuw i32 %n, %a
+  %bn = mul nuw i32 %b, %n
+  %r = call i8 @llvm.ucmp(i32 %an, i32 %bn)
+  ret i8 %r
+}
+
+; Negative test: multiplication by zero would erase the original ordering.
+define i8 @ucmp_mul_common_maybe_zero(i32 %a, i32 %b, i32 %n) {
+; CHECK-LABEL: define i8 @ucmp_mul_common_maybe_zero(
+; CHECK-SAME: i32 [[A:%.*]], i32 [[B:%.*]], i32 [[N:%.*]]) {
+; CHECK-NEXT:    [[AN:%.*]] = mul nuw i32 [[A]], [[N]]
+; CHECK-NEXT:    [[BN:%.*]] = mul nuw i32 [[B]], [[N]]
+; CHECK-NEXT:    [[R:%.*]] = call i8 @llvm.ucmp.i8.i32(i32 [[AN]], i32 [[BN]])
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  %an = mul nuw i32 %a, %n
+  %bn = mul nuw i32 %b, %n
+  %r = call i8 @llvm.ucmp(i32 %an, i32 %bn)
+  ret i8 %r
+}
+
+; Negative test: unsigned multiplication needs nuw on both operations.
+define i8 @ucmp_mul_common_nonzero_no_nuw(i32 %a, i32 %b,
+; CHECK-LABEL: define i8 @ucmp_mul_common_nonzero_no_nuw(
+; CHECK-SAME: i32 [[A:%.*]], i32 [[B:%.*]], i32 range(i32 1, 0) [[N:%.*]]) {
+; CHECK-NEXT:    [[AN:%.*]] = mul i32 [[A]], [[N]]
+; CHECK-NEXT:    [[BN:%.*]] = mul nuw i32 [[B]], [[N]]
+; CHECK-NEXT:    [[R:%.*]] = call i8 @llvm.ucmp.i8.i32(i32 [[AN]], i32 [[BN]])
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  i32 range(i32 1, 0) %n) {
+  %an = mul i32 %a, %n
+  %bn = mul nuw i32 %b, %n
+  %r = call i8 @llvm.ucmp(i32 %an, i32 %bn)
+  ret i8 %r
+}
+
+define <2 x i8> @ucmp_add_common_op_vec(<2 x i32> %a, <2 x i32> %b,
+; CHECK-LABEL: define <2 x i8> @ucmp_add_common_op_vec(
+; CHECK-SAME: <2 x i32> [[A:%.*]], <2 x i32> [[B:%.*]], <2 x i32> [[N:%.*]]) {
+; CHECK-NEXT:    [[R:%.*]] = call <2 x i8> @llvm.ucmp.v2i8.v2i32(<2 x i32> [[A]], <2 x i32> [[B]])
+; CHECK-NEXT:    ret <2 x i8> [[R]]
+;
+  <2 x i32> %n) {
+  %an = add nuw <2 x i32> %a, %n
+  %bn = add nuw <2 x i32> %b, %n
+  %r = call <2 x i8> @llvm.ucmp(<2 x i32> %an, <2 x i32> %bn)
+  ret <2 x i8> %r
+}


### PR DESCRIPTION
This PR extends #216157, which adds a missed `[su]cmp` fold for matching operands in order-preserving/reversing binops (covers `add`, `sub`, `mul`)

- Extracted common-operand logic from `foldICmpBinOp()` into a `matchCommonBinOpOperands()` helper function for `icmp`, `scmp`, and `ucmp`. However, existing specialized `icmp` equality and signed multiplication folds remain separate - see current state of `foldICmpBinOp()`.
- The helper accepts the comparison predicate by reference so `icmp` can canonically keep operand order (predicate flips with an order-reversing operation), while `[su]cmp` can use the predicate to swap operand order afterward.
- `m_AddLike` is explicitly used in the helper to support `or disjoint` for `[su]cmp`, equivalent to non-wrapping addition.
- Moved `hasNoWrapProblem()` outside into a file-level function for both the new helper and existing passes that rely on it.
- Tests: positive and negative coverage for nowrap flags, incorrect signedness flags, zero factors, unknown sign factors, commuted operands, order reversal, and vector addition.

These just cover the add-like operations, refer to #216157 for the other proofs:

- `add nuw` and `or disjoint` https://alive2.llvm.org/ce/z/N6csUo
- `add nsw` and `or disjoint` https://alive2.llvm.org/ce/z/INbB_v

Note: support for `shl nuw`, `lshr exact`, and `udiv exact` are intentionally deferred, but they should ideally reuse this helper function later.

Partially fixes #216127.