### PR TITLE
[lldb] Initialize the host platform under Emscripten

### DIFF
--- a/lldb/source/Plugins/Platform/Linux/PlatformLinux.cpp
+++ b/lldb/source/Plugins/Platform/Linux/PlatformLinux.cpp
@@ -102,7 +102,7 @@ void PlatformLinux::Initialize() {
   PlatformPOSIX::Initialize();
 
   if (g_initialize_count++ == 0) {
-#if defined(__linux__) && !defined(__ANDROID__)
+#if (defined(__linux__) || defined(__EMSCRIPTEN__)) && !defined(__ANDROID__)
     PlatformSP default_platform_sp(new PlatformLinux(true));
     default_platform_sp->SetSystemArchitecture(HostInfo::GetArchitecture());
     Platform::SetHostPlatform(default_platform_sp);


### PR DESCRIPTION


Hey @JDevlieghere, I’m not sure whether you’ve had a chance to see my [RFC: Embeddable LLVM tool drivers for long-lived hosts](https://discourse.llvm.org/t/rfc-embeddable-llvm-tool-drivers-for-long-lived-hosts/91754), but I’m working on [WasmBolt](https://github.com/anutosh491/WasmBolt) (try [here](https://anutosh21.github.io/WasmBolt/)) —essentially an attempt to bring a Godbolt-style LLVM playground into the browser, with the LLVM toolchain itself running through WebAssembly rather than a remote compilation server.

I’ve now started investigating LLDB support. The first milestone is to compile `liblldb` with Emscripten and use LLDB’s real SB API for static inspection of a WebAssembly binary entirely inside the browser process.

**The initial experiment is working**: the Emscripten-built LLDB can load a Wasm binary containing DWARF information, discover C++ symbols and source lines, inspect sections, disassemble functions, and resolve/set a breakpoint by function name.

While testing this, I found that LLDB did not initialize a host platform under Emscripten. `HostInfo` already treats Emscripten as using `HostInfoLinux`, but `PlatformLinux::Initialize()` only creates the corresponding host platform when `__linux__` is defined. This leaves the debugger without a selected platform and causes `CreateTarget` to fail when it checks the discovered Wasm architecture.

This patch extends that existing condition to `__EMSCRIPTEN__`. With the change, the same LLDB SB API program works without manually selecting a platform.

This is intended to be the **first of a few small patches** needed to make building and embedding `liblldb` under Emscripten cleanly supported. I’m keeping the patches separate so each change can be reviewed on its own.

There is currently no upstream LLDB Emscripten CI configuration that exercises this branch, so I validated it manually using an Emscripten-built `liblldb` and a Wasm binary compiled with debug information. Hope that's okay !