### PR TITLE
[SelectionDAG] Reduce RRList scheduling overhead

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/ScheduleDAGRRList.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/ScheduleDAGRRList.cpp
@@ -1724,6 +1724,10 @@ protected:
   // SethiUllmanNumbers - The SethiUllman number for each node.
   std::vector<unsigned> SethiUllmanNumbers;
 
+  // A queued node's successors are already scheduled. Their heights remain
+  // fixed until the node leaves the queue or its dependencies are updated.
+  DenseMap<const SUnit *, unsigned> ClosestSuccs;
+
   /// RegPressure - Tracking current reg pressure per register class.
   std::vector<unsigned> RegPressure;
 
@@ -1769,10 +1773,13 @@ public:
   void releaseState() override {
     SUnits = nullptr;
     SethiUllmanNumbers.clear();
+    ClosestSuccs.clear();
     llvm::fill(RegPressure, 0);
   }
 
   unsigned getNodePriority(const SUnit *SU) const;
+
+  unsigned getClosestSucc(const SUnit *SU);
 
   unsigned getNodeOrdering(const SUnit *SU) const {
     if (!SU->getNode()) return 0;
@@ -1795,6 +1802,7 @@ public:
     if (I != std::prev(Queue.end()))
       std::swap(*I, Queue.back());
     Queue.pop_back();
+    ClosestSuccs.erase(SU);
     SU->NodeQueueId = 0;
   }
 
@@ -1879,6 +1887,7 @@ public:
     if (Queue.empty()) return nullptr;
 
     SUnit *V = popFromQueue(Queue, Picker, scheduleDAG);
+    ClosestSuccs.erase(V);
     V->NodeQueueId = 0;
     return V;
   }
@@ -1948,11 +1957,10 @@ CalcNodeSethiUllmanNumber(const SUnit *SU, std::vector<unsigned> &SUNumbers) {
       if (Pred.isCtrl()) continue;  // ignore chain preds
       SUnit *PredSU = Pred.getSUnit();
       if (SUNumbers[PredSU->NodeNum] == 0) {
-#ifndef NDEBUG
-        // In debug mode, check that we don't have such element in the stack.
-        for (auto It : WorkList)
-          assert(It.SU != PredSU && "Trying to push an element twice?");
-#endif
+        // An acyclic path cannot contain more nodes than SUNumbers. Avoid
+        // scanning the worklist, which is quadratic for long paths.
+        assert(WorkList.size() < SUNumbers.size() &&
+               "Trying to push an element twice?");
         // Next time start processing this one starting from the next pred.
         Temp.PredsProcessed = P + 1;
         WorkList.push_back(PredSU);
@@ -2007,6 +2015,7 @@ void RegReductionPQBase::addNode(const SUnit *SU) {
 }
 
 void RegReductionPQBase::updateNode(const SUnit *SU) {
+  ClosestSuccs.erase(SU);
   SethiUllmanNumbers[SU->NodeNum] = 0;
   CalcNodeSethiUllmanNumber(SU, SethiUllmanNumbers);
 }
@@ -2335,6 +2344,13 @@ static unsigned closestSucc(const SUnit *SU) {
   return MaxHeight;
 }
 
+unsigned RegReductionPQBase::getClosestSucc(const SUnit *SU) {
+  auto It = ClosestSuccs.find(SU);
+  if (It != ClosestSuccs.end())
+    return It->second;
+  return ClosestSuccs.try_emplace(SU, closestSucc(SU)).first->second;
+}
+
 /// calcMaxScratches - Returns an cost estimate of the worse case requirement
 /// for scratch registers, i.e. number of data dependencies.
 static unsigned calcMaxScratches(const SUnit *SU) {
@@ -2581,8 +2597,8 @@ static bool BURRSort(SUnit *left, SUnit *right, RegReductionPQBase *SPQ) {
   // t3 = op t4, c2
   //
   // This creates more short live intervals.
-  unsigned LDist = closestSucc(left);
-  unsigned RDist = closestSucc(right);
+  unsigned LDist = SPQ->getClosestSucc(left);
+  unsigned RDist = SPQ->getClosestSucc(right);
   if (LDist != RDist)
     return LDist < RDist;
 


### PR DESCRIPTION
Cache closest-successor distances while nodes are in the available queue.
Successor heights are stable during this interval; invalidate entries on pop,
removal, node updates and state release.

Replace the quadratic assertion-only Sethi–Ullman worklist scan with a depth
bound, preserving iterative traversal and bounded detection of uncached cycles.

For the 65536-lane reproducer, the initial matched-run median whole-`llc` time
drops from 14.12 to 5.58 s with assertions and from 9.35 to 4.07 s without.
A fresh 10-trial replication on independent Ubuntu 24.04 runners measured
11.44 to 4.68 s (2.44x) with assertions and 4.48 to 2.78 s (1.61x) without.
Each comparison used matching build options, one warm-up, interleaved
baseline/candidate runs, and identical assembly.

Fork CI passed with [10-trial assertions validation](https://github.com/1sgtpepper/llvm-project/actions/runs/34808578564)
and [10-trial release validation](https://github.com/1sgtpepper/llvm-project/actions/runs/34808549647):
all NVPTX CodeGen tests and nine focused X86 tests (597/592 passed; five require
assertions), 1838 differential input pairs, priority/cache fixtures, and separate
checks against freshly computed cache values. Benchmarks also cover vector scaling,
small functions and scalar controls.

AI disclosure: Codex.

Fixes #211018.
