### PR TITLE
[Vectorize] Fix a warning

### DIFF
--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -33446,10 +33446,10 @@ bool SLPVectorizerPass::vectorizeNonVectorizableInsts(
   }
   if (Operands.size() <= 1)
     return Changed;
-  constexpr unsigned Limit = 32;
   Changed |= tryToVectorizeSequence<Value>(
       Operands, OperandSorter, AreCompatibleOperands,
-      [this, &R, Limit](ArrayRef<Value *> Candidates, bool MaxVFOnly) {
+      [this, &R](ArrayRef<Value *> Candidates, bool MaxVFOnly) {
+        constexpr unsigned Limit = 32;
         // Limit to StandaloneSeeds if !MaxVFOnly to avoid quadratic scan for
         // large set of candidates.
         return tryToVectorizeList(Candidates, R, MaxVFOnly,


### PR DESCRIPTION
This patch fixes:

  llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp:33452:18: error:
  lambda capture 'Limit' is not required to be captured for this use
  [-Werror,-Wunused-lambda-capture]
