### PR TITLE
[MISched] Fix pre-RA pickOnlyChoice tracing

### DIFF
--- a/llvm/lib/CodeGen/MachineScheduler.cpp
+++ b/llvm/lib/CodeGen/MachineScheduler.cpp
@@ -4167,7 +4167,9 @@ SUnit *GenericScheduler::pickNode(bool &IsTopNode) {
   SUnit *SU;
   if (RegionPolicy.OnlyTopDown) {
     SU = Top.pickOnlyChoice();
-    if (!SU) {
+    if (SU) {
+      tracePick(SU, Only1, /*IsTopNode=*/true);
+    } else {
       CandPolicy NoPolicy;
       TopCand.reset(NoPolicy);
       pickNodeFromQueue(Top, NoPolicy, DAG->getTopRPTracker(), TopCand);
@@ -4178,7 +4180,9 @@ SUnit *GenericScheduler::pickNode(bool &IsTopNode) {
     IsTopNode = true;
   } else if (RegionPolicy.OnlyBottomUp) {
     SU = Bot.pickOnlyChoice();
-    if (!SU) {
+    if (SU) {
+      tracePick(SU, Only1, /*IsTopNode=*/false);
+    } else {
       CandPolicy NoPolicy;
       BotCand.reset(NoPolicy);
       pickNodeFromQueue(Bot, NoPolicy, DAG->getBotRPTracker(), BotCand);

--- a/llvm/test/CodeGen/AArch64/misched-detail-resource-booking-01.mir
+++ b/llvm/test/CodeGen/AArch64/misched-detail-resource-booking-01.mir
@@ -477,6 +477,7 @@ body:             |
 # CHECK-NEXT:     selecting CortexA55UnitALU[1] available @3c
 # CHECK-NEXT: Queue BotQ.P: 10
 # CHECK-NEXT: Queue BotQ.A: 11
+# CHECK-NEXT: Pick Bot Cand SU(11) ONLY1      [pre-RA]
 # CHECK-NEXT: Scheduling SU(11) $q0 = COPY %10:fpr128
 # CHECK-NEXT:   Ready @3c
 # CHECK-NEXT:   CortexA55UnitALU +1x1u
@@ -667,6 +668,7 @@ body:             |
 # CHECK-NEXT:     selecting CortexA55UnitFPALU[1] available @8c
 # CHECK-NEXT: Queue BotQ.P: 9 3
 # CHECK-NEXT: Queue BotQ.A: 8
+# CHECK-NEXT: Pick Bot Cand SU(8) ONLY1      [pre-RA]
 # CHECK-NEXT: Scheduling SU(8) %10:fpr128 = UMULLv4i16_v4i32 %0.dsub:fpr128, %9:fpr64
 # CHECK-NEXT:   Ready @8c
 # CHECK-NEXT:   CortexA55UnitFPALU +2x1u
@@ -769,6 +771,7 @@ body:             |
 # CHECK-NEXT:     selecting CortexA55UnitFPALU[0] available @9c
 # CHECK-NEXT: Queue BotQ.P: 7 3
 # CHECK-NEXT: Queue BotQ.A: 9
+# CHECK-NEXT: Pick Bot Cand SU(9) ONLY1      [pre-RA]
 # CHECK-NEXT: Scheduling SU(9) %11:fpr64 = XTNv4i16 %7:fpr128
 # CHECK-NEXT:   Ready @9c
 # CHECK-NEXT:   CortexA55UnitFPALU +1x1u
@@ -948,6 +951,7 @@ body:             |
 # CHECK-NEXT:     selecting CortexA55UnitFPALU[1] available @10c
 # CHECK-NEXT: Queue BotQ.P: 3 6
 # CHECK-NEXT: Queue BotQ.A: 5
+# CHECK-NEXT: Pick Bot Cand SU(5) ONLY1      [pre-RA]
 # CHECK-NEXT: Scheduling SU(5) %7:fpr128 = ANDv16i8 %2:fpr128, %6:fpr128
 # CHECK-NEXT:   Ready @10c
 # CHECK-NEXT:   CortexA55UnitFPALU +2x1u
@@ -1302,6 +1306,7 @@ body:             |
 # CHECK-NEXT:     selecting CortexA55UnitALU[0] available @14c
 # CHECK-NEXT: Queue BotQ.P: 1 4 2
 # CHECK-NEXT: Queue BotQ.A: 0
+# CHECK-NEXT: Pick Bot Cand SU(0) ONLY1      [pre-RA]
 # CHECK-NEXT: Scheduling SU(0) %2:fpr128 = COPY $q2
 # CHECK-NEXT:   Ready @14c
 # CHECK-NEXT:   CortexA55UnitALU +1x1u
@@ -1385,6 +1390,7 @@ body:             |
 # CHECK-NEXT:   hazard: SU(4) ReadyCycle = 16 is later than CurrCycle = 15 on an unbuffered resource
 # CHECK-NEXT: Queue BotQ.P: 2 4
 # CHECK-NEXT: Queue BotQ.A: 1
+# CHECK-NEXT: Pick Bot Cand SU(1) ONLY1      [pre-RA]
 # CHECK-NEXT: Scheduling SU(1) %1:fpr128 = COPY $q1
 # CHECK-NEXT:   Ready @15c
 # CHECK-NEXT:   CortexA55UnitALU +1x1u
@@ -1563,6 +1569,7 @@ body:             |
 # CHECK-NEXT:     selecting CortexA55UnitALU[0] available @17c
 # CHECK-NEXT: Queue BotQ.P:
 # CHECK-NEXT: Queue BotQ.A: 2
+# CHECK-NEXT: Pick Bot Cand SU(2) ONLY1      [pre-RA]
 # CHECK-NEXT: Scheduling SU(2) %0:fpr128 = COPY $q0
 # CHECK-NEXT:   Ready @17c
 # CHECK-NEXT:   CortexA55UnitALU +1x1u

--- a/llvm/test/CodeGen/AArch64/misched-detail-resource-booking-02.mir
+++ b/llvm/test/CodeGen/AArch64/misched-detail-resource-booking-02.mir
@@ -404,6 +404,7 @@ body:             |
 # CHECK-NEXT:     selecting CortexA55UnitALU[0] available @1c
 # CHECK-NEXT: Queue BotQ.P:
 # CHECK-NEXT: Queue BotQ.A: 0
+# CHECK-NEXT: Pick Bot Cand SU(0) ONLY1      [pre-RA]
 # CHECK-NEXT: Scheduling SU(0) $x3 = ADDXrr $x0, $x0
 # CHECK-NEXT:   Ready @1c
 # CHECK-NEXT:   CortexA55UnitALU +1x1u

--- a/llvm/test/CodeGen/AArch64/misched-prera-only1.mir
+++ b/llvm/test/CodeGen/AArch64/misched-prera-only1.mir
@@ -1,0 +1,114 @@
+# REQUIRES: asserts
+
+# RUN: llc -mtriple=aarch64 -mcpu=apple-m5 -run-pass=machine-scheduler \
+# RUN:   -verify-machineinstrs \
+# RUN:   -debug-only=machine-scheduler -misched-prera-direction=topdown \
+# RUN:   -o - %s 2>&1 | FileCheck --check-prefix=TOPDOWN %s
+# RUN: llc -mtriple=aarch64 -mcpu=apple-m5 -run-pass=machine-scheduler \
+# RUN:   -verify-machineinstrs \
+# RUN:   -debug-only=machine-scheduler -misched-prera-direction=bottomup \
+# RUN:   -o - %s 2>&1 | FileCheck --check-prefix=BOTTOMUP %s
+# RUN: llc -mtriple=aarch64 -mcpu=apple-m5 -run-pass=machine-scheduler \
+# RUN:   -verify-machineinstrs \
+# RUN:   -debug-only=machine-scheduler -misched-prera-direction=bidirectional \
+# RUN:   -o - %s 2>&1 | FileCheck --check-prefix=BIDIR %s
+
+---
+# A linear dependency chain leaves exactly one node available in either zone at
+# every step, so every pick comes from pickOnlyChoice(). Bidirectional picks
+# bottom-up throughout, because the bottom zone is queried first.
+
+# TOPDOWN:      chain:%bb.0
+# TOPDOWN:      Pick Top Cand SU(0) ONLY1      [pre-RA]
+# TOPDOWN-NEXT: Scheduling SU(0)
+# TOPDOWN:      Pick Top Cand SU(1) ONLY1      [pre-RA]
+# TOPDOWN-NEXT: Scheduling SU(1)
+# TOPDOWN:      Pick Top Cand SU(2) ONLY1      [pre-RA]
+# TOPDOWN-NEXT: Scheduling SU(2)
+# TOPDOWN:      *** Final schedule for %bb.0 ***
+# TOPDOWN-NEXT: SU(0):   %0:gpr64common = ADDXri $x0, 1, 0
+# TOPDOWN-NEXT: SU(1):   %1:gpr64common = ADDXri %0:gpr64common, 1, 0
+# TOPDOWN-NEXT: SU(2):   dead %2:gpr64common = ADDXri %1:gpr64common, 1, 0
+
+# BOTTOMUP:      chain:%bb.0
+# BOTTOMUP:      Pick Bot Cand SU(2) ONLY1      [pre-RA]
+# BOTTOMUP-NEXT: Scheduling SU(2)
+# BOTTOMUP:      Pick Bot Cand SU(1) ONLY1      [pre-RA]
+# BOTTOMUP-NEXT: Scheduling SU(1)
+# BOTTOMUP:      Pick Bot Cand SU(0) ONLY1      [pre-RA]
+# BOTTOMUP-NEXT: Scheduling SU(0)
+# BOTTOMUP:      *** Final schedule for %bb.0 ***
+# BOTTOMUP-NEXT: SU(0):   %0:gpr64common = ADDXri $x0, 1, 0
+# BOTTOMUP-NEXT: SU(1):   %1:gpr64common = ADDXri %0:gpr64common, 1, 0
+# BOTTOMUP-NEXT: SU(2):   dead %2:gpr64common = ADDXri %1:gpr64common, 1, 0
+
+# BIDIR:      chain:%bb.0
+# BIDIR:      Pick Bot Cand SU(2) ONLY1      [pre-RA]
+# BIDIR-NEXT: Scheduling SU(2)
+# BIDIR:      Pick Bot Cand SU(1) ONLY1      [pre-RA]
+# BIDIR-NEXT: Scheduling SU(1)
+# BIDIR:      Pick Bot Cand SU(0) ONLY1      [pre-RA]
+# BIDIR-NEXT: Scheduling SU(0)
+# BIDIR:      *** Final schedule for %bb.0 ***
+# BIDIR-NEXT: SU(0):   %0:gpr64common = ADDXri $x0, 1, 0
+# BIDIR-NEXT: SU(1):   %1:gpr64common = ADDXri %0:gpr64common, 1, 0
+# BIDIR-NEXT: SU(2):   dead %2:gpr64common = ADDXri %1:gpr64common, 1, 0
+name:            chain
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    liveins: $x0
+    %0:gpr64common = ADDXri $x0, 1, 0
+    %1:gpr64common = ADDXri %0, 1, 0
+    %2:gpr64common = ADDXri %1, 1, 0
+    RET_ReallyLR
+...
+---
+# A fan-out leaves two nodes available at the bottom but only one at the top,
+# so bidirectional scheduling falls through to Top.pickOnlyChoice().
+
+# TOPDOWN:      fanout:%bb.0
+# TOPDOWN:      Pick Top Cand SU(0) ONLY1      [pre-RA]
+# TOPDOWN-NEXT: Scheduling SU(0)
+# TOPDOWN:      Pick Top Cand SU(1) ORDER      [pre-RA]
+# TOPDOWN-NEXT: Scheduling SU(1)
+# TOPDOWN:      Pick Top Cand SU(2) ONLY1      [pre-RA]
+# TOPDOWN-NEXT: Scheduling SU(2)
+# TOPDOWN:      *** Final schedule for %bb.0 ***
+# TOPDOWN-NEXT: SU(0):   %0:gpr64common = ADDXri $x0, 1, 0
+# TOPDOWN-NEXT: SU(1):   dead %1:gpr64common = ADDXri %0:gpr64common, 1, 0
+# TOPDOWN-NEXT: SU(2):   dead %2:gpr64common = ADDXri %0:gpr64common, 2, 0
+
+# BOTTOMUP:      fanout:%bb.0
+# BOTTOMUP:      Pick Bot Cand SU(2) FIRST      [pre-RA]
+# BOTTOMUP-NEXT: Scheduling SU(2)
+# BOTTOMUP:      Pick Bot Cand SU(1) ONLY1      [pre-RA]
+# BOTTOMUP-NEXT: Scheduling SU(1)
+# BOTTOMUP:      Pick Bot Cand SU(0) ONLY1      [pre-RA]
+# BOTTOMUP-NEXT: Scheduling SU(0)
+# BOTTOMUP:      *** Final schedule for %bb.0 ***
+# BOTTOMUP-NEXT: SU(0):   %0:gpr64common = ADDXri $x0, 1, 0
+# BOTTOMUP-NEXT: SU(1):   dead %1:gpr64common = ADDXri %0:gpr64common, 1, 0
+# BOTTOMUP-NEXT: SU(2):   dead %2:gpr64common = ADDXri %0:gpr64common, 2, 0
+
+# BIDIR:      fanout:%bb.0
+# BIDIR:      Pick Top Cand SU(0) ONLY1      [pre-RA]
+# BIDIR-NEXT: Scheduling SU(0)
+# BIDIR:      Pick Bot Cand SU(2) FIRST      [pre-RA]
+# BIDIR-NEXT: Scheduling SU(2)
+# BIDIR:      Pick Bot Cand SU(1) ONLY1      [pre-RA]
+# BIDIR-NEXT: Scheduling SU(1)
+# BIDIR:      *** Final schedule for %bb.0 ***
+# BIDIR-NEXT: SU(0):   %0:gpr64common = ADDXri $x0, 1, 0
+# BIDIR-NEXT: SU(1):   dead %1:gpr64common = ADDXri %0:gpr64common, 1, 0
+# BIDIR-NEXT: SU(2):   dead %2:gpr64common = ADDXri %0:gpr64common, 2, 0
+name:            fanout
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    liveins: $x0
+    %0:gpr64common = ADDXri $x0, 1, 0
+    %1:gpr64common = ADDXri %0, 1, 0
+    %2:gpr64common = ADDXri %0, 2, 0
+    RET_ReallyLR
+...


### PR DESCRIPTION
Add missing tracePick calls. Now GenericScheduler and PostGenericScheduler tracing coverage is complete. Add a stable only1 test for pre-RA scheduling.