### PR TITLE
[Support] Fix the return type of AddOverflow, SubOverflow, and MulOverflow

### DIFF
--- a/llvm/include/llvm/Support/MathExtras.h
+++ b/llvm/include/llvm/Support/MathExtras.h
@@ -717,7 +717,7 @@ AddOverflow(T X, T Y) {
 /// Add two signed integers, computing the two's complement truncated result,
 /// returning true if overflow occurred.
 template <typename T>
-std::enable_if_t<std::is_signed_v<T>, T> AddOverflow(T X, T Y, T &Result) {
+std::enable_if_t<std::is_signed_v<T>, bool> AddOverflow(T X, T Y, T &Result) {
 #if __has_builtin(__builtin_add_overflow)
   return __builtin_add_overflow(X, Y, &Result);
 #else
@@ -754,7 +754,7 @@ SubOverflow(T X, T Y) {
 /// Subtract two signed integers, computing the two's complement truncated
 /// result, returning true if an overflow occurred.
 template <typename T>
-std::enable_if_t<std::is_signed_v<T>, T> SubOverflow(T X, T Y, T &Result) {
+std::enable_if_t<std::is_signed_v<T>, bool> SubOverflow(T X, T Y, T &Result) {
 #if __has_builtin(__builtin_sub_overflow)
   return __builtin_sub_overflow(X, Y, &Result);
 #else
@@ -798,7 +798,7 @@ MulOverflow(T X, T Y) {
 /// Multiply two signed integers, computing the two's complement truncated
 /// result, returning true if an overflow occurred.
 template <typename T>
-std::enable_if_t<std::is_signed_v<T>, T> MulOverflow(T X, T Y, T &Result) {
+std::enable_if_t<std::is_signed_v<T>, bool> MulOverflow(T X, T Y, T &Result) {
 #if __has_builtin(__builtin_mul_overflow)
   return __builtin_mul_overflow(X, Y, &Result);
 #else


### PR DESCRIPTION
This patch fixes the return type of the 3-argument overloads of
AddOverflow, SubOverflow, and MulOverflow to bool.

Without this patch, these functions are declared with a return type
of T:

  template <typename T>
  std::enable_if_t<std::is_signed_v<T>, T> AddOverflow(T X, T Y, T &Result);

even though they return a boolean indicating whether an overflow
occurred, as stated in the comment:

  /// Add two signed integers, computing the two's complement truncated result,
  /// returning true if overflow occurred.

Assisted-by: Antigravity
