### PR TITLE
[RISCV] Consistently use RISCVSubtarget::is64Bit() instead of isRV32/isRV64.

### DIFF
--- a/llvm/lib/Target/RISCV/GISel/RISCVInstructionSelector.cpp
+++ b/llvm/lib/Target/RISCV/GISel/RISCVInstructionSelector.cpp
@@ -1361,9 +1361,9 @@ bool RISCVInstructionSelector::select(MachineInstr &MI) {
     // Use sext.h/zext.h for i16 with Zbb.
     if (SrcSize == 16 &&
         (STI.hasStdExtZbb() || (!IsSigned && STI.hasStdExtZbkb()))) {
-      MI.setDesc(TII.get(IsSigned       ? RISCV::SEXT_H
-                         : STI.isRV64() ? RISCV::ZEXT_H_RV64
-                                        : RISCV::ZEXT_H_RV32));
+      MI.setDesc(TII.get(IsSigned        ? RISCV::SEXT_H
+                         : STI.is64Bit() ? RISCV::ZEXT_H_RV64
+                                         : RISCV::ZEXT_H_RV32));
       constrainSelectedInstRegOperands(MI, TII, TRI, RBI);
       return true;
     }

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -4808,7 +4808,7 @@ static SDValue lowerBUILD_VECTOR(SDValue Op, SelectionDAG &DAG,
 
   SDLoc DL(Op);
 
-  if (Subtarget.isRV32() && Subtarget.hasStdExtP()) {
+  if (!Subtarget.is64Bit() && Subtarget.hasStdExtP()) {
     if (VT == MVT::v2i16) {
       SDValue Lo = DAG.getBitcast(
           MVT::v2i16,

--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.cpp
@@ -544,7 +544,7 @@ void RISCVInstrInfo::copyPhysReg(MachineBasicBlock &MBB,
   }
 
   if (RISCV::GPRPairRegClass.contains(DstReg, SrcReg)) {
-    if (STI.isRV32()) {
+    if (!STI.is64Bit()) {
       if (STI.hasStdExtZdinx()) {
         // On RV32_Zdinx, FMV.D will move a pair of registers to another pair of
         // registers, in one instruction.

--- a/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.cpp
@@ -262,8 +262,7 @@ InstructionCost RISCVTTIImpl::getIntImmCostInst(unsigned Opcode, unsigned Idx,
     if (Imm == UINT64_C(0xffff) && ST->hasStdExtZbb())
       return TTI::TCC_Free;
     // zext.w
-    if (Imm == UINT64_C(0xffffffff) &&
-        ((ST->hasStdExtZba() && ST->isRV64()) || ST->isRV32()))
+    if (Imm == UINT64_C(0xffffffff) && (!ST->is64Bit() || ST->hasStdExtZba()))
       return TTI::TCC_Free;
     // bclri
     if (ST->hasStdExtZbs() && (~Imm).isPowerOf2())


### PR DESCRIPTION
99% of code uses RISCVSubtarget::is64Bit().

Maybe we should consider removing is64Bit(), and using isRV64() instead but right now I think we should be consistent.