### PR TITLE
[Clang][MinGW] Link default-manifest.o if exists

### DIFF
--- a/clang/lib/Driver/ToolChains/MinGW.cpp
+++ b/clang/lib/Driver/ToolChains/MinGW.cpp
@@ -378,6 +378,11 @@ void tools::MinGW::Linker::ConstructJob(Compilation &C, const JobAction &JA,
       // Add crtfastmath.o if available and fast math is enabled.
       TC.addFastMathRuntimeIfAvailable(Args, CmdArgs);
 
+      if (!Args.hasArg(options::OPT_mdll, options::OPT_shared)) {
+        if (auto O = TC.GetFilePathIfExists("default-manifest.o"))
+          CmdArgs.push_back(Args.MakeArgString(std::move(*O)));
+      }
+
       CmdArgs.push_back(Args.MakeArgString(TC.GetFilePath("crtend.o")));
     }
   }

--- a/clang/test/Driver/mingw.cpp
+++ b/clang/test/Driver/mingw.cpp
@@ -106,3 +106,13 @@
 // CHECK_MINGW_NOLIBC-NOT: "-lmsvcrt"
 // CHECK_MINGW_NOLIBC-NOT: "-lshell32"
 // CHECK_MINGW_NOLIBC-NOT: "-luser32"
+
+// RUN: %clang --target=i686-pc-windows-gnu -### --sysroot=%S/Inputs/mingw_msys2_tree/msys64/mingw32 %s 2>&1 | FileCheck %s --check-prefix=CHECK_MINGW_MANIFEST_PROVIDED
+// CHECK_MINGW_MANIFEST_PROVIDED: "{{[^"]+}}/Inputs/mingw_msys2_tree/msys64/mingw32{{/|\\\\}}lib{{/|\\\\}}default-manifest.o"
+
+// RUN: %clang --target=i686-pc-windows-gnu -### --sysroot=%S/Inputs/mingw_msys2_tree/msys64/mingw32 %s -mdll 2>&1 | FileCheck %s --check-prefix=CHECK_MINGW_MANIFEST_UNUSED_FOR_DLL
+// RUN: %clang --target=i686-pc-windows-gnu -### --sysroot=%S/Inputs/mingw_msys2_tree/msys64/mingw32 %s -shared 2>&1 | FileCheck %s --check-prefix=CHECK_MINGW_MANIFEST_UNUSED_FOR_DLL
+// CHECK_MINGW_MANIFEST_UNUSED_FOR_DLL-NOT: default-manifest
+
+// RUN: %clang --target=x86_64-pc-windows-gnu -### --sysroot=%S/Inputs/mingw_arch_tree %s 2>&1 | FileCheck %s --check-prefix=CHECK_MINGW_MANIFEST_ABSENT
+// CHECK_MINGW_MANIFEST_ABSENT-NOT: default-manifest


### PR DESCRIPTION
Some MinGW distributions provide a pre-compiled manifest xml to disable the UAC escalation dialog.
Link automatically the manifest only if it exists when linking an executable.
Do the same as Cygwin (#220875) and align with GCC.