### PR TITLE
[dfsan] Fix big-endian origin mask

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/DataFlowSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/DataFlowSanitizer.cpp
@@ -2212,7 +2212,7 @@ std::pair<Value *, Value *> DFSanFunction::loadShadowFast(
               : IRB.CreateAnd(
                     WideShadow,
                     ConstantInt::get(WideShadowTy,
-                                     (1 - (1 << (WideShadowBitWidth / 2)))
+                                     ((1ULL << (WideShadowBitWidth / 2)) - 1)
                                          << (WideShadowBitWidth / 2)));
       Shadows.push_back(WideShadow);
       Origins.push_back(DFS.loadNextOrigin(Pos, OriginAlign, &OriginAddr));

--- a/llvm/test/Instrumentation/DataFlowSanitizer/origin_load_big_endian.ll
+++ b/llvm/test/Instrumentation/DataFlowSanitizer/origin_load_big_endian.ll
@@ -1,0 +1,13 @@
+; RUN: opt < %s -passes=dfsan -dfsan-track-origins=1 -S | FileCheck %s
+
+target datalayout = "E-p:64:64:64-i1:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-n8:16:32:64-S128"
+target triple = "s390x-unknown-linux-gnu"
+
+define i64 @load64(ptr %p) {
+  ; CHECK-LABEL: @load64.dfsan
+  ; CHECK: %[[SHADOW:.*]] = load i64, ptr {{.*}}, align 1
+  ; CHECK-NEXT: and i64 %[[SHADOW]], -4294967296
+
+  %a = load i64, ptr %p
+  ret i64 %a
+}


### PR DESCRIPTION
Fix the mask used when loading wide shadows on big-endian targets.

The previous expression used a 32-bit integer for the shift, producing an incorrect zero mask for 64-bit wide shadows. Changed the expression to use 1ULL so that a 64-bit mask is constructed correctly. The resulting mask keeps the upper 32 bits and clears the lower 32 bits.

Previously, the big-endian path generated:

```ll
%10 = load i64, ptr %6, align 1
%11 = and i64 %10, 0
```

With this change, it generates:

```ll
%10 = load i64, ptr %6, align 1
%11 = and i64 %10, -4294967296
```
Added a SystemZ big-endian regression test.

cc: @uweigand @anoopkg6
