### PR TITLE
[flang][acc] Add missing dependencies for TestOpenACCSupport

### DIFF
--- a/flang/test/lib/OpenACC/CMakeLists.txt
+++ b/flang/test/lib/OpenACC/CMakeLists.txt
@@ -19,14 +19,18 @@ add_flang_library(FIRTestOpenACCInterfaces
   MLIR_DEPS
   MLIRDLTIDialect
   MLIRIR
+  MLIROpenACCAnalysis
   MLIROpenACCDialect
+  MLIROpenACCUtils
   MLIRPass
   MLIRSupport
 
   MLIR_LIBS
   MLIRDLTIDialect
   MLIRIR
+  MLIROpenACCAnalysis
   MLIROpenACCDialect
+  MLIROpenACCUtils
   MLIRPass
   MLIRSupport
 )


### PR DESCRIPTION
Adds missing dependencies to avoid:
undefined reference to `mlir::acc::getOrCreateGPUModule` undefined reference to `mlir::acc::OpenACCSupport::getVariableName` after https://github.com/llvm/llvm-project/pull/222815