### PR TITLE
[SLP] Fix -Wunused-lambda-capture in #223016

### DIFF
--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -33449,11 +33449,7 @@ bool SLPVectorizerPass::vectorizeNonVectorizableInsts(
   constexpr unsigned Limit = 32;
   Changed |= tryToVectorizeSequence<Value>(
       Operands, OperandSorter, AreCompatibleOperands,
-      [this, &R, Limit](ArrayRef<Value *> Candidates, bool MaxVFOnly) {
-        // We are required to capture Limit for MSVC, but clang will warn that
-        // it is an unused lambda capture. We cannot mark it [[maybe_unused]],
-        // so we are forced to cast to void;
-        (void)Limit;
+      [this, &R, Limit=Limit](ArrayRef<Value *> Candidates, bool MaxVFOnly) {
         // Limit to StandaloneSeeds if !MaxVFOnly to avoid quadratic scan for
         // large set of candidates.
         return tryToVectorizeList(Candidates, R, MaxVFOnly,

--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -33450,6 +33450,10 @@ bool SLPVectorizerPass::vectorizeNonVectorizableInsts(
   Changed |= tryToVectorizeSequence<Value>(
       Operands, OperandSorter, AreCompatibleOperands,
       [this, &R, Limit](ArrayRef<Value *> Candidates, bool MaxVFOnly) {
+        // We are required to capture Limit for MSVC, but clang will warn that
+        // it is an unused lambda capture. We cannot mark it [[maybe_unused]],
+        // so we are forced to cast to void;
+        (void)Limit;
         // Limit to StandaloneSeeds if !MaxVFOnly to avoid quadratic scan for
         // large set of candidates.
         return tryToVectorizeList(Candidates, R, MaxVFOnly,

--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -33449,7 +33449,7 @@ bool SLPVectorizerPass::vectorizeNonVectorizableInsts(
   constexpr unsigned Limit = 32;
   Changed |= tryToVectorizeSequence<Value>(
       Operands, OperandSorter, AreCompatibleOperands,
-      [this, &R, Limit=Limit](ArrayRef<Value *> Candidates, bool MaxVFOnly) {
+      [this, &R, Limit = Limit](ArrayRef<Value *> Candidates, bool MaxVFOnly) {
         // Limit to StandaloneSeeds if !MaxVFOnly to avoid quadratic scan for
         // large set of candidates.
         return tryToVectorizeList(Candidates, R, MaxVFOnly,

--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -33446,10 +33446,10 @@ bool SLPVectorizerPass::vectorizeNonVectorizableInsts(
   }
   if (Operands.size() <= 1)
     return Changed;
-  constexpr unsigned Limit = 32;
   Changed |= tryToVectorizeSequence<Value>(
       Operands, OperandSorter, AreCompatibleOperands,
-      [this, &R, Limit = Limit](ArrayRef<Value *> Candidates, bool MaxVFOnly) {
+      [this, &R](ArrayRef<Value *> Candidates, bool MaxVFOnly) {
+        constexpr unsigned Limit = 32;
         // Limit to StandaloneSeeds if !MaxVFOnly to avoid quadratic scan for
         // large set of candidates.
         return tryToVectorizeList(Candidates, R, MaxVFOnly,


### PR DESCRIPTION
Clang will warn on this despite this being required for MSVC, so add a workaround for now.