### PR TITLE
[Clang] Make Unlabeled the default control flow branch label scheme

### DIFF
--- a/clang/lib/Basic/Targets/RISCV.cpp
+++ b/clang/lib/Basic/Targets/RISCV.cpp
@@ -651,12 +651,7 @@ bool RISCVTargetInfo::checkCFBranchLabelSchemeSupported(
   // implements it
   switch (Scheme) {
   case CFBranchLabelSchemeKind::Default:
-    Diags.Report(diag::err_opt_not_valid_without_opt)
-        << "-fcf-protection=branch"
-        << (Twine("-mcf-branch-label-scheme=") +
-            getCFBranchLabelSchemeFlagVal(CFBranchLabelSchemeKind::Unlabeled))
-               .str();
-    return false;
+   return true;
   case CFBranchLabelSchemeKind::Unlabeled:
     return true;
   case CFBranchLabelSchemeKind::FuncSig:

--- a/clang/lib/Basic/Targets/RISCV.h
+++ b/clang/lib/Basic/Targets/RISCV.h
@@ -154,7 +154,7 @@ public:
   }
 
   CFBranchLabelSchemeKind getDefaultCFBranchLabelScheme() const override {
-    return CFBranchLabelSchemeKind::FuncSig;
+    return CFBranchLabelSchemeKind::Unlabeled;
   }
 
   bool

--- a/clang/test/CodeGen/RISCV/riscv-cf-protection.c
+++ b/clang/test/CodeGen/RISCV/riscv-cf-protection.c
@@ -70,22 +70,12 @@
 // RUN: -emit-llvm %s -o - 2>&1 | FileCheck \
 // RUN: --check-prefixes=NO-FLAG,FUNC-SIG-SCHEME-UNUSED %s
 
-// Default -mcf-branch-label-scheme is func-sig
-// RUN: not %clang --target=riscv32 -fcf-protection=branch -S -emit-llvm %s \
-// RUN: -o - 2>&1 | FileCheck --check-prefixes=FORCE-UNLABELED %s
-
-// Default -mcf-branch-label-scheme is func-sig
-// RUN: not %clang --target=riscv64 -fcf-protection=branch -S -emit-llvm %s \
-// RUN: -o - 2>&1 | FileCheck --check-prefixes=FORCE-UNLABELED %s
-
 // UNLABELED-SCHEME-UNUSED: warning: argument unused during compilation:
 // UNLABELED-SCHEME-UNUSED-SAME: '-mcf-branch-label-scheme=unlabeled'
 // FUNC-SIG-SCHEME-UNUSED: warning: argument unused during compilation:
 // FUNC-SIG-SCHEME-UNUSED-SAME: '-mcf-branch-label-scheme=func-sig'
 // FUNC-SIG-NOSUPPORT: error: option '-mcf-branch-label-scheme=func-sig' is
 // FUNC-SIG-NOSUPPORT-SAME: unsupported; consider using '-mcf-branch-label-scheme=unlabeled'
-// FORCE-UNLABELED: error: option '-fcf-protection=branch' cannot be specified
-// FORCE-UNLABELED-SAME: without '-mcf-branch-label-scheme=unlabeled'
 
 // BRANCH-PROT-FLAG-DAG: [[P_FLAG:![0-9]+]] = !{i32 8, !"cf-protection-branch", i32 1}
 // UNLABELED-FLAG-DAG: [[S_FLAG:![0-9]+]] = !{i32 1, !"cf-branch-label-scheme", !"unlabeled"}


### PR DESCRIPTION
The work on "func-sig" label scheme is discontinued, so it's better to switch the default to unlabeled at this time.