### PR TITLE
clang: Emit the "thread-model" module flag

### DIFF
--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -1434,6 +1434,15 @@ void CodeGenModule::Release() {
                             llvm::FloatABI::getABITypeName(FloatABI)));
   }
 
+  // Record the thread model as a module flag when it differs from the target
+  // default.
+  llvm::ThreadModel ThreadModel =
+      LangOpts.getThreadModel() == LangOptions::ThreadModelKind::Single
+          ? llvm::ThreadModel::Single
+          : llvm::ThreadModel::POSIX;
+  if (ThreadModel != getTriple().getDefaultThreadModel())
+    getModule().setThreadModel(ThreadModel);
+
   if (getTypes().isLongDoubleReferenced()) {
     const llvm::fltSemantics *flt = &getTarget().getLongDoubleFormat();
 

--- a/clang/test/CodeGen/thread-model.c
+++ b/clang/test/CodeGen/thread-model.c
@@ -1,0 +1,11 @@
+// Check that the "thread-model" module flag is emitted for -mthread-model
+// single, and omitted when the model matches the target default (posix).
+
+// RUN: %clang_cc1 -triple arm-none-linux-gnueabi -mthread-model single -emit-llvm %s -o - | FileCheck %s --check-prefix=SINGLE
+// RUN: %clang_cc1 -triple arm-none-linux-gnueabi -mthread-model posix -emit-llvm %s -o - | FileCheck %s --check-prefix=POSIX
+// RUN: %clang_cc1 -triple arm-none-linux-gnueabi -emit-llvm %s -o - | FileCheck %s --check-prefix=POSIX
+
+void f(void) {}
+
+// SINGLE: !{i32 1, !"thread-model", !"single"}
+// POSIX-NOT: "thread-model"


### PR DESCRIPTION
Emit the threading model as the "thread-model" IR module flag. This
will eventually replace the TargetOptions field.

Co-authored-by: Claude (Claude-Opus-4.8) <noreply@anthropic.com>