### PR TITLE
[llvm-mc] Add --load to support dynamically loaded plugins

### DIFF
--- a/llvm/examples/CMakeLists.txt
+++ b/llvm/examples/CMakeLists.txt
@@ -8,6 +8,7 @@ add_subdirectory(ModuleMaker)
 add_subdirectory(OrcV2Examples)
 add_subdirectory(SpeculativeJIT)
 add_subdirectory(Bye)
+add_subdirectory(MCTargetPlugin)
 add_subdirectory(OptSubcommand)
 
 if(LLVM_ENABLE_EH AND (NOT WIN32) AND (NOT "${LLVM_NATIVE_ARCH}" STREQUAL "ARM"))

--- a/llvm/examples/MCTargetPlugin/CMakeLists.txt
+++ b/llvm/examples/MCTargetPlugin/CMakeLists.txt
@@ -1,0 +1,17 @@
+# The plugin expects to not link against the MC and Support libraries, but
+# expects them to exist in the process loading the plugin. This doesn't work
+# with DLLs on Windows (where a shared library can't have undefined
+# references), so just skip this example on Windows.
+if (NOT WIN32 AND NOT CYGWIN)
+  add_llvm_example_library(MCTargetPlugin
+    MODULE
+    BUILDTREE_ONLY
+    PLUGIN_TOOL
+    llvm-mc
+
+    MCTargetPlugin.cpp
+    MCTargetPluginAsmParser.cpp
+    )
+
+  set_target_properties(MCTargetPlugin PROPERTIES FOLDER "Examples")
+endif()

