### PR TITLE
[CIR][CUDA] Add semantic surface reference type

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
@@ -402,6 +402,20 @@ def CIR_VPtrType : CIR_Type<"VPtr", "vptr", [
 }
 
 //===----------------------------------------------------------------------===//
+// CUDADeviceSurfaceType
+//===----------------------------------------------------------------------===//
+
+def CIR_CUDADeviceSurfaceType :
+    CIR_Type<"CUDADeviceSurface", "cuda_surface"> {
+  let summary = "CUDA device surface reference type";
+  let description = [{
+    `!cir.cuda_surface` represents a CUDA built-in surface reference in CIR.
+    The type preserves surface semantics at the CIR level and is lowered to
+    the target device representation during lowering to LLVM IR.
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // CUDADeviceTextureType
 //===----------------------------------------------------------------------===//
 
@@ -1165,7 +1179,8 @@ def CIR_AnyType : AnyTypeOf<[
   CIR_VoidType, CIR_BoolType, CIR_ArrayType, CIR_VectorType, CIR_IntType,
   CIR_AnyFloatType, CIR_PointerType, CIR_FuncType, CIR_StructType,
   CIR_UnionType, CIR_BitFieldType,
-  CIR_ComplexType, CIR_VPtrType, CIR_CUDADeviceTextureType,
+  CIR_ComplexType, CIR_VPtrType, CIR_CUDADeviceSurfaceType,
+  CIR_CUDADeviceTextureType,
   CIR_DataMemberType, CIR_MethodType,
   CIR_EhTokenType, CIR_CleanupTokenType, CIR_CatchTokenType
 ]>;

--- a/clang/lib/CIR/CodeGen/Targets/NVPTX.cpp
+++ b/clang/lib/CIR/CodeGen/Targets/NVPTX.cpp
@@ -110,10 +110,7 @@ public:
   }
 
   mlir::Type getCUDADeviceBuiltinSurfaceDeviceType() const override {
-    // On the device side, surface reference is represented as an object handle
-    // in 64-bit integer.
-    return cir::IntType::get(&getABIInfo().cgt.getMLIRContext(), 64,
-                             /*isSigned=*/true);
+    return cir::CUDADeviceSurfaceType::get(&getABIInfo().cgt.getMLIRContext());
   }
 
   mlir::Type getCUDADeviceBuiltinTextureDeviceType() const override {

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -3855,6 +3855,9 @@ static void prepareTypeConverter(mlir::LLVMTypeConverter &converter,
     assert(!cir::MissingFeatures::addressSpace());
     return mlir::LLVM::LLVMPointerType::get(type.getContext());
   });
+  converter.addConversion([&](cir::CUDADeviceSurfaceType type) -> mlir::Type {
+    return mlir::IntegerType::get(type.getContext(), 64);
+  });
   converter.addConversion([&](cir::CUDADeviceTextureType type) -> mlir::Type {
     return mlir::IntegerType::get(type.getContext(), 64);
   });

--- a/clang/test/CIR/CodeGenCUDA/surface.cu
+++ b/clang/test/CIR/CodeGenCUDA/surface.cu
@@ -18,7 +18,7 @@ struct __attribute__((device_builtin_surface_type)) surface<void, dim>
 
 surface<void, 2> surf;
 
-// CIR-DEVICE: cir.global external target_address_space(1) @surf = #cir.undef : !s64i
+// CIR-DEVICE: cir.global external target_address_space(1) @surf = #cir.undef : !cir.cuda_surface
 
 // CIR now matches OG CodeGen and emits undef for CUDA shadow variables.
 // LLVM-DEVICE: @surf ={{.*}} addrspace(1) externally_initialized global i64 undef


### PR DESCRIPTION
Related: #179278  
Follow-up to #214781.

This patch introduces a dedicated CIR type for CUDA built-in surface references.

Previously, CUDA surface references were represented directly as `!s64i` in CIR. This change preserves the surface semantics at the CIR level using `!cir.cuda_surface`, while continuing to lower the type to the NVPTX device-handle representation (`i64`).

## Changes

- Add `CUDADeviceSurfaceType` (`!cir.cuda_surface`) to the CIR dialect
- Update `NVPTXTargetCIRGenInfo` to use `CUDADeviceSurfaceType` for CUDA surface references
- Lower `CUDADeviceSurfaceType` to `i64` in DirectToLLVM
- Update CUDA surface test coverage to check the semantic CIR type

## Testing

- `clang/test/CIR/CodeGenCUDA/surface.cu`
- `clang/test/CIR/CodeGenCUDA/texture.cu`
- Full `clang/test/CIR` suite: 1015 passed, 22 unsupported, 0 failed