### PR TITLE
[lldb] Fix batched breakpoint step-over mock

### DIFF
--- a/lldb/test/API/functionalities/gdb_remote_client/TestBatchedBreakpointStepOver.py
+++ b/lldb/test/API/functionalities/gdb_remote_client/TestBatchedBreakpointStepOver.py
@@ -59,6 +59,9 @@ class TestBatchedBreakpointStepOver(GDBRemoteTestBase):
                     threadnum, threads_str, pcs_str
                 )
 
+            def cont(self):
+                return "W00"
+
             def setBreakpoint(self, packet):
                 return "OK"
 
@@ -160,7 +163,9 @@ class TestBatchedBreakpointStepOver(GDBRemoteTestBase):
         self.assertTrue(bkpt.IsValid())
 
         # Continue, LLDB should step all threads over the breakpoint.
-        process.Continue()
+        self.assertSuccess(process.Continue())
+        self.assertState(process.GetState(), lldb.eStateExited)
+        self.assertEqual(process.GetExitStatus(), 0)
 
         # Collect packets from the log.
         received = self.server.responder.packetLog.get_received()


### PR DESCRIPTION
This PR fixes the test that printed an `UnexpectedPacketException` because its mock GDB server did not handle LLDB’s final continue packet. It adds a normal exit response for that packet and verifies that the process exits successfully with status zero.

Before:
```
  An exception happened when receiving the response from the gdb server. Closing the client...
  Traceback (most recent call last):
    File "/home/barsolo/llvm-sand/external/llvm-project/lldb/packages/Python/lldbsuite/test/gdbclientutils.py", line
    694, in run
      self._receive(data)
    File "/home/barsolo/llvm-sand/external/llvm-project/lldb/packages/Python/lldbsuite/test/gdbclientutils.py", line
    714, in _receive
      self._handlePacket(packet)
    File "/home/barsolo/llvm-sand/external/llvm-project/lldb/packages/Python/lldbsuite/test/gdbclientutils.py", line
    807, in _handlePacket
      response = self.responder.respond(packet)
    File "/home/barsolo/llvm-sand/external/llvm-project/lldb/packages/Python/lldbsuite/test/gdbclientutils.py", line
    218, in respond
      response = self._respond_impl(packet)
    File "/home/barsolo/llvm-sand/external/llvm-project/lldb/packages/Python/lldbsuite/test/gdbclientutils.py", line
    231, in _respond_impl
      return self.cont()
    File "/home/barsolo/llvm-sand/external/llvm-project/lldb/packages/Python/lldbsuite/test/gdbclientutils.py", line
    383, in cont
      raise self.UnexpectedPacketException()
  lldbsuite.test.gdbclientutils.MockGDBServerResponder.UnexpectedPacketException

  PASS: LLDB (...) :: test (TestBatchedBreakpointStepOver.TestBatchedBreakpointStepOver.test)
  ----------------------------------------------------------------------
  Ran 1 test in 0.070s

OK
```

After:
```
  PASS: LLDB (...) :: test (TestBatchedBreakpointStepOver.TestBatchedBreakpointStepOver.test)
  ----------------------------------------------------------------------
  Ran 1 test in 0.065s

  OK
```