### PR TITLE
[clang-tidy] Fix convert-member-functions-to-static crash on attributed methods

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/ConvertMemberFunctionsToStaticCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ConvertMemberFunctionsToStaticCheck.cpp
@@ -148,7 +148,7 @@ static SourceRange getLocationOfConst(const TypeSourceInfo *TSI,
                                       const SourceManager &SourceMgr,
                                       const LangOptions &LangOpts) {
   assert(TSI);
-  const auto FTL = TSI->getTypeLoc().IgnoreParens().getAs<FunctionTypeLoc>();
+  const auto FTL = TSI->getTypeLoc().getAsAdjusted<FunctionTypeLoc>();
   assert(FTL);
 
   const SourceRange Range{FTL.getRParenLoc().getLocWithOffset(1),

--- a/clang-tools-extra/docs/ReleaseNotes.md
+++ b/clang-tools-extra/docs/ReleaseNotes.md
@@ -210,6 +210,11 @@ infrastructure are described first, followed by tool-specific sections.
   offered when an argument covers only part of a macro expansion, as it then
   has no source text of its own.
 
+- Improved {doc}`readability-convert-member-functions-to-static
+  <clang-tidy/checks/readability/convert-member-functions-to-static>` check by
+  fixing a crash when checking a const-qualified method declared with the
+  `lifetimebound` attribute.
+
 - Improved {doc}`readability-enum-initial-value
   <clang-tidy/checks/readability/enum-initial-value>` check by adding
   the {option}`AllowReferencedInitialValues` to support the

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/convert-member-functions-to-static.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/convert-member-functions-to-static.cpp
@@ -74,6 +74,12 @@ class A {
     return static_field;
   }
 
+  int lifetime_bound() const [[clang::lifetimebound]] {
+    // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: method 'lifetime_bound' can be made static
+    // CHECK-FIXES: static int lifetime_bound() {{\[\[}}clang::lifetimebound{{\]\]}} {
+    return static_field;
+  }
+
   static int out_of_line_already_static();
 
   void out_of_line_call_static();


### PR DESCRIPTION
Fixes #222951