### PR TITLE
[MLIR] Fix -Wunused-template (#221480)

### DIFF
--- a/mlir/include/mlir/CAPI/Wrap.h
+++ b/mlir/include/mlir/CAPI/Wrap.h
@@ -37,8 +37,8 @@
   }
 
 template <typename CppTy, typename CTy>
-static llvm::ArrayRef<CppTy> unwrapList(size_t size, CTy *first,
-                                        llvm::SmallVectorImpl<CppTy> &storage) {
+llvm::ArrayRef<CppTy> unwrapList(size_t size, CTy *first,
+                                 llvm::SmallVectorImpl<CppTy> &storage) {
   static_assert(
       std::is_same<decltype(unwrap(std::declval<CTy>())), CppTy>::value,
       "incompatible C and C++ types");

--- a/mlir/include/mlir/Dialect/OpenACC/OpenACC.h
+++ b/mlir/include/mlir/Dialect/OpenACC/OpenACC.h
@@ -240,7 +240,7 @@ struct CurrentDeviceIdResource
 };
 
 template <typename ComputeOpT>
-static bool isGangWorkerVectorAllOne(ComputeOpT op) {
+bool isGangWorkerVectorAllOne(ComputeOpT op) {
   // Strip index_cast operations from a value before checking for a constant.
   auto stripIndexCasts = [](Value val) -> Value {
     while (auto castOp = val.getDefiningOp<arith::IndexCastOp>())

--- a/mlir/include/mlir/Dialect/Tosa/Utils/ConversionUtils.h
+++ b/mlir/include/mlir/Dialect/Tosa/Utils/ConversionUtils.h
@@ -84,8 +84,6 @@ LogicalResult EqualizeRanks(PatternRewriter &rewriter, Location loc,
 LogicalResult EqualizeRanks(ImplicitLocOpBuilder &builder, Value &input1,
                             Value &input2);
 
-namespace {
-
 // Creates a TOSA operation and performs shape inference on the individual
 // op. This allows shape inference when lowering down to TOSA.
 template <typename TosaOp, typename... Args>
@@ -135,8 +133,6 @@ TosaOp createOpAndInferShape(ImplicitLocOpBuilder &builder, Type resultTy,
   result.setType(newTy);
   return op;
 }
-
-} // namespace
 
 // Creates a TOSA operation by:
 //   - first equalize ranks for ops with SameOperandsAndResultRank trait

--- a/mlir/include/mlir/Query/Matcher/Marshallers.h
+++ b/mlir/include/mlir/Query/Matcher/Marshallers.h
@@ -233,7 +233,7 @@ inline bool checkArgTypeAtIndex(llvm::StringRef matcherName,
 
 // Marshaller function for fixed number of arguments
 template <typename ReturnType, typename... ArgTypes, size_t... Is>
-static VariantMatcher
+VariantMatcher
 matcherMarshallFixedImpl(void (*matcherFunc)(), llvm::StringRef matcherName,
                          SourceRange nameRange,
                          llvm::ArrayRef<ParserValue> args, Diagnostics *error,
@@ -256,7 +256,7 @@ matcherMarshallFixedImpl(void (*matcherFunc)(), llvm::StringRef matcherName,
 }
 
 template <typename ReturnType, typename... ArgTypes>
-static VariantMatcher
+VariantMatcher
 matcherMarshallFixed(void (*matcherFunc)(), llvm::StringRef matcherName,
                      SourceRange nameRange, llvm::ArrayRef<ParserValue> args,
                      Diagnostics *error) {

--- a/mlir/include/mlir/Support/DebugStringHelper.h
+++ b/mlir/include/mlir/Support/DebugStringHelper.h
@@ -25,7 +25,7 @@ namespace mlir {
 
 // Simple helper function that returns a string as printed from a op.
 template <typename T>
-static std::string debugString(T &&op) {
+std::string debugString(T &&op) {
   std::string instrStr;
   llvm::raw_string_ostream os(instrStr);
   os << op;

--- a/mlir/lib/Conversion/GPUCommon/GPUToLLVMConversion.cpp
+++ b/mlir/lib/Conversion/GPUCommon/GPUToLLVMConversion.cpp
@@ -1225,14 +1225,6 @@ static Value genConstInt32From(OpBuilder &builder, Location loc, T tValue) {
                                   static_cast<int32_t>(tValue));
 }
 
-template <typename T>
-static Value genConstFloat32From(OpBuilder &builder, Location loc, T tValue) {
-  Type llvmFloat32Type = builder.getF32Type();
-  return LLVM::ConstantOp::create(
-      builder, loc, llvmFloat32Type,
-      builder.getF32FloatAttr(static_cast<float>(tValue)));
-}
-
 LogicalResult ConvertCreateDnTensorOpToGpuRuntimeCallPattern::matchAndRewrite(
     gpu::CreateDnTensorOp op, OpAdaptor adaptor,
     ConversionPatternRewriter &rewriter) const {

--- a/mlir/lib/Conversion/VectorToLLVM/ConvertVectorToLLVM.cpp
+++ b/mlir/lib/Conversion/VectorToLLVM/ConvertVectorToLLVM.cpp
@@ -755,20 +755,6 @@ lowerReductionWithStartValue(ConversionPatternRewriter &rewriter, Location loc,
                                  fmf);
 }
 
-/// Overloaded methods to lower a *predicated* reduction to an llvm intrinsic
-/// that requires a start value. This start value format spans across fp
-/// reductions without mask and all the masked reduction intrinsics.
-template <class LLVMVPRedIntrinOp, class ReductionNeutral>
-static Value
-lowerPredicatedReductionWithStartValue(ConversionPatternRewriter &rewriter,
-                                       Location loc, Type llvmType,
-                                       Value vectorOperand, Value accumulator) {
-  accumulator = getOrCreateAccumulator<ReductionNeutral>(rewriter, loc,
-                                                         llvmType, accumulator);
-  return LLVMVPRedIntrinOp::create(rewriter, loc, llvmType,
-                                   /*startValue=*/accumulator, vectorOperand);
-}
-
 template <class LLVMVPRedIntrinOp, class ReductionNeutral>
 static Value lowerPredicatedReductionWithStartValue(
     ConversionPatternRewriter &rewriter, Location loc, Type llvmType,

--- a/mlir/lib/Dialect/Affine/Utils/LoopUtils.cpp
+++ b/mlir/lib/Dialect/Affine/Utils/LoopUtils.cpp
@@ -1572,20 +1572,6 @@ stripmineSink(AffineForOp forOp, uint64_t factor,
   return innerLoops;
 }
 
-// Stripmines a `forOp` by `factor` and sinks it under a single `target`.
-// Returns the new AffineForOps, nested immediately under `target`.
-template <typename SizeType>
-static AffineForOp stripmineSink(AffineForOp forOp, SizeType factor,
-                                 AffineForOp target) {
-  // TODO: Use cheap structural assertions that targets are nested under
-  // forOp and that targets are not nested under each other when DominanceInfo
-  // exposes the capability. It seems overkill to construct a whole function
-  // dominance tree at this point.
-  auto res = stripmineSink(forOp, factor, ArrayRef<AffineForOp>(target));
-  assert(res.size() == 1 && "Expected 1 inner forOp");
-  return res[0];
-}
-
 SmallVector<SmallVector<AffineForOp, 8>, 8>
 mlir::affine::tile(ArrayRef<AffineForOp> forOps, ArrayRef<uint64_t> sizes,
                    ArrayRef<AffineForOp> targets) {

--- a/mlir/lib/Dialect/Linalg/TransformOps/LinalgTransformOps.cpp
+++ b/mlir/lib/Dialect/Linalg/TransformOps/LinalgTransformOps.cpp
@@ -54,32 +54,6 @@ using namespace mlir::transform;
 
 #define DEBUG_TYPE "linalg-transforms"
 
-/// Attempts to apply the pattern specified as template argument to the given
-/// operation. The pattern is expected to have a `returningMatchAndRewrite`
-/// function that returns the "main" result or failure. Returns failure if the
-/// pattern failed to apply. Extra arguments are forwarded to the pattern
-/// constructor.
-template <typename PatternTy, typename... Args>
-static FailureOr<LinalgOp> tryApply(Operation *operation, Args &&...args) {
-  // Check if the given operation has the type expected by the pattern.
-  using OpTy = typename llvm::function_traits<
-      decltype(&PatternTy::returningMatchAndRewrite)>::template arg_t<0>;
-  auto op = dyn_cast<OpTy>(operation);
-  if (!op)
-    return failure();
-
-  // Apply the pattern directly to the op.
-  PatternTy pattern(operation->getContext(), std::forward<Args>(args)...);
-  // We want to discourage direct use of PatternRewriter in APIs but In this
-  // very specific case, an IRRewriter is not enough.
-  PatternRewriter rewriter(operation->getContext());
-  rewriter.setInsertionPoint(operation);
-  auto result = pattern.returningMatchAndRewrite(op, rewriter);
-  if (failed(result))
-    return failure();
-  return cast<LinalgOp>(result->getOperation());
-}
-
 /// Assuming that `ofr` is an index attr or a param of index type
 /// or a transform dialect handle mapped to exactly one op
 /// with one index result, return that value.

--- a/mlir/lib/Dialect/Linalg/Transforms/Loops.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/Loops.cpp
@@ -76,24 +76,6 @@ static void inlineRegionAndEmitStore(OpBuilder &b, Location loc, OpType op,
   }
 }
 
-// Returns a pair that contains input indices and output indices of a
-// SingleInputPoolingOp `op`.
-struct InputAndOutputIndices {
-  SmallVector<Value> inputs;
-  SmallVector<Value> outputs;
-};
-template <typename SingleInputPoolingOp>
-static InputAndOutputIndices
-getInputAndOutputIndices(OpBuilder &b, Location loc, ArrayRef<Value> allIvs,
-                         SingleInputPoolingOp op) {
-  auto mapsRange = op.getIndexingMapsArray();
-  auto maps = llvm::to_vector<8>(
-      llvm::map_range(mapsRange, [](AffineMapAttr a) { return a.getValue(); }));
-  return InputAndOutputIndices{
-      makeCanonicalAffineApplies(b, loc, maps[0], allIvs),
-      makeCanonicalAffineApplies(b, loc, maps[2], allIvs)};
-}
-
 /// Emits the MLIR for the scalar part of the generic op by:
 ///   1. Emitting load ops for each input and output view in order. This is
 ///      achieved by applying the appropriate input or output map to the

--- a/mlir/lib/Dialect/Linalg/Transforms/Vectorization.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/Vectorization.cpp
@@ -89,22 +89,6 @@ vectorizeAsInsertSliceOp(RewriterBase &rewriter, tensor::InsertSliceOp sliceOp,
 /// otherwise.
 static Value getStaticPadVal(Operation *op);
 
-/// Return the unique instance of OpType in `block` if it is indeed unique.
-/// Return null if none or more than 1 instances exist.
-template <typename OpType>
-static OpType getSingleOpOfType(Block &block) {
-  OpType res;
-  block.walk([&](OpType op) {
-    if (res) {
-      res = nullptr;
-      return WalkResult::interrupt();
-    }
-    res = op;
-    return WalkResult::advance();
-  });
-  return res;
-}
-
 /// Helper function to extract the input slices after filter is unrolled along
 /// kw.
 static SmallVector<Value>

--- a/mlir/lib/Dialect/OpenACC/IR/OpenACC.cpp
+++ b/mlir/lib/Dialect/OpenACC/IR/OpenACC.cpp
@@ -1686,21 +1686,6 @@ void acc::UpdateHostOp::getEffects(
   addOperandEffect<MemoryEffects::Write>(effects, getVarMutable());
 }
 
-template <typename StructureOp>
-static ParseResult parseRegions(OpAsmParser &parser, OperationState &state,
-                                unsigned nRegions = 1) {
-
-  SmallVector<Region *, 2> regions;
-  for (unsigned i = 0; i < nRegions; ++i)
-    regions.push_back(state.addRegion());
-
-  for (Region *region : regions)
-    if (parser.parseRegion(*region, /*arguments=*/{}, /*argTypes=*/{}))
-      return failure();
-
-  return success();
-}
-
 namespace {
 /// Pattern to remove operation without region that have constant false `ifCond`
 /// and remove the condition from the operation if the `ifCond` is a true

--- a/mlir/lib/Dialect/SCF/IR/SCF.cpp
+++ b/mlir/lib/Dialect/SCF/IR/SCF.cpp
@@ -3365,28 +3365,6 @@ void scf::WhileOp::print(OpAsmPrinter &p) {
       (*this)->getDiscardableAttrDictionary().getValue());
 }
 
-/// Verifies that two ranges of types match, i.e. have the same number of
-/// entries and that types are pairwise equals. Reports errors on the given
-/// operation in case of mismatch.
-template <typename OpTy>
-static LogicalResult verifyTypeRangesMatch(OpTy op, TypeRange left,
-                                           TypeRange right, StringRef message) {
-  if (left.size() != right.size())
-    return op.emitOpError("expects the same number of ") << message;
-
-  for (unsigned i = 0, e = left.size(); i < e; ++i) {
-    if (left[i] != right[i]) {
-      InFlightDiagnostic diag = op.emitOpError("expects the same types for ")
-                                << message;
-      diag.attachNote() << "for argument " << i << ", found " << left[i]
-                        << " and " << right[i];
-      return diag;
-    }
-  }
-
-  return success();
-}
-
 LogicalResult scf::WhileOp::verify() {
   auto beforeTerminator = verifyAndGetTerminator<scf::ConditionOp>(
       *this, getBefore(),

--- a/mlir/lib/Dialect/SCF/Utils/Utils.cpp
+++ b/mlir/lib/Dialect/SCF/Utils/Utils.cpp
@@ -1377,20 +1377,6 @@ static Loops stripmineSink(scf::ForOp forOp, Value factor,
   return innerLoops;
 }
 
-// Stripmines a `forOp` by `factor` and sinks it under a single `target`.
-// Returns the new for operation, nested immediately under `target`.
-template <typename SizeType>
-static scf::ForOp stripmineSink(scf::ForOp forOp, SizeType factor,
-                                scf::ForOp target) {
-  // TODO: Use cheap structural assertions that targets are nested under
-  // forOp and that targets are not nested under each other when DominanceInfo
-  // exposes the capability. It seems overkill to construct a whole function
-  // dominance tree at this point.
-  auto res = stripmineSink(forOp, factor, ArrayRef<scf::ForOp>(target));
-  assert(res.size() == 1 && "Expected 1 inner forOp");
-  return res[0];
-}
-
 SmallVector<Loops, 8> mlir::tile(ArrayRef<scf::ForOp> forOps,
                                  ArrayRef<Value> sizes,
                                  ArrayRef<scf::ForOp> targets) {

--- a/mlir/lib/Dialect/SPIRV/IR/MemoryOps.cpp
+++ b/mlir/lib/Dialect/SPIRV/IR/MemoryOps.cpp
@@ -319,12 +319,6 @@ void AccessChainOp::build(OpBuilder &builder, OperationState &state,
 }
 
 template <typename Op>
-static void printAccessChain(Op op, ValueRange indices, OpAsmPrinter &printer) {
-  printer << ' ' << op.getBasePtr() << '[' << indices
-          << "] : " << op.getBasePtr().getType() << ", " << indices.getTypes();
-}
-
-template <typename Op>
 static LogicalResult verifyAccessChain(Op accessChainOp, ValueRange indices) {
   auto resultType = getElementPtrType(accessChainOp.getBasePtr().getType(),
                                       indices, accessChainOp.getLoc());

--- a/mlir/lib/Dialect/Shard/Transforms/Partition.cpp
+++ b/mlir/lib/Dialect/Shard/Transforms/Partition.cpp
@@ -38,14 +38,6 @@
 
 namespace mlir::shard {
 
-template <typename SourceAxes, typename TargetAxes>
-static bool arePartialAxesCompatible(const SourceAxes &sourceAxes,
-                                     const TargetAxes &targetAxes) {
-  return llvm::all_of(targetAxes, [&sourceAxes](auto &targetAxis) {
-    return sourceAxes.contains(targetAxis);
-  });
-}
-
 /// Base class for resharding patterns.
 /// Subclasses implement `tryApply` to detect and apply a specific resharding.
 class ReshardingPattern {

--- a/mlir/lib/Dialect/Tosa/Transforms/TosaNarrowTypes.cpp
+++ b/mlir/lib/Dialect/Tosa/Transforms/TosaNarrowTypes.cpp
@@ -96,15 +96,6 @@ bool isSourceElement(Type type) {
 }
 
 template <TosaNarrowKind Kind>
-Type convertElement(Type type) {
-  if (auto intTy = dyn_cast<IntegerType>(type))
-    return convertInteger<Kind>(intTy);
-  if (auto floatTy = dyn_cast<FloatType>(type))
-    return convertFloat<Kind>(floatTy);
-  return type;
-}
-
-template <TosaNarrowKind Kind>
 bool typeNeedsConversion(Type type) {
   if (auto shaped = dyn_cast<ShapedType>(type))
     return isSourceElement<Kind>(shaped.getElementType());

--- a/mlir/lib/Dialect/Vector/Transforms/VectorTransforms.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/VectorTransforms.cpp
@@ -49,13 +49,6 @@ static Operation *createWithProperties(OpBuilder &builder, Operation *op,
   return builder.create(state);
 }
 
-template <typename IntType>
-static SmallVector<IntType> extractVector(ArrayAttr arrayAttr) {
-  return llvm::to_vector<4>(llvm::map_range(
-      arrayAttr.getAsRange<IntegerAttr>(),
-      [](IntegerAttr attr) { return static_cast<IntType>(attr.getInt()); }));
-}
-
 // Helper to find an index in an affine map.
 static std::optional<int64_t> getResultIndex(AffineMap map, int64_t index) {
   for (int64_t i = 0, e = map.getNumResults(); i < e; ++i) {

--- a/mlir/lib/IR/MLIRContext.cpp
+++ b/mlir/lib/IR/MLIRContext.cpp
@@ -373,16 +373,6 @@ MLIRContext::~MLIRContext() {
   impl->remarkEngine.reset();
 }
 
-/// Copy the specified array of elements into memory managed by the provided
-/// bump pointer allocator.  This assumes the elements are all PODs.
-template <typename T>
-static ArrayRef<T> copyArrayRefInto(llvm::BumpPtrAllocator &allocator,
-                                    ArrayRef<T> elements) {
-  auto result = allocator.Allocate<T>(elements.size());
-  llvm::uninitialized_copy(elements, result);
-  return ArrayRef<T>(result, elements.size());
-}
-
 //===----------------------------------------------------------------------===//
 // Action Handling
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Target/Cpp/TranslateToCpp.cpp
+++ b/mlir/lib/Target/Cpp/TranslateToCpp.cpp
@@ -54,13 +54,6 @@ interleaveWithError(ForwardIterator begin, ForwardIterator end,
   return success();
 }
 
-template <typename Container, typename UnaryFunctor, typename NullaryFunctor>
-static inline LogicalResult interleaveWithError(const Container &c,
-                                                UnaryFunctor eachFn,
-                                                NullaryFunctor betweenFn) {
-  return interleaveWithError(c.begin(), c.end(), eachFn, betweenFn);
-}
-
 template <typename Container, typename UnaryFunctor>
 static inline LogicalResult interleaveCommaWithError(const Container &c,
                                                      raw_ostream &os,

--- a/mlir/lib/Tools/mlir-pdll-lsp-server/Protocol.cpp
+++ b/mlir/lib/Tools/mlir-pdll-lsp-server/Protocol.cpp
@@ -18,21 +18,6 @@
 using namespace mlir;
 using namespace mlir::lsp;
 
-// Helper that doesn't treat `null` and absent fields as failures.
-template <typename T>
-static bool mapOptOrNull(const llvm::json::Value &params,
-                         llvm::StringLiteral prop, T &out,
-                         llvm::json::Path path) {
-  const llvm::json::Object *o = params.getAsObject();
-  assert(o);
-
-  // Field is missing or null.
-  auto *v = o->get(prop);
-  if (!v || v->getAsNull())
-    return true;
-  return fromJSON(*v, out, path.field(prop));
-}
-
 //===----------------------------------------------------------------------===//
 // PDLLViewOutputParams
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
This warning was enabled by default for clang 23 (although reverted in 23.1.1). Given someone might enable it in the future and the cleanup seemed nice, we should just do it.

This was done primarily by removing static from templates in headers and then deleting any unused templates in translation units.

Previously attempted to land this in #221480, but accidentally merged into a user branch rather than main.