--- a/llvm/examples/MCTargetPlugin/MCTargetPlugin.cpp
+++ b/llvm/examples/MCTargetPlugin/MCTargetPlugin.cpp
@@ -1,0 +1,162 @@
+//===-- MCTargetPlugin.cpp - Example llvm-mc target plugin ----------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// A minimal MC-only target, built as a shared module instead of being linked
+// into the tools. Loading it with llvm-mc's --load option registers the
+// "mcplugin" target, which knows exactly one instruction:
+//
+//   nop     # encoding: [0x2a]
+//
+// The point of the example is the registration path rather than the
+// instruction set: everything here is registered from a static initializer
+// that runs at dlopen time, which is early enough for the tool to find the
+// target in the TargetRegistry afterwards.
+//
+// It has no register file, no relocations and no TableGen'd tables, so the
+// hand-written MC components below are as small as the interfaces allow.
+//
+// Only textual output is supported: -filetype=obj additionally needs an
+// object streamer and an asm backend, which a one-instruction target with no
+// object format of its own has nothing useful to say about.
+//
+//===----------------------------------------------------------------------===//
+
+#include "MCTargetPlugin.h"
+#include "llvm/MC/MCAsmInfo.h"
+#include "llvm/MC/MCCodeEmitter.h"
+#include "llvm/MC/MCInst.h"
+#include "llvm/MC/MCInstPrinter.h"
+#include "llvm/MC/MCInstrInfo.h"
+#include "llvm/MC/MCRegisterInfo.h"
+#include "llvm/MC/MCSubtargetInfo.h"
+#include "llvm/MC/TargetRegistry.h"
+
+using namespace llvm;
+
+namespace {
+
+//===----------------------------------------------------------------------===//
+// Target description
+//===----------------------------------------------------------------------===//
+
+/// The instruction table this target would have had TableGen generate.
+enum { NOP = 0, NumOpcodes };
+
+const MCInstrDesc Instrs[NumOpcodes] = {
+    // Opcode, NumOperands, NumDefs, Size, SchedClass, NumImplicitUses,
+    // NumImplicitDefs, OpInfoOffset, ImplicitOffset, Flags, TSFlags
+    {NOP, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0},
+};
+const unsigned InstrNameIndices[NumOpcodes] = {0};
+const char InstrNameData[] = "NOP";
+
+/// MCSubtargetInfo insists on a processor table; this target has no CPUs and
+/// no features, so every table below is empty.
+constexpr char EmptyProcNames[] = "";
+
+class MCPluginSubtargetInfo : public MCSubtargetInfo {
+public:
+  MCPluginSubtargetInfo(const Triple &TT, StringRef CPU, StringRef FS)
+      : MCSubtargetInfo(TT, CPU, /*TuneCPU=*/"", FS, StringTable(EmptyProcNames),
+                        /*PF=*/{}, /*PD=*/{}, /*PSM=*/nullptr, /*WPR=*/nullptr,
+                        /*WL=*/nullptr, /*RA=*/nullptr, /*IS=*/nullptr,
+                        /*OC=*/nullptr, /*FP=*/nullptr) {}
+};
+
+class MCPluginInstPrinter : public MCInstPrinter {
+public:
+  using MCInstPrinter::MCInstPrinter;
+
+  std::pair<const char *, uint64_t> getMnemonic(const MCInst &MI) const override {
+    return {"nop", 0};
+  }
+
+  void printInst(const MCInst *MI, uint64_t Address, StringRef Annot,
+                 const MCSubtargetInfo &STI, raw_ostream &OS) override {
+    OS << "\tnop";
+    printAnnotation(OS, Annot);
+  }
+};
+
+class MCPluginCodeEmitter : public MCCodeEmitter {
+public:
+  void encodeInstruction(const MCInst &Inst, SmallVectorImpl<char> &CB,
+                         SmallVectorImpl<MCFixup> &Fixups,
+                         const MCSubtargetInfo &STI) const override {
+    assert(Inst.getOpcode() == NOP && "mcplugin has one instruction");
+    CB.push_back(0x2a);
+  }
+};
+
+} // namespace
+
+//===----------------------------------------------------------------------===//
+// Registration
+//===----------------------------------------------------------------------===//
+
+Target &llvm::getTheMCPluginTarget() {
+  static Target TheMCPluginTarget;
+  return TheMCPluginTarget;
+}
+
+static MCAsmInfo *createMCPluginAsmInfo(const MCRegisterInfo &MRI,
+                                        const Triple &TT,
+                                        const MCTargetOptions &Options) {
+  return new MCAsmInfo(Options);
+}
+
+static MCRegisterInfo *createMCPluginRegInfo(const Triple &TT) {
+  // A target with no registers still needs an (empty) MCRegisterInfo.
+  return new MCRegisterInfo();
+}
+
+static MCInstrInfo *createMCPluginInstrInfo() {
+  auto *II = new MCInstrInfo();
+  II->InitMCInstrInfo(Instrs, InstrNameIndices, InstrNameData,
+                      /*DF=*/nullptr, /*CDI=*/nullptr, NumOpcodes);
+  return II;
+}
+
+static MCSubtargetInfo *createMCPluginSubtargetInfo(const Triple &TT,
+                                                    StringRef CPU,
+                                                    StringRef FS) {
+  return new MCPluginSubtargetInfo(TT, CPU, FS);
+}
+
+static MCInstPrinter *createMCPluginInstPrinter(const Triple &T,
+                                                unsigned SyntaxVariant,
+                                                const MCAsmInfo &MAI,
+                                                const MCInstrInfo &MII,
+                                                const MCRegisterInfo &MRI) {
+  return new MCPluginInstPrinter(MAI, MII, MRI);
+}
+
+static MCCodeEmitter *createMCPluginCodeEmitter(const MCInstrInfo &II,
+                                                MCContext &Ctx) {
+  return new MCPluginCodeEmitter();
+}
+
+/// Registering from a static initializer is what makes this usable through
+/// --load: by the time the loading tool looks a target up, dlopen has already
+/// run this.
+static struct RegisterMCPluginTarget {
+  RegisterMCPluginTarget() {
+    Target &T = getTheMCPluginTarget();
+    // The target has no Triple::ArchType of its own, so it never matches a
+    // triple and has to be selected by name, with llvm-mc's --arch option.
+    TargetRegistry::RegisterTarget(
+        T, "mcplugin", "Example MC target plugin", "MCPlugin",
+        [](Triple::ArchType) { return false; }, /*HasJIT=*/false);
+    TargetRegistry::RegisterMCAsmInfo(T, createMCPluginAsmInfo);
+    TargetRegistry::RegisterMCRegInfo(T, createMCPluginRegInfo);
+    TargetRegistry::RegisterMCInstrInfo(T, createMCPluginInstrInfo);
+    TargetRegistry::RegisterMCSubtargetInfo(T, createMCPluginSubtargetInfo);
+    TargetRegistry::RegisterMCInstPrinter(T, createMCPluginInstPrinter);
+    TargetRegistry::RegisterMCCodeEmitter(T, createMCPluginCodeEmitter);
+  }
+} Registration;

