### PR TITLE
[CIR] Remove the NYI test case for a pointer-element vector

### DIFF
--- a/clang/lib/CIR/Dialect/Transforms/CallConvLoweringPass.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CallConvLoweringPass.cpp
@@ -183,8 +183,7 @@ static bool isSupportedType(mlir::Type ty, const DataLayout &dl) {
     // an element is only usable where that width is the one clang gives it.
     // It is not for bool (a bit to clang, a byte here), for a _BitInt narrower
     // than a byte (clang rounds to the storage container), or for x87 long
-    // double (80 bits here against clang's 128).  A pointer is excluded for a
-    // different reason, its pointee being what abiTypeToCIR drops.
+    // double (80 bits here against clang's 128).
     mlir::Type elemTy = vecTy.getElementType();
     if (auto elemInt = dyn_cast<cir::IntType>(elemTy)) {
       if (elemInt.getWidth() % 8)

--- a/clang/test/CIR/Transforms/abi-lowering/x86_64-aggregate-nyi.cir
+++ b/clang/test/CIR/Transforms/abi-lowering/x86_64-aggregate-nyi.cir
@@ -167,15 +167,6 @@ module attributes {
 
   // CHECK: not yet implemented for type '!cir.vector<3 x !cir.int<s, 8>>
 
-  // A pointer element loses its pointee on the way back from the classifier,
-  // which would rewrite the signature to a vector of void pointers.  No C
-  // vector has a pointer element, so this is rejected instead.
-  cir.func @take_ptr_vector(%arg0: !cir.vector<2 x !cir.ptr<!s32i>>) {
-    cir.return
-  }
-
-  // CHECK: not yet implemented for type '!cir.vector<2 x !cir.ptr<!cir.int<s, 32>>>
-
   // An element narrower than a byte is rounded up to its storage container by
   // clang but not by the classifier, so the two would size the vector
   // differently.  Classic passes this one in an xmm register from its 128-bit


### PR DESCRIPTION
#222736 removed CIR_AnyPtrType from VectorElementType, so `!cir.vector<2 x !cir.ptr<!s32i>>` no longer verifies.  That stops x86_64-aggregate-nyi.cir parsing at all, so the whole test fails rather than just that case.

The case only pinned that the x86_64 bridge refuses the shape.  No C or C++ source produces it, since clang rejects a pointer element with "invalid vector element type", so the verifier is the earlier and better place for that rejection.  The comment in isSupportedType justifying the bridge-side exclusion is also removed.

Assisted-by: Cursor / claude-opus-5
