### PR TITLE
[CIR][NFCI] Refactor uses of 'mlir::Location' vs 'SourceRange' on calls/etc

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenCUDARuntime.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCUDARuntime.cpp
@@ -26,9 +26,7 @@ RValue CIRGenCUDARuntime::emitCUDAKernelCallExpr(CIRGenFunction &cgf,
                                                  const CUDAKernelCallExpr *expr,
                                                  ReturnValueSlot retValue) {
 
-  CIRGenBuilderTy &builder = cgm.getBuilder();
-  mlir::Location loc =
-      cgf.currSrcLoc ? cgf.currSrcLoc.value() : builder.getUnknownLoc();
+  mlir::Location loc = cgf.getLoc(SourceLocation{});
 
   cgf.emitIfOnBoolExpr(
       expr->getConfig(),

--- a/clang/lib/CIR/CodeGen/CIRGenCXX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCXX.cpp
@@ -80,7 +80,7 @@ static void emitDeclInit(CIRGenFunction &cgf, const VarDecl *varDecl,
   switch (CIRGenFunction::getEvaluationKind(type)) {
   case cir::TEK_Scalar:
     assert(!cir::MissingFeatures::objCGC());
-    cgf.emitScalarInit(init, cgf.getLoc(varDecl->getLocation()), lv, false);
+    cgf.emitScalarInit(init, varDecl->getLocation(), lv, false);
     break;
   case cir::TEK_Complex:
     cgf.emitComplexExprIntoLValue(init, lv, /*isInit=*/true);
@@ -397,8 +397,7 @@ void CIRGenModule::emitCXXGlobalVarDeclInit(const VarDecl *varDecl,
   llvm::SaveAndRestore<CIRGenFunction *> savedCGF(curCGF, &cgf);
   curCGF->curFn = addr;
 
-  CIRGenFunction::SourceLocRAIIObject fnLoc{cgf,
-                                            getLoc(varDecl->getLocation())};
+  CIRGenFunction::SourceLocRAIIObject fnLoc{cgf, varDecl->getSourceRange()};
 
   // Set up the constrained FP environment for the dynamic initializer.
   llvm::RoundingMode rm = getLangOpts().getDefaultRoundingMode();

--- a/clang/lib/CIR/CodeGen/CIRGenCXX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCXX.cpp
@@ -80,7 +80,7 @@ static void emitDeclInit(CIRGenFunction &cgf, const VarDecl *varDecl,
   switch (CIRGenFunction::getEvaluationKind(type)) {
   case cir::TEK_Scalar:
     assert(!cir::MissingFeatures::objCGC());
-    cgf.emitScalarInit(init, varDecl->getLocation(), lv, false);
+    cgf.emitScalarInit(init, lv, false);
     break;
   case cir::TEK_Complex:
     cgf.emitComplexExprIntoLValue(init, lv, /*isInit=*/true);

--- a/clang/lib/CIR/CodeGen/CIRGenCall.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCall.cpp
@@ -104,7 +104,7 @@ void CIRGenFunction::emitAggregateStore(mlir::Value value, Address dest) {
   // scope as the value, don't make assumptions about current insertion point.
   mlir::OpBuilder::InsertionGuard guard(builder);
   builder.setInsertionPointAfter(value.getDefiningOp());
-  builder.createStore(*currSrcLoc, value, dest);
+  builder.createStore(getLoc(*currSrcLoc), value, dest);
 }
 
 static void addAttributesFromFunctionProtoType(CIRGenBuilderTy &builder,
@@ -1210,9 +1210,10 @@ RValue CIRGenFunction::emitCall(const CIRGenFunctionInfo &funcInfo,
                                 ReturnValueSlot returnValue,
                                 const CallArgList &args,
                                 cir::CIRCallOpInterface *callOp,
-                                bool isMustTail, mlir::Location loc) {
+                                bool isMustTail, SourceRange clangLoc) {
   QualType retTy = funcInfo.getReturnType();
   cir::FuncType cirFuncTy = getTypes().getFunctionType(funcInfo);
+  mlir::Location loc = getLoc(clangLoc);
 
   SmallVector<mlir::Value, 16> cirCallArgs(args.size());
 
@@ -1452,7 +1453,7 @@ RValue CIRGenFunction::emitCall(const CIRGenFunctionInfo &funcInfo,
     mlir::ResultRange results = theCall->getOpResults();
     assert(results.size() <= 1 && "multiple returns from a call");
 
-    SourceLocRAIIObject loc{*this, callLoc};
+    SourceLocRAIIObject loc{*this, clangLoc};
     emitAggregateStore(results[0], destPtr);
     return RValue::getAggregate(destPtr);
   }

--- a/clang/lib/CIR/CodeGen/CIRGenClass.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenClass.cpp
@@ -173,8 +173,8 @@ struct CallBaseDtor final : EHScopeStack::Cleanup {
     QualType thisTy = d->getFunctionObjectParameterType();
     assert(cgf.currSrcLoc && "expected source location");
     Address addr = cgf.getAddressOfDirectBaseInCompleteClass(
-        *cgf.currSrcLoc, cgf.loadCXXThisAddress(), derivedClass, baseClass,
-        baseIsVirtual);
+        cgf.getLoc(*cgf.currSrcLoc), cgf.loadCXXThisAddress(), derivedClass,
+        baseClass, baseIsVirtual);
     cgf.emitCXXDestructorCall(d, Dtor_Base, baseIsVirtual,
                               /*delegating=*/false, addr, thisTy);
   }
@@ -774,7 +774,7 @@ void CIRGenFunction::emitCXXAggrConstructorCall(
   CharUnits eltAlignment = arrayBase.getAlignment().alignmentOfArrayElement(
       getContext().getTypeSizeInChars(type));
 
-  mlir::Location loc = *currSrcLoc;
+  mlir::Location loc = getLoc(*currSrcLoc);
 
   mlir::Value dynamicElPtr;
   if (useDynamicArrayCtor)
@@ -947,9 +947,9 @@ void CIRGenFunction::emitForwardingCallToLambda(
         resultType->isObjCRetainableType())
       cgm.errorNYI(callOperator->getSourceRange(),
                    "emitForwardingCallToLambda: ObjCAutoRefCount");
-    emitReturnOfRValue(*currSrcLoc, rv, resultType);
+    emitReturnOfRValue(getLoc(*currSrcLoc), rv, resultType);
   } else {
-    cir::ReturnOp::create(builder, *currSrcLoc);
+    cir::ReturnOp::create(builder, getLoc(*currSrcLoc));
   }
 }
 
@@ -1537,7 +1537,7 @@ void CIRGenFunction::emitCXXConstructorCall(
   CIRGenCallee callee = CIRGenCallee::forDirect(calleePtr, GlobalDecl(d, type));
   cir::CIRCallOpInterface c;
   emitCall(info, callee, ReturnValueSlot(), args, &c, /*isMustTail=*/false,
-           getLoc(loc));
+           loc);
 
   if (cgm.getCodeGenOpts().OptimizationLevel != 0 && !crd->isDynamicClass() &&
       type != Ctor_Base && cgm.getCodeGenOpts().StrictVTablePointers)

--- a/clang/lib/CIR/CodeGen/CIRGenDecl.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenDecl.cpp
@@ -810,7 +810,7 @@ void CIRGenFunction::emitStaticVarDecl(const VarDecl &d,
   assert(!cir::MissingFeatures::generateDebugInfo());
 }
 
-void CIRGenFunction::emitScalarInit(const Expr *init, mlir::Location loc,
+void CIRGenFunction::emitScalarInit(const Expr *init, SourceRange loc,
                                     LValue lvalue, bool capturedByInit) {
   assert(!cir::MissingFeatures::objCLifetime());
 
@@ -826,7 +826,7 @@ void CIRGenFunction::emitScalarInit(const Expr *init, mlir::Location loc,
 
 void CIRGenFunction::emitExprAsInit(const Expr *init, const ValueDecl *d,
                                     LValue lvalue, bool capturedByInit) {
-  SourceLocRAIIObject loc{*this, getLoc(init->getSourceRange())};
+  SourceLocRAIIObject loc{*this, init->getSourceRange()};
   if (capturedByInit) {
     cgm.errorNYI(init->getSourceRange(), "emitExprAsInit: captured by init");
     return;
@@ -843,7 +843,7 @@ void CIRGenFunction::emitExprAsInit(const Expr *init, const ValueDecl *d,
   }
   switch (CIRGenFunction::getEvaluationKind(type)) {
   case cir::TEK_Scalar:
-    emitScalarInit(init, getLoc(d->getSourceRange()), lvalue);
+    emitScalarInit(init, d->getSourceRange(), lvalue);
     return;
   case cir::TEK_Complex: {
     mlir::Value complex = emitComplexExpr(init);
@@ -1292,13 +1292,14 @@ void CIRGenFunction::emitArrayDestroy(mlir::Value begin,
       size = constIntAttr.getUInt();
     auto arrayTy = cir::ArrayType::get(cirElementType, size);
     mlir::Value arrayOp = builder.createPtrBitcast(begin, arrayTy);
-    cir::ArrayDtor::create(builder, *currSrcLoc, arrayOp, regionBuilder);
+    cir::ArrayDtor::create(builder, getLoc(*currSrcLoc), arrayOp,
+                           regionBuilder);
     return;
   }
 
   // For a dynamic array size (VLA), use the dynamic form of ArrayDtor.
   mlir::Value elemBegin = builder.createPtrBitcast(begin, cirElementType);
-  cir::ArrayDtor::create(builder, *currSrcLoc, elemBegin, numElements,
+  cir::ArrayDtor::create(builder, getLoc(*currSrcLoc), elemBegin, numElements,
                          regionBuilder);
 }
 

--- a/clang/lib/CIR/CodeGen/CIRGenDecl.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenDecl.cpp
@@ -810,11 +810,11 @@ void CIRGenFunction::emitStaticVarDecl(const VarDecl &d,
   assert(!cir::MissingFeatures::generateDebugInfo());
 }
 
-void CIRGenFunction::emitScalarInit(const Expr *init, SourceRange loc,
-                                    LValue lvalue, bool capturedByInit) {
+void CIRGenFunction::emitScalarInit(const Expr *init, LValue lvalue,
+                                    bool capturedByInit) {
   assert(!cir::MissingFeatures::objCLifetime());
 
-  SourceLocRAIIObject locRAII{*this, loc};
+  SourceLocRAIIObject locRAII{*this, init->getSourceRange()};
   mlir::Value value = emitScalarExpr(init);
   if (capturedByInit) {
     cgm.errorNYI(init->getSourceRange(), "emitScalarInit: captured by init");
@@ -843,7 +843,7 @@ void CIRGenFunction::emitExprAsInit(const Expr *init, const ValueDecl *d,
   }
   switch (CIRGenFunction::getEvaluationKind(type)) {
   case cir::TEK_Scalar:
-    emitScalarInit(init, d->getSourceRange(), lvalue);
+    emitScalarInit(init, lvalue);
     return;
   case cir::TEK_Complex: {
     mlir::Value complex = emitComplexExpr(init);

--- a/clang/lib/CIR/CodeGen/CIRGenDeclOpenACC.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenDeclOpenACC.cpp
@@ -167,7 +167,8 @@ void CIRGenModule::emitGlobalOpenACCDeclareDataOperands(
     CIRGenFunction cgf{*this, builder, true};
     llvm::SaveAndRestore<CIRGenFunction *> savedCGF(curCGF, &cgf);
     cgf.curFn = ctorOp;
-    CIRGenFunction::SourceLocRAIIObject fnLoc{cgf, exprLoc};
+    CIRGenFunction::SourceLocRAIIObject fnLoc{cgf,
+                                              varOperand->getSourceRange()};
 
     // This gets the information we need, PLUS emits the bounds correctly, so we
     // have to do this in both enter and exit.
@@ -204,7 +205,8 @@ void CIRGenModule::emitGlobalOpenACCDeclareDataOperands(
     CIRGenFunction cgf{*this, builder, true};
     llvm::SaveAndRestore<CIRGenFunction *> savedCGF(curCGF, &cgf);
     cgf.curFn = ctorOp;
-    CIRGenFunction::SourceLocRAIIObject fnLoc{cgf, exprLoc};
+    CIRGenFunction::SourceLocRAIIObject fnLoc{cgf,
+                                              varOperand->getSourceRange()};
 
     CIRGenFunction::OpenACCDataOperandInfo inf =
         cgf.getOpenACCDataOperandInfo(varOperand);

--- a/clang/lib/CIR/CodeGen/CIRGenException.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenException.cpp
@@ -279,8 +279,9 @@ struct CallEndCatch final : EHScopeStack::Cleanup {
   mlir::Value catchToken;
 
   void emit(CIRGenFunction &cgf, Flags flags) override {
-    cir::EndCatchOp::create(cgf.getBuilder(), *cgf.currSrcLoc, catchToken);
-    cir::YieldOp::create(cgf.getBuilder(), *cgf.currSrcLoc);
+    cir::EndCatchOp::create(cgf.getBuilder(), cgf.getLoc(*cgf.currSrcLoc),
+                            catchToken);
+    cir::YieldOp::create(cgf.getBuilder(), cgf.getLoc(*cgf.currSrcLoc));
   }
 };
 } // namespace
@@ -309,7 +310,8 @@ static mlir::Value callBeginCatch(CIRGenFunction &cgf, mlir::Value ehToken,
 static cir::FuncOp getOrCreateCopyThunk(CIRGenFunction &cgf,
                                         const VarDecl &catchParam,
                                         cir::PointerType paramAddrType,
-                                        mlir::Location loc) {
+                                        SourceLocation clangLoc) {
+  mlir::Location loc = cgf.getLoc(clangLoc);
   CIRGenModule &cgm = cgf.cgm;
   CIRGenBuilderTy &builder = cgm.getBuilder();
   mlir::ModuleOp mod = cgm.getModule();
@@ -354,7 +356,7 @@ static cir::FuncOp getOrCreateCopyThunk(CIRGenFunction &cgf,
   // emitAnyExprToTemp) need both a current source location and a lexical
   // scope to anchor allocas. Since we bypass startFunction, install both
   // explicitly for the lifetime of the thunk's body emission.
-  CIRGenFunction::SourceLocRAIIObject thunkLoc(subCgf, loc);
+  CIRGenFunction::SourceLocRAIIObject thunkLoc(subCgf, clangLoc);
   CIRGenFunction::LexicalScope thunkScope(subCgf, loc, entry);
 
   // Bind the OpaqueValueExpr at the source position of the catch parameter's
@@ -441,7 +443,7 @@ static void initCatchParam(CIRGenFunction &cgf, CIRGenBuilderTy &builder,
       auto paramAddrType =
           mlir::cast<cir::PointerType>(paramAddr.getPointer().getType());
       cir::FuncOp thunk =
-          getOrCreateCopyThunk(cgf, catchParam, paramAddrType, mloc);
+          getOrCreateCopyThunk(cgf, catchParam, paramAddrType, loc);
       copyFun = mlir::FlatSymbolRefAttr::get(thunk.getSymNameAttr());
     }
 

--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -503,7 +503,8 @@ void CIRGenFunction::emitStoreOfScalar(mlir::Value value, Address addr,
   }
 
   assert(currSrcLoc && "must pass in source location");
-  builder.createStore(*currSrcLoc, value, addr, isVolatile, isNontemporal);
+  builder.createStore(getLoc(*currSrcLoc), value, addr, isVolatile,
+                      isNontemporal);
 
   assert(!cir::MissingFeatures::opTBAA());
 }
@@ -521,7 +522,7 @@ mlir::Value CIRGenFunction::emitStoreThroughBitfieldLValue(RValue src,
 
   assert(currSrcLoc && "must pass in source location");
 
-  return builder.createSetBitfield(*currSrcLoc, resLTy, ptr,
+  return builder.createSetBitfield(getLoc(*currSrcLoc), resLTy, ptr,
                                    ptr.getElementType(), src.getValue(), info,
                                    dst.isVolatileQualified(), useVoaltile);
 }
@@ -2172,7 +2173,7 @@ LValue CIRGenFunction::emitBinaryOperatorLValue(const BinaryOperator *e) {
     RValue rv = emitAnyExpr(e->getRHS());
     LValue lv = emitLValue(e->getLHS());
 
-    SourceLocRAIIObject loc{*this, getLoc(e->getSourceRange())};
+    SourceLocRAIIObject loc{*this, e->getSourceRange()};
     if (lv.isBitField())
       emitStoreThroughBitfieldLValue(rv, lv);
     else
@@ -2414,7 +2415,7 @@ RValue CIRGenFunction::emitCall(clang::QualType calleeTy,
 
   cir::CIRCallOpInterface callOp;
   RValue callResult = emitCall(funcInfo, callee, returnValue, args, &callOp,
-                               e == mustTailCall, getLoc(e->getExprLoc()));
+                               e == mustTailCall, e->getSourceRange());
 
   assert(!cir::MissingFeatures::generateDebugInfo());
 

--- a/clang/lib/CIR/CodeGen/CIRGenExprAggregate.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprAggregate.cpp
@@ -1026,7 +1026,7 @@ void AggExprEmitter::emitInitializationToLValue(Expr *e, LValue lv) {
     return;
   case cir::TEK_Scalar:
     if (lv.isSimple())
-      cgf.emitScalarInit(e, e->getSourceRange(), lv);
+      cgf.emitScalarInit(e, lv);
     else
       cgf.emitStoreThroughLValue(RValue::get(cgf.emitScalarExpr(e)), lv);
     return;

--- a/clang/lib/CIR/CodeGen/CIRGenExprAggregate.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprAggregate.cpp
@@ -1001,9 +1001,7 @@ void AggExprEmitter::emitInitializationToLValue(Expr *e, LValue lv) {
   const QualType type = lv.getType();
 
   if (isa<ImplicitValueInitExpr, CXXScalarValueInitExpr>(e)) {
-    const mlir::Location loc = e->getSourceRange().isValid()
-                                   ? cgf.getLoc(e->getSourceRange())
-                                   : *cgf.currSrcLoc;
+    const mlir::Location loc = cgf.getLoc(e->getSourceRange());
     return emitNullInitializationToLValue(loc, lv);
   }
 
@@ -1028,7 +1026,7 @@ void AggExprEmitter::emitInitializationToLValue(Expr *e, LValue lv) {
     return;
   case cir::TEK_Scalar:
     if (lv.isSimple())
-      cgf.emitScalarInit(e, cgf.getLoc(e->getSourceRange()), lv);
+      cgf.emitScalarInit(e, e->getSourceRange(), lv);
     else
       cgf.emitStoreThroughLValue(RValue::get(cgf.emitScalarExpr(e)), lv);
     return;
@@ -1083,7 +1081,7 @@ void AggExprEmitter::emitComparisonResult(const Expr *e, mlir::Location loc,
 }
 
 void AggExprEmitter::VisitLambdaExpr(LambdaExpr *e) {
-  CIRGenFunction::SourceLocRAIIObject loc{cgf, cgf.getLoc(e->getSourceRange())};
+  CIRGenFunction::SourceLocRAIIObject loc{cgf, e->getSourceRange()};
   AggValueSlot slot = ensureSlot(cgf.getLoc(e->getSourceRange()), e->getType());
   LValue slotLV = cgf.makeAddrLValue(slot.getAddress(), e->getType());
 
@@ -1305,8 +1303,7 @@ void AggExprEmitter::visitCXXParenListOrInitListExpr(
 
     if (curInitIndex < numInitElements) {
       // Store the initializer into the field.
-      CIRGenFunction::SourceLocRAIIObject loc{
-          cgf, cgf.getLoc(record->getSourceRange())};
+      CIRGenFunction::SourceLocRAIIObject loc{cgf, record->getSourceRange()};
       emitInitializationToLValue(args[curInitIndex++], lv);
     } else {
       // We're out of initializers; default-initialize to null

--- a/clang/lib/CIR/CodeGen/CIRGenExprCXX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprCXX.cpp
@@ -1006,8 +1006,7 @@ static void storeAnyExprIntoOneUnit(CIRGenFunction &cgf, const Expr *init,
   // FIXME: Refactor with emitExprAsInit.
   switch (cgf.getEvaluationKind(allocType)) {
   case cir::TEK_Scalar:
-    cgf.emitScalarInit(init, init->getSourceRange(),
-                       cgf.makeAddrLValue(newPtr, allocType), false);
+    cgf.emitScalarInit(init, cgf.makeAddrLValue(newPtr, allocType), false);
     return;
   case cir::TEK_Complex:
     cgf.emitComplexExprIntoLValue(init, cgf.makeAddrLValue(newPtr, allocType),

--- a/clang/lib/CIR/CodeGen/CIRGenExprCXX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprCXX.cpp
@@ -121,7 +121,7 @@ CIRGenFunction::emitCXXMemberPointerCallExpr(const CXXMemberCallExpr *ce,
   return emitCall(cgm.getTypes().arrangeCXXMethodCall(argsList, fpt, required,
                                                       /*PrefixSize=*/0),
                   callee, returnValue, argsList, nullptr, ce == mustTailCall,
-                  loc);
+                  ce->getSourceRange());
 }
 
 RValue CIRGenFunction::emitCXXMemberOrOperatorMemberCallExpr(
@@ -321,7 +321,7 @@ RValue CIRGenFunction::emitCXXMemberOrOperatorCall(
   auto &fnInfo = cgm.getTypes().arrangeCXXMethodCall(
       args, fpt, callInfo.reqArgs, callInfo.prefixSize);
   assert((ce || currSrcLoc) && "expected source location");
-  mlir::Location loc = ce ? getLoc(ce->getExprLoc()) : *currSrcLoc;
+  SourceRange loc = ce ? ce->getSourceRange() : *currSrcLoc;
   return emitCall(fnInfo, callee, returnValue, args, nullptr,
                   ce && ce == mustTailCall, loc);
 }
@@ -901,7 +901,7 @@ public:
     if (isAlignedAllocation(params.Alignment)) {
       QualType sizeType = cgf.getContext().getSizeType();
       cir::ConstantOp align = cgf.getBuilder().getAlignment(
-          *cgf.currSrcLoc, cgf.convertType(sizeType), allocAlign);
+          cgf.getLoc(*cgf.currSrcLoc), cgf.convertType(sizeType), allocAlign);
       deleteArgs.add(RValue::get(align), sizeType);
     }
 
@@ -1006,7 +1006,7 @@ static void storeAnyExprIntoOneUnit(CIRGenFunction &cgf, const Expr *init,
   // FIXME: Refactor with emitExprAsInit.
   switch (cgf.getEvaluationKind(allocType)) {
   case cir::TEK_Scalar:
-    cgf.emitScalarInit(init, cgf.getLoc(init->getSourceRange()),
+    cgf.emitScalarInit(init, init->getSourceRange(),
                        cgf.makeAddrLValue(newPtr, allocType), false);
     return;
   case cir::TEK_Complex:
@@ -1369,8 +1369,7 @@ RValue CIRGenFunction::emitCXXDestructorCall(
   assert((ce || dtor.getDecl()) && "expected source location provider");
   return emitCall(cgm.getTypes().arrangeCXXStructorDeclaration(dtor), callee,
                   ReturnValueSlot(), args, nullptr, ce && ce == mustTailCall,
-                  ce ? getLoc(ce->getExprLoc())
-                     : getLoc(dtor.getDecl()->getSourceRange()));
+                  ce ? ce->getSourceRange() : dtor.getDecl()->getSourceRange());
 }
 
 RValue CIRGenFunction::emitCXXPseudoDestructorExpr(
@@ -1643,7 +1642,7 @@ mlir::Value CIRGenFunction::emitCXXNewExpr(const CXXNewExpr *e) {
       if (allocatorType->getNumParams() > indexOfAlignArg)
         alignValType = allocatorType->getParamType(indexOfAlignArg);
       cir::ConstantOp align = builder.getAlignment(
-          *currSrcLoc, convertType(alignValType), allocAlign);
+          getLoc(*currSrcLoc), convertType(alignValType), allocAlign);
       allocatorArgs.add(RValue::get(align), alignValType);
       ++paramsToSkip;
     }
@@ -1857,8 +1856,9 @@ void CIRGenFunction::emitDeleteCall(const FunctionDecl *deleteFD,
     CharUnits deleteTypeSize = getContext().getTypeSizeInChars(deleteTy);
     assert(mlir::isa<cir::IntType>(convertType(sizeType)) &&
            "expected cir::IntType");
-    cir::ConstantOp size = builder.getConstInt(
-        *currSrcLoc, convertType(sizeType), deleteTypeSize.getQuantity());
+    cir::ConstantOp size =
+        builder.getConstInt(getLoc(*currSrcLoc), convertType(sizeType),
+                            deleteTypeSize.getQuantity());
 
     deleteArgs.add(RValue::get(size), sizeType);
   }
@@ -1870,7 +1870,7 @@ void CIRGenFunction::emitDeleteCall(const FunctionDecl *deleteFD,
         getContext().toCharUnitsFromBits(getContext().getTypeAlignIfKnown(
             deleteTy, /*NeedsPreferredAlignment=*/true));
     cir::ConstantOp align = builder.getAlignment(
-        *currSrcLoc, convertType(alignValType), deleteTypeAlign);
+        getLoc(*currSrcLoc), convertType(alignValType), deleteTypeAlign);
     deleteArgs.add(RValue::get(align), alignValType);
   }
 

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -738,8 +738,7 @@ public:
       return {};
     }
 
-    CIRGenFunction::SourceLocRAIIObject sourceloc{
-        cgf, cgf.getLoc(e->getSourceRange())};
+    CIRGenFunction::SourceLocRAIIObject sourceloc{cgf, e->getSourceRange()};
 
     // Store the updated result through the lvalue
     if (lv.isBitField())
@@ -1288,13 +1287,11 @@ public:
       // 'An assignment expression has the value of the left operand after the
       // assignment...'.
       if (lhs.isBitField()) {
-        CIRGenFunction::SourceLocRAIIObject loc{
-            cgf, cgf.getLoc(e->getSourceRange())};
+        CIRGenFunction::SourceLocRAIIObject loc{cgf, e->getSourceRange()};
         rhs = cgf.emitStoreThroughBitfieldLValue(RValue::get(rhs), lhs);
       } else {
         cgf.emitNullabilityCheck(lhs, rhs, e->getExprLoc());
-        CIRGenFunction::SourceLocRAIIObject loc{
-            cgf, cgf.getLoc(e->getSourceRange())};
+        CIRGenFunction::SourceLocRAIIObject loc{cgf, e->getSourceRange()};
         cgf.emitStoreThroughLValue(RValue::get(rhs), lhs);
       }
     }
@@ -1600,8 +1597,7 @@ LValue ScalarExprEmitter::emitCompoundAssignLValue(
 
   opInfo.lhs = emitLoadOfLValue(lhsLV, e->getExprLoc());
 
-  CIRGenFunction::SourceLocRAIIObject sourceloc{
-      cgf, cgf.getLoc(e->getSourceRange())};
+  CIRGenFunction::SourceLocRAIIObject sourceloc{cgf, e->getSourceRange()};
   SourceLocation loc = e->getExprLoc();
   if (!promotionTypeLHS.isNull())
     opInfo.lhs = emitScalarConversion(opInfo.lhs, lhsTy, promotionTypeLHS, loc);

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
@@ -151,12 +151,11 @@ mlir::Location CIRGenFunction::getLoc(SourceLocation srcLoc) {
     return mlir::FileLineColLoc::get(builder.getStringAttr(filename),
                                      pLoc.getLine(), pLoc.getColumn());
   }
-  // We expect to have a currSrcLoc set, so we assert here, but it isn't
-  // critical for the correctness of compilation, so in non-assert builds
-  // we fallback on using an unknown location.
-  assert(currSrcLoc && "expected to inherit some source location");
-  if (currSrcLoc)
-    return *currSrcLoc;
+  // We expect to have a currSrcLoc set, but it isn't critical for the
+  // correctness of compilation, so in non-assert builds we fallback on using an
+  // unknown location.
+  if (currSrcLoc && currSrcLoc->isValid())
+    return getLoc(*currSrcLoc);
   // We're brave, but time to give up.
   return builder.getUnknownLoc();
 }
@@ -164,19 +163,24 @@ mlir::Location CIRGenFunction::getLoc(SourceLocation srcLoc) {
 mlir::Location CIRGenFunction::getLoc(SourceRange srcLoc) {
   // Some AST nodes might contain invalid source locations (e.g.
   // CXXDefaultArgExpr), workaround that to still get something out.
-  if (srcLoc.isValid()) {
-    mlir::Location beg = getLoc(srcLoc.getBegin());
-    mlir::Location end = getLoc(srcLoc.getEnd());
-    SmallVector<mlir::Location, 2> locs = {beg, end};
-    mlir::Attribute metadata;
-    return mlir::FusedLoc::get(locs, metadata, &getMLIRContext());
-  }
-  // We expect to have a currSrcLoc set, so we assert here, but it isn't
-  // critical for the correctness of compilation, so in non-assert builds
-  // we fallback on using an unknown location.
-  assert(currSrcLoc && "expected to inherit some source location");
-  if (currSrcLoc)
-    return *currSrcLoc;
+
+  // SourceRange is only valid if BOTH are valid, so get the fused location from
+  // the 2-mlir::Location version of this.
+  if (srcLoc.isValid())
+    return getLoc(getLoc(srcLoc.getBegin()), getLoc(srcLoc.getEnd()));
+
+  // If only ONE of the two is valid, try our hardest to get this right.
+  if (srcLoc.getBegin().isValid())
+    return getLoc(srcLoc.getBegin());
+  if (srcLoc.getEnd().isValid())
+    return getLoc(srcLoc.getEnd());
+
+  // We expect to have a currSrcLoc set, but it isn't critical for the
+  // correctness of compilation, so in non-assert builds we fallback on using an
+  // unknown location.
+  if (currSrcLoc &&
+      (currSrcLoc->getBegin().isValid() || currSrcLoc->getEnd().isValid()))
+    return getLoc(*currSrcLoc);
   // We're brave, but time to give up.
   return builder.getUnknownLoc();
 }
@@ -764,8 +768,7 @@ cir::FuncOp CIRGenFunction::generateCode(clang::GlobalDecl gd, cir::FuncOp fn,
   SourceRange bodyRange =
       body ? body->getSourceRange() : funcDecl->getLocation();
 
-  SourceLocRAIIObject fnLoc{*this, loc.isValid() ? getLoc(loc)
-                                                 : builder.getUnknownLoc()};
+  SourceLocRAIIObject fnLoc{*this, funcDecl->getSourceRange()};
 
   auto validMLIRLoc = [&](clang::SourceLocation clangLoc) {
     return clangLoc.isValid() ? getLoc(clangLoc) : builder.getUnknownLoc();
@@ -1564,7 +1567,7 @@ CIRGenFunction::emitArrayLength(const clang::ArrayType *origArrayType,
   baseType = eltType;
 
   mlir::Value numElements =
-      builder.getConstInt(*currSrcLoc, sizeTy, countFromCLAs);
+      builder.getConstInt(getLoc(*currSrcLoc), sizeTy, countFromCLAs);
 
   // If we had any VLA dimensions, factor them in.
   if (numVLAElements)

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -536,13 +536,14 @@ private:
 public:
   /// Use to track source locations across nested visitor traversals.
   /// Always use a `SourceLocRAIIObject` to change currSrcLoc.
-  std::optional<mlir::Location> currSrcLoc;
+  std::optional<SourceRange> currSrcLoc;
+
   class SourceLocRAIIObject {
     CIRGenFunction &cgf;
-    std::optional<mlir::Location> oldLoc;
+    std::optional<SourceRange> oldLoc;
 
   public:
-    SourceLocRAIIObject(CIRGenFunction &cgf, mlir::Location value) : cgf(cgf) {
+    SourceLocRAIIObject(CIRGenFunction &cgf, SourceRange value) : cgf(cgf) {
       if (cgf.currSrcLoc)
         oldLoc = cgf.currSrcLoc;
       cgf.currSrcLoc = value;
@@ -1618,9 +1619,9 @@ public:
   void finishThunk();
 
   /// Generate code for a thunk function.
-  void generateThunk(cir::FuncOp fn, const CIRGenFunctionInfo &fnInfo,
-                     GlobalDecl gd, const ThunkInfo &thunk,
-                     bool isUnprototyped);
+  void generateThunk(cir::FuncOp fn, SourceRange fnLoc,
+                     const CIRGenFunctionInfo &fnInfo, GlobalDecl gd,
+                     const ThunkInfo &thunk, bool isUnprototyped);
 
   /// ----------------------
   /// CIR emit functions
@@ -1851,7 +1852,7 @@ public:
   RValue emitCall(const CIRGenFunctionInfo &funcInfo,
                   const CIRGenCallee &callee, ReturnValueSlot returnValue,
                   const CallArgList &args, cir::CIRCallOpInterface *callOp,
-                  bool isMustTail, mlir::Location loc);
+                  bool isMustTail, SourceRange clangLoc);
   RValue emitCall(const CIRGenFunctionInfo &funcInfo,
                   const CIRGenCallee &callee, ReturnValueSlot returnValue,
                   const CallArgList &args, bool isMustTail,
@@ -1865,8 +1866,8 @@ public:
                   const clang::CallExpr *e, ReturnValueSlot returnValue);
 
   /// Emit the call and return for a thunk function.
-  void emitCallAndReturnForThunk(cir::FuncOp callee, const ThunkInfo *thunk,
-                                 bool isUnprototyped);
+  void emitCallAndReturnForThunk(cir::FuncOp callee, SourceRange fnLoc,
+                                 const ThunkInfo *thunk, bool isUnprototyped);
 
   void emitCallArg(CallArgList &args, const clang::Expr *e,
                    clang::QualType argType);
@@ -2295,8 +2296,8 @@ public:
                                    clang::QualType dstType,
                                    clang::SourceLocation loc);
 
-  void emitScalarInit(const clang::Expr *init, mlir::Location loc,
-                      LValue lvalue, bool capturedByInit = false);
+  void emitScalarInit(const clang::Expr *init, SourceRange loc, LValue lvalue,
+                      bool capturedByInit = false);
 
   mlir::Value emitScalarOrConstFoldImmArg(unsigned iceArguments, unsigned idx,
                                           const Expr *argExpr);

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -2296,7 +2296,7 @@ public:
                                    clang::QualType dstType,
                                    clang::SourceLocation loc);
 
-  void emitScalarInit(const clang::Expr *init, SourceRange loc, LValue lvalue,
+  void emitScalarInit(const clang::Expr *init, LValue lvalue,
                       bool capturedByInit = false);
 
   mlir::Value emitScalarOrConstFoldImmArg(unsigned iceArguments, unsigned idx,

--- a/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
@@ -1812,7 +1812,7 @@ void CIRGenItaniumCXXABI::emitRethrow(CIRGenFunction &cgf, bool isNoReturn) {
   if (isNoReturn) {
     CIRGenBuilderTy &builder = cgf.getBuilder();
     assert(cgf.currSrcLoc && "expected source location");
-    mlir::Location loc = *cgf.currSrcLoc;
+    mlir::Location loc = cgf.getLoc(*cgf.currSrcLoc);
     insertThrowAndSplit(builder, loc);
   } else {
     cgm.errorNYI("emitRethrow with isNoReturn false");

--- a/clang/lib/CIR/CodeGen/CIRGenSYCL.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenSYCL.cpp
@@ -54,8 +54,7 @@ void CIRGenFunction::emitSYCLKernelCaller(
   // Synthesized entry point: no FunctionDecl, emitted with an empty GlobalDecl.
   curGD = GlobalDecl();
 
-  SourceLocRAIIObject fnLoc{*this, loc.isValid() ? getLoc(loc)
-                                                 : builder.getUnknownLoc()};
+  SourceLocRAIIObject fnLoc{*this, loc};
 
   mlir::Location fusedLoc = getLoc(bodyRange);
   mlir::Block *entryBB = funcOp.addEntryBlock();

--- a/clang/lib/CIR/CodeGen/CIRGenVTables.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenVTables.cpp
@@ -666,6 +666,7 @@ void CIRGenFunction::finishThunk() {
 }
 
 void CIRGenFunction::emitCallAndReturnForThunk(cir::FuncOp callee,
+                                               SourceRange fnLoc,
                                                const ThunkInfo *thunk,
                                                bool isUnprototyped) {
   assert(isa<CXXMethodDecl>(curGD.getDecl()) &&
@@ -744,8 +745,9 @@ void CIRGenFunction::emitCallAndReturnForThunk(cir::FuncOp callee,
   // Now emit our call.
   CIRGenCallee cirCallee = CIRGenCallee::forDirect(callee, curGD);
   mlir::Location loc = builder.getUnknownLoc();
-  RValue rv = emitCall(*curFnInfo, cirCallee, slot, callArgs,
-                       /*callOrTryCall=*/nullptr, /*isMustTail=*/false, loc);
+  RValue rv =
+      emitCall(*curFnInfo, cirCallee, slot, callArgs,
+               /*callOrTryCall=*/nullptr, /*isMustTail=*/false, fnLoc);
 
   // Consider return adjustment if we have ThunkInfo.
   if (thunk && !thunk->Return.isEmpty())
@@ -805,6 +807,7 @@ void CIRGenFunction::emitMustTailThunk(GlobalDecl gd,
 }
 
 void CIRGenFunction::generateThunk(cir::FuncOp fn,
+                                   SourceRange fnLoc,
                                    const CIRGenFunctionInfo &fnInfo,
                                    GlobalDecl gd, const ThunkInfo &thunk,
                                    bool isUnprototyped) {
@@ -822,7 +825,7 @@ void CIRGenFunction::generateThunk(cir::FuncOp fn,
 
   // Create lexical scope - must stay alive for entire thunk generation.
   // startFunction() requires currLexScope to be set.
-  SourceLocRAIIObject locRAII(*this, fn.getLoc());
+  SourceLocRAIIObject locRAII(*this, fnLoc);
   LexicalScope lexScope{*this, fn.getLoc(), entryBb};
 
   startThunk(fn, gd, fnInfo, isUnprototyped);
@@ -839,7 +842,7 @@ void CIRGenFunction::generateThunk(cir::FuncOp fn,
   cir::FuncOp calleeOp = cgm.getAddrOfFunction(gd, ty, /*forVTable=*/true);
 
   // Make the call and return the result.
-  emitCallAndReturnForThunk(calleeOp, &thunk, isUnprototyped);
+  emitCallAndReturnForThunk(calleeOp, fnLoc, &thunk, isUnprototyped);
 }
 
 static bool shouldEmitVTableThunk(CIRGenModule &cgm, const CXXMethodDecl *md,
@@ -974,7 +977,8 @@ cir::FuncOp CIRGenVTables::maybeEmitThunk(GlobalDecl gd,
     // Normal thunk body generation.
     mlir::OpBuilder::InsertionGuard guard(cgm.getBuilder());
     CIRGenFunction cgf(cgm, cgm.getBuilder());
-    cgf.generateThunk(thunkFn, fnInfo, gd, thunkAdjustments, isUnprototyped);
+    cgf.generateThunk(thunkFn, md->getSourceRange(), fnInfo, gd,
+                      thunkAdjustments, isUnprototyped);
   }
 
   setThunkProperties(cgm, thunkAdjustments, thunkFn, forVTable, gd);

--- a/clang/lib/CIR/CodeGen/CIRGenVTables.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenVTables.cpp
@@ -745,9 +745,8 @@ void CIRGenFunction::emitCallAndReturnForThunk(cir::FuncOp callee,
   // Now emit our call.
   CIRGenCallee cirCallee = CIRGenCallee::forDirect(callee, curGD);
   mlir::Location loc = builder.getUnknownLoc();
-  RValue rv =
-      emitCall(*curFnInfo, cirCallee, slot, callArgs,
-               /*callOrTryCall=*/nullptr, /*isMustTail=*/false, fnLoc);
+  RValue rv = emitCall(*curFnInfo, cirCallee, slot, callArgs,
+                       /*callOrTryCall=*/nullptr, /*isMustTail=*/false, fnLoc);
 
   // Consider return adjustment if we have ThunkInfo.
   if (thunk && !thunk->Return.isEmpty())
@@ -806,8 +805,7 @@ void CIRGenFunction::emitMustTailThunk(GlobalDecl gd,
   finishThunk();
 }
 
-void CIRGenFunction::generateThunk(cir::FuncOp fn,
-                                   SourceRange fnLoc,
+void CIRGenFunction::generateThunk(cir::FuncOp fn, SourceRange fnLoc,
                                    const CIRGenFunctionInfo &fnInfo,
                                    GlobalDecl gd, const ThunkInfo &thunk,
                                    bool isUnprototyped) {

--- a/clang/test/CIR/CodeGen/paren-list-agg-init.cpp
+++ b/clang/test/CIR/CodeGen/paren-list-agg-init.cpp
@@ -145,7 +145,7 @@ constexpr C c1(b1, a1);
 constexpr U u1(A(1, 1));
 // LLVMCIR-DAG: [[D1:@.*d1.*]] = internal constant [[STRUCT_D]] { [[STRUCT_A]] { i8 2, double 2.000000e+00 }, [[STRUCT_A]] { i8 2, double 2.000000e+00 }, i8 0, [[STRUCT_A]] zeroinitializer }, align 8
 // OGCG-DAG:    [[D1:@.*d1.*]] = internal constant { [[STRUCT_A]], [[STRUCT_A]], [8 x i8], [[STRUCT_A]] } { [[STRUCT_A]] { i8 2, double 2.000000e+00 }, [[STRUCT_A]] { i8 2, double 2.000000e+00 }, [8 x i8] {{.*}}, [[STRUCT_A]] zeroinitializer }, align 8
-// CIR-DAG: cir.global "private" constant internal dso_local @_ZL2d1 = #cir.const_record<{#cir.const_record<{#cir.int<2> : !s8i, #cir.fp<2.000000e+00> : !cir.double}> : ![[STRUCT_A]], #cir.const_record<{#cir.int<2> : !s8i, #cir.fp<2.000000e+00> : !cir.double}> : ![[STRUCT_A]], #cir.int<0> : !u8i, #cir.zero : ![[STRUCT_A]]}> : !rec_D {alignment = 8 : i64} loc(#loc284)
+// CIR-DAG: cir.global "private" constant internal dso_local @_ZL2d1 = #cir.const_record<{#cir.const_record<{#cir.int<2> : !s8i, #cir.fp<2.000000e+00> : !cir.double}> : ![[STRUCT_A]], #cir.const_record<{#cir.int<2> : !s8i, #cir.fp<2.000000e+00> : !cir.double}> : ![[STRUCT_A]], #cir.int<0> : !u8i, #cir.zero : ![[STRUCT_A]]}> : !rec_D {alignment = 8 : i64}
 constexpr D d1(A(2, 2));
 // LLVM-DAG: [[ARR1:@.*arr1.*]] = internal constant [3 x i32] [i32 1, i32 2, i32 0], align 4
 // CIR-DAG: cir.global "private" constant internal dso_local @_ZL4arr1 = #cir.const_array<[#cir.int<1> : !s32i, #cir.int<2> : !s32i], trailing_zeros> : !cir.array<!s32i x 3> {alignment = 4 : i64}

--- a/clang/test/CIR/CodeGenCXX/init-priority-attr.cpp
+++ b/clang/test/CIR/CodeGenCXX/init-priority-attr.cpp
@@ -62,12 +62,12 @@ A C::a = A();
 // CIR-NEXT:    cir.return
 
 // CIR-LABEL: cir.func internal private @__cxx_global_var_init.2() {
-// CIR-NEXT:    cir.get_global @a1 : !cir.ptr<!rec_A1> loc(#loc36)
+// CIR-NEXT:    cir.get_global @a1 : !cir.ptr<!rec_A1>
 // CIR-NEXT:    cir.call @_ZN2A1C1Ev(
 // CIR-NEXT:    cir.return
 
 // CIR-LABEL: cir.func internal private @__cxx_global_var_init.4() {
-// CIR-NEXT:    cir.get_global @b : !cir.ptr<!rec_B> loc(#loc38)
+// CIR-NEXT:    cir.get_global @b : !cir.ptr<!rec_B>
 // CIR-NEXT:    cir.call @_ZN1BC1Ev(
 // CIR-NEXT:    cir.return
 

--- a/clang/test/CIR/CodeGenHIP/ternary-struct-addrspace.hip
+++ b/clang/test/CIR/CodeGenHIP/ternary-struct-addrspace.hip
@@ -16,7 +16,7 @@ __attribute__((device)) S choose(const S x) {
 
 
 // CHECK: %[[X:.*]] = cir.alloca "x" {{.*}} : !cir.ptr<!rec_S, target_address_space(5)>
-// CHECK: %[[Y:.*]] = cir.alloca "y" {{.*}} : !cir.ptr<!rec_S, target_address_space(5)> loc(#loc18)
+// CHECK: %[[Y:.*]] = cir.alloca "y" {{.*}} : !cir.ptr<!rec_S, target_address_space(5)>
 
 // CHECK: %[[Y_CAST:.*]] = cir.cast address_space %[[Y]] : !cir.ptr<!rec_S, target_address_space(5)> -> !cir.ptr<!rec_S>
 // CHECK: %[[X_CAST:.*]] = cir.cast address_space %[[X]] : !cir.ptr<!rec_S, target_address_space(5)> -> !cir.ptr<!rec_S>

--- a/clang/test/CIR/CodeGenOpenACC/compute-reduction-clause-int.cpp
+++ b/clang/test/CIR/CodeGenOpenACC/compute-reduction-clause-int.cpp
@@ -395,8 +395,8 @@ void acc_compute() {
 // CHECK-NEXT: acc.reduction.recipe @reduction_ior__ZTSA5_i : !cir.ptr<!cir.array<!s32i x 5>> reduction_operator <ior> init {
 // CHECK-NEXT: ^bb0(%[[ARG:.*]]: !cir.ptr<!cir.array<!s32i x 5>>{{.*}})
 // CHECK-NEXT: %[[ALLOCA:.*]] = cir.alloca "openacc.reduction.init" {{.*}} init : !cir.ptr<!cir.array<!s32i x 5>>
-// CHECK-NEXT: %[[ZERO:.*]] = cir.const #cir.zero : !cir.array<!s32i x 5> loc(#loc12)
-// CHECK-NEXT: cir.store {{.*}} %[[ZERO]], %[[ALLOCA]] : !cir.array<!s32i x 5>, !cir.ptr<!cir.array<!s32i x 5>> loc(#loc12)
+// CHECK-NEXT: %[[ZERO:.*]] = cir.const #cir.zero : !cir.array<!s32i x 5>
+// CHECK-NEXT: cir.store {{.*}} %[[ZERO]], %[[ALLOCA]] : !cir.array<!s32i x 5>, !cir.ptr<!cir.array<!s32i x 5>>
 // CHECK-NEXT: acc.yield
 //
 // CHECK-NEXT: } combiner {
@@ -433,8 +433,8 @@ void acc_compute() {
 // CHECK-NEXT: acc.reduction.recipe @reduction_xor__ZTSA5_i : !cir.ptr<!cir.array<!s32i x 5>> reduction_operator <xor> init {
 // CHECK-NEXT: ^bb0(%[[ARG:.*]]: !cir.ptr<!cir.array<!s32i x 5>>{{.*}})
 // CHECK-NEXT: %[[ALLOCA:.*]] = cir.alloca "openacc.reduction.init" {{.*}} init : !cir.ptr<!cir.array<!s32i x 5>>
-// CHECK-NEXT: %[[ZERO:.*]] = cir.const #cir.zero : !cir.array<!s32i x 5> loc(#loc12)
-// CHECK-NEXT: cir.store {{.*}} %[[ZERO]], %[[ALLOCA]] : !cir.array<!s32i x 5>, !cir.ptr<!cir.array<!s32i x 5>> loc(#loc12)
+// CHECK-NEXT: %[[ZERO:.*]] = cir.const #cir.zero : !cir.array<!s32i x 5>
+// CHECK-NEXT: cir.store {{.*}} %[[ZERO]], %[[ALLOCA]] : !cir.array<!s32i x 5>, !cir.ptr<!cir.array<!s32i x 5>>
 // CHECK-NEXT: acc.yield
 //
 // CHECK-NEXT: } combiner {
@@ -519,8 +519,8 @@ void acc_compute() {
 // CHECK-NEXT: acc.reduction.recipe @reduction_lor__ZTSA5_i : !cir.ptr<!cir.array<!s32i x 5>> reduction_operator <lor> init {
 // CHECK-NEXT: ^bb0(%[[ARG:.*]]: !cir.ptr<!cir.array<!s32i x 5>>{{.*}})
 // CHECK-NEXT: %[[ALLOCA:.*]] = cir.alloca "openacc.reduction.init" {{.*}} init : !cir.ptr<!cir.array<!s32i x 5>>
-// CHECK-NEXT: %[[ZERO:.*]] = cir.const #cir.zero : !cir.array<!s32i x 5> loc(#loc12)
-// CHECK-NEXT: cir.store {{.*}} %[[ZERO]], %[[ALLOCA]] : !cir.array<!s32i x 5>, !cir.ptr<!cir.array<!s32i x 5>> loc(#loc12)
+// CHECK-NEXT: %[[ZERO:.*]] = cir.const #cir.zero : !cir.array<!s32i x 5>
+// CHECK-NEXT: cir.store {{.*}} %[[ZERO]], %[[ALLOCA]] : !cir.array<!s32i x 5>, !cir.ptr<!cir.array<!s32i x 5>>
 // CHECK-NEXT: acc.yield
 //
 // CHECK-NEXT: } combiner {


### PR DESCRIPTION
As a prerequisite to an upcoming patch, emitCall needs access to the Clang source locations, not just the mlir::Location.  We're going to need this in quite a few more places in the future, since there are various diagnostics that use clang locations in the code generation.

This patch also has to change the RAII source location stuff, which I switched to SourceRange.  This should improve the amount of data we give for our source information.

I DID have to remove the assertion on it though, because we do have a few places that intentionally wanted an invalid location if other stuff wasn't available (see the CUDA use in particular), but otherwise this should allow us to improve our source location info, AND use it for diagnostics in the future.