### PR TITLE
[mlir][Cpp] Stop using Operation::getAttrs

### DIFF
--- a/mlir/lib/Target/Cpp/TranslateToCpp.cpp
+++ b/mlir/lib/Target/Cpp/TranslateToCpp.cpp
@@ -1836,9 +1836,10 @@ CppEmitter::emitOperandsAndAttributes(Operation &op,
                                       ArrayRef<StringRef> exclude) {
   if (failed(emitOperands(op)))
     return failure();
+  auto attrs = op.getDiscardableAttrs();
   // Insert comma in between operands and non-filtered attributes if needed.
   if (op.getNumOperands() > 0) {
-    for (NamedAttribute attr : op.getAttrs()) {
+    for (NamedAttribute attr : attrs) {
       if (!llvm::is_contained(exclude, attr.getName().strref())) {
         os << ", ";
         break;
@@ -1854,7 +1855,7 @@ CppEmitter::emitOperandsAndAttributes(Operation &op,
       return failure();
     return success();
   };
-  return interleaveCommaWithError(op.getAttrs(), os, emitNamedAttribute);
+  return interleaveCommaWithError(attrs, os, emitNamedAttribute);
 }
 
 LogicalResult CppEmitter::emitVariableAssignment(OpResult result) {


### PR DESCRIPTION
Only discardable attributes on multi-result func.return operations are C++ tuple arguments; the operation has no inherent attributes relevant to the translation.

This is part of a general migration to use the "new" properties-based APIs and stop mixing discardable/inherent attributes, see #155475

Assisted-by: Codex