### PR TITLE
[clang][test] Remove an uninitialized read in a test case

### DIFF
--- a/clang/test/SemaCXX/ms-ctor-closure.cpp
+++ b/clang/test/SemaCXX/ms-ctor-closure.cpp
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 %s -triple=i386-pc-win32 -std=c++23 -fms-extensions -verify
+// RUN: %clang_cc1 %s -triple=i386-pc-win32 -std=c++23 -fms-extensions -verify -fexperimental-new-constant-interpreter
 
 consteval int bad(int x) { return 42 / x; } // expected-note{{division by zero}}
 
@@ -16,10 +17,10 @@ public:
 };
 
 consteval int f1() {
-  Test1 var;
+  Test1 var{10};
   var.Test1::Test1(var); // expected-warning {{explicit constructor calls are a Microsoft extension}}
-  return 1;
+  return var.a;
 }
 
-static_assert(f1());
+static_assert(f1() == 10);
 }


### PR DESCRIPTION
This test case was added in https://github.com/llvm/llvm-project/pull/222212. Its purpose is to check that explicit constructor calls work at compile time.

However, the test case left var.a uninitialized and the copy constructor reads an unitialized value. MSVC diagnoses this, but clang currently fails to do so.

Change the test case to remove the unrelated problem of an uninitialized read.