### PR TITLE
[IR] Make verify<domtree> work in non-asserts builds

### DIFF
--- a/llvm/lib/IR/Dominators.cpp
+++ b/llvm/lib/IR/Dominators.cpp
@@ -25,6 +25,8 @@
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Compiler.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/GenericDomTreeConstruction.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -353,8 +355,9 @@ PreservedAnalyses DominatorTreePrinterPass::run(Function &F,
 PreservedAnalyses DominatorTreeVerifierPass::run(Function &F,
                                                  FunctionAnalysisManager &AM) {
   auto &DT = AM.getResult<DominatorTreeAnalysis>(F);
-  assert(DT.verify());
-  (void)DT;
+  if (!DT.verify())
+    reportFatalInternalError(createStringError(
+        "verify<domtree> detected an invalid dominator tree"));
   return PreservedAnalyses::all();
 }
 


### PR DESCRIPTION
It doesn't make sense to lose this test coverage in non-assert builds, and I would expect a release build of opt to have a working verify<domtree> pass. This also better matches the behavior of the other verify<*> passes.