### PR TITLE
Fix bazel build for libc:__support_fputil_fenv_impl

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -3147,6 +3147,7 @@ libc_support_library(
         ":hdr_fenv_macros",
         ":hdr_math_macros",
         ":hdr_stdint_proxy",
+        ":string_memory_utils",
         ":types_fenv_t",
     ],
 )


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/pull/192079 (commit 041300fa0515) by adding missing dependency.