### PR TITLE
[libc] Template printf_core::Parser to support wchar_t.

### DIFF
--- a/libc/fuzzing/stdio/printf_parser_fuzz.cpp
+++ b/libc/fuzzing/stdio/printf_parser_fuzz.cpp
@@ -34,7 +34,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   auto mock_arg_list = internal::MockArgList();
 
   auto parser =
-      printf_core::Parser<internal::MockArgList>(in_str, mock_arg_list);
+      printf_core::Parser<internal::MockArgList, char>(in_str, mock_arg_list);
 
   int str_percent_count = 0;
 

--- a/libc/src/__support/printf_core/CMakeLists.txt
+++ b/libc/src/__support/printf_core/CMakeLists.txt
@@ -85,6 +85,7 @@ add_header_library(
     libc.include.inttypes
     libc.src.__support.CPP.string_view
     libc.src.__support.FPUtil.fp_bits
+    libc.src.__support.macros.properties.types
     libc.hdr.errno_macros
 )
 

--- a/libc/src/__support/printf_core/core_structs.h
+++ b/libc/src/__support/printf_core/core_structs.h
@@ -14,6 +14,7 @@
 #include "src/__support/CPP/string_view.h"
 #include "src/__support/CPP/type_traits.h"
 #include "src/__support/FPUtil/FPBits.h"
+#include "src/__support/macros/properties/types.h"
 #include "src/__support/printf_core/printf_config.h"
 
 #include <inttypes.h>
