### PR TITLE
Fix lambda added in #222755 which did not build with VS2019.

### DIFF
--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -33450,7 +33450,7 @@ bool SLPVectorizerPass::vectorizeNonVectorizableInsts(
   constexpr unsigned Limit = 32;
   Changed |= tryToVectorizeSequence<Value>(
       Operands, OperandSorter, AreCompatibleOperands,
-      [this, &R](ArrayRef<Value *> Candidates, bool MaxVFOnly) {
+      [this, &R, Limit](ArrayRef<Value *> Candidates, bool MaxVFOnly) {
         // Limit to StandaloneSeeds if !MaxVFOnly to avoid quadratic scan for
         // large set of candidates.
         return tryToVectorizeList(Candidates, R, MaxVFOnly,


### PR DESCRIPTION
PR #222755 added a lambda which fails to compile with VS2019 as can be seen on our bot:
https://lab.llvm.org/buildbot/#/builders/46/builds/41157:
```
[3628/5386] Building CXX object lib\Transforms\Vectorize\CMakeFiles\LLVMVectorize.dir\SLPVectorizer.cpp.obj
FAILED: lib/Transforms/Vectorize/CMakeFiles/LLVMVectorize.dir/SLPVectorizer.cpp.obj 
C:\bin\ccache.exe C:\PROGRA~2\MICROS~1\2019\BUILDT~1\VC\Tools\MSVC\1429~1.301\bin\HostX64\x64\cl.exe  /nologo /TP -DUNICODE -D_CRT_NONSTDC_NO_DEPRECATE -D_CRT_NONSTDC_NO_WARNINGS -D_CRT_SECURE_NO_DEPRECATE -D_CRT_SECURE_NO_WARNINGS -D_GLIBCXX_ASSERTIONS -D_HAS_EXCEPTIONS=0 -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_EXTENSIVE -D_SCL_SECURE_NO_DEPRECATE -D_SCL_SECURE_NO_WARNINGS -D_UNICODE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -Ilib\Transforms\Vectorize -IZ:\b\llvm-clang-x86_64-sie-win\llvm-project\llvm\lib\Transforms\Vectorize -Iinclude -IZ:\b\llvm-clang-x86_64-sie-win\llvm-project\llvm\include -I"C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\DIA SDK\include" /DWIN32 /D_WINDOWS   /Zc:inline /Zc:preprocessor /Zc:__cplusplus /Oi /bigobj /permissive- /W4 -wd4146 -wd4244 -wd4267 -wd4456 -wd4457 -wd4458 -wd4459 -wd4624 -wd4100 -wd4127 -wd4505 -wd4702 -wd4245 -wd4310 -wd4701 -wd4703 -wd4389 -wd4805 -wd4577 -wd4319 -wd4324 -wd4251 -wd4275 -w14062 -we4238 /Gw /O2 /Ob2  -MD -UNDEBUG /EHs-c- /GR- -std:c++17 /showIncludes /Folib\Transforms\Vectorize\CMakeFiles\LLVMVectorize.dir\SLPVectorizer.cpp.obj /Fdlib\Transforms\Vectorize\CMakeFiles\LLVMVectorize.dir\LLVMVectorize.pdb /FS -c Z:\b\llvm-clang-x86_64-sie-win\llvm-project\llvm\lib\Transforms\Vectorize\SLPVectorizer.cpp
Z:\b\llvm-clang-x86_64-sie-win\llvm-project\llvm\lib\Transforms\Vectorize\SLPVectorizer.cpp(33373): error C3493: 'Limit' cannot be implicitly captured because no default capture mode has been specified
Z:\b\llvm-clang-x86_64-sie-win\llvm-project\llvm\lib\Transforms\Vectorize\SLPVectorizer.cpp(33669): note: see reference to function template instantiation 'bool llvm::SLPVectorizerPass::vectorizeNonVectorizableInsts<std::reverse_iterator<llvm::Instruction *const *>>(llvm::iterator_range<std::reverse_iterator<llvm::Instruction *const *>>,llvm::BasicBlock *,llvm::slpvectorizer::BoUpSLP &,llvm::SmallSetVector<llvm::Instruction *,8> &)' being compiled
Z:\b\llvm-clang-x86_64-sie-win\llvm-project\llvm\lib\Transforms\Vectorize\SLPVectorizer.cpp(33366): error C2664: 'bool tryToVectorizeSequence<llvm::Value>(llvm::SmallVectorImpl<llvm::Value *> &,llvm::function_ref<bool (llvm::Value *,llvm::Value *)>,llvm::function_ref<bool (llvm::ArrayRef<llvm::Value *>,llvm::Value *)>,llvm::function_ref<bool (llvm::ArrayRef<llvm::Value *>,bool)>,bool,llvm::slpvectorizer::BoUpSLP &)': cannot convert argument 4 from 'int' to 'llvm::function_ref<bool (llvm::ArrayRef<llvm::Value *>,bool)>'
Z:\b\llvm-clang-x86_64-sie-win\llvm-project\llvm\lib\Transforms\Vectorize\SLPVectorizer.cpp(33375): note: No constructor could take the source type, or constructor overload resolution was ambiguous
Z:\b\llvm-clang-x86_64-sie-win\llvm-project\llvm\lib\Transforms\Vectorize\SLPVectorizer.cpp(32859): note: see declaration of 'tryToVectorizeSequence'
```

This change fixes the error by explicitly adding the variable Limit to the lambda capture list.