### PR TITLE
[LLVM-C] expose LLVMDIBuilderGetOrCreateSubrange2

### DIFF
--- a/llvm/include/llvm-c/DebugInfo.h
+++ b/llvm/include/llvm-c/DebugInfo.h
@@ -1197,6 +1197,21 @@ LLVM_C_ABI LLVMMetadataRef LLVMDIBuilderGetOrCreateSubrange(
     LLVMDIBuilderRef Builder, int64_t LowerBound, int64_t Count);
 
 /**
+ * Create a descriptor for a value range with support for expressions.
+ * \param Builder    The DIBuilder.
+ * \param Count Count of elements in the subrange
+ * \param Low Lower bound of the subrange, e.g. 0 for C, 1 for Fortran.
+ * \param High Higher bound of the subrange. Not needed when Count is already specified
+ * \param Stride Stride of the subrange 
+ */    
+LLVM_C_ABI LLVMMetadataRef LLVMDIBuilderGetOrCreateSubrange2(
+                                                 LLVMDIBuilderRef Builder,
+                                                 LLVMMetadataRef Count,
+                                                 LLVMMetadataRef Low,
+                                                 LLVMMetadataRef High, 
+                                                 LLVMMetadataRef Stride);
+
+/**
  * Create an array of DI Nodes.
  * \param Builder        The DIBuilder.
  * \param Data           The DI Node elements.

--- a/llvm/lib/IR/DebugInfo.cpp
+++ b/llvm/lib/IR/DebugInfo.cpp
@@ -1936,6 +1936,14 @@ LLVMMetadataRef LLVMDIBuilderCreateParameterVariable(
                   map_from_llvmDIFlags(Flags)));
 }
 
+LLVMMetadataRef LLVMDIBuilderGetOrCreateSubrange2(LLVMDIBuilderRef Builder,
+                                                 LLVMMetadataRef Count,
+                                                 LLVMMetadataRef Low,
+                                                 LLVMMetadataRef High, 
+                                                 LLVMMetadataRef Stride) {
+  return wrap(unwrap(Builder)->getOrCreateSubrange(unwrap(Count), unwrap(Low), unwrap(High), unwrap(Stride)));
+}
+
 LLVMMetadataRef LLVMDIBuilderGetOrCreateSubrange(LLVMDIBuilderRef Builder,
                                                  int64_t Lo, int64_t Count) {
   return wrap(unwrap(Builder)->getOrCreateSubrange(Lo, Count));


### PR DESCRIPTION
Right now, the only 2 ways to create a subrange for Dwarf is by using `LLVMDIBuilderGetOrCreateSubrange` or `LLVMDIBuilderCreateSubrangeType`

**LLVMDIBuilderGetOrCreateSubrange**
Simple usage, allows setting for DW_AT_Count. But allows literal values only. No Dwarf-Expressions.

**LLVMDIBuilderCreateSubrangeType**
More control, a bit more (maybe too?) complex for basic scenarious. Supports Dwarf-Expressions but allows for Low/High-Bound only. Which means any count based expressions need to adjust by 1, too.

For this reason, I'd like to introduce `LLVMDIBuilderCreateSubrangeType2`. It leverages an overload that's already there and exposes proper Dwarf-Expression support for basic needs without getting to complicated.

