### PR TITLE
[libc] Use execve syscall wrapper in execve.cpp

### DIFF
--- a/libc/src/unistd/linux/CMakeLists.txt
+++ b/libc/src/unistd/linux/CMakeLists.txt
@@ -226,8 +226,10 @@ add_entrypoint_object(
   HDRS
     ../execve.h
   DEPENDS
-    libc.include.sys_syscall
-    libc.src.__support.OSUtil.osutil
+    libc.src.__support.common
+    libc.src.__support.libc_errno
+    libc.src.__support.macros.config
+    libc.src.__support.OSUtil.linux.syscall_wrappers.execve
     libc.src.errno.errno
 )
 

--- a/libc/src/unistd/linux/execve.cpp
+++ b/libc/src/unistd/linux/execve.cpp
@@ -8,27 +8,25 @@
 
 #include "src/unistd/execve.h"
 #include "src/__support/macros/config.h"
-#include "src/unistd/environ.h"
 
-#include "src/__support/OSUtil/syscall.h" // For internal syscall function.
+#include "src/__support/OSUtil/linux/syscall_wrappers/execve.h"
 #include "src/__support/common.h"
 
 #include "src/__support/libc_errno.h"
-#include <sys/syscall.h> // For syscall numbers.
 
 namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(int, execve,
                    (const char *path, char *const argv[], char *const envp[])) {
-  int ret = LIBC_NAMESPACE::syscall_impl<int>(SYS_execve, path, argv, envp);
-  if (ret < 0) {
-    libc_errno = -ret;
+  auto ret = linux_syscalls::execve(path, argv, envp);
+  if (!ret) {
+    libc_errno = ret.error();
     return -1;
   }
 
   // Control will not reach here on success but have a return statement will
   // keep the compilers happy.
-  return ret;
+  return *ret;
 }
 
 } // namespace LIBC_NAMESPACE_DECL


### PR DESCRIPTION
Use the existing execve syscall wrapper in `execve.cpp` instead of invoking SYS_execve directly.