### PR TITLE
[mlir][SMT] Stop using Operation::getAttrs (NFC)

### DIFF
--- a/mlir/lib/Dialect/SMT/IR/SMTOps.cpp
+++ b/mlir/lib/Dialect/SMT/IR/SMTOps.cpp
@@ -117,7 +117,8 @@ ParseResult EqOp::parse(OpAsmParser &parser, OperationState &result) {
 
 void EqOp::print(OpAsmPrinter &printer) {
   printer << ' ' << getInputs();
-  printer.printOptionalAttrDict(getOperation()->getAttrs());
+  printer.printOptionalAttrDict(
+      getOperation()->getDiscardableAttrDictionary().getValue());
   printer << " : " << getInputs().front().getType();
 }
 
@@ -139,7 +140,8 @@ ParseResult DistinctOp::parse(OpAsmParser &parser, OperationState &result) {
 
 void DistinctOp::print(OpAsmPrinter &printer) {
   printer << ' ' << getInputs();
-  printer.printOptionalAttrDict(getOperation()->getAttrs());
+  printer.printOptionalAttrDict(
+      getOperation()->getDiscardableAttrDictionary().getValue());
   printer << " : " << getInputs().front().getType();
 }
 
@@ -258,7 +260,8 @@ ParseResult RepeatOp::parse(OpAsmParser &parser, OperationState &result) {
 
 void RepeatOp::print(OpAsmPrinter &printer) {
   printer << " " << getCount() << " times " << getInput();
-  printer.printOptionalAttrDict((*this)->getAttrs());
+  printer.printOptionalAttrDict(
+      (*this)->getDiscardableAttrDictionary().getValue());
   printer << " : " << getInput().getType();
 }
 
@@ -295,7 +298,7 @@ OpFoldResult IntConstantOp::fold(FoldAdaptor adaptor) {
 
 void IntConstantOp::print(OpAsmPrinter &p) {
   p << " " << getValue();
-  p.printOptionalAttrDict((*this)->getAttrs(), /*elidedAttrs=*/{"value"});
+  p.printOptionalAttrDict((*this)->getDiscardableAttrDictionary().getValue());
 }
 
 ParseResult IntConstantOp::parse(OpAsmParser &parser, OperationState &result) {


### PR DESCRIPTION
Print only discardable attributes after inherent fields are handled by the custom operation printers.

This is part of a general migration to use the "new" properties-based APIs and stop mixing discardable/inherent attributes, see #155475

Assisted-by: Codex