### PR TITLE
Fix bazel build for libc/test/UnitTest:string_utils

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/test/UnitTest/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/UnitTest/BUILD.bazel
@@ -180,7 +180,10 @@ libc_test_library(
     deps = [
         "//libc:__support_big_int",
         "//libc:__support_cpp_string",
+        "//libc:__support_cpp_string_view",
         "//libc:__support_cpp_type_traits",
         "//libc:__support_macros_config",
+        "//libc:__support_macros_properties_types",
+        "//libc:__support_wchar_string_converter",
     ],
 )


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/pull/222988 (commit 18db3eee9d04) by adding missing dependencies.