### PR TITLE
[NFC] Hoist DiagOpts.showColors(OS.has_colors()) out of emitSnippet's per-character loop

### DIFF
--- a/clang/lib/Frontend/TextDiagnostic.cpp
+++ b/clang/lib/Frontend/TextDiagnostic.cpp
@@ -1544,12 +1544,13 @@ void TextDiagnostic::emitSnippet(StringRef SourceLine,
   bool PrintReversed = false;
   std::optional<llvm::raw_ostream::Colors> CurrentColor;
   size_t I = 0; // Bytes.
+  const bool ShowColors = DiagOpts.showColors(OS.has_colors());
   while (I < SourceLine.size()) {
     auto [Str, WasPrintable] =
         printableTextForNextCharacter(SourceLine, &I, DiagOpts.TabStop);
 
     // Toggle inverted colors on or off for this character.
-    if (DiagOpts.showColors(OS.has_colors())) {
+    if (ShowColors) {
       if (WasPrintable == PrintReversed) {
         PrintReversed = !PrintReversed;
         if (PrintReversed)
@@ -1580,7 +1581,7 @@ void TextDiagnostic::emitSnippet(StringRef SourceLine,
     OS << Str;
   }
 
-  if (DiagOpts.showColors(OS.has_colors()))
+  if (ShowColors)
     OS.resetColor();
 
   OS << '\n';


### PR DESCRIPTION
The result of DiagOpts.showColors(OS.has_colors()) does not change while printing a single source snippet, so recomputing it for every character is unnecessary. Compute it once per snippet instead.

rdar://186469856