### PR TITLE
[libc++][docs] Use Furo theme

### DIFF
--- a/libcxx/docs/AddingNewCIJobs.rst
+++ b/libcxx/docs/AddingNewCIJobs.rst
@@ -4,9 +4,6 @@
 Adding New CI Jobs
 ==================
 
-.. contents::
-  :local:
-
 Adding The Job
 ==============
 

--- a/libcxx/docs/CodingGuidelines.rst
+++ b/libcxx/docs/CodingGuidelines.rst
@@ -4,9 +4,6 @@
 libc++ Coding Guidelines
 ========================
 
-.. contents::
-  :local:
-
 Use ``__ugly_names`` for implementation details
 ===============================================
 

--- a/libcxx/docs/DesignDocs/CapturingConfigInfo.rst
+++ b/libcxx/docs/DesignDocs/CapturingConfigInfo.rst
@@ -2,9 +2,6 @@
 Capturing configuration information in the headers
 ==================================================
 
-.. contents::
-   :local:
-
 The Problem
 ===========
 

--- a/libcxx/docs/DesignDocs/ExperimentalFeatures.rst
+++ b/libcxx/docs/DesignDocs/ExperimentalFeatures.rst
@@ -2,9 +2,6 @@
 Experimental Features
 =====================
 
-.. contents::
-   :local:
-
 .. _experimental features:
 
 Overview

--- a/libcxx/docs/DesignDocs/ExtendedCXX03Support.rst
+++ b/libcxx/docs/DesignDocs/ExtendedCXX03Support.rst
@@ -2,9 +2,6 @@
 Extended C++03 Support
 =======================
 
-.. contents::
-   :local:
-
 Overview
 ========
 

--- a/libcxx/docs/DesignDocs/FeatureTestMacros.rst
+++ b/libcxx/docs/DesignDocs/FeatureTestMacros.rst
@@ -2,9 +2,6 @@
 Feature Test Macros
 ===================
 
-.. contents::
-   :local:
-
 Overview
 ========
 

--- a/libcxx/docs/DesignDocs/FileTimeType.rst
+++ b/libcxx/docs/DesignDocs/FileTimeType.rst
@@ -2,9 +2,6 @@
 File Time Type
 ==============
 
-.. contents::
-   :local:
-
 .. _file-time-type-motivation:
 
 Motivation

--- a/libcxx/docs/DesignDocs/ThreadingSupportAPI.rst
+++ b/libcxx/docs/DesignDocs/ThreadingSupportAPI.rst
@@ -2,9 +2,6 @@
 Threading Support API
 =====================
 
-.. contents::
-   :local:
-
 Overview
 ========
 

--- a/libcxx/docs/DesignDocs/VisibilityMacros.rst
+++ b/libcxx/docs/DesignDocs/VisibilityMacros.rst
@@ -2,9 +2,6 @@
 Symbol Visibility Macros
 ========================
 
-.. contents::
-   :local:
-
 .. _visibility-macros:
 
 Overview

--- a/libcxx/docs/Hardening.rst
+++ b/libcxx/docs/Hardening.rst
@@ -4,9 +4,6 @@
 Hardening Modes
 ===============
 
-.. contents::
-   :local:
-
 .. _using-hardening-modes:
 
 Using hardening modes

--- a/libcxx/docs/Helpers/ReleaseNotesTemplate.rst
+++ b/libcxx/docs/Helpers/ReleaseNotesTemplate.rst
@@ -2,10 +2,6 @@
 Libc++ XX.YY.ZZ (In-Progress) Release Notes
 ===========================================
 
-.. contents::
-   :local:
-   :depth: 2
-
 Written by the `Libc++ Team <https://libcxx.llvm.org>`_
 
 .. warning::

--- a/libcxx/docs/ReleaseNotes/20.rst
+++ b/libcxx/docs/ReleaseNotes/20.rst
@@ -2,10 +2,6 @@
 Libc++ 20.0.0 (In-Progress) Release Notes
 ===========================================
 
-.. contents::
-   :local:
-   :depth: 2
-
 Written by the `Libc++ Team <https://libcxx.llvm.org>`_
 
 .. warning::

--- a/libcxx/docs/ReleaseNotes/21.rst
+++ b/libcxx/docs/ReleaseNotes/21.rst
@@ -2,10 +2,6 @@
 Libc++ 21.0.0 (In-Progress) Release Notes
 ===========================================
 
-.. contents::
-   :local:
-   :depth: 2
-
 Written by the `Libc++ Team <https://libcxx.llvm.org>`_
 
 .. warning::

--- a/libcxx/docs/ReleaseNotes/22.rst
+++ b/libcxx/docs/ReleaseNotes/22.rst
@@ -2,10 +2,6 @@
 Libc++ 22.0.0 (In-Progress) Release Notes
 ===========================================
 
-.. contents::
-   :local:
-   :depth: 2
-
 Written by the `Libc++ Team <https://libcxx.llvm.org>`_
 
 .. warning::

