### PR TITLE
[clang][Modules] Add explicit PrivateModuleFragmentDecl AST node

### DIFF
--- a/clang/include/clang/AST/Decl.h
+++ b/clang/include/clang/AST/Decl.h
@@ -5309,6 +5309,49 @@ public:
   }
 };
 
+/// Represents the private module fragment of a module unit.
+///
+/// For example:
+/// \code
+///   export module A;
+///   ...
+///   module :private;   // <- this fragment
+///   int internal_only();
+/// \endcode
+class PrivateModuleFragmentDecl final : public Decl {
+  Module *Fragment;
+  SourceLocation PrivateLoc;
+
+  PrivateModuleFragmentDecl(DeclContext *DC, SourceLocation ModuleLoc,
+                            SourceLocation PrivateLoc, Module *Fragment)
+      : Decl(PrivateModuleFragment, DC, ModuleLoc), Fragment(Fragment),
+        PrivateLoc(PrivateLoc) {}
+  PrivateModuleFragmentDecl(EmptyShell Empty)
+      : Decl(PrivateModuleFragment, Empty) {}
+
+public:
+  static PrivateModuleFragmentDecl *Create(ASTContext &C, DeclContext *DC,
+                                           SourceLocation ModuleLoc,
+                                           SourceLocation PrivateLoc,
+                                           Module *Fragment) {
+    return new (C, DC)
+        PrivateModuleFragmentDecl(DC, ModuleLoc, PrivateLoc, Fragment);
+  }
+  static PrivateModuleFragmentDecl *CreateDeserialized(ASTContext &C,
+                                                       GlobalDeclID ID);
+
+  Module *getFragment() const { return Fragment; }
+  SourceLocation getPrivateLoc() const { return PrivateLoc; }
+  void setPrivateLoc(SourceLocation Loc) { PrivateLoc = Loc; }
+  void setFragment(Module *Frag) { Fragment = Frag; }
+  SourceRange getSourceRange() const override LLVM_READONLY {
+    return SourceRange(getLocation(), PrivateLoc);
+  }
+  static bool classof(const Decl *D) {
+    return D->getKind() == Decl::PrivateModuleFragment;
+  }
+};
+
 /// Represents an empty-declaration.
 class EmptyDecl : public Decl {
   EmptyDecl(DeclContext *DC, SourceLocation L) : Decl(Empty, DC, L) {}

--- a/clang/include/clang/AST/RecursiveASTVisitor.h
+++ b/clang/include/clang/AST/RecursiveASTVisitor.h
@@ -1723,6 +1723,7 @@ DEF_TRAVERSE_DECL(FileScopeAsmDecl,
 DEF_TRAVERSE_DECL(TopLevelStmtDecl, { TRY_TO(TraverseStmt(D->getStmt())); })
 
 DEF_TRAVERSE_DECL(ImportDecl, {})
+DEF_TRAVERSE_DECL(PrivateModuleFragmentDecl, {})
 
 DEF_TRAVERSE_DECL(FriendDecl, {
   // Friend is either decl or a type.

--- a/clang/include/clang/AST/TextNodeDumper.h
+++ b/clang/include/clang/AST/TextNodeDumper.h
@@ -373,6 +373,7 @@ public:
   void VisitBindingDecl(const BindingDecl *D);
   void VisitCapturedDecl(const CapturedDecl *D);
   void VisitImportDecl(const ImportDecl *D);
+  void VisitPrivateModuleFragmentDecl(const PrivateModuleFragmentDecl *D);
   void VisitPragmaCommentDecl(const PragmaCommentDecl *D);
   void VisitPragmaDetectMismatchDecl(const PragmaDetectMismatchDecl *D);
   void VisitOMPExecutableDirective(const OMPExecutableDirective *D);

--- a/clang/include/clang/Basic/DeclNodes.td
+++ b/clang/include/clang/Basic/DeclNodes.td
@@ -107,6 +107,7 @@ def Block : DeclNode<Decl, "blocks">, DeclContext;
 def OutlinedFunction : DeclNode<Decl>, DeclContext;
 def Captured : DeclNode<Decl>, DeclContext;
 def Import : DeclNode<Decl>;
+def PrivateModuleFragment : DeclNode<Decl>;
 def OMPThreadPrivate : DeclNode<Decl>;
 def OMPGroupPrivate : DeclNode<Decl>;
 def OMPAllocate : DeclNode<Decl>;

--- a/clang/include/clang/Sema/Template.h
+++ b/clang/include/clang/Sema/Template.h
@@ -634,6 +634,7 @@ enum class TemplateSubstitutionKind : char {
 #define FILESCOPEASM(DERIVED, BASE)
 #define TOPLEVELSTMT(DERIVED, BASE)
 #define IMPORT(DERIVED, BASE)
+#define PRIVATEMODULEFRAGMENT(DERIVED, BASE)
 #define EXPORT(DERIVED, BASE)
 #define LINKAGESPEC(DERIVED, BASE)
 #define OBJCCOMPATIBLEALIAS(DERIVED, BASE)
@@ -645,10 +646,10 @@ enum class TemplateSubstitutionKind : char {
 #define EMPTY(DERIVED, BASE)
 #define LIFETIMEEXTENDEDTEMPORARY(DERIVED, BASE)
 
-// Decls which never appear inside a template.
+    // Decls which never appear inside a template.
 #define OUTLINEDFUNCTION(DERIVED, BASE)
 
-// Decls which use special-case instantiation code.
+    // Decls which use special-case instantiation code.
 #define BLOCK(DERIVED, BASE)
 #define CAPTURED(DERIVED, BASE)
 #define IMPLICITPARAM(DERIVED, BASE)

--- a/clang/include/clang/Serialization/ASTBitCodes.h
+++ b/clang/include/clang/Serialization/ASTBitCodes.h
@@ -1492,7 +1492,10 @@ enum DeclCode {
   /// An ImportDecl recording a module import.
   DECL_IMPORT,
 
-  /// An OMPThreadPrivateDecl record.
+  /// A PrivateModuleFragmentDecl record.
+  DECL_PRIVATE_MODULE_FRAGMENT,
+
+  /// An OMPThreadPrivateDecl Record.
   DECL_OMP_THREADPRIVATE,
 
   /// An OMPRequiresDecl record.

--- a/clang/lib/AST/Decl.cpp
+++ b/clang/lib/AST/Decl.cpp
@@ -6192,3 +6192,12 @@ bool clang::hasArmZT0State(const FunctionDecl *FD) {
                    FunctionType::ARM_None) ||
          (FD->hasAttr<ArmNewAttr>() && FD->getAttr<ArmNewAttr>()->isNewZT0());
 }
+
+//===----------------------------------------------------------------------===//
+// PrivateModuleFragmentDecl Implementation
+//===----------------------------------------------------------------------===//
+
+PrivateModuleFragmentDecl *
+PrivateModuleFragmentDecl::CreateDeserialized(ASTContext &C, GlobalDeclID ID) {
+  return new (C, ID) PrivateModuleFragmentDecl(EmptyShell());
+}

--- a/clang/lib/AST/DeclBase.cpp
+++ b/clang/lib/AST/DeclBase.cpp
@@ -986,6 +986,7 @@ unsigned Decl::getIdentifierNamespaceForKind(Kind DeclKind) {
     case Friend:
     case FriendTemplate:
     case AccessSpec:
+    case PrivateModuleFragment:
     case LinkageSpec:
     case Export:
     case FileScopeAsm:

--- a/clang/lib/AST/DeclPrinter.cpp
+++ b/clang/lib/AST/DeclPrinter.cpp
@@ -78,6 +78,7 @@ namespace {
     void VisitFileScopeAsmDecl(FileScopeAsmDecl *D);
     void VisitTopLevelStmtDecl(TopLevelStmtDecl *D);
     void VisitImportDecl(ImportDecl *D);
+    void VisitPrivateModuleFragmentDecl(PrivateModuleFragmentDecl *D);
     void VisitStaticAssertDecl(StaticAssertDecl *D);
     void VisitNamespaceDecl(NamespaceDecl *D);
     void VisitUsingDirectiveDecl(UsingDirectiveDecl *D);
@@ -1063,6 +1064,10 @@ void DeclPrinter::VisitTopLevelStmtDecl(TopLevelStmtDecl *D) {
 void DeclPrinter::VisitImportDecl(ImportDecl *D) {
   Out << "@import " << D->getImportedModule()->getFullModuleName()
       << ";\n";
+}
+
+void DeclPrinter::VisitPrivateModuleFragmentDecl(PrivateModuleFragmentDecl *D) {
+  Out << "module :private;\n";
 }
 
 void DeclPrinter::VisitStaticAssertDecl(StaticAssertDecl *D) {

--- a/clang/lib/AST/TextNodeDumper.cpp
+++ b/clang/lib/AST/TextNodeDumper.cpp
@@ -2643,6 +2643,11 @@ void TextNodeDumper::VisitImportDecl(const ImportDecl *D) {
     dumpDeclRef(InitD, "initializer");
 }
 
+void TextNodeDumper::VisitPrivateModuleFragmentDecl(
+    const PrivateModuleFragmentDecl *D) {
+  OS << ' ' << D->getFragment()->getFullModuleName();
+}
+
 void TextNodeDumper::VisitPragmaCommentDecl(const PragmaCommentDecl *D) {
   OS << ' ';
   switch (D->getCommentKind()) {

--- a/clang/lib/CodeGen/CGDecl.cpp
+++ b/clang/lib/CodeGen/CGDecl.cpp
@@ -128,6 +128,7 @@ void CodeGenFunction::EmitDecl(const Decl &D, bool EvaluateConditionDecl) {
   case Decl::ExplicitInstantiation:
   case Decl::Label:        // __label__ x;
   case Decl::Import:
+  case Decl::PrivateModuleFragment:
   case Decl::MSGuid:    // __declspec(uuid("..."))
   case Decl::UnnamedGlobalConstant:
   case Decl::TemplateParamObject:

--- a/clang/lib/Parse/Parser.cpp
+++ b/clang/lib/Parse/Parser.cpp
@@ -2360,10 +2360,14 @@ Parser::ParseModuleDecl(Sema::ModuleImportState &ImportState) {
     SourceLocation PrivateLoc = ConsumeToken();
     DiagnoseAndSkipCXX11Attributes();
     ExpectAndConsumeSemi(diag::err_private_module_fragment_expected_semi);
+    auto Result = Actions.ActOnPrivateModuleFragmentDecl(ModuleLoc, PrivateLoc);
+
+    if (!Result)
+      return nullptr;
     ImportState = ImportState == Sema::ModuleImportState::ImportAllowed
                       ? Sema::ModuleImportState::PrivateFragmentImportAllowed
                       : Sema::ModuleImportState::PrivateFragmentImportFinished;
-    return Actions.ActOnPrivateModuleFragmentDecl(ModuleLoc, PrivateLoc);
+    return Result;
   }
 
   SmallVector<IdentifierLoc, 2> Path;

--- a/clang/lib/Sema/SemaModule.cpp
+++ b/clang/lib/Sema/SemaModule.cpp
@@ -565,8 +565,10 @@ Sema::ActOnPrivateModuleFragmentDecl(SourceLocation ModuleLoc,
   TU->setModuleOwnershipKind(Decl::ModuleOwnershipKind::ModulePrivate);
   TU->setLocalOwningModule(PrivateModuleFragment);
 
-  // FIXME: Consider creating an explicit representation of this declaration.
-  return nullptr;
+  auto *PMF = PrivateModuleFragmentDecl::Create(
+      Context, CurContext, ModuleLoc, PrivateLoc, PrivateModuleFragment);
+  CurContext->addDecl(PMF);
+  return ConvertDeclToDeclGroup(PMF);
 }
 
 DeclResult Sema::ActOnModuleImport(SourceLocation StartLoc,

--- a/clang/lib/Serialization/ASTCommon.cpp
+++ b/clang/lib/Serialization/ASTCommon.cpp
@@ -446,6 +446,7 @@ bool serialization::isRedeclarableDeclKind(unsigned Kind) {
   case Decl::OutlinedFunction:
   case Decl::Captured:
   case Decl::Import:
+  case Decl::PrivateModuleFragment:
   case Decl::OMPThreadPrivate:
   case Decl::OMPGroupPrivate:
   case Decl::OMPAllocate:

--- a/clang/lib/Serialization/ASTReaderDecl.cpp
+++ b/clang/lib/Serialization/ASTReaderDecl.cpp
@@ -402,6 +402,7 @@ public:
   void VisitTopLevelStmtDecl(TopLevelStmtDecl *D);
   void VisitImportDecl(ImportDecl *D);
   void VisitAccessSpecDecl(AccessSpecDecl *D);
+  void VisitPrivateModuleFragmentDecl(PrivateModuleFragmentDecl *D);
   void VisitFriendDecl(FriendDecl *D);
   void VisitFriendTemplateDecl(FriendTemplateDecl *D);
   void VisitStaticAssertDecl(StaticAssertDecl *D);
@@ -2397,6 +2398,13 @@ void ASTDeclReader::VisitImportDecl(ImportDecl *D) {
   Record.skipInts(1); // The number of stored source locations.
 }
 
+void ASTDeclReader::VisitPrivateModuleFragmentDecl(
+    PrivateModuleFragmentDecl *D) {
+  VisitDecl(D);
+  D->setFragment(readModule());
+  D->setPrivateLoc(readSourceLocation());
+}
+
 void ASTDeclReader::VisitAccessSpecDecl(AccessSpecDecl *D) {
   VisitDecl(D);
   D->setColonLoc(readSourceLocation());
@@ -4277,6 +4285,9 @@ Decl *ASTReader::ReadDeclRecord(GlobalDeclID ID) {
     // Note: last entry of the ImportDecl record is the number of stored source
     // locations.
     D = ImportDecl::CreateDeserialized(Context, ID, Record.back());
+    break;
+  case DECL_PRIVATE_MODULE_FRAGMENT:
+    D = PrivateModuleFragmentDecl::CreateDeserialized(Context, ID);
     break;
   case DECL_OMP_THREADPRIVATE: {
     Record.skipInts(1);

--- a/clang/lib/Serialization/ASTWriterDecl.cpp
+++ b/clang/lib/Serialization/ASTWriterDecl.cpp
@@ -140,6 +140,7 @@ namespace clang {
     void VisitFileScopeAsmDecl(FileScopeAsmDecl *D);
     void VisitTopLevelStmtDecl(TopLevelStmtDecl *D);
     void VisitImportDecl(ImportDecl *D);
+    void VisitPrivateModuleFragmentDecl(PrivateModuleFragmentDecl *D);
     void VisitAccessSpecDecl(AccessSpecDecl *D);
     void VisitFriendDecl(FriendDecl *D);
     void VisitFriendTemplateDecl(FriendTemplateDecl *D);
@@ -1828,6 +1829,13 @@ void ASTDeclWriter::VisitAccessSpecDecl(AccessSpecDecl *D) {
   VisitDecl(D);
   Record.AddSourceLocation(D->getColonLoc());
   Code = serialization::DECL_ACCESS_SPEC;
+}
+void ASTDeclWriter::VisitPrivateModuleFragmentDecl(
+    PrivateModuleFragmentDecl *D) {
+  VisitDecl(D);
+  Record.push_back(Writer.getSubmoduleID(D->getFragment()));
+  Record.AddSourceLocation(D->getPrivateLoc());
+  Code = serialization::DECL_PRIVATE_MODULE_FRAGMENT;
 }
 
 void ASTDeclWriter::VisitFriendDecl(FriendDecl *D) {

--- a/clang/test/AST/ast-dump-private-module-fragment.cppm
+++ b/clang/test/AST/ast-dump-private-module-fragment.cppm
@@ -1,0 +1,12 @@
+//RUN: %clang_cc1 -std=c++20 -ast-dump %s | FileCheck %s
+
+export module A;
+
+int inTheInterface();
+// CHECK: FunctionDecl 0x{{[0-9a-f]+}} <{{.*}}> {{.*}}inTheInterface 'int ()'
+
+module :private;
+// CHECK: PrivateModuleFragmentDecl 0x{{[0-9a-f]+}} <{{.*}}>
+
+int inThePrivateFragment();
+// CHECK: FunctionDecl 0x{{[0-9a-f]+}} <{{.*}}> {{.*}}inThePrivateFragment 'int ()'

--- a/clang/test/Modules/mismatched_global_module_state.cppm
+++ b/clang/test/Modules/mismatched_global_module_state.cppm
@@ -1,0 +1,5 @@
+// RUN: %clang_cc1 --std=c++23 -fsyntax-only -verify %s
+// see ISSUE 219950 and PR 223044
+module;
+module :private; // expected-error {{private module fragment declaration with no preceding module declaration}}
+export module Foo;

--- a/clang/tools/libclang/CIndex.cpp
+++ b/clang/tools/libclang/CIndex.cpp
@@ -7299,6 +7299,7 @@ CXCursor clang_getCursorDefinition(CXCursor C) {
   case Decl::Label: // FIXME: Is this right??
   case Decl::CXXDeductionGuide:
   case Decl::Import:
+  case Decl::PrivateModuleFragment:
   case Decl::OMPThreadPrivate:
   case Decl::OMPGroupPrivate:
   case Decl::OMPAllocate:


### PR DESCRIPTION
in #219950 
this code
```cpp
module;
module :private;
export module Foo;
```
a Private module fragment here is illegal because it can only be declared in a primary module interface unit, instead of raising an error clang crashed because of this assertion
```cpp
  assert((!getLangOpts().CPlusPlusModules ||
          SeenGMF == (bool)this->TheGlobalModuleFragment) &&
         "mismatched global module state");
``` 
the mismatch happened because `ParseModuleDecl`  assigned ImporState wether or not it was semantically correct:
```cpp
 ImportState = ImportState == Sema::ModuleImportState::ImportAllowed
                      ? Sema::ModuleImportState::PrivateFragmentImportAllowed
                      : Sema::ModuleImportState::PrivateFragmentImportFinished;
    return Actions.ActOnPrivateModuleFragmentDecl(ModuleLoc, PrivateLoc);
  }
```
Also `ActOnPrivateModuleFragmentDecl` was returning `nullptr` in both failure and success cases. 
it also had a fixme:   `// FIXME: Consider creating an explicit representation of this declaration.`

I created: `PrivateModuleFragmentDecl` as that explicit representation and assigned `ImporState` only if `ActOnPrivateModuleFragmentDecl` returned a valid `PrivateModuleFragmentDecl`.

Fixes #219950