--- a/llvm/examples/MCTargetPlugin/MCTargetPlugin.h
+++ b/llvm/examples/MCTargetPlugin/MCTargetPlugin.h
@@ -1,0 +1,20 @@
+//===-- MCTargetPlugin.h - Example llvm-mc target plugin --------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_EXAMPLES_MCTARGETPLUGIN_MCTARGETPLUGIN_H
+#define LLVM_EXAMPLES_MCTARGETPLUGIN_MCTARGETPLUGIN_H
+
+namespace llvm {
+class Target;
+
+/// The one Target this plugin registers, shared by the pieces of the example
+/// that live in different files.
+Target &getTheMCPluginTarget();
+} // namespace llvm
+
+#endif

--- a/llvm/examples/MCTargetPlugin/MCTargetPluginAsmParser.cpp
+++ b/llvm/examples/MCTargetPlugin/MCTargetPluginAsmParser.cpp
@@ -1,0 +1,78 @@
+//===-- MCTargetPluginAsmParser.cpp - Asm parser for the example target --===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// The "mcplugin" assembly parser. Real targets have TableGen write the matcher
+// for them; with a single operand-less mnemonic to recognize, this one is
+// written by hand.
+//
+//===----------------------------------------------------------------------===//
+
+#include "MCTargetPlugin.h"
+#include "llvm/MC/MCInst.h"
+#include "llvm/MC/MCParser/MCAsmParser.h"
+#include "llvm/MC/MCParser/MCTargetAsmParser.h"
+#include "llvm/MC/MCStreamer.h"
+#include "llvm/MC/TargetRegistry.h"
+
+using namespace llvm;
+
+namespace {
+
+class MCPluginAsmParser : public MCTargetAsmParser {
+public:
+  MCPluginAsmParser(const MCSubtargetInfo &STI, MCAsmParser &Parser,
+                    const MCInstrInfo &MII)
+      : MCTargetAsmParser(STI, MII) {}
+
+  bool parseRegister(MCRegister &Reg, SMLoc &StartLoc,
+                     SMLoc &EndLoc) override {
+    return true;
+  }
+
+  ParseStatus tryParseRegister(MCRegister &Reg, SMLoc &StartLoc,
+                               SMLoc &EndLoc) override {
+    return ParseStatus::NoMatch;
+  }
+
+  bool parseInstruction(ParseInstructionInfo &Info, StringRef Name,
+                        SMLoc NameLoc, OperandVector &Operands) override {
+    if (Name != "nop")
+      return Error(NameLoc, "unknown instruction '" + Name + "'");
+
+    return parseEOL();
+  }
+
+  bool matchAndEmitInstruction(SMLoc IDLoc, unsigned &Opcode,
+                               OperandVector &Operands, MCStreamer &Out,
+                               uint64_t &ErrorInfo,
+                               bool MatchingInlineAsm) override {
+    MCInst Inst;
+    Inst.setOpcode(0);
+    Inst.setLoc(IDLoc);
+    Out.emitInstruction(Inst, getSTI());
+    return false;
+  }
+
+  void convertToMapAndConstraints(unsigned Kind,
+                                  const OperandVector &Operands) override {}
+};
+
+} // namespace
+
+static MCTargetAsmParser *createMCPluginAsmParser(const MCSubtargetInfo &STI,
+                                                  MCAsmParser &Parser,
+                                                  const MCInstrInfo &MII) {
+  return new MCPluginAsmParser(STI, Parser, MII);
+}
+
+static struct RegisterMCPluginAsmParser {
+  RegisterMCPluginAsmParser() {
+    TargetRegistry::RegisterMCAsmParser(getTheMCPluginTarget(),
+                                        createMCPluginAsmParser);
+  }
+} Registration;

