### PR TITLE
[CodeGen][test] use -float-abi=soft in 2009-03-29-SoftFloatVectorExtract.ll

### DIFF
--- a/llvm/test/CodeGen/Generic/2009-03-29-SoftFloatVectorExtract.ll
+++ b/llvm/test/CodeGen/Generic/2009-03-29-SoftFloatVectorExtract.ll
@@ -1,5 +1,5 @@
 ; XFAIL: target={{.*}}-aix{{.*}}
-; RUN: llc < %s
+; RUN: llc -float-abi=soft < %s
 ; PR3899
 
 @m = external global <2 x double>


### PR DESCRIPTION
In #221434, using +soft-float with a hard-float ABI is now an error on ARM.
This test does not specify a target triple, so it will fail when the
default triple is hard-float ARM. Explicitly specify -float-abi=soft
so the test will continue to use the host triple but force the soft-float ABI
where applicable.
