### PR TITLE
[SystemZ][z/OS] Align constant pool

### DIFF
--- a/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZTargetStreamer.cpp
+++ b/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZTargetStreamer.cpp
@@ -30,6 +30,7 @@ void SystemZTargetStreamer::emitConstantPools() {
   // Switch to the .text section.
   const MCObjectFileInfo &OFI = *Streamer.getContext().getObjectFileInfo();
   Streamer.switchSection(OFI.getTextSection());
+  Streamer.emitValueToAlignment(Align(2));
   for (auto &I : EXRLTargets2Sym) {
     Streamer.emitLabel(I.second);
     const MCInstSTIPair &MCI_STI = I.first;
@@ -157,7 +158,7 @@ void SystemZTargetzOSStreamer::emitPPA1(PPA1Info &Info) {
   assert(PPA2Sym != nullptr && "PPA2 Symbol not defined");
   MCStreamer &OutStreamer = getStreamer();
   MCContext &OutContext = OutStreamer.getContext();
-  getStreamer().emitValueToAlignment(Align(2));
+  OutStreamer.emitValueToAlignment(Align(2));
 
   // Optional Argument Area Length.
   // Note: This represents the length of the argument area that we reserve
@@ -284,7 +285,6 @@ void SystemZTargetzOSStreamer::emitPPA1(PPA1Info &Info) {
 
 void SystemZTargetzOSStreamer::emitConstantPools() {
   // Emit EXRL target instructions (base class prolog).
-  getStreamer().emitValueToAlignment(Align(2));
   SystemZTargetStreamer::emitConstantPools();
 
   // Emit deferred PPA1 blocks into the text section.

--- a/llvm/test/CodeGen/SystemZ/zos-align-constpool.ll
+++ b/llvm/test/CodeGen/SystemZ/zos-align-constpool.ll
@@ -1,4 +1,5 @@
-; RUN: llc < %s -mtriple=s390x-ibm-zos -mcpu=z10 | FileCheck %s
+; RUN: llc < %s -mtriple=s390x-ibm-zos -mcpu=z10 -filetype=obj -o %t.o
+; RUN llc < %s -mtriple=s390x-ibm-zos -mcpu=z10 | FileCheck %s
 ; Checks that the instruction is half-word aligned, even if there is a
 ; string constant with odd length.
 


### PR DESCRIPTION
Follow-up to #222128: The call to emit the alignment was places on the wrong line but the test did not catch it because it checked only the textual output (which never emits the error message). Fix is to move the call and update the test.