### PR TITLE
[mlir][LLVM] Add invariant load attribute to LLVM's CallIntrinsicOp

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
@@ -2666,7 +2666,8 @@ def LLVM_CallIntrinsicOp
                        DenseI32ArrayAttr:$op_bundle_sizes,
                        OptionalAttr<ArrayAttr>:$op_bundle_tags,
                        OptionalAttr<DictArrayAttr>:$arg_attrs,
-                       OptionalAttr<DictArrayAttr>:$res_attrs);
+                       OptionalAttr<DictArrayAttr>:$res_attrs,
+                       UnitAttr:$invariant);
   let results = (outs Optional<LLVM_Type>:$results);
   let llvmBuilder = [{
     return convertCallLLVMIntrinsicOp(op, builder, moduleTranslation);

--- a/mlir/lib/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.cpp
@@ -205,6 +205,11 @@ convertCallLLVMIntrinsicOp(CallIntrinsicOp op, llvm::IRBuilderBase &builder,
   if (failed(moduleTranslation.convertArgAndResultAttrs(op, inst)))
     return failure();
 
+  if (op.getInvariant()) {
+    llvm::MDNode *metadata = llvm::MDNode::get(inst->getContext(), {});
+    inst->setMetadata(llvm::LLVMContext::MD_invariant_load, metadata);
+  }
+
   if (op.getNumResults() == 1)
     moduleTranslation.mapValue(op->getResults().front()) = inst;
   return success();

--- a/mlir/test/Target/LLVMIR/llvmir.mlir
+++ b/mlir/test/Target/LLVMIR/llvmir.mlir
@@ -3486,6 +3486,17 @@ llvm.func @call_intrin_with_opbundle(%arg0 : !llvm.ptr) {
 
 // -----
 
+llvm.func @call_intrin_invariant(%arg0 : !llvm.ptr<8>, %arg1 : i32) -> f32 {
+  %0 = llvm.mlir.constant(0 : i32) : i32
+  %1 = llvm.call_intrinsic "llvm.amdgcn.ptr.s.buffer.load.f32"(%arg0, %arg1, %0) {invariant} : (!llvm.ptr<8>, i32, i32) -> f32
+  llvm.return %1 : f32
+}
+
+// CHECK-LABEL: define float @call_intrin_invariant(
+//      CHECK:   call float @llvm.amdgcn.ptr.s.buffer.load.f32({{.*}}), !invariant.load
+
+// -----
+
 module {
   llvm.module_flags [#llvm.mlir.module_flag<error, "wchar_size", 4 : i32>,
                      #llvm.mlir.module_flag<min, "PIC Level", 2 : i32>,


### PR DESCRIPTION
In LLVM IR, the `llvm.amdgcn.ptr.s.buffer.load` intrinsic has an `!invariant.load` metadata attached. LLVMCallIntrinsicOp had no corresponding attribute so this patch adds the attribute to the op.

Assisted by: Claude Opus 5