### PR TITLE
[Support] Make formatted_raw_ostream::has_colors() delegate to the wrapped stream

### DIFF
--- a/llvm/include/llvm/Support/FormattedStream.h
+++ b/llvm/include/llvm/Support/FormattedStream.h
@@ -193,6 +193,9 @@ public:
     return TheStream->is_displayed();
   }
 
+  /// Forward to the underlying stream.
+  bool has_colors() const override { return TheStream->has_colors(); }
+
 private:
   void releaseStream() {
     // Transfer the buffer settings from this raw_ostream back to the underlying

--- a/llvm/unittests/Support/formatted_raw_ostream_test.cpp
+++ b/llvm/unittests/Support/formatted_raw_ostream_test.cpp
@@ -15,6 +15,42 @@ using namespace llvm;
 
 namespace {
 
+/// A fake stream that lets the test control has_colors()/is_displayed()
+/// independently, mimicking a tty that doesn't support color: is_displayed()
+/// is true but has_colors() is false.
+class FakeColorStream : public raw_ostream {
+public:
+  uint64_t current_pos() const override { return Buffer.size(); }
+  void write_impl(const char *Ptr, size_t Size) override {
+    Buffer.append(Ptr, Ptr + Size);
+  }
+
+  bool is_displayed() const override { return IsDisplayed; }
+  bool has_colors() const override { return HasColors; }
+
+  ~FakeColorStream() override { flush(); }
+
+  std::string Buffer;
+  bool IsDisplayed = false;
+  bool HasColors = false;
+};
+
+TEST(formatted_raw_ostreamTest, Test_HasColorsDelegates) {
+  // formatted_raw_ostream should forward has_colors() to the wrapped stream
+  // rather than falling back to raw_ostream's default (which just returns
+  // is_displayed()).
+  FakeColorStream Inner;
+  Inner.IsDisplayed = true;
+  Inner.HasColors = false;
+  formatted_raw_ostream Outer(Inner);
+
+  EXPECT_TRUE(Outer.is_displayed());
+  EXPECT_FALSE(Outer.has_colors());
+
+  Inner.HasColors = true;
+  EXPECT_TRUE(Outer.has_colors());
+}
+
 TEST(formatted_raw_ostreamTest, Test_Tell) {
   // Check offset when underlying stream has buffer contents.
   SmallString<128> A;


### PR DESCRIPTION
Without this override, has_colors() falls back to is_displayed(), which isn't always expected to give the same answer as the underlying stream's has_colors().

This also fixes a compile-time regression when the underlying stream is a raw_fd_ostream: raw_fd_ostream::has_colors() memoizes its result, but without this override that memoization was bypassed in favor of the uncached is_displayed(), issuing an isatty() syscall on every call. #202441 is what surfaced this, by adding a has_colors() call to TextDiagnostic's per-character hot loop.

rdar://186469856