### PR TITLE
[lldb] Test undefined return addresses in signal frames

### DIFF
--- a/lldb/test/Shell/Unwind/Inputs/signal-frame-undefined-ra.s
+++ b/lldb/test/Shell/Unwind/Inputs/signal-frame-undefined-ra.s
@@ -1,0 +1,19 @@
+        .att_syntax
+        .text
+        .globl  asm_main
+asm_main:
+        .cfi_startproc
+        callq   terminal
+        xorl    %eax, %eax
+        retq
+        .cfi_endproc
+
+        .globl  terminal
+terminal:
+        .cfi_startproc
+        .cfi_signal_frame
+        .cfi_def_cfa %rsp, 8
+        .cfi_undefined %rip
+        int3
+        retq
+        .cfi_endproc

--- a/lldb/test/Shell/Unwind/signal-frame-undefined-ra.test
+++ b/lldb/test/Shell/Unwind/signal-frame-undefined-ra.test
@@ -1,0 +1,18 @@
+# Test that an undefined return address terminates a signal frame without
+# creating a caller.
+
+# UNSUPPORTED: system-windows
+# REQUIRES: target-x86_64, native
+
+# RUN: %clang_host %p/Inputs/call-asm.c %p/Inputs/signal-frame-undefined-ra.s -o %t
+# RUN: %lldb %t -s %s -o exit | FileCheck %s
+
+breakpoint set -n terminal
+# CHECK: Breakpoint 1: where = {{.*}}`terminal
+
+process launch
+# CHECK: stop reason = breakpoint 1.1
+
+thread backtrace -u
+# CHECK: frame #0: {{.*}}`terminal
+# CHECK-NOT: frame #1:


### PR DESCRIPTION
Signal-frame CFI can explicitly mark its return-address register undefined to represent a terminal synthetic context.  This is useful for contexts such as newly created FreeBSD kernel threads that do not have an interrupted caller.

Verify that LLDB keeps the signal frame in the backtrace and terminates the unwind without creating a caller.

Assisted-by: GPT