### PR TITLE
[libc] Restrict sysconf/confstr to full-build mode.

### DIFF
--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -408,7 +408,6 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.chdir
     libc.src.unistd.chown
     libc.src.unistd.chroot
-    libc.src.unistd.confstr
     libc.src.unistd.close
     libc.src.unistd.dup
     libc.src.unistd.dup2
@@ -458,7 +457,6 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.sleep
     libc.src.unistd.symlink
     libc.src.unistd.symlinkat
-    libc.src.unistd.sysconf
     libc.src.unistd.tcgetpgrp
     libc.src.unistd.tcsetpgrp
     libc.src.unistd.truncate
@@ -1381,6 +1379,7 @@ if(LLVM_LIBC_FULL_BUILD)
     # unistd.h entrypoints
     libc.src.unistd.__llvm_libc_syscall
     libc.src.unistd._exit
+    libc.src.unistd.confstr
     libc.src.unistd.environ
     libc.src.unistd.execl
     libc.src.unistd.execv
@@ -1391,6 +1390,7 @@ if(LLVM_LIBC_FULL_BUILD)
     libc.src.unistd.optind
     libc.src.unistd.optopt
     libc.src.unistd.swab
+    libc.src.unistd.sysconf
 
     # sys/select.h entrypoints
     libc.src.sys.select.select

--- a/libc/config/linux/arm/entrypoints.txt
+++ b/libc/config/linux/arm/entrypoints.txt
@@ -234,7 +234,6 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.chdir
     libc.src.unistd.chown
     libc.src.unistd.chroot
-    libc.src.unistd.confstr
     libc.src.unistd.close
     libc.src.unistd.dup
     libc.src.unistd.dup2
@@ -278,7 +277,6 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.setuid
     libc.src.unistd.symlink
     libc.src.unistd.symlinkat
-    libc.src.unistd.sysconf
     libc.src.unistd.tcgetpgrp
     libc.src.unistd.tcsetpgrp
     libc.src.unistd.truncate
@@ -320,6 +318,10 @@ if(LLVM_LIBC_FULL_BUILD)
     libc.src.dirent.opendir
     libc.src.dirent.readdir
     libc.src.dirent.fdopendir
+
+    # unistd.h entrypoints
+    libc.src.unistd.confstr
+    libc.src.unistd.sysconf
   )
 endif()
 

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -438,7 +438,6 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.chdir
     libc.src.unistd.chown
     libc.src.unistd.chroot
-    libc.src.unistd.confstr
     libc.src.unistd.close
     libc.src.unistd.dup
     libc.src.unistd.dup2
@@ -488,7 +487,6 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.sleep
     libc.src.unistd.symlink
     libc.src.unistd.symlinkat
-    libc.src.unistd.sysconf
     libc.src.unistd.tcgetpgrp
     libc.src.unistd.tcsetpgrp
     libc.src.unistd.truncate
@@ -1591,6 +1589,7 @@ if(LLVM_LIBC_FULL_BUILD)
     # unistd.h entrypoints
     libc.src.unistd.__llvm_libc_syscall
     libc.src.unistd._exit
+    libc.src.unistd.confstr
     libc.src.unistd.environ
     libc.src.unistd.execl
     libc.src.unistd.execv
@@ -1601,6 +1600,7 @@ if(LLVM_LIBC_FULL_BUILD)
     libc.src.unistd.optind
     libc.src.unistd.optopt
     libc.src.unistd.swab
+    libc.src.unistd.sysconf
 
     # sys/select.h entrypoints
     libc.src.sys.select.select

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -447,7 +447,6 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.chdir
     libc.src.unistd.chown
     libc.src.unistd.chroot
-    libc.src.unistd.confstr
     libc.src.unistd.close
     libc.src.unistd.dup
     libc.src.unistd.dup2
@@ -497,7 +496,6 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.sleep
     libc.src.unistd.symlink
     libc.src.unistd.symlinkat
-    libc.src.unistd.sysconf
     libc.src.unistd.tcgetpgrp
     libc.src.unistd.tcsetpgrp
     libc.src.unistd.truncate
@@ -1606,6 +1604,7 @@ if(LLVM_LIBC_FULL_BUILD)
     # unistd.h entrypoints
     libc.src.unistd.__llvm_libc_syscall
     libc.src.unistd._exit
+    libc.src.unistd.confstr
     libc.src.unistd.environ
     libc.src.unistd.execl
     libc.src.unistd.execv
@@ -1616,6 +1615,7 @@ if(LLVM_LIBC_FULL_BUILD)
     libc.src.unistd.optind
     libc.src.unistd.optopt
     libc.src.unistd.swab
+    libc.src.unistd.sysconf
 
     # sys/select.h entrypoints
     libc.src.sys.select.select

--- a/libc/src/unistd/linux/sysconf.cpp
+++ b/libc/src/unistd/linux/sysconf.cpp
@@ -28,13 +28,6 @@
 #include "src/__support/macros/config.h"
 #include <linux/limits.h>
 
