### PR TITLE
[LLDB] fix a crash when dealing with prefix-remapped sysroot attributes

### DIFF
--- a/lldb/include/lldb/Utility/XcodeSDK.h
+++ b/lldb/include/lldb/Utility/XcodeSDK.h
@@ -64,10 +64,12 @@ public:
   /// directory component of a path one would pass to clang's -isysroot
   /// parameter. For example, "MacOSX.10.14.sdk".
   XcodeSDK(std::string &&name) : m_name(std::move(name)) {}
+  /// Initialize an XcodeSDK object with an SDK name and the sysroot the SDK
+  /// was used from. The sysroot is not necessarily a path to the SDK named by
+  /// \c name: a compiler may record a sysroot that was remapped, for example
+  /// with -fdebug-prefix-map.
   XcodeSDK(std::string name, FileSpec sysroot)
-      : m_name(std::move(name)), m_sysroot(std::move(sysroot)) {
-    assert(!m_sysroot || m_name == m_sysroot.GetFilename());
-  }
+      : m_name(std::move(name)), m_sysroot(std::move(sysroot)) {}
   static XcodeSDK GetAnyMacOS() { return XcodeSDK("MacOSX.sdk"); }
 
   /// The merge function follows a strict order to maintain monotonicity:

--- a/lldb/source/Utility/XcodeSDK.cpp
+++ b/lldb/source/Utility/XcodeSDK.cpp
@@ -155,6 +155,10 @@ bool XcodeSDK::Info::operator==(const Info &other) const {
 }
 
 void XcodeSDK::Merge(const XcodeSDK &other) {
+  auto add_internal_sdk_suffix = [](llvm::StringRef sdk) {
+    return (sdk.substr(0, sdk.size() - 3) + "Internal.sdk").str();
+  };
+
   // The "bigger" SDK always wins.
   auto l = Parse();
   auto r = other.Parse();
@@ -163,15 +167,19 @@ void XcodeSDK::Merge(const XcodeSDK &other) {
   else {
     // The Internal flag always wins.
     if (!l.internal && r.internal) {
-      if (llvm::StringRef(m_name).ends_with(".sdk"))
-        m_name =
-            m_name.substr(0, m_name.size() - 3) + std::string("Internal.sdk");
+      if (llvm::StringRef(m_name).ends_with(".sdk")) {
+        m_name = add_internal_sdk_suffix(m_name);
+
+        // The internal SDK is a sibling of the public one, so the sysroot can
+        // be renamed along with the SDK. Leave a sysroot that doesn't name an
+        // SDK directory alone: the compiler may have remapped it, in which
+        // case it is only meaningful verbatim.
+        if (m_sysroot.GetFileNameExtension() == ".sdk")
+          m_sysroot.SetFilename(
+              add_internal_sdk_suffix(m_sysroot.GetFilename()));
+      }
     }
   }
-
-  // We changed the SDK name. Adjust the sysroot accordingly.
-  if (m_sysroot && m_sysroot.GetFilename() != m_name)
-    m_sysroot.SetFilename(m_name);
 }
 
 std::string XcodeSDK::GetCanonicalName(XcodeSDK::Info info) {

--- a/lldb/unittests/SymbolFile/DWARF/XcodeSDKModuleTests.cpp
+++ b/lldb/unittests/SymbolFile/DWARF/XcodeSDKModuleTests.cpp
@@ -212,6 +212,76 @@ DWARF:
   llvm::consumeError(path_or_err.takeError());
 }
 
+TEST_F(XcodeSDKModuleTests, TestSDKPathFromDebugInfo_RemappedSysroot) {
+  // Tests that we can parse a CU whose DW_AT_LLVM_sysroot doesn't end in the
+  // SDK name recorded in DW_AT_APPLE_sdk. Clang produces such debug-info
+  // whenever the sysroot is subject to a -fdebug-prefix-map remapping, because
+  // it derives DW_AT_APPLE_sdk from the unremapped sysroot path. The remapped
+  // sysroot is what the source path mappings are keyed off, so it needs to
+  // survive parsing unchanged.
+
+  const char *yamldata = R"(
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_EXEC
+  Machine: EM_386
+DWARF:
+  debug_abbrev:
+    - Table:
+        - Code:            0x00000001
+          Tag:             DW_TAG_compile_unit
+          Children:        DW_CHILDREN_no
+          Attributes:
+            - Attribute:       DW_AT_language
+              Form:            DW_FORM_data2
+            - Attribute:       DW_AT_APPLE_sdk
+              Form:            DW_FORM_string
+            - Attribute:       DW_AT_LLVM_sysroot
+              Form:            DW_FORM_string
+  debug_info:
+    - Version:         2
+      AddrSize:        8
+      AbbrevTableID:   0
+      AbbrOffset:      0x0
+      Entries:
+        - AbbrCode:        0x00000001
+          Values:
+            - Value:       0x000000000000000C
+            - CStr:        "MacOSX10.9.sdk"
+            - CStr:        "/REMAPPED_SYSROOT"
+        - AbbrCode:        0x00000000
+...
+)";
+
+  YAMLModuleTester t(yamldata);
+  DWARFUnit *dwarf_unit = t.GetDwarfUnit();
+  auto *dwarf_cu = llvm::cast<DWARFCompileUnit>(dwarf_unit);
+  ASSERT_TRUE(static_cast<bool>(dwarf_cu));
+  SymbolFileDWARF &sym_file = dwarf_cu->GetSymbolFileDWARF();
+  CompUnitSP comp_unit = sym_file.GetCompileUnitAtIndex(0);
+  ASSERT_TRUE(static_cast<bool>(comp_unit.get()));
+
+  XcodeSDK cu_sdk = sym_file.ParseXcodeSDK(*comp_unit);
+  EXPECT_EQ(cu_sdk.GetString(), "MacOSX10.9.sdk");
+  EXPECT_EQ(cu_sdk.GetSysroot().GetPath(), "/REMAPPED_SYSROOT");
+
+  // Merging must not rewrite the sysroot to match the SDK name either.
+  ModuleSP module = t.GetModule();
+  ASSERT_NE(module, nullptr);
+
+  auto platform_sp = Platform::GetHostPlatform();
+  ASSERT_TRUE(platform_sp);
+  auto sdk_or_err = platform_sp->GetSDKPathFromDebugInfo(*module);
+  ASSERT_TRUE(static_cast<bool>(sdk_or_err));
+
+  auto [sdk, found_mismatch] = *sdk_or_err;
+  EXPECT_FALSE(found_mismatch);
+  EXPECT_EQ(sdk.GetString(), "MacOSX10.9.sdk");
+  EXPECT_EQ(sdk.GetSysroot().GetPath(), "/REMAPPED_SYSROOT");
+}
+
 TEST_P(SDKPathParsingMultiparamTests, TestSDKPathFromDebugInfo) {
   // Tests that we can parse the SDK path from debug-info.
   // In the presence of multiple compile units, one of which


### PR DESCRIPTION
rdar://165704312
