### PR TITLE
[AST] Make TypeOfExprType's dependence match its actual dependence

### DIFF
--- a/clang/include/clang/AST/DependenceFlags.h
+++ b/clang/include/clang/AST/DependenceFlags.h
@@ -191,10 +191,18 @@ public:
     return Result;
   }
 
-  TypeDependence type() const {
+  // If ValueDependenceImpliesTypeDependence is false, an expression that is
+  // only value-dependent (not type-dependent) does not set
+  // TypeDependence::Dependent on the result. This is appropriate for types
+  // that sugar an expression's type verbatim (e.g., __typeof), where the
+  // type cannot actually vary across instantiations unless the expression's
+  // own type does.
+  TypeDependence type(bool ValueDependenceImpliesTypeDependence = true) const {
+    Bits DependentBits =
+        ValueDependenceImpliesTypeDependence ? Dependent : Dependent & ~Value;
     return translate(V, UnexpandedPack, TypeDependence::UnexpandedPack) |
            translate(V, Instantiation, TypeDependence::Instantiation) |
-           translate(V, Dependent, TypeDependence::Dependent) |
+           translate(V, DependentBits, TypeDependence::Dependent) |
            translate(V, Error, TypeDependence::Error) |
            translate(V, VariablyModified, TypeDependence::VariablyModified);
   }
@@ -275,8 +283,10 @@ inline ExprDependence turnValueToTypeDependence(ExprDependence D) {
 }
 
 // Returned type-dependence will never have VariablyModified set.
-inline TypeDependence toTypeDependence(ExprDependence D) {
-  return Dependence(D).type();
+inline TypeDependence
+toTypeDependence(ExprDependence D,
+                 bool ValueDependenceImpliesTypeDependence = true) {
+  return Dependence(D).type(ValueDependenceImpliesTypeDependence);
 }
 inline TypeDependence toTypeDependence(NestedNameSpecifierDependence D) {
   return Dependence(D).type();

--- a/clang/lib/AST/Type.cpp
+++ b/clang/lib/AST/Type.cpp
@@ -4259,7 +4259,11 @@ TypeOfExprType::TypeOfExprType(const ASTContext &Context, Expr *E,
            Kind == TypeOfKind::Unqualified && !Can.isNull()
                ? Context.getUnqualifiedArrayType(Can).getAtomicUnqualifiedType()
                : Can,
-           toTypeDependence(E->getDependence()) |
+           // __typeof(expr) is always the type of expr. Mere
+           // value-dependence of the expression doesn't make this type
+           // dependent. Only type-dependence of the expression does.
+           toTypeDependence(E->getDependence(),
+                            /*ValueDependenceImpliesTypeDependence=*/false) |
                (E->getType()->getDependence() &
                 TypeDependence::VariablyModified)),
       TOExpr(E), Context(Context) {

--- a/clang/test/SemaCXX/typeof.cpp
+++ b/clang/test/SemaCXX/typeof.cpp
@@ -8,7 +8,7 @@ namespace GH97646 {
   template<bool B>
   void f() {
     __typeof__(B) x = false;
-    !x;
+    !x; // expected-warning {{expression result unused}}
   }
 }
 

--- a/clang/test/SemaTemplate/current-instantiation.cpp
+++ b/clang/test/SemaTemplate/current-instantiation.cpp
@@ -247,3 +247,26 @@ namespace RebuildDependentScopeDeclRefExpr {
   // FIXME: We should issue a typo-correction here.
   template<typename T> N<X<T>::think> X<T>::foo() {} // expected-error {{no member named 'think' in 'RebuildDependentScopeDeclRefExpr::X<T>'}}
 }
+
+namespace TypeofValueDependence {
+  struct A { int value() const; };
+  A f(unsigned);
+
+  // 'sizeof(T)' makes 'f(sizeof(T))' value-dependent, but overload
+  // resolution for 'f' only looks at argument types, so the type of
+  // 'f(sizeof(T))' is always 'A' regardless of 'T'. '__typeof(f(sizeof(T)))'
+  // is therefore not type-dependent, so member access on it is checked
+  // immediately rather than deferred to instantiation.
+  template<typename T> struct B {
+    int g() {
+      __typeof(f(sizeof(T))) a = f(0);
+      return a.value();
+    }
+    int h() {
+      __typeof(f(sizeof(T))) a = f(0);
+      return a.nope(); // expected-error {{no member named 'nope' in 'TypeofValueDependence::A'}}
+    }
+  };
+
+  int i() { return B<int>().g() + B<int>().h(); }
+}


### PR DESCRIPTION
TypeOfExprType based its dependence bits on the full Expr::getDependence() of its operand, so TypeDependence::Dependent was set even when the operand was merely value-dependent, not type-dependent. For example, the type __typeof(sizeof(T)) was marked dependent even though the operand, sizeof(T), is merely value-dependent, not type-dependent, and its type is size_t regardless of T.

Added a parameter to Dependence::type() and toTypeDependence that indicates whether value dependence should imply type dependence, and use it to compute TypeOfExprType's dependence from only its operand's type dependence.

This follows the review discussion on PR #219324:
https://github.com/llvm/llvm-project/pull/219324#pullrequestreview-5095251894

rdar://184775733