### PR TITLE
[mlir] Remove the memory space attribute restriction on memref types

### DIFF
--- a/mlir/include/mlir/IR/BuiltinTypes.td
+++ b/mlir/include/mlir/IR/BuiltinTypes.td
@@ -894,7 +894,8 @@ def Builtin_MemRef : Builtin_Type<"MemRef", "memref", [
     form which is converted to a semi-affine map automatically.
 
     The memory space of a memref is specified by a target-specific attribute.
-    It might be an integer value, string, dictionary or custom dialect attribute.
+    It might be an integer value, string, dictionary or custom dialect
+    attribute; no restriction is placed on the kind of attribute used.
     The empty memory space (attribute is None) is target specific.
 
     The notionally dynamic value of a memref value includes the address of the

--- a/mlir/lib/IR/BuiltinTypes.cpp
+++ b/mlir/lib/IR/BuiltinTypes.cpp
@@ -608,28 +608,6 @@ mlir::isRankReducedType(ShapedType originalType,
   return SliceVerificationResult::Success;
 }
 
-bool mlir::detail::isSupportedMemorySpace(Attribute memorySpace) {
-  // Empty attribute is allowed as default memory space.
-  if (!memorySpace)
-    return true;
-
-  // Supported built-in attributes.
-  if (llvm::isa<IntegerAttr, StringAttr, DictionaryAttr>(memorySpace))
-    return true;
-
-  // Allow opaque attributes if unregistered dialects are allowed.
-  // They hold unregistered custom dialect attributes.
-  if (memorySpace.getContext()->allowsUnregisteredDialects() &&
-      isa<OpaqueAttr>(memorySpace))
-    return true;
-
-  // Allow custom dialect attributes.
-  if (!isa<BuiltinDialect>(memorySpace.getDialect()))
-    return true;
-
-  return false;
-}
-
 Attribute mlir::detail::wrapIntegerMemorySpace(unsigned memorySpace,
                                                MLIRContext *ctx) {
   if (memorySpace == 0)
@@ -785,9 +763,6 @@ LogicalResult MemRefType::verify(function_ref<InFlightDiagnostic()> emitError,
   if (failed(layout.verifyLayout(shape, emitError)))
     return failure();
 
-  if (!isSupportedMemorySpace(memorySpace))
-    return emitError() << "unsupported memory space Attribute";
-
   return success();
 }
 
@@ -913,9 +888,6 @@ UnrankedMemRefType::verify(function_ref<InFlightDiagnostic()> emitError,
                            Type elementType, Attribute memorySpace) {
   if (!BaseMemRefType::isValidElementType(elementType))
     return emitError() << "invalid memref element type";
-
-  if (!isSupportedMemorySpace(memorySpace))
-    return emitError() << "unsupported memory space Attribute";
 
   return success();
 }

--- a/mlir/lib/IR/TypeDetail.h
+++ b/mlir/lib/IR/TypeDetail.h
@@ -135,9 +135,6 @@ struct TupleTypeStorage final
   unsigned numElements;
 };
 
-/// Checks if the memorySpace has supported Attribute type.
-bool isSupportedMemorySpace(Attribute memorySpace);
-
 /// Wraps deprecated integer memory space to the new Attribute form.
 Attribute wrapIntegerMemorySpace(unsigned memorySpace, MLIRContext *ctx);
 

--- a/mlir/test/IR/invalid-builtin-types.mlir
+++ b/mlir/test/IR/invalid-builtin-types.mlir
@@ -34,10 +34,6 @@ func.func @memrefs(memref<2x4xi8, >) // expected-error {{expected list element}}
 func.func @memrefs(memref<2x4xi8, #map7>) // expected-error {{undefined symbol alias id 'map7'}}
 
 // -----
-// Test unsupported memory space.
-func.func @memrefs(memref<2x4xi8, i8>) // expected-error {{unsupported memory space Attribute}}
-
-// -----
 // Test non-existent map in map composition of memref type.
 #map0 = affine_map<(d0, d1) -> (d0, d1)>
 

--- a/mlir/test/IR/parser.mlir
+++ b/mlir/test/IR/parser.mlir
@@ -133,6 +133,12 @@ func.func private @memrefs_nomap_opaquespace(memref<5x6x7xf32, #unknown_dialect.
 // CHECK: func private @memrefs_map_opaquespace(memref<5x6x7xf32, #map{{[0-9]*}}, #unknown_dialect.unknown_attr>)
 func.func private @memrefs_map_opaquespace(memref<5x6x7xf32, #map3, #unknown_dialect.unknown_attr>)
 
+// CHECK: func private @memrefs_nomap_typespace(memref<5x6x7xf32, i8>)
+func.func private @memrefs_nomap_typespace(memref<5x6x7xf32, i8>)
+
+// CHECK: func private @memrefs_map_typespace(memref<5x6x7xf32, #map{{[0-9]*}}, i8>)
+func.func private @memrefs_map_typespace(memref<5x6x7xf32, #map3, i8>)
+
 // CHECK: func private @complex_types(complex<i1>) -> complex<f32>
 func.func private @complex_types(complex<i1>) -> complex<f32>
 


### PR DESCRIPTION
Follow-up to #187682. `isSupportedMemorySpace` only rejected builtin attributes other than IntegerAttr/StringAttr/DictionaryAttr. This is a leftover from when memory spaces were restricted to integers, and is now inconsistent.