@@ -21,6 +22,22 @@
 
 namespace LIBC_NAMESPACE_DECL {
 namespace printf_core {
+
+template <typename CharT, char ascii_value> struct CharConstant {};
+
+template <char ascii_value> struct CharConstant<char, ascii_value> {
+  LIBC_INLINE static constexpr char value = ascii_value;
+};
+
+#if defined(LIBC_TYPES_WCHAR_T_IS_UTF32)
+template <char ascii_value> struct CharConstant<wchar_t, ascii_value> {
+  LIBC_INLINE static constexpr wchar_t value = ascii_value;
+};
+#endif // LIBC_TYPES_WCHAR_T_IS_UTF32
+
+template <typename CharT, char ascii_value>
+LIBC_INLINE_VAR constexpr CharT char_constant_v =
+    CharConstant<CharT, ascii_value>::value;
 
 // These length modifiers match the length modifiers in the format string, which
 // is why they are formatted differently from the rest of the file.
@@ -66,10 +83,10 @@ enum FormatFlags : uint8_t {
   //  locale_digits = 0x40,  // I
 };
 
-struct FormatSection {
+template <typename CharT> struct BasicFormatSection {
   bool has_conv;
 
-  cpp::string_view raw_string;
+  cpp::basic_string_view<CharT> raw_string;
 
   // Format Specifier Values
   FormatFlags flags = FormatFlags(0);
@@ -81,11 +98,11 @@ struct FormatSection {
   AnyFloatStorageType conv_val_raw;
   void *conv_val_ptr;
 
-  char conv_name;
+  CharT conv_name;
 
   // This operator is only used for testing and should be automatically
   // optimized out for release builds.
-  LIBC_INLINE bool operator==(const FormatSection &other) const {
+  LIBC_INLINE bool operator==(const BasicFormatSection &other) const {
     if (has_conv != other.has_conv)
       return false;
 
@@ -101,14 +118,18 @@ struct FormatSection {
             (conv_name == other.conv_name)))
         return false;
 
-      if (conv_name == 'p' || conv_name == 'n' || conv_name == 's')
+      if (conv_name == char_constant_v<CharT, 'p'> ||
+          conv_name == char_constant_v<CharT, 'n'> ||
+          conv_name == char_constant_v<CharT, 's'>)
         return (conv_val_ptr == other.conv_val_ptr);
-      else if (conv_name != '%')
+      else if (conv_name != char_constant_v<CharT, '%'>)
         return (conv_val_raw == other.conv_val_raw);
     }
     return true;
   }
 };
+
+using FormatSection = BasicFormatSection<char>;
 
 enum PrimaryType : uint8_t {
   Unknown = 0,

--- a/libc/src/__support/printf_core/core_structs.h
+++ b/libc/src/__support/printf_core/core_structs.h
@@ -26,12 +26,12 @@ namespace printf_core {
 template <typename CharT, char ascii_value> struct CharConstant {};
 
 template <char ascii_value> struct CharConstant<char, ascii_value> {
-  LIBC_INLINE static constexpr char value = ascii_value;
+  LIBC_INLINE_VAR static constexpr char value = ascii_value;
 };
 
 #if defined(LIBC_TYPES_WCHAR_T_IS_UTF32)
 template <char ascii_value> struct CharConstant<wchar_t, ascii_value> {
-  LIBC_INLINE static constexpr wchar_t value = ascii_value;
+  LIBC_INLINE_VAR static constexpr wchar_t value = ascii_value;
 };
 #endif // LIBC_TYPES_WCHAR_T_IS_UTF32
 

--- a/libc/src/__support/printf_core/parser.h
+++ b/libc/src/__support/printf_core/parser.h
@@ -76,8 +76,8 @@ template <typename T> using int_type_of_v = typename int_type_of<T>::type;
   dst = cpp::bit_cast<int_type_of_v<arg_type>>(get_next_arg_value<arg_type>())
 #endif // LIBC_COPT_PRINTF_DISABLE_INDEX_MODE
 
-template <typename ArgProvider> class Parser {
-  const char *__restrict str;
+template <typename ArgProvider, typename CharT> class Parser {
+  const CharT *__restrict str;
 
   size_t cur_pos = 0;
   ArgProvider args_cur;
@@ -105,10 +105,10 @@ template <typename ArgProvider> class Parser {
 
 public:
 #ifndef LIBC_COPT_PRINTF_DISABLE_INDEX_MODE
-  LIBC_INLINE Parser(const char *__restrict new_str, ArgProvider &args)
+  LIBC_INLINE Parser(const CharT *__restrict new_str, ArgProvider &args)
       : str(new_str), args_cur(args), args_start(args) {}
 #else
-  LIBC_INLINE Parser(const char *__restrict new_str, ArgProvider &args)
+  LIBC_INLINE Parser(const CharT *__restrict new_str, ArgProvider &args)
       : str(new_str), args_cur(args) {}
 #endif // LIBC_COPT_PRINTF_DISABLE_INDEX_MODE
 
@@ -116,10 +116,10 @@ public:
   // specified format section. This can either be a raw format section with no
   // conversion, or a format section with a conversion that has all of its
   // variables stored in the format section.
-  LIBC_INLINE FormatSection get_next_section() {
-    FormatSection section;
+  LIBC_INLINE BasicFormatSection<CharT> get_next_section() {
+    BasicFormatSection<CharT> section;
     size_t starting_pos = cur_pos;
-    if (str[cur_pos] == '%') {
+    if (str[cur_pos] == char_constant_v<CharT, '%'>) {
       // format section
       section.has_conv = true;
 
@@ -134,7 +134,7 @@ public:
 
       // handle width
       section.min_width = 0;
-      if (str[cur_pos] == '*') {
+      if (str[cur_pos] == char_constant_v<CharT, '*'>) {
         ++cur_pos;
 
         WRITE_ARG_VAL_SIMPLEST(section.min_width, int, parse_index(&cur_pos));
@@ -173,7 +173,7 @@ public:
       section.conv_name = str[cur_pos];
       section.bit_width = bw;
       switch (str[cur_pos]) {
-      case ('%'):
+      case (char_constant_v<CharT, '%'>):
         // Regardless of options, a % conversion is always safe. The standard
         // says that "The complete conversion specification shall be %%" but it
         // also says that "If a conversion specification is invalid, the
@@ -182,7 +182,7 @@ public:
         // valid or invalid options.
         section.has_conv = true;
         break;
-      case ('c'):
+      case (char_constant_v<CharT, 'c'>):
         if (section.length_modifier == LengthModifier::l) {
 #ifdef LIBC_COPT_PRINTF_DISABLE_WIDE
           using WideCharArgType = int;
@@ -195,14 +195,14 @@ public:
           WRITE_ARG_VAL_SIMPLEST(section.conv_val_raw, int, conv_index);
         }
         break;
-      case ('d'):
-      case ('i'):
-      case ('o'):
-      case ('x'):
-      case ('X'):
-      case ('u'):
-      case ('b'):
-      case ('B'):
+      case (char_constant_v<CharT, 'd'>):
+      case (char_constant_v<CharT, 'i'>):
+      case (char_constant_v<CharT, 'o'>):
+      case (char_constant_v<CharT, 'x'>):
+      case (char_constant_v<CharT, 'X'>):
+      case (char_constant_v<CharT, 'u'>):
+      case (char_constant_v<CharT, 'b'>):
+      case (char_constant_v<CharT, 'B'>):
         switch (lm) {
         case (LengthModifier::hh):
         case (LengthModifier::h):
@@ -255,14 +255,14 @@ public:
         }
         break;
 #ifndef LIBC_COPT_PRINTF_DISABLE_FLOAT
-      case ('f'):
-      case ('F'):
-      case ('e'):
-      case ('E'):
-      case ('a'):
-      case ('A'):
-      case ('g'):
-      case ('G'):
+      case (char_constant_v<CharT, 'f'>):
+      case (char_constant_v<CharT, 'F'>):
+      case (char_constant_v<CharT, 'e'>):
+      case (char_constant_v<CharT, 'E'>):
+      case (char_constant_v<CharT, 'a'>):
+      case (char_constant_v<CharT, 'A'>):
+      case (char_constant_v<CharT, 'g'>):
+      case (char_constant_v<CharT, 'G'>):
         switch (lm) {
 #if defined(LIBC_INTERNAL_PRINTF_CONVERT_FLOAT128)
         case (LengthModifier::Q):
@@ -283,15 +283,15 @@ public:
 #ifdef LIBC_INTERNAL_PRINTF_HAS_FIXED_POINT
       // Capitalization represents sign, but we only need to get the right
       // bitwidth here so we ignore that.
-      case ('r'):
-      case ('R'):
+      case (char_constant_v<CharT, 'r'>):
+      case (char_constant_v<CharT, 'R'>):
         // all fract sizes we support are less than 32 bits, and currently doing
         // va_args with fixed point types just doesn't work.
         // TODO: Move to fixed point types once va_args supports it.
         WRITE_ARG_VAL_SIMPLEST(section.conv_val_raw, uint32_t, conv_index);
         break;
-      case ('k'):
-      case ('K'):
+      case (char_constant_v<CharT, 'k'>):
+      case (char_constant_v<CharT, 'K'>):
         if (lm == LengthModifier::l) {
           WRITE_ARG_VAL_SIMPLEST(section.conv_val_raw, uint64_t, conv_index);
         } else {
@@ -300,7 +300,7 @@ public:
         break;
 #endif // LIBC_INTERNAL_PRINTF_HAS_FIXED_POINT
 #ifndef LIBC_COPT_PRINTF_DISABLE_STRERROR
-      case ('m'):
+      case (char_constant_v<CharT, 'm'>):
         // %m is an odd conversion in that it doesn't consume an argument, it
         // just takes the current value of errno as its argument.
         section.conv_val_raw =
@@ -308,12 +308,12 @@ public:
         break;
 #endif // LIBC_COPT_PRINTF_DISABLE_STRERROR
 #ifndef LIBC_COPT_PRINTF_DISABLE_WRITE_INT
-      case ('n'): // Intentional fallthrough
+      case (char_constant_v<CharT, 'n'>): // Intentional fallthrough
 #endif            // LIBC_COPT_PRINTF_DISABLE_WRITE_INT
-      case ('p'):
+      case (char_constant_v<CharT, 'p'>):
         WRITE_ARG_VAL_SIMPLEST(section.conv_val_ptr, void *, conv_index);
         break;
-      case ('s'):
+      case (char_constant_v<CharT, 's'>):
         WRITE_ARG_VAL_SIMPLEST(section.conv_val_ptr, void *, conv_index);
         break;
       default:
@@ -323,13 +323,14 @@ public:
       }
       // If the end of the format section is on the '\0'. This means we need to
       // not advance the cur_pos.
-      if (str[cur_pos] != '\0')
+      if (str[cur_pos] != char_constant_v<CharT, '\0'>)
         ++cur_pos;
 
     } else {
       // raw section
       section.has_conv = false;
-      while (str[cur_pos] != '%' && str[cur_pos] != '\0')
+      while (str[cur_pos] != char_constant_v<CharT, '%'> &&
+             str[cur_pos] != char_constant_v<CharT, '\0'>)
         ++cur_pos;
     }
     section.raw_string = {str + starting_pos, cur_pos - starting_pos};
@@ -346,19 +347,19 @@ private:
     FormatFlags flags = FormatFlags(0);
     while (found_flag) {
       switch (str[*local_pos]) {
-      case '-':
+      case char_constant_v<CharT, '-'>:
         flags = static_cast<FormatFlags>(flags | FormatFlags::LEFT_JUSTIFIED);
         break;
-      case '+':
+      case char_constant_v<CharT, '+'>:
         flags = static_cast<FormatFlags>(flags | FormatFlags::FORCE_SIGN);
         break;
-      case ' ':
+      case char_constant_v<CharT, ' '>:
         flags = static_cast<FormatFlags>(flags | FormatFlags::SPACE_PREFIX);
         break;
-      case '#':
+      case char_constant_v<CharT, '#'>:
         flags = static_cast<FormatFlags>(flags | FormatFlags::ALTERNATE_FORM);
         break;
-      case '0':
+      case char_constant_v<CharT, '0'>:
         flags = static_cast<FormatFlags>(flags | FormatFlags::LEADING_ZEROES);
         break;
       default:
@@ -376,8 +377,8 @@ private:
   // after the format specifier if one is found.
   LIBC_INLINE LengthSpec parse_length_modifier(size_t *local_pos) {
     switch (str[*local_pos]) {
-    case ('l'):
-      if (str[*local_pos + 1] == 'l') {
+    case (char_constant_v<CharT, 'l'>):
+      if (str[*local_pos + 1] == char_constant_v<CharT, 'l'>) {
         *local_pos += 2;
         return {LengthModifier::ll, 0};
       } else {
@@ -385,9 +386,9 @@ private:
         return {LengthModifier::l, 0};
       }
 #ifndef LIBC_COPT_PRINTF_DISABLE_BITINT
-    case ('w'): {
+    case (char_constant_v<CharT, 'w'>): {
       LengthModifier lm;
-      if (str[*local_pos + 1] == 'f') {
+      if (str[*local_pos + 1] == char_constant_v<CharT, 'f'>) {
         *local_pos += 2;
         lm = LengthModifier::wf;
       } else {
@@ -402,29 +403,29 @@ private:
       return {lm, 0};
     }
 #endif // LIBC_COPT_PRINTF_DISABLE_BITINT
-    case ('h'):
-      if (str[*local_pos + 1] == 'h') {
+    case (char_constant_v<CharT, 'h'>):
+      if (str[*local_pos + 1] == char_constant_v<CharT, 'h'>) {
         *local_pos += 2;
         return {LengthModifier::hh, 0};
       } else {
         ++*local_pos;
         return {LengthModifier::h, 0};
       }
-    case ('L'):
+    case (char_constant_v<CharT, 'L'>):
       ++*local_pos;
       return {LengthModifier::L, 0};
 #if defined(LIBC_INTERNAL_PRINTF_CONVERT_FLOAT128)
-    case ('Q'):
+    case (char_constant_v<CharT, 'Q'>):
       ++*local_pos;
       return {LengthModifier::Q, 0};
 #endif // LIBC_INTERNAL_PRINTF_CONVERT_FLOAT128
-    case ('j'):
+    case (char_constant_v<CharT, 'j'>):
       ++*local_pos;
       return {LengthModifier::j, 0};
-    case ('z'):
+    case (char_constant_v<CharT, 'z'>):
       ++*local_pos;
       return {LengthModifier::z, 0};
-    case ('t'):
+    case (char_constant_v<CharT, 't'>):
       ++*local_pos;
       return {LengthModifier::t, 0};
     default:
@@ -452,7 +453,8 @@ private:
     if (internal::isdigit(str[*local_pos])) {
       auto result = internal::strtointeger<int>(str + *local_pos, 10);
       size_t index = static_cast<size_t>(result.value);
-      if (str[*local_pos + static_cast<size_t>(result.parsed_len)] != '$')
+      if (str[*local_pos + static_cast<size_t>(result.parsed_len)] !=
+          char_constant_v<CharT, '$'>)
         return 0;
       *local_pos = static_cast<size_t>(1 + result.parsed_len) + *local_pos;
       return index;
@@ -562,7 +564,7 @@ private:
     size_t local_pos = 0;
 
     while (str[local_pos]) {
-      if (str[local_pos] == '%') {
+      if (str[local_pos] == char_constant_v<CharT, '%'>) {
         ++local_pos;
 
         size_t conv_index = parse_index(&local_pos);
@@ -609,17 +611,17 @@ private:
         // logic has been for skipping past this conversion properly to avoid
         // weirdness with %%.
         if (conv_index == 0) {
-          if (str[local_pos] != '\0')
+          if (str[local_pos] != char_constant_v<CharT, '\0'>)
             ++local_pos;
           continue;
         }
 
         TypeDesc conv_size = type_desc_from_type<void>();
         switch (str[local_pos]) {
-        case ('%'):
+        case (char_constant_v<CharT, '%'>):
           conv_size = type_desc_from_type<void>();
           break;
-        case ('c'):
+        case (char_constant_v<CharT, 'c'>):
           if (lm == LengthModifier::l) {
 #ifdef LIBC_COPT_PRINTF_DISABLE_WIDE
             using WideCharArgType = int;
@@ -631,14 +633,14 @@ private:
             conv_size = type_desc_from_type<int>();
           }
           break;
-        case ('d'):
-        case ('i'):
-        case ('o'):
-        case ('x'):
-        case ('X'):
-        case ('u'):
-        case ('b'):
-        case ('B'):
+        case (char_constant_v<CharT, 'd'>):
+        case (char_constant_v<CharT, 'i'>):
+        case (char_constant_v<CharT, 'o'>):
+        case (char_constant_v<CharT, 'x'>):
+        case (char_constant_v<CharT, 'X'>):
+        case (char_constant_v<CharT, 'u'>):
+        case (char_constant_v<CharT, 'b'>):
+        case (char_constant_v<CharT, 'B'>):
           switch (lm) {
           case (LengthModifier::hh):
           case (LengthModifier::h):
@@ -684,14 +686,14 @@ private:
           }
           break;
 #ifndef LIBC_COPT_PRINTF_DISABLE_FLOAT
-        case ('f'):
-        case ('F'):
-        case ('e'):
-        case ('E'):
-        case ('a'):
-        case ('A'):
-        case ('g'):
-        case ('G'):
+        case (char_constant_v<CharT, 'f'>):
+        case (char_constant_v<CharT, 'F'>):
+        case (char_constant_v<CharT, 'e'>):
+        case (char_constant_v<CharT, 'E'>):
+        case (char_constant_v<CharT, 'a'>):
+        case (char_constant_v<CharT, 'A'>):
+        case (char_constant_v<CharT, 'g'>):
+        case (char_constant_v<CharT, 'G'>):
           switch (lm) {
 #if defined(LIBC_INTERNAL_PRINTF_CONVERT_FLOAT128)
           case LengthModifier::Q:
@@ -712,12 +714,12 @@ private:
 #ifdef LIBC_INTERNAL_PRINTF_HAS_FIXED_POINT
         // Capitalization represents sign, but we only need to get the right
         // bitwidth here so we ignore that.
-        case ('r'):
-        case ('R'):
+        case (char_constant_v<CharT, 'r'>):
+        case (char_constant_v<CharT, 'R'>):
           conv_size = type_desc_from_type<uint32_t>();
           break;
-        case ('k'):
-        case ('K'):
+        case (char_constant_v<CharT, 'k'>):
+        case (char_constant_v<CharT, 'K'>):
           if (lm == LengthModifier::l) {
             conv_size = type_desc_from_type<uint64_t>();
           } else {
@@ -726,10 +728,10 @@ private:
           break;
 #endif // LIBC_INTERNAL_PRINTF_HAS_FIXED_POINT
 #ifndef LIBC_COPT_PRINTF_DISABLE_WRITE_INT
-        case ('n'):
+        case (char_constant_v<CharT, 'n'>):
 #endif // LIBC_COPT_PRINTF_DISABLE_WRITE_INT
-        case ('p'):
-        case ('s'):
+        case (char_constant_v<CharT, 'p'>):
+        case (char_constant_v<CharT, 's'>):
           conv_size = type_desc_from_type<void *>();
           break;
         default:
@@ -743,7 +745,7 @@ private:
       }
       // If the end of the format section is on the '\0'. This means we need to
       // not advance the local_pos.
-      if (str[local_pos] != '\0')
+      if (str[local_pos] != char_constant_v<CharT, '\0'>)
         ++local_pos;
     }
 

--- a/libc/src/__support/printf_core/parser.h
+++ b/libc/src/__support/printf_core/parser.h
@@ -152,11 +152,11 @@ public:
 
       // handle precision
       section.precision = -1; // negative precisions are ignored.
-      if (str[cur_pos] == '.') {
+      if (str[cur_pos] == char_constant_v<CharT, '.'>) {
         ++cur_pos;
         section.precision = 0; // if there's a . but no specified precision, the
                                // precision is implicitly 0.
-        if (str[cur_pos] == '*') {
+        if (str[cur_pos] == char_constant_v<CharT, '*'>) {
           ++cur_pos;
 
           WRITE_ARG_VAL_SIMPLEST(section.precision, int, parse_index(&cur_pos));
@@ -574,7 +574,7 @@ private:
         parse_flags(&local_pos);
 
         // handle width
-        if (str[local_pos] == '*') {
+        if (str[local_pos] == char_constant_v<CharT, '*'>) {
           ++local_pos;
 
           size_t width_index = parse_index(&local_pos);
@@ -588,9 +588,9 @@ private:
         }
 
         // handle precision
-        if (str[local_pos] == '.') {
+        if (str[local_pos] == char_constant_v<CharT, '.'>) {
           ++local_pos;
-          if (str[local_pos] == '*') {
+          if (str[local_pos] == char_constant_v<CharT, '*'>) {
             ++local_pos;
 
             size_t precision_index = parse_index(&local_pos);

--- a/libc/src/__support/printf_core/printf_main.h
+++ b/libc/src/__support/printf_core/printf_main.h
@@ -26,7 +26,7 @@ template <OverflowMode mode>
 ErrorOr<size_t> printf_main_modular(Writer<mode> *writer,
                                     const char *__restrict str,
                                     internal::ArgList &args) {
-  Parser<internal::ArgList> parser(str, args);
+  Parser<internal::ArgList, char> parser(str, args);
   int result = 0;
   for (FormatSection cur_section = parser.get_next_section();
        !cur_section.raw_string.empty();

--- a/libc/test/UnitTest/CMakeLists.txt
+++ b/libc/test/UnitTest/CMakeLists.txt
@@ -101,6 +101,7 @@ add_unittest_framework_library(
   COMPILE_OPTIONS
     ${test_logger_compile_options}
   DEPENDS
+    .string_utils
     libc.hdr.stdint_proxy
     libc.src.__support.big_int
     libc.src.__support.c_string
@@ -109,8 +110,6 @@ add_unittest_framework_library(
     libc.src.__support.CPP.type_traits
     libc.src.__support.fixed_point.fx_rep
     libc.src.__support.macros.properties.compiler
-    libc.src.__support.macros.properties.types
-    libc.src.__support.wchar.string_converter
     libc.src.__support.uint128
     ${test_logger_osutil}
 )
@@ -181,7 +180,10 @@ add_header_library(
   DEPENDS
     libc.src.__support.big_int
     libc.src.__support.CPP.string
+    libc.src.__support.CPP.string_view
     libc.src.__support.CPP.type_traits
+    libc.src.__support.macros.properties.types
+    libc.src.__support.wchar.string_converter
 )
 
 add_unittest_framework_library(
@@ -238,6 +240,7 @@ add_unittest_framework_library(
     .LibcTest
     .string_utils
     libc.hdr.stdint_proxy
+    libc.src.__support.CPP.type_traits
     libc.src.__support.FPUtil.fp_bits
     libc.src.__support.printf_core.core_structs
     libc.src.__support.printf_core.printf_config

--- a/libc/test/UnitTest/LibcTest.cpp
+++ b/libc/test/UnitTest/LibcTest.cpp
@@ -13,9 +13,8 @@
 #include "src/__support/CPP/string_view.h"
 #include "src/__support/fixed_point/fx_rep.h"
 #include "src/__support/macros/config.h"
-#include "src/__support/macros/properties/types.h"
 #include "src/__support/uint128.h"
-#include "src/__support/wchar/string_converter.h"
+#include "test/UnitTest/StringUtils.h"
 #include "test/UnitTest/TestLogger.h"
 
 #if __STDC_HOSTED__
@@ -74,35 +73,7 @@ cpp::string_view describeValue(const cpp::string &Value) { return Value; }
 cpp::string_view describeValue(cpp::string_view Value) { return Value; }
 
 cpp::string describeValue(cpp::wstring_view Value) {
-#if defined(LIBC_TYPES_WCHAR_T_IS_UTF32)
-  LIBC_NAMESPACE::internal::mbstate State;
-  LIBC_NAMESPACE::internal::StringConverter<wchar_t> StringConv(
-      Value.data(), &State, /* dstlen = */ SIZE_MAX, Value.size());
-
-  cpp::string S;
-  for (auto Conv = StringConv.pop<char8_t>(); Conv.has_value();
-       Conv = StringConv.pop<char8_t>()) {
-    S += static_cast<char>(*Conv);
-  }
-
-  if (S.empty() && !Value.empty())
-    S = cpp::string("<Failed Conversion To UTF-8>");
-
-  return S;
-#else  // LIBC_TYPES_WCHAR_T_IS_UTF32
-  if (Value.empty())
-    return "{}";
-
-  cpp::string S;
-  S += '{';
-  for (const wchar_t *Iter = Value.begin(); Iter + 1 != Value.end(); ++Iter) {
-    S += cpp::to_string(*Iter);
-    S += ',';
-  }
-  S += cpp::to_string(Value.back());
-  S += '}';
-  return S;
-#endif // LIBC_TYPES_WCHAR_T_IS_UTF32
+  return try_convert_to_utf8(Value);
 }
 
 template <typename ValType>

--- a/libc/test/UnitTest/PrintfMatcher.cpp
+++ b/libc/test/UnitTest/PrintfMatcher.cpp
@@ -9,6 +9,7 @@
 #include "PrintfMatcher.h"
 
 #include "hdr/stdint_proxy.h"
+#include "src/__support/CPP/type_traits.h"
 #include "src/__support/FPUtil/FPBits.h"
 #include "src/__support/macros/config.h"
 #include "src/__support/printf_core/core_structs.h"
@@ -20,14 +21,9 @@
 namespace LIBC_NAMESPACE_DECL {
 namespace testing {
 
+using printf_core::BasicFormatSection;
 using printf_core::FormatFlags;
-using printf_core::FormatSection;
 using printf_core::LengthModifier;
-
-bool FormatSectionMatcher::match(FormatSection actualValue) {
-  actual = actualValue;
-  return expected == actual;
-}
 
 namespace {
 
@@ -45,10 +41,16 @@ namespace {
     tlog << #lm << "\n\tbit width: :" << bw;                                   \
     break
 
-static void display(FormatSection form) {
+template <typename CharT> void display_impl(BasicFormatSection<CharT> form) {
   tlog << "Raw String (len " << form.raw_string.size() << "): \"";
-  for (size_t i = 0; i < form.raw_string.size(); ++i) {
-    tlog << form.raw_string[i];
+  cpp::string raw_string_utf8;
+  if constexpr (cpp::is_same_v<CharT, char>) {
+    raw_string_utf8 = form.raw_string;
+  } else {
+    raw_string_utf8 = try_convert_to_utf8(form.raw_string);
+  }
+  for (size_t i = 0; i < raw_string_utf8.size(); ++i) {
+    tlog << raw_string_utf8[i];
   }
   tlog << "\"";
   if (form.has_conv) {
@@ -80,26 +82,34 @@ static void display(FormatSection form) {
       CASE_LM_BIT_WIDTH(wf, form.bit_width);
 #endif // LIBC_COPT_PRINTF_DISABLE_BITINT
     }
+
+    cpp::string conv_name_utf8;
+    if constexpr (cpp::is_same_v<CharT, char>) {
+      conv_name_utf8 = cpp::string(&form.conv_name, 1);
+    } else {
+      conv_name_utf8 =
+          try_convert_to_utf8(cpp::wstring_view(&form.conv_name, 1));
+    }
     tlog << "\n";
-    tlog << "\tconversion name: " << form.conv_name << "\n";
-    if (form.conv_name == 'p' || form.conv_name == 'n' || form.conv_name == 's')
+    tlog << "\tconversion name: " << conv_name_utf8 << "\n";
+    if (conv_name_utf8 == "p" || conv_name_utf8 == "n" || conv_name_utf8 == "s")
       tlog << "\tpointer value: "
            << int_to_hex<uintptr_t>(
                   reinterpret_cast<uintptr_t>(form.conv_val_ptr))
            << "\n";
-    else if (form.conv_name != '%')
+    else if (conv_name_utf8 != "%")
       tlog << "\tvalue: " << int_to_hex(form.conv_val_raw) << "\n";
   }
 }
+
 } // anonymous namespace
 
-void FormatSectionMatcher::explainError() {
-  tlog << "expected format section: ";
-  display(expected);
-  tlog << '\n';
-  tlog << "actual format section  : ";
-  display(actual);
-  tlog << '\n';
+void display(const BasicFormatSection<char> &format_section) {
+  display_impl(format_section);
+}
+
+void display(const BasicFormatSection<wchar_t> &format_section) {
+  display_impl(format_section);
 }
 
 } // namespace testing

--- a/libc/test/UnitTest/PrintfMatcher.h
+++ b/libc/test/UnitTest/PrintfMatcher.h
@@ -16,26 +16,49 @@
 namespace LIBC_NAMESPACE_DECL {
 namespace testing {
 
-class FormatSectionMatcher : public Matcher<printf_core::FormatSection> {
-  printf_core::FormatSection expected;
-  printf_core::FormatSection actual;
+void display(const printf_core::BasicFormatSection<char> &format_section);
+void display(const printf_core::BasicFormatSection<wchar_t> &format_section);
+
+template <typename CharT>
+class FormatSectionMatcher
+    : public Matcher<printf_core::BasicFormatSection<CharT>> {
+  printf_core::BasicFormatSection<CharT> expected;
+  printf_core::BasicFormatSection<CharT> actual;
 
 public:
-  FormatSectionMatcher(printf_core::FormatSection expectedValue)
+  FormatSectionMatcher(printf_core::BasicFormatSection<CharT> expectedValue)
       : expected(expectedValue) {}
 
-  bool match(printf_core::FormatSection actualValue);
+  bool match(printf_core::BasicFormatSection<CharT> actualValue) {
+    actual = actualValue;
+    return expected == actual;
+  }
 
-  void explainError() override;
+  void explainError() override {
+    tlog << "expected format section: ";
+    display(expected);
+    tlog << '\n';
+    tlog << "actual format section  : ";
+    display(actual);
+    tlog << '\n';
+  }
 };
+
+template <typename CharT>
+FormatSectionMatcher<CharT>
+MakeFormatSectionMatcher(printf_core::BasicFormatSection<CharT> expected) {
+  return FormatSectionMatcher<CharT>(expected);
+}
 
 } // namespace testing
 } // namespace LIBC_NAMESPACE_DECL
 
 #define EXPECT_PFORMAT_EQ(expected, actual)                                    \
-  EXPECT_THAT(actual, LIBC_NAMESPACE::testing::FormatSectionMatcher(expected))
+  EXPECT_THAT(actual,                                                          \
+              LIBC_NAMESPACE::testing::MakeFormatSectionMatcher(expected))
 
 #define ASSERT_PFORMAT_EQ(expected, actual)                                    \
-  ASSERT_THAT(actual, LIBC_NAMESPACE::testing::FormatSectionMatcher(expected))
+  ASSERT_THAT(actual,                                                          \
+              LIBC_NAMESPACE::testing::MakeFormatSectionMatcher(expected))
 
 #endif // LLVM_LIBC_UTILS_UNITTEST_PRINTF_MATCHER_H

--- a/libc/test/UnitTest/StringUtils.h
+++ b/libc/test/UnitTest/StringUtils.h
@@ -10,9 +10,12 @@
 #define LLVM_LIBC_TEST_UNITTEST_STRINGUTILS_H
 
 #include "src/__support/CPP/string.h"
+#include "src/__support/CPP/string_view.h"
 #include "src/__support/CPP/type_traits.h"
 #include "src/__support/big_int.h"
 #include "src/__support/macros/config.h"
+#include "src/__support/macros/properties/types.h"
+#include "src/__support/wchar/string_converter.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
@@ -31,6 +34,38 @@ int_to_hex(T value, size_t length = sizeof(T) * 2) {
   }
 
   return "0x" + s;
+}
+
+LIBC_INLINE cpp::string try_convert_to_utf8(cpp::wstring_view str) {
+#if defined(LIBC_TYPES_WCHAR_T_IS_UTF32)
+  LIBC_NAMESPACE::internal::mbstate state;
+  LIBC_NAMESPACE::internal::StringConverter<wchar_t> string_conv(
+      str.data(), &state, /* dstlen = */ SIZE_MAX, str.size());
+
+  cpp::string result;
+  for (auto conv = string_conv.pop<char8_t>(); conv.has_value();
+       conv = string_conv.pop<char8_t>()) {
+    result += static_cast<char>(*conv);
+  }
+
+  if (result.empty() && !str.empty())
+    result = cpp::string("<Failed Conversion To UTF-8>");
+
+  return result;
+#else  // LIBC_TYPES_WCHAR_T_IS_UTF32
+  if (str.empty())
+    return "{}";
+
+  cpp::string result;
+  result += '{';
+  for (const wchar_t *iter = str.begin(); iter + 1 != str.end(); ++iter) {
+    result += cpp::to_string(*iter);
+    result += ',';
+  }
+  result += cpp::to_string(str.back());
+  result += '}';
+  return result;
+#endif // LIBC_TYPES_WCHAR_T_IS_UTF32
 }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/test/src/__support/printf_core/CMakeLists.txt
+++ b/libc/test/src/__support/printf_core/CMakeLists.txt
@@ -9,6 +9,7 @@ add_libc_test(
     libc.src.__support.printf_core.core_structs
     libc.src.__support.CPP.string_view
     libc.src.__support.arg_list
+    libc.src.__support.macros.properties.types
     libc.test.UnitTest.PrintfMatcher
 )
 

--- a/libc/test/src/__support/printf_core/parser_test.cpp
+++ b/libc/test/src/__support/printf_core/parser_test.cpp
@@ -13,29 +13,32 @@
 
 #include <stdarg.h>
 
+#include "test/UnitTest/CharLiteralUtils.h"
 #include "test/UnitTest/PrintfMatcher.h"
 #include "test/UnitTest/Test.h"
 
 using LIBC_NAMESPACE::cpp::string_view;
 using LIBC_NAMESPACE::internal::ArgList;
 
-void init(const char *__restrict str, ...) {
+template <typename CharT> void init(const CharT *__restrict str, ...) {
   va_list vlist;
   va_start(vlist, str);
   ArgList v(vlist);
   va_end(vlist);
 
-  LIBC_NAMESPACE::printf_core::Parser<ArgList> parser(str, v);
+  LIBC_NAMESPACE::printf_core::Parser<ArgList, CharT> parser(str, v);
 }
 
-void evaluate(LIBC_NAMESPACE::printf_core::FormatSection *format_arr,
-              const char *__restrict str, ...) {
+template <typename CharT>
+void evaluate(
+    LIBC_NAMESPACE::printf_core::BasicFormatSection<CharT> *format_arr,
+    const CharT *__restrict str, ...) {
   va_list vlist;
   va_start(vlist, str);
   ArgList v(vlist);
   va_end(vlist);
 
-  LIBC_NAMESPACE::printf_core::Parser<ArgList> parser(str, v);
+  LIBC_NAMESPACE::printf_core::Parser<ArgList, CharT> parser(str, v);
 
   for (auto cur_section = parser.get_next_section();
        !cur_section.raw_string.empty();
@@ -45,14 +48,20 @@ void evaluate(LIBC_NAMESPACE::printf_core::FormatSection *format_arr,
   }
 }
 
-TEST(LlvmLibcPrintfParserTest, Constructor) { init("test", 1, 2); }
+using TestCharTypes = LIBC_NAMESPACE::testing::TypeList<char, wchar_t>;
 
-TEST(LlvmLibcPrintfParserTest, EvalRaw) {
-  LIBC_NAMESPACE::printf_core::FormatSection format_arr[10];
-  const char *str = "test";
+TYPED_TEST(LlvmLibcPrintfParserTest, Constructor, TestCharTypes) {
+  using CharT = ParamType;
+  init(ENCODED(CharT, "test"), 1, 2);
+}
+
+TYPED_TEST(LlvmLibcPrintfParserTest, EvalRaw, TestCharTypes) {
+  using CharT = ParamType;
+  LIBC_NAMESPACE::printf_core::BasicFormatSection<CharT> format_arr[10];
+  const CharT *str = ENCODED(CharT, "test");
   evaluate(format_arr, str);
 
-  LIBC_NAMESPACE::printf_core::FormatSection expected;
+  LIBC_NAMESPACE::printf_core::BasicFormatSection<CharT> expected;
   expected.has_conv = false;
 
   expected.raw_string = {str, 4};
@@ -61,12 +70,14 @@ TEST(LlvmLibcPrintfParserTest, EvalRaw) {
   // TODO: add checks that the format_arr after the last one has length 0
 }
 
-TEST(LlvmLibcPrintfParserTest, EvalSimple) {
-  LIBC_NAMESPACE::printf_core::FormatSection format_arr[10];
-  const char *str = "test %% test";
+TYPED_TEST(LlvmLibcPrintfParserTest, EvalSimple, TestCharTypes) {
+  using CharT = ParamType;
+  LIBC_NAMESPACE::printf_core::BasicFormatSection<CharT> format_arr[10];
+  const CharT *str = ENCODED(CharT, "test %% test");
   evaluate(format_arr, str);
 
-  LIBC_NAMESPACE::printf_core::FormatSection expected0, expected1, expected2;
+  LIBC_NAMESPACE::printf_core::BasicFormatSection<CharT> expected0, expected1,
+      expected2;
   expected0.has_conv = false;
 
   expected0.raw_string = {str, 5};
@@ -76,7 +87,7 @@ TEST(LlvmLibcPrintfParserTest, EvalSimple) {
   expected1.has_conv = true;
 
   expected1.raw_string = {str + 5, 2};
-  expected1.conv_name = '%';
+  expected1.conv_name = ENCODED(CharT, '%');
 
   ASSERT_PFORMAT_EQ(expected1, format_arr[1]);
 
@@ -87,43 +98,46 @@ TEST(LlvmLibcPrintfParserTest, EvalSimple) {
   ASSERT_PFORMAT_EQ(expected2, format_arr[2]);
 }
 
-TEST(LlvmLibcPrintfParserTest, EvalOneArg) {
-  LIBC_NAMESPACE::printf_core::FormatSection format_arr[10];
-  const char *str = "%d";
+TYPED_TEST(LlvmLibcPrintfParserTest, EvalOneArg, TestCharTypes) {
+  using CharT = ParamType;
+  LIBC_NAMESPACE::printf_core::BasicFormatSection<CharT> format_arr[10];
+  const CharT *str = ENCODED(CharT, "%d");
   int arg1 = 12345;
   evaluate(format_arr, str, arg1);
 
-  LIBC_NAMESPACE::printf_core::FormatSection expected;
+  LIBC_NAMESPACE::printf_core::BasicFormatSection<CharT> expected;
   expected.has_conv = true;
 
   expected.raw_string = {str, 2};
   expected.conv_val_raw =
       static_cast<LIBC_NAMESPACE::fputil::FPBits<double>::StorageType>(arg1);
-  expected.conv_name = 'd';
+  expected.conv_name = ENCODED(CharT, 'd');
 
   ASSERT_PFORMAT_EQ(expected, format_arr[0]);
 }
 
-TEST(LlvmLibcPrintfParserTest, EvalBadArg) {
-  LIBC_NAMESPACE::printf_core::FormatSection format_arr[10];
-  const char *str = "%\0abc";
+TYPED_TEST(LlvmLibcPrintfParserTest, EvalBadArg, TestCharTypes) {
+  using CharT = ParamType;
+  LIBC_NAMESPACE::printf_core::BasicFormatSection<CharT> format_arr[10];
+  const CharT *str = ENCODED(CharT, "%\0abc");
   int arg1 = 12345;
   evaluate(format_arr, str, arg1);
 
-  LIBC_NAMESPACE::printf_core::FormatSection expected;
+  LIBC_NAMESPACE::printf_core::BasicFormatSection<CharT> expected;
   expected.has_conv = false;
   expected.raw_string = {str, 1};
 
   ASSERT_PFORMAT_EQ(expected, format_arr[0]);
 }
 
-TEST(LlvmLibcPrintfParserTest, EvalOneArgWithFlags) {
-  LIBC_NAMESPACE::printf_core::FormatSection format_arr[10];
-  const char *str = "%+-0 #d";
+TYPED_TEST(LlvmLibcPrintfParserTest, EvalOneArgWithFlags, TestCharTypes) {
+  using CharT = ParamType;
+  LIBC_NAMESPACE::printf_core::BasicFormatSection<CharT> format_arr[10];
+  const CharT *str = ENCODED(CharT, "%+-0 #d");
   int arg1 = 12345;
   evaluate(format_arr, str, arg1);
 
-  LIBC_NAMESPACE::printf_core::FormatSection expected;
+  LIBC_NAMESPACE::printf_core::BasicFormatSection<CharT> expected;
   expected.has_conv = true;
 
   expected.raw_string = {str, 7};
@@ -135,109 +149,119 @@ TEST(LlvmLibcPrintfParserTest, EvalOneArgWithFlags) {
       LIBC_NAMESPACE::printf_core::FormatFlags::ALTERNATE_FORM);
   expected.conv_val_raw =
       static_cast<LIBC_NAMESPACE::fputil::FPBits<double>::StorageType>(arg1);
-  expected.conv_name = 'd';
+  expected.conv_name = ENCODED(CharT, 'd');
 
   ASSERT_PFORMAT_EQ(expected, format_arr[0]);
 }
 
-TEST(LlvmLibcPrintfParserTest, EvalOneArgWithWidth) {
-  LIBC_NAMESPACE::printf_core::FormatSection format_arr[10];
-  const char *str = "%12d";
+TYPED_TEST(LlvmLibcPrintfParserTest, EvalOneArgWithWidth, TestCharTypes) {
+  using CharT = ParamType;
+  LIBC_NAMESPACE::printf_core::BasicFormatSection<CharT> format_arr[10];
+  const CharT *str = ENCODED(CharT, "%12d");
   int arg1 = 12345;
   evaluate(format_arr, str, arg1);
 
-  LIBC_NAMESPACE::printf_core::FormatSection expected;
+  LIBC_NAMESPACE::printf_core::BasicFormatSection<CharT> expected;
   expected.has_conv = true;
 
   expected.raw_string = {str, 4};
   expected.min_width = 12;
   expected.conv_val_raw =
       static_cast<LIBC_NAMESPACE::fputil::FPBits<double>::StorageType>(arg1);
-  expected.conv_name = 'd';
+  expected.conv_name = ENCODED(CharT, 'd');
 
   ASSERT_PFORMAT_EQ(expected, format_arr[0]);
 }
 
-TEST(LlvmLibcPrintfParserTest, EvalOneArgWithPrecision) {
-  LIBC_NAMESPACE::printf_core::FormatSection format_arr[10];
-  const char *str = "%.34d";
+TYPED_TEST(LlvmLibcPrintfParserTest, EvalOneArgWithPrecision, TestCharTypes) {
+  using CharT = ParamType;
+  LIBC_NAMESPACE::printf_core::BasicFormatSection<CharT> format_arr[10];
+  const CharT *str = ENCODED(CharT, "%.34d");
   int arg1 = 12345;
   evaluate(format_arr, str, arg1);
 
-  LIBC_NAMESPACE::printf_core::FormatSection expected;
+  LIBC_NAMESPACE::printf_core::BasicFormatSection<CharT> expected;
   expected.has_conv = true;
 
   expected.raw_string = {str, 5};
   expected.precision = 34;
   expected.conv_val_raw =
       static_cast<LIBC_NAMESPACE::fputil::FPBits<double>::StorageType>(arg1);
-  expected.conv_name = 'd';
+  expected.conv_name = ENCODED(CharT, 'd');
 
   ASSERT_PFORMAT_EQ(expected, format_arr[0]);
 }
 
-TEST(LlvmLibcPrintfParserTest, EvalOneArgWithTrivialPrecision) {
-  LIBC_NAMESPACE::printf_core::FormatSection format_arr[10];
-  const char *str = "%.d";
+TYPED_TEST(LlvmLibcPrintfParserTest, EvalOneArgWithTrivialPrecision,
+           TestCharTypes) {
+  using CharT = ParamType;
+  LIBC_NAMESPACE::printf_core::BasicFormatSection<CharT> format_arr[10];
+  const CharT *str = ENCODED(CharT, "%.d");
   int arg1 = 12345;
   evaluate(format_arr, str, arg1);
 
-  LIBC_NAMESPACE::printf_core::FormatSection expected;
+  LIBC_NAMESPACE::printf_core::BasicFormatSection<CharT> expected;
   expected.has_conv = true;
 
   expected.raw_string = {str, 3};
   expected.precision = 0;
   expected.conv_val_raw =
       static_cast<LIBC_NAMESPACE::fputil::FPBits<double>::StorageType>(arg1);
-  expected.conv_name = 'd';
+  expected.conv_name = ENCODED(CharT, 'd');
 
   ASSERT_PFORMAT_EQ(expected, format_arr[0]);
 }
 
-TEST(LlvmLibcPrintfParserTest, EvalOneArgWithShortLengthModifier) {
-  LIBC_NAMESPACE::printf_core::FormatSection format_arr[10];
-  const char *str = "%hd";
+TYPED_TEST(LlvmLibcPrintfParserTest, EvalOneArgWithShortLengthModifier,
+           TestCharTypes) {
+  using CharT = ParamType;
+  LIBC_NAMESPACE::printf_core::BasicFormatSection<CharT> format_arr[10];
+  const CharT *str = ENCODED(CharT, "%hd");
   int arg1 = 12345;
   evaluate(format_arr, str, arg1);
 
-  LIBC_NAMESPACE::printf_core::FormatSection expected;
+  LIBC_NAMESPACE::printf_core::BasicFormatSection<CharT> expected;
   expected.has_conv = true;
 
   expected.raw_string = {str, 3};
   expected.length_modifier = LIBC_NAMESPACE::printf_core::LengthModifier::h;
   expected.conv_val_raw =
       static_cast<LIBC_NAMESPACE::fputil::FPBits<double>::StorageType>(arg1);
-  expected.conv_name = 'd';
+  expected.conv_name = ENCODED(CharT, 'd');
 
   ASSERT_PFORMAT_EQ(expected, format_arr[0]);
 }
 
-TEST(LlvmLibcPrintfParserTest, EvalOneArgWithLongLengthModifier) {
-  LIBC_NAMESPACE::printf_core::FormatSection format_arr[10];
-  const char *str = "%lld";
+TYPED_TEST(LlvmLibcPrintfParserTest, EvalOneArgWithLongLengthModifier,
+           TestCharTypes) {
+  using CharT = ParamType;
+  LIBC_NAMESPACE::printf_core::BasicFormatSection<CharT> format_arr[10];
+  const CharT *str = ENCODED(CharT, "%lld");
   long long arg1 = 12345;
   evaluate(format_arr, str, arg1);
 
-  LIBC_NAMESPACE::printf_core::FormatSection expected;
+  LIBC_NAMESPACE::printf_core::BasicFormatSection<CharT> expected;
   expected.has_conv = true;
 
   expected.raw_string = {str, 4};
   expected.length_modifier = LIBC_NAMESPACE::printf_core::LengthModifier::ll;
   expected.conv_val_raw =
       static_cast<LIBC_NAMESPACE::fputil::FPBits<double>::StorageType>(arg1);
-  expected.conv_name = 'd';
+  expected.conv_name = ENCODED(CharT, 'd');
 
   ASSERT_PFORMAT_EQ(expected, format_arr[0]);
 }
 
 #ifndef LIBC_COPT_PRINTF_DISABLE_BITINT
-TEST(LlvmLibcPrintfParserTest, EvalOneArgWithBitWidthLengthModifier) {
-  LIBC_NAMESPACE::printf_core::FormatSection format_arr[10];
-  const char *str = "%w32d";
+TYPED_TEST(LlvmLibcPrintfParserTest, EvalOneArgWithBitWidthLengthModifier,
+           TestCharTypes) {
+  using CharT = ParamType;
+  LIBC_NAMESPACE::printf_core::BasicFormatSection<CharT> format_arr[10];
+  const CharT *str = ENCODED(CharT, "%w32d");
   long long arg1 = 12345;
   evaluate(format_arr, str, arg1);
 
-  LIBC_NAMESPACE::printf_core::FormatSection expected;
+  LIBC_NAMESPACE::printf_core::BasicFormatSection<CharT> expected;
   expected.has_conv = true;
 
   expected.raw_string = {str, 5};
@@ -245,18 +269,20 @@ TEST(LlvmLibcPrintfParserTest, EvalOneArgWithBitWidthLengthModifier) {
   expected.bit_width = 32;
   expected.conv_val_raw =
       static_cast<LIBC_NAMESPACE::fputil::FPBits<double>::StorageType>(arg1);
-  expected.conv_name = 'd';
+  expected.conv_name = ENCODED(CharT, 'd');
 
   ASSERT_PFORMAT_EQ(expected, format_arr[0]);
 }
 
-TEST(LlvmLibcPrintfParserTest, EvalOneArgWithFastBitWidthLengthModifier) {
-  LIBC_NAMESPACE::printf_core::FormatSection format_arr[10];
-  const char *str = "%wf32d";
+TYPED_TEST(LlvmLibcPrintfParserTest, EvalOneArgWithFastBitWidthLengthModifier,
+           TestCharTypes) {
+  using CharT = ParamType;
+  LIBC_NAMESPACE::printf_core::BasicFormatSection<CharT> format_arr[10];
+  const CharT *str = ENCODED(CharT, "%wf32d");
   long long arg1 = 12345;
   evaluate(format_arr, str, arg1);
 
-  LIBC_NAMESPACE::printf_core::FormatSection expected;
+  LIBC_NAMESPACE::printf_core::BasicFormatSection<CharT> expected;
   expected.has_conv = true;
 
   expected.raw_string = {str, 6};
@@ -264,19 +290,20 @@ TEST(LlvmLibcPrintfParserTest, EvalOneArgWithFastBitWidthLengthModifier) {
   expected.bit_width = 32;
   expected.conv_val_raw =
       static_cast<LIBC_NAMESPACE::fputil::FPBits<double>::StorageType>(arg1);
-  expected.conv_name = 'd';
+  expected.conv_name = ENCODED(CharT, 'd');
 
   ASSERT_PFORMAT_EQ(expected, format_arr[0]);
 }
 #endif // LIBC_COPT_PRINTF_DISABLE_BITINT
 
-TEST(LlvmLibcPrintfParserTest, EvalOneArgWithAllOptions) {
-  LIBC_NAMESPACE::printf_core::FormatSection format_arr[10];
-  const char *str = "% -056.78jd";
+TYPED_TEST(LlvmLibcPrintfParserTest, EvalOneArgWithAllOptions, TestCharTypes) {
+  using CharT = ParamType;
+  LIBC_NAMESPACE::printf_core::BasicFormatSection<CharT> format_arr[10];
+  const CharT *str = ENCODED(CharT, "% -056.78jd");
   intmax_t arg1 = 12345;
   evaluate(format_arr, str, arg1);
 
-  LIBC_NAMESPACE::printf_core::FormatSection expected;
+  LIBC_NAMESPACE::printf_core::BasicFormatSection<CharT> expected;
   expected.has_conv = true;
 
   expected.raw_string = {str, 11};
@@ -289,26 +316,28 @@ TEST(LlvmLibcPrintfParserTest, EvalOneArgWithAllOptions) {
   expected.length_modifier = LIBC_NAMESPACE::printf_core::LengthModifier::j;
   expected.conv_val_raw =
       static_cast<LIBC_NAMESPACE::fputil::FPBits<double>::StorageType>(arg1);
-  expected.conv_name = 'd';
+  expected.conv_name = ENCODED(CharT, 'd');
 
   ASSERT_PFORMAT_EQ(expected, format_arr[0]);
 }
 
-TEST(LlvmLibcPrintfParserTest, EvalThreeArgs) {
-  LIBC_NAMESPACE::printf_core::FormatSection format_arr[10];
-  const char *str = "%d%f%s";
+TYPED_TEST(LlvmLibcPrintfParserTest, EvalThreeArgs, TestCharTypes) {
+  using CharT = ParamType;
+  LIBC_NAMESPACE::printf_core::BasicFormatSection<CharT> format_arr[10];
+  const CharT *str = ENCODED(CharT, "%d%f%s");
   int arg1 = 12345;
   double arg2 = 123.45;
-  const char *arg3 = "12345";
+  const CharT *arg3 = ENCODED(CharT, "12345");
   evaluate(format_arr, str, arg1, arg2, arg3);
 
-  LIBC_NAMESPACE::printf_core::FormatSection expected0, expected1, expected2;
+  LIBC_NAMESPACE::printf_core::BasicFormatSection<CharT> expected0, expected1,
+      expected2;
   expected0.has_conv = true;
 
   expected0.raw_string = {str, 2};
   expected0.conv_val_raw =
       static_cast<LIBC_NAMESPACE::fputil::FPBits<double>::StorageType>(arg1);
-  expected0.conv_name = 'd';
+  expected0.conv_name = ENCODED(CharT, 'd');
 
   ASSERT_PFORMAT_EQ(expected0, format_arr[0]);
 
@@ -316,26 +345,28 @@ TEST(LlvmLibcPrintfParserTest, EvalThreeArgs) {
 
   expected1.raw_string = {str + 2, 2};
   expected1.conv_val_raw = LIBC_NAMESPACE::cpp::bit_cast<uint64_t>(arg2);
-  expected1.conv_name = 'f';
+  expected1.conv_name = ENCODED(CharT, 'f');
 
   ASSERT_PFORMAT_EQ(expected1, format_arr[1]);
 
   expected2.has_conv = true;
 
   expected2.raw_string = {str + 4, 2};
-  expected2.conv_val_ptr = const_cast<char *>(arg3);
-  expected2.conv_name = 's';
+  expected2.conv_val_ptr = const_cast<CharT *>(arg3);
+  expected2.conv_name = ENCODED(CharT, 's');
 
   ASSERT_PFORMAT_EQ(expected2, format_arr[2]);
 }
 
-TEST(LlvmLibcPrintfParserTest, EvalOneArgWithOverflowingWidthAndPrecision) {
-  LIBC_NAMESPACE::printf_core::FormatSection format_arr[10];
-  const char *str = "%-999999999999.999999999999d";
+TYPED_TEST(LlvmLibcPrintfParserTest, EvalOneArgWithOverflowingWidthAndPrecision,
+           TestCharTypes) {
+  using CharT = ParamType;
+  LIBC_NAMESPACE::printf_core::BasicFormatSection<CharT> format_arr[10];
+  const CharT *str = ENCODED(CharT, "%-999999999999.999999999999d");
   int arg1 = 12345;
   evaluate(format_arr, str, arg1);
 
-  LIBC_NAMESPACE::printf_core::FormatSection expected;
+  LIBC_NAMESPACE::printf_core::BasicFormatSection<CharT> expected;
   expected.has_conv = true;
 
   expected.raw_string = {str, 28};
@@ -344,21 +375,22 @@ TEST(LlvmLibcPrintfParserTest, EvalOneArgWithOverflowingWidthAndPrecision) {
   expected.precision = INT_MAX;
   expected.conv_val_raw =
       static_cast<LIBC_NAMESPACE::fputil::FPBits<double>::StorageType>(arg1);
-  expected.conv_name = 'd';
+  expected.conv_name = ENCODED(CharT, 'd');
 
   ASSERT_PFORMAT_EQ(expected, format_arr[0]);
 }
 
-TEST(LlvmLibcPrintfParserTest,
-     EvalOneArgWithOverflowingWidthAndPrecisionAsArgs) {
-  LIBC_NAMESPACE::printf_core::FormatSection format_arr[10];
-  const char *str = "%*.*d";
+TYPED_TEST(LlvmLibcPrintfParserTest,
+           EvalOneArgWithOverflowingWidthAndPrecisionAsArgs, TestCharTypes) {
+  using CharT = ParamType;
+  LIBC_NAMESPACE::printf_core::BasicFormatSection<CharT> format_arr[10];
+  const CharT *str = ENCODED(CharT, "%*.*d");
   int arg1 = INT_MIN; // INT_MIN = -2147483648 if int is 32 bits.
   int arg2 = INT_MIN;
   int arg3 = 12345;
   evaluate(format_arr, str, arg1, arg2, arg3);
 
-  LIBC_NAMESPACE::printf_core::FormatSection expected;
+  LIBC_NAMESPACE::printf_core::BasicFormatSection<CharT> expected;
   expected.has_conv = true;
 
   expected.raw_string = {str, 5};
@@ -367,45 +399,49 @@ TEST(LlvmLibcPrintfParserTest,
   expected.precision = arg2;
   expected.conv_val_raw =
       static_cast<LIBC_NAMESPACE::fputil::FPBits<double>::StorageType>(arg3);
-  expected.conv_name = 'd';
+  expected.conv_name = ENCODED(CharT, 'd');
 
   ASSERT_PFORMAT_EQ(expected, format_arr[0]);
 }
 
 #ifndef LIBC_COPT_PRINTF_DISABLE_INDEX_MODE
 
-TEST(LlvmLibcPrintfParserTest, IndexModeOneArg) {
-  LIBC_NAMESPACE::printf_core::FormatSection format_arr[10];
-  const char *str = "%1$d";
+TYPED_TEST(LlvmLibcPrintfParserTest, IndexModeOneArg, TestCharTypes) {
+  using CharT = ParamType;
+  LIBC_NAMESPACE::printf_core::BasicFormatSection<CharT> format_arr[10];
+  const CharT *str = ENCODED(CharT, "%1$d");
   int arg1 = 12345;
   evaluate(format_arr, str, arg1);
 
-  LIBC_NAMESPACE::printf_core::FormatSection expected;
+  LIBC_NAMESPACE::printf_core::BasicFormatSection<CharT> expected;
   expected.has_conv = true;
 
   expected.raw_string = {str, 4};
   expected.conv_val_raw =
       static_cast<LIBC_NAMESPACE::fputil::FPBits<double>::StorageType>(arg1);
-  expected.conv_name = 'd';
+  expected.conv_name = ENCODED(CharT, 'd');
 
   ASSERT_PFORMAT_EQ(expected, format_arr[0]);
 }
 
-TEST(LlvmLibcPrintfParserTest, IndexModeThreeArgsSequential) {
-  LIBC_NAMESPACE::printf_core::FormatSection format_arr[10];
-  const char *str = "%1$d%2$f%3$s";
+TYPED_TEST(LlvmLibcPrintfParserTest, IndexModeThreeArgsSequential,
+           TestCharTypes) {
+  using CharT = ParamType;
+  LIBC_NAMESPACE::printf_core::BasicFormatSection<CharT> format_arr[10];
+  const CharT *str = ENCODED(CharT, "%1$d%2$f%3$s");
   int arg1 = 12345;
   double arg2 = 123.45;
-  const char *arg3 = "12345";
+  const CharT *arg3 = ENCODED(CharT, "12345");
   evaluate(format_arr, str, arg1, arg2, arg3);
 
-  LIBC_NAMESPACE::printf_core::FormatSection expected0, expected1, expected2;
+  LIBC_NAMESPACE::printf_core::BasicFormatSection<CharT> expected0, expected1,
+      expected2;
   expected0.has_conv = true;
 
   expected0.raw_string = {str, 4};
   expected0.conv_val_raw =
       static_cast<LIBC_NAMESPACE::fputil::FPBits<double>::StorageType>(arg1);
-  expected0.conv_name = 'd';
+  expected0.conv_name = ENCODED(CharT, 'd');
 
   ASSERT_PFORMAT_EQ(expected0, format_arr[0]);
 
@@ -413,34 +449,36 @@ TEST(LlvmLibcPrintfParserTest, IndexModeThreeArgsSequential) {
 
   expected1.raw_string = {str + 4, 4};
   expected1.conv_val_raw = LIBC_NAMESPACE::cpp::bit_cast<uint64_t>(arg2);
-  expected1.conv_name = 'f';
+  expected1.conv_name = ENCODED(CharT, 'f');
 
   ASSERT_PFORMAT_EQ(expected1, format_arr[1]);
 
   expected2.has_conv = true;
 
   expected2.raw_string = {str + 8, 4};
-  expected2.conv_val_ptr = const_cast<char *>(arg3);
-  expected2.conv_name = 's';
+  expected2.conv_val_ptr = const_cast<CharT *>(arg3);
+  expected2.conv_name = ENCODED(CharT, 's');
 
   ASSERT_PFORMAT_EQ(expected2, format_arr[2]);
 }
 
-TEST(LlvmLibcPrintfParserTest, IndexModeThreeArgsReverse) {
-  LIBC_NAMESPACE::printf_core::FormatSection format_arr[10];
-  const char *str = "%3$d%2$f%1$s";
+TYPED_TEST(LlvmLibcPrintfParserTest, IndexModeThreeArgsReverse, TestCharTypes) {
+  using CharT = ParamType;
+  LIBC_NAMESPACE::printf_core::BasicFormatSection<CharT> format_arr[10];
+  const CharT *str = ENCODED(CharT, "%3$d%2$f%1$s");
   int arg1 = 12345;
   double arg2 = 123.45;
-  const char *arg3 = "12345";
+  const CharT *arg3 = ENCODED(CharT, "12345");
   evaluate(format_arr, str, arg3, arg2, arg1);
 
-  LIBC_NAMESPACE::printf_core::FormatSection expected0, expected1, expected2;
+  LIBC_NAMESPACE::printf_core::BasicFormatSection<CharT> expected0, expected1,
+      expected2;
   expected0.has_conv = true;
 
   expected0.raw_string = {str, 4};
   expected0.conv_val_raw =
       static_cast<LIBC_NAMESPACE::fputil::FPBits<double>::StorageType>(arg1);
-  expected0.conv_name = 'd';
+  expected0.conv_name = ENCODED(CharT, 'd');
 
   ASSERT_PFORMAT_EQ(expected0, format_arr[0]);
 
@@ -448,50 +486,54 @@ TEST(LlvmLibcPrintfParserTest, IndexModeThreeArgsReverse) {
 
   expected1.raw_string = {str + 4, 4};
   expected1.conv_val_raw = LIBC_NAMESPACE::cpp::bit_cast<uint64_t>(arg2);
-  expected1.conv_name = 'f';
+  expected1.conv_name = ENCODED(CharT, 'f');
 
   ASSERT_PFORMAT_EQ(expected1, format_arr[1]);
 
   expected2.has_conv = true;
 
   expected2.raw_string = {str + 8, 4};
-  expected2.conv_val_ptr = const_cast<char *>(arg3);
-  expected2.conv_name = 's';
+  expected2.conv_val_ptr = const_cast<CharT *>(arg3);
+  expected2.conv_name = ENCODED(CharT, 's');
 
   ASSERT_PFORMAT_EQ(expected2, format_arr[2]);
 }
 
-TEST(LlvmLibcPrintfParserTest, IndexModeTenArgsRandom) {
-  LIBC_NAMESPACE::printf_core::FormatSection format_arr[10];
-  const char *str = "%6$d%3$d%7$d%2$d%8$d%1$d%4$d%9$d%5$d%10$d";
+TYPED_TEST(LlvmLibcPrintfParserTest, IndexModeTenArgsRandom, TestCharTypes) {
+  using CharT = ParamType;
+  LIBC_NAMESPACE::printf_core::BasicFormatSection<CharT> format_arr[10];
+  const CharT *str =
+      ENCODED(CharT, "%6$d%3$d%7$d%2$d%8$d%1$d%4$d%9$d%5$d%10$d");
   int args[10] = {6, 4, 2, 7, 9, 1, 3, 5, 8, 10};
   evaluate(format_arr, str, args[0], args[1], args[2], args[3], args[4],
            args[5], args[6], args[7], args[8], args[9]);
 
   for (size_t i = 0; i < 10; ++i) {
-    LIBC_NAMESPACE::printf_core::FormatSection expected;
+    LIBC_NAMESPACE::printf_core::BasicFormatSection<CharT> expected;
     expected.has_conv = true;
 
     expected.raw_string = {str + (4 * i),
                            static_cast<size_t>(4 + (i >= 9 ? 1 : 0))};
     expected.conv_val_raw = i + 1;
-    expected.conv_name = 'd';
+    expected.conv_name = ENCODED(CharT, 'd');
     EXPECT_PFORMAT_EQ(expected, format_arr[i]);
   }
 }
 
-TEST(LlvmLibcPrintfParserTest, IndexModeComplexParsing) {
-  LIBC_NAMESPACE::printf_core::FormatSection format_arr[10];
-  const char *str = "normal text %3$llu %% %2$ *4$f %2$ .*4$f %1$1.1c";
-  char arg1 = '1';
+TYPED_TEST(LlvmLibcPrintfParserTest, IndexModeComplexParsing, TestCharTypes) {
+  using CharT = ParamType;
+  LIBC_NAMESPACE::printf_core::BasicFormatSection<CharT> format_arr[10];
+  const CharT *str =
+      ENCODED(CharT, "normal text %3$llu %% %2$ *4$f %2$ .*4$f %1$1.1c");
+  CharT arg1 = ENCODED(CharT, '1');
   double arg2 = 123.45;
   unsigned long long arg3 = 12345;
   int arg4 = 10;
   evaluate(format_arr, str, arg1, arg2, arg3, arg4);
 
-  LIBC_NAMESPACE::printf_core::FormatSection expected0, expected1, expected2,
-      expected3, expected4, expected5, expected6, expected7, expected8,
-      expected9;
+  LIBC_NAMESPACE::printf_core::BasicFormatSection<CharT> expected0, expected1,
+      expected2, expected3, expected4, expected5, expected6, expected7,
+      expected8, expected9;
 
   expected0.has_conv = false;
 
@@ -505,7 +547,7 @@ TEST(LlvmLibcPrintfParserTest, IndexModeComplexParsing) {
   expected1.length_modifier = LIBC_NAMESPACE::printf_core::LengthModifier::ll;
   expected1.conv_val_raw =
       static_cast<LIBC_NAMESPACE::fputil::FPBits<double>::StorageType>(arg3);
-  expected1.conv_name = 'u';
+  expected1.conv_name = ENCODED(CharT, 'u');
 
   EXPECT_PFORMAT_EQ(expected1, format_arr[1]);
 
@@ -518,7 +560,7 @@ TEST(LlvmLibcPrintfParserTest, IndexModeComplexParsing) {
   expected3.has_conv = true;
 
   expected3.raw_string = {str + 19, 2};
-  expected3.conv_name = '%';
+  expected3.conv_name = ENCODED(CharT, '%');
 
   EXPECT_PFORMAT_EQ(expected3, format_arr[3]);
 
@@ -534,7 +576,7 @@ TEST(LlvmLibcPrintfParserTest, IndexModeComplexParsing) {
   expected5.flags = LIBC_NAMESPACE::printf_core::FormatFlags::SPACE_PREFIX;
   expected5.min_width = arg4;
   expected5.conv_val_raw = LIBC_NAMESPACE::cpp::bit_cast<uint64_t>(arg2);
-  expected5.conv_name = 'f';
+  expected5.conv_name = ENCODED(CharT, 'f');
 
   EXPECT_PFORMAT_EQ(expected5, format_arr[5]);
 
@@ -550,7 +592,7 @@ TEST(LlvmLibcPrintfParserTest, IndexModeComplexParsing) {
   expected7.flags = LIBC_NAMESPACE::printf_core::FormatFlags::SPACE_PREFIX;
   expected7.precision = arg4;
   expected7.conv_val_raw = LIBC_NAMESPACE::cpp::bit_cast<uint64_t>(arg2);
-  expected7.conv_name = 'f';
+  expected7.conv_name = ENCODED(CharT, 'f');
 
   EXPECT_PFORMAT_EQ(expected7, format_arr[7]);
 
@@ -567,14 +609,15 @@ TEST(LlvmLibcPrintfParserTest, IndexModeComplexParsing) {
   expected9.precision = 1;
   expected9.conv_val_raw =
       static_cast<LIBC_NAMESPACE::fputil::FPBits<double>::StorageType>(arg1);
-  expected9.conv_name = 'c';
+  expected9.conv_name = ENCODED(CharT, 'c');
 
   EXPECT_PFORMAT_EQ(expected9, format_arr[9]);
 }
 
-TEST(LlvmLibcPrintfParserTest, IndexModeGapCheck) {
-  LIBC_NAMESPACE::printf_core::FormatSection format_arr[10];
-  const char *str = "%1$d%2$d%4$d";
+TYPED_TEST(LlvmLibcPrintfParserTest, IndexModeGapCheck, TestCharTypes) {
+  using CharT = ParamType;
+  LIBC_NAMESPACE::printf_core::BasicFormatSection<CharT> format_arr[10];
+  const CharT *str = ENCODED(CharT, "%1$d%2$d%4$d");
   int arg1 = 1;
   int arg2 = 2;
   int arg3 = 3;
@@ -582,13 +625,14 @@ TEST(LlvmLibcPrintfParserTest, IndexModeGapCheck) {
 
   evaluate(format_arr, str, arg1, arg2, arg3, arg4);
 
-  LIBC_NAMESPACE::printf_core::FormatSection expected0, expected1, expected2;
+  LIBC_NAMESPACE::printf_core::BasicFormatSection<CharT> expected0, expected1,
+      expected2;
 
   expected0.has_conv = true;
   expected0.raw_string = {str, 4};
   expected0.conv_val_raw =
       static_cast<LIBC_NAMESPACE::fputil::FPBits<double>::StorageType>(arg1);
-  expected0.conv_name = 'd';
+  expected0.conv_name = ENCODED(CharT, 'd');
 
   EXPECT_PFORMAT_EQ(expected0, format_arr[0]);
 
@@ -596,7 +640,7 @@ TEST(LlvmLibcPrintfParserTest, IndexModeGapCheck) {
   expected1.raw_string = {str + 4, 4};
   expected1.conv_val_raw =
       static_cast<LIBC_NAMESPACE::fputil::FPBits<double>::StorageType>(arg2);
-  expected1.conv_name = 'd';
+  expected1.conv_name = ENCODED(CharT, 'd');
 
   EXPECT_PFORMAT_EQ(expected1, format_arr[1]);
 
@@ -606,12 +650,14 @@ TEST(LlvmLibcPrintfParserTest, IndexModeGapCheck) {
   EXPECT_PFORMAT_EQ(expected2, format_arr[2]);
 }
 
-TEST(LlvmLibcPrintfParserTest, IndexModeTrailingPercentCrash) {
-  LIBC_NAMESPACE::printf_core::FormatSection format_arr[10];
-  const char *str = "%2$d%";
+TYPED_TEST(LlvmLibcPrintfParserTest, IndexModeTrailingPercentCrash,
+           TestCharTypes) {
+  using CharT = ParamType;
+  LIBC_NAMESPACE::printf_core::BasicFormatSection<CharT> format_arr[10];
+  const CharT *str = ENCODED(CharT, "%2$d%");
   evaluate(format_arr, str, 1, 2);
 
-  LIBC_NAMESPACE::printf_core::FormatSection expected0, expected1;
+  LIBC_NAMESPACE::printf_core::BasicFormatSection<CharT> expected0, expected1;
   expected0.has_conv = false;
 
   expected0.raw_string = {str, 4};
@@ -623,8 +669,10 @@ TEST(LlvmLibcPrintfParserTest, IndexModeTrailingPercentCrash) {
   EXPECT_PFORMAT_EQ(expected1, format_arr[1]);
 }
 
-TEST(LlvmLibcPrintfParserTest, DoublePercentIsAllowedInvalidIndex) {
-  LIBC_NAMESPACE::printf_core::FormatSection format_arr[10];
+TYPED_TEST(LlvmLibcPrintfParserTest, DoublePercentIsAllowedInvalidIndex,
+           TestCharTypes) {
+  using CharT = ParamType;
+  LIBC_NAMESPACE::printf_core::BasicFormatSection<CharT> format_arr[10];
 
   // Normally this conversion specifier would be raw (due to having a width
   // defined as an invalid argument) but since it's a % conversion it's allowed
@@ -636,15 +684,15 @@ TEST(LlvmLibcPrintfParserTest, DoublePercentIsAllowedInvalidIndex) {
   // Finally, "%*%" traditionally is displayed as "%" but also traditionally
   // consumes an argument, since the * consumes an integer. Therefore, having
   // "%*2$%" display as "%" is consistent with other printf behavior.
-  const char *str = "%*2$%";
+  const CharT *str = ENCODED(CharT, "%*2$%");
 
   evaluate(format_arr, str, 1, 2);
 
-  LIBC_NAMESPACE::printf_core::FormatSection expected0;
+  LIBC_NAMESPACE::printf_core::BasicFormatSection<CharT> expected0;
   expected0.has_conv = true;
 
   expected0.raw_string = str;
-  expected0.conv_name = '%';
+  expected0.conv_name = ENCODED(CharT, '%');
   EXPECT_PFORMAT_EQ(expected0, format_arr[0]);
 }
 

--- a/libc/test/src/__support/printf_core/parser_test.cpp
+++ b/libc/test/src/__support/printf_core/parser_test.cpp
@@ -9,6 +9,7 @@
 #include "src/__support/CPP/bit.h"
 #include "src/__support/CPP/string_view.h"
 #include "src/__support/arg_list.h"
+#include "src/__support/macros/properties/types.h"
 #include "src/__support/printf_core/parser.h"
 
 #include <stdarg.h>
@@ -48,7 +49,11 @@ void evaluate(
   }
 }
 
+#if defined(LIBC_TYPES_WCHAR_T_IS_UTF32)
 using TestCharTypes = LIBC_NAMESPACE::testing::TypeList<char, wchar_t>;
+#else
+using TestCharTypes = LIBC_NAMESPACE::testing::TypeList<char>;
+#endif
 
 TYPED_TEST(LlvmLibcPrintfParserTest, Constructor, TestCharTypes) {
   using CharT = ParamType;


### PR DESCRIPTION
This is the next step in the ongoing refactor to support wide character printf functions.

`printf_core::FormatSection` is also templated on character type as it is required for parser_test. `FormatSection` is named in many more places. In order to keep this PR on the smaller side, it also gets a rename + `char` alias in the pattern of `basic_string_view` / `string_view`.

Assisted-by: Automated tooling, human reviewed.