### PR TITLE
[ORC] Retire rt::SimpleExecutorMemoryManager* for sps_ci

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h
@@ -22,12 +22,6 @@ namespace llvm {
 namespace orc {
 namespace rt {
 
-LLVM_ABI extern const char *SimpleExecutorMemoryManagerInstanceName;
-LLVM_ABI extern const char *SimpleExecutorMemoryManagerReserveWrapperName;
-LLVM_ABI extern const char *SimpleExecutorMemoryManagerInitializeWrapperName;
-LLVM_ABI extern const char *SimpleExecutorMemoryManagerDeinitializeWrapperName;
-LLVM_ABI extern const char *SimpleExecutorMemoryManagerReleaseWrapperName;
-
 LLVM_ABI extern const char *RegisterEHFrameSectionAllocActionName;
 LLVM_ABI extern const char *DeregisterEHFrameSectionAllocActionName;
 
@@ -48,17 +42,6 @@ struct MachOUnwindInfoRegistrarSymbolNames {
 /// StandaloneMachOUnwindInfoRegistrar SPS interface.
 extern const LLVM_ABI MachOUnwindInfoRegistrarSymbolNames
     orc_rt_MachOUnwindInfoRegistrarSPSSymbols;
-
-using SPSSimpleExecutorMemoryManagerReserveSignature =
-    shared::SPSExpected<shared::SPSExecutorAddr>(shared::SPSExecutorAddr,
-                                                 uint64_t);
-using SPSSimpleExecutorMemoryManagerInitializeSignature =
-    shared::SPSExpected<shared::SPSExecutorAddr>(shared::SPSExecutorAddr,
-                                                 shared::SPSFinalizeRequest);
-using SPSSimpleExecutorMemoryManagerDeinitializeSignature = shared::SPSError(
-    shared::SPSExecutorAddr, shared::SPSSequence<shared::SPSExecutorAddr>);
-using SPSSimpleExecutorMemoryManagerReleaseSignature = shared::SPSError(
-    shared::SPSExecutorAddr, shared::SPSSequence<shared::SPSExecutorAddr>);
 
 } // end namespace rt
 

--- a/llvm/lib/ExecutionEngine/Orc/EPCGenericRTDyldMemoryManager.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/EPCGenericRTDyldMemoryManager.cpp
@@ -8,6 +8,7 @@
 
 #include "llvm/ExecutionEngine/Orc/EPCGenericRTDyldMemoryManager.h"
 #include "llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h"
+#include "llvm/ExecutionEngine/Orc/Shared/SPSCI/SimpleNativeMemoryMapSPSCI.h"
 #include "llvm/Support/Alignment.h"
 #include "llvm/Support/FormatVariadic.h"
 
@@ -23,11 +24,10 @@ EPCGenericRTDyldMemoryManager::CreateWithDefaultBootstrapSymbols(
     ExecutorProcessControl &EPC) {
   SymbolAddrs SAs;
   if (auto Err = EPC.getBootstrapSymbols(
-          {{SAs.Instance, rt::SimpleExecutorMemoryManagerInstanceName},
-           {SAs.Reserve, rt::SimpleExecutorMemoryManagerReserveWrapperName},
-           {SAs.Initialize,
-            rt::SimpleExecutorMemoryManagerInitializeWrapperName},
-           {SAs.Release, rt::SimpleExecutorMemoryManagerReleaseWrapperName},
+          {{SAs.Instance, rt::sps_ci::SimpleNativeMemoryMapInstanceName},
+           {SAs.Reserve, rt::sps_ci::MemMgrReserve::Name},
+           {SAs.Initialize, rt::sps_ci::MemMgrInitialize::Name},
+           {SAs.Release, rt::sps_ci::MemMgrRelease::Name},
            {SAs.RegisterEHFrame, rt::RegisterEHFrameSectionAllocActionName},
            {SAs.DeregisterEHFrame,
             rt::DeregisterEHFrameSectionAllocActionName}}))
@@ -47,8 +47,7 @@ EPCGenericRTDyldMemoryManager::~EPCGenericRTDyldMemoryManager() {
     errs() << "Destroying with existing errors:\n" << ErrMsg << "\n";
 
   Error Err = Error::success();
-  if (auto Err2 = EPC.callSPSWrapper<
-                  rt::SPSSimpleExecutorMemoryManagerReleaseSignature>(
+  if (auto Err2 = EPC.callSPSWrapper<rt::sps_ci::MemMgrRelease::SPSSig>(
           SAs.Reserve, Err, SAs.Instance, FinalizedAllocs)) {
     // FIXME: Report errors through EPC once that functionality is available.
     logAllUnhandledErrors(std::move(Err2), errs(), "");
@@ -128,8 +127,7 @@ void EPCGenericRTDyldMemoryManager::reserveAllocationSpace(
   });
 
   Expected<ExecutorAddr> TargetAllocAddr((ExecutorAddr()));
-  if (auto Err = EPC.callSPSWrapper<
-                 rt::SPSSimpleExecutorMemoryManagerReserveSignature>(
+  if (auto Err = EPC.callSPSWrapper<rt::sps_ci::MemMgrReserve::SPSSig>(
           SAs.Reserve, TargetAllocAddr, SAs.Instance, TotalSize)) {
     std::lock_guard<std::mutex> Lock(M);
     ErrMsg = toString(std::move(Err));
@@ -268,8 +266,7 @@ bool EPCGenericRTDyldMemoryManager::finalizeMemory(std::string *ErrMsg) {
     // We'll also need to make an extra allocation for the eh-frame wrapper call
     // arguments.
     Expected<ExecutorAddr> InitializeKey((ExecutorAddr()));
-    if (auto Err = EPC.callSPSWrapper<
-                   rt::SPSSimpleExecutorMemoryManagerInitializeSignature>(
+    if (auto Err = EPC.callSPSWrapper<rt::sps_ci::MemMgrInitialize::SPSSig>(
             SAs.Initialize, InitializeKey, SAs.Instance, std::move(FR))) {
       std::lock_guard<std::mutex> Lock(M);
       this->ErrMsg = toString(std::move(Err));

--- a/llvm/lib/ExecutionEngine/Orc/Shared/OrcRTBridge.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/Shared/OrcRTBridge.cpp
@@ -12,17 +12,6 @@ namespace llvm {
 namespace orc {
 namespace rt {
 
-const char *SimpleExecutorMemoryManagerInstanceName =
-    "__llvm_orc_SimpleExecutorMemoryManager_Instance";
-const char *SimpleExecutorMemoryManagerReserveWrapperName =
-    "__llvm_orc_SimpleExecutorMemoryManager_reserve_wrapper";
-const char *SimpleExecutorMemoryManagerInitializeWrapperName =
-    "__llvm_orc_SimpleExecutorMemoryManager_initialize_wrapper";
-const char *SimpleExecutorMemoryManagerDeinitializeWrapperName =
-    "__llvm_orc_SimpleExecutorMemoryManager_deinitialize_wrapper";
-const char *SimpleExecutorMemoryManagerReleaseWrapperName =
-    "__llvm_orc_SimpleExecutorMemoryManager_release_wrapper";
-
 const char *RegisterEHFrameSectionAllocActionName =
     "llvm_orc_registerEHFrameAllocAction";
 const char *DeregisterEHFrameSectionAllocActionName =

--- a/llvm/lib/ExecutionEngine/Orc/TargetProcess/SimpleExecutorMemoryManager.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/TargetProcess/SimpleExecutorMemoryManager.cpp
@@ -9,7 +9,6 @@
 #include "llvm/ExecutionEngine/Orc/TargetProcess/SimpleExecutorMemoryManager.h"
 
 #include "llvm/ADT/ScopeExit.h"
-#include "llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h"
 #include "llvm/ExecutionEngine/Orc/Shared/SPSCI/SimpleNativeMemoryMapSPSCI.h"
 #include "llvm/Support/FormatVariadic.h"
 
@@ -199,30 +198,13 @@ Error SimpleExecutorMemoryManager::shutdown() {
 
 void SimpleExecutorMemoryManager::addBootstrapSymbols(
     StringMap<ExecutorAddr> &M) {
-  M[rt::SimpleExecutorMemoryManagerInstanceName] = ExecutorAddr::fromPtr(this);
-  M[rt::SimpleExecutorMemoryManagerReserveWrapperName] =
-      ExecutorAddr::fromPtr(&reserveWrapper);
-  M[rt::SimpleExecutorMemoryManagerInitializeWrapperName] =
-      ExecutorAddr::fromPtr(&initializeWrapper);
-  M[rt::SimpleExecutorMemoryManagerDeinitializeWrapperName] =
-      ExecutorAddr::fromPtr(&deinitializeWrapper);
-  M[rt::SimpleExecutorMemoryManagerReleaseWrapperName] =
-      ExecutorAddr::fromPtr(&releaseWrapper);
-
-  {
-    // Also provide SimpleNativeMemoryMap symbols for compatibility.
-    // FIXME: We should codify a "simple" memory manager interface and make
-    // SimpleExecutorMemoryManager its LLVM-based implementation, and
-    // SimpleNativeMemoryMap its ORC-runtime implementation.
-    namespace sps_ci = rt::sps_ci;
-    M[sps_ci::SimpleNativeMemoryMapInstanceName] = ExecutorAddr::fromPtr(this);
-    M[sps_ci::MemMgrReserve::Name] = ExecutorAddr::fromPtr(reserveWrapper);
-    M[sps_ci::MemMgrInitialize::Name] =
-        ExecutorAddr::fromPtr(initializeWrapper);
-    M[sps_ci::MemMgrDeinitialize::Name] =
-        ExecutorAddr::fromPtr(deinitializeWrapper);
-    M[sps_ci::MemMgrRelease::Name] = ExecutorAddr::fromPtr(releaseWrapper);
-  }
+  namespace sps_ci = rt::sps_ci;
+  M[sps_ci::SimpleNativeMemoryMapInstanceName] = ExecutorAddr::fromPtr(this);
+  M[sps_ci::MemMgrReserve::Name] = ExecutorAddr::fromPtr(reserveWrapper);
+  M[sps_ci::MemMgrInitialize::Name] = ExecutorAddr::fromPtr(initializeWrapper);
+  M[sps_ci::MemMgrDeinitialize::Name] =
+      ExecutorAddr::fromPtr(deinitializeWrapper);
+  M[sps_ci::MemMgrRelease::Name] = ExecutorAddr::fromPtr(releaseWrapper);
 }
 
 Expected<SimpleExecutorMemoryManager::SlabInfo &>

--- a/llvm/unittests/ExecutionEngine/Orc/EPCGenericJITLinkMemoryManagerTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/EPCGenericJITLinkMemoryManagerTest.cpp
@@ -85,25 +85,24 @@ private:
 };
 
 CWrapperFunctionBuffer testReserve(const char *ArgData, size_t ArgSize) {
-  return WrapperFunction<rt::SPSSimpleExecutorMemoryManagerReserveSignature>::
-      handle(ArgData, ArgSize,
+  return WrapperFunction<rt::sps_ci::MemMgrReserve::SPSSig>::handle(
+             ArgData, ArgSize,
              makeMethodWrapperHandler(&SimpleAllocator::reserve))
-          .release();
+      .release();
 }
 
 CWrapperFunctionBuffer testInitialize(const char *ArgData, size_t ArgSize) {
-  return WrapperFunction<
-             rt::SPSSimpleExecutorMemoryManagerInitializeSignature>::
-      handle(ArgData, ArgSize,
+  return WrapperFunction<rt::sps_ci::MemMgrInitialize::SPSSig>::handle(
+             ArgData, ArgSize,
              makeMethodWrapperHandler(&SimpleAllocator::initialize))
-          .release();
+      .release();
 }
 
 CWrapperFunctionBuffer testRelease(const char *ArgData, size_t ArgSize) {
-  return WrapperFunction<rt::SPSSimpleExecutorMemoryManagerReleaseSignature>::
-      handle(ArgData, ArgSize,
+  return WrapperFunction<rt::sps_ci::MemMgrRelease::SPSSig>::handle(
+             ArgData, ArgSize,
              makeMethodWrapperHandler(&SimpleAllocator::release))
-          .release();
+      .release();
 }
 
 TEST(EPCGenericJITLinkMemoryManagerTest, AllocFinalizeFree) {


### PR DESCRIPTION
Move all clients to the sps_ci SimpleNativeMemoryMap / MemMgr counterparts and retire the old rt::SimpleExecutorMemoryManager* interface names.