### PR TITLE
Use -fsyntax-only for modules-driver-depscan-log.cpp test

### DIFF
--- a/clang/test/Driver/modules-driver-depscan-log.cpp
+++ b/clang/test/Driver/modules-driver-depscan-log.cpp
@@ -5,7 +5,7 @@
 // RUN: split-file %s %t
 
 // RUN: %clang -c -std=c++23 -fmodules-driver -fdepscan-log-path=%t/scan.log \
-// RUN:   %t/A.cppm -o %t/A.o
+// RUN:   %t/A.cppm -fsyntax-only
 // RUN: FileCheck %s --input-file %t/scan.log
 
 // CHECK: logging_start


### PR DESCRIPTION
The modules-driver-depscan-log.cpp is failing after PR#222209 was landed on mac when building LLVM with libcxx. This patch changed the `-o` flag to `-fsyntax-only` to mitigate this issue.