### PR TITLE
[Clang] Handle unsatisfied NestedRequirement correctly

### DIFF
--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -8175,6 +8175,15 @@ Sema::BuildNestedRequirement(Expr *Constraint) {
                                   /*TemplateArgs=*/{},
                                   Constraint->getSourceRange(), Satisfaction))
     return nullptr;
+
+  if (!Satisfaction.IsSatisfied) {
+    SmallString<128> Entity;
+    llvm::raw_svector_ostream OS(Entity);
+    Constraint->printPretty(OS, nullptr, SemaRef.getPrintingPolicy());
+    return new (Context) concepts::NestedRequirement(
+        Context, Context.backupStr(Entity), std::move(Satisfaction));
+  }
+
   return new (Context) concepts::NestedRequirement(Context, Constraint,
                                                    Satisfaction);
 }

--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -8176,7 +8176,7 @@ Sema::BuildNestedRequirement(Expr *Constraint) {
                                   Constraint->getSourceRange(), Satisfaction))
     return nullptr;
 
-  if (!Satisfaction.IsSatisfied) {
+  if (Satisfaction.HasSubstitutionFailure()) {
     SmallString<128> Entity;
     llvm::raw_svector_ostream OS(Entity);
     Constraint->printPretty(OS, nullptr, SemaRef.getPrintingPolicy());

--- a/clang/test/SemaCXX/concept-crash-on-diagnostic.cpp
+++ b/clang/test/SemaCXX/concept-crash-on-diagnostic.cpp
@@ -73,3 +73,16 @@ namespace GH138823 {
 
   void test() { bar(1); }
 }
+
+namespace GH222954 {
+
+template <typename T> struct foo {};
+template <typename T>
+concept bar = foo<T>::baz;
+
+static_assert(requires { requires bar<int>; });
+// expected-error@-1 {{static assertion failed}}
+// expected-note@-2 {{because 'int' does not satisfy 'bar'}}
+// expected-note@-4 {{because 'bar<int>' would be invalid}}
+
+}

--- a/clang/test/SemaCXX/concept-crash-on-diagnostic.cpp
+++ b/clang/test/SemaCXX/concept-crash-on-diagnostic.cpp
@@ -83,6 +83,6 @@ concept bar = foo<T>::baz;
 static_assert(requires { requires bar<int>; });
 // expected-error@-1 {{static assertion failed}}
 // expected-note@-2 {{because 'int' does not satisfy 'bar'}}
-// expected-note@-4 {{because 'bar<int>' would be invalid}}
+// expected-note@-5 {{because 'bar<int>' would be invalid}}
 
 }


### PR DESCRIPTION
Sema::BuildNestedRequirement(Expr *Constraint) built an incorrect NestedRequirement even when unsatisfied. It was never triggered because they were never diagnosed (we didn't diagnose concept details for static_assert until ab896c6c6f2) and the other error handlings were done properly in instantiator.

No release note because of regression-on-trunk.

Fixes https://github.com/llvm/llvm-project/issues/222954
