### PR TITLE
[libc] Use execve syscall wrapper in execv.cpp

### DIFF
--- a/libc/src/unistd/linux/CMakeLists.txt
+++ b/libc/src/unistd/linux/CMakeLists.txt
@@ -213,8 +213,10 @@ add_entrypoint_object(
   HDRS
     ../execv.h
   DEPENDS
-    libc.include.sys_syscall
-    libc.src.__support.OSUtil.osutil
+    libc.src.__support.common
+    libc.src.__support.libc_errno
+    libc.src.__support.macros.config
+    libc.src.__support.OSUtil.linux.syscall_wrappers.execve
     libc.src.errno.errno
     libc.src.unistd.environ
 )

--- a/libc/src/unistd/linux/execv.cpp
+++ b/libc/src/unistd/linux/execv.cpp
@@ -10,25 +10,24 @@
 #include "src/__support/macros/config.h"
 #include "src/unistd/environ.h"
 
-#include "src/__support/OSUtil/syscall.h" // For internal syscall function.
+#include "src/__support/OSUtil/linux/syscall_wrappers/execve.h"
 #include "src/__support/common.h"
 
 #include "src/__support/libc_errno.h"
-#include <sys/syscall.h> // For syscall numbers.
 
 namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(int, execv, (const char *path, char *const argv[])) {
-  int ret = LIBC_NAMESPACE::syscall_impl<int>(SYS_execve, path, argv,
-                                              LIBC_NAMESPACE::environ);
-  if (ret < 0) {
-    libc_errno = -ret;
+  auto ret = linux_syscalls::execve(
+      path, argv, const_cast<char *const *>(LIBC_NAMESPACE::environ));
+  if (!ret) {
+    libc_errno = ret.error();
     return -1;
   }
 
   // Control will not reach here on success but have a return statement will
   // keep the compilers happy.
-  return ret;
+  return *ret;
 }
 
 } // namespace LIBC_NAMESPACE_DECL


### PR DESCRIPTION
Use the existing execve syscall wrapper in `execv.cpp` instead of invoking SYS_execve directly.