### PR TITLE
[SelectionDAG] Remove unused float promotion in DAGTypeLegalizer (NFC)

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/LegalizeTypes.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/LegalizeTypes.cpp
@@ -120,10 +120,8 @@ void DAGTypeLegalizer::PerformExpensiveChecks() {
           Mapped |= 64;
         if (WidenedVectors.count(ResId))
           Mapped |= 128;
-        if (PromotedFloats.count(ResId))
-          Mapped |= 256;
         if (SoftPromotedHalfs.count(ResId))
-          Mapped |= 512;
+          Mapped |= 256;
       }
 
       if (Node.getNodeId() != Processed) {
@@ -176,8 +174,6 @@ void DAGTypeLegalizer::PerformExpensiveChecks() {
         if (Mapped & 128)
           dbgs() << " WidenedVectors";
         if (Mapped & 256)
-          dbgs() << " PromotedFloats";
-        if (Mapped & 512)
           dbgs() << " SoftPromoteHalfs";
         dbgs() << "\n";
         llvm_unreachable(nullptr);
@@ -730,17 +726,6 @@ void DAGTypeLegalizer::SetSoftenedFloat(SDValue Op, SDValue Result) {
 
   auto &OpIdEntry = SoftenedFloats[getTableId(Op)];
   assert((OpIdEntry == 0) && "Node is already converted to integer!");
-  OpIdEntry = getTableId(Result);
-}
-
-void DAGTypeLegalizer::SetPromotedFloat(SDValue Op, SDValue Result) {
-  assert(Result.getValueType() ==
-         TLI.getTypeToTransformTo(*DAG.getContext(), Op.getValueType()) &&
-         "Invalid type for promoted float");
-  AnalyzeNewValue(Result);
-
-  auto &OpIdEntry = PromotedFloats[getTableId(Op)];
-  assert((OpIdEntry == 0) && "Node is already promoted!");
   OpIdEntry = getTableId(Result);
 }
 

--- a/llvm/lib/CodeGen/SelectionDAG/LegalizeTypes.h
+++ b/llvm/lib/CodeGen/SelectionDAG/LegalizeTypes.h
@@ -105,10 +105,6 @@ private:
   SmallDenseMap<TableId, TableId, 8> SoftenedFloats;
 
   /// For floating-point nodes that have a smaller precision than the smallest
-  /// supported precision, this map indicates what promoted value to use.
-  SmallDenseMap<TableId, TableId, 8> PromotedFloats;
-
-  /// For floating-point nodes that have a smaller precision than the smallest
   /// supported precision, this map indicates the converted value to use.
   SmallDenseMap<TableId, TableId, 8> SoftPromotedHalfs;
 
@@ -190,7 +186,6 @@ public:
         PromotedIntegers.erase(OldId);
         ExpandedIntegers.erase(OldId);
         SoftenedFloats.erase(OldId);
-        PromotedFloats.erase(OldId);
         SoftPromotedHalfs.erase(OldId);
         ExpandedFloats.erase(OldId);
         ScalarizedVectors.erase(OldId);
@@ -748,18 +743,6 @@ private:
   void FloatExpandSetCCOperands(SDValue &NewLHS, SDValue &NewRHS,
                                 ISD::CondCode &CCCode, const SDLoc &dl,
                                 SDValue &Chain, bool IsSignaling = false);
-
-  //===--------------------------------------------------------------------===//
-  // Float promotion support: LegalizeFloatTypes.cpp
-  //===--------------------------------------------------------------------===//
-
-  SDValue GetPromotedFloat(SDValue Op) {
-    TableId &PromotedId = PromotedFloats[getTableId(Op)];
-    SDValue PromotedOp = getSDValue(PromotedId);
-    assert(PromotedOp.getNode() && "Operand wasn't promoted?");
-    return PromotedOp;
-  }
-  void SetPromotedFloat(SDValue Op, SDValue Result);
 
   SDValue BitcastToInt_ATOMIC_SWAP(SDNode *N);
 


### PR DESCRIPTION
This patch removes PromotedFloats along with GetPromotedFloat and
SetPromotedFloat.  The Mapped bitmask in PerformExpensiveChecks is
adjusted accordingly, shifting the bit for SoftPromotedHalfs.

The last uses of DAGTypeLegalizer::GetPromotedFloat and
DAGTypeLegalizer::SetPromotedFloat were removed on January 26, 2026 in
commit a7d48bd305ef3aa4bd543da6f4cd8682a3d35c32 when TypePromoteFloat
and its associated DAG machinery were removed.

With these accessors gone, DAGTypeLegalizer::PromotedFloats is no longer
populated.

Assisted-by: Antigravity
