### PR TITLE
[mlir][PDLInterp] Stop using Operation::getAttrs (NFC)

### DIFF
--- a/mlir/lib/Dialect/PDLInterp/IR/PDLInterp.cpp
+++ b/mlir/lib/Dialect/PDLInterp/IR/PDLInterp.cpp
@@ -183,7 +183,7 @@ void ForEachOp::print(OpAsmPrinter &p) {
   BlockArgument arg = getLoopVariable();
   p << ' ' << arg << " : " << arg.getType() << " in " << getValues() << ' ';
   p.printRegion(getRegion(), /*printEntryBlockArgs=*/false);
-  p.printOptionalAttrDict((*this)->getAttrs());
+  p.printOptionalAttrDict((*this)->getDiscardableAttrDictionary().getValue());
   p << " -> ";
   p.printSuccessor(getSuccessor());
 }


### PR DESCRIPTION
Print the discardable dictionary after the inherent fields handled by the custom assembly format.

This is part of a general migration to use the "new" properties-based APIs and stop mixing discardable/inherent attributes, see #155475

Assisted-by: Codex