--- a/llvm/test/lit.cfg.py
+++ b/llvm/test/lit.cfg.py
@@ -566,6 +566,15 @@ else:
         )
     )
 
+config.substitutions.append(
+    (
+        "%loadmctargetplugin",
+        "--load={}/MCTargetPlugin{}".format(
+            config.llvm_shlib_dir, config.llvm_shlib_ext
+        ),
+    )
+)
+
 # Static libraries are not built if BUILD_SHARED_LIBS is ON.
 if not config.build_shared_libs and not config.link_llvm_dylib:
     config.available_features.add("static-libs")

--- a/llvm/test/tools/llvm-mc/load-plugin.test
+++ b/llvm/test/tools/llvm-mc/load-plugin.test
@@ -1,0 +1,20 @@
+## Check that --load can bring in a target: MCTargetPlugin registers the
+## "mcplugin" target from a static initializer at dlopen time, and llvm-mc
+## then assembles with it.
+
+# REQUIRES: plugins, examples
+# UNSUPPORTED: target={{.*windows.*}}
+## Plugins are currently broken on AIX, at least in the CI.
+# XFAIL: target={{.*}}-aix{{.*}}
+
+# RUN: llvm-mc %loadmctargetplugin --arch=mcplugin --show-encoding %s \
+# RUN:   | FileCheck %s
+# RUN: llvm-mc %loadmctargetplugin --version | FileCheck %s --check-prefix=VERSION
+# RUN: not llvm-mc --arch=mcplugin %s 2>&1 | FileCheck %s --check-prefix=NOPLUGIN
+
+# CHECK: nop # encoding: [0x2a]
+# VERSION: mcplugin - Example MC target plugin
+## Without the plugin there is no such target, so --arch is rejected.
+# NOPLUGIN: error: invalid target 'mcplugin'.
+
+nop

--- a/llvm/tools/llvm-mc/CMakeLists.txt
+++ b/llvm/tools/llvm-mc/CMakeLists.txt
@@ -13,5 +13,8 @@ set(LLVM_LINK_COMPONENTS
 add_llvm_tool(llvm-mc
   llvm-mc.cpp
   Disassembler.cpp
+
+  SUPPORT_PLUGINS
   )
 
+export_executable_symbols_for_plugins(llvm-mc)

--- a/llvm/tools/llvm-mc/llvm-mc.cpp
+++ b/llvm/tools/llvm-mc/llvm-mc.cpp
@@ -37,6 +37,7 @@
 #include "llvm/Support/FormattedStream.h"
 #include "llvm/Support/InitLLVM.h"
 #include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/PluginLoader.h"
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/TimeProfiler.h"


### PR DESCRIPTION
Include PluginLoader.h to give llvm-mc the same --load option llc and opt have, so out-of-tree targets built as shared libraries can register themselves with the TargetRegistry before the triple is looked up.

To have something to test that with, add the MCTargetPlugin example: a hand-written MC-only target, built as a shared module rather than linked into the tools, that registers the "mcplugin" target and its one instruction.