-// In overlay mode, system headers (like glibc's <bits/local_lim.h>) may
-// explicitly undefine ARG_MAX to indicate it is dynamic. We define a fallback
-// here using the standard Linux kernel minimum floor of 128KB.
-#ifndef ARG_MAX
-#define ARG_MAX 131072
-#endif
-
 namespace LIBC_NAMESPACE_DECL {
 
 namespace { // Anonymous namespace for internal helpers
@@ -45,17 +38,9 @@ namespace { // Anonymous namespace for internal helpers
 constexpr long DEFAULT_STACK_LIMIT = 8 * 1024 * 1024;          // 8MB
 constexpr long ARG_MAX_FALLBACK = DEFAULT_STACK_LIMIT / 4 * 3; // 6MB
 
-// We define a local structure for prlimit64 to avoid type mismatches
-// and stack corruption on 32-bit systems when in overlay mode.
-struct rlimit64 {
-  uint64_t rlim_cur;
-  uint64_t rlim_max;
-};
-
 long get_arg_max() {
-  struct rlimit64 limits;
-  ErrorOr<int> ret = linux_syscalls::prlimit(
-      0, RLIMIT_STACK, nullptr, reinterpret_cast<struct rlimit *>(&limits));
+  struct rlimit limits;
+  ErrorOr<int> ret = linux_syscalls::prlimit(0, RLIMIT_STACK, nullptr, &limits);
   if (!ret) {
     libc_errno = -ret.error();
     return -1;
@@ -68,9 +53,9 @@ long get_arg_max() {
 }
 
 long get_open_max() {
-  struct rlimit64 limits;
-  ErrorOr<int> ret = linux_syscalls::prlimit(
-      0, RLIMIT_NOFILE, nullptr, reinterpret_cast<struct rlimit *>(&limits));
+  struct rlimit limits;
+  ErrorOr<int> ret =
+      linux_syscalls::prlimit(0, RLIMIT_NOFILE, nullptr, &limits);
   if (!ret) {
     libc_errno = -ret.error();
     return -1;

--- a/libc/test/src/sys/mman/linux/CMakeLists.txt
+++ b/libc/test/src/sys/mman/linux/CMakeLists.txt
@@ -132,7 +132,7 @@ add_libc_test(
     libc.src.sys.mman.mincore
     libc.src.sys.mman.mlock
     libc.src.sys.mman.munlock
-    libc.src.unistd.sysconf
+    libc.src.unistd.getpagesize
     libc.test.UnitTest.ErrnoCheckingTest
     libc.test.UnitTest.ErrnoSetterMatcher
 )
@@ -159,7 +159,7 @@ add_libc_test(
     libc.src.sys.mman.munlockall
     libc.hdr.sys_resource_macros
     libc.src.sys.resource.getrlimit
-    libc.src.unistd.sysconf
+    libc.src.unistd.getpagesize
     libc.src.__support.OSUtil.osutil
     libc.test.UnitTest.ErrnoCheckingTest
     libc.test.UnitTest.ErrnoSetterMatcher
@@ -182,7 +182,7 @@ add_libc_test(
     libc.src.sys.mman.mincore
     libc.src.sys.mman.mlock
     libc.src.sys.mman.munlock
-    libc.src.unistd.sysconf
+    libc.src.unistd.getpagesize
     libc.test.UnitTest.ErrnoCheckingTest
     libc.test.UnitTest.ErrnoSetterMatcher
 )
@@ -209,7 +209,7 @@ else()
       libc.src.sys.mman.munmap
       libc.src.fcntl.open
       libc.src.unistd.close
-      libc.src.unistd.sysconf
+      libc.src.unistd.getpagesize
   )
 endif()
 

--- a/libc/test/src/sys/mman/linux/mincore_test.cpp
+++ b/libc/test/src/sys/mman/linux/mincore_test.cpp
@@ -13,7 +13,7 @@
 #include "src/sys/mman/mmap.h"
 #include "src/sys/mman/munlock.h"
 #include "src/sys/mman/munmap.h"
-#include "src/unistd/sysconf.h"
+#include "src/unistd/getpagesize.h"
 #include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
@@ -22,7 +22,7 @@ using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
 using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
 using LlvmLibcMincoreTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
-const size_t PAGE_SIZE = LIBC_NAMESPACE::sysconf(_SC_PAGESIZE);
+const size_t PAGE_SIZE = LIBC_NAMESPACE::getpagesize();
 
 TEST_F(LlvmLibcMincoreTest, UnMappedMemory) {
   unsigned char vec;

--- a/libc/test/src/sys/mman/linux/mlock_test.cpp
+++ b/libc/test/src/sys/mman/linux/mlock_test.cpp
@@ -24,14 +24,14 @@
 #include "src/sys/mman/munlockall.h"
 #include "src/sys/mman/munmap.h"
 #include "src/sys/resource/getrlimit.h"
-#include "src/unistd/sysconf.h"
+#include "src/unistd/getpagesize.h"
 #include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
 
 #include <sys/syscall.h>
 
-const size_t PAGE_SIZE = LIBC_NAMESPACE::sysconf(_SC_PAGESIZE);
+const size_t PAGE_SIZE = LIBC_NAMESPACE::getpagesize();
 
 using namespace LIBC_NAMESPACE::testing::ErrnoSetterMatcher;
 using LlvmLibcMlockTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;

--- a/libc/test/src/sys/mman/linux/msync_test.cpp
+++ b/libc/test/src/sys/mman/linux/msync_test.cpp
@@ -12,12 +12,12 @@
 #include "src/sys/mman/msync.h"
 #include "src/sys/mman/munlock.h"
 #include "src/sys/mman/munmap.h"
-#include "src/unistd/sysconf.h"
+#include "src/unistd/getpagesize.h"
 #include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
 
-const size_t PAGE_SIZE = LIBC_NAMESPACE::sysconf(_SC_PAGESIZE);
+const size_t PAGE_SIZE = LIBC_NAMESPACE::getpagesize();
 
 using namespace LIBC_NAMESPACE::testing::ErrnoSetterMatcher;
 using LlvmLibcMsyncTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;

--- a/libc/test/src/sys/mman/linux/remap_file_pages_test.cpp
+++ b/libc/test/src/sys/mman/linux/remap_file_pages_test.cpp
@@ -13,12 +13,12 @@
 #include "src/sys/mman/munmap.h"
 #include "src/sys/mman/remap_file_pages.h"
 #include "src/unistd/close.h"
-#include "src/unistd/sysconf.h"
+#include "src/unistd/getpagesize.h"
 #include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
 
-const size_t PAGE_SIZE = LIBC_NAMESPACE::sysconf(_SC_PAGESIZE);
+const size_t PAGE_SIZE = LIBC_NAMESPACE::getpagesize();
 
 using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
 using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -16942,6 +16942,10 @@ libc_function(
     name = "sysconf",
     srcs = ["src/unistd/linux/sysconf.cpp"],
     hdrs = ["src/unistd/sysconf.h"],
+    target_compatible_with = select({
+        ":full_build_linux": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
     deps = [
         ":__support_common",
         ":__support_libc_errno",

--- a/utils/bazel/llvm-project-overlay/libc/test/src/sys/mman/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/sys/mman/BUILD.bazel
@@ -25,6 +25,7 @@ libc_test(
     name = "mincore_test",
     srcs = ["linux/mincore_test.cpp"],
     deps = [
+        "//libc:getpagesize",
         "//libc:hdr_sys_mman_macros",
         "//libc:madvise",
         "//libc:mincore",
@@ -32,7 +33,6 @@ libc_test(
         "//libc:mmap",
         "//libc:munlock",
         "//libc:munmap",
-        "//libc:sysconf",
     ],
 )
 
@@ -41,6 +41,7 @@ libc_test(
     srcs = ["linux/mlock_test.cpp"],
     deps = [
         "//libc:__support_osutil_syscall",
+        "//libc:getpagesize",
         "//libc:getrlimit",
         "//libc:hdr_sys_mman_macros",
         "//libc:hdr_sys_resource_macros",
@@ -53,7 +54,6 @@ libc_test(
         "//libc:munlock",
         "//libc:munlockall",
         "//libc:munmap",
-        "//libc:sysconf",
     ],
 )
 
@@ -97,13 +97,13 @@ libc_test(
     name = "msync_test",
     srcs = ["linux/msync_test.cpp"],
     deps = [
+        "//libc:getpagesize",
         "//libc:hdr_sys_mman_macros",
         "//libc:mlock",
         "//libc:mmap",
         "//libc:msync",
         "//libc:munlock",
         "//libc:munmap",
-        "//libc:sysconf",
     ],
 )
 
@@ -142,13 +142,13 @@ libc_test(
     srcs = ["linux/remap_file_pages_test.cpp"],
     deps = [
         "//libc:close",
+        "//libc:getpagesize",
         "//libc:hdr_sys_mman_macros",
         "//libc:hdr_sys_stat_macros",
         "//libc:mmap",
         "//libc:munmap",
         "//libc:open",
         "//libc:remap_file_pages",
-        "//libc:sysconf",
     ],
 )
 


### PR DESCRIPTION
`sysconf` (and its sibling `confstr`) from `<unistd.h>` return some values specific to the kernel/environment,
and some values specific to the system library (e.g. features available in system library's pthread implementation).

Using LLVM-libc sysconf in overlay mode is inherently problematic - we don't know what features host libc has,
and trying to reverse-engineer it would be brittle. Since we include host libc's `<unistd.h>`, we can't even know in
advance what `_SC_` values or what macros would be available there, so the portable implementation of `sysconf`
will be convoluted, and there's little benefits to it anyway.

Conversely, making sure that our `sysconf` implementation only compiles against LLVM-libc's own headers will allow
us to precisely handle macro / features that we know are available / supported.

Migrate four tests from sys/mman.h to use `getpagesize()` function instead of generic `sysconf` to ensure those
tests won't be auto-excluded in overlay mode.

Remove the workarounds for overlay-mode added to sysconf(), since those are no longer needed.