### PR TITLE
[Flang/CI] Hotfix of flang/test/Driver/flang-f-opts.f90.

### DIFF
--- a/flang/test/Driver/flang-f-opts.f90
+++ b/flang/test/Driver/flang-f-opts.f90
@@ -68,8 +68,6 @@
 ! RUN:     -fexpensive-optimizations                                        \
 ! RUN:     -fno-expensive-optimizations                                     \
 ! RUN:     -fno-defer-pop                                                   \
-! RUN:     -fkeep-inline-functions                                          \
-! RUN:     -fno-keep-inline-functions                                       \
 ! RUN:     -freorder-blocks                                                 \
 ! RUN:     -ffloat-store                                                    \
 ! RUN:     -fgcse                                                           \
@@ -122,8 +120,6 @@
 ! CHECK-WARNING-DAG: optimization flag '-fexpensive-optimizations' is not supported
 ! CHECK-WARNING-DAG: optimization flag '-fno-expensive-optimizations' is not supported
 ! CHECK-WARNING-DAG: optimization flag '-fno-defer-pop' is not supported
-! CHECK-WARNING-DAG: optimization flag '-fkeep-inline-functions' is not supported
-! CHECK-WARNING-DAG: optimization flag '-fno-keep-inline-functions' is not supported
 ! CHECK-WARNING-DAG: optimization flag '-freorder-blocks' is not supported
 ! CHECK-WARNING-DAG: optimization flag '-ffloat-store' is not supported
 ! CHECK-WARNING-DAG: optimization flag '-fgcse' is not supported


### PR DESCRIPTION
The test started failing in Flang CI after #218533. This is just a hotfix.