--- a/libcxx/docs/ReleaseNotes/23.rst
+++ b/libcxx/docs/ReleaseNotes/23.rst
@@ -2,10 +2,6 @@
 Libc++ 23.0.0 (In-Progress) Release Notes
 ===========================================
 
-.. contents::
-   :local:
-   :depth: 2
-
 Written by the `Libc++ Team <https://libcxx.llvm.org>`_
 
 .. warning::

--- a/libcxx/docs/ReleaseNotes/24.rst
+++ b/libcxx/docs/ReleaseNotes/24.rst
@@ -2,10 +2,6 @@
 Libc++ 24.0.0 Release Notes
 ===========================
 
-.. contents::
-   :local:
-   :depth: 2
-
 Written by the `Libc++ Team <https://libcxx.llvm.org>`_
 
 .. warning::

--- a/libcxx/docs/Status/Cxx29.md
+++ b/libcxx/docs/Status/Cxx29.md
@@ -5,9 +5,6 @@
 ```{include} ../Helpers/Styles.md
 ```
 
-```{contents}
-:local: true
-```
 
 ## Overview
 

--- a/libcxx/docs/TestingLibcxx.rst
+++ b/libcxx/docs/TestingLibcxx.rst
@@ -4,9 +4,6 @@
 Testing libc++
 ==============
 
-.. contents::
-  :local:
-
 Getting Started
 ===============
 

--- a/libcxx/docs/UserDocumentation.rst
+++ b/libcxx/docs/UserDocumentation.rst
@@ -4,9 +4,6 @@
 User documentation
 ==================
 
-.. contents::
-  :local:
-
 This page contains information for users of libc++: how to use libc++ if it is not
 the default library used by the toolchain, and what configuration knobs are available
 if libc++ is used by the toolchain. This page is aimed at users of libc++, whereas a

--- a/libcxx/docs/VendorDocumentation.rst
+++ b/libcxx/docs/VendorDocumentation.rst
@@ -4,9 +4,6 @@
 Vendor Documentation
 ====================
 
-.. contents::
-  :local:
-
 The instructions on this page are aimed at vendors who ship libc++ as part of an
 operating system distribution, a toolchain or similar shipping vehicles. If you
 are a user merely trying to use libc++ in your program, you most likely want to

--- a/libcxx/docs/_static/custom.css
+++ b/libcxx/docs/_static/custom.css
@@ -1,0 +1,20 @@
+/* Use the full viewport on ordinary desktop displays, where Furo's fixed
+   content width leaves little room after both sidebars. Once the content area
+   reaches 90em (84em plus padding), grow symmetric outer margins instead. */
+@media (min-width: 67em) {
+  .page .sidebar-drawer {
+    width: max(15em, calc(50% - 45em));
+  }
+
+  .main > .content {
+    width: min(84em, calc(100vw - 36em));
+  }
+}
+
+/* Furo moves the page-local TOC into a drawer below 82em, freeing its 15em
+   column for the main content. */
+@media (min-width: 67em) and (max-width: 82em) {
+  .main > .content {
+    width: calc(100vw - 21em);
+  }
+}

--- a/libcxx/docs/conf.py
+++ b/libcxx/docs/conf.py
@@ -82,21 +82,17 @@ pygments_style = "friendly"
 
 # -- Options for HTML output ---------------------------------------------------
 
-# The theme to use for HTML and HTML Help pages.  See the documentation for
-# a list of builtin themes.
-html_theme = "haiku"
-
-# Theme options are theme-specific and customize the look and feel of a theme
-# further.  For a list of options available for each theme, see the
-# documentation.
-# html_theme_options = {}
+configure_furo(
+    globals(),
+    source_directory="libcxx/docs/",
+    html_title="libc++",
+    html_logo=shared_static_asset("LLVMWyvernSmall.png"),
+    local_static_path=["_static"],
+    extra_css_files=["custom.css"],
+)
 
 # Add any paths that contain custom themes here, relative to this directory.
 # html_theme_path = []
-
-# The name for this set of Sphinx documents.  If None, it defaults to
-# "<project> v<release> documentation".
-# html_title = None
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
 # html_short_title = None
@@ -109,11 +105,6 @@ html_theme = "haiku"
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.
 # html_favicon = None
-
-# Add any paths that contain custom static files (such as style sheets) here,
-# relative to this directory. They are copied after the builtin static files,
-# so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = []
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.


### PR DESCRIPTION
Preview: https://clangdocs.staging.reidkleckner.dev/after/libcxx/docs/
Current: https://libcxx.llvm.org/

I ported over the LLVM wyvern logo and the Clang CSS viewport width customizations.

Most of the changes are removing page-local contents directives that duplicate Furo’s right-hand navbar. I stacked this on top of the libc++ markdown migration to avoid self-conflicts, but it's conceptually independent and I could rebase on main if necessary.

Clang Furo PR: llvm/llvm-project#214869
Related, flang: llvm/llvm-project#223151
RFC for Clang: https://discourse.llvm.org/t/rfc-use-furo-theme-for-clang-docs/91505/7

libc++ is using the Clang doc theme (perhaps it's the default) so I feel like it's a good candidate to migrate, but let me know if you feel differently.

Assisted-by: codex