### PR TITLE
[clang-repl] Support XDG state directory for history

### DIFF
--- a/llvm/lib/LineEditor/LineEditor.cpp
+++ b/llvm/lib/LineEditor/LineEditor.cpp
@@ -10,7 +10,9 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Config/config.h"
+#include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
+#include "llvm/Support/Process.h"
 #include "llvm/Support/raw_ostream.h"
 #include <algorithm>
 #include <cassert>
@@ -24,11 +26,30 @@ using namespace llvm;
 
 std::string LineEditor::getDefaultHistoryPath(StringRef ProgName) {
   SmallString<32> Path;
-  if (sys::path::home_directory(Path)) {
-    sys::path::append(Path, "." + ProgName + "-history");
-    return std::string(Path);
+  if (!sys::path::home_directory(Path))
+    return std::string();
+
+#ifdef __linux__
+  SmallString<32> LegacyPath(Path);
+  sys::path::append(LegacyPath, "." + ProgName + "-history");
+
+  if (sys::fs::exists(LegacyPath))
+    return std::string(LegacyPath);
+
+  if (auto StateHome = sys::Process::GetEnv("XDG_STATE_HOME")) {
+    Path = *StateHome;
+  } else {
+    sys::path::append(Path, ".local", "state");
   }
-  return std::string();
+
+  (void)sys::fs::create_directories(Path);
+
+  sys::path::append(Path, ProgName + "-history");
+  return std::string(Path);
+#else
+  sys::path::append(Path, "." + ProgName + "-history");
+  return std::string(Path);
+#endif
 }
 
 LineEditor::CompleterConcept::~CompleterConcept() = default;

--- a/llvm/unittests/LineEditor/LineEditor.cpp
+++ b/llvm/unittests/LineEditor/LineEditor.cpp
@@ -80,3 +80,84 @@ TEST_F(LineEditorTest, ListCompleters) {
   EXPECT_EQ(LineEditor::CompletionAction::AK_Insert, CA.Kind);
   EXPECT_EQ("f", CA.Text);
 }
+
+
+#ifdef __linux__
+
+#include <cstdlib>
+
+TEST(LineEditorDefaultHistoryPath, DefaultHistoryPathUsesXDGStateHome) {
+  SmallString<128> TempDir;
+  ASSERT_FALSE(sys::fs::createUniqueDirectory("xdg-state", TempDir));
+
+  setenv("XDG_STATE_HOME", TempDir.c_str(), 1);
+
+  std::string Path = LineEditor::getDefaultHistoryPath("clang-repl");
+
+  EXPECT_EQ((TempDir + "/clang-repl-history").str().str(), Path);
+
+  unsetenv("XDG_STATE_HOME");
+  sys::fs::remove_directories(TempDir);
+}
+
+#endif
+
+#ifdef __linux__
+
+TEST(LineEditorDefaultHistoryPath, ExistingLegacyHistoryTakesPrecedence) {
+  SmallString<128> HomeDir;
+  ASSERT_FALSE(sys::fs::createUniqueDirectory("lineeditor-home", HomeDir));
+
+  SmallString<128> Legacy(HomeDir);
+  sys::path::append(Legacy, ".clang-repl-history");
+
+  std::error_code EC;
+  raw_fd_ostream OS(Legacy, EC);
+  ASSERT_FALSE(EC);
+  OS.close();
+
+  setenv("HOME", HomeDir.c_str(), 1);
+
+  SmallString<128> XDGDir;
+  ASSERT_FALSE(sys::fs::createUniqueDirectory("xdg-state", XDGDir));
+  setenv("XDG_STATE_HOME", XDGDir.c_str(), 1);
+
+  EXPECT_EQ(Legacy.str(), LineEditor::getDefaultHistoryPath("clang-repl"));
+
+  unsetenv("HOME");
+  unsetenv("XDG_STATE_HOME");
+  sys::fs::remove_directories(HomeDir);
+  sys::fs::remove_directories(XDGDir);
+}
+
+#endif
+
+#ifdef __linux__
+
+TEST(LineEditorDefaultHistoryPath, ExistingLegacyHistoryTakesPrecedence) {
+  SmallString<128> HomeDir;
+  ASSERT_FALSE(sys::fs::createUniqueDirectory("lineeditor-home", HomeDir));
+
+  SmallString<128> Legacy(HomeDir);
+  sys::path::append(Legacy, ".clang-repl-history");
+
+  std::error_code EC;
+  raw_fd_ostream OS(Legacy, EC);
+  ASSERT_FALSE(EC);
+  OS.close();
+
+  setenv("HOME", HomeDir.c_str(), 1);
+
+  SmallString<128> XDGDir;
+  ASSERT_FALSE(sys::fs::createUniqueDirectory("xdg-state", XDGDir));
+  setenv("XDG_STATE_HOME", XDGDir.c_str(), 1);
+
+  EXPECT_EQ(Legacy.str(), LineEditor::getDefaultHistoryPath("clang-repl"));
+
+  unsetenv("HOME");
+  unsetenv("XDG_STATE_HOME");
+  sys::fs::remove_directories(HomeDir);
+  sys::fs::remove_directories(XDGDir);
+}
+
+#endif


### PR DESCRIPTION
## Summary

On Linux, `clang-repl` currently stores its history in `~/.clang-repl-history`. This change adds support for the XDG Base Directory specification by using `XDG_STATE_HOME` for new history files while preserving existing user history.

### Behavior

* Continue using `~/.clang-repl-history` if it already exists.
* Otherwise, use `$XDG_STATE_HOME/clang-repl-history` when `XDG_STATE_HOME` is set.
* Fall back to `~/.local/state/clang-repl-history` when `XDG_STATE_HOME` is unset.
* Create the state directory if needed.

### Testing

* Added a regression test for `XDG_STATE_HOME`.
* Added a regression test to verify that an existing legacy history file takes precedence over the XDG location.

Fixes #218266

Signed-off-by: rohan rohanpxquantum@gmail.com
