### PR TITLE
[orc-rt] Build RTTICrossDylibTestLib with ORC_RT_COMPILE_FLAGS

### DIFF
--- a/orc-rt/test/unit/CMakeLists.txt
+++ b/orc-rt/test/unit/CMakeLists.txt
@@ -131,5 +131,6 @@ set_target_properties(RTTICrossDylibTestLib PROPERTIES
   PREFIX ""
   CXX_VISIBILITY_PRESET hidden
   VISIBILITY_INLINES_HIDDEN ON)
+target_compile_options(RTTICrossDylibTestLib PRIVATE ${ORC_RT_COMPILE_FLAGS})
 target_link_libraries(RTTICrossDylibTestLib PRIVATE orc-rt-bedrock)
 target_link_libraries(SupportTests PRIVATE RTTICrossDylibTestLib)


### PR DESCRIPTION
Without ORC_RT_COMPILE_FLAGS, the test library builds with C++ RTTI on by default. This leads to link errors when the ORC runtime is built with C++ RTTI turned off.