### PR TITLE
[flang][OpenACC] Do not emit declare ctor/dtor for module PARAMETER variables

### DIFF
--- a/flang/lib/Lower/OpenACC.cpp
+++ b/flang/lib/Lower/OpenACC.cpp
@@ -4183,6 +4183,11 @@ genGlobalCtors(Fortran::lower::AbstractConverter &converter,
     }
 
     addDeclareAttr(builder, globalOp.getOperation(), clause);
+    // Named constants are emitted as initialized device globals. Do not
+    // emit a host ctor/dtor: that would register a symbol that already has
+    // a device definition.
+    if (Fortran::semantics::IsNamedConstant(symbol.GetUltimate()))
+      return;
     auto crtPos = builder.saveInsertionPoint();
     modBuilder.setInsertionPointAfter(globalOp);
     if (mlir::isa<fir::BaseBoxType>(fir::unwrapRefType(globalOp.getType()))) {

--- a/flang/test/Lower/OpenACC/acc-declare-globals.f90
+++ b/flang/test/Lower/OpenACC/acc-declare-globals.f90
@@ -117,3 +117,17 @@ end module
 ! CHECK:         acc.declare_enter dataOperands(%[[LINK]] : !fir.ref<!fir.array<5000xi32>>)
 ! CHECK:         acc.terminator
 ! CHECK:       }
+
+! PARAMETER arrays keep acc.declare so they are copied into the GPU module
+! with their initializer, but they are not registered via a host ctor/dtor.
+module acc_declare_parameter_test
+  real, parameter :: vals(2) = (/ 1.0, 2.0 /)
+  !$acc declare create(vals)
+end module
+
+! CHECK-LABEL: fir.global @_QMacc_declare_parameter_testECvals
+! CHECK-SAME: dense<
+! CHECK-SAME: acc.declare = #acc.declare<dataClause = acc_create>
+! CHECK-SAME: constant
+! CHECK-NOT: acc.global_ctor @_QMacc_declare_parameter_testECvals_acc_ctor
+! CHECK-NOT: acc.global_dtor @_QMacc_declare_parameter_testECvals_acc_dtor

--- a/flang/test/Lower/module-parameter-linkonce-odr.f90
+++ b/flang/test/Lower/module-parameter-linkonce-odr.f90
@@ -48,9 +48,12 @@ subroutine use_decl()
 end subroutine
 
 ! Defining TU has an initialized definition; using TU is a declaration.
+! No host ctor/dtor: a PARAMETER is a device constant, not a registered mapping.
 ! DECL-DEF: fir.global @_QMmod_declECp {acc.declare = #acc.declare<dataClause = acc_create>} constant : f32 {
 ! DECL-DEF: fir.has_value
 ! DECL-DEF-NOT: fir.global linkonce_odr @_QMmod_declECp
+! DECL-DEF-NOT: acc.global_ctor @_QMmod_declECp_acc_ctor
+! DECL-DEF-NOT: acc.global_dtor @_QMmod_declECp_acc_dtor
 
 ! DECL-USE: fir.global @_QMmod_declECp {acc.declare = #acc.declare<dataClause = acc_create>
 ! DECL-USE-NOT: fir.global @_QMmod_declECp(


### PR DESCRIPTION
A module PARAMETER in !$acc declare is already emitted as an initialized
device global. A host ctor/dtor would still register that same symbol
with the runtime. Skip the registration pair and keep acc.declare so the constant is
still emitted as an initialized global in the